### PR TITLE
mobile website

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -71,3 +71,31 @@ section {
   top: 2px;
   right: 6px;
 }
+
+.wrapper {
+  overflow-y: auto;
+}
+
+span.wrapper {
+  display: block;
+}
+
+@media screen and (max-width: 600px) {
+  #leftColumn {
+    float: none;
+    width: auto;
+    margin: 1.5em;
+  }
+
+  #bodyColumn {
+    margin: 1.5em;
+  }
+
+  #bannerRight {
+    display: none;
+  }
+
+  p, h1, h2, h3, h4, h5, h6, li {
+    word-break: break-word;
+  }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -179,12 +179,20 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
     private static void populateProperties(Node subSection) {
         boolean skip = true;
 
-        for (Node row : XmlUtil.getChildrenElements(XmlUtil.getFirstChildElement(subSection))) {
+        // if the first child is a wrapper element instead of the first table row containing
+        // the table head
+        //   set element to populate properties for to the current elements first child
+        Node child = XmlUtil.getFirstChildElement(subSection);
+        if (child.hasAttributes() && child.getAttributes().getNamedItem("class") != null
+                && "wrapper".equals(child.getAttributes().getNamedItem("class")
+                .getTextContent())) {
+            child = XmlUtil.getFirstChildElement(child);
+        }
+        for (Node row : XmlUtil.getChildrenElements(child)) {
             if (skip) {
                 skip = false;
                 continue;
             }
-
             CHECK_PROPERTIES.add(new ArrayList<>(XmlUtil.getChildrenElements(row)));
         }
     }
@@ -245,7 +253,14 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
                 }
             }
             else {
-                appendNodeText(result, child);
+                if (child.hasAttributes() && child.getAttributes().getNamedItem("class") != null
+                        && "wrapper".equals(child.getAttributes().getNamedItem("class")
+                        .getNodeValue())) {
+                    appendNodeText(result, XmlUtil.getFirstChildElement(child));
+                }
+                else {
+                    appendNodeText(result, child);
+                }
             }
         }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsMobileWrapperTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsMobileWrapperTest.java
@@ -1,0 +1,100 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2019 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.internal;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import com.puppycrawl.tools.checkstyle.internal.utils.XdocUtil;
+import com.puppycrawl.tools.checkstyle.internal.utils.XmlUtil;
+
+public class XdocsMobileWrapperTest {
+
+    private static final List<String> NODES_TO_WRAP = new ArrayList<>();
+
+    @Before
+    public void setUp() {
+        NODES_TO_WRAP.add("pre");
+        NODES_TO_WRAP.add("table");
+        NODES_TO_WRAP.add("svg");
+        NODES_TO_WRAP.add("img");
+    }
+
+    @Test
+    public void testAllCheckSectionMobileWrapper() throws Exception {
+        for (Path path : XdocUtil.getXdocsConfigFilePaths(XdocUtil.getXdocsFilePaths())) {
+            final File file = path.toFile();
+            final String fileName = file.getName();
+
+            final String input = new String(Files.readAllBytes(path), UTF_8);
+            Assert.assertNotEquals(fileName + ": input file cannot be empty", "",
+                    input);
+            final Document document = XmlUtil.getRawXml(fileName, input, input);
+            final NodeList sources = document.getElementsByTagName("section");
+
+            for (int position = 0; position < sources.getLength(); position++) {
+                final Node section = sources.item(position);
+                final String sectionName = section.getAttributes().getNamedItem("name")
+                        .getNodeValue();
+
+                if ("Content".equals(sectionName) || "Overview".equals(sectionName)) {
+                    continue;
+                }
+
+                iterateNode(section, fileName, sectionName);
+            }
+        }
+    }
+
+    private static void iterateNode(Node node, String fileName, String sectionName) {
+        for (Node child : XmlUtil.getChildrenElements(node)) {
+            if (NODES_TO_WRAP.contains(child.getNodeName())) {
+                final String wrapperMessage = fileName + "/" + sectionName + ": Tag '"
+                        + child.getNodeName() + "' in '" + node.getNodeName()
+                        + "' needs a wrapping <span> or <div> with the class 'wrapper'.";
+                Assert.assertTrue(wrapperMessage, "div".equals(node.getNodeName())
+                        || "span".equals(node.getNodeName()));
+                Assert.assertTrue(wrapperMessage, node.hasAttributes());
+                Assert.assertNotNull(wrapperMessage, node.getAttributes().getNamedItem("class"));
+                Assert.assertTrue(wrapperMessage,
+                        node.getAttributes().getNamedItem("class").getNodeValue()
+                                .contains("wrapper"));
+                if ("table".equals(child.getNodeName())) {
+                    iterateNode(child, fileName, sectionName);
+                }
+            }
+            else {
+                iterateNode(child, fileName, sectionName);
+            }
+        }
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -608,10 +608,23 @@ public class XdocsPagesTest {
                     + "' subsection 'Properties' should have one child node",
                 1, nodes.size());
 
-            final Node table = nodes.iterator().next();
+            final Node div = nodes.iterator().next();
             Assert.assertEquals(fileName + " section '" + sectionName
                     + "' subsection 'Properties' has unexpected child node",
-                "table", table.getNodeName());
+                "div", div.getNodeName());
+            final String wrapperMessage = fileName + " section '" + sectionName
+                    + "' subsection 'Properties' wrapping div for table needs the"
+                    + " class 'wrapper'";
+            Assert.assertTrue(wrapperMessage, div.hasAttributes());
+            Assert.assertNotNull(wrapperMessage,
+                    div.getAttributes().getNamedItem("class").getNodeValue());
+            Assert.assertTrue(wrapperMessage,
+                    div.getAttributes().getNamedItem("class").getNodeValue().contains("wrapper"));
+
+            final Node table = XmlUtil.getFirstChildElement(div);
+            Assert.assertEquals(fileName + " section '" + sectionName
+                            + "' subsection 'Properties' has unexpected child node",
+                    "table", table.getNodeName());
 
             validatePropertySectionProperties(fileName, sectionName, table, instance,
                     properties);

--- a/src/xdocs/anttask.xml.vm
+++ b/src/xdocs/anttask.xml.vm
@@ -91,140 +91,142 @@
 
     <section name="Parameters">
 
-      <table summary="parameters">
+      <div class="wrapper">
+        <table summary="parameters">
 
-        <tr>
-          <td><b>Attribute</b></td>
-          <td><b>Description</b></td>
-          <td><b>Required</b></td>
-        </tr>
+          <tr>
+            <td><b>Attribute</b></td>
+            <td><b>Description</b></td>
+            <td><b>Required</b></td>
+          </tr>
 
-        <tr>
-          <td>file</td>
-          <td>File to run checkstyle on.</td>
-          <td>
-            One of either <i>file</i> or at least one nested <i>fileset</i> or <i>path</i>
-            element
-          </td>
-        </tr>
+          <tr>
+            <td>file</td>
+            <td>File to run checkstyle on.</td>
+            <td>
+              One of either <i>file</i> or at least one nested <i>fileset</i> or <i>path</i>
+              element
+            </td>
+          </tr>
 
-        <tr>
-          <td>fileset</td>
-          <td>
-            A set of files to run checkstyle on. Nested attribute.
-            See <a href="http://ant.apache.org/manual/Types/fileset.html">fileset</a>
-            ant documentation for details
-          </td>
-          <td>
-            One of either <i>file</i> or at least one nested <i>fileset</i> or <i>path</i>
-            element
-          </td>
-        </tr>
+          <tr>
+            <td>fileset</td>
+            <td>
+              A set of files to run checkstyle on. Nested attribute.
+              See <a href="http://ant.apache.org/manual/Types/fileset.html">fileset</a>
+              ant documentation for details
+            </td>
+            <td>
+              One of either <i>file</i> or at least one nested <i>fileset</i> or <i>path</i>
+              element
+            </td>
+          </tr>
 
-        <tr>
-          <td>path</td>
-          <td>
-            A set of path to run checkstyle on. Nested attribute.
-            See <a href="http://ant.apache.org/manual/using.html#path">path</a>
-            ant documentation for details
-          </td>
-          <td>
-            One of either <i>file</i> or at least one nested <i>fileset</i> or <i>path</i>
-            element
-          </td>
-        </tr>
+          <tr>
+            <td>path</td>
+            <td>
+              A set of path to run checkstyle on. Nested attribute.
+              See <a href="http://ant.apache.org/manual/using.html#path">path</a>
+              ant documentation for details
+            </td>
+            <td>
+              One of either <i>file</i> or at least one nested <i>fileset</i> or <i>path</i>
+              element
+            </td>
+          </tr>
 
-        <tr>
-          <td>config</td>
-          <td>
-            Specifies the location of the file, URL, or Java resource that defines the configuration
-            modules.
-            <br/>
-            <a href="config.html">See here</a> for a description of how to
-            define a configuration.
-          </td>
-          <td>Exactly one config location</td>
-        </tr>
+          <tr>
+            <td>config</td>
+            <td>
+              Specifies the location of the file, URL, or Java resource that defines the
+              configuration modules.
+              <br/>
+              <a href="config.html">See here</a> for a description of how to
+              define a configuration.
+            </td>
+            <td>Exactly one config location</td>
+          </tr>
 
-        <tr>
-          <td>properties</td>
-          <td>
-            Specifies a file that contains properties for <a
-            href="config.html#Properties"> expanded property values</a> of the
-            configuration.  Ant properties (like ${basedir}) and nested
-            property elements override the properties in this file.
-          </td>
-          <td>No</td>
-        </tr>
+          <tr>
+            <td>properties</td>
+            <td>
+              Specifies a file that contains properties for <a
+              href="config.html#Properties"> expanded property values</a> of the
+              configuration.  Ant properties (like ${basedir}) and nested
+              property elements override the properties in this file.
+            </td>
+            <td>No</td>
+          </tr>
 
-        <tr>
-          <td>failOnViolation</td>
-          <td>
-            Specifies whether the build will continue even if there are
-            violations. Defaults to <code>&quot;true&quot;</code>.
-          </td>
-          <td>No</td>
-        </tr>
+          <tr>
+            <td>failOnViolation</td>
+            <td>
+              Specifies whether the build will continue even if there are
+              violations. Defaults to <code>&quot;true&quot;</code>.
+            </td>
+            <td>No</td>
+          </tr>
 
-        <tr>
-          <td>failureProperty</td>
-          <td>The name of a property to set in the event of a violation.</td>
-          <td>No</td>
-        </tr>
+          <tr>
+            <td>failureProperty</td>
+            <td>The name of a property to set in the event of a violation.</td>
+            <td>No</td>
+          </tr>
 
-        <tr>
-          <td>maxErrors</td>
-          <td>
-            The maximum number of errors that are tolerated before
-            breaking the build or setting the failure property. Defaults
-            to <code>&quot;0&quot;</code>.
-          </td>
-          <td>No</td>
-        </tr>
+          <tr>
+            <td>maxErrors</td>
+            <td>
+              The maximum number of errors that are tolerated before
+              breaking the build or setting the failure property. Defaults
+              to <code>&quot;0&quot;</code>.
+            </td>
+            <td>No</td>
+          </tr>
 
-        <tr>
-          <td>maxWarnings</td>
-          <td>
-            The maximum number of warnings that are tolerated before
-            breaking the build or setting the failure property. Defaults
-            to <code>&quot;2147483647&quot;</code>, i.e.
+          <tr>
+            <td>maxWarnings</td>
+            <td>
+              The maximum number of warnings that are tolerated before
+              breaking the build or setting the failure property. Defaults
+              to <code>&quot;2147483647&quot;</code>, i.e.
 
-            <a href="https://docs.oracle.com/javase/7/docs/api/java/lang/Integer.html#MAX_VALUE">
-                Integer.MAX_VALUE</a>.
-          </td>
-          <td>No</td>
-        </tr>
+              <a href="https://docs.oracle.com/javase/7/docs/api/java/lang/Integer.html#MAX_VALUE">
+                  Integer.MAX_VALUE</a>.
+            </td>
+            <td>No</td>
+          </tr>
 
-        <tr>
-          <td>classpath</td>
-          <td>
-            The classpath to use when looking up classes. Defaults to the
-            current classpath.
-          </td>
-          <td>No</td>
-        </tr>
+          <tr>
+            <td>classpath</td>
+            <td>
+              The classpath to use when looking up classes. Defaults to the
+              current classpath.
+            </td>
+            <td>No</td>
+          </tr>
 
-        <tr>
-          <td>classpathref</td>
-          <td>
-            The classpath to use when looking up classes, given as a reference
-            to a path defined elsewhere.
-          </td>
-          <td>No</td>
-        </tr>
+          <tr>
+            <td>classpathref</td>
+            <td>
+              The classpath to use when looking up classes, given as a reference
+              to a path defined elsewhere.
+            </td>
+            <td>No</td>
+          </tr>
 
-        <tr>
-          <td>executeIgnoredModules</td>
-          <td>
-            For efficiency, Checkstyle does not invoke modules with a configured severity of
-            "ignore" (since their output would be ignored anyway). A small number of modules
-            may choose to log above their configured severity level and so always need to be
-            invoked. This settings specifies that behaviour.
-            Defaults to <code>&quot;false&quot;</code>.
-          </td>
-          <td>No</td>
-        </tr>
-      </table>
+          <tr>
+            <td>executeIgnoredModules</td>
+            <td>
+              For efficiency, Checkstyle does not invoke modules with a configured severity of
+              "ignore" (since their output would be ignored anyway). A small number of modules
+              may choose to log above their configured severity level and so always need to be
+              invoked. This settings specifies that behaviour.
+              Defaults to <code>&quot;false&quot;</code>.
+            </td>
+            <td>No</td>
+          </tr>
+        </table>
+      </div>
 
       <p>
         Note that the <code>packageNamesFile</code>
@@ -256,47 +258,50 @@
         element are:
       </p>
 
-      <table summary="nested elements">
-        <tr>
-          <td><b>Attribute</b></td>
-          <td><b>Description</b></td>
-          <td><b>Required</b></td>
-        </tr>
+      <div class="wrapper">
+        <table summary="nested elements">
+          <tr>
+            <td><b>Attribute</b></td>
+            <td><b>Description</b></td>
+            <td><b>Required</b></td>
+          </tr>
 
-        <tr>
-          <td>type</td>
-          <td>
-            <p>The type of output to generate. The valid values are:</p>
-            <ul>
-              <li>
-                <code>plain</code> - specifies the <a
-                href="apidocs/com/puppycrawl/tools/checkstyle/DefaultLogger.html">DefaultLogger</a>
-              </li>
-              <li>
-                <code>xml</code> - specifies the <a
-                href="apidocs/com/puppycrawl/tools/checkstyle/XMLLogger.html">XMLLogger</a>
-              </li>
-            </ul>
-            <p>Defaults to <code>"plain"</code>.</p>
-          </td>
-          <td>No</td>
-        </tr>
+          <tr>
+            <td>type</td>
+            <td>
+              <p>The type of output to generate. The valid values are:</p>
+              <ul>
+                <li>
+                  <code>plain</code> - specifies the <a
+                  href="apidocs/com/puppycrawl/tools/checkstyle/DefaultLogger.html">
+                    DefaultLogger</a>
+                </li>
+                <li>
+                  <code>xml</code> - specifies the <a
+                  href="apidocs/com/puppycrawl/tools/checkstyle/XMLLogger.html">XMLLogger</a>
+                </li>
+              </ul>
+              <p>Defaults to <code>"plain"</code>.</p>
+            </td>
+            <td>No</td>
+          </tr>
 
-        <tr>
-          <td>toFile</td>
-          <td>
-            The file to write output to. Defaults to standard output. Note,
-            there is no way to explicitly specify standard output.
-          </td>
-          <td>No</td>
-        </tr>
-        <tr>
-          <td>useFile</td>
-          <td>Boolean that determines whether output should be sent to
-          a file.  Default is <code>true</code>.</td>
-          <td>No</td>
-        </tr>
-      </table>
+          <tr>
+            <td>toFile</td>
+            <td>
+              The file to write output to. Defaults to standard output. Note,
+              there is no way to explicitly specify standard output.
+            </td>
+            <td>No</td>
+          </tr>
+          <tr>
+            <td>useFile</td>
+            <td>Boolean that determines whether output should be sent to
+            a file.  Default is <code>true</code>.</td>
+            <td>No</td>
+          </tr>
+        </table>
+      </div>
 
       <p>
         A <code>&lt;property&gt;</code> element provides a property for
@@ -305,33 +310,35 @@
         <code>&lt;property&gt;</code> element are:
       </p>
 
-      <table summary="nested elements">
-        <tr>
-          <td><b>Attribute</b></td>
-          <td><b>Description</b></td>
-          <td><b>Required</b></td>
-        </tr>
-        <tr>
-          <td>key</td>
-          <td><p>The key for the property.</p></td>
-          <td>Yes</td>
-        </tr>
+      <div class="wrapper">
+        <table summary="nested elements">
+          <tr>
+            <td><b>Attribute</b></td>
+            <td><b>Description</b></td>
+            <td><b>Required</b></td>
+          </tr>
+          <tr>
+            <td>key</td>
+            <td><p>The key for the property.</p></td>
+            <td>Yes</td>
+          </tr>
 
-        <tr>
-          <td>value</td>
-          <td>The value of the property specified as a string.</td>
-          <td>Either <i>value</i> or <i>file</i></td>
-        </tr>
+          <tr>
+            <td>value</td>
+            <td>The value of the property specified as a string.</td>
+            <td>Either <i>value</i> or <i>file</i></td>
+          </tr>
 
-        <tr>
-          <td>file</td>
-          <td>
-            The value of the property specified as a file. This is great for
-            specifying file names relative to the ANT build file.
-          </td>
-          <td>Either <i>value</i> or <i>file</i></td>
-        </tr>
-      </table>
+          <tr>
+            <td>file</td>
+            <td>
+              The value of the property specified as a file. This is great for
+              specifying file names relative to the ANT build file.
+            </td>
+            <td>Either <i>value</i> or <i>file</i></td>
+          </tr>
+        </table>
+      </div>
 
     </section>
 

--- a/src/xdocs/checks.xml
+++ b/src/xdocs/checks.xml
@@ -31,865 +31,877 @@
       source code. Below is an alphabetical reference, the site
       navigation menu provides a reference organized by functionality.
     </p>
-    <table>
-      <tr>
-        <td><a href="config_naming.html#AbbreviationAsWordInName">AbbreviationAsWordInName</a></td>
-        <td>The Check validate abbreviations(consecutive capital letters)
-         length in identifier name, it also allow in enforce camel case naming.</td>
-      </tr>
-      <tr>
-        <td><a href="config_naming.html#AbstractClassName">AbstractClassName</a></td>
-        <td>
-          Ensures that the names of abstract classes conforming to some regular expression and
-          check that <code>abstract</code> modifier exists.
-        </td>
-      </tr>
-      <tr>
-        <td><a href="config_annotation.html#AnnotationLocation">AnnotationLocation</a></td>
-        <td>Check location of annotation on language elements.</td>
-      </tr>
-      <tr>
-        <td><a href="config_annotation.html#AnnotationOnSameLine">AnnotationOnSameLine</a></td>
-        <td>The check does verifying that annotations are located on the same line with their
-            targets.</td>
-      </tr>
-      <tr>
-        <td><a href="config_annotation.html#AnnotationUseStyle">AnnotationUseStyle</a></td>
-        <td>This check controls the style with the usage of annotations.</td>
-      </tr>
-      <tr>
-        <td><a href="config_sizes.html#AnonInnerLength">AnonInnerLength</a></td>
-        <td>Checks for long anonymous inner classes.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#ArrayTrailingComma">ArrayTrailingComma</a></td>
-        <td>Checks if array initialization contains optional trailing comma.</td>
-      </tr>
-      <tr>
-        <td><a href="config_misc.html#ArrayTypeStyle">ArrayTypeStyle</a></td>
-        <td>Checks the style of array type definitions.</td>
-      </tr>
-      <tr>
-        <td><a href="config_javadoc.html#AtclauseOrder">AtclauseOrder</a></td>
-        <td>Checks the order of at-clauses.</td>
-      </tr>
-      <tr>
-        <td><a href="config_misc.html#AvoidEscapedUnicodeCharacters">
-          AvoidEscapedUnicodeCharacters</a></td>
-        <td>Restrict using Unicode escapes.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#AvoidInlineConditionals">AvoidInlineConditionals</a></td>
-        <td>Detects inline conditionals.</td>
-      </tr>
-      <tr>
-        <td><a href="config_blocks.html#AvoidNestedBlocks">AvoidNestedBlocks</a></td>
-        <td>Finds nested blocks.</td>
-      </tr>
-      <tr>
-        <td><a href="config_imports.html#AvoidStarImport">AvoidStarImport</a></td>
-        <td>Check that finds import statements that use the * notation.</td>
-      </tr>
-      <tr>
-        <td><a href="config_imports.html#AvoidStaticImport">AvoidStaticImport</a></td>
-        <td>Check that finds static imports.</td>
-      </tr>
-      <tr>
-        <td><a href="config_metrics.html#BooleanExpressionComplexity">
-          BooleanExpressionComplexity</a></td>
-        <td>
-          Restricts nested boolean operators (&amp;&amp;, ||, &amp;, |
-          and ^) to a specified depth (default = 3).
-        </td>
-      </tr>
-      <tr>
-        <td><a href="config_naming.html#CatchParameterName">CatchParameterName</a></td>
-        <td>Checks that <code>catch</code> parameter names conform to a format specified by the
-            format property.</td>
-      </tr>
-      <tr>
-        <td><a href="config_metrics.html#ClassDataAbstractionCoupling">
-          ClassDataAbstractionCoupling</a></td>
-        <td>This metric measures the number of instantiations of other classes within the given
-            class.</td>
-      </tr>
-      <tr>
-        <td><a href="config_metrics.html#ClassFanOutComplexity">ClassFanOutComplexity</a></td>
-        <td>The number of other classes a given class relies on.</td>
-      </tr>
-      <tr>
-        <td><a href="config_modifier.html#ClassMemberImpliedModifier">
-          ClassMemberImpliedModifier</a></td>
-        <td>
-          Checks for implicit modifiers on class members and nested types.</td>
-      </tr>
-      <tr>
-        <td><a href="config_naming.html#ClassTypeParameterName">ClassTypeParameterName</a></td>
-        <td>
-          Checks that class type parameter names conform to a format
-          specified by the format property.
-        </td>
-      </tr>
-      <tr>
-        <td><a href="config_misc.html#CommentsIndentation">CommentsIndentation</a></td>
-        <td>Controls the indentation between comments and surrounding code.</td>
-      </tr>
-      <tr>
-        <td><a href="config_naming.html#ConstantName">ConstantName</a></td>
-        <td>Checks that constant names conform to a format specified by the format property.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#CovariantEquals">CovariantEquals</a></td>
-        <td>
-          Checks that if a class defines a covariant method equals, then
-          it defines method equals(java.lang.Object).
-        </td>
-      </tr>
-      <tr>
-        <td><a href="config_imports.html#CustomImportOrder">CustomImportOrder</a></td>
-        <td>
-          Checks that the groups of import declarations appear in the order specified
-          by the user.
-        </td>
-      </tr>
-      <tr>
-        <td><a href="config_metrics.html#CyclomaticComplexity">CyclomaticComplexity</a></td>
-        <td>Checks cyclomatic complexity against a specified limit.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#DeclarationOrder">DeclarationOrder</a></td>
-        <td>
-          Checks that the parts of a class or interface declaration
-          appear in the order suggested by the <a
-          href="styleguides/sun-code-conventions-19990420/CodeConventions.doc2.html#a1852"
-          >Code Conventions for the Java Programming Language</a>.
-        </td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#DefaultComesLast">DefaultComesLast</a></td>
-        <td>
-          Check that the <code>default</code> is after all the
-          <code>case</code>s in a <code>switch</code> statement.
-        </td>
-      </tr>
-      <tr>
-        <td><a href="config_misc.html#DescendantToken">DescendantToken</a></td>
-        <td>Checks for restricted tokens beneath other tokens.</td>
-      </tr>
-      <tr>
-        <td><a href="config_design.html#DesignForExtension">DesignForExtension</a></td>
-        <td>Checks that classes are designed for inheritance.</td>
-      </tr>
-      <tr>
-        <td><a href="config_blocks.html#EmptyBlock">EmptyBlock</a></td>
-        <td>Checks for empty blocks but does not validate sequential blocks.</td>
-      </tr>
-      <tr>
-        <td><a href="config_blocks.html#EmptyCatchBlock">EmptyCatchBlock</a></td>
-        <td>Checks for empty catch blocks with few options to skip violation.</td>
-      </tr>
-      <tr>
-        <td><a href="config_whitespace.html#EmptyForInitializerPad">EmptyForInitializerPad</a></td>
-        <td>Checks the padding of an empty for initializer; that is whether a
-        space is required at an empty for initializer, or such spaces are
-        forbidden.</td>
-      </tr>
-      <tr>
-        <td><a href="config_whitespace.html#EmptyForIteratorPad">EmptyForIteratorPad</a></td>
-        <td>Checks the padding of an empty for iterator; that is whether a
-        space is required at an empty for iterator, or such spaces are
-        forbidden.</td>
-      </tr>
-      <tr>
-        <td><a href="config_whitespace.html#EmptyLineSeparator">EmptyLineSeparator</a></td>
-        <td>Checks for blank line separators.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#EmptyStatement">EmptyStatement</a></td>
-        <td>
-        Detects empty statements (standalone ';').</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#EqualsAvoidNull">EqualsAvoidNull</a></td>
-        <td>
-          Checks that any combination of String literals
-          is on the left side of an equals() comparison.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#EqualsHashCode">EqualsHashCode</a></td>
-        <td>
-        Checks that classes that override equals() also override hashCode().</td>
-      </tr>
-      <tr>
-        <td><a href="config_sizes.html#ExecutableStatementCount">ExecutableStatementCount</a></td>
-        <td>
-          Restricts the number of executable statements to a specified
-          limit (default = 30).
-        </td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#ExplicitInitialization">ExplicitInitialization</a></td>
-        <td>
-          Checks if any class or object member explicitly initialized
-          to default for its type value (<code>null</code> for object
-          references, zero for numeric types and <code>char</code>
-          and <code>false</code> for <code>boolean</code>.
-        </td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#FallThrough">FallThrough</a></td>
-        <td>Checks for fall through in switch statements
-        Finds locations where a case contains Java code -
-        but lacks a break, return, throw or continue statement.</td>
-      </tr>
-      <tr>
-        <td><a href="config_sizes.html#FileLength">FileLength</a></td>
-        <td>
-        Checks for long source files.</td>
-      </tr>
-      <tr>
-        <td><a href="config_whitespace.html#FileTabCharacter">FileTabCharacter</a></td>
-        <td>Checks to see if a file contains a tab character.</td>
-      </tr>
-      <tr>
-        <td><a href="config_design.html#FinalClass">FinalClass</a></td>
-        <td>
-          Checks that class which has only private constructors
-        is declared as final.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#FinalLocalVariable">FinalLocalVariable</a></td>
-        <td>
-          Ensures that local variables that never get their values changed,
-        must be declared final.</td>
-      </tr>
-      <tr>
-        <td><a href="config_misc.html#FinalParameters">FinalParameters</a></td>
-        <td>Check that method/constructor/catch/foreach parameters are final.</td>
-      </tr>
-      <tr>
-        <td><a href="config_whitespace.html#GenericWhitespace">GenericWhitespace</a></td>
-        <td>Checks that the whitespace around the Generic tokens &lt; and &gt; are
-        correct to the <i>typical</i> convention.</td>
-      </tr>
-      <tr>
-        <td><a href="config_header.html#Header">Header</a></td>
-        <td>Checks the header of the source against a fixed header file.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#HiddenField">HiddenField</a></td>
-        <td>Checks that a local variable or a parameter does not shadow
-        a field that is defined in the same class.</td>
-      </tr>
-      <tr>
-        <td><a href="config_design.html#HideUtilityClassConstructor">
-          HideUtilityClassConstructor</a></td>
-        <td>Make sure that utility classes (classes that contain only static methods)
-        do not have a public constructor.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#IllegalCatch">IllegalCatch</a></td>
-        <td>Catching java.lang.Exception, java.lang.Error or java.lang.RuntimeException
-        is almost never acceptable.</td>
-      </tr>
-      <tr>
-        <td><a href="config_imports.html#IllegalImport">IllegalImport</a></td>
-        <td>
-        Checks for imports from a set of illegal packages.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#IllegalInstantiation">IllegalInstantiation</a></td>
-        <td>
-        Checks for illegal instantiations where a factory method is preferred.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#IllegalThrows">IllegalThrows</a></td>
-        <td>Throwing java.lang.Error or java.lang.RuntimeException
-        is almost never acceptable.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#IllegalToken">IllegalToken</a></td>
-        <td>
-        Checks for illegal tokens.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#IllegalTokenText">IllegalTokenText</a></td>
-        <td>
-        Checks for illegal token text.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#IllegalType">IllegalType</a></td>
-        <td>
-          Checks that particular classes or interfaces are never used.</td>
-      </tr>
-      <tr>
-        <td><a href="config_imports.html#ImportControl">ImportControl</a></td>
-        <td>Check that controls what can be imported in each package and file.</td>
-      </tr>
-      <tr>
-        <td><a href="config_imports.html#ImportOrder">ImportOrder</a></td>
-        <td>Ensures that groups of imports come in a specific order.</td>
-      </tr>
-      <tr>
-        <td><a href="config_misc.html#Indentation">Indentation</a></td>
-        <td>Checks correct indentation of Java Code.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#InnerAssignment">InnerAssignment</a></td>
-        <td>
-          Checks for assignments in subexpressions, such as in
-        <code>String s = Integer.toString(i = 2);</code>.</td>
-      </tr>
-      <tr>
-        <td><a href="config_design.html#InnerTypeLast">InnerTypeLast</a></td>
-        <td>
-          Check nested (internal) classes/interfaces are declared at the bottom of the
-        class after all method and field declarations.</td>
-      </tr>
-      <tr>
-        <td><a href="config_design.html#InterfaceIsType">InterfaceIsType</a></td>
-        <td>Implements Bloch, Effective Java, Item 17 -
-        Use Interfaces only to define types.</td>
-      </tr>
-      <tr>
-        <td><a href="config_modifier.html#InterfaceMemberImpliedModifier">
-          InterfaceMemberImpliedModifier</a></td>
-        <td>
-          Checks for implicit modifiers on interface members and nested types.</td>
-      </tr>
-      <tr>
-        <td><a href="config_naming.html#InterfaceTypeParameterName">
-          InterfaceTypeParameterName</a></td>
-        <td>
-          Checks that interface type parameter names conform to a format specified
-        by the format property.</td>
-      </tr>
-      <tr>
-        <td><a href="config_naming.html#InvalidJavadocPosition">
-          InvalidJavadocPosition</a></td>
-        <td>
-          Checks that Javadocs are located at the correct position.</td>
-      </tr>
-      <tr>
-        <td><a href="config_javadoc.html#JavadocBlockTagLocation">JavadocBlockTagLocation</a></td>
-        <td>Checks that a javadoc block tag appears only at the beginning of a line.</td>
-      </tr>
-      <tr>
-        <td><a href="config_javadoc.html#JavadocContentLocation">
-          JavadocContentLocation</a></td>
-        <td>
-          Checks that the Javadoc content begins from the same position
-          for all Javadoc comments in the project.
-        </td>
-      </tr>
-      <tr>
-        <td><a href="config_javadoc.html#JavadocMethod">JavadocMethod</a></td>
-        <td>Checks the Javadoc of a method or constructor.</td>
-      </tr>
-      <tr>
-        <td><a href="config_javadoc.html#JavadocPackage">JavadocPackage</a></td>
-        <td>Checks that all packages have a package documentation.</td>
-      </tr>
-      <tr>
-        <td><a href="config_javadoc.html#JavadocParagraph">JavadocParagraph</a></td>
-        <td>Checks Javadoc paragraphs.</td>
-      </tr>
-      <tr>
-        <td><a href="config_javadoc.html#JavadocStyle">JavadocStyle</a></td>
-        <td>Custom Checkstyle Check to validate Javadoc.</td>
-      </tr>
-      <tr>
-        <td><a href="config_javadoc.html#JavadocTagContinuationIndentation">
-          JavadocTagContinuationIndentation</a></td>
-        <td>Checks the indentation of the continuation lines in at-clauses.</td>
-      </tr>
-      <tr>
-        <td><a href="config_javadoc.html#JavadocType">JavadocType</a></td>
-        <td>Checks the Javadoc of a type.</td>
-      </tr>
-      <tr>
-        <td><a href="config_javadoc.html#JavadocVariable">JavadocVariable</a></td>
-        <td>Checks that a variable has Javadoc comment.</td>
-      </tr>
-      <tr>
-        <td><a href="config_metrics.html#JavaNCSS">JavaNCSS</a></td>
-        <td>This check calculates the Non Commenting Source Statements (NCSS) metric for
-        Java source files and methods.</td>
-      </tr>
-      <tr>
-        <td><a href="config_naming.html#LambdaParameterName">LambdaParameterName</a></td>
-        <td>Check to verify lambda parameter names.</td>
-      </tr>
-      <tr>
-        <td><a href="config_blocks.html#LeftCurly">LeftCurly</a></td>
-        <td>
-          Checks the placement of left curly braces on types, methods and
-          other blocks:
-        </td>
-      </tr>
-      <tr>
-        <td><a href="config_sizes.html#LineLength">LineLength</a></td>
-        <td>Checks for long lines.</td>
-      </tr>
-      <tr>
-        <td><a href="config_naming.html#LocalFinalVariableName">LocalFinalVariableName</a></td>
-        <td>
-          Checks that local final variable names conform to a format specified
-        by the format property.</td>
-      </tr>
-      <tr>
-        <td><a href="config_naming.html#LocalVariableName">LocalVariableName</a></td>
-        <td>
-          Checks that local, non-final variable names conform to a format specified
-        by the format property.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#MagicNumber">MagicNumber</a></td>
-        <td>
-        Checks for magic numbers.</td>
-      </tr>
-      <tr>
-        <td><a href="config_naming.html#MemberName">MemberName</a></td>
-        <td>
-          Checks that instance variable names conform to a format specified
-        by the format property.</td>
-      </tr>
-      <tr>
-        <td><a href="config_sizes.html#MethodCount">MethodCount</a></td>
-        <td>Checks the number of methods declared in each type declaration by access modifier
-        or total count.</td>
-      </tr>
-      <tr>
-        <td><a href="config_sizes.html#MethodLength">MethodLength</a></td>
-        <td>
-        Checks for long methods.</td>
-      </tr>
-      <tr>
-        <td><a href="config_naming.html#MethodName">MethodName</a></td>
-        <td>
-          Checks that method names conform to a format specified
-        by the format property.</td>
-      </tr>
-      <tr>
-        <td><a href="config_whitespace.html#MethodParamPad">MethodParamPad</a></td>
-        <td>
-          Checks the padding between the identifier of a method definition,
-          constructor definition, method call, or constructor invocation;
-        and the left parenthesis of the parameter list.</td>
-      </tr>
-      <tr>
-        <td><a href="config_naming.html#MethodTypeParameterName">MethodTypeParameterName</a></td>
-        <td>
-          Checks that class type parameter names conform to a format specified
-        by the format property.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#MissingCtor">MissingCtor</a></td>
-        <td>
-          Checks that classes (except abstract one) define a ctor and don't rely
-        on the default one.</td>
-      </tr>
-      <tr>
-        <td><a href="config_annotation.html#MissingDeprecated">MissingDeprecated</a></td>
-        <td>
-          This class is used to verify that both the java.lang.Deprecated annotation is
-          present and the @deprecated Javadoc tag is present when either is present.
-        </td>
-      </tr>
-      <tr>
-        <td><a href="config_javadoc.html#MissingJavadocMethod">MissingJavadocMethod</a></td>
-        <td>Checks for missing Javadoc comments for a method or constructor.</td>
-      </tr>
-      <tr>
-        <td><a href="config_javadoc.html#MissingJavadocPackage">MissingJavadocPackage</a></td>
-        <td>Checks for missing Javadoc comments in package-info.java files.</td>
-      </tr>
-      <tr>
-        <td><a href="config_javadoc.html#MissingJavadocType">MissingJavadocType</a></td>
-        <td>Checks for missing Javadoc comments for class, enum, interface, and annotation
-        interface definitions.</td>
-      </tr>
-      <tr>
-        <td><a href="config_annotation.html#MissingOverride">MissingOverride</a></td>
-        <td>
-        This class is used to verify that the java.lang.Override annotation is present
-        when the {@inheritDoc} javadoc tag is present.
-        </td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#MissingSwitchDefault">MissingSwitchDefault</a></td>
-        <td>
-        Checks that switch statement has &quot;default&quot; clause.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#ModifiedControlVariable">ModifiedControlVariable</a></td>
-        <td>Check for ensuring that for loop control variables are not modified
-        inside the for block.</td>
-      </tr>
-      <tr>
-        <td><a href="config_modifier.html#ModifierOrder">ModifierOrder</a></td>
-        <td>
-          Checks that the order of modifiers conforms to the suggestions in the
-          <a
-              href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html">
-        Java Language specification, sections 8.1.1, 8.3.1 and 8.4.3</a>.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#MultipleStringLiterals">MultipleStringLiterals</a></td>
-        <td>Checks for multiple occurrences of the same string literal within a
-        single file.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#MultipleVariableDeclarations">
-          MultipleVariableDeclarations</a></td>
-        <td>
-          Checks that each variable declaration is in its own statement
-        and on its own line.</td>
-      </tr>
-      <tr>
-        <td><a href="config_design.html#MutableException">MutableException</a></td>
-        <td> Ensures that exceptions (defined as any class name conforming
-        to some regular expression) are immutable.</td>
-      </tr>
-      <tr>
-        <td><a href="config_blocks.html#NeedBraces">NeedBraces</a></td>
-        <td>
-        Checks for braces around code blocks.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#NestedForDepth">NestedForDepth</a></td>
-        <td>Restricts nested <code>for</code> blocks to a specified depth (default = 1).</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#NestedIfDepth">NestedIfDepth</a></td>
-        <td>Restricts nested if-else blocks to a specified depth (default = 1).</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#NestedTryDepth">NestedTryDepth</a></td>
-        <td>Restricts nested try-catch-finally blocks to a specified depth (default = 1).</td>
-      </tr>
-      <tr>
-        <td><a href="config_misc.html#NewlineAtEndOfFile">NewlineAtEndOfFile</a></td>
-        <td>
-        Checks that there is a newline at the end of each file.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#NoClone">NoClone</a></td>
-        <td>
-          Checks that the clone method is not overridden from the
-        Object class.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#NoFinalizer">NoFinalizer</a></td>
-        <td>Checks that no method having zero parameters is defined
-        using the name <em>finalize</em>.</td>
-      </tr>
-      <tr>
-        <td><a href="config_whitespace.html#NoLineWrap">NoLineWrap</a></td>
-        <td>
-        Checks that chosen statements are not line-wrapped.</td>
-      </tr>
-      <tr>
-        <td><a href="config_javadoc.html#NonEmptyAtclauseDescription">
-          NonEmptyAtclauseDescription</a></td>
-        <td>
-        Checks that the at-clause tag is followed by description .</td>
-      </tr>
-      <tr>
-        <td><a href="config_whitespace.html#NoWhitespaceAfter">NoWhitespaceAfter</a></td>
-        <td>
-        Checks that there is no whitespace after a token.</td>
-      </tr>
-      <tr>
-        <td><a href="config_whitespace.html#NoWhitespaceBefore">NoWhitespaceBefore</a></td>
-        <td>
-        Checks that there is no whitespace before a token.</td>
-      </tr>
-      <tr>
-        <td><a href="config_metrics.html#NPathComplexity">NPathComplexity</a></td>
-        <td>Checks the npath complexity against a specified limit (default = 200).</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#OneStatementPerLine">OneStatementPerLine</a></td>
-        <td>Checks that there is only one statement per line.</td>
-      </tr>
-      <tr>
-        <td><a href="config_design.html#OneTopLevelClass">OneTopLevelClass</a></td>
-        <td>Checks that each top-level class, interfaces or enum resides in a source file of
-            its own.</td>
-      </tr>
-      <tr>
-        <td><a href="config_whitespace.html#OperatorWrap">OperatorWrap</a></td>
-        <td>
-        Checks line wrapping for operators.</td>
-      </tr>
-      <tr>
-        <td><a href="config_misc.html#OrderedProperties">OrderedProperties</a></td>
-        <td>Detects if keys in properties files are in correct order.</td>
-      </tr>
-      <tr>
-        <td><a href="config_misc.html#OuterTypeFilename">OuterTypeFilename</a></td>
-        <td>Checks that the outer type name and the file name match.</td>
-      </tr>
-      <tr>
-        <td><a href="config_sizes.html#OuterTypeNumber">OuterTypeNumber</a></td>
-        <td>Checks for the number of defined types at the "outer" level.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#OverloadMethodsDeclarationOrder">
-          OverloadMethodsDeclarationOrder</a></td>
-        <td>Checks that overload methods are grouped together.</td>
-      </tr>
-      <tr>
-        <td><a href="config_annotation.html#PackageAnnotation">PackageAnnotation</a></td>
-        <td>This check makes sure that all package annotations are in the
-        package-info.java file.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#PackageDeclaration">PackageDeclaration</a></td>
-        <td>Ensures there is a package declaration and (optionally) in the correct directory.</td>
-      </tr>
-      <tr>
-        <td><a href="config_naming.html#PackageName">PackageName</a></td>
-        <td>
-          Checks that package names conform to a format specified
-        by the format property.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#ParameterAssignment">ParameterAssignment</a></td>
-        <td>
-        Disallow assignment of parameters.</td>
-      </tr>
-      <tr>
-        <td><a href="config_naming.html#ParameterName">ParameterName</a></td>
-        <td>
-          Checks that parameter names conform to a format specified
-        by the format property.</td>
-      </tr>
-      <tr>
-        <td><a href="config_sizes.html#ParameterNumber">ParameterNumber</a></td>
-        <td>
-        Checks the number of parameters that a method or constructor has.</td>
-      </tr>
-      <tr>
-        <td><a href="config_whitespace.html#ParenPad">ParenPad</a></td>
-        <td>Checks the padding of parentheses; that is whether a space is required
-        after a left parenthesis and before a right parenthesis, or such spaces are
-        forbidden, with the exception that it does
-        not check for padding of the right parenthesis at an empty for iterator.</td>
-      </tr>
-      <tr>
-        <td><a href="config_imports.html#RedundantImport">RedundantImport</a></td>
-        <td>
-        Checks for imports that are redundant.</td>
-      </tr>
-      <tr>
-        <td><a href="config_modifier.html#RedundantModifier">RedundantModifier</a></td>
-        <td>Checks for redundant modifiers in interface and annotation definitions,
-          final modifier on methods of final classes, inner <code>interface</code>
-          declarations that are declared as <code>static</code>, non public class
-          constructors and enum constructors, nested enum definitions that are declared
-          as <code>static</code>.</td>
-      </tr>
-      <tr>
-        <td><a href="config_regexp.html#Regexp">Regexp</a></td>
-        <td>
-        A check that makes sure that a specified pattern exists (or not) in the file.</td>
-      </tr>
-      <tr>
-        <td><a href="config_header.html#RegexpHeader">RegexpHeader</a></td>
-        <td>Checks the header of the source against a header file that contains a
-        </td>
-      </tr>
-      <tr>
-        <td><a href="config_regexp.html#RegexpMultiline">RegexpMultiline</a></td>
-        <td>Implementation of a check that looks that matches across multiple lines in
-        any file type.</td>
-      </tr>
-      <tr>
-        <td><a href="config_regexp.html#RegexpOnFilename">RegexpOnFilename</a></td>
-        <td>Implementation of a check that matches based on file and/or folder path.</td>
-      </tr>
-      <tr>
-        <td><a href="config_regexp.html#RegexpSingleline">RegexpSingleline</a></td>
-        <td>Implementation of a check that looks for a single line in any file type.</td>
-      </tr>
-      <tr>
-        <td><a href="config_regexp.html#RegexpSinglelineJava">RegexpSinglelineJava</a></td>
-        <td>Implementation of a check that looks for a single line in Java files.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#RequireThis">RequireThis</a></td>
-        <td>Checks that code doesn't rely on the &quot;this&quot; default.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#ReturnCount">ReturnCount</a></td>
-        <td>
-        Restricts return statements to a specified count (default = 2).</td>
-      </tr>
-      <tr>
-        <td><a href="config_blocks.html#RightCurly">RightCurly</a></td>
-        <td>
-        Checks the placement of right curly braces.</td>
-      </tr>
-      <tr>
-        <td><a href="config_whitespace.html#SeparatorWrap">SeparatorWrap</a></td>
-        <td>
-        Checks line wrapping with separators.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#SimplifyBooleanExpression">
-          SimplifyBooleanExpression</a></td>
-        <td>
-        Checks for overly complicated boolean expressions.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#SimplifyBooleanReturn">SimplifyBooleanReturn</a></td>
-        <td>
-        Checks for overly complicated boolean return statements.</td>
-      </tr>
-      <tr>
-        <td><a href="config_javadoc.html#SingleLineJavadoc">SingleLineJavadoc</a></td>
-        <td>
-         Checks that a JavaDoc block which can fit on a single line and doesn't contain
-         at-clauses</td>
-      </tr>
-      <tr>
-        <td><a href="config_whitespace.html#SingleSpaceSeparator">SingleSpaceSeparator</a></td>
-        <td>
-         Checks that non-whitespace characters are separated by no more than one whitespace.</td>
-      </tr>
-      <tr>
-        <td><a href="config_naming.html#StaticVariableName">StaticVariableName</a></td>
-        <td>
-          Checks that static, non-final variable names conform to a format specified
-        by the format property.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#StringLiteralEquality">StringLiteralEquality</a></td>
-        <td>Checks that string literals are not used with
-        <code>==</code> or <code>&#33;=</code>.</td>
-      </tr>
-      <tr>
-        <td><a href="config_javadoc.html#SummaryJavadoc">SummaryJavadoc</a></td>
-        <td>
-        Checks that Javadoc summary sentence does not contain phrases that are not recommended
-        to use.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#SuperClone">SuperClone</a></td>
-        <td>
-        Checks that an overriding clone() method invokes super.clone().</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#SuperFinalize">SuperFinalize</a></td>
-        <td>
-        Checks that an overriding finalize() method invokes super.finalize().</td>
-      </tr>
-      <tr>
-        <td><a href="config_annotation.html#SuppressWarnings">SuppressWarnings</a></td>
-        <td>
-          This check allows you to specify what warnings that
-        </td>
-      </tr>
-      <tr>
-        <td><a href="config_design.html#ThrowsCount">ThrowsCount</a></td>
-        <td>
-        Restricts throws statements to a specified count (default = 4).</td>
-      </tr>
-      <tr>
-        <td><a href="config_misc.html#TodoComment">TodoComment</a></td>
-        <td>
-        A check for TODO comments.</td>
-      </tr>
-      <tr>
-        <td><a href="config_misc.html#TrailingComment">TrailingComment</a></td>
-        <td>
-        The check to ensure that requires that comments be the only thing on a line.</td>
-      </tr>
-      <tr>
-        <td><a href="config_misc.html#Translation">Translation</a></td>
-        <td>
-          The TranslationCheck class helps to ensure the correct translation of code by
-        checking property files for consistency regarding their keys.</td>
-      </tr>
-      <tr>
-        <td><a href="config_whitespace.html#TypecastParenPad">TypecastParenPad</a></td>
-        <td>Checks the padding of parentheses for typecasts.</td>
-      </tr>
-      <tr>
-        <td><a href="config_naming.html#TypeName">TypeName</a></td>
-        <td>
-          Checks that type names conform to a format specified
-        by the format property.</td>
-      </tr>
-      <tr>
-        <td><a href="config_misc.html#UncommentedMain">UncommentedMain</a></td>
-        <td>Detects uncommented main methods.</td>
-      </tr>
-      <tr>
-        <td><a href="config_misc.html#UniqueProperties">UniqueProperties</a></td>
-        <td>Detects duplicated keys in properties files.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#UnnecessaryParentheses">UnnecessaryParentheses</a></td>
-        <td>
-        Checks if unnecessary parentheses are used in a statement or expression.</td>
-      </tr>
-      <tr>
-        <td>
-          <a href="config_coding.html#UnnecessarySemicolonInEnumeration">
-          UnnecessarySemicolonInEnumeration</a>
-        </td>
-        <td>Checks if unnecessary semicolon is in enum definitions.</td>
-      </tr>
-      <tr>
-        <td>
-          <a href="config_coding.html#UnnecessarySemicolonInTryWithResources">
-          UnnecessarySemicolonInTryWithResources</a>
-        </td>
-        <td>Checks if unnecessary semicolon is used in last resource declaration.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#UnnecessarySemicolonAfterTypeMemberDeclaration">
-          UnnecessarySemicolonAfterTypeMemberDeclaration</a></td>
-        <td>Checks if unnecessary semicolon is used after type member declaration.</td>
-      </tr>
-      <tr>
-        <td><a href="config_imports.html#UnusedImports">UnusedImports</a></td>
-        <td>
-        Checks for unused import statements.</td>
-      </tr>
-      <tr>
-        <td><a href="config_misc.html#UpperEll">UpperEll</a></td>
-        <td>Checks that long constants are defined with an upper ell.</td>
-      </tr>
-      <tr>
-        <td><a href="config_coding.html#VariableDeclarationUsageDistance">
-          VariableDeclarationUsageDistance</a></td>
-        <td>Checks the distance between declaration of variable and its first usage.</td>
-      </tr>
-      <tr>
-        <td><a href="config_design.html#VisibilityModifier">VisibilityModifier</a></td>
-        <td>Checks visibility of class members.</td>
-      </tr>
-      <tr>
-        <td><a href="config_whitespace.html#WhitespaceAfter">WhitespaceAfter</a></td>
-        <td>
-          Checks that a token is followed by whitespace, with the exception that it
-        does not check for whitespace after the semicolon of an empty for iterator.</td>
-      </tr>
-      <tr>
-        <td><a href="config_whitespace.html#WhitespaceAround">WhitespaceAround</a></td>
-        <td>
-        Checks that a token is surrounded by whitespace.</td>
-      </tr>
-      <tr>
-        <td><a href="config_javadoc.html#WriteTag">WriteTag</a></td>
-        <td>
-        Outputs a JavaDoc tag as information.</td>
-      </tr>
-    </table>
+      <div class="wrapper">
+        <table>
+          <tr>
+            <td><a href="config_naming.html#AbbreviationAsWordInName">
+              AbbreviationAsWordInName</a></td>
+            <td>The Check validate abbreviations(consecutive capital letters)
+             length in identifier name, it also allow in enforce camel case naming.</td>
+          </tr>
+          <tr>
+            <td><a href="config_naming.html#AbstractClassName">AbstractClassName</a></td>
+            <td>
+              Ensures that the names of abstract classes conforming to some regular expression and
+              check that <code>abstract</code> modifier exists.
+            </td>
+          </tr>
+          <tr>
+            <td><a href="config_annotation.html#AnnotationLocation">AnnotationLocation</a></td>
+            <td>Check location of annotation on language elements.</td>
+          </tr>
+          <tr>
+            <td><a href="config_annotation.html#AnnotationOnSameLine">AnnotationOnSameLine</a></td>
+            <td>The check does verifying that annotations are located on the same line with their
+                targets.</td>
+          </tr>
+          <tr>
+            <td><a href="config_annotation.html#AnnotationUseStyle">AnnotationUseStyle</a></td>
+            <td>This check controls the style with the usage of annotations.</td>
+          </tr>
+          <tr>
+            <td><a href="config_sizes.html#AnonInnerLength">AnonInnerLength</a></td>
+            <td>Checks for long anonymous inner classes.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#ArrayTrailingComma">ArrayTrailingComma</a></td>
+            <td>Checks if array initialization contains optional trailing comma.</td>
+          </tr>
+          <tr>
+            <td><a href="config_misc.html#ArrayTypeStyle">ArrayTypeStyle</a></td>
+            <td>Checks the style of array type definitions.</td>
+          </tr>
+          <tr>
+            <td><a href="config_javadoc.html#AtclauseOrder">AtclauseOrder</a></td>
+            <td>Checks the order of at-clauses.</td>
+          </tr>
+          <tr>
+            <td><a href="config_misc.html#AvoidEscapedUnicodeCharacters">
+              AvoidEscapedUnicodeCharacters</a></td>
+            <td>Restrict using Unicode escapes.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#AvoidInlineConditionals">
+              AvoidInlineConditionals</a></td>
+            <td>Detects inline conditionals.</td>
+          </tr>
+          <tr>
+            <td><a href="config_blocks.html#AvoidNestedBlocks">AvoidNestedBlocks</a></td>
+            <td>Finds nested blocks.</td>
+          </tr>
+          <tr>
+            <td><a href="config_imports.html#AvoidStarImport">AvoidStarImport</a></td>
+            <td>Check that finds import statements that use the * notation.</td>
+          </tr>
+          <tr>
+            <td><a href="config_imports.html#AvoidStaticImport">AvoidStaticImport</a></td>
+            <td>Check that finds static imports.</td>
+          </tr>
+          <tr>
+            <td><a href="config_metrics.html#BooleanExpressionComplexity">
+              BooleanExpressionComplexity</a></td>
+            <td>
+              Restricts nested boolean operators (&amp;&amp;, ||, &amp;, |
+              and ^) to a specified depth (default = 3).
+            </td>
+          </tr>
+          <tr>
+            <td><a href="config_naming.html#CatchParameterName">CatchParameterName</a></td>
+            <td>Checks that <code>catch</code> parameter names conform to a format specified by the
+                format property.</td>
+          </tr>
+          <tr>
+            <td><a href="config_metrics.html#ClassDataAbstractionCoupling">
+              ClassDataAbstractionCoupling</a></td>
+            <td>This metric measures the number of instantiations of other classes within the given
+                class.</td>
+          </tr>
+          <tr>
+            <td><a href="config_metrics.html#ClassFanOutComplexity">ClassFanOutComplexity</a></td>
+            <td>The number of other classes a given class relies on.</td>
+          </tr>
+          <tr>
+            <td><a href="config_modifier.html#ClassMemberImpliedModifier">
+              ClassMemberImpliedModifier</a></td>
+            <td>
+              Checks for implicit modifiers on class members and nested types.</td>
+          </tr>
+          <tr>
+            <td><a href="config_naming.html#ClassTypeParameterName">ClassTypeParameterName</a></td>
+            <td>
+              Checks that class type parameter names conform to a format
+              specified by the format property.
+            </td>
+          </tr>
+          <tr>
+            <td><a href="config_misc.html#CommentsIndentation">CommentsIndentation</a></td>
+            <td>Controls the indentation between comments and surrounding code.</td>
+          </tr>
+          <tr>
+            <td><a href="config_naming.html#ConstantName">ConstantName</a></td>
+            <td>Checks that constant names conform to a format specified by the
+              format property.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#CovariantEquals">CovariantEquals</a></td>
+            <td>
+              Checks that if a class defines a covariant method equals, then
+              it defines method equals(java.lang.Object).
+            </td>
+          </tr>
+          <tr>
+            <td><a href="config_imports.html#CustomImportOrder">CustomImportOrder</a></td>
+            <td>
+              Checks that the groups of import declarations appear in the order specified
+              by the user.
+            </td>
+          </tr>
+          <tr>
+            <td><a href="config_metrics.html#CyclomaticComplexity">CyclomaticComplexity</a></td>
+            <td>Checks cyclomatic complexity against a specified limit.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#DeclarationOrder">DeclarationOrder</a></td>
+            <td>
+              Checks that the parts of a class or interface declaration
+              appear in the order suggested by the <a
+              href="styleguides/sun-code-conventions-19990420/CodeConventions.doc2.html#a1852"
+              >Code Conventions for the Java Programming Language</a>.
+            </td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#DefaultComesLast">DefaultComesLast</a></td>
+            <td>
+              Check that the <code>default</code> is after all the
+              <code>case</code>s in a <code>switch</code> statement.
+            </td>
+          </tr>
+          <tr>
+            <td><a href="config_misc.html#DescendantToken">DescendantToken</a></td>
+            <td>Checks for restricted tokens beneath other tokens.</td>
+          </tr>
+          <tr>
+            <td><a href="config_design.html#DesignForExtension">DesignForExtension</a></td>
+            <td>Checks that classes are designed for inheritance.</td>
+          </tr>
+          <tr>
+            <td><a href="config_blocks.html#EmptyBlock">EmptyBlock</a></td>
+            <td>Checks for empty blocks but does not validate sequential blocks.</td>
+          </tr>
+          <tr>
+            <td><a href="config_blocks.html#EmptyCatchBlock">EmptyCatchBlock</a></td>
+            <td>Checks for empty catch blocks with few options to skip violation.</td>
+          </tr>
+          <tr>
+            <td><a href="config_whitespace.html#EmptyForInitializerPad">
+              EmptyForInitializerPad</a></td>
+            <td>Checks the padding of an empty for initializer; that is whether a
+            space is required at an empty for initializer, or such spaces are
+            forbidden.</td>
+          </tr>
+          <tr>
+            <td><a href="config_whitespace.html#EmptyForIteratorPad">EmptyForIteratorPad</a></td>
+            <td>Checks the padding of an empty for iterator; that is whether a
+            space is required at an empty for iterator, or such spaces are
+            forbidden.</td>
+          </tr>
+          <tr>
+            <td><a href="config_whitespace.html#EmptyLineSeparator">EmptyLineSeparator</a></td>
+            <td>Checks for blank line separators.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#EmptyStatement">EmptyStatement</a></td>
+            <td>
+            Detects empty statements (standalone ';').</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#EqualsAvoidNull">EqualsAvoidNull</a></td>
+            <td>
+              Checks that any combination of String literals
+              is on the left side of an equals() comparison.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#EqualsHashCode">EqualsHashCode</a></td>
+            <td>
+            Checks that classes that override equals() also override hashCode().</td>
+          </tr>
+          <tr>
+            <td><a href="config_sizes.html#ExecutableStatementCount">
+              ExecutableStatementCount</a></td>
+            <td>
+              Restricts the number of executable statements to a specified
+              limit (default = 30).
+            </td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#ExplicitInitialization">ExplicitInitialization</a></td>
+            <td>
+              Checks if any class or object member explicitly initialized
+              to default for its type value (<code>null</code> for object
+              references, zero for numeric types and <code>char</code>
+              and <code>false</code> for <code>boolean</code>.
+            </td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#FallThrough">FallThrough</a></td>
+            <td>Checks for fall through in switch statements
+            Finds locations where a case contains Java code -
+            but lacks a break, return, throw or continue statement.</td>
+          </tr>
+          <tr>
+            <td><a href="config_sizes.html#FileLength">FileLength</a></td>
+            <td>
+            Checks for long source files.</td>
+          </tr>
+          <tr>
+            <td><a href="config_whitespace.html#FileTabCharacter">FileTabCharacter</a></td>
+            <td>Checks to see if a file contains a tab character.</td>
+          </tr>
+          <tr>
+            <td><a href="config_design.html#FinalClass">FinalClass</a></td>
+            <td>
+              Checks that class which has only private constructors
+            is declared as final.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#FinalLocalVariable">FinalLocalVariable</a></td>
+            <td>
+              Ensures that local variables that never get their values changed,
+            must be declared final.</td>
+          </tr>
+          <tr>
+            <td><a href="config_misc.html#FinalParameters">FinalParameters</a></td>
+            <td>Check that method/constructor/catch/foreach parameters are final.</td>
+          </tr>
+          <tr>
+            <td><a href="config_whitespace.html#GenericWhitespace">GenericWhitespace</a></td>
+            <td>Checks that the whitespace around the Generic tokens &lt; and &gt; are
+            correct to the <i>typical</i> convention.</td>
+          </tr>
+          <tr>
+            <td><a href="config_header.html#Header">Header</a></td>
+            <td>Checks the header of the source against a fixed header file.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#HiddenField">HiddenField</a></td>
+            <td>Checks that a local variable or a parameter does not shadow
+            a field that is defined in the same class.</td>
+          </tr>
+          <tr>
+            <td><a href="config_design.html#HideUtilityClassConstructor">
+              HideUtilityClassConstructor</a></td>
+            <td>Make sure that utility classes (classes that contain only static methods)
+            do not have a public constructor.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#IllegalCatch">IllegalCatch</a></td>
+            <td>Catching java.lang.Exception, java.lang.Error or java.lang.RuntimeException
+            is almost never acceptable.</td>
+          </tr>
+          <tr>
+            <td><a href="config_imports.html#IllegalImport">IllegalImport</a></td>
+            <td>
+            Checks for imports from a set of illegal packages.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#IllegalInstantiation">IllegalInstantiation</a></td>
+            <td>
+            Checks for illegal instantiations where a factory method is preferred.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#IllegalThrows">IllegalThrows</a></td>
+            <td>Throwing java.lang.Error or java.lang.RuntimeException
+            is almost never acceptable.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#IllegalToken">IllegalToken</a></td>
+            <td>
+            Checks for illegal tokens.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#IllegalTokenText">IllegalTokenText</a></td>
+            <td>
+            Checks for illegal token text.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#IllegalType">IllegalType</a></td>
+            <td>
+              Checks that particular classes or interfaces are never used.</td>
+          </tr>
+          <tr>
+            <td><a href="config_imports.html#ImportControl">ImportControl</a></td>
+            <td>Check that controls what can be imported in each package and file.</td>
+          </tr>
+          <tr>
+            <td><a href="config_imports.html#ImportOrder">ImportOrder</a></td>
+            <td>Ensures that groups of imports come in a specific order.</td>
+          </tr>
+          <tr>
+            <td><a href="config_misc.html#Indentation">Indentation</a></td>
+            <td>Checks correct indentation of Java Code.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#InnerAssignment">InnerAssignment</a></td>
+            <td>
+              Checks for assignments in subexpressions, such as in
+            <code>String s = Integer.toString(i = 2);</code>.</td>
+          </tr>
+          <tr>
+            <td><a href="config_design.html#InnerTypeLast">InnerTypeLast</a></td>
+            <td>
+              Check nested (internal) classes/interfaces are declared at the bottom of the
+            class after all method and field declarations.</td>
+          </tr>
+          <tr>
+            <td><a href="config_design.html#InterfaceIsType">InterfaceIsType</a></td>
+            <td>Implements Bloch, Effective Java, Item 17 -
+            Use Interfaces only to define types.</td>
+          </tr>
+          <tr>
+            <td><a href="config_modifier.html#InterfaceMemberImpliedModifier">
+              InterfaceMemberImpliedModifier</a></td>
+            <td>
+              Checks for implicit modifiers on interface members and nested types.</td>
+          </tr>
+          <tr>
+            <td><a href="config_naming.html#InterfaceTypeParameterName">
+              InterfaceTypeParameterName</a></td>
+            <td>
+              Checks that interface type parameter names conform to a format specified
+            by the format property.</td>
+          </tr>
+          <tr>
+            <td><a href="config_naming.html#InvalidJavadocPosition">
+              InvalidJavadocPosition</a></td>
+            <td>
+              Checks that Javadocs are located at the correct position.</td>
+          </tr>
+          <tr>
+            <td><a href="config_javadoc.html#JavadocBlockTagLocation">
+              JavadocBlockTagLocation</a></td>
+            <td>Checks that a javadoc block tag appears only at the beginning of a line.</td>
+          </tr>
+          <tr>
+            <td><a href="config_javadoc.html#JavadocContentLocation">
+              JavadocContentLocation</a></td>
+            <td>
+              Checks that the Javadoc content begins from the same position
+              for all Javadoc comments in the project.
+            </td>
+          </tr>
+          <tr>
+            <td><a href="config_javadoc.html#JavadocMethod">JavadocMethod</a></td>
+            <td>Checks the Javadoc of a method or constructor.</td>
+          </tr>
+          <tr>
+            <td><a href="config_javadoc.html#JavadocPackage">JavadocPackage</a></td>
+            <td>Checks that all packages have a package documentation.</td>
+          </tr>
+          <tr>
+            <td><a href="config_javadoc.html#JavadocParagraph">JavadocParagraph</a></td>
+            <td>Checks Javadoc paragraphs.</td>
+          </tr>
+          <tr>
+            <td><a href="config_javadoc.html#JavadocStyle">JavadocStyle</a></td>
+            <td>Custom Checkstyle Check to validate Javadoc.</td>
+          </tr>
+          <tr>
+            <td><a href="config_javadoc.html#JavadocTagContinuationIndentation">
+              JavadocTagContinuationIndentation</a></td>
+            <td>Checks the indentation of the continuation lines in at-clauses.</td>
+          </tr>
+          <tr>
+            <td><a href="config_javadoc.html#JavadocType">JavadocType</a></td>
+            <td>Checks the Javadoc of a type.</td>
+          </tr>
+          <tr>
+            <td><a href="config_javadoc.html#JavadocVariable">JavadocVariable</a></td>
+            <td>Checks that a variable has Javadoc comment.</td>
+          </tr>
+          <tr>
+            <td><a href="config_metrics.html#JavaNCSS">JavaNCSS</a></td>
+            <td>This check calculates the Non Commenting Source Statements (NCSS) metric for
+            Java source files and methods.</td>
+          </tr>
+          <tr>
+            <td><a href="config_naming.html#LambdaParameterName">LambdaParameterName</a></td>
+            <td>Check to verify lambda parameter names.</td>
+          </tr>
+          <tr>
+            <td><a href="config_blocks.html#LeftCurly">LeftCurly</a></td>
+            <td>
+              Checks the placement of left curly braces on types, methods and
+              other blocks:
+            </td>
+          </tr>
+          <tr>
+            <td><a href="config_sizes.html#LineLength">LineLength</a></td>
+            <td>Checks for long lines.</td>
+          </tr>
+          <tr>
+            <td><a href="config_naming.html#LocalFinalVariableName">LocalFinalVariableName</a></td>
+            <td>
+              Checks that local final variable names conform to a format specified
+            by the format property.</td>
+          </tr>
+          <tr>
+            <td><a href="config_naming.html#LocalVariableName">LocalVariableName</a></td>
+            <td>
+              Checks that local, non-final variable names conform to a format specified
+            by the format property.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#MagicNumber">MagicNumber</a></td>
+            <td>
+            Checks for magic numbers.</td>
+          </tr>
+          <tr>
+            <td><a href="config_naming.html#MemberName">MemberName</a></td>
+            <td>
+              Checks that instance variable names conform to a format specified
+            by the format property.</td>
+          </tr>
+          <tr>
+            <td><a href="config_sizes.html#MethodCount">MethodCount</a></td>
+            <td>Checks the number of methods declared in each type declaration by access modifier
+            or total count.</td>
+          </tr>
+          <tr>
+            <td><a href="config_sizes.html#MethodLength">MethodLength</a></td>
+            <td>
+            Checks for long methods.</td>
+          </tr>
+          <tr>
+            <td><a href="config_naming.html#MethodName">MethodName</a></td>
+            <td>
+              Checks that method names conform to a format specified
+            by the format property.</td>
+          </tr>
+          <tr>
+            <td><a href="config_whitespace.html#MethodParamPad">MethodParamPad</a></td>
+            <td>
+              Checks the padding between the identifier of a method definition,
+              constructor definition, method call, or constructor invocation;
+            and the left parenthesis of the parameter list.</td>
+          </tr>
+          <tr>
+            <td><a href="config_naming.html#MethodTypeParameterName">
+              MethodTypeParameterName</a></td>
+            <td>
+              Checks that class type parameter names conform to a format specified
+            by the format property.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#MissingCtor">MissingCtor</a></td>
+            <td>
+              Checks that classes (except abstract one) define a ctor and don't rely
+            on the default one.</td>
+          </tr>
+          <tr>
+            <td><a href="config_annotation.html#MissingDeprecated">MissingDeprecated</a></td>
+            <td>
+              This class is used to verify that both the java.lang.Deprecated annotation is
+              present and the @deprecated Javadoc tag is present when either is present.
+            </td>
+          </tr>
+          <tr>
+            <td><a href="config_javadoc.html#MissingJavadocMethod">MissingJavadocMethod</a></td>
+            <td>Checks for missing Javadoc comments for a method or constructor.</td>
+          </tr>
+          <tr>
+            <td><a href="config_javadoc.html#MissingJavadocPackage">MissingJavadocPackage</a></td>
+            <td>Checks for missing Javadoc comments in package-info.java files.</td>
+          </tr>
+          <tr>
+            <td><a href="config_javadoc.html#MissingJavadocType">MissingJavadocType</a></td>
+            <td>Checks for missing Javadoc comments for class, enum, interface, and annotation
+            interface definitions.</td>
+          </tr>
+          <tr>
+            <td><a href="config_annotation.html#MissingOverride">MissingOverride</a></td>
+            <td>
+            This class is used to verify that the java.lang.Override annotation is present
+            when the {@inheritDoc} javadoc tag is present.
+            </td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#MissingSwitchDefault">MissingSwitchDefault</a></td>
+            <td>
+            Checks that switch statement has &quot;default&quot; clause.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#ModifiedControlVariable">
+              ModifiedControlVariable</a></td>
+            <td>Check for ensuring that for loop control variables are not modified
+            inside the for block.</td>
+          </tr>
+          <tr>
+            <td><a href="config_modifier.html#ModifierOrder">ModifierOrder</a></td>
+            <td>
+              Checks that the order of modifiers conforms to the suggestions in the
+              <a
+                  href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html">
+            Java Language specification, sections 8.1.1, 8.3.1 and 8.4.3</a>.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#MultipleStringLiterals">MultipleStringLiterals</a></td>
+            <td>Checks for multiple occurrences of the same string literal within a
+            single file.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#MultipleVariableDeclarations">
+              MultipleVariableDeclarations</a></td>
+            <td>
+              Checks that each variable declaration is in its own statement
+            and on its own line.</td>
+          </tr>
+          <tr>
+            <td><a href="config_design.html#MutableException">MutableException</a></td>
+            <td> Ensures that exceptions (defined as any class name conforming
+            to some regular expression) are immutable.</td>
+          </tr>
+          <tr>
+            <td><a href="config_blocks.html#NeedBraces">NeedBraces</a></td>
+            <td>
+            Checks for braces around code blocks.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#NestedForDepth">NestedForDepth</a></td>
+            <td>Restricts nested <code>for</code> blocks to a specified depth (default = 1).</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#NestedIfDepth">NestedIfDepth</a></td>
+            <td>Restricts nested if-else blocks to a specified depth (default = 1).</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#NestedTryDepth">NestedTryDepth</a></td>
+            <td>Restricts nested try-catch-finally blocks to a specified depth (default = 1).</td>
+          </tr>
+          <tr>
+            <td><a href="config_misc.html#NewlineAtEndOfFile">NewlineAtEndOfFile</a></td>
+            <td>
+            Checks that there is a newline at the end of each file.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#NoClone">NoClone</a></td>
+            <td>
+              Checks that the clone method is not overridden from the
+            Object class.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#NoFinalizer">NoFinalizer</a></td>
+            <td>Checks that no method having zero parameters is defined
+            using the name <em>finalize</em>.</td>
+          </tr>
+          <tr>
+            <td><a href="config_whitespace.html#NoLineWrap">NoLineWrap</a></td>
+            <td>
+            Checks that chosen statements are not line-wrapped.</td>
+          </tr>
+          <tr>
+            <td><a href="config_javadoc.html#NonEmptyAtclauseDescription">
+              NonEmptyAtclauseDescription</a></td>
+            <td>
+            Checks that the at-clause tag is followed by description .</td>
+          </tr>
+          <tr>
+            <td><a href="config_whitespace.html#NoWhitespaceAfter">NoWhitespaceAfter</a></td>
+            <td>
+            Checks that there is no whitespace after a token.</td>
+          </tr>
+          <tr>
+            <td><a href="config_whitespace.html#NoWhitespaceBefore">NoWhitespaceBefore</a></td>
+            <td>
+            Checks that there is no whitespace before a token.</td>
+          </tr>
+          <tr>
+            <td><a href="config_metrics.html#NPathComplexity">NPathComplexity</a></td>
+            <td>Checks the npath complexity against a specified limit (default = 200).</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#OneStatementPerLine">OneStatementPerLine</a></td>
+            <td>Checks that there is only one statement per line.</td>
+          </tr>
+          <tr>
+            <td><a href="config_design.html#OneTopLevelClass">OneTopLevelClass</a></td>
+            <td>Checks that each top-level class, interfaces or enum resides in a source file of
+                its own.</td>
+          </tr>
+          <tr>
+            <td><a href="config_whitespace.html#OperatorWrap">OperatorWrap</a></td>
+            <td>
+            Checks line wrapping for operators.</td>
+          </tr>
+          <tr>
+            <td><a href="config_misc.html#OrderedProperties">OrderedProperties</a></td>
+            <td>Detects if keys in properties files are in correct order.</td>
+          </tr>
+          <tr>
+            <td><a href="config_misc.html#OuterTypeFilename">OuterTypeFilename</a></td>
+            <td>Checks that the outer type name and the file name match.</td>
+          </tr>
+          <tr>
+            <td><a href="config_sizes.html#OuterTypeNumber">OuterTypeNumber</a></td>
+            <td>Checks for the number of defined types at the "outer" level.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#OverloadMethodsDeclarationOrder">
+              OverloadMethodsDeclarationOrder</a></td>
+            <td>Checks that overload methods are grouped together.</td>
+          </tr>
+          <tr>
+            <td><a href="config_annotation.html#PackageAnnotation">PackageAnnotation</a></td>
+            <td>This check makes sure that all package annotations are in the
+            package-info.java file.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#PackageDeclaration">PackageDeclaration</a></td>
+            <td>Ensures there is a package declaration and (optionally) in the correct
+              directory.</td>
+          </tr>
+          <tr>
+            <td><a href="config_naming.html#PackageName">PackageName</a></td>
+            <td>
+              Checks that package names conform to a format specified
+            by the format property.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#ParameterAssignment">ParameterAssignment</a></td>
+            <td>
+            Disallow assignment of parameters.</td>
+          </tr>
+          <tr>
+            <td><a href="config_naming.html#ParameterName">ParameterName</a></td>
+            <td>
+              Checks that parameter names conform to a format specified
+            by the format property.</td>
+          </tr>
+          <tr>
+            <td><a href="config_sizes.html#ParameterNumber">ParameterNumber</a></td>
+            <td>
+            Checks the number of parameters that a method or constructor has.</td>
+          </tr>
+          <tr>
+            <td><a href="config_whitespace.html#ParenPad">ParenPad</a></td>
+            <td>Checks the padding of parentheses; that is whether a space is required
+            after a left parenthesis and before a right parenthesis, or such spaces are
+            forbidden, with the exception that it does
+            not check for padding of the right parenthesis at an empty for iterator.</td>
+          </tr>
+          <tr>
+            <td><a href="config_imports.html#RedundantImport">RedundantImport</a></td>
+            <td>
+            Checks for imports that are redundant.</td>
+          </tr>
+          <tr>
+            <td><a href="config_modifier.html#RedundantModifier">RedundantModifier</a></td>
+            <td>Checks for redundant modifiers in interface and annotation definitions,
+              final modifier on methods of final classes, inner <code>interface</code>
+              declarations that are declared as <code>static</code>, non public class
+              constructors and enum constructors, nested enum definitions that are declared
+              as <code>static</code>.</td>
+          </tr>
+          <tr>
+            <td><a href="config_regexp.html#Regexp">Regexp</a></td>
+            <td>
+            A check that makes sure that a specified pattern exists (or not) in the file.</td>
+          </tr>
+          <tr>
+            <td><a href="config_header.html#RegexpHeader">RegexpHeader</a></td>
+            <td>Checks the header of the source against a header file that contains a
+            </td>
+          </tr>
+          <tr>
+            <td><a href="config_regexp.html#RegexpMultiline">RegexpMultiline</a></td>
+            <td>Implementation of a check that looks that matches across multiple lines in
+            any file type.</td>
+          </tr>
+          <tr>
+            <td><a href="config_regexp.html#RegexpOnFilename">RegexpOnFilename</a></td>
+            <td>Implementation of a check that matches based on file and/or folder path.</td>
+          </tr>
+          <tr>
+            <td><a href="config_regexp.html#RegexpSingleline">RegexpSingleline</a></td>
+            <td>Implementation of a check that looks for a single line in any file type.</td>
+          </tr>
+          <tr>
+            <td><a href="config_regexp.html#RegexpSinglelineJava">RegexpSinglelineJava</a></td>
+            <td>Implementation of a check that looks for a single line in Java files.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#RequireThis">RequireThis</a></td>
+            <td>Checks that code doesn't rely on the &quot;this&quot; default.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#ReturnCount">ReturnCount</a></td>
+            <td>
+            Restricts return statements to a specified count (default = 2).</td>
+          </tr>
+          <tr>
+            <td><a href="config_blocks.html#RightCurly">RightCurly</a></td>
+            <td>
+            Checks the placement of right curly braces.</td>
+          </tr>
+          <tr>
+            <td><a href="config_whitespace.html#SeparatorWrap">SeparatorWrap</a></td>
+            <td>
+            Checks line wrapping with separators.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#SimplifyBooleanExpression">
+              SimplifyBooleanExpression</a></td>
+            <td>
+            Checks for overly complicated boolean expressions.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#SimplifyBooleanReturn">SimplifyBooleanReturn</a></td>
+            <td>
+            Checks for overly complicated boolean return statements.</td>
+          </tr>
+          <tr>
+            <td><a href="config_javadoc.html#SingleLineJavadoc">SingleLineJavadoc</a></td>
+            <td>
+             Checks that a JavaDoc block which can fit on a single line and doesn't contain
+             at-clauses</td>
+          </tr>
+          <tr>
+            <td><a href="config_whitespace.html#SingleSpaceSeparator">SingleSpaceSeparator</a></td>
+            <td>
+             Checks that non-whitespace characters are separated by no more than one
+              whitespace.</td>
+          </tr>
+          <tr>
+            <td><a href="config_naming.html#StaticVariableName">StaticVariableName</a></td>
+            <td>
+              Checks that static, non-final variable names conform to a format specified
+            by the format property.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#StringLiteralEquality">StringLiteralEquality</a></td>
+            <td>Checks that string literals are not used with
+            <code>==</code> or <code>&#33;=</code>.</td>
+          </tr>
+          <tr>
+            <td><a href="config_javadoc.html#SummaryJavadoc">SummaryJavadoc</a></td>
+            <td>
+            Checks that Javadoc summary sentence does not contain phrases that are not recommended
+            to use.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#SuperClone">SuperClone</a></td>
+            <td>
+            Checks that an overriding clone() method invokes super.clone().</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#SuperFinalize">SuperFinalize</a></td>
+            <td>
+            Checks that an overriding finalize() method invokes super.finalize().</td>
+          </tr>
+          <tr>
+            <td><a href="config_annotation.html#SuppressWarnings">SuppressWarnings</a></td>
+            <td>
+              This check allows you to specify what warnings that
+            </td>
+          </tr>
+          <tr>
+            <td><a href="config_design.html#ThrowsCount">ThrowsCount</a></td>
+            <td>
+            Restricts throws statements to a specified count (default = 4).</td>
+          </tr>
+          <tr>
+            <td><a href="config_misc.html#TodoComment">TodoComment</a></td>
+            <td>
+            A check for TODO comments.</td>
+          </tr>
+          <tr>
+            <td><a href="config_misc.html#TrailingComment">TrailingComment</a></td>
+            <td>
+            The check to ensure that requires that comments be the only thing on a line.</td>
+          </tr>
+          <tr>
+            <td><a href="config_misc.html#Translation">Translation</a></td>
+            <td>
+              The TranslationCheck class helps to ensure the correct translation of code by
+            checking property files for consistency regarding their keys.</td>
+          </tr>
+          <tr>
+            <td><a href="config_whitespace.html#TypecastParenPad">TypecastParenPad</a></td>
+            <td>Checks the padding of parentheses for typecasts.</td>
+          </tr>
+          <tr>
+            <td><a href="config_naming.html#TypeName">TypeName</a></td>
+            <td>
+              Checks that type names conform to a format specified
+            by the format property.</td>
+          </tr>
+          <tr>
+            <td><a href="config_misc.html#UncommentedMain">UncommentedMain</a></td>
+            <td>Detects uncommented main methods.</td>
+          </tr>
+          <tr>
+            <td><a href="config_misc.html#UniqueProperties">UniqueProperties</a></td>
+            <td>Detects duplicated keys in properties files.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#UnnecessaryParentheses">UnnecessaryParentheses</a></td>
+            <td>
+            Checks if unnecessary parentheses are used in a statement or expression.</td>
+          </tr>
+          <tr>
+            <td>
+              <a href="config_coding.html#UnnecessarySemicolonInEnumeration">
+              UnnecessarySemicolonInEnumeration</a>
+            </td>
+            <td>Checks if unnecessary semicolon is in enum definitions.</td>
+          </tr>
+          <tr>
+            <td>
+              <a href="config_coding.html#UnnecessarySemicolonInTryWithResources">
+              UnnecessarySemicolonInTryWithResources</a>
+            </td>
+            <td>Checks if unnecessary semicolon is used in last resource declaration.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#UnnecessarySemicolonAfterTypeMemberDeclaration">
+              UnnecessarySemicolonAfterTypeMemberDeclaration</a></td>
+            <td>Checks if unnecessary semicolon is used after type member declaration.</td>
+          </tr>
+          <tr>
+            <td><a href="config_imports.html#UnusedImports">UnusedImports</a></td>
+            <td>
+            Checks for unused import statements.</td>
+          </tr>
+          <tr>
+            <td><a href="config_misc.html#UpperEll">UpperEll</a></td>
+            <td>Checks that long constants are defined with an upper ell.</td>
+          </tr>
+          <tr>
+            <td><a href="config_coding.html#VariableDeclarationUsageDistance">
+              VariableDeclarationUsageDistance</a></td>
+            <td>Checks the distance between declaration of variable and its first usage.</td>
+          </tr>
+          <tr>
+            <td><a href="config_design.html#VisibilityModifier">VisibilityModifier</a></td>
+            <td>Checks visibility of class members.</td>
+          </tr>
+          <tr>
+            <td><a href="config_whitespace.html#WhitespaceAfter">WhitespaceAfter</a></td>
+            <td>
+              Checks that a token is followed by whitespace, with the exception that it
+            does not check for whitespace after the semicolon of an empty for iterator.</td>
+          </tr>
+          <tr>
+            <td><a href="config_whitespace.html#WhitespaceAround">WhitespaceAround</a></td>
+            <td>
+            Checks that a token is surrounded by whitespace.</td>
+          </tr>
+          <tr>
+            <td><a href="config_javadoc.html#WriteTag">WriteTag</a></td>
+            <td>
+            Outputs a JavaDoc tag as information.</td>
+          </tr>
+        </table>
+      </div>
     </section>
 
     <section name="Holder Checks">
@@ -898,14 +910,17 @@
       to gather information the filter can't get on it's own.
     </p>
 
-    <table>
-      <tr>
-        <td><a href="config_annotation.html#SuppressWarningsHolder">SuppressWarningsHolder</a></td>
-        <td>
-          Maintains a set of check suppressions from <code>SuppressWarnings</code> annotations.
-        </td>
-      </tr>
-    </table>
+      <div class="wrapper">
+        <table>
+          <tr>
+            <td><a href="config_annotation.html#SuppressWarningsHolder">
+              SuppressWarningsHolder</a></td>
+            <td>
+              Maintains a set of check suppressions from <code>SuppressWarnings</code> annotations.
+            </td>
+          </tr>
+        </table>
+      </div>
     </section>
   </body>
 </document>

--- a/src/xdocs/config.xml
+++ b/src/xdocs/config.xml
@@ -293,83 +293,85 @@
       </subsection>
 
       <subsection name="Properties" id="Checker_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>basedir</td>
-            <td>base directory name; stripped off in messages about files</td>
-            <td><a href="property_types.html#string">String</a></td>
-            <td><code>null</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>cacheFile</td>
-            <td>caches information about files that have checked OK; used
-                to avoid repeated checks of the same files</td>
-            <td><a href="property_types.html#file">File</a></td>
-            <td><code>null</code> (no cache file)</td>
-            <td>6.16</td>
-          </tr>
-          <tr>
-            <td>localeCountry</td>
-            <td>locale country for messages</td>
-            <td><a href="property_types.html#string">String</a> (either
-            the empty string or an uppercase ISO 3166 2-letter code)</td>
-            <td>default locale country for the Java Virtual Machine</td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>localeLanguage</td>
-            <td>locale language for messages</td>
-            <td><a href="property_types.html#string">String</a> (either
-            the empty string or a lowercase ISO 639 code)</td>
-            <td>default locale language for the Java Virtual Machine</td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>charset</td>
-            <td>name of the file charset</td>
-            <td><a href="property_types.html#string">String</a></td>
-            <td>System property &quot;file.encoding&quot;</td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>fileExtensions</td>
-            <td>file extensions that are accepted</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>all files</code></td>
-            <td>6.3</td>
-          </tr>
-          <tr>
-            <td>severity</td>
-            <td>the default severity level of all violations</td>
-            <td><a href="property_types.html#severity">Severity</a></td>
-            <td><code>error</code></td>
-            <td>3.1</td>
-          </tr>
-          <tr>
-            <td>haltOnException</td>
-            <td>whether to stop execution of Checkstyle if a single file produces any kind of
-            exception during verification</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>7.4</td>
-          </tr>
-          <tr>
-            <td>tabWidth</td>
-            <td>number of expanded spaces for a tab character (<code>'\t'</code>); used in
-            messages and Checks that print violations on files with tabs</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>8</code></td>
-            <td>8.19</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>basedir</td>
+              <td>base directory name; stripped off in messages about files</td>
+              <td><a href="property_types.html#string">String</a></td>
+              <td><code>null</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>cacheFile</td>
+              <td>caches information about files that have checked OK; used
+                  to avoid repeated checks of the same files</td>
+              <td><a href="property_types.html#file">File</a></td>
+              <td><code>null</code> (no cache file)</td>
+              <td>6.16</td>
+            </tr>
+            <tr>
+              <td>localeCountry</td>
+              <td>locale country for messages</td>
+              <td><a href="property_types.html#string">String</a> (either
+              the empty string or an uppercase ISO 3166 2-letter code)</td>
+              <td>default locale country for the Java Virtual Machine</td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>localeLanguage</td>
+              <td>locale language for messages</td>
+              <td><a href="property_types.html#string">String</a> (either
+              the empty string or a lowercase ISO 639 code)</td>
+              <td>default locale language for the Java Virtual Machine</td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>charset</td>
+              <td>name of the file charset</td>
+              <td><a href="property_types.html#string">String</a></td>
+              <td>System property &quot;file.encoding&quot;</td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>fileExtensions</td>
+              <td>file extensions that are accepted</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>all files</code></td>
+              <td>6.3</td>
+            </tr>
+            <tr>
+              <td>severity</td>
+              <td>the default severity level of all violations</td>
+              <td><a href="property_types.html#severity">Severity</a></td>
+              <td><code>error</code></td>
+              <td>3.1</td>
+            </tr>
+            <tr>
+              <td>haltOnException</td>
+              <td>whether to stop execution of Checkstyle if a single file produces any kind of
+              exception during verification</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>7.4</td>
+            </tr>
+            <tr>
+              <td>tabWidth</td>
+              <td>number of expanded spaces for a tab character (<code>'\t'</code>); used in
+              messages and Checks that print violations on files with tabs</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>8</code></td>
+              <td>8.19</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Metadata" id="Checker_Metadata">
@@ -511,25 +513,27 @@
       </subsection>
 
       <subsection name="Properties" id="TreeWalker_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>fileExtensions</td>
-            <td>file type extension to identify Java files. Setting this
-            property is typically only required if your Java source code
-            is preprocessed before compilation and the original files do
-            not have the extension <code>.java</code></td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>.java</code></td>
-            <td>3.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>fileExtensions</td>
+              <td>file type extension to identify Java files. Setting this
+              property is typically only required if your Java source code
+              is preprocessed before compilation and the original files do
+              not have the extension <code>.java</code></td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>.java</code></td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="TreeWalker_Examples">

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -57,85 +57,87 @@ public String getNameIfPresent() { ... }
       </subsection>
 
       <subsection name="Properties" id="AnnotationLocation_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>allowSamelineMultipleAnnotations</td>
-            <td>Allow annotation(s) to be located on the same line as target element.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-           <td><code>false</code></td>
-            <td>6.0</td>
-          </tr>
-          <tr>
-            <td>allowSamelineSingleParameterlessAnnotation</td>
-            <td>Allow single parameterless annotation to be located on the same line as
-                target element.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>6.1</td>
-          </tr>
-          <tr>
-            <td>allowSamelineParameterizedAnnotation</td>
-            <td>Allow one and only parameterized annotation to be located on the same line as
-                target element.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>6.4</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                  CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                  INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">
-                  PACKAGE_DEF</a>,
-              <a href=
-                  "apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
-                  ENUM_CONSTANT_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                  ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                  METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                  CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                  VARIABLE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                  ANNOTATION_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
-                  ANNOTATION_FIELD_DEF</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                  CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                  INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">
-                  PACKAGE_DEF</a>,
-              <a href=
-                  "apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
-                  ENUM_CONSTANT_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                  ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                  METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                  CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                  VARIABLE_DEF</a>.
-            </td>
-            <td>6.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>allowSamelineMultipleAnnotations</td>
+              <td>Allow annotation(s) to be located on the same line as target element.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+             <td><code>false</code></td>
+              <td>6.0</td>
+            </tr>
+            <tr>
+              <td>allowSamelineSingleParameterlessAnnotation</td>
+              <td>Allow single parameterless annotation to be located on the same line as
+                  target element.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>6.1</td>
+            </tr>
+            <tr>
+              <td>allowSamelineParameterizedAnnotation</td>
+              <td>Allow one and only parameterized annotation to be located on the same line as
+                  target element.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>6.4</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                    CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                    INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">
+                    PACKAGE_DEF</a>,
+                <a href=
+                    "apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
+                    ENUM_CONSTANT_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                    ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                    METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                    CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                    VARIABLE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                    ANNOTATION_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
+                    ANNOTATION_FIELD_DEF</a>.
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                    CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                    INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">
+                    PACKAGE_DEF</a>,
+                <a href=
+                    "apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
+                    ENUM_CONSTANT_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                    ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                    METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                    CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                    VARIABLE_DEF</a>.
+              </td>
+              <td>6.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="AnnotationLocation_Examples">
@@ -243,65 +245,67 @@ public String getNameIfPresent() { ... }
       </subsection>
 
       <subsection name="Properties" id="AnnotationOnSameLine_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                  CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                  INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                  ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                  METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                  CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                  VARIABLE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
-                  PARAMETER_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                  ANNOTATION_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPECAST">
-                  TYPECAST</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_THROWS">
-                  LITERAL_THROWS</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPLEMENTS_CLAUSE">
-                  IMPLEMENTS_CLAUSE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPE_ARGUMENT">
-                  TYPE_ARGUMENT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NEW">
-                  LITERAL_NEW</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">DOT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
-                  ANNOTATION_FIELD_DEF</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                  CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                  INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                  ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                  METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                  CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                  VARIABLE_DEF</a>.
-            </td>
-            <td>8.2</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                    CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                    INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                    ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                    METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                    CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                    VARIABLE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
+                    PARAMETER_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                    ANNOTATION_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPECAST">
+                    TYPECAST</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_THROWS">
+                    LITERAL_THROWS</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPLEMENTS_CLAUSE">
+                    IMPLEMENTS_CLAUSE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPE_ARGUMENT">
+                    TYPE_ARGUMENT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NEW">
+                    LITERAL_NEW</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">DOT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
+                    ANNOTATION_FIELD_DEF</a>.
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                    CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                    INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                    ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                    METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                    CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                    VARIABLE_DEF</a>.
+              </td>
+              <td>8.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="AnnotationOnSameLine_Examples">
@@ -427,54 +431,56 @@ public int foo() { ... }
         </p>
       </subsection>
       <subsection name="Properties" id="AnnotationUseStyle_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>elementStyle</td>
-            <td>
-              Define the annotation element styles.
-            </td>
-            <td>
-              <a href="property_types.html#elementStyle">Element Style</a>
-            </td>
-            <td>
-              <code>compact_no_array</code>
-            </td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>closingParens</td>
-            <td>
-              Define the policy for ending parenthesis.
-            </td>
-            <td>
-              <a href="property_types.html#closingParens">Closing Parens</a>
-            </td>
-            <td>
-              <code>never</code>
-            </td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>trailingArrayComma</td>
-            <td>
-              Define the policy for trailing comma in arrays.
-            </td>
-            <td>
-              <a href="property_types.html#trailingArrayComma">Trailing Comma</a>
-            </td>
-            <td>
-              <code>never</code>
-            </td>
-            <td>5.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>elementStyle</td>
+              <td>
+                Define the annotation element styles.
+              </td>
+              <td>
+                <a href="property_types.html#elementStyle">Element Style</a>
+              </td>
+              <td>
+                <code>compact_no_array</code>
+              </td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>closingParens</td>
+              <td>
+                Define the policy for ending parenthesis.
+              </td>
+              <td>
+                <a href="property_types.html#closingParens">Closing Parens</a>
+              </td>
+              <td>
+                <code>never</code>
+              </td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>trailingArrayComma</td>
+              <td>
+                Define the policy for trailing comma in arrays.
+              </td>
+              <td>
+                <a href="property_types.html#trailingArrayComma">Trailing Comma</a>
+              </td>
+              <td>
+                <code>never</code>
+              </td>
+              <td>5.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
       <subsection name="Examples" id="AnnotationUseStyle_Examples">
         <p> To configure the check:</p>
@@ -583,25 +589,27 @@ public int foo() { ... }
         </source>
       </subsection>
       <subsection name="Properties" id="MissingDeprecated_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>violateExecutionOnNonTightHtml</td>
-            <td>
-              If turned on, will print violations if the Javadoc being examined by this check
-              violates the tight html rules defined at
-              <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>8.24</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>violateExecutionOnNonTightHtml</td>
+              <td>
+                If turned on, will print violations if the Javadoc being examined by this check
+                violates the tight html rules defined at
+                <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>8.24</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
       <subsection name="Examples" id="MissingDeprecated_Examples">
         <p> To configure the check:</p>
@@ -700,28 +708,30 @@ public static final int COUNTER = 10; // violation
 
       </subsection>
       <subsection name="Properties" id="MissingOverride_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>javaFiveCompatibility</td>
-            <td>
-              Enable java 5 compatibility mode.
-            </td>
-            <td>
-              <a href="property_types.html#boolean">Boolean</a>
-            </td>
-            <td>
-              <code>false</code>
-            </td>
-            <td>5.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>javaFiveCompatibility</td>
+              <td>
+                Enable java 5 compatibility mode.
+              </td>
+              <td>
+                <a href="property_types.html#boolean">Boolean</a>
+              </td>
+              <td>
+                <code>false</code>
+              </td>
+              <td>5.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
       <subsection name="Examples" id="MissingOverride_Examples">
         <p> To configure the check:</p>
@@ -876,83 +886,85 @@ public static final int COUNTER = 10; // violation
         </p>
       </subsection>
       <subsection name="Properties" id="SuppressWarnings_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>
-               Specify the RegExp to match against warnings. Any warning
-               being suppressed matching this pattern will be flagged.
-            </td>
-            <td>
-              <a href="property_types.html#regexp">Regular Expression</a>
-            </td>
-            <td>
-              <code>"^\s*+$"</code>
-            </td>
-            <td>5.0</td>
-          </tr>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>
+                 Specify the RegExp to match against warnings. Any warning
+                 being suppressed matching this pattern will be flagged.
+              </td>
+              <td>
+                <a href="property_types.html#regexp">Regular Expression</a>
+              </td>
+              <td>
+                <code>"^\s*+$"</code>
+              </td>
+              <td>5.0</td>
+            </tr>
 
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
 
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                  CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                  INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                  ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                  ANNOTATION_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
-                  ANNOTATION_FIELD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
-                  ENUM_CONSTANT_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
-                  PARAMETER_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                  VARIABLE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                  METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                  CTOR_DEF</a>.
-            </td>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                    CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                    INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                    ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                    ANNOTATION_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
+                    ANNOTATION_FIELD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
+                    ENUM_CONSTANT_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
+                    PARAMETER_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                    VARIABLE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                    METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                    CTOR_DEF</a>.
+              </td>
 
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                  CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                  INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                  ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                  ANNOTATION_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
-                  ANNOTATION_FIELD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
-                  ENUM_CONSTANT_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
-                  PARAMETER_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                  VARIABLE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                  METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                  CTOR_DEF</a>.
-            </td>
-            <td>5.0</td>
-          </tr>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                    CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                    INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                    ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                    ANNOTATION_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
+                    ANNOTATION_FIELD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
+                    ENUM_CONSTANT_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
+                    PARAMETER_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                    VARIABLE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                    METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                    CTOR_DEF</a>.
+              </td>
+              <td>5.0</td>
+            </tr>
 
-        </table>
+          </table>
+        </div>
       </subsection>
       <subsection name="Examples" id="SuppressWarnings_Examples">
         <p> To configure the check:</p>
@@ -1023,25 +1035,27 @@ public static final int COUNTER = 10; // violation
       </subsection>
 
       <subsection name="Properties" id="SuppressWarningsHolder_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>aliasList</td>
-            <td>Specify aliases for check names that can be used in code within
-                <code>SuppressWarnings</code>.</td>
-            <td><a href="property_types.html#stringSet">String Set</a>
-                in a format of comma separated attribute=value entries.
-            The attribute is the fully qualified name of the Check and value is its alias.</td>
-            <td><code>null</code></td>
-            <td>5.7</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>aliasList</td>
+              <td>Specify aliases for check names that can be used in code within
+                  <code>SuppressWarnings</code>.</td>
+              <td><a href="property_types.html#stringSet">String Set</a>
+                  in a format of comma separated attribute=value entries.
+              The attribute is the fully qualified name of the Check and value is its alias.</td>
+              <td><code>null</code></td>
+              <td>5.7</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="SuppressWarningsHolder_Examples">

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -91,22 +91,24 @@ switch (a)
       </subsection>
 
       <subsection name="Properties" id="AvoidNestedBlocks_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>allowInSwitchCase</td>
-            <td>Allow nested blocks if they are the only child of a switch case.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>3.2</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>allowInSwitchCase</td>
+              <td>Allow nested blocks if they are the only child of a switch case.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>3.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="AvoidNestedBlocks_Examples">
@@ -187,84 +189,86 @@ switch (a) {
       </subsection>
 
       <subsection name="Properties" id="EmptyBlock_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>option</td>
-            <td>specify the policy on block contents.</td>
-            <td><a href="property_types.html#block">Block Policy</a></td>
-            <td><code>statement</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
-                LITERAL_WHILE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">
-                LITERAL_TRY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
-                LITERAL_CATCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">
-                LITERAL_FINALLY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
-                LITERAL_DO</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
-                LITERAL_IF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">
-                LITERAL_ELSE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
-                LITERAL_FOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">
-                INSTANCE_INIT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">
-                STATIC_INIT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">
-                LITERAL_SWITCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">
-                LITERAL_SYNCHRONIZED</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CASE">
-                LITERAL_CASE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DEFAULT">
-                LITERAL_DEFAULT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_INIT">
-                ARRAY_INIT</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
-                LITERAL_WHILE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">
-                LITERAL_TRY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">
-                LITERAL_FINALLY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
-                LITERAL_DO</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
-                LITERAL_IF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">
-                LITERAL_ELSE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
-                LITERAL_FOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">
-                INSTANCE_INIT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">
-                STATIC_INIT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">
-                LITERAL_SWITCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">
-                LITERAL_SYNCHRONIZED</a>.
-            </td>
-            <td>3.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>option</td>
+              <td>specify the policy on block contents.</td>
+              <td><a href="property_types.html#block">Block Policy</a></td>
+              <td><code>statement</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
+                  LITERAL_WHILE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">
+                  LITERAL_TRY</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
+                  LITERAL_CATCH</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">
+                  LITERAL_FINALLY</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
+                  LITERAL_DO</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
+                  LITERAL_IF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">
+                  LITERAL_ELSE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
+                  LITERAL_FOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">
+                  INSTANCE_INIT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">
+                  STATIC_INIT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">
+                  LITERAL_SWITCH</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">
+                  LITERAL_SYNCHRONIZED</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CASE">
+                  LITERAL_CASE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DEFAULT">
+                  LITERAL_DEFAULT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_INIT">
+                  ARRAY_INIT</a>.
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
+                  LITERAL_WHILE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">
+                  LITERAL_TRY</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">
+                  LITERAL_FINALLY</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
+                  LITERAL_DO</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
+                  LITERAL_IF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">
+                  LITERAL_ELSE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
+                  LITERAL_FOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">
+                  INSTANCE_INIT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">
+                  STATIC_INIT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">
+                  LITERAL_SWITCH</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">
+                  LITERAL_SYNCHRONIZED</a>.
+              </td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="EmptyBlock_Examples">
@@ -346,36 +350,38 @@ switch (a) {
       </subsection>
 
       <subsection name="Properties" id="EmptyCatchBlock_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>exceptionVariableName</td>
-            <td>
-              Specify the RegExp for the name of the variable associated with exception.
-              If check meets variable name matching specified value - empty block is suppressed.
-            </td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>&quot;^$&quot; (empty)</code></td>
-            <td>6.4</td>
-          </tr>
-          <tr>
-            <td>commentFormat</td>
-            <td>
-              Specify the RegExp for the first comment inside empty catch block.
-              If check meets comment inside empty catch block matching specified format - empty
-              block is suppressed. If it is multi-line comment - only its first line is analyzed.
-            </td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>&quot;.*&quot;</code></td>
-            <td>6.4</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>exceptionVariableName</td>
+              <td>
+                Specify the RegExp for the name of the variable associated with exception.
+                If check meets variable name matching specified value - empty block is suppressed.
+              </td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>&quot;^$&quot; (empty)</code></td>
+              <td>6.4</td>
+            </tr>
+            <tr>
+              <td>commentFormat</td>
+              <td>
+                Specify the RegExp for the first comment inside empty catch block.
+                If check meets comment inside empty catch block matching specified format - empty
+                block is suppressed. If it is multi-line comment - only its first line is analyzed.
+              </td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>&quot;.*&quot;</code></td>
+              <td>6.4</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="EmptyCatchBlock_Examples">
@@ -523,127 +529,129 @@ try {
       </subsection>
 
       <subsection name="Properties" id="LeftCurly_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>option</td>
-            <td>Specify the policy on placement of a left curly brace (<code>'{'</code>).</td>
-            <td><a href="property_types.html#lcurly">Left Curly Brace Policy</a></td>
-            <td><code>eol</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>ignoreEnums</td>
-            <td>Allow to ignore enums when left curly brace policy is EOL.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>6.9</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                ANNOTATION_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
-                ENUM_CONSTANT_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
-                LAMBDA</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CASE">
-                LITERAL_CASE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
-                LITERAL_CATCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DEFAULT">
-                LITERAL_DEFAULT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
-                LITERAL_DO</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">
-                LITERAL_ELSE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">
-                LITERAL_FINALLY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
-                LITERAL_FOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
-                LITERAL_IF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">
-                LITERAL_SWITCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">
-                LITERAL_SYNCHRONIZED</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">
-                LITERAL_TRY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
-                LITERAL_WHILE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#OBJBLOCK">
-                OBJBLOCK</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">
-                STATIC_INIT</a>.
-            </td>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>option</td>
+              <td>Specify the policy on placement of a left curly brace (<code>'{'</code>).</td>
+              <td><a href="property_types.html#lcurly">Left Curly Brace Policy</a></td>
+              <td><code>eol</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>ignoreEnums</td>
+              <td>Allow to ignore enums when left curly brace policy is EOL.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>6.9</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                  ANNOTATION_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                  CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
+                  ENUM_CONSTANT_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                  ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
+                  LAMBDA</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CASE">
+                  LITERAL_CASE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
+                  LITERAL_CATCH</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DEFAULT">
+                  LITERAL_DEFAULT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
+                  LITERAL_DO</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">
+                  LITERAL_ELSE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">
+                  LITERAL_FINALLY</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
+                  LITERAL_FOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
+                  LITERAL_IF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">
+                  LITERAL_SWITCH</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">
+                  LITERAL_SYNCHRONIZED</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">
+                  LITERAL_TRY</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
+                  LITERAL_WHILE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#OBJBLOCK">
+                  OBJBLOCK</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">
+                  STATIC_INIT</a>.
+              </td>
 
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                ANNOTATION_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
-                ENUM_CONSTANT_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
-                LAMBDA</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CASE">
-                LITERAL_CASE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
-                LITERAL_CATCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DEFAULT">
-                LITERAL_DEFAULT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
-                LITERAL_DO</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">
-                LITERAL_ELSE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">
-                LITERAL_FINALLY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
-                LITERAL_FOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
-                LITERAL_IF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">
-                LITERAL_SWITCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">
-                LITERAL_SYNCHRONIZED</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">
-                LITERAL_TRY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
-                LITERAL_WHILE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#OBJBLOCK">
-                OBJBLOCK</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">
-                STATIC_INIT</a>.
-            </td>
-            <td>3.0</td>
-          </tr>
-        </table>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                  ANNOTATION_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                  CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
+                  ENUM_CONSTANT_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                  ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
+                  LAMBDA</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CASE">
+                  LITERAL_CASE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
+                  LITERAL_CATCH</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DEFAULT">
+                  LITERAL_DEFAULT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
+                  LITERAL_DO</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">
+                  LITERAL_ELSE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">
+                  LITERAL_FINALLY</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
+                  LITERAL_FOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
+                  LITERAL_IF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">
+                  LITERAL_SWITCH</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">
+                  LITERAL_SYNCHRONIZED</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">
+                  LITERAL_TRY</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
+                  LITERAL_WHILE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#OBJBLOCK">
+                  OBJBLOCK</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">
+                  STATIC_INIT</a>.
+              </td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="LeftCurly_Examples">
@@ -725,65 +733,67 @@ try {
       </subsection>
 
       <subsection name="Properties" id="NeedBraces_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>allowSingleLineStatement</td>
-            <td>allow single-line statements without braces.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>6.5</td>
-          </tr>
-          <tr>
-            <td>allowEmptyLoopBody</td>
-            <td>allow loops with empty bodies.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>6.12.1</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
-                LITERAL_DO</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">
-                LITERAL_ELSE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
-                LITERAL_FOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
-                LITERAL_IF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
-                LITERAL_WHILE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CASE">
-                LITERAL_CASE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DEFAULT">
-                LITERAL_DEFAULT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
-                LAMBDA</a>.
-            </td>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>allowSingleLineStatement</td>
+              <td>allow single-line statements without braces.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>6.5</td>
+            </tr>
+            <tr>
+              <td>allowEmptyLoopBody</td>
+              <td>allow loops with empty bodies.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>6.12.1</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
+                  LITERAL_DO</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">
+                  LITERAL_ELSE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
+                  LITERAL_FOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
+                  LITERAL_IF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
+                  LITERAL_WHILE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CASE">
+                  LITERAL_CASE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DEFAULT">
+                  LITERAL_DEFAULT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
+                  LAMBDA</a>.
+              </td>
 
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
-                LITERAL_DO</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">
-                LITERAL_ELSE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
-                LITERAL_FOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
-                LITERAL_IF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
-                LITERAL_WHILE</a>.
-            </td>
-            <td>3.0</td>
-          </tr>
-        </table>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
+                  LITERAL_DO</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">
+                  LITERAL_ELSE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
+                  LITERAL_FOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
+                  LITERAL_IF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
+                  LITERAL_WHILE</a>.
+              </td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="NeedBraces_Examples">
@@ -846,31 +856,34 @@ switch (num) {
         <p>
           To configure the check to allow loops (<code>while, for</code>) with empty bodies:
         </p>
-          <source>
+        <source>
 &lt;module name=&quot;NeedBraces&quot;&gt;
   &lt;property name=&quot;allowEmptyLoopBody&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
-          </source>
+        </source>
 
-          <p>
-              Next statements won't be violated by check:
-          </p>
-          <source>
+        <p>
+            Next statements won't be violated by check:
+        </p>
+        <source>
 while (value.incrementValue() &lt; 5); // OK
 for(int i = 0; i &lt; 10; value.incrementValue()); // OK
-          </source>
-          <p>
-            To configure the check to lambdas:
-          </p>
+        </source>
+        <p>
+          To configure the check to lambdas:
+        </p>
+        <div class="wrapper">
           <pre>
 &lt;module name=&quot;NeedBraces&quot;&gt;
   &lt;property name=&quot;tokens&quot; value=&quot;LAMBDA&quot;/&gt;
   &lt;property name=&quot;allowSingleLineStatement&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
           </pre>
-          <p>
-            Results in following:
-          </p>
+        </div>
+        <p>
+          Results in following:
+        </p>
+        <div class="wrapper">
           <pre>
 allowedFuture.addCallback(result -> assertEquals("Invalid response",
   EnumSet.of(HttpMethod.GET, HttpMethod.OPTIONS), result), // violation, lambda spans 2 lines
@@ -882,6 +895,7 @@ allowedFuture.addCallback(result -> {
   }, // OK
   ex -> fail(ex.getMessage()));
           </pre>
+        </div>
       </subsection>
 
       <subsection name="Example of Usage" id="NeedBraces_Example_of_Usage">
@@ -937,82 +951,84 @@ allowedFuture.addCallback(result -> {
       </subsection>
 
       <subsection name="Properties" id="RightCurly_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>option</td>
-            <td>Specify the policy on placement of a right curly brace (<code>'}'</code>).</td>
-            <td><a href="property_types.html#rcurly">Right Curly Brace Policy</a></td>
-            <td><code>same</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>subset of tokens <a
-             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">
-                LITERAL_TRY</a>,
-            <a
-             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
-                LITERAL_CATCH</a>,
-            <a
-             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">
-                LITERAL_FINALLY</a>,
-            <a
-             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
-                LITERAL_IF</a>,
-            <a
-             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">
-                LITERAL_ELSE</a>,
-            <a
-             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-            <a
-             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-            <a
-             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-             <a
-             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
-                LITERAL_FOR</a>,
-            <a
-             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
-                LITERAL_WHILE</a>,
-            <a
-             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
-                LITERAL_DO</a>,
-            <a
-             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">
-                STATIC_INIT</a>,
-            <a
-             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">
-                INSTANCE_INIT</a>.</td>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>option</td>
+              <td>Specify the policy on placement of a right curly brace (<code>'}'</code>).</td>
+              <td><a href="property_types.html#rcurly">Right Curly Brace Policy</a></td>
+              <td><code>same</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>subset of tokens <a
+               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">
+                  LITERAL_TRY</a>,
+              <a
+               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
+                  LITERAL_CATCH</a>,
+              <a
+               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">
+                  LITERAL_FINALLY</a>,
+              <a
+               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
+                  LITERAL_IF</a>,
+              <a
+               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">
+                  LITERAL_ELSE</a>,
+              <a
+               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                  CLASS_DEF</a>,
+              <a
+               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+              <a
+               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+               <a
+               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
+                  LITERAL_FOR</a>,
+              <a
+               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
+                  LITERAL_WHILE</a>,
+              <a
+               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
+                  LITERAL_DO</a>,
+              <a
+               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">
+                  STATIC_INIT</a>,
+              <a
+               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">
+                  INSTANCE_INIT</a>.</td>
 
-            <td><a
-             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">
-                LITERAL_TRY</a>,
-            <a
-             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
-                LITERAL_CATCH</a>,
-            <a
-             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">
-                LITERAL_FINALLY</a>,
-            <a
-             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
-                LITERAL_IF</a>,
-            <a
-             href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">
-                LITERAL_ELSE</a>.</td>
-            <td>3.0</td>
-          </tr>
-        </table>
+              <td><a
+               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">
+                  LITERAL_TRY</a>,
+              <a
+               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
+                  LITERAL_CATCH</a>,
+              <a
+               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">
+                  LITERAL_FINALLY</a>,
+              <a
+               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
+                  LITERAL_IF</a>,
+              <a
+               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">
+                  LITERAL_ELSE</a>.</td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="RightCurly_Examples">

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -409,29 +409,31 @@ public class A {
       </subsection>
 
       <subsection name="Properties" id="DeclarationOrder_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>ignoreConstructors</td>
-            <td>control whether to ignore constructors.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.2</td>
-          </tr>
-          <tr>
-            <td>ignoreModifiers</td>
-            <td>control whether to ignore modifiers (fields, ...).</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.2</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>ignoreConstructors</td>
+              <td>control whether to ignore constructors.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.2</td>
+            </tr>
+            <tr>
+              <td>ignoreModifiers</td>
+              <td>control whether to ignore modifiers (fields, ...).</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="DeclarationOrder_Examples">
@@ -538,25 +540,27 @@ class K {
         </p>
       </subsection>
       <subsection name="Properties" id="DefaultComesLast_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>skipIfLastAndSharedWithCase</td>
-            <td>
-              Control whether to allow <code>default</code> along with
-              <code>case</code> if they are not last.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>7.7</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>skipIfLastAndSharedWithCase</td>
+              <td>
+                Control whether to allow <code>default</code> along with
+                <code>case</code> if they are not last.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>7.7</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
       <subsection name="Examples" id="DefaultComesLast_Examples">
         <p>
@@ -732,24 +736,26 @@ String nullString = null;
       </subsection>
 
       <subsection name="Properties" id="EqualsAvoidNull_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>ignoreEqualsIgnoreCase</td>
-            <td>
-              Control whether to ignore <code>String.equalsIgnoreCase(String)</code> invocations.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.4</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>ignoreEqualsIgnoreCase</td>
+              <td>
+                Control whether to ignore <code>String.equalsIgnoreCase(String)</code> invocations.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.4</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="EqualsAvoidNull_Examples">
@@ -892,23 +898,25 @@ String nullString = null;
       </subsection>
 
       <subsection name="Properties" id="ExplicitInitialization_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>onlyObjectReferences</td>
-            <td>control whether only explicit initializations made to
-                null for objects should be checked.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>7.8</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>onlyObjectReferences</td>
+              <td>control whether only explicit initializations made to
+                  null for objects should be checked.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>7.8</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="ExplicitInitialization_Examples">
@@ -1043,7 +1051,8 @@ case 5:
           because of the comment "fallthru" and absence of any Java code
           in case 5.
         </p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 case 3:
     x = 2;
     // fallthru
@@ -1051,38 +1060,41 @@ case 4:
 case 5:
 case 6:
     break;
-        </pre>
+          </pre>
+        </div>
       </subsection>
 
       <subsection name="Properties" id="FallThrough_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>checkLastCaseGroup</td>
-            <td>
-              Control whether the last case group must be checked.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>4.0</td>
-          </tr>
-          <tr>
-            <td>reliefPattern</td>
-            <td>
-              Define the RegExp to match the relief comment that suppresses
-              the warning about a fall through.
-            </td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"fallthru|falls? ?through"</code></td>
-            <td>4.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>checkLastCaseGroup</td>
+              <td>
+                Control whether the last case group must be checked.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>4.0</td>
+            </tr>
+            <tr>
+              <td>reliefPattern</td>
+              <td>
+                Define the RegExp to match the relief comment that suppresses
+                the warning about a fall through.
+              </td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"fallthru|falls? ?through"</code></td>
+              <td>4.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="FallThrough_Examples">
@@ -1163,50 +1175,52 @@ case 6:
       </subsection>
 
       <subsection name="Properties" id="FinalLocalVariable_Properties">
-        <table>
-          <tr class="header">
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>validateEnhancedForLoopVariable</td>
-            <td>
-              Control whether to check
-              <a href = "https://docs.oracle.com/javase/specs/jls/se11/html/jls-14.html#jls-14.14.2">
-              enhanced for-loop</a> variable.</td>
-            <td>
-              <a
-              href="property_types.html#boolean">Boolean</a>
-            </td>
-            <td>
-             <code>
-              false
-             </code>
-            </td>
-            <td>6.5</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>
-              subset of tokens <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                VARIABLE_DEF</a>,
-              <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
-                PARAMETER_DEF</a>.
-            </td>
-            <td>
-              <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                VARIABLE_DEF</a>.
-            </td>
-            <td>3.2</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr class="header">
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>validateEnhancedForLoopVariable</td>
+              <td>
+                Control whether to check
+                <a href = "https://docs.oracle.com/javase/specs/jls/se11/html/jls-14.html#jls-14.14.2">
+                enhanced for-loop</a> variable.</td>
+              <td>
+                <a
+                href="property_types.html#boolean">Boolean</a>
+              </td>
+              <td>
+               <code>
+                false
+               </code>
+              </td>
+              <td>6.5</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>
+                subset of tokens <a
+                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                  VARIABLE_DEF</a>,
+                <a
+                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
+                  PARAMETER_DEF</a>.
+              </td>
+              <td>
+                <a
+                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                  VARIABLE_DEF</a>.
+              </td>
+              <td>3.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="FinalLocalVariable_Examples">
@@ -1358,88 +1372,90 @@ class PageBuilder {
       </subsection>
 
       <subsection name="Properties" id="HiddenField_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>ignoreFormat</td>
-            <td>Define the RegExp for names of variables and parameters to ignore.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>null</code></td>
-            <td>3.2</td>
-          </tr>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>ignoreFormat</td>
+              <td>Define the RegExp for names of variables and parameters to ignore.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>null</code></td>
+              <td>3.2</td>
+            </tr>
 
-          <tr>
-            <td>ignoreConstructorParameter</td>
-            <td>Control whether to ignore constructor parameters.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>3.2</td>
-          </tr>
+            <tr>
+              <td>ignoreConstructorParameter</td>
+              <td>Control whether to ignore constructor parameters.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>3.2</td>
+            </tr>
 
-          <tr>
-            <td>ignoreSetter</td>
-            <td>
-              Allow to ignore the parameter of a property setter method.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>3.2</td>
-          </tr>
+            <tr>
+              <td>ignoreSetter</td>
+              <td>
+                Allow to ignore the parameter of a property setter method.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>3.2</td>
+            </tr>
 
-          <tr>
-            <td>setterCanReturnItsClass</td>
-            <td>
-              Allow to expand the definition of a setter method
-              to include methods that return the class' instance.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>6.3</td>
-          </tr>
+            <tr>
+              <td>setterCanReturnItsClass</td>
+              <td>
+                Allow to expand the definition of a setter method
+                to include methods that return the class' instance.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>6.3</td>
+            </tr>
 
-          <tr>
-            <td>ignoreAbstractMethods</td>
-            <td>Control whether to ignore parameters of abstract methods.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>4.0</td>
-          </tr>
+            <tr>
+              <td>ignoreAbstractMethods</td>
+              <td>Control whether to ignore parameters of abstract methods.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>4.0</td>
+            </tr>
 
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>
-              subset of tokens <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                VARIABLE_DEF</a>,
-              <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
-                PARAMETER_DEF</a>,
-              <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
-                LAMBDA</a>.
-            </td>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>
+                subset of tokens <a
+                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                  VARIABLE_DEF</a>,
+                <a
+                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
+                  PARAMETER_DEF</a>,
+                <a
+                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
+                  LAMBDA</a>.
+              </td>
 
-            <td>
-              <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                VARIABLE_DEF</a>,
-              <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
-                PARAMETER_DEF</a>,
-              <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
-                LAMBDA</a>.
-            </td>
-            <td>3.0</td>
-          </tr>
-        </table>
+              <td>
+                <a
+                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                  VARIABLE_DEF</a>,
+                <a
+                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
+                  PARAMETER_DEF</a>,
+                <a
+                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
+                  LAMBDA</a>.
+              </td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="HiddenField_Examples">
@@ -1578,23 +1594,25 @@ class SomeClass
       </subsection>
 
       <subsection name="Properties" id="IllegalCatch_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>illegalClassNames</td>
-            <td>Specify exception class names to reject.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>Error, Exception, RuntimeException, Throwable, java.lang.Error,
-              java.lang.Exception, java.lang.RuntimeException, java.lang.Throwable</code></td>
-            <td>3.2</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>illegalClassNames</td>
+              <td>Specify exception class names to reject.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>Error, Exception, RuntimeException, Throwable, java.lang.Error,
+                java.lang.Exception, java.lang.RuntimeException, java.lang.Throwable</code></td>
+              <td>3.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="IllegalCatch_Examples">
@@ -1678,39 +1696,41 @@ class SomeClass
       </subsection>
 
       <subsection name="Properties" id="IllegalInstantiation_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>classes</td>
-            <td>Specify fully qualified class names that should not be instantiated.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>{}</code></td>
-            <td>3.0</td>
-          </tr>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>classes</td>
+              <td>Specify fully qualified class names that should not be instantiated.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>{}</code></td>
+              <td>3.0</td>
+            </tr>
 
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
 
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-              CLASS_DEF</a>.
-            </td>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                CLASS_DEF</a>.
+              </td>
 
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-              CLASS_DEF</a>.
-            </td>
-            <td>3.0</td>
-          </tr>
-        </table>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                CLASS_DEF</a>.
+              </td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="IllegalInstantiation_Examples">
@@ -1774,41 +1794,43 @@ class SomeClass
       </subsection>
 
       <subsection name="Properties" id="IllegalThrows_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>illegalClassNames</td>
-            <td>Specify throw class names to reject.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>Error, RuntimeException, Throwable, java.lang.Error,
-              java.lang.RuntimeException, java.lang.Throwable</code>
-            </td>
-            <td>4.0</td>
-          </tr>
-          <tr>
-            <td>ignoredMethodNames</td>
-            <td>Specify names of methods to ignore.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>finalize</code></td>
-            <td>5.4</td>
-          </tr>
-          <tr>
-            <td>ignoreOverriddenMethods</td>
-            <td>
-              allow to ignore checking overridden methods (marked with <code>Override</code>
-              or <code>java.lang.Override</code> annotation).
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>6.4</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>illegalClassNames</td>
+              <td>Specify throw class names to reject.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>Error, RuntimeException, Throwable, java.lang.Error,
+                java.lang.RuntimeException, java.lang.Throwable</code>
+              </td>
+              <td>4.0</td>
+            </tr>
+            <tr>
+              <td>ignoredMethodNames</td>
+              <td>Specify names of methods to ignore.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>finalize</code></td>
+              <td>5.4</td>
+            </tr>
+            <tr>
+              <td>ignoreOverriddenMethods</td>
+              <td>
+                allow to ignore checking overridden methods (marked with <code>Override</code>
+                or <code>java.lang.Override</code> annotation).
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>6.4</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="IllegalThrows_Examples">
@@ -1895,27 +1917,29 @@ class SomeClass
       </subsection>
 
       <subsection name="Properties" id="IllegalToken_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LABELED_STAT">LABELED_STAT</a>.
-            </td>
-            <td>3.2</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>.
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LABELED_STAT">LABELED_STAT</a>.
+              </td>
+              <td>3.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="IllegalToken_Examples">
@@ -1980,61 +2004,63 @@ class SomeClass
       </subsection>
 
       <subsection name="Properties" id="IllegalTokenText_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Define the RegExp for illegal pattern.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>&quot;^$&quot; (empty)</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>ignoreCase</td>
-            <td>Control whether to ignore case when matching.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>message</td>
-            <td>Define the message which is used to notify about violations;
-            if empty then the default message is used.</td>
-            <td><a href="property_types.html#string">String</a></td>
-            <td><code>&quot;&quot;</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>subset of tokens
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_DOUBLE">
-                NUM_DOUBLE</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_FLOAT">
-                NUM_FLOAT</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_INT">
-                NUM_INT</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_LONG">
-                NUM_LONG</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IDENT">
-                IDENT</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMMENT_CONTENT">
-                COMMENT_CONTENT</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STRING_LITERAL">
-                STRING_LITERAL</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CHAR_LITERAL">
-                CHAR_LITERAL</a>.
-            </td>
-            <td>empty</td>
-            <td>3.2</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Define the RegExp for illegal pattern.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>&quot;^$&quot; (empty)</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>ignoreCase</td>
+              <td>Control whether to ignore case when matching.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>message</td>
+              <td>Define the message which is used to notify about violations;
+              if empty then the default message is used.</td>
+              <td><a href="property_types.html#string">String</a></td>
+              <td><code>&quot;&quot;</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>subset of tokens
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_DOUBLE">
+                  NUM_DOUBLE</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_FLOAT">
+                  NUM_FLOAT</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_INT">
+                  NUM_INT</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_LONG">
+                  NUM_LONG</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IDENT">
+                  IDENT</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMMENT_CONTENT">
+                  COMMENT_CONTENT</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STRING_LITERAL">
+                  STRING_LITERAL</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CHAR_LITERAL">
+                  CHAR_LITERAL</a>.
+              </td>
+              <td>empty</td>
+              <td>3.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="IllegalTokenText_Examples">
@@ -2119,107 +2145,109 @@ class SomeClass
       </subsection>
 
       <subsection name="Properties" id="IllegalType_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>validateAbstractClassNames</td>
-            <td>Control whether to validate abstract class names.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>6.10</td>
-          </tr>
-          <tr>
-            <td>illegalClassNames</td>
-            <td>Specify classes that should not be used as types in variable
-            declarations, return values or parameters.</td>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>validateAbstractClassNames</td>
+              <td>Control whether to validate abstract class names.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>6.10</td>
+            </tr>
+            <tr>
+              <td>illegalClassNames</td>
+              <td>Specify classes that should not be used as types in variable
+              declarations, return values or parameters.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>HashMap, HashSet, LinkedHashMap, LinkedHashSet, TreeMap, TreeSet,
+                java.util.HashMap, java.util.HashSet, java.util.LinkedHashMap,
+                java.util.LinkedHashSet, java.util.TreeMap, java.util.TreeSet</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+            <td>legalAbstractClassNames</td>
+            <td>Define abstract classes that may be used as types. </td>
             <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>HashMap, HashSet, LinkedHashMap, LinkedHashSet, TreeMap, TreeSet,
-              java.util.HashMap, java.util.HashSet, java.util.LinkedHashMap,
-              java.util.LinkedHashSet, java.util.TreeMap, java.util.TreeSet</code></td>
-            <td>3.2</td>
+            <td><code>{}</code></td>
+            <td>4.2</td>
           </tr>
           <tr>
-          <td>legalAbstractClassNames</td>
-          <td>Define abstract classes that may be used as types. </td>
-          <td><a href="property_types.html#stringSet">String Set</a></td>
-          <td><code>{}</code></td>
-          <td>4.2</td>
-        </tr>
-        <tr>
-            <td>ignoredMethodNames</td>
-            <td>Specify methods that should not be checked.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>getEnvironment, getInitialContext</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>illegalAbstractClassNameFormat</td>
-            <td>Specify RegExp for illegal abstract class names.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^(.*[.])?Abstract.*$"</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>memberModifiers</td>
-            <td>
-              Control whether to check only methods and fields with any of the specified modifiers.
-              This property does not affect method calls nor method references.
-            </td>
-            <td>subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>
-            </td>
-            <td>no tokens</td>
-            <td>6.3</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
-                ANNOTATION_FIELD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_CALL">
-                METHOD_CALL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_REF">
-                METHOD_REF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
-                PARAMETER_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                VARIABLE_DEF</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
-                ANNOTATION_FIELD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_CALL">
-                METHOD_CALL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_REF">
-                METHOD_REF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
-                PARAMETER_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                VARIABLE_DEF</a>.
-            </td>
-            <td>3.2</td>
-          </tr>
-        </table>
+              <td>ignoredMethodNames</td>
+              <td>Specify methods that should not be checked.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>getEnvironment, getInitialContext</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>illegalAbstractClassNameFormat</td>
+              <td>Specify RegExp for illegal abstract class names.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^(.*[.])?Abstract.*$"</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>memberModifiers</td>
+              <td>
+                Control whether to check only methods and fields with any of the specified
+                modifiers. This property does not affect method calls nor method references.
+              </td>
+              <td>subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>
+              </td>
+              <td>no tokens</td>
+              <td>6.3</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
+                  ANNOTATION_FIELD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                  CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_CALL">
+                  METHOD_CALL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_REF">
+                  METHOD_REF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
+                  PARAMETER_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                  VARIABLE_DEF</a>.
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
+                  ANNOTATION_FIELD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                  CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_CALL">
+                  METHOD_CALL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_REF">
+                  METHOD_REF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
+                  PARAMETER_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                  VARIABLE_DEF</a>.
+              </td>
+              <td>3.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Notes" id="IllegalType_Notes">
@@ -2232,11 +2260,13 @@ class SomeClass
           (of variables, methods or parameters). This helps to avoid ambiguous cases, e.g.:
           <code>java.awt.List</code> was set as illegal class name, then, code like:
         </p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 import java.util.List;
 ...
 List list; //No violation here
-        </pre>
+          </pre>
+        </div>
         <p>
           will be ok.
         </p>
@@ -2448,112 +2478,114 @@ static final Integer ANSWER_TO_THE_ULTIMATE_QUESTION_OF_LIFE = new Integer(42);
       </subsection>
 
       <subsection name="Properties" id="MagicNumber_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>ignoreNumbers</td>
-            <td>Specify non-magic numbers.</td>
-            <td><a href="property_types.html#intSet">Number Set</a></td>
-            <td><code>-1, 0, 1, 2</code></td>
-            <td>3.1</td>
-          </tr>
-          <tr>
-            <td>ignoreHashCodeMethod</td>
-            <td>Ignore magic numbers in hashCode methods.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.3</td>
-          </tr>
-          <tr>
-            <td>ignoreAnnotation</td>
-            <td>Ignore magic numbers in annotation declarations.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-              <td><code>false</code></td>
-            <td>5.4</td>
-          </tr>
-          <tr>
-              <td>ignoreFieldDeclaration</td>
-              <td>Ignore magic numbers in field declarations.</td>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>ignoreNumbers</td>
+              <td>Specify non-magic numbers.</td>
+              <td><a href="property_types.html#intSet">Number Set</a></td>
+              <td><code>-1, 0, 1, 2</code></td>
+              <td>3.1</td>
+            </tr>
+            <tr>
+              <td>ignoreHashCodeMethod</td>
+              <td>Ignore magic numbers in hashCode methods.</td>
               <td><a href="property_types.html#boolean">Boolean</a></td>
               <td><code>false</code></td>
-              <td>6.6</td>
-          </tr>
-          <tr>
-            <td>ignoreAnnotationElementDefaults</td>
-            <td>Ignore magic numbers in annotation elements defaults.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>8.23</td>
-          </tr>
-          <tr>
-              <td>constantWaiverParentToken</td>
-              <td>Specify tokens that are allowed in the AST path from the number literal to the
-                  enclosing constant definition.</td>
+              <td>5.3</td>
+            </tr>
+            <tr>
+              <td>ignoreAnnotation</td>
+              <td>Ignore magic numbers in annotation declarations.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+                <td><code>false</code></td>
+              <td>5.4</td>
+            </tr>
+            <tr>
+                <td>ignoreFieldDeclaration</td>
+                <td>Ignore magic numbers in field declarations.</td>
+                <td><a href="property_types.html#boolean">Boolean</a></td>
+                <td><code>false</code></td>
+                <td>6.6</td>
+            </tr>
+            <tr>
+              <td>ignoreAnnotationElementDefaults</td>
+              <td>Ignore magic numbers in annotation elements defaults.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>8.23</td>
+            </tr>
+            <tr>
+                <td>constantWaiverParentToken</td>
+                <td>Specify tokens that are allowed in the AST path from the number literal to the
+                    enclosing constant definition.</td>
+                <td>subset of tokens
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>
+                </td>
+                <td>
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPECAST">
+                  TYPECAST</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_CALL">
+                  METHOD_CALL</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EXPR">
+                  EXPR</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_INIT">
+                  ARRAY_INIT</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_MINUS">
+                  UNARY_MINUS</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_PLUS">
+                  UNARY_PLUS</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ELIST">
+                  ELIST</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR">
+                  STAR</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">
+                  ASSIGN</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS">
+                  PLUS</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS">
+                  MINUS</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV">
+                  DIV</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NEW">
+                  LITERAL_NEW</a>
+                </td>
+                <td>6.11</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
               <td>subset of tokens
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_DOUBLE">
+                  NUM_DOUBLE</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_FLOAT">
+                  NUM_FLOAT</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_INT">
+                  NUM_INT</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_LONG">
+                  NUM_LONG</a>.
               </td>
               <td>
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPECAST">
-                TYPECAST</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_CALL">
-                METHOD_CALL</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EXPR">
-                EXPR</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_INIT">
-                ARRAY_INIT</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_MINUS">
-                UNARY_MINUS</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_PLUS">
-                UNARY_PLUS</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ELIST">
-                ELIST</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR">
-                STAR</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">
-                ASSIGN</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS">
-                PLUS</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS">
-                MINUS</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV">
-                DIV</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NEW">
-                LITERAL_NEW</a>
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_DOUBLE">
+                  NUM_DOUBLE</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_FLOAT">
+                  NUM_FLOAT</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_INT">
+                  NUM_INT</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_LONG">
+                  NUM_LONG</a>.
               </td>
-              <td>6.11</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>subset of tokens
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_DOUBLE">
-                NUM_DOUBLE</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_FLOAT">
-                NUM_FLOAT</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_INT">
-                NUM_INT</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_LONG">
-                NUM_LONG</a>.
-            </td>
-            <td>
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_DOUBLE">
-                NUM_DOUBLE</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_FLOAT">
-                NUM_FLOAT</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_INT">
-                NUM_INT</a>,
-                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_LONG">
-                NUM_LONG</a>.
-            </td>
-            <td>3.1</td>
-          </tr>
-        </table>
+              <td>3.1</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="MagicNumber_Examples">
@@ -2844,32 +2876,34 @@ for (int i = 0; i &lt; 10;) {
       </subsection>
 
        <subsection name="Properties" id="ModifiedControlVariable_Properties">
-        <table>
-          <tr class="header">
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
+         <div class="wrapper">
+           <table>
+             <tr class="header">
+               <th>name</th>
+               <th>description</th>
+               <th>type</th>
+               <th>default value</th>
+               <th>since</th>
+            </tr>
 
-          <tr>
-            <td>skipEnhancedForLoopVariable</td>
-            <td>Control whether to check
-              <a href = "https://docs.oracle.com/javase/specs/jls/se11/html/jls-14.html#jls-14.14.2">
-              enhanced for-loop</a> variable.</td>
-            <td>
-              <a
-              href="property_types.html#boolean">Boolean</a>
-            </td>
-            <td>
-             <code>
-              false
-             </code>
-            </td>
-            <td>6.8</td>
-          </tr>
-        </table>
+           <tr>
+             <td>skipEnhancedForLoopVariable</td>
+             <td>Control whether to check
+               <a href = "https://docs.oracle.com/javase/specs/jls/se11/html/jls-14.html#jls-14.14.2">
+                 enhanced for-loop</a> variable.</td>
+             <td>
+               <a
+                   href="property_types.html#boolean">Boolean</a>
+             </td>
+             <td>
+               <code>
+                 false
+               </code>
+             </td>
+             <td>6.8</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="ModifiedControlVariable_Examples">
@@ -2955,50 +2989,52 @@ for (String line: lines) {
       </subsection>
 
       <subsection name="Properties" id="MultipleStringLiterals_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>allowedDuplicates</td>
-            <td>
-              Specify the maximum number of occurrences to allow without generating a
-              warning.
-            </td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>1</code></td>
-            <td>3.5</td>
-          </tr>
-          <tr>
-            <td>ignoreStringsRegexp</td>
-            <td>
-              Specify RegExp for ignored strings (with quotation marks).
-            </td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^""$"</code></td>
-            <td>4.0</td>
-          </tr>
-          <tr>
-            <td>ignoreOccurrenceContext</td>
-            <td>
-              Specify token type names where duplicate strings are ignored even if they don't match
-              ignoredStringsRegexp. This allows you to exclude syntactical contexts like
-              annotations or static initializers from the check.
-            </td>
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>
-            </td>
-            <td>
-              <code>ANNOTATION</code>
-            </td>
-            <td>4.4</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>allowedDuplicates</td>
+              <td>
+                Specify the maximum number of occurrences to allow without generating a
+                warning.
+              </td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>1</code></td>
+              <td>3.5</td>
+            </tr>
+            <tr>
+              <td>ignoreStringsRegexp</td>
+              <td>
+                Specify RegExp for ignored strings (with quotation marks).
+              </td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^""$"</code></td>
+              <td>4.0</td>
+            </tr>
+            <tr>
+              <td>ignoreOccurrenceContext</td>
+              <td>
+                Specify token type names where duplicate strings are ignored even if they don't
+                match ignoredStringsRegexp. This allows you to exclude syntactical contexts like
+                annotations or static initializers from the check.
+              </td>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>
+              </td>
+              <td>
+                <code>ANNOTATION</code>
+              </td>
+              <td>4.4</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="MultipleStringLiterals_Examples">
@@ -3158,22 +3194,24 @@ for (String line: lines) {
       </subsection>
 
       <subsection name="Properties" id="NestedForDepth_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>max</td>
-            <td>Specify maximum allowed nesting depth.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>1</code></td>
-            <td>5.3</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>max</td>
+              <td>Specify maximum allowed nesting depth.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>1</code></td>
+              <td>5.3</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="NestedForDepth_Examples">
@@ -3238,22 +3276,24 @@ for (String line: lines) {
       </subsection>
 
       <subsection name="Properties" id="NestedIfDepth_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>max</td>
-            <td>Specify maximum allowed nesting depth.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>1</code></td>
-            <td>3.2</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>max</td>
+              <td>Specify maximum allowed nesting depth.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>1</code></td>
+              <td>3.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="NestedIfDepth_Examples">
@@ -3318,22 +3358,24 @@ for (String line: lines) {
       </subsection>
 
       <subsection name="Properties" id="NestedTryDepth_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>max</td>
-            <td>Specify maximum allowed nesting depth.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>1</code></td>
-            <td>3.2</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>max</td>
+              <td>Specify maximum allowed nesting depth.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>1</code></td>
+              <td>3.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="NestedTryDepth_Examples">
@@ -3629,22 +3671,24 @@ System.out.println(s2 instanceof Square); //true
       </subsection>
 
       <subsection name="Properties" id="OneStatementPerLine_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>treatTryResourcesAsStatement</td>
-            <td>Enable resources processing.</td>
-            <td><a href="property_types.html#Boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>8.23</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>treatTryResourcesAsStatement</td>
+              <td>Enable resources processing.</td>
+              <td><a href="property_types.html#Boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>8.23</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="OneStatementPerLine_Examples">
@@ -3828,22 +3872,24 @@ public void foo(int i, String s) {}
       </subsection>
 
       <subsection name="Properties" id="PackageDeclaration_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>matchDirectoryStructure</td>
-            <td>Control whether to check for directory and package name match.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>7.6.1</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>matchDirectoryStructure</td>
+              <td>Control whether to check for directory and package name match.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>7.6.1</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="PackageDeclaration_Examples">
@@ -4018,36 +4064,38 @@ public class AnnotationLocationCheck extends AbstractCheck {
       </subsection>
 
       <subsection name="Properties" id="RequireThis_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>checkFields</td>
-            <td>Control whether to check references to fields.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>3.4</td>
-          </tr>
-          <tr>
-            <td>checkMethods</td>
-            <td>Control whether to check references to methods.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>3.4</td>
-          </tr>
-          <tr>
-            <td>validateOnlyOverlapping</td>
-            <td>Control whether to check only overlapping by variables or arguments.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>6.17</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>checkFields</td>
+              <td>Control whether to check references to fields.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>3.4</td>
+            </tr>
+            <tr>
+              <td>checkMethods</td>
+              <td>Control whether to check references to methods.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>3.4</td>
+            </tr>
+            <tr>
+              <td>validateOnlyOverlapping</td>
+              <td>Control whether to check only overlapping by variables or arguments.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>6.17</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="RequireThis_Examples">
@@ -4250,61 +4298,63 @@ class C {
       </subsection>
 
       <subsection name="Properties" id="ReturnCount_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>max</td>
-            <td>
-              Specify maximum allowed number of return statements in non-void methods/lambdas.
-            </td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>2</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>maxForVoid</td>
-            <td>Specify maximum allowed number of return statements in void
-                methods/constructors/lambdas.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>1</code></td>
-            <td>6.19</td>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Specify method names to ignore.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^equals$"</code></td>
-            <td>3.4</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
-                LAMBDA</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
-                LAMBDA</a>.
-            </td>
-            <td>3.2</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>max</td>
+              <td>
+                Specify maximum allowed number of return statements in non-void methods/lambdas.
+              </td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>2</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>maxForVoid</td>
+              <td>Specify maximum allowed number of return statements in void
+                  methods/constructors/lambdas.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>1</code></td>
+              <td>6.19</td>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specify method names to ignore.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^equals$"</code></td>
+              <td>3.4</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
+                  LAMBDA</a>.
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
+                  LAMBDA</a>.
+              </td>
+              <td>3.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="ReturnCount_Examples">
@@ -4769,117 +4819,119 @@ if (&quot;something&quot;.equals(x))
       </subsection>
 
       <subsection name="Properties" id="UnnecessaryParentheses_Properties">
+        <div class="wrapper">
           <table>
-              <tr>
-                  <th>name</th>
-                  <th>description</th>
-                  <th>type</th>
-                  <th>default value</th>
-                  <th>since</th>
-              </tr>
-              <tr>
-                  <td>tokens</td>
-                  <td>tokens to check</td>
-                  <td>
-                    subset of tokens
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EXPR">
-                EXPR</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IDENT">
-                IDENT</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_DOUBLE">
-                NUM_DOUBLE</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_FLOAT">
-                NUM_FLOAT</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_INT">
-                NUM_INT</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_LONG">
-                NUM_LONG</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STRING_LITERAL">
-                STRING_LITERAL</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NULL">
-                LITERAL_NULL</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FALSE">
-                LITERAL_FALSE</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRUE">
-                LITERAL_TRUE</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">
-                ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND_ASSIGN">
-                BAND_ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR_ASSIGN">
-                BOR_ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR_ASSIGN">
-                BSR_ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR_ASSIGN">
-                BXOR_ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV_ASSIGN">
-                DIV_ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS_ASSIGN">
-                MINUS_ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD_ASSIGN">
-                MOD_ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS_ASSIGN">
-                PLUS_ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL_ASSIGN">
-                SL_ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR_ASSIGN">
-                SR_ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR_ASSIGN">
-                STAR_ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
-                LAMBDA</a>.
-                  </td>
-                  <td>
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EXPR">
-                EXPR</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IDENT">
-                IDENT</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_DOUBLE">
-                NUM_DOUBLE</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_FLOAT">
-                NUM_FLOAT</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_INT">
-                NUM_INT</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_LONG">
-                NUM_LONG</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STRING_LITERAL">
-                STRING_LITERAL</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NULL">
-                LITERAL_NULL</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FALSE">
-                LITERAL_FALSE</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRUE">
-                LITERAL_TRUE</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">
-                ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND_ASSIGN">
-                BAND_ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR_ASSIGN">
-                BOR_ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR_ASSIGN">
-                BSR_ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR_ASSIGN">
-                BXOR_ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV_ASSIGN">
-                DIV_ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS_ASSIGN">
-                MINUS_ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD_ASSIGN">
-                MOD_ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS_ASSIGN">
-                PLUS_ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL_ASSIGN">
-                SL_ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR_ASSIGN">
-                SR_ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR_ASSIGN">
-                STAR_ASSIGN</a>,
-                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
-                LAMBDA</a>.
-                  </td>
-                  <td>3.4</td>
-              </tr>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EXPR">
+                  EXPR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IDENT">
+                  IDENT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_DOUBLE">
+                  NUM_DOUBLE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_FLOAT">
+                  NUM_FLOAT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_INT">
+                  NUM_INT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_LONG">
+                  NUM_LONG</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STRING_LITERAL">
+                  STRING_LITERAL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NULL">
+                  LITERAL_NULL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FALSE">
+                  LITERAL_FALSE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRUE">
+                  LITERAL_TRUE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">
+                  ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND_ASSIGN">
+                  BAND_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR_ASSIGN">
+                  BOR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR_ASSIGN">
+                  BSR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR_ASSIGN">
+                  BXOR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV_ASSIGN">
+                  DIV_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS_ASSIGN">
+                  MINUS_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD_ASSIGN">
+                  MOD_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS_ASSIGN">
+                  PLUS_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL_ASSIGN">
+                  SL_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR_ASSIGN">
+                  SR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR_ASSIGN">
+                  STAR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
+                  LAMBDA</a>.
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EXPR">
+                  EXPR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IDENT">
+                  IDENT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_DOUBLE">
+                  NUM_DOUBLE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_FLOAT">
+                  NUM_FLOAT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_INT">
+                  NUM_INT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NUM_LONG">
+                  NUM_LONG</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STRING_LITERAL">
+                  STRING_LITERAL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NULL">
+                  LITERAL_NULL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FALSE">
+                  LITERAL_FALSE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRUE">
+                  LITERAL_TRUE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">
+                  ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND_ASSIGN">
+                  BAND_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR_ASSIGN">
+                  BOR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR_ASSIGN">
+                  BSR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR_ASSIGN">
+                  BXOR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV_ASSIGN">
+                  DIV_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS_ASSIGN">
+                  MINUS_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD_ASSIGN">
+                  MOD_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS_ASSIGN">
+                  PLUS_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL_ASSIGN">
+                  SL_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR_ASSIGN">
+                  SR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR_ASSIGN">
+                  STAR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
+                  LAMBDA</a>.
+              </td>
+              <td>3.4</td>
+            </tr>
           </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="UnnecessaryParentheses_Examples">
@@ -4986,42 +5038,44 @@ myList.stream()
         </p>
       </subsection>
       <subsection name="Properties" id="UnnecessarySemicolonAfterTypeMemberDeclaration_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>
-                subset of tokens <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>
+                subset of tokens
+                <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
                  CLASS_DEF</a>,
-                 <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                 INTERFACE_DEF</a>,
-                 <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                 ENUM_DEF</a>,
-                 <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                 ANNOTATION_DEF</a>,
-                 <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                 VARIABLE_DEF</a>,
-                 <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
-                 ANNOTATION_FIELD_DEF</a>,
-                 <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">
-                 STATIC_INIT</a>,
-                 <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">
-                 INSTANCE_INIT</a>,
-                 <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                 CTOR_DEF</a>,
-                 <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                 METHOD_DEF</a>,
-                 <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
-                 ENUM_CONSTANT_DEF</a>.
-            </td>
-            <td>
+                <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                INTERFACE_DEF</a>,
+                <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                ENUM_DEF</a>,
+                <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                ANNOTATION_DEF</a>,
+                <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                VARIABLE_DEF</a>,
+                <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
+                ANNOTATION_FIELD_DEF</a>,
+                <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">
+                STATIC_INIT</a>,
+                <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">
+                INSTANCE_INIT</a>,
+                <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                CTOR_DEF</a>,
+                <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                METHOD_DEF</a>,
+                <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
+                ENUM_CONSTANT_DEF</a>.
+              </td>
+              <td>
                 <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
                     CLASS_DEF</a>,
                 <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
@@ -5044,10 +5098,11 @@ myList.stream()
                     METHOD_DEF</a>,
                 <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
                     ENUM_CONSTANT_DEF</a>.
-            </td>
-            <td>8.24</td>
-          </tr>
-        </table>
+              </td>
+              <td>8.24</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="UnnecessarySemicolonAfterTypeMemberDeclaration_Examples">
@@ -5223,23 +5278,25 @@ enum NoSemicolon {
       </subsection>
 
       <subsection name="Properties" id="UnnecessarySemicolonInTryWithResources_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
 
-          <tr>
-            <td>allowWhenNoBraceAfterSemicolon</td>
-            <td>Allow unnecessary semicolon if closing paren is not on the same line.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>8.22</td>
-          </tr>
-        </table>
+            <tr>
+              <td>allowWhenNoBraceAfterSemicolon</td>
+              <td>Allow unnecessary semicolon if closing paren is not on the same line.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>8.22</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="UnnecessarySemicolonInTryWithResources_Examples">
@@ -5335,51 +5392,53 @@ class A {
       </subsection>
 
       <subsection name="Properties" id="VariableDeclarationUsageDistance_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
 
-          <tr>
-            <td>allowedDistance</td>
-            <td>Specify distance between declaration of variable and its first usage.
-                Values should be greater than 0.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>3</code></td>
-            <td>5.8</td>
-          </tr>
+            <tr>
+              <td>allowedDistance</td>
+              <td>Specify distance between declaration of variable and its first usage.
+                  Values should be greater than 0.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>3</code></td>
+              <td>5.8</td>
+            </tr>
 
-          <tr>
-            <td>ignoreVariablePattern</td>
-            <td>
-              Define RegExp to ignore distance calculation for variables listed in this pattern.
-            </td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>""</code></td>
-            <td>5.8</td>
-          </tr>
+            <tr>
+              <td>ignoreVariablePattern</td>
+              <td>
+                Define RegExp to ignore distance calculation for variables listed in this pattern.
+              </td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>""</code></td>
+              <td>5.8</td>
+            </tr>
 
-          <tr>
-            <td>validateBetweenScopes</td>
-            <td>Allow to calculate the distance between declaration of variable and its
-                first usage in the different scopes.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.8</td>
-          </tr>
+            <tr>
+              <td>validateBetweenScopes</td>
+              <td>Allow to calculate the distance between declaration of variable and its
+                  first usage in the different scopes.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.8</td>
+            </tr>
 
-          <tr>
-            <td>ignoreFinal</td>
-            <td>Allow to ignore variables with a 'final' modifier.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>5.8</td>
-          </tr>
-        </table>
+            <tr>
+              <td>ignoreFinal</td>
+              <td>Allow to ignore variables with a 'final' modifier.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>5.8</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="VariableDeclarationUsageDistance_Examples">

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -145,24 +145,26 @@ public abstract class Plant {
       </subsection>
 
       <subsection name="Properties" id="DesignForExtension_Properties">
-            <table>
-                <tr>
-                    <th>name</th>
-                    <th>description</th>
-                    <th>type</th>
-                    <th>default value</th>
-                    <th>since</th>
-                </tr>
-                <tr>
-                    <td>ignoredAnnotations</td>
-                    <td>
-                      Specify annotations which allow the check to skip the method from validation.
-                    </td>
-                    <td><a href="property_types.html#stringSet">String Set</a></td>
-                    <td><code>After, AfterClass, Before, BeforeClass, Test</code></td>
-                    <td>7.2</td>
-                </tr>
-            </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>ignoredAnnotations</td>
+              <td>
+                Specify annotations which allow the check to skip the method from validation.
+              </td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>After, AfterClass, Before, BeforeClass, Test</code></td>
+              <td>7.2</td>
+            </tr>
+          </table>
+        </div>
         </subsection>
 
       <subsection name="Examples" id="DesignForExtension_Examples">
@@ -478,25 +480,27 @@ public class StringUtils // not final to allow subclassing
       </subsection>
 
       <subsection name="Properties" id="InterfaceIsType_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>allowMarkerInterfaces</td>
-            <td>
-              Control whether marker interfaces like Serializable are
-              allowed.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>3.1</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>allowMarkerInterfaces</td>
+              <td>
+                Control whether marker interfaces like Serializable are
+                allowed.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>3.1</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="InterfaceIsType_Examples">
@@ -575,29 +579,31 @@ public class StringUtils // not final to allow subclassing
       </subsection>
 
       <subsection name="Properties" id="MutableException_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Specify pattern for exception class names.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^.*Exception$|^.*Error$|^.*Throwable$"</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>extendedClassNameFormat</td>
-            <td>Specify pattern for extended class names.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^.*Exception$|^.*Error$|^.*Throwable$"</code></td>
-            <td>6.2</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specify pattern for exception class names.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^.*Exception$|^.*Error$|^.*Throwable$"</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>extendedClassNameFormat</td>
+              <td>Specify pattern for extended class names.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^.*Exception$|^.*Error$|^.*Throwable$"</code></td>
+              <td>6.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="MutableException_Examples">
@@ -773,29 +779,31 @@ public class Foo{
       </subsection>
 
       <subsection name="Properties" id="ThrowsCount_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>max</td>
-            <td>Specify maximum allowed number of throws statements.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>4</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>ignorePrivateMethods</td>
-            <td>Allow private methods to be ignored.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>6.7</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>max</td>
+              <td>Specify maximum allowed number of throws statements.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>4</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>ignorePrivateMethods</td>
+              <td>Allow private methods to be ignored.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>6.7</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="ThrowsCount_Examples">
@@ -927,73 +935,75 @@ public class Foo{
       </subsection>
 
       <subsection name="Properties" id="VisibilityModifier_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>packageAllowed</td>
-            <td>Control whether package visible members are allowed.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>protectedAllowed</td>
-            <td>Control whether protected members are allowed.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>publicMemberPattern</td>
-            <td>Specify pattern for public members that should be ignored.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^serialVersionUID$"</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>allowPublicFinalFields</td>
-            <td>Allow final fields to be declared as public.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>7.0</td>
-          </tr>
-          <tr>
-            <td>allowPublicImmutableFields</td>
-            <td>Allow immutable fields to be declared as public if defined in final class.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>6.4</td>
-          </tr>
-          <tr>
-            <td>immutableClassCanonicalNames</td>
-            <td>Specify immutable classes canonical names.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>java.io.File, java.lang.Boolean, java.lang.Byte, java.lang.Character,
-              java.lang.Double, java.lang.Float, java.lang.Integer, java.lang.Long,
-              java.lang.Short, java.lang.StackTraceElement, java.lang.String,
-              java.math.BigDecimal, java.math.BigInteger, java.net.Inet4Address,
-              java.net.Inet6Address, java.net.InetSocketAddress, java.net.URI,
-              java.net.URL, java.util.Locale, java.util.UUID</code></td>
-            <td>6.4.1</td>
-          </tr>
-          <tr>
-            <td>ignoreAnnotationCanonicalNames</td>
-            <td>
-              Specify the list of annotations canonical names which ignore variables in
-              consideration.
-            </td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>com.google.common.annotations.VisibleForTesting,
-              org.junit.ClassRule, org.junit.Rule</code></td>
-            <td>6.5</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>packageAllowed</td>
+              <td>Control whether package visible members are allowed.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>protectedAllowed</td>
+              <td>Control whether protected members are allowed.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>publicMemberPattern</td>
+              <td>Specify pattern for public members that should be ignored.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^serialVersionUID$"</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>allowPublicFinalFields</td>
+              <td>Allow final fields to be declared as public.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>7.0</td>
+            </tr>
+            <tr>
+              <td>allowPublicImmutableFields</td>
+              <td>Allow immutable fields to be declared as public if defined in final class.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>6.4</td>
+            </tr>
+            <tr>
+              <td>immutableClassCanonicalNames</td>
+              <td>Specify immutable classes canonical names.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>java.io.File, java.lang.Boolean, java.lang.Byte, java.lang.Character,
+                java.lang.Double, java.lang.Float, java.lang.Integer, java.lang.Long,
+                java.lang.Short, java.lang.StackTraceElement, java.lang.String,
+                java.math.BigDecimal, java.math.BigInteger, java.net.Inet4Address,
+                java.net.Inet6Address, java.net.InetSocketAddress, java.net.URI,
+                java.net.URL, java.util.Locale, java.util.UUID</code></td>
+              <td>6.4.1</td>
+            </tr>
+            <tr>
+              <td>ignoreAnnotationCanonicalNames</td>
+              <td>
+                Specify the list of annotations canonical names which ignore variables in
+                consideration.
+              </td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>com.google.common.annotations.VisibleForTesting,
+                org.junit.ClassRule, org.junit.Rule</code></td>
+              <td>6.5</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="VisibilityModifier_Examples">

--- a/src/xdocs/config_filefilters.xml
+++ b/src/xdocs/config_filefilters.xml
@@ -46,22 +46,24 @@
         </p>
       </subsection>
       <subsection name="Properties" id="BeforeExecutionExclusionFileFilter_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>fileNamePattern</td>
-            <td>Define regular expression to match the file name against.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>null</code></td>
-            <td>7.2</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>fileNamePattern</td>
+              <td>Define regular expression to match the file name against.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>null</code></td>
+              <td>7.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
       <subsection name="Examples" id="BeforeExecutionExclusionFileFilter_Examples">
           <p>

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -32,36 +32,38 @@
         </p>
       </subsection>
       <subsection name="Properties" id="SeverityMatchFilter_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>severity</td>
-            <td>Specify the severity level of this filter.</td>
-            <td><a href="property_types.html#severity">Severity</a></td>
-            <td><code>error</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>acceptOnMatch</td>
-            <td>
-               Control whether the filter accepts an audit event if and only if there is
-               a match between the event's severity level and property
-               severity. If acceptOnMatch
-               is <code>false</code>, then the filter
-               accepts an audit event if and only if there is not a match
-               between the event's severity level and property severity.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>3.2</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>severity</td>
+              <td>Specify the severity level of this filter.</td>
+              <td><a href="property_types.html#severity">Severity</a></td>
+              <td><code>error</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>acceptOnMatch</td>
+              <td>
+                 Control whether the filter accepts an audit event if and only if there is
+                 a match between the event's severity level and property
+                 severity. If acceptOnMatch
+                 is <code>false</code>, then the filter
+                 accepts an audit event if and only if there is not a match
+                 between the event's severity level and property severity.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>3.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
       <subsection name="Examples" id="SeverityMatchFilter_Examples">
           <p>
@@ -130,6 +132,7 @@
         </p>
       </subsection>
       <subsection name="Properties" id="SuppressionCommentFilter_Properties">
+        <div class="wrapper">
           <table>
               <tr>
                   <th>name</th>
@@ -188,6 +191,7 @@
                   <td>3.5</td>
               </tr>
           </table>
+        </div>
       </subsection>
       <subsection name="Examples" id="SuppressionCommentFilter_Examples">
           <p>
@@ -440,37 +444,39 @@ public class UserService {
           </p>
       </subsection>
       <subsection name="Properties" id="SuppressionFilter_Properties">
+        <div class="wrapper">
           <table>
-             <tr>
-               <th>name</th>
-               <th>description</th>
-               <th>type</th>
-               <th>default value</th>
-               <th>since</th>
-             </tr>
-             <tr>
-               <td>file</td>
-               <td>
-                  Specify the location of the <em>suppressions XML document</em> file.
-               </td>
-               <td><a href="property_types.html#string">String</a></td>
-               <td><code>null</code></td>
-               <td>3.2</td>
-             </tr>
-             <tr>
-               <td>optional</td>
-               <td>
-                   Control what to do when the file is not existing. If
-                   <code>optional</code> is set to <code>false</code> the file must exist, or else
-                   it ends with error. On the other hand if optional is
-                   <code>true</code> and file is not found, the filter accept all
-                   audit events.
-               </td>
-               <td><a href="property_types.html#boolean">Boolean</a></td>
-               <td><code>false</code></td>
-               <td>6.15</td>
-             </tr>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>file</td>
+              <td>
+                Specify the location of the <em>suppressions XML document</em> file.
+              </td>
+              <td><a href="property_types.html#string">String</a></td>
+              <td><code>null</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>optional</td>
+              <td>
+                Control what to do when the file is not existing. If
+                <code>optional</code> is set to <code>false</code> the file must exist, or else
+                it ends with error. On the other hand if optional is
+                <code>true</code> and file is not found, the filter accept all
+                audit events.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>6.15</td>
+            </tr>
           </table>
+        </div>
       </subsection>
       <subsection name="Notes" id="SuppressionFilter_Notes">
         <p>
@@ -687,63 +693,65 @@ public class UserService {
         </p>
       </subsection>
       <subsection name="Properties" id="SuppressionSingleFilter_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>files</td>
-            <td>Define the RegExp for matching against the file name associated
-                with an audit event.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>null</code></td>
-            <td>8.23</td>
-          </tr>
-          <tr>
-            <td>checks</td>
-            <td>Define the RegExp for matching against the name of the check
-                associated with an audit event.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>null</code></td>
-            <td>8.23</td>
-          </tr>
-          <tr>
-            <td>message</td>
-            <td>Define the RegExp for matching against the message of the check associated
-                with an audit event.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>null</code></td>
-            <td>8.23</td>
-          </tr>
-          <tr>
-            <td>id</td>
-            <td>Specify a string matched against the ID of the check associated with an audit
-                event.</td>
-            <td><a href="property_types.html#string">String</a></td>
-            <td><code>null</code></td>
-            <td>8.23</td>
-          </tr>
-          <tr>
-            <td>lines</td>
-            <td>Specify a comma-separated list of values, where each value is an integer or a range
-                of integers denoted by integer-integer.</td>
-            <td><a href="property_types.html#string">String</a></td>
-            <td><code>null</code></td>
-            <td>8.23</td>
-          </tr>
-          <tr>
-            <td>columns</td>
-            <td>Specify a comma-separated list of values, where each value is an integer or a range
-                of integers denoted by integer-integer.</td>
-            <td><a href="property_types.html#string">String</a></td>
-            <td><code>null</code></td>
-            <td>8.23</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>files</td>
+              <td>Define the RegExp for matching against the file name associated
+                  with an audit event.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>null</code></td>
+              <td>8.23</td>
+            </tr>
+            <tr>
+              <td>checks</td>
+              <td>Define the RegExp for matching against the name of the check
+                  associated with an audit event.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>null</code></td>
+              <td>8.23</td>
+            </tr>
+            <tr>
+              <td>message</td>
+              <td>Define the RegExp for matching against the message of the check associated
+                  with an audit event.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>null</code></td>
+              <td>8.23</td>
+            </tr>
+            <tr>
+              <td>id</td>
+              <td>Specify a string matched against the ID of the check associated with an audit
+                  event.</td>
+              <td><a href="property_types.html#string">String</a></td>
+              <td><code>null</code></td>
+              <td>8.23</td>
+            </tr>
+            <tr>
+              <td>lines</td>
+              <td>Specify a comma-separated list of values, where each value is an integer or a
+                range of integers denoted by integer-integer.</td>
+              <td><a href="property_types.html#string">String</a></td>
+              <td><code>null</code></td>
+              <td>8.23</td>
+            </tr>
+            <tr>
+              <td>columns</td>
+              <td>Specify a comma-separated list of values, where each value is an integer or a
+                range of integers denoted by integer-integer.</td>
+              <td><a href="property_types.html#string">String</a></td>
+              <td><code>null</code></td>
+              <td>8.23</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
       <subsection name="Examples" id="SuppressionSingleFilter_Examples">
           <p>
@@ -1032,37 +1040,39 @@ public class UserService {
         </ol>
       </subsection>
       <subsection name="Properties" id="SuppressionXpathFilter_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>file</td>
-            <td>
-              Specify the location of the <em>suppressions XML document</em> file.
-            </td>
-            <td><a href="property_types.html#string">String</a></td>
-            <td><code>null</code></td>
-            <td>8.6</td>
-          </tr>
-          <tr>
-            <td>optional</td>
-            <td>
-              Control what to do when the file is not existing. If
-              optional is set to false the file must exist, or else
-              it ends with error. On the other hand if optional is
-              true and file is not found, the filter accepts all
-              audit events.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>8.6</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>file</td>
+              <td>
+                Specify the location of the <em>suppressions XML document</em> file.
+              </td>
+              <td><a href="property_types.html#string">String</a></td>
+              <td><code>null</code></td>
+              <td>8.6</td>
+            </tr>
+            <tr>
+              <td>optional</td>
+              <td>
+                Control what to do when the file is not existing. If
+                optional is set to false the file must exist, or else
+                it ends with error. On the other hand if optional is
+                true and file is not found, the filter accepts all
+                audit events.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>8.6</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
       <subsection name="Examples" id="SuppressionXpathFilter_Examples">
         <p>
@@ -1421,54 +1431,56 @@ CLASS_DEF -> CLASS_DEF [1:0]
         </p>
       </subsection>
       <subsection name="Properties" id="SuppressionXpathSingleFilter_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>files</td>
-            <td>Define a Regular Expression matched against the file name associated
-                with an audit event.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>null</code></td>
-            <td>8.18</td>
-          </tr>
-          <tr>
-            <td>checks</td>
-            <td>Define a Regular Expression matched against the name of the check
-                associated with an audit event.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>null</code></td>
-            <td>8.18</td>
-          </tr>
-          <tr>
-            <td>message</td>
-            <td>Define a Regular Expression matched against the message of the check associated
-                with an audit event.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>null</code></td>
-            <td>8.18</td>
-          </tr>
-          <tr>
-            <td>id</td>
-            <td>Define a string matched against the ID of the check associated with an audit
-                event.</td>
-            <td><a href="property_types.html#string">String</a></td>
-            <td><code>null</code></td>
-            <td>8.18</td>
-          </tr>
-          <tr>
-            <td>query</td>
-            <td>Define a string xpath query.</td>
-            <td><a href="property_types.html#string">String</a></td>
-            <td><code>null</code></td>
-            <td>8.18</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>files</td>
+              <td>Define a Regular Expression matched against the file name associated
+                  with an audit event.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>null</code></td>
+              <td>8.18</td>
+            </tr>
+            <tr>
+              <td>checks</td>
+              <td>Define a Regular Expression matched against the name of the check
+                  associated with an audit event.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>null</code></td>
+              <td>8.18</td>
+            </tr>
+            <tr>
+              <td>message</td>
+              <td>Define a Regular Expression matched against the message of the check associated
+                  with an audit event.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>null</code></td>
+              <td>8.18</td>
+            </tr>
+            <tr>
+              <td>id</td>
+              <td>Define a string matched against the ID of the check associated with an audit
+                  event.</td>
+              <td><a href="property_types.html#string">String</a></td>
+              <td><code>null</code></td>
+              <td>8.18</td>
+            </tr>
+            <tr>
+              <td>query</td>
+              <td>Define a string xpath query.</td>
+              <td><a href="property_types.html#string">String</a></td>
+              <td><code>null</code></td>
+              <td>8.18</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
       <subsection name="Examples" id="SuppressionXpathSingleFilter_Examples">
         <p>
@@ -1476,7 +1488,8 @@ CLASS_DEF -> CLASS_DEF [1:0]
           for all methods with name MyMethod
           inside FileOne and FileTwo files:
         </p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 &lt;module name="SuppressionXpathSingleFilter"&gt;
   &lt;property name="files" value="File(One|Two)\.java"/&gt;
   &lt;property name="checks" value="MethodName"/&gt;
@@ -1484,9 +1497,11 @@ CLASS_DEF -> CLASS_DEF [1:0]
             METHOD_DEF[@text='MyMethod']/IDENT)|
             (/CLASS_DEF[@text='FileTwo']/OBJBLOCK/METHOD_DEF[@text='MyMethod']/IDENT)"/&gt;
 &lt;/module&gt;
-        </pre>
+          </pre>
+        </div>
         <p>Code example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 public class FileOne {
   public void MyMethod() {} // OK
 }
@@ -1499,29 +1514,35 @@ public class FileThree {
   public void MyMethod() {} // violation, name 'MyMethod'
                             // must match pattern '^[a-z](_?[a-zA-Z0-9]+)*$'
 }
-        </pre>
+          </pre>
+        </div>
         <p>
           To suppress MethodName check for method names matched pattern 'MyMethod[0-9]':
         </p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 &lt;module name="SuppressionXpathSingleFilter"&gt;
   &lt;property name="checks" value="MethodName"/&gt;
   &lt;property name="message" value="MyMethod[0-9]"/&gt;
 &lt;/module&gt;
-        </pre>
+          </pre>
+        </div>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 public class FileOne {
   public void MyMethod1() {} // OK
   public void MyMethod2() {} // OK
   public void MyMethodA() {} // violation, name 'MyMethodA' must
                              // match pattern '^[a-z](_?[a-zA-Z0-9]+)*$'
 }
-        </pre>
+          </pre>
+        </div>
         <p>
           To suppress checks being specified by id property:
         </p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 &lt;module name="MethodName"&gt;
   &lt;property name="id" value="MethodName1"/&gt;
   &lt;property name="format" value="^[a-z](_?[a-zA-Z0-9]+)*$"/&gt;
@@ -1530,9 +1551,11 @@ public class FileOne {
   &lt;property name="files" value="FileOne.java"/&gt;
   &lt;property name="id" value="MethodName1"/&gt;
 &lt;module/&gt;
-        </pre>
+          </pre>
+        </div>
         <p>Code example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 public class FileOne {
   public void MyMethod() {} // OK
 }
@@ -1540,48 +1563,60 @@ public class FileTwo {
   public void MyMethod() {} // violation,  name 'MyMethod' must
                             //match pattern '^[a-z](_?[a-zA-Z0-9]+)*$'
 }
-        </pre>
+          </pre>
+        </div>
         <p>
           To suppress checks for all package definitions:
         </p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 &lt;module name="SuppressionXpathSingleFilter&gt;
   &lt;property name="checks" value="PackageName"/&gt;
   &lt;property name="query" query="/PACKAGE_DEF[@text='File']/IDENT"/&gt;
 &lt;/module&gt;
-        </pre>
+          </pre>
+        </div>
         <p>Code example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 package File; // OK
 
 public class FileOne {}
-        </pre>
+          </pre>
+        </div>
         <p>
           To suppress RedundantModifier check for interface definitions:
         </p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 &lt;module name="SuppressionXpathSingleFilter"&gt;
   &lt;property name="checks" value="RedundantModifier"/&gt;
   &lt;property name="query" value="/INTERFACE_DEF//*"/&gt;
 &lt;module/&gt;
-        </pre>
+          </pre>
+        </div>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 public interface TestClass {
   public static final int CONSTANT1 = 1;  // OK
 }
-        </pre>
+          </pre>
+        </div>
         <p>
           To suppress checks in the FileOne file by non-query:
         </p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 &lt;module name="SuppressionXpathSingleFilter"&gt;
   &lt;property name="files" value="FileOne.java"/&gt;
   &lt;property name="checks" value="MyMethod"/&gt;
 &lt;/module&gt;
-        </pre>
+          </pre>
+        </div>
         <p>Code example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 public class FileOne {
   public void MyMethod() {} // OK
 }
@@ -1590,21 +1625,25 @@ public class FileTwo {
   public void MyMethod() {} // violation, name 'MyMethod'
                             // must match pattern '^[a-z](_?[a-zA-Z0-9]+)*$'
 }
-        </pre>
+          </pre>
+        </div>
         <p>
           Suppress checks for elements which are either class definitions,
           either method definitions:
         </p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 &lt;module name="SuppressionXpathSingleFilter"&gt;
   &lt;property name="checks" value=".*"/&gt;
   &lt;property name="query"
             value="(/CLASS_DEF[@text='FileOne'])|
             (/CLASS_DEF[@text='FileOne']/OBJBLOCK/METHOD_DEF[@text='MyMethod']/IDENT)"/&gt;
 &lt;/module&gt;
-        </pre>
+          </pre>
+        </div>
         <p>Code example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 abstract class FileOne { // OK
   public void MyMethod() {} // OK
 }
@@ -1614,40 +1653,48 @@ abstract class FileTwo { // violation of the AbstractClassName check,
   public void MyMethod() {} // violation, name 'MyMethod'
                             // must match pattern '^[a-z](_?[a-zA-Z0-9]+)*$'
 }
-        </pre>
+          </pre>
+        </div>
         <p>
           Suppress checks for MyMethod1 or MyMethod2 methods:
         </p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 &lt;module name="SuppressionXpathSingleFilter"&gt;
   &lt;property name="checks" value="MethodName"/&gt;
   &lt;property name="query" value="/CLASS_DEF[@text='FileOne']/OBJBLOCK/
             METHOD_DEF[@text='MyMethod1' or @text='MyMethod2']/IDENT"/&gt;
 &lt;/module&gt;
-        </pre>
+          </pre>
+        </div>
         <p>Code example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 public class FileOne {
   public void MyMethod1() {} // OK
   public void MyMethod2() {} // OK
   public void MyMethod3() {} // violation, name 'MyMethod3' must
                              // match pattern '^[a-z](_?[a-zA-Z0-9]+)*$'
 }
-        </pre>
+          </pre>
+        </div>
         <p>
           Suppress checks for variable testVariable inside
           testMethod method inside TestClass class:
         </p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 &lt;module name="SuppressionXpathSingleFilter"&gt;
   &lt;property name="checks" value="LocalFinalVariableName"/&gt;
   &lt;property name="query" value="/CLASS_DEF[@text='TestClass']/OBJBLOCK
         /METHOD_DEF[@text='testMethod']/SLIST
         /VARIABLE_DEF[@text='testVariable1']/IDENT"/&gt;
 &lt;/module&gt;
-        </pre>
+          </pre>
+        </div>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 public class TestClass {
   public void testMethod() {
     final int testVariable1 = 10; // OK
@@ -1655,21 +1702,25 @@ public class TestClass {
                                   // name 'testVariable2' must match pattern '^[A-Z][A-Z0-9]*$'
   }
 }
-        </pre>
+          </pre>
+        </div>
         <p>
           In the following sample, violations for LeftCurly check
           will be suppressed for classes with name Main or for methods
           with name calculate.
         </p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 &lt;module name="SuppressionXpathSingleFilter"&gt;
   &lt;property name="checks" value="LeftCurly"/&gt;
   &lt;property name="query" value="/CLASS_DEF[@text='TestClass']/OBJBLOCK
         /METHOD_DEF[@text='testMethod1']/SLIST*"/&gt;
 &lt;/module&gt;
-        </pre>
+          </pre>
+        </div>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 public class TestClass {
   public void testMethod1()
   { // OK
@@ -1679,20 +1730,24 @@ public class TestClass {
   { // violation, '{' should be on the previous line
   }
 }
-        </pre>
+          </pre>
+        </div>
         <p>
           The following example demonstrates how to suppress
           RequireThis violations for variable age inside changeAge method.
         </p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 &lt;module name="SuppressionXpathSingleFilter"&gt;
   &lt;property name="checks" value="RequireThis"/&gt;
   &lt;property name="query" value="/CLASS_DEF[@text='InputTest']
         //METHOD_DEF[@text='changeAge']//ASSIGN[@text='age']/IDENT"/&gt;
 &lt;/module&gt;
-        </pre>
+          </pre>
+        </div>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 public class InputTest {
   private int age = 23;
 
@@ -1700,7 +1755,8 @@ public class InputTest {
     age = 24; // violation will be suppressed
   }
 }
-        </pre>
+          </pre>
+        </div>
         <p>
           Suppress <code>IllegalThrows</code> violations only for methods with name
           <i>throwsMethod</i> and only for <code>RuntimeException</code> exceptions.
@@ -1709,15 +1765,18 @@ public class InputTest {
           <code>METHOD_DEF</code> and name <i>throwsMethod</i>. Please read more about xpath axes at
           <a href="https://www.w3schools.com/xml/xpath_axes.asp">W3Schools Xpath Axes</a>.
         </p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 &lt;module name="SuppressionXpathSingleFilter"&gt;
   &lt;property name="checks" value="IllegalThrows"/&gt;
   &lt;property name="query" value="//LITERAL_THROWS/IDENT[
       ..[@text='RuntimeException'] and ./ancestor::METHOD_DEF[@text='throwsMethod']]"/&gt;
 &lt;/module&gt;
-        </pre>
+          </pre>
+        </div>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 public class InputTest {
   public void throwsMethod() throws RuntimeException { // violation will be suppressed
   }
@@ -1725,7 +1784,8 @@ public class InputTest {
   public void sampleMethod() throws RuntimeException { // will throw violation here
   }
 }
-        </pre>
+          </pre>
+        </div>
         <p>
           The following sample demonstrates how to suppress all violations for method itself and
           all descendants. <code>descendant-or-self</code> axis iterates through current node and
@@ -1733,15 +1793,18 @@ public class InputTest {
           Please read more about xpath syntax at
           <a href="https://www.w3schools.com/xml/xpath_syntax.asp">W3Schools Xpath Syntax</a>.
         </p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 &lt;module name="SuppressionXpathSingleFilter"&gt;
   &lt;property name="checks" value=".*"/&gt;
   &lt;property name="query" value="//METHOD_DEF[@text='TestMethod1']
         /descendant-or-self::node()"/&gt;
 &lt;/module&gt;
-        </pre>
+          </pre>
+        </div>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 public class TestClass {
   public void TestMethod1() { // OK
     final int num = 10; // OK
@@ -1753,14 +1816,16 @@ public class TestClass {
                         // name 'num' must match pattern '^[A-Z][A-Z0-9]*$'
   }
 }
-        </pre>
+          </pre>
+        </div>
         <p>
           The following example is an example of what checks would be suppressed
           while building Spring projects with checkstyle plugin.
           Please find more information at:
           <a href="https://github.com/spring-io/spring-javaformat">spring-javaformat</a>
         </p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 &lt;module name="SuppressionXpathSingleFilter"&gt;
   &lt;property name="files" value="[\\/]src[\\/]test[\\/]java[\\/]"/&gt;
   &lt;property name="checks" value="Javadoc*"/&gt;
@@ -1773,7 +1838,8 @@ public class TestClass {
   &lt;property name="files" value="generated-sources"&gt;
   &lt;property name="checks" value="[a-zA-Z0-9]*"&gt;
 &lt;/module&gt;
-        </pre>
+          </pre>
+        </div>
       </subsection>
       <subsection name="Example of Usage" id="SuppressionXpathSingleFilter_Example_of_Usage">
         <ul>
@@ -1925,6 +1991,7 @@ public static void foo() {
             </p>
         </subsection>
         <subsection name="Properties" id="SuppressWithNearbyCommentFilter_Properties">
+          <div class="wrapper">
             <table>
                 <tr>
                     <th>name</th>
@@ -1984,6 +2051,7 @@ public static void foo() {
                     <td>5.0</td>
                 </tr>
             </table>
+          </div>
         </subsection>
         <subsection name="Examples" id="SuppressWithNearbyCommentFilter_Examples">
             <p>
@@ -2198,6 +2266,7 @@ public class UserService {
               </p>
           </subsection>
           <subsection name="Properties" id="SuppressWithPlainTextCommentFilter_Properties">
+            <div class="wrapper">
               <table>
                   <tr>
                       <th>name</th>
@@ -2242,6 +2311,7 @@ public class UserService {
                       <td>8.24</td>
                   </tr>
               </table>
+            </div>
           </subsection>
           <subsection name="Notes" id="SuppressWithPlainTextCommentFilter_Notes">
               <p>

--- a/src/xdocs/config_header.xml
+++ b/src/xdocs/config_header.xml
@@ -64,55 +64,57 @@ line 5: ////////////////////////////////////////////////////////////////////
       </subsection>
 
       <subsection name="Properties" id="Header_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>headerFile</td>
-            <td>Specify the name of the file containing the required header.</td>
-            <td><a href="property_types.html#uri">URI</a></td>
-            <td><code>null</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>charset</td>
-            <td>Specify the character encoding to use when reading the headerFile.</td>
-            <td><a href="property_types.html#string">String</a></td>
-            <td>the charset property of the parent
-            <a href="config.html#Checker">Checker</a> module</td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>header</td>
-            <td>
-              Specify the required header specified inline. Individual header lines
-              must be separated by the string <code>&quot;\n&quot;</code> (even on platforms with a
-              different line separator), see examples below.
-            </td>
-            <td><a href="property_types.html#string">String</a></td>
-            <td><code>null</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>ignoreLines</td>
-            <td>Specify the line numbers to ignore.</td>
-            <td><a href="property_types.html#intSet">Integer Set</a></td>
-            <td><code>{}</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>fileExtensions</td>
-            <td>Specify the file type extension of files to process.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>all files</code></td>
-            <td>6.9</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>headerFile</td>
+              <td>Specify the name of the file containing the required header.</td>
+              <td><a href="property_types.html#uri">URI</a></td>
+              <td><code>null</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>charset</td>
+              <td>Specify the character encoding to use when reading the headerFile.</td>
+              <td><a href="property_types.html#string">String</a></td>
+              <td>the charset property of the parent
+              <a href="config.html#Checker">Checker</a> module</td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>header</td>
+              <td>
+                Specify the required header specified inline. Individual header lines
+                must be separated by the string <code>&quot;\n&quot;</code> (even on platforms with
+                a different line separator), see examples below.
+              </td>
+              <td><a href="property_types.html#string">String</a></td>
+              <td><code>null</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>ignoreLines</td>
+              <td>Specify the line numbers to ignore.</td>
+              <td><a href="property_types.html#intSet">Integer Set</a></td>
+              <td><code>{}</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>fileExtensions</td>
+              <td>Specify the file type extension of files to process.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>all files</code></td>
+              <td>6.9</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="Header_Examples">
@@ -277,57 +279,59 @@ line 6: ^\W*$
       </subsection>
 
       <subsection name="Properties" id="RegexpHeader_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>headerFile</td>
-            <td>Specify the name of the file containing the required header.</td>
-            <td><a href="property_types.html#uri">URI</a></td>
-            <td><code>null</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>charset</td>
-            <td>Specify the character encoding to use when reading the headerFile.</td>
-            <td><a href="property_types.html#string">String</a></td>
-            <td>the charset property of the parent
-            <a href="config.html#Checker">Checker</a> module</td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>header</td>
-            <td>
-              Define the required header specified inline. Individual header lines
-              must be separated by the string <code>&quot;\n&quot;</code> (even on platforms with a
-              different line separator). For header lines containing <code>&quot;\n\n&quot;</code>
-              checkstyle will forcefully expect an empty line to exist. See examples
-              below. Regular expressions must not span multiple lines.
-            </td>
-            <td><a href="property_types.html#string">String</a></td>
-            <td><code>null</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>multiLines</td>
-            <td>Specify the line numbers to repeat (zero or more times).</td>
-            <td><a href="property_types.html#intSet">Integer Set</a></td>
-            <td><code>{}</code></td>
-            <td>3.4</td>
-          </tr>
-          <tr>
-            <td>fileExtensions</td>
-            <td>Specify the file type extension of files to process.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>all files</code></td>
-            <td>6.9</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>headerFile</td>
+              <td>Specify the name of the file containing the required header.</td>
+              <td><a href="property_types.html#uri">URI</a></td>
+              <td><code>null</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>charset</td>
+              <td>Specify the character encoding to use when reading the headerFile.</td>
+              <td><a href="property_types.html#string">String</a></td>
+              <td>the charset property of the parent
+              <a href="config.html#Checker">Checker</a> module</td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>header</td>
+              <td>
+                Define the required header specified inline. Individual header lines
+                must be separated by the string <code>&quot;\n&quot;</code> (even on platforms with
+                a different line separator). For header lines containing
+                <code>&quot;\n\n&quot;</code> checkstyle will forcefully expect an empty line to
+                exist. See examples below. Regular expressions must not span multiple lines.
+              </td>
+              <td><a href="property_types.html#string">String</a></td>
+              <td><code>null</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>multiLines</td>
+              <td>Specify the line numbers to repeat (zero or more times).</td>
+              <td><a href="property_types.html#intSet">Integer Set</a></td>
+              <td><code>{}</code></td>
+              <td>3.4</td>
+            </tr>
+            <tr>
+              <td>fileExtensions</td>
+              <td>Specify the file type extension of files to process.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>all files</code></td>
+              <td>6.9</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="RegexpHeader_Examples">

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -45,44 +45,46 @@
       </subsection>
 
       <subsection name="Properties" id="AvoidStarImport_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>excludes</td>
-            <td>
-              Specify packages where star imports are allowed.
-            </td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>{}</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>allowClassImports</td>
-            <td>
-              Control whether to allow starred class imports like
-              <code>import java.util.*;</code>.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.3</td>
-          </tr>
-          <tr>
-            <td>allowStaticMemberImports</td>
-            <td>
-              Control whether to allow starred static member imports like
-              <code>import static org.junit.Assert.*;</code>.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.3</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>excludes</td>
+              <td>
+                Specify packages where star imports are allowed.
+              </td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>{}</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>allowClassImports</td>
+              <td>
+                Control whether to allow starred class imports like
+                <code>import java.util.*;</code>.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.3</td>
+            </tr>
+            <tr>
+              <td>allowStaticMemberImports</td>
+              <td>
+                Control whether to allow starred static member imports like
+                <code>import static org.junit.Assert.*;</code>.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.3</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="AvoidStarImport_Examples">
@@ -171,27 +173,29 @@
       </subsection>
 
       <subsection name="Properties" id="AvoidStaticImport_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>excludes</td>
-            <td>
-              Control whether to allow for certain classes via a star notation to be
-              excluded such as <code>java.lang.Math.*</code> or specific static
-              members to be excluded like <code>java.lang.System.out</code> for a variable or
-              <code>java.lang.Math.random</code> for a method. See notes section for details.
-            </td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>{}</code></td>
-            <td>5.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>excludes</td>
+              <td>
+                Control whether to allow for certain classes via a star notation to be
+                excluded such as <code>java.lang.Math.*</code> or specific static
+                members to be excluded like <code>java.lang.System.out</code> for a variable or
+                <code>java.lang.Math.random</code> for a method. See notes section for details.
+              </td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>{}</code></td>
+              <td>5.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="AvoidStaticImport_Examples">
@@ -352,59 +356,61 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
       </subsection>
 
       <subsection name="Properties" id="CustomImportOrder_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>customImportOrderRules</td>
-            <td>Specify list of order declaration customizing by user.</td>
-            <td><a href="property_types.html#string">String</a></td>
-            <td><code>{}</code></td>
-            <td>5.8</td>
-          </tr>
-          <tr>
-            <td>standardPackageRegExp</td>
-            <td>Specify RegExp for STANDARD_JAVA_PACKAGE group imports.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^(java|javax)\."</code></td>
-            <td>5.8</td>
-          </tr>
-          <tr>
-            <td>thirdPartyPackageRegExp</td>
-            <td>Specify RegExp for THIRD_PARTY_PACKAGE group imports.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>".*"</code></td>
-            <td>5.8</td>
-          </tr>
-          <tr>
-            <td>specialImportsRegExp</td>
-            <td>Specify RegExp for SPECIAL_IMPORTS group imports.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^$" (empty)</code></td>
-            <td>5.8</td>
-          </tr>
-          <tr>
-            <td>separateLineBetweenGroups</td>
-            <td>Force empty line separator between import groups.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>5.8</td>
-          </tr>
-          <tr>
-            <td>sortImportsInGroupAlphabetically</td>
-            <td>Force grouping alphabetically, in
-                <a href="https://en.wikipedia.org/wiki/ASCII#Order">
-                   ASCII sort order</a>.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.8</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>customImportOrderRules</td>
+              <td>Specify list of order declaration customizing by user.</td>
+              <td><a href="property_types.html#string">String</a></td>
+              <td><code>{}</code></td>
+              <td>5.8</td>
+            </tr>
+            <tr>
+              <td>standardPackageRegExp</td>
+              <td>Specify RegExp for STANDARD_JAVA_PACKAGE group imports.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^(java|javax)\."</code></td>
+              <td>5.8</td>
+            </tr>
+            <tr>
+              <td>thirdPartyPackageRegExp</td>
+              <td>Specify RegExp for THIRD_PARTY_PACKAGE group imports.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>".*"</code></td>
+              <td>5.8</td>
+            </tr>
+            <tr>
+              <td>specialImportsRegExp</td>
+              <td>Specify RegExp for SPECIAL_IMPORTS group imports.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^$" (empty)</code></td>
+              <td>5.8</td>
+            </tr>
+            <tr>
+              <td>separateLineBetweenGroups</td>
+              <td>Force empty line separator between import groups.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>5.8</td>
+            </tr>
+            <tr>
+              <td>sortImportsInGroupAlphabetically</td>
+              <td>Force grouping alphabetically, in
+                  <a href="https://en.wikipedia.org/wiki/ASCII#Order">
+                     ASCII sort order</a>.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.8</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="CustomImportOrder_Examples">
@@ -639,45 +645,47 @@ import android.*;
       </subsection>
 
       <subsection name="Properties" id="IllegalImport_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>illegalPkgs</td>
-            <td>Specify packages to reject, if <b>regexp</b> property is not set, checks if import
-              is the part of package. If <b>regexp</b> property is set, then list of packages will
-              be interpreted as regular expressions. Note, all properties for match will be used.
-            </td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>sun</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>illegalClasses</td>
-            <td>Specify class names to reject, if <b>regexp</b> property is not set, checks if
-              import equals class name. If <b>regexp</b> property is set, then list of class names
-              will be interpreted as regular expressions. Note, all properties for match will be
-              used.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>{}</code></td>
-            <td>7.8</td>
-          </tr>
-          <tr>
-            <td>regexp</td>
-            <td>
-              Control whether the <code>illegalPkgs</code> and <code>illegalClasses</code>
-              should be interpreted as regular expressions.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>7.8</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>illegalPkgs</td>
+              <td>Specify packages to reject, if <b>regexp</b> property is not set, checks if import
+                is the part of package. If <b>regexp</b> property is set, then list of packages will
+                be interpreted as regular expressions. Note, all properties for match will be used.
+              </td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>sun</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>illegalClasses</td>
+              <td>Specify class names to reject, if <b>regexp</b> property is not set, checks if
+                import equals class name. If <b>regexp</b> property is set, then list of class names
+                will be interpreted as regular expressions. Note, all properties for match will be
+                used.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>{}</code></td>
+              <td>7.8</td>
+            </tr>
+            <tr>
+              <td>regexp</td>
+              <td>
+                Control whether the <code>illegalPkgs</code> and <code>illegalClasses</code>
+                should be interpreted as regular expressions.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>7.8</td>
+            </tr>
+          </table>
+        </div>
 
       </subsection>
 
@@ -964,45 +972,49 @@ public class InputIllegalImport { }
           document type declaration in your XML document:
         </p>
 
-        <pre>
+        <div class="wrapper">
+          <pre>
 &lt;!DOCTYPE import-control PUBLIC
     &quot;-//Checkstyle//DTD ImportControl Configuration 1.4//EN&quot;
     &quot;https://checkstyle.org/dtds/import_control_1_4.dtd&quot;&gt;
-        </pre>
+          </pre>
+        </div>
       </subsection>
 
       <subsection name="Properties" id="ImportControl_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>file</td>
-            <td>
-              Specify the location of the file containing the import control configuration.
-              It can be a regular file, URL or resource path. It will try loading
-              the path as a URL first, then as a file, and finally as a resource.
-            </td>
-            <td><a href="property_types.html#uri">URI</a></td>
-            <td><code>null</code></td>
-            <td>4.0</td>
-          </tr>
-          <tr>
-            <td>path</td>
-            <td>
-              Specify the regular expression of file paths to which this check should apply. Files
-              that don't match the pattern will not be checked. The pattern will be matched against
-              the full absolute file path.
-            </td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>".*"</code></td>
-            <td>7.5</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>file</td>
+              <td>
+                Specify the location of the file containing the import control configuration.
+                It can be a regular file, URL or resource path. It will try loading
+                the path as a URL first, then as a file, and finally as a resource.
+              </td>
+              <td><a href="property_types.html#uri">URI</a></td>
+              <td><code>null</code></td>
+              <td>4.0</td>
+            </tr>
+            <tr>
+              <td>path</td>
+              <td>
+                Specify the regular expression of file paths to which this check should apply. Files
+                that don't match the pattern will not be checked. The pattern will be matched
+                against the full absolute file path.
+              </td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>".*"</code></td>
+              <td>7.5</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="ImportControl_Examples">
@@ -1400,129 +1412,132 @@ import java.util.stream.IntStream;
       </subsection>
 
       <subsection name="Properties" id="ImportOrder_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>option</td>
-            <td>specify policy on the relative order between type imports and static imports.</td>
-            <td><a href="property_types.html#importOrder">Import Order Policy</a></td>
-            <td><code>under</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>groups</td>
-            <td>
-              specify list of <b>type import</b> groups (every group identified either by a
-              common prefix string, or by a regular expression enclosed
-              in forward slashes (e.g. <code>/regexp/</code>). All type imports,
-              which does not match any group, falls into an additional group, located at the end.
-              Thus, the empty list of type groups (the default value) means
-              one group for all type imports.
-            </td>
-            <td><a href="property_types.html#regexp">Regular Expressions</a></td>
-            <td><code>{}</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>ordered</td>
-            <td>control whether type imports within each group should be sorted.
-              It doesn't affect sorting for static imports.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td>true</td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>separated</td>
-            <td>
-              control whether type import groups should be separated by, at least, one
-              blank line or comment and aren't separated internally.
-              It doesn't affect separations for static imports.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td>false</td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-          <td>separatedStaticGroups</td>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>option</td>
+              <td>specify policy on the relative order between type imports and static imports.</td>
+              <td><a href="property_types.html#importOrder">Import Order Policy</a></td>
+              <td><code>under</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>groups</td>
               <td>
-              control whether static import groups should be separated by, at least, one
-              blank line or comment and aren't separated internally.
-              This property has effect only when the property <code>option</code>
-              is is set to <code>top</code> or <code>bottom</code>.
-              </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td>false</td>
-            <td>8.12</td>
-          </tr>
-          <tr>
-            <td>caseSensitive</td>
-            <td>control whether string comparison should be case sensitive or not.
-              Case sensitive sorting is in
-              <a href="https://en.wikipedia.org/wiki/ASCII#Order">ASCII sort order</a>.
-              It affects both type imports and static imports.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td>true</td>
-            <td>3.3</td>
-          </tr>
-          <tr>
-            <td>staticGroups</td>
-            <td>
-                specify list of <b>static</b> import groups (every group identified either by a
+                specify list of <b>type import</b> groups (every group identified either by a
                 common prefix string, or by a regular expression enclosed
-                in forward slashes (e.g. <code>/regexp/</code>). All static imports,
+                in forward slashes (e.g. <code>/regexp/</code>). All type imports,
                 which does not match any group, falls into an additional group, located at the end.
-                Thus, the empty list of static groups (the default value) means
-                one group for all static imports. This property has effect only when
-                the property <code>option</code> is set to <code>top</code> or <code>bottom</code>.
-            </td>
-            <td><a href="property_types.html#regexp">Regular Expressions</a></td>
-            <td><code>{}</code></td>
-            <td>8.12</td>
-          </tr>
-          <tr>
-            <td>sortStaticImportsAlphabetically</td>
-            <td>
-                control whether <b>static imports</b> located at <b>top</b> or
-                <b>bottom</b> are sorted within the group.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td>false</td>
-            <td>6.5</td>
-          </tr>
-          <tr>
-            <td>useContainerOrderingForStatic</td>
-            <td>
-                control whether to use container ordering (Eclipse IDE term) for static
-                imports or not.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td>false</td>
-            <td>7.1</td>
-          </tr>
+                Thus, the empty list of type groups (the default value) means
+                one group for all type imports.
+              </td>
+              <td><a href="property_types.html#regexp">Regular Expressions</a></td>
+              <td><code>{}</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>ordered</td>
+              <td>control whether type imports within each group should be sorted.
+                It doesn't affect sorting for static imports.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td>true</td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>separated</td>
+              <td>
+                control whether type import groups should be separated by, at least, one
+                blank line or comment and aren't separated internally.
+                It doesn't affect separations for static imports.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td>false</td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+            <td>separatedStaticGroups</td>
+                <td>
+                control whether static import groups should be separated by, at least, one
+                blank line or comment and aren't separated internally.
+                This property has effect only when the property <code>option</code>
+                is is set to <code>top</code> or <code>bottom</code>.
+                </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td>false</td>
+              <td>8.12</td>
+            </tr>
+            <tr>
+              <td>caseSensitive</td>
+              <td>control whether string comparison should be case sensitive or not.
+                Case sensitive sorting is in
+                <a href="https://en.wikipedia.org/wiki/ASCII#Order">ASCII sort order</a>.
+                It affects both type imports and static imports.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td>true</td>
+              <td>3.3</td>
+            </tr>
+            <tr>
+              <td>staticGroups</td>
+              <td>
+                  specify list of <b>static</b> import groups (every group identified either by a
+                  common prefix string, or by a regular expression enclosed
+                  in forward slashes (e.g. <code>/regexp/</code>). All static imports,
+                  which does not match any group, falls into an additional group, located at the
+                  end. Thus, the empty list of static groups (the default value) means
+                  one group for all static imports. This property has effect only when
+                  the property <code>option</code> is set to <code>top</code> or
+                  <code>bottom</code>.
+              </td>
+              <td><a href="property_types.html#regexp">Regular Expressions</a></td>
+              <td><code>{}</code></td>
+              <td>8.12</td>
+            </tr>
+            <tr>
+              <td>sortStaticImportsAlphabetically</td>
+              <td>
+                  control whether <b>static imports</b> located at <b>top</b> or
+                  <b>bottom</b> are sorted within the group.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td>false</td>
+              <td>6.5</td>
+            </tr>
+            <tr>
+              <td>useContainerOrderingForStatic</td>
+              <td>
+                  control whether to use container ordering (Eclipse IDE term) for static
+                  imports or not.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td>false</td>
+              <td>7.1</td>
+            </tr>
 
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
 
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_IMPORT">
-                  STATIC_IMPORT</a>.
-            </td>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_IMPORT">
+                    STATIC_IMPORT</a>.
+              </td>
 
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_IMPORT">
-                  STATIC_IMPORT</a>.
-            </td>
-            <td>3.2</td>
-          </tr>
-        </table>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_IMPORT">
+                    STATIC_IMPORT</a>.
+              </td>
+              <td>3.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="ImportOrder_Examples">
@@ -1926,22 +1941,24 @@ class FooBar {
       </subsection>
 
       <subsection name="Properties" id="UnusedImports_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>processJavadoc</td>
-            <td>Control whether to process Javadoc comments.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>5.4</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>processJavadoc</td>
+              <td>Control whether to process Javadoc comments.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>5.4</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="UnusedImports_Examples">

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -36,56 +36,58 @@
       </subsection>
 
       <subsection name="Properties" id="AtclauseOrder_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>violateExecutionOnNonTightHtml</td>
-            <td>
-              If turned on, will print violations if the Javadoc being examined by this check
-              violates the tight html rules defined at
-              <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>8.3</td>
-          </tr>
-          <tr>
-            <td>target</td>
-            <td>Specify the list of targets to check at-clauses.</td>
-            <td>subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                VARIABLE_DEF</a>
-            </td>
-            <td>6.0</td>
-          </tr>
-          <tr>
-            <td>tagOrder</td>
-            <td>Specify the order by tags.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>&#64;author, &#64;deprecated, &#64;exception, &#64;param,
-              &#64;return, &#64;see, &#64;serial, &#64;serialData, &#64;serialField,
-              &#64;since, &#64;throws, &#64;version</code></td>
-            <td>6.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>violateExecutionOnNonTightHtml</td>
+              <td>
+                If turned on, will print violations if the Javadoc being examined by this check
+                violates the tight html rules defined at
+                <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>8.3</td>
+            </tr>
+            <tr>
+              <td>target</td>
+              <td>Specify the list of targets to check at-clauses.</td>
+              <td>subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                  CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                  ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                  VARIABLE_DEF</a>
+              </td>
+              <td>6.0</td>
+            </tr>
+            <tr>
+              <td>tagOrder</td>
+              <td>Specify the order by tags.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>&#64;author, &#64;deprecated, &#64;exception, &#64;param,
+                &#64;return, &#64;see, &#64;serial, &#64;serialData, &#64;serialField,
+                &#64;since, &#64;throws, &#64;version</code></td>
+              <td>6.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="AtclauseOrder_Examples">
@@ -269,33 +271,35 @@ public class TestClass {
         </source>
       </subsection>
       <subsection name="Properties" id="JavadocBlockTagLocation_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>tags</td>
-            <td>Specify the javadoc tags to process.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>author, deprecated, exception, hidden, param, provides, return,
-              see, serial, serialData, serialField, since, throws, uses, version</code></td>
-            <td>8.24</td>
-          </tr>
-          <tr>
-            <td>violateExecutionOnNonTightHtml</td>
-            <td>
-              Control when to print violations if the Javadoc being examined by this check
-              violates the tight html rules defined at
-              <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>8.24</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>tags</td>
+              <td>Specify the javadoc tags to process.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>author, deprecated, exception, hidden, param, provides, return,
+                see, serial, serialData, serialField, since, throws, uses, version</code></td>
+              <td>8.24</td>
+            </tr>
+            <tr>
+              <td>violateExecutionOnNonTightHtml</td>
+              <td>
+                Control when to print violations if the Javadoc being examined by this check
+                violates the tight html rules defined at
+                <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>8.24</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="JavadocBlockTagLocation_Examples">
@@ -461,24 +465,26 @@ public void method();
       </subsection>
 
       <subsection name="Properties" id="JavadocContentLocation_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>location</td>
-            <td>Specify the policy on placement of the Javadoc content.</td>
-            <td>
-              <a href="property_types.html#javadocContentLocation">Javadoc Content Location</a>
-            </td>
-            <td><code>second_line</code></td>
-            <td>8.27</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>location</td>
+              <td>Specify the policy on placement of the Javadoc content.</td>
+              <td>
+                <a href="property_types.html#javadocContentLocation">Javadoc Content Location</a>
+              </td>
+              <td><code>second_line</code></td>
+              <td>8.27</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="JavadocContentLocation_Examples">
@@ -629,137 +635,139 @@ public int checkReturnTag(final int aTagIndex,
       </subsection>
 
       <subsection name="Properties" id="JavadocMethod_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>allowedAnnotations</td>
-            <td>Specify the list of annotations that allow missed documentation.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>Override</code></td>
-            <td>6.0</td>
-          </tr>
-          <tr>
-            <td>validateThrows</td>
-            <td>Control whether to validate <code>throws</code> tags.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>6.0</td>
-          </tr>
-          <tr>
-            <td>scope</td>
-            <td>Specify the visibility scope where Javadoc comments are checked.</td>
-            <td><a href="property_types.html#scope">Scope</a></td>
-            <td><code>private</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>excludeScope</td>
-            <td>Specify the visibility scope where Javadoc comments are not checked.</td>
-            <td><a href="property_types.html#scope">Scope</a></td>
-            <td><code>null</code></td>
-            <td>3.4</td>
-          </tr>
-          <tr>
-            <td>allowUndeclaredRTE</td>
-            <td>Control whether to allow documented exceptions that are not declared
-            if they are a subclass of <code>java.lang.RuntimeException</code>.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>allowThrowsTagsForSubclasses</td>
-            <td>Control whether to allow documented exceptions that
-            are subclass of one of declared exception.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>3.1</td>
-          </tr>
-          <tr>
-            <td>allowMissingParamTags</td>
-            <td>Control whether to ignore violations when a method has parameters
-            but does not have matching <code>param</code> tags in the javadoc.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>3.1</td>
-          </tr>
-          <tr>
-            <td>allowMissingThrowsTags</td>
-            <td>Control whether to ignore violations when a method declares
-            that it throws exceptions but does not have matching <code>throws</code> tags
-            in the javadoc.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>3.1</td>
-          </tr>
-          <tr>
-            <td>allowMissingReturnTag</td>
-            <td>Control whether to ignore violations when a method returns
-            non-void type and does not have a <code>return</code> tag in the javadoc.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>3.1</td>
-          </tr>
-          <tr>
-            <td>logLoadErrors</td>
-            <td>Control checkstyle's error handling when a class loading fails.
-            This check may need to load exception classes mentioned in
-            the <code>@throws</code> tag to check whether they are RuntimeExceptions.
-            If set to <code>false</code> a
-            classpath configuration problem is assumed and the TreeWalker
-            stops operating on the class completely.
-            If set to <code>true</code> (the default), checkstyle assumes a
-            typo or refactoring problem in the
-            javadoc and logs the problem in the normal checkstyle report
-            (potentially masking a configuration error).</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>4.2</td>
-          </tr>
-          <tr>
-            <td>suppressLoadErrors</td>
-            <td>Control whether to suppress violations when a class loading fails.
-            When logLoadErrors is set to true, the TreeWalker completely
-            processes a class and displays any problems with loading exceptions
-            as checkstyle violations.
-            When this property is set to true, the violations generated when
-            logLoadErrors is set true are suppressed from being reported as
-            violations in the checkstyle report.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>4.2</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>allowedAnnotations</td>
+              <td>Specify the list of annotations that allow missed documentation.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>Override</code></td>
+              <td>6.0</td>
+            </tr>
+            <tr>
+              <td>validateThrows</td>
+              <td>Control whether to validate <code>throws</code> tags.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>6.0</td>
+            </tr>
+            <tr>
+              <td>scope</td>
+              <td>Specify the visibility scope where Javadoc comments are checked.</td>
+              <td><a href="property_types.html#scope">Scope</a></td>
+              <td><code>private</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>excludeScope</td>
+              <td>Specify the visibility scope where Javadoc comments are not checked.</td>
+              <td><a href="property_types.html#scope">Scope</a></td>
+              <td><code>null</code></td>
+              <td>3.4</td>
+            </tr>
+            <tr>
+              <td>allowUndeclaredRTE</td>
+              <td>Control whether to allow documented exceptions that are not declared
+              if they are a subclass of <code>java.lang.RuntimeException</code>.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>allowThrowsTagsForSubclasses</td>
+              <td>Control whether to allow documented exceptions that
+              are subclass of one of declared exception.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>3.1</td>
+            </tr>
+            <tr>
+              <td>allowMissingParamTags</td>
+              <td>Control whether to ignore violations when a method has parameters
+              but does not have matching <code>param</code> tags in the javadoc.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>3.1</td>
+            </tr>
+            <tr>
+              <td>allowMissingThrowsTags</td>
+              <td>Control whether to ignore violations when a method declares
+              that it throws exceptions but does not have matching <code>throws</code> tags
+              in the javadoc.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>3.1</td>
+            </tr>
+            <tr>
+              <td>allowMissingReturnTag</td>
+              <td>Control whether to ignore violations when a method returns
+              non-void type and does not have a <code>return</code> tag in the javadoc.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>3.1</td>
+            </tr>
+            <tr>
+              <td>logLoadErrors</td>
+              <td>Control checkstyle's error handling when a class loading fails.
+              This check may need to load exception classes mentioned in
+              the <code>@throws</code> tag to check whether they are RuntimeExceptions.
+              If set to <code>false</code> a
+              classpath configuration problem is assumed and the TreeWalker
+              stops operating on the class completely.
+              If set to <code>true</code> (the default), checkstyle assumes a
+              typo or refactoring problem in the
+              javadoc and logs the problem in the normal checkstyle report
+              (potentially masking a configuration error).</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>4.2</td>
+            </tr>
+            <tr>
+              <td>suppressLoadErrors</td>
+              <td>Control whether to suppress violations when a class loading fails.
+              When logLoadErrors is set to true, the TreeWalker completely
+              processes a class and displays any problems with loading exceptions
+              as checkstyle violations.
+              When this property is set to true, the violations generated when
+              logLoadErrors is set true are suppressed from being reported as
+              violations in the checkstyle report.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>4.2</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
 
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
-                ANNOTATION_FIELD_DEF</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
-                ANNOTATION_FIELD_DEF</a>.
-            </td>
-            <td>3.0</td>
-          </tr>
-        </table>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
+                  ANNOTATION_FIELD_DEF</a>.
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
+                  ANNOTATION_FIELD_DEF</a>.
+              </td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="JavadocMethod_Examples">
@@ -891,31 +899,33 @@ public int checkReturnTag(final int aTagIndex,
       </subsection>
 
       <subsection name="Properties" id="JavadocPackage_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>allowLegacy</td>
-            <td>
-              Allow legacy <code>package.html</code> file to be used.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>fileExtensions</td>
-            <td>Specify the file type extension of files to process.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>.java</code></td>
-            <td>5.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>allowLegacy</td>
+              <td>
+                Allow legacy <code>package.html</code> file to be used.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>fileExtensions</td>
+              <td>Specify the file type extension of files to process.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>.java</code></td>
+              <td>5.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="JavadocPackage_Examples">
@@ -1001,34 +1011,37 @@ public int checkReturnTag(final int aTagIndex,
       </subsection>
 
       <subsection name="Properties" id="JavadocParagraph_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>violateExecutionOnNonTightHtml</td>
-            <td>
-              Control when to print violations if the Javadoc being examined by this check
-              violates the tight html rules defined at
-              <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>8.3</td>
-          </tr>
-          <tr>
-            <td>allowNewlineParagraph</td>
-            <td>
-              Control whether the &lt;p&gt; tag should be placed immediately before the first word.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>6.9</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>violateExecutionOnNonTightHtml</td>
+              <td>
+                Control when to print violations if the Javadoc being examined by this check
+                violates the tight html rules defined at
+                <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>8.3</td>
+            </tr>
+            <tr>
+              <td>allowNewlineParagraph</td>
+              <td>
+                Control whether the &lt;p&gt; tag should be placed immediately before the first
+                word.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>6.9</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="JavadocParagraph_Examples">
@@ -1206,112 +1219,114 @@ public class TestClass {
       </subsection>
 
       <subsection name="Properties" id="JavadocStyle_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>scope</td>
-            <td>Specify the visibility scope where Javadoc comments are checked.</td>
-            <td><a href="property_types.html#scope">Scope</a></td>
-            <td><code>private</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>excludeScope</td>
-            <td>Specify the visibility scope where Javadoc comments are not checked.</td>
-            <td><a href="property_types.html#scope">Scope</a></td>
-            <td><code>null</code></td>
-            <td>3.4</td>
-          </tr>
-          <tr>
-            <td>checkFirstSentence</td>
-            <td>
-              Control whether to check the first sentence for proper end of sentence.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>endOfSentenceFormat</td>
-            <td>
-              Specify the format for matching the end of a sentence.
-            </td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"([.?!][ \t\n\r\f&lt;])|([.?!]$)"</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>checkEmptyJavadoc</td>
-            <td>
-              Control whether to check if the Javadoc is missing a describing text.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>3.4</td>
-          </tr>
-          <tr>
-            <td>checkHtml</td>
-            <td>Control whether to check for incomplete HTML tags.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                ANNOTATION_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
-                ANNOTATION_FIELD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
-                ENUM_CONSTANT_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">
-                PACKAGE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                VARIABLE_DEF</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                ANNOTATION_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
-                ANNOTATION_FIELD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
-                ENUM_CONSTANT_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">
-                PACKAGE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                VARIABLE_DEF</a>.
-            </td>
-            <td>3.2</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>scope</td>
+              <td>Specify the visibility scope where Javadoc comments are checked.</td>
+              <td><a href="property_types.html#scope">Scope</a></td>
+              <td><code>private</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>excludeScope</td>
+              <td>Specify the visibility scope where Javadoc comments are not checked.</td>
+              <td><a href="property_types.html#scope">Scope</a></td>
+              <td><code>null</code></td>
+              <td>3.4</td>
+            </tr>
+            <tr>
+              <td>checkFirstSentence</td>
+              <td>
+                Control whether to check the first sentence for proper end of sentence.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>endOfSentenceFormat</td>
+              <td>
+                Specify the format for matching the end of a sentence.
+              </td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"([.?!][ \t\n\r\f&lt;])|([.?!]$)"</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>checkEmptyJavadoc</td>
+              <td>
+                Control whether to check if the Javadoc is missing a describing text.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>3.4</td>
+            </tr>
+            <tr>
+              <td>checkHtml</td>
+              <td>Control whether to check for incomplete HTML tags.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                  ANNOTATION_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
+                  ANNOTATION_FIELD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                  CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
+                  ENUM_CONSTANT_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                  ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">
+                  PACKAGE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                  VARIABLE_DEF</a>.
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                  ANNOTATION_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
+                  ANNOTATION_FIELD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                  CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
+                  ENUM_CONSTANT_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                  ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">
+                  PACKAGE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                  VARIABLE_DEF</a>.
+              </td>
+              <td>3.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="JavadocStyle_Examples">
@@ -1425,32 +1440,34 @@ public class TestClass {
       </subsection>
 
       <subsection name="Properties" id="JavadocTagContinuationIndentation_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>violateExecutionOnNonTightHtml</td>
-            <td>
-              Control when to print violations if the Javadoc being examined by this check
-              violates the tight html rules defined at
-              <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>8.3</td>
-          </tr>
-          <tr>
-            <td>offset</td>
-            <td>Specify how many spaces to use for new indentation level.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>4</code></td>
-            <td>6.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>violateExecutionOnNonTightHtml</td>
+              <td>
+                Control when to print violations if the Javadoc being examined by this check
+                violates the tight html rules defined at
+                <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>8.3</td>
+            </tr>
+            <tr>
+              <td>offset</td>
+              <td>Specify how many spaces to use for new indentation level.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>4</code></td>
+              <td>6.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="JavadocTagContinuationIndentation_Examples">
@@ -1549,94 +1566,96 @@ public class TestClass {
       </subsection>
 
       <subsection name="Properties" id="JavadocType_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>scope</td>
-            <td>Specify the visibility scope where Javadoc comments are checked.</td>
-            <td><a href="property_types.html#scope">Scope</a></td>
-            <td><code>private</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>excludeScope</td>
-            <td>Specify the visibility scope where Javadoc comments are not checked.</td>
-            <td><a href="property_types.html#scope">Scope</a></td>
-            <td><code>null</code></td>
-            <td>3.4</td>
-          </tr>
-          <tr>
-            <td>authorFormat</td>
-            <td>Specify the pattern for <code>@author</code> tag.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>null</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>versionFormat</td>
-            <td>Specify the pattern for <code>@version</code> tag.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>null</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>allowMissingParamTags</td>
-            <td>Control whether to ignore violations when a class has type parameters
-                but does not have matching param tags in the Javadoc.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>4.0</td>
-          </tr>
-          <tr>
-            <td>allowUnknownTags</td>
-            <td>Control whether to ignore violations when a Javadoc tag is not recognised.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.1</td>
-          </tr>
-          <tr>
-            <td>allowedAnnotations</td>
-            <td>
-              Specify the list of annotations that allow missed documentation.
-              Only short names are allowed, e.g. <code>Generated</code>.
-            </td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>Generated</code></td>
-            <td>8.15</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                ANNOTATION_DEF</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                ANNOTATION_DEF</a>.
-            </td>
-            <td>3.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>scope</td>
+              <td>Specify the visibility scope where Javadoc comments are checked.</td>
+              <td><a href="property_types.html#scope">Scope</a></td>
+              <td><code>private</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>excludeScope</td>
+              <td>Specify the visibility scope where Javadoc comments are not checked.</td>
+              <td><a href="property_types.html#scope">Scope</a></td>
+              <td><code>null</code></td>
+              <td>3.4</td>
+            </tr>
+            <tr>
+              <td>authorFormat</td>
+              <td>Specify the pattern for <code>@author</code> tag.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>null</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>versionFormat</td>
+              <td>Specify the pattern for <code>@version</code> tag.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>null</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>allowMissingParamTags</td>
+              <td>Control whether to ignore violations when a class has type parameters
+                  but does not have matching param tags in the Javadoc.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>4.0</td>
+            </tr>
+            <tr>
+              <td>allowUnknownTags</td>
+              <td>Control whether to ignore violations when a Javadoc tag is not recognised.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.1</td>
+            </tr>
+            <tr>
+              <td>allowedAnnotations</td>
+              <td>
+                Specify the list of annotations that allow missed documentation.
+                Only short names are allowed, e.g. <code>Generated</code>.
+              </td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>Generated</code></td>
+              <td>8.15</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                  CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                  ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                  ANNOTATION_DEF</a>.
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                  CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                  ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                  ANNOTATION_DEF</a>.
+              </td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="JavadocType_Examples">
@@ -1768,47 +1787,49 @@ class DatabaseConfiguration {}
       </subsection>
 
       <subsection name="Properties" id="JavadocVariable_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>scope</td>
-            <td>Specify the visibility scope where Javadoc comments are checked.</td>
-            <td><a href="property_types.html#scope">Scope</a></td>
-            <td><code>private</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>excludeScope</td>
-            <td>Specify the visibility scope where Javadoc comments are not checked.</td>
-            <td><a href="property_types.html#scope">Scope</a></td>
-            <td><code>null</code></td>
-            <td>3.4</td>
-          </tr>
-          <tr>
-              <td>ignoreNamePattern</td>
-              <td>Specify the regexp to define variable names to ignore.</td>
-              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>scope</td>
+              <td>Specify the visibility scope where Javadoc comments are checked.</td>
+              <td><a href="property_types.html#scope">Scope</a></td>
+              <td><code>private</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>excludeScope</td>
+              <td>Specify the visibility scope where Javadoc comments are not checked.</td>
+              <td><a href="property_types.html#scope">Scope</a></td>
               <td><code>null</code></td>
-              <td>5.8</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">ENUM_CONSTANT_DEF</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">ENUM_CONSTANT_DEF</a>.
-            </td>
-            <td>3.0</td>
-          </tr>
-        </table>
+              <td>3.4</td>
+            </tr>
+            <tr>
+                <td>ignoreNamePattern</td>
+                <td>Specify the regexp to define variable names to ignore.</td>
+                <td><a href="property_types.html#regexp">Regular Expression</a></td>
+                <td><code>null</code></td>
+                <td>5.8</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">ENUM_CONSTANT_DEF</a>.
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">ENUM_CONSTANT_DEF</a>.
+              </td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="JavadocVariable_Examples">
@@ -1918,7 +1939,8 @@ class DatabaseConfiguration {}
           For getters and setters for the property <code>allowMissingPropertyJavadoc</code>,
           the methods must match exactly the structures below.
         </p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 public void setNumber(final int number)
 {
     mNumber = number;
@@ -1933,87 +1955,90 @@ public boolean isSomething()
 {
     return false;
 }
-        </pre>
+          </pre>
+        </div>
       </subsection>
 
       <subsection name="Properties" id="MissingJavadocMethod_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>minLineCount</td>
-            <td>Control the minimal amount of lines in method to allow no documentation.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>-1</code></td>
-            <td>8.21</td>
-          </tr>
-          <tr>
-            <td>allowedAnnotations</td>
-            <td>Configure the list of annotations that allow missed documentation.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>Override</code></td>
-            <td>8.21</td>
-          </tr>
-          <tr>
-            <td>scope</td>
-            <td>Specify the visibility scope where Javadoc comments are checked.</td>
-            <td><a href="property_types.html#scope">Scope</a></td>
-            <td><code>public</code></td>
-            <td>8.21</td>
-          </tr>
-          <tr>
-            <td>excludeScope</td>
-            <td>Specify the visibility scope where Javadoc comments are not checked.</td>
-            <td><a href="property_types.html#scope">Scope</a></td>
-            <td><code>null</code></td>
-            <td>8.21</td>
-          </tr>
-          <tr>
-            <td>allowMissingPropertyJavadoc</td>
-            <td>
-              Control whether to allow missing Javadoc on accessor methods for
-              properties (setters and getters).
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>8.21</td>
-          </tr>
-          <tr>
-            <td>ignoreMethodNamesRegex</td>
-            <td>ignore method whose names are matching specified regex.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>null</code></td>
-            <td>8.21</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>minLineCount</td>
+              <td>Control the minimal amount of lines in method to allow no documentation.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>-1</code></td>
+              <td>8.21</td>
+            </tr>
+            <tr>
+              <td>allowedAnnotations</td>
+              <td>Configure the list of annotations that allow missed documentation.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>Override</code></td>
+              <td>8.21</td>
+            </tr>
+            <tr>
+              <td>scope</td>
+              <td>Specify the visibility scope where Javadoc comments are checked.</td>
+              <td><a href="property_types.html#scope">Scope</a></td>
+              <td><code>public</code></td>
+              <td>8.21</td>
+            </tr>
+            <tr>
+              <td>excludeScope</td>
+              <td>Specify the visibility scope where Javadoc comments are not checked.</td>
+              <td><a href="property_types.html#scope">Scope</a></td>
+              <td><code>null</code></td>
+              <td>8.21</td>
+            </tr>
+            <tr>
+              <td>allowMissingPropertyJavadoc</td>
+              <td>
+                Control whether to allow missing Javadoc on accessor methods for
+                properties (setters and getters).
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>8.21</td>
+            </tr>
+            <tr>
+              <td>ignoreMethodNamesRegex</td>
+              <td>ignore method whose names are matching specified regex.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>null</code></td>
+              <td>8.21</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
 
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
-                ANNOTATION_FIELD_DEF</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
-                ANNOTATION_FIELD_DEF</a>.
-            </td>
-            <td>8.21</td>
-          </tr>
-        </table>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
+                  ANNOTATION_FIELD_DEF</a>.
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
+                  ANNOTATION_FIELD_DEF</a>.
+              </td>
+              <td>8.21</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="MissingJavadocMethod_Examples">
@@ -2181,65 +2206,67 @@ package com.checkstyle.api; // violation
       </subsection>
 
       <subsection name="Properties" id="MissingJavadocType_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>scope</td>
-            <td>specify the visibility scope where Javadoc comments are checked.</td>
-            <td><a href="property_types.html#scope">Scope</a></td>
-            <td><code>public</code></td>
-            <td>8.20</td>
-          </tr>
-          <tr>
-            <td>excludeScope</td>
-            <td>specify the visibility scope where Javadoc comments are not checked.</td>
-            <td><a href="property_types.html#scope">Scope</a></td>
-            <td><code>null</code></td>
-            <td>8.20</td>
-          </tr>
-          <tr>
-            <td>skipAnnotations</td>
-            <td>
-              specify the list of annotations that allow missed documentation.
-              Only short names are allowed, e.g. <code>Generated</code>.
-            </td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>Generated</code></td>
-            <td>8.20</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                ANNOTATION_DEF</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                ANNOTATION_DEF</a>.
-            </td>
-            <td>8.20</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>scope</td>
+              <td>specify the visibility scope where Javadoc comments are checked.</td>
+              <td><a href="property_types.html#scope">Scope</a></td>
+              <td><code>public</code></td>
+              <td>8.20</td>
+            </tr>
+            <tr>
+              <td>excludeScope</td>
+              <td>specify the visibility scope where Javadoc comments are not checked.</td>
+              <td><a href="property_types.html#scope">Scope</a></td>
+              <td><code>null</code></td>
+              <td>8.20</td>
+            </tr>
+            <tr>
+              <td>skipAnnotations</td>
+              <td>
+                specify the list of annotations that allow missed documentation.
+                Only short names are allowed, e.g. <code>Generated</code>.
+              </td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>Generated</code></td>
+              <td>8.20</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                  CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                  ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                  ANNOTATION_DEF</a>.
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                  CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                  ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                  ANNOTATION_DEF</a>.
+              </td>
+              <td>8.20</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="MissingJavadocType_Examples">
@@ -2252,12 +2279,14 @@ package com.checkstyle.api; // violation
         </source>
 
         <p>Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 public class PublicClass {} // violation
 private class PublicClass {}
 protected class PublicClass {}
 class PackagePrivateClass {}
-        </pre>
+          </pre>
+        </div>
 
         <p>
           To configure the check for <code>private</code> scope:
@@ -2269,12 +2298,14 @@ class PackagePrivateClass {}
         </source>
 
         <p>Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 public class PublicClass {} // violation
 private class PublicClass {} // violation
 protected class PublicClass {} // violation
 class PackagePrivateClass {} // violation
-        </pre>
+          </pre>
+        </div>
 
         <p>
           To configure the check for <code>private</code> classes only:
@@ -2287,12 +2318,14 @@ class PackagePrivateClass {} // violation
         </source>
 
         <p>Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 public class PublicClass {}
 private class PublicClass {} // violation
 protected class PublicClass {}
 class PackagePrivateClass {}
-        </pre>
+          </pre>
+        </div>
 
         <p>
           Example that allows missing comments for classes annotated with
@@ -2357,54 +2390,56 @@ class DatabaseConfiguration {}
       </subsection>
 
       <subsection name="Properties" id="NonEmptyAtclauseDescription_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>violateExecutionOnNonTightHtml</td>
-            <td>
-              Control when to print violations if the Javadoc being examined by this check
-              violates the tight html rules defined at
-              <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>8.3</td>
-          </tr>
-          <tr>
-            <td>javadocTokens</td>
-            <td>javadoc tokens to check</td>
-            <td>subset of javadoc tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#PARAM_LITERAL">
-                PARAM_LITERAL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#RETURN_LITERAL">
-                RETURN_LITERAL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#THROWS_LITERAL">
-                THROWS_LITERAL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#TEXCEPTION_LITERAL">
-                EXCEPTION_LITERAL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#DEPRECATED_LITERAL">
-                DEPRECATED_LITERAL</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#PARAM_LITERAL">
-                PARAM_LITERAL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#RETURN_LITERAL">
-                RETURN_LITERAL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#THROWS_LITERAL">
-                THROWS_LITERAL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#TEXCEPTION_LITERAL">
-                EXCEPTION_LITERAL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#DEPRECATED_LITERAL">
-                DEPRECATED_LITERAL</a>.
-            </td>
-            <td>7.3</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>violateExecutionOnNonTightHtml</td>
+              <td>
+                Control when to print violations if the Javadoc being examined by this check
+                violates the tight html rules defined at
+                <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>8.3</td>
+            </tr>
+            <tr>
+              <td>javadocTokens</td>
+              <td>javadoc tokens to check</td>
+              <td>subset of javadoc tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#PARAM_LITERAL">
+                  PARAM_LITERAL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#RETURN_LITERAL">
+                  RETURN_LITERAL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#THROWS_LITERAL">
+                  THROWS_LITERAL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#TEXCEPTION_LITERAL">
+                  EXCEPTION_LITERAL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#DEPRECATED_LITERAL">
+                  DEPRECATED_LITERAL</a>.
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#PARAM_LITERAL">
+                  PARAM_LITERAL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#RETURN_LITERAL">
+                  RETURN_LITERAL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#THROWS_LITERAL">
+                  THROWS_LITERAL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#TEXCEPTION_LITERAL">
+                  EXCEPTION_LITERAL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html#DEPRECATED_LITERAL">
+                  DEPRECATED_LITERAL</a>.
+              </td>
+              <td>7.3</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="NonEmptyAtclauseDescription_Examples">
@@ -2488,39 +2523,41 @@ class DatabaseConfiguration {}
       </subsection>
 
       <subsection name="Properties" id="SingleLineJavadoc_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>violateExecutionOnNonTightHtml</td>
-            <td>
-              Control when to print violations if the Javadoc being examined by this check
-              violates the tight html rules defined at
-              <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>8.3</td>
-          </tr>
-          <tr>
-            <td>ignoredTags</td>
-            <td>Specify at-clauses which are ignored by the check.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>{}</code></td>
-            <td>6.8</td>
-          </tr>
-          <tr>
-            <td>ignoreInlineTags</td>
-            <td>Control whether inline tags must be ignored.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>6.8</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>violateExecutionOnNonTightHtml</td>
+              <td>
+                Control when to print violations if the Javadoc being examined by this check
+                violates the tight html rules defined at
+                <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>8.3</td>
+            </tr>
+            <tr>
+              <td>ignoredTags</td>
+              <td>Specify at-clauses which are ignored by the check.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>{}</code></td>
+              <td>6.8</td>
+            </tr>
+            <tr>
+              <td>ignoreInlineTags</td>
+              <td>Control whether inline tags must be ignored.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>6.8</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="SingleLineJavadoc_Examples">
@@ -2606,39 +2643,41 @@ class DatabaseConfiguration {}
       </subsection>
 
       <subsection name="Properties" id="SummaryJavadoc_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>violateExecutionOnNonTightHtml</td>
-            <td>
-              Control when to print violations if the Javadoc being examined by this check
-              violates the tight html rules defined at
-              <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>8.3</td>
-          </tr>
-          <tr>
-            <td>forbiddenSummaryFragments</td>
-            <td>Specify the regexp for forbidden summary fragments.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^$" (empty)</code></td>
-            <td>6.0</td>
-          </tr>
-          <tr>
-            <td>period</td>
-            <td>Specify the period symbol at the end of first javadoc sentence.</td>
-            <td><a href="property_types.html#string">String</a></td>
-            <td><code>"."</code></td>
-            <td>6.2</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>violateExecutionOnNonTightHtml</td>
+              <td>
+                Control when to print violations if the Javadoc being examined by this check
+                violates the tight html rules defined at
+                <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>8.3</td>
+            </tr>
+            <tr>
+              <td>forbiddenSummaryFragments</td>
+              <td>Specify the regexp for forbidden summary fragments.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^$" (empty)</code></td>
+              <td>6.0</td>
+            </tr>
+            <tr>
+              <td>period</td>
+              <td>Specify the period symbol at the end of first javadoc sentence.</td>
+              <td><a href="property_types.html#string">String</a></td>
+              <td><code>"."</code></td>
+              <td>6.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="SummaryJavadoc_Examples">
@@ -2777,69 +2816,71 @@ public class TestClass {
       </subsection>
 
       <subsection name="Properties" id="WriteTag_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>tag</td>
-            <td>Specify the name of tag.</td>
-            <td><a href="property_types.html#string">String</a></td>
-           <td><code>null</code></td>
-           <td>4.2</td>
-          </tr>
-          <tr>
-            <td>tagFormat</td>
-            <td>Specify the regexp to match tag content.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>null</code></td>
-            <td>4.2</td>
-          </tr>
-          <tr>
-            <td>tagSeverity</td>
-            <td>Specify the severity level when tag is found and printed.</td>
-            <td><a href="property_types.html#severity">Severity</a></td>
-            <td><code>info</code></td>
-            <td>4.2</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                ANNOTATION_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
-                ENUM_CONSTANT_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
-                ANNOTATION_FIELD_DEF</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                ANNOTATION_DEF</a>.
-            </td>
-            <td>4.2</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>tag</td>
+              <td>Specify the name of tag.</td>
+              <td><a href="property_types.html#string">String</a></td>
+             <td><code>null</code></td>
+             <td>4.2</td>
+            </tr>
+            <tr>
+              <td>tagFormat</td>
+              <td>Specify the regexp to match tag content.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>null</code></td>
+              <td>4.2</td>
+            </tr>
+            <tr>
+              <td>tagSeverity</td>
+              <td>Specify the severity level when tag is found and printed.</td>
+              <td><a href="property_types.html#severity">Severity</a></td>
+              <td><code>info</code></td>
+              <td>4.2</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                  CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                  ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                  ANNOTATION_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
+                  ENUM_CONSTANT_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
+                  ANNOTATION_FIELD_DEF</a>.
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                  CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                  ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                  ANNOTATION_DEF</a>.
+              </td>
+              <td>4.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="WriteTag_Examples">

--- a/src/xdocs/config_metrics.xml
+++ b/src/xdocs/config_metrics.xml
@@ -52,45 +52,47 @@
       </subsection>
 
       <subsection name="Properties" id="BooleanExpressionComplexity_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>max</td>
-            <td>
-              Specify the maximum number of boolean operations allowed in one
-              expression.
-            </td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>3</code></td>
-            <td>3.4</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">LAND</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND">BAND</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">LOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR">BOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR">BXOR</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">LAND</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND">BAND</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">LOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR">BOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR">BXOR</a>.
-            </td>
-            <td>3.4</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>max</td>
+              <td>
+                Specify the maximum number of boolean operations allowed in one
+                expression.
+              </td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>3</code></td>
+              <td>3.4</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">LAND</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND">BAND</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">LOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR">BOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR">BXOR</a>.
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">LAND</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND">BAND</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">LOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR">BOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR">BXOR</a>.
+              </td>
+              <td>3.4</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="BooleanExpressionComplexity_Examples">
@@ -218,53 +220,55 @@
       </subsection>
 
       <subsection name="Properties" id="ClassDataAbstractionCoupling_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>max</td>
-            <td>Specify the maximum threshold allowed.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>7</code></td>
-            <td>3.4</td>
-          </tr>
-          <tr>
-            <td>excludedClasses</td>
-            <td>Specify user-configured class names to ignore.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>
-              ArrayIndexOutOfBoundsException, ArrayList, Boolean, Byte, Character,
-              Class, Deprecated, Deque, Double, Exception, Float, FunctionalInterface,
-              HashMap, HashSet, IllegalArgumentException, IllegalStateException,
-              IndexOutOfBoundsException, Integer, LinkedList, List, Long, Map,
-              NullPointerException, Object, Override, Queue, RuntimeException,
-              SafeVarargs, SecurityException, Set, Short, SortedMap, SortedSet,
-              String, StringBuffer, StringBuilder, SuppressWarnings, Throwable,
-              TreeMap, TreeSet, UnsupportedOperationException, Void, boolean,
-              byte, char, double, float, int, long, short, void</code>
-            </td>
-            <td>5.7</td>
-          </tr>
-          <tr>
-            <td>excludeClassesRegexps</td>
-            <td>Specify user-configured regular expressions to ignore classes.</td>
-            <td><a href="property_types.html#regexp">Regular Expressions</a></td>
-            <td><code>^$</code></td>
-            <td>7.7</td>
-          </tr>
-          <tr>
-            <td>excludedPackages</td>
-            <td>Specify user-configured packages to ignore.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>{}</code></td>
-            <td>7.7</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>max</td>
+              <td>Specify the maximum threshold allowed.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>7</code></td>
+              <td>3.4</td>
+            </tr>
+            <tr>
+              <td>excludedClasses</td>
+              <td>Specify user-configured class names to ignore.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>
+                ArrayIndexOutOfBoundsException, ArrayList, Boolean, Byte, Character,
+                Class, Deprecated, Deque, Double, Exception, Float, FunctionalInterface,
+                HashMap, HashSet, IllegalArgumentException, IllegalStateException,
+                IndexOutOfBoundsException, Integer, LinkedList, List, Long, Map,
+                NullPointerException, Object, Override, Queue, RuntimeException,
+                SafeVarargs, SecurityException, Set, Short, SortedMap, SortedSet,
+                String, StringBuffer, StringBuilder, SuppressWarnings, Throwable,
+                TreeMap, TreeSet, UnsupportedOperationException, Void, boolean,
+                byte, char, double, float, int, long, short, void</code>
+              </td>
+              <td>5.7</td>
+            </tr>
+            <tr>
+              <td>excludeClassesRegexps</td>
+              <td>Specify user-configured regular expressions to ignore classes.</td>
+              <td><a href="property_types.html#regexp">Regular Expressions</a></td>
+              <td><code>^$</code></td>
+              <td>7.7</td>
+            </tr>
+            <tr>
+              <td>excludedPackages</td>
+              <td>Specify user-configured packages to ignore.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>{}</code></td>
+              <td>7.7</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="ClassDataAbstractionCoupling_Examples">
@@ -508,56 +512,58 @@ public class Foo {
       </subsection>
 
       <subsection name="Properties" id="ClassFanOutComplexity_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>max</td>
-            <td>Specify the maximum threshold allowed.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>20</code></td>
-            <td>3.4</td>
-          </tr>
-          <tr>
-            <td>excludedClasses</td>
-            <td>Specify user-configured class names to ignore.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>
-              ArrayIndexOutOfBoundsException, ArrayList, Boolean, Byte, Character,
-              Class, Deprecated, Deque, Double, Exception, Float, FunctionalInterface,
-              HashMap, HashSet, IllegalArgumentException, IllegalStateException,
-              IndexOutOfBoundsException, Integer, LinkedList, List, Long, Map,
-              NullPointerException, Object, Override, Queue, RuntimeException,
-              SafeVarargs, SecurityException, Set, Short, SortedMap, SortedSet,
-              String, StringBuffer, StringBuilder, SuppressWarnings, Throwable,
-              TreeMap, TreeSet, UnsupportedOperationException, Void, boolean,
-              byte, char, double, float, int, long, short, void</code>
-            </td>
-            <td>5.7</td>
-          </tr>
-          <tr>
-            <td>excludeClassesRegexps</td>
-            <td>Specify user-configured regular expressions to ignore classes.</td>
-            <td><a href="property_types.html#regexp">Regular Expressions</a></td>
-            <td><code>^$</code></td>
-            <td>7.7</td>
-          </tr>
-          <tr>
-            <td>excludedPackages</td>
-            <td>
-              Specify user-configured packages to ignore. All excluded packages
-              should end with a period, so it also appends a dot to a package name.
-            </td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>{}</code></td>
-            <td>7.7</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>max</td>
+              <td>Specify the maximum threshold allowed.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>20</code></td>
+              <td>3.4</td>
+            </tr>
+            <tr>
+              <td>excludedClasses</td>
+              <td>Specify user-configured class names to ignore.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>
+                ArrayIndexOutOfBoundsException, ArrayList, Boolean, Byte, Character,
+                Class, Deprecated, Deque, Double, Exception, Float, FunctionalInterface,
+                HashMap, HashSet, IllegalArgumentException, IllegalStateException,
+                IndexOutOfBoundsException, Integer, LinkedList, List, Long, Map,
+                NullPointerException, Object, Override, Queue, RuntimeException,
+                SafeVarargs, SecurityException, Set, Short, SortedMap, SortedSet,
+                String, StringBuffer, StringBuilder, SuppressWarnings, Throwable,
+                TreeMap, TreeSet, UnsupportedOperationException, Void, boolean,
+                byte, char, double, float, int, long, short, void</code>
+              </td>
+              <td>5.7</td>
+            </tr>
+            <tr>
+              <td>excludeClassesRegexps</td>
+              <td>Specify user-configured regular expressions to ignore classes.</td>
+              <td><a href="property_types.html#regexp">Regular Expressions</a></td>
+              <td><code>^$</code></td>
+              <td>7.7</td>
+            </tr>
+            <tr>
+              <td>excludedPackages</td>
+              <td>
+                Specify user-configured packages to ignore. All excluded packages
+                should end with a period, so it also appends a dot to a package name.
+              </td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>{}</code></td>
+              <td>7.7</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="ClassFanOutComplexity_Examples">
@@ -722,82 +728,84 @@ public class Foo {
       </subsection>
 
       <subsection name="Properties" id="CyclomaticComplexity_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>max</td>
-            <td>Specify the maximum threshold allowed.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>10</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>switchBlockAsSingleDecisionPoint</td>
-            <td>Control whether to treat the whole switch block as a single decision point.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>6.11</td>
-          </tr>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>max</td>
+              <td>Specify the maximum threshold allowed.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>10</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>switchBlockAsSingleDecisionPoint</td>
+              <td>Control whether to treat the whole switch block as a single decision point.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>6.11</td>
+            </tr>
 
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
 
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
-                LITERAL_WHILE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
-                LITERAL_DO</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
-                LITERAL_FOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
-                LITERAL_IF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">
-                LITERAL_SWITCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CASE">
-                LITERAL_CASE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
-                LITERAL_CATCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">
-                QUESTION</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">
-                LAND</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">
-                LOR</a>.
-            </td>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
+                  LITERAL_WHILE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
+                  LITERAL_DO</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
+                  LITERAL_FOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
+                  LITERAL_IF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">
+                  LITERAL_SWITCH</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CASE">
+                  LITERAL_CASE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
+                  LITERAL_CATCH</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">
+                  QUESTION</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">
+                  LAND</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">
+                  LOR</a>.
+              </td>
 
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
-                LITERAL_WHILE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
-                LITERAL_DO</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
-                LITERAL_FOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
-                LITERAL_IF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">
-                LITERAL_SWITCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CASE">
-                LITERAL_CASE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
-                LITERAL_CATCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">
-                QUESTION</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">
-                LAND</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">
-                LOR</a>.
-            </td>
-            <td>3.2</td>
-          </tr>
-        </table>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
+                  LITERAL_WHILE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
+                  LITERAL_DO</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
+                  LITERAL_FOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
+                  LITERAL_IF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">
+                  LITERAL_SWITCH</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CASE">
+                  LITERAL_CASE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
+                  LITERAL_CATCH</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">
+                  QUESTION</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">
+                  LAND</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">
+                  LOR</a>.
+              </td>
+              <td>3.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="CyclomaticComplexity_Examples">
@@ -958,45 +966,47 @@ class SwitchExample {
       </subsection>
 
       <subsection name="Properties" id="JavaNCSS_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>methodMaximum</td>
-            <td>
-              Specify the maximum allowed number of non commenting lines in a
-              method.
-            </td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>50</code></td>
-            <td>3.5</td>
-          </tr>
-          <tr>
-            <td>classMaximum</td>
-            <td>
-              Specify the maximum allowed number of non commenting lines in a
-              class.
-            </td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>1500</code></td>
-            <td>3.5</td>
-          </tr>
-          <tr>
-            <td>fileMaximum</td>
-            <td>
-              Specify the maximum allowed number of non commenting lines in a
-              file including all top level and nested classes.
-            </td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>2000</code></td>
-            <td>3.5</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>methodMaximum</td>
+              <td>
+                Specify the maximum allowed number of non commenting lines in a
+                method.
+              </td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>50</code></td>
+              <td>3.5</td>
+            </tr>
+            <tr>
+              <td>classMaximum</td>
+              <td>
+                Specify the maximum allowed number of non commenting lines in a
+                class.
+              </td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>1500</code></td>
+              <td>3.5</td>
+            </tr>
+            <tr>
+              <td>fileMaximum</td>
+              <td>
+                Specify the maximum allowed number of non commenting lines in a
+                file including all top level and nested classes.
+              </td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>2000</code></td>
+              <td>3.5</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="JavaNCSS_Examples">
@@ -1114,30 +1124,33 @@ class SwitchExample {
         logical clarity of the system structure.
         </blockquote>
 
-        <table>
-        <caption>Examples</caption>
-        <thead><tr><th>Structure</th><th> Complexity expression </th></tr></thead>
-        <tr><td>if ([expr]) { [if-range] }</td><td>NP(if-range) + 1 + NP(expr)</td></tr>
-        <tr><td>if ([expr]) { [if-range] } else { [else-range] }</td><td>NP(if-range)
-                + NP(else-range) + NP(expr)</td></tr>
-        <tr><td>while ([expr]) { [while-range] } </td><td>NP(while-range) + NP(expr) + 1</td></tr>
-        <tr><td>do { [do-range] } while ([expr])</td><td>NP(do-range) + NP(expr) + 1</td></tr>
-        <tr><td>for([expr1]; [expr2]; [expr3]) { [for-range] }</td><td>NP(for-range) + NP(expr1)
-                + NP(expr2) + NP(expr3) + 1</td></tr>
-        <tr><td>switch ([expr]) { case : [case-range] default: [default-range] }</td>
-            <td>S(i=1:i=n)NP(case-range[i]) + NP(default-range) + NP(expr)</td></tr>
-        <tr><td>[expr1] ? [expr2] : [expr3]</td><td>NP(expr1) + NP(expr2) + NP(expr3) + 2</td></tr>
-        <tr><td>goto label</td><td>1</td></tr>
-        <tr><td>break</td><td>1</td></tr>
-        <tr><td>Expressions</td><td>Number of &amp;&amp; and || operators in expression. No
-                operators - 0</td></tr>
-        <tr><td>continue</td><td>1</td></tr>
-        <tr><td>return</td><td>1</td></tr>
-        <tr><td>Statement (even sequential statements)</td><td>1</td></tr>
-        <tr><td>Empty block {}</td><td>1</td></tr>
-        <tr><td>Function call</td><td>1</td></tr>
-        <tr><td>Function(Method) declaration or Block</td><td>P(i=1:i=N)NP(Statement[i])</td></tr>
-        </table>
+        <div class="wrapper">
+          <table>
+          <caption>Examples</caption>
+          <thead><tr><th>Structure</th><th> Complexity expression </th></tr></thead>
+          <tr><td>if ([expr]) { [if-range] }</td><td>NP(if-range) + 1 + NP(expr)</td></tr>
+          <tr><td>if ([expr]) { [if-range] } else { [else-range] }</td><td>NP(if-range)
+                  + NP(else-range) + NP(expr)</td></tr>
+          <tr><td>while ([expr]) { [while-range] } </td><td>NP(while-range) + NP(expr) + 1</td></tr>
+          <tr><td>do { [do-range] } while ([expr])</td><td>NP(do-range) + NP(expr) + 1</td></tr>
+          <tr><td>for([expr1]; [expr2]; [expr3]) { [for-range] }</td><td>NP(for-range) + NP(expr1)
+                  + NP(expr2) + NP(expr3) + 1</td></tr>
+          <tr><td>switch ([expr]) { case : [case-range] default: [default-range] }</td>
+              <td>S(i=1:i=n)NP(case-range[i]) + NP(default-range) + NP(expr)</td></tr>
+          <tr><td>[expr1] ? [expr2] : [expr3]</td><td>NP(expr1) + NP(expr2) + NP(expr3) + 2
+          </td></tr>
+          <tr><td>goto label</td><td>1</td></tr>
+          <tr><td>break</td><td>1</td></tr>
+          <tr><td>Expressions</td><td>Number of &amp;&amp; and || operators in expression. No
+                  operators - 0</td></tr>
+          <tr><td>continue</td><td>1</td></tr>
+          <tr><td>return</td><td>1</td></tr>
+          <tr><td>Statement (even sequential statements)</td><td>1</td></tr>
+          <tr><td>Empty block {}</td><td>1</td></tr>
+          <tr><td>Function call</td><td>1</td></tr>
+          <tr><td>Function(Method) declaration or Block</td><td>P(i=1:i=N)NP(Statement[i])</td></tr>
+          </table>
+        </div>
 
         <p>
           <b>Rationale:</b> Nejmeh says that his group had an informal NPATH
@@ -1152,22 +1165,24 @@ class SwitchExample {
       </subsection>
 
       <subsection name="Properties" id="NPathComplexity_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>max</td>
-            <td>Specify the maximum threshold allowed.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>200</code></td>
-            <td>3.4</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>max</td>
+              <td>Specify the maximum threshold allowed.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>200</code></td>
+              <td>3.4</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="NPathComplexity_Examples">

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -41,24 +41,26 @@
       </subsection>
 
       <subsection name="Properties" id="ArrayTypeStyle_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>javaStyle</td>
-            <td>
-              Control whether to enforce Java style (true) or C style (false).
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>3.1</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>javaStyle</td>
+              <td>
+                Control whether to enforce Java style (true) or C style (false).
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>3.1</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="ArrayTypeStyle_Examples">
@@ -172,44 +174,46 @@ public class MyClass {
       </subsection>
 
        <subsection name="Properties" id="AvoidEscapedUnicodeCharacters_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>allowEscapesForControlCharacters</td>
-            <td>Allow use escapes for non-printable, control characters.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.8</td>
-          </tr>
-          <tr>
-            <td>allowByTailComment</td>
-            <td>Allow use escapes if trail comment is present.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.8</td>
-          </tr>
-          <tr>
-            <td>allowIfAllCharactersEscaped</td>
-            <td>Allow if all characters in literal are escaped.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.8</td>
-          </tr>
-          <tr>
-            <td>allowNonPrintableEscapes</td>
-            <td>Allow use escapes for non-printable, whitespace characters.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.8</td>
-          </tr>
-        </table>
-      </subsection>
+         <div class="wrapper">
+           <table>
+             <tr>
+               <th>name</th>
+               <th>description</th>
+               <th>type</th>
+               <th>default value</th>
+               <th>since</th>
+             </tr>
+             <tr>
+               <td>allowEscapesForControlCharacters</td>
+               <td>Allow use escapes for non-printable, control characters.</td>
+               <td><a href="property_types.html#boolean">Boolean</a></td>
+               <td><code>false</code></td>
+               <td>5.8</td>
+             </tr>
+             <tr>
+               <td>allowByTailComment</td>
+               <td>Allow use escapes if trail comment is present.</td>
+               <td><a href="property_types.html#boolean">Boolean</a></td>
+               <td><code>false</code></td>
+               <td>5.8</td>
+             </tr>
+             <tr>
+               <td>allowIfAllCharactersEscaped</td>
+               <td>Allow if all characters in literal are escaped.</td>
+               <td><a href="property_types.html#boolean">Boolean</a></td>
+               <td><code>false</code></td>
+               <td>5.8</td>
+             </tr>
+             <tr>
+               <td>allowNonPrintableEscapes</td>
+               <td>Allow use escapes for non-printable, whitespace characters.</td>
+               <td><a href="property_types.html#boolean">Boolean</a></td>
+               <td><code>false</code></td>
+               <td>5.8</td>
+             </tr>
+           </table>
+         </div>
+       </subsection>
 
       <subsection name="Examples" id="AvoidEscapedUnicodeCharacters_Examples">
        <p>
@@ -492,33 +496,35 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
         </source>
       </subsection>
       <subsection name="Properties" id="CommentsIndentation_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
+        <div class="wrapper">
+          <table>
             <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SINGLE_LINE_COMMENT">
-                SINGLE_LINE_COMMENT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BLOCK_COMMENT_BEGIN">
-                BLOCK_COMMENT_BEGIN</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SINGLE_LINE_COMMENT">
-                SINGLE_LINE_COMMENT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BLOCK_COMMENT_BEGIN">
-                BLOCK_COMMENT_BEGIN</a>.
-            </td>
-            <td>6.10</td>
-          </tr>
-        </table>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+              <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SINGLE_LINE_COMMENT">
+                  SINGLE_LINE_COMMENT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BLOCK_COMMENT_BEGIN">
+                  BLOCK_COMMENT_BEGIN</a>.
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SINGLE_LINE_COMMENT">
+                  SINGLE_LINE_COMMENT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BLOCK_COMMENT_BEGIN">
+                  BLOCK_COMMENT_BEGIN</a>.
+              </td>
+              <td>6.10</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="CommentsIndentation_Examples">
@@ -591,77 +597,79 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
       </subsection>
 
       <subsection name="Properties" id="DescendantToken_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>limitedTokens</td>
-            <td>Specify set of tokens with limited occurrences as descendants.</td>
-            <td>
-             subset of tokens
-             <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>
-            </td>
-            <td><code>{}</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>minimumDepth</td>
-            <td>Specify the minimum depth for descendant counts.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>0</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>maximumDepth</td>
-            <td>Specify the maximum depth for descendant counts.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>java.lang.Integer.MAX_VALUE</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>minimumNumber</td>
-            <td>Specify a minimum count for descendants.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>0</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>maximumNumber</td>
-            <td>Specify a maximum count for descendants.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>java.lang.Integer.MAX_VALUE</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>sumTokenCounts</td>
-            <td>
-              Control whether the number of tokens found should be calculated
-              from the sum of the individual token counts.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>minimumMessage</td>
-            <td>Define the violation message when the minimum count is not reached.</td>
-            <td><a href="property_types.html#string">String</a></td>
-            <td><code>null</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>maximumMessage</td>
-            <td>Define the violation message when the maximum count is exceeded.</td>
-            <td><a href="property_types.html#string">String</a></td>
-            <td><code>null</code></td>
-            <td>3.2</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>limitedTokens</td>
+              <td>Specify set of tokens with limited occurrences as descendants.</td>
+              <td>
+               subset of tokens
+               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>
+              </td>
+              <td><code>{}</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>minimumDepth</td>
+              <td>Specify the minimum depth for descendant counts.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>0</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>maximumDepth</td>
+              <td>Specify the maximum depth for descendant counts.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>java.lang.Integer.MAX_VALUE</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>minimumNumber</td>
+              <td>Specify a minimum count for descendants.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>0</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>maximumNumber</td>
+              <td>Specify a maximum count for descendants.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>java.lang.Integer.MAX_VALUE</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>sumTokenCounts</td>
+              <td>
+                Control whether the number of tokens found should be calculated
+                from the sum of the individual token counts.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>minimumMessage</td>
+              <td>Define the violation message when the minimum count is not reached.</td>
+              <td><a href="property_types.html#string">String</a></td>
+              <td><code>null</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>maximumMessage</td>
+              <td>Define the violation message when the maximum count is exceeded.</td>
+              <td><a href="property_types.html#string">String</a></td>
+              <td><code>null</code></td>
+              <td>3.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="DescendantToken_Examples">
@@ -950,44 +958,46 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
       </subsection>
 
       <subsection name="Properties" id="FinalParameters_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>ignorePrimitiveTypes</td>
-            <td>Ignore primitive types as parameters.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>6.2</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
-                LITERAL_CATCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#FOR_EACH_CLAUSE">
-                FOR_EACH_CLAUSE</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>.
-            </td>
-            <td>3.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>ignorePrimitiveTypes</td>
+              <td>Ignore primitive types as parameters.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>6.2</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
+                  LITERAL_CATCH</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#FOR_EACH_CLAUSE">
+                  FOR_EACH_CLAUSE</a>.
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>.
+              </td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="FinalParameters_Examples">
@@ -1077,70 +1087,72 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
       </subsection>
 
       <subsection name="Properties" id="Indentation_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>basicOffset</td>
-            <td>
-              Specify how far new indentation level should be indented when on the next line.
-            </td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>4</code></td>
-            <td>3.1</td>
-          </tr>
-          <tr>
-            <td>braceAdjustment</td>
-            <td>Specify how far a braces should be indented when on the next line.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>0</code></td>
-            <td>3.1</td>
-          </tr>
-          <tr>
-            <td>caseIndent</td>
-            <td>Specify how far a case label should be indented when on next line.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>4</code></td>
-            <td>3.1</td>
-          </tr>
-          <tr>
-            <td>throwsIndent</td>
-            <td>Specify how far a throws clause should be indented when on next line.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>4</code></td>
-            <td>5.7</td>
-          </tr>
-          <tr>
-            <td>arrayInitIndent</td>
-            <td>Specify how far an array initialisation should be indented when on next line.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>4</code></td>
-            <td>5.8</td>
-          </tr>
-          <tr>
-            <td>lineWrappingIndentation</td>
-            <td>
-              Specify how far continuation line should be indented when line-wrapping is present.
-            </td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>4</code></td>
-            <td>5.9</td>
-          </tr>
-          <tr>
-            <td>forceStrictCondition</td>
-            <td>Force strict indent level in line wrapping case. If value is true, line wrap indent
-                have to be same as lineWrappingIndentation parameter. If value is false, line wrap
-                indent could be bigger on any value user would like.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>6.3</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>basicOffset</td>
+              <td>
+                Specify how far new indentation level should be indented when on the next line.
+              </td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>4</code></td>
+              <td>3.1</td>
+            </tr>
+            <tr>
+              <td>braceAdjustment</td>
+              <td>Specify how far a braces should be indented when on the next line.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>0</code></td>
+              <td>3.1</td>
+            </tr>
+            <tr>
+              <td>caseIndent</td>
+              <td>Specify how far a case label should be indented when on next line.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>4</code></td>
+              <td>3.1</td>
+            </tr>
+            <tr>
+              <td>throwsIndent</td>
+              <td>Specify how far a throws clause should be indented when on next line.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>4</code></td>
+              <td>5.7</td>
+            </tr>
+            <tr>
+              <td>arrayInitIndent</td>
+              <td>Specify how far an array initialisation should be indented when on next line.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>4</code></td>
+              <td>5.8</td>
+            </tr>
+            <tr>
+              <td>lineWrappingIndentation</td>
+              <td>
+                Specify how far continuation line should be indented when line-wrapping is present.
+              </td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>4</code></td>
+              <td>5.9</td>
+            </tr>
+            <tr>
+              <td>forceStrictCondition</td>
+              <td>Force strict indent level in line wrapping case. If value is true, line wrap
+                  indent have to be same as lineWrappingIndentation parameter. If value is false,
+                  line wrap indent could be bigger on any value user would like.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>6.3</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="Indentation_Examples">
@@ -1291,30 +1303,32 @@ StaticMethodCandidateCheck.name = Static Method Candidate
       </subsection>
 
       <subsection name="Properties" id="NewlineAtEndOfFile_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>lineSeparator</td>
-            <td>Specify the type of line separator.</td>
-            <td><a href="property_types.html#lineSeparator">Line Separator Policy</a></td>
-            <td><code>lf_cr_crlf</code></td>
-            <td>3.1</td>
-          </tr>
-          <tr>
-            <td>fileExtensions</td>
-            <td>Specify the file type extension of the files to check.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>all files</code></td>
-            <td>3.1</td>
-          </tr>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>lineSeparator</td>
+              <td>Specify the type of line separator.</td>
+              <td><a href="property_types.html#lineSeparator">Line Separator Policy</a></td>
+              <td><code>lf_cr_crlf</code></td>
+              <td>3.1</td>
+            </tr>
+            <tr>
+              <td>fileExtensions</td>
+              <td>Specify the file type extension of the files to check.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>all files</code></td>
+              <td>3.1</td>
+            </tr>
 
-        </table>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="NewlineAtEndOfFile_Examples">
@@ -1413,22 +1427,24 @@ StaticMethodCandidateCheck.name = Static Method Candidate
       </subsection>
 
       <subsection name="Properties" id="OrderedProperties_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>fileExtensions</td>
-            <td>Specify file type extension of the files to check.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>.properties</code></td>
-            <td>8.22</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>fileExtensions</td>
+              <td>Specify file type extension of the files to check.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>.properties</code></td>
+              <td>8.22</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="OrderedProperties_Examples">
@@ -1577,22 +1593,24 @@ key.png =value - violation
       </subsection>
 
       <subsection name="Properties" id="TodoComment_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Specify pattern to match comments against.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"TODO:"</code></td>
-            <td>3.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specify pattern to match comments against.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"TODO:"</code></td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Notes" id="TodoComment_Notes">
@@ -1727,31 +1745,33 @@ d = e / f;        // Another comment for this line
       </subsection>
 
       <subsection name="Properties" id="TrailingComment_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Specify pattern for strings allowed before the comment.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^[\s});]*$"</code></td>
-            <td>3.4</td>
-          </tr>
-          <tr>
-            <td>legalComment</td>
-            <td>Define pattern for text allowed in trailing comments. (This
-                pattern will not be applied to multiline comments and the text of the
-                comment will be trimmed before matching.)</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>null</code></td>
-            <td>4.2</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specify pattern for strings allowed before the comment.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^[\s});]*$"</code></td>
+              <td>3.4</td>
+            </tr>
+            <tr>
+              <td>legalComment</td>
+              <td>Define pattern for text allowed in trailing comments. (This
+                  pattern will not be applied to multiline comments and the text of the
+                  comment will be trimmed before matching.)</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>null</code></td>
+              <td>4.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="TrailingComment_Examples">
@@ -1870,46 +1890,48 @@ messages.properties: Key 'ok' missing.
       </subsection>
 
       <subsection name="Properties" id="Translation_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>fileExtensions</td>
-            <td>
-              Specify file type extension to identify translation files. Setting
-              this property is typically only required if your
-              translation files are preprocessed and the original files
-              do not have the extension <code>.properties</code>
-            </td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>.properties</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>baseName</td>
-            <td>Specify
-              <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ResourceBundle.html">
-              Base name</a> of resource bundles which contain message resources. It helps
-              the check to distinguish config and localization resources.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^messages.*$"</code></td>
-            <td>6.17</td>
-          </tr>
-          <tr>
-            <td>requiredTranslations</td>
-            <td>
-              Specify language codes of required translations which must exist in project.
-            </td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>{}</code></td>
-            <td>6.11</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>fileExtensions</td>
+              <td>
+                Specify file type extension to identify translation files. Setting
+                this property is typically only required if your
+                translation files are preprocessed and the original files
+                do not have the extension <code>.properties</code>
+              </td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>.properties</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>baseName</td>
+              <td>Specify
+                <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/ResourceBundle.html">
+                Base name</a> of resource bundles which contain message resources. It helps
+                the check to distinguish config and localization resources.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^messages.*$"</code></td>
+              <td>6.17</td>
+            </tr>
+            <tr>
+              <td>requiredTranslations</td>
+              <td>
+                Specify language codes of required translations which must exist in project.
+              </td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>{}</code></td>
+              <td>6.11</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="Translation_Examples">
@@ -2031,23 +2053,25 @@ messages_home_fr_CA_UNIX.properties
       </subsection>
 
       <subsection name="Properties" id="UncommentedMain_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>excludedClasses</td>
-            <td>Specify pattern for qualified names of classes which are allowed
-            to have a main method.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^$" (empty)</code></td>
-            <td>3.2</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>excludedClasses</td>
+              <td>Specify pattern for qualified names of classes which are allowed
+              to have a main method.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^$" (empty)</code></td>
+              <td>3.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="UncommentedMain_Examples">
@@ -2120,22 +2144,24 @@ messages_home_fr_CA_UNIX.properties
       </subsection>
 
       <subsection name="Properties" id="UniqueProperties_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>fileExtensions</td>
-            <td>Specify file type extension of the files to check.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>.properties</code></td>
-            <td>5.7</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>fileExtensions</td>
+              <td>Specify file type extension of the files to check.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>.properties</code></td>
+              <td>5.7</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="UniqueProperties_Examples">

--- a/src/xdocs/config_modifier.xml
+++ b/src/xdocs/config_modifier.xml
@@ -56,33 +56,35 @@ public final class Person {
       </subsection>
 
       <subsection name="Properties" id="ClassMemberImpliedModifier_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>violateImpliedStaticOnNestedEnum</td>
-            <td>
-              Control whether to enforce that <code>static</code> is explicitly coded
-              on nested enums in classes.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>8.16</td>
-          </tr>
-          <tr>
-            <td>violateImpliedStaticOnNestedInterface</td>
-            <td>
-              Control whether to enforce that <code>static</code> is explicitly coded
-              on nested interfaces in classes.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>8.16</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>violateImpliedStaticOnNestedEnum</td>
+              <td>
+                Control whether to enforce that <code>static</code> is explicitly coded
+                on nested enums in classes.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>8.16</td>
+            </tr>
+            <tr>
+              <td>violateImpliedStaticOnNestedInterface</td>
+              <td>
+                Control whether to enforce that <code>static</code> is explicitly coded
+                on nested interfaces in classes.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>8.16</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="ClassMemberImpliedModifier_Examples">
@@ -227,78 +229,80 @@ public interface AddressFactory {
       </subsection>
 
       <subsection name="Properties" id="InterfaceMemberImpliedModifier_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>violateImpliedPublicField</td>
-            <td>
-              Control whether to enforce that <code>public</code> is explicitly coded
-              on interface fields.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>8.12</td>
-          </tr>
-          <tr>
-            <td>violateImpliedStaticField</td>
-            <td>
-              Control whether to enforce that <code>static</code> is explicitly coded
-              on interface fields.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>8.12</td>
-          </tr>
-          <tr>
-            <td>violateImpliedFinalField</td>
-            <td>
-              Control whether to enforce that <code>final</code> is explicitly coded
-              on interface fields.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>8.12</td>
-          </tr>
-          <tr>
-            <td>violateImpliedPublicMethod</td>
-            <td>
-              Control whether to enforce that <code>public</code> is explicitly coded
-              on interface methods.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>8.12</td>
-          </tr>
-          <tr>
-            <td>violateImpliedAbstractMethod</td>
-            <td>
-              Control whether to enforce that <code>abstract</code> is explicitly coded
-              on interface methods.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>8.12</td>
-          </tr>
-          <tr>
-            <td>violateImpliedPublicNested</td>
-            <td>
-              Control whether to enforce that <code>public</code> is explicitly coded
-              on interface nested types.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>8.12</td>
-          </tr>
-          <tr>
-            <td>violateImpliedStaticNested</td>
-            <td>
-              Control whether to enforce that <code>static</code> is explicitly coded
-              on interface nested types.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>8.12</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>violateImpliedPublicField</td>
+              <td>
+                Control whether to enforce that <code>public</code> is explicitly coded
+                on interface fields.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>8.12</td>
+            </tr>
+            <tr>
+              <td>violateImpliedStaticField</td>
+              <td>
+                Control whether to enforce that <code>static</code> is explicitly coded
+                on interface fields.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>8.12</td>
+            </tr>
+            <tr>
+              <td>violateImpliedFinalField</td>
+              <td>
+                Control whether to enforce that <code>final</code> is explicitly coded
+                on interface fields.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>8.12</td>
+            </tr>
+            <tr>
+              <td>violateImpliedPublicMethod</td>
+              <td>
+                Control whether to enforce that <code>public</code> is explicitly coded
+                on interface methods.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>8.12</td>
+            </tr>
+            <tr>
+              <td>violateImpliedAbstractMethod</td>
+              <td>
+                Control whether to enforce that <code>abstract</code> is explicitly coded
+                on interface methods.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>8.12</td>
+            </tr>
+            <tr>
+              <td>violateImpliedPublicNested</td>
+              <td>
+                Control whether to enforce that <code>public</code> is explicitly coded
+                on interface nested types.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>8.12</td>
+            </tr>
+            <tr>
+              <td>violateImpliedStaticNested</td>
+              <td>
+                Control whether to enforce that <code>static</code> is explicitly coded
+                on interface nested types.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>8.12</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="InterfaceMemberImpliedModifier_Examples">
@@ -638,57 +642,59 @@ public class ClassExtending extends ClassExample {
       </subsection>
 
       <subsection name="Properties" id="RedundantModifier_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                VARIABLE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
-                ANNOTATION_FIELD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RESOURCE">
-                RESOURCE</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                VARIABLE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
-                ANNOTATION_FIELD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RESOURCE">
-                RESOURCE</a>.
-            </td>
-            <td>3.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                  VARIABLE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
+                  ANNOTATION_FIELD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                  CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                  ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RESOURCE">
+                  RESOURCE</a>.
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                  VARIABLE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
+                  ANNOTATION_FIELD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                  CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                  ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RESOURCE">
+                  RESOURCE</a>.
+              </td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="RedundantModifier_Examples">

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -56,98 +56,100 @@
       </subsection>
 
        <subsection name="Properties" id="AbbreviationAsWordInName_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>allowedAbbreviationLength</td>
-            <td>Indicate the number of consecutive capital letters allowed in targeted
-             identifiers (abbreviations in the classes, interfaces, variables and methods
-             names, ... ).</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>3</code></td>
-            <td>5.8</td>
-          </tr>
-          <tr>
-            <td>allowedAbbreviations</td>
-            <td>Specify list of abbreviations that must be skipped for checking.
-            Abbreviations should be separated by comma.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>{}</code></td>
-            <td>5.8</td>
-          </tr>
-          <tr>
-            <td>ignoreFinal</td>
-            <td>Allow to skip variables with <code>final</code> modifier.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>5.8</td>
-          </tr>
-          <tr>
-            <td>ignoreStatic</td>
-            <td>Allow to skip variables with <code>static</code> modifier.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>5.8</td>
-          </tr>
-          <tr>
-            <td>ignoreOverriddenMethods</td>
-            <td>Allow to ignore methods tagged with <code>@Override</code> annotation
-            (that usually mean inherited name).</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>5.8</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                ANNOTATION_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
-                ANNOTATION_FIELD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
-                PARAMETER_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                VARIABLE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
-                ENUM_CONSTANT_DEF</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                ANNOTATION_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
-                ANNOTATION_FIELD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
-                PARAMETER_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                VARIABLE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>.
-            </td>
-            <td>5.8</td>
-          </tr>
-        </table>
+         <div class="wrapper">
+           <table>
+             <tr>
+               <th>name</th>
+               <th>description</th>
+               <th>type</th>
+               <th>default value</th>
+               <th>since</th>
+             </tr>
+             <tr>
+               <td>allowedAbbreviationLength</td>
+               <td>Indicate the number of consecutive capital letters allowed in targeted
+                identifiers (abbreviations in the classes, interfaces, variables and methods
+                names, ... ).</td>
+               <td><a href="property_types.html#integer">Integer</a></td>
+               <td><code>3</code></td>
+               <td>5.8</td>
+             </tr>
+             <tr>
+               <td>allowedAbbreviations</td>
+               <td>Specify list of abbreviations that must be skipped for checking.
+               Abbreviations should be separated by comma.</td>
+               <td><a href="property_types.html#stringSet">String Set</a></td>
+               <td><code>{}</code></td>
+               <td>5.8</td>
+             </tr>
+             <tr>
+               <td>ignoreFinal</td>
+               <td>Allow to skip variables with <code>final</code> modifier.</td>
+               <td><a href="property_types.html#boolean">Boolean</a></td>
+               <td><code>true</code></td>
+               <td>5.8</td>
+             </tr>
+             <tr>
+               <td>ignoreStatic</td>
+               <td>Allow to skip variables with <code>static</code> modifier.</td>
+               <td><a href="property_types.html#boolean">Boolean</a></td>
+               <td><code>true</code></td>
+               <td>5.8</td>
+             </tr>
+             <tr>
+               <td>ignoreOverriddenMethods</td>
+               <td>Allow to ignore methods tagged with <code>@Override</code> annotation
+               (that usually mean inherited name).</td>
+               <td><a href="property_types.html#boolean">Boolean</a></td>
+               <td><code>true</code></td>
+               <td>5.8</td>
+             </tr>
+             <tr>
+               <td>tokens</td>
+               <td>tokens to check</td>
+               <td>
+                 subset of tokens
+                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                   CLASS_DEF</a>,
+                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                   INTERFACE_DEF</a>,
+                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                   ENUM_DEF</a>,
+                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                   ANNOTATION_DEF</a>,
+                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
+                   ANNOTATION_FIELD_DEF</a>,
+                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
+                   PARAMETER_DEF</a>,
+                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                   VARIABLE_DEF</a>,
+                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                   METHOD_DEF</a>,
+                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
+                   ENUM_CONSTANT_DEF</a>.
+               </td>
+               <td>
+                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                   CLASS_DEF</a>,
+                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                   INTERFACE_DEF</a>,
+                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                   ENUM_DEF</a>,
+                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                   ANNOTATION_DEF</a>,
+                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
+                   ANNOTATION_FIELD_DEF</a>,
+                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
+                   PARAMETER_DEF</a>,
+                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                   VARIABLE_DEF</a>,
+                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                   METHOD_DEF</a>.
+               </td>
+               <td>5.8</td>
+             </tr>
+           </table>
+         </div>
       </subsection>
 
       <subsection name="Examples" id="AbbreviationAsWordInName_Examples">
@@ -173,7 +175,8 @@
 &lt;/module&gt;
         </source>
         <p>Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 public class MyClass { // OK
   int firstNum; // OK
   int secondNUM; // violation, it allowed only 1 consecutive capital letter
@@ -183,23 +186,27 @@ public class MyClass { // OK
   String firstXML; // OK, XML abbreviation is allowed
   String firstURL; // OK, URL abbreviation is allowed
 }
-        </pre>
+          </pre>
+        </div>
         <p>
           To configure to check variables, excluding fields with
           the static modifier, and allow abbreviations up to 2
           consecutive capital letters ignoring the longer word 'CSV'.
         </p>
         <p>Configuration:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 &lt;module name="AbbreviationAsWordInName"&gt;
   &lt;property name="tokens" value="VARIABLE_DEF"/&gt;
   &lt;property name="ignoreStatic" value="true"/&gt;
   &lt;property name="allowedAbbreviationLength" value="1"/&gt;
   &lt;property name="allowedAbbreviations" value="CSV"/&gt;
 &lt;/module&gt;
-        </pre>
+          </pre>
+        </div>
         <p>Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 public class MyClass { // OK, ignore checking the class name
   int firstNum; // OK, abbreviation "N" is of allowed length 1
   int secondNUm; // OK
@@ -212,7 +219,8 @@ public class MyClass { // OK, ignore checking the class name
   String firstCSV; // OK, CSV abbreviation is allowed
   String firstXML; // violation, XML abbreviation is not allowed
 }
-        </pre>
+          </pre>
+        </div>
       </subsection>
 
       <subsection name="Example of Usage" id="AbbreviationAsWordInName_Example_of_Usage">
@@ -266,44 +274,46 @@ public class MyClass { // OK, ignore checking the class name
       </subsection>
 
       <subsection name="Properties" id="AbstractClassName_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Specify valid identifiers.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^Abstract.+$"</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>ignoreModifier</td>
-            <td>
-              Control whether to ignore checking for the
-              <code>abstract</code> modifier on classes that match the
-              name.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.3</td>
-          </tr>
-          <tr>
-            <td>ignoreName</td>
-            <td>
-              Control whether to ignore checking the name. Realistically
-              only useful if using the check to identify that match name
-              and do not have the <code>abstract</code> modifier.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.3</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specify valid identifiers.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^Abstract.+$"</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>ignoreModifier</td>
+              <td>
+                Control whether to ignore checking for the
+                <code>abstract</code> modifier on classes that match the
+                name.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.3</td>
+            </tr>
+            <tr>
+              <td>ignoreName</td>
+              <td>
+                Control whether to ignore checking the name. Realistically
+                only useful if using the check to identify that match name
+                and do not have the <code>abstract</code> modifier.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.3</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="AbstractClassName_Examples">
@@ -319,11 +329,13 @@ public class MyClass { // OK, ignore checking the class name
 &lt;/module&gt;
         </source>
         <p>Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 abstract class AbstractFirstClass {} // OK
 abstract class SecondClass {} // violation, it should match the pattern "^Abstract.+$"
 class AbstractThirdClass {} // OK, no "abstract" modifier
-        </pre>
+          </pre>
+        </div>
       </subsection>
 
       <subsection name="Example of Usage" id="AbstractClassName_Example_of_Usage">
@@ -385,26 +397,28 @@ class AbstractThirdClass {} // OK, no "abstract" modifier
       </subsection>
 
       <subsection name="Properties" id="CatchParameterName_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Specifies valid identifiers.</td>
-            <td>
-              <a href="property_types.html#regexp">Regular Expression</a>
-            </td>
-            <td>
-              <code>"^(e|t|ex|[a-z][a-z][a-zA-Z]+)$"</code>
-            </td>
-            <td>6.14</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specifies valid identifiers.</td>
+              <td>
+                <a href="property_types.html#regexp">Regular Expression</a>
+              </td>
+              <td>
+                <code>"^(e|t|ex|[a-z][a-z][a-zA-Z]+)$"</code>
+              </td>
+              <td>6.14</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="CatchParameterName_Examples">
@@ -425,7 +439,8 @@ class AbstractThirdClass {} // OK, no "abstract" modifier
 &lt;/module&gt;
         </source>
         <p>Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 public class MyTest {
   public void myTest() {
     try {
@@ -442,7 +457,8 @@ public class MyTest {
     }
   }
 }
-        </pre>
+          </pre>
+        </div>
       </subsection>
 
       <subsection name="Example of Usage" id="CatchParameterName_Example_of_Usage">
@@ -492,22 +508,24 @@ public class MyTest {
       </subsection>
 
       <subsection name="Properties" id="ClassTypeParameterName_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^[A-Z]$"</code></td>
-            <td>5.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specifies valid identifiers.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^[A-Z]$"</code></td>
+              <td>5.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="ClassTypeParameterName_Examples">
@@ -527,12 +545,14 @@ public class MyTest {
 &lt;/module&gt;
         </source>
         <p>Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 class MyClass1&lt;T&gt; {} // OK
 class MyClass2&lt;t&gt; {} // OK
 class MyClass3&lt;abc&gt; {} // violation, the class type parameter
                              // name should match the regular expression "^[a-zA-Z]$"
-        </pre>
+         </pre>
+        </div>
       </subsection>
 
       <subsection name="Example of Usage" id="ClassTypeParameterName_Example_of_Usage">
@@ -582,52 +602,54 @@ class MyClass3&lt;abc&gt; {} // violation, the class type parameter
       </subsection>
 
       <subsection name="Properties" id="ConstantName_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>applyToPublic</td>
-            <td>Controls whether to apply the check to public member.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>applyToProtected</td>
-            <td>Controls whether to apply the check to protected member.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>applyToPackage</td>
-            <td>
-              Controls whether to apply the check to package-private member.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>applyToPrivate</td>
-            <td>Controls whether to apply the check to private member.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>5.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specifies valid identifiers.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>applyToPublic</td>
+              <td>Controls whether to apply the check to public member.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>applyToProtected</td>
+              <td>Controls whether to apply the check to protected member.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>applyToPackage</td>
+              <td>
+                Controls whether to apply the check to package-private member.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>applyToPrivate</td>
+              <td>Controls whether to apply the check to private member.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>5.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="ConstantName_Examples">
@@ -650,7 +672,8 @@ class MyClass3&lt;abc&gt; {} // violation, the class type parameter
 &lt;/module&gt;
         </source>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 class MyClass {
   final static int log = 10; // OK
   final static int logger = 50; // OK
@@ -662,19 +685,23 @@ class MyClass {
   final static int myselfConstant = 1; // violation, name 'myselfConstant' must match pattern
                                        // '^log(ger)?$|^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'
 }
-        </pre>
+          </pre>
+        </div>
         <p>
           The following configuration skip validation on
           public constant field and protected constant field.
         </p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 &lt;module name=&quot;ConstantName&quot;&gt;
   &lt;property name="applyToPublic" value="false"/&gt;
   &lt;property name="applyToProtected" value="false"/&gt;
 &lt;/module&gt;
-        </pre>
+          </pre>
+        </div>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 class MyClass {
   public final static int firstConstant = 10; // OK
   protected final static int secondConstant = 100; // OK
@@ -683,7 +710,8 @@ class MyClass {
   private final static int fourthConstant = 50; // violation, name 'fourthConstant' must match
                                                 // pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'
 }
-        </pre>
+          </pre>
+        </div>
       </subsection>
 
       <subsection name="Example of Usage" id="ConstantName_Example_of_Usage">
@@ -731,22 +759,24 @@ class MyClass {
       </subsection>
 
       <subsection name="Properties" id="InterfaceTypeParameterName_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^[A-Z]$"</code></td>
-            <td>5.8</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specifies valid identifiers.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^[A-Z]$"</code></td>
+              <td>5.8</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="InterfaceTypeParameterName_Examples">
@@ -757,10 +787,12 @@ class MyClass {
 &lt;module name=&quot;InterfaceTypeParameterName&quot;/&gt;
         </source>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 interface FirstInterface&lt;T&gt; {} // OK
 interface SecondInterface&lt;t&gt; {} // violation, name 't' must match pattern '^[A-Z]$'
-        </pre>
+          </pre>
+        </div>
         <p>
           An example of how to configure the check for names that are only a single
           letter is:
@@ -771,12 +803,14 @@ interface SecondInterface&lt;t&gt; {} // violation, name 't' must match pattern 
 &lt;/module&gt;
         </source>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 interface FirstInterface&lt;T&gt; {} // OK
 interface SecondInterface&lt;t&gt; {} // OK
 interface ThirdInterface&lt;type&gt; {} // violation, name 'type' must
                                         // match pattern '^[a-zA-Z]$'
-        </pre>
+          </pre>
+        </div>
       </subsection>
 
       <subsection name="Example of Usage" id="InterfaceTypeParameterName_Example_of_Usage">
@@ -823,22 +857,24 @@ interface ThirdInterface&lt;type&gt; {} // violation, name 'type' must
       </subsection>
 
       <subsection name="Properties" id="LambdaParameterName_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
-            <td>8.11</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specifies valid identifiers.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
+              <td>8.11</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="LambdaParameterName_Examples">
@@ -924,44 +960,46 @@ public class TestClass {
       </subsection>
 
       <subsection name="Properties" id="LocalFinalVariableName_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specifies valid identifiers.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+            <td>tokens</td>
+            <td>tokens to check</td>
+            <td>
+              subset of tokens
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                  VARIABLE_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
+                  PARAMETER_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RESOURCE">
+                  RESOURCE</a>.
+            </td>
+            <td>
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                  VARIABLE_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
+                  PARAMETER_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RESOURCE">
+                  RESOURCE</a>.
+            </td>
             <td>3.0</td>
           </tr>
-          <tr>
-          <td>tokens</td>
-          <td>tokens to check</td>
-          <td>
-            subset of tokens
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                VARIABLE_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
-                PARAMETER_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RESOURCE">
-                RESOURCE</a>.
-          </td>
-          <td>
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                VARIABLE_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
-                PARAMETER_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RESOURCE">
-                RESOURCE</a>.
-          </td>
-          <td>3.0</td>
-        </tr>
-        </table>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="LocalFinalVariableName_Examples">
@@ -981,7 +1019,8 @@ public class TestClass {
 &lt;/module&gt;
         </source>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 class MyClass {
   void MyMethod() {
     try {
@@ -993,19 +1032,23 @@ class MyClass {
     }
   }
 }
-        </pre>
+          </pre>
+        </div>
         <p>
           An example of how to configure the check for names of local final parameters and
           resources in try statements (without checks on variables):
         </p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 &lt;module name=&quot;LocalFinalVariableName&quot;&gt;
   &lt;property name="format" value="^[A-Z][A-Z0-9]*$"/&gt;
   &lt;property name="tokens" value="PARAMETER_DEF,RESOURCE"&gt;
 &lt;/module&gt;
-        </pre>
+          </pre>
+        </div>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 class MyClass {
   void MyMethod() {
     try(Scanner scanner = new Scanner()) { // violation, name 'scanner' must
@@ -1019,7 +1062,8 @@ class MyClass {
     }
   }
 }
-        </pre>
+          </pre>
+        </div>
       </subsection>
 
       <subsection name="Example of Usage" id="LocalFinalVariableName_Example_of_Usage">
@@ -1067,29 +1111,31 @@ class MyClass {
       </subsection>
 
       <subsection name="Properties" id="LocalVariableName_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>allowOneCharVarInForLoop</td>
-            <td>
-            Allow one character variable name in
-              <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/for.html">
-                initialization expressions</a> in FOR loop if one char variable name
-                is prohibited by {@code format} regexp. For example:
-                <pre>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specifies valid identifiers.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>allowOneCharVarInForLoop</td>
+              <td>
+              Allow one character variable name in
+                <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/for.html">
+                  initialization expressions</a> in FOR loop if one char variable name
+                  is prohibited by {@code format} regexp. For example:
+                  <div class="wrapper">
+                  <pre>
 for (int i = 1; i &lt; 10; i++) { // OK
     int j = 1; // violation
 }
@@ -1103,13 +1149,15 @@ for (Object o : list) { // OK
 for (Object O : list) { // OK
     int j = 1; // violation
 }
-              </pre>
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.8</td>
-          </tr>
-        </table>
+                </pre>
+                  </div>
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.8</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="LocalVariableName_Examples">
@@ -1121,7 +1169,8 @@ for (Object O : list) { // OK
 &lt;module name=&quot;LocalVariableName&quot;/&gt;
         </source>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 class MyClass {
   void MyMethod() {
     for (int var = 1; var &lt; 10; var++) {} // OK
@@ -1132,7 +1181,8 @@ class MyClass {
                                                    // pattern '^[a-z][a-zA-Z0-9]*$'
   }
 }
-        </pre>
+          </pre>
+        </div>
         <p>
           An example of how to configure the check for names that begin with a lower
           case letter, followed by letters, digits, and underscores is:
@@ -1143,7 +1193,8 @@ class MyClass {
 &lt;/module&gt;
         </source>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 class MyClass {
   void MyMethod() {
     for (int var = 1; var &lt; 10; var++) {} // OK
@@ -1153,18 +1204,21 @@ class MyClass {
     for (int var_1 = 0; var_1 &lt; 10; var_1++) {} // OK
   }
 }
-        </pre>
+          </pre>
+        </div>
         <p>
           An example of one character variable name in initialization expression(like "i")
           in FOR loop:
         </p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 for(int i = 1; i &lt; 10; i++) {}
 for(int K = 1; K &lt; 10; K++) {}
 List list = new ArrayList();
 for (Object o : list) {}
 for (Object O : list) {}
-        </pre>
+          </pre>
+        </div>
         <p>
           An example of how to configure the check to allow one character variable name in
           <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/for.html">
@@ -1177,7 +1231,8 @@ for (Object O : list) {}
 &lt;/module&gt;
         </source>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 class MyClass {
   void MyMethod() {
     int good = 1;
@@ -1197,7 +1252,8 @@ class MyClass {
     }
   }
 }
-        </pre>
+          </pre>
+        </div>
         <p>
         An example of how to configure the check to that all variables have 3 or more chars in name:
         </p>
@@ -1207,7 +1263,8 @@ class MyClass {
 &lt;/module&gt;
         </source>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 class MyClass {
   void MyMethod() {
     int goodName = 0;
@@ -1217,7 +1274,8 @@ class MyClass {
     }
   }
 }
-        </pre>
+          </pre>
+        </div>
       </subsection>
 
       <subsection name="Example of Usage" id="LocalVariableName_Example_of_Usage">
@@ -1268,52 +1326,54 @@ class MyClass {
       </subsection>
 
       <subsection name="Properties" id="MemberName_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>applyToPublic</td>
-            <td>Controls whether to apply the check to public member.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>3.4</td>
-          </tr>
-          <tr>
-            <td>applyToProtected</td>
-            <td>Controls whether to apply the check to protected member.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>3.4</td>
-          </tr>
-          <tr>
-            <td>applyToPackage</td>
-            <td>
-              Controls whether to apply the check to package-private member.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>3.4</td>
-          </tr>
-          <tr>
-            <td>applyToPrivate</td>
-            <td>Controls whether to apply the check to private member.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>3.4</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specifies valid identifiers.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>applyToPublic</td>
+              <td>Controls whether to apply the check to public member.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>3.4</td>
+            </tr>
+            <tr>
+              <td>applyToProtected</td>
+              <td>Controls whether to apply the check to protected member.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>3.4</td>
+            </tr>
+            <tr>
+              <td>applyToPackage</td>
+              <td>
+                Controls whether to apply the check to package-private member.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>3.4</td>
+            </tr>
+            <tr>
+              <td>applyToPrivate</td>
+              <td>Controls whether to apply the check to private member.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>3.4</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="MemberName_Examples">
@@ -1324,7 +1384,8 @@ class MyClass {
 &lt;module name=&quot;MemberName&quot;/&gt;
         </source>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 class MyClass {
   public int num1; // OK
   protected int num2; // OK
@@ -1340,7 +1401,8 @@ class MyClass {
   private int NUM4; // violation, name 'NUM4'
                     // must match pattern '^[a-z][a-zA-Z0-9]*$'
 }
-        </pre>
+          </pre>
+        </div>
         <p>
           An example of how to configure the check for names that begin with
           <code>&quot;m&quot;</code>, followed by an upper case letter, and then letters
@@ -1356,7 +1418,8 @@ class MyClass {
 &lt;/module&gt;
         </source>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 class MyClass {
   public int num1; // violation, name 'num1'
                    // must match pattern '^m[A-Z][a-zA-Z0-9]*$'
@@ -1365,19 +1428,23 @@ class MyClass {
   private int num4; // violation, name 'num4'
                     // must match pattern '^m[A-Z][a-zA-Z0-9]*$'
 }
-        </pre>
+          </pre>
+        </div>
         <p>
           An example of how to suppress the check which is applied to
           public and private member:
         </p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 &lt;module name=&quot;MemberName&quot;&gt;
   &lt;property name=&quot;applyToPublic&quot; value=&quot;false&quot;/&gt;
   &lt;property name=&quot;applyToPrivate&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
-        </pre>
+          </pre>
+        </div>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 class MyClass {
   public int NUM1; // OK
   protected int NUM2; // violation, name 'NUM2'
@@ -1386,7 +1453,8 @@ class MyClass {
             // must match pattern '^[a-z][a-zA-Z0-9]*$'
   private int NUM4; // OK
 }
-        </pre>
+          </pre>
+        </div>
       </subsection>
 
       <subsection name="Example of Usage" id="MemberName_Example_of_Usage">
@@ -1445,71 +1513,75 @@ class MyClass {
       </subsection>
 
       <subsection name="Properties" id="MethodName_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>allowClassName</td>
-            <td>
-              Controls whether to allow a method name to have the same
-              name as the residing class name. This is not to be confused
-              with a constructor. An easy mistake is to place a return
-              type on a constructor declaration which turns it into a
-              method. For example:
-              <pre>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specifies valid identifiers.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>allowClassName</td>
+              <td>
+                Controls whether to allow a method name to have the same
+                name as the residing class name. This is not to be confused
+                with a constructor. An easy mistake is to place a return
+                type on a constructor declaration which turns it into a
+                method. For example:
+                <div class="wrapper">
+                  <pre>
 class MyClass {
     public void MyClass() {} //this is a method
     public MyClass() {} //this is a constructor
 }
-              </pre>
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>applyToPublic</td>
-            <td>Controls whether to apply the check to public member.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>5.1</td>
-          </tr>
-          <tr>
-            <td>applyToProtected</td>
-            <td>Controls whether to apply the check to protected member.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>5.1</td>
-          </tr>
-          <tr>
-            <td>applyToPackage</td>
-            <td>
-              Controls whether to apply the check to package-private member.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>5.1</td>
-          </tr>
-          <tr>
-            <td>applyToPrivate</td>
-            <td>Controls whether to apply the check to private member.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>5.1</td>
-          </tr>
-        </table>
+                </pre>
+              </div>
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>applyToPublic</td>
+              <td>Controls whether to apply the check to public member.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>5.1</td>
+            </tr>
+            <tr>
+              <td>applyToProtected</td>
+              <td>Controls whether to apply the check to protected member.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>5.1</td>
+            </tr>
+            <tr>
+              <td>applyToPackage</td>
+              <td>
+                Controls whether to apply the check to package-private member.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>5.1</td>
+            </tr>
+            <tr>
+              <td>applyToPrivate</td>
+              <td>Controls whether to apply the check to private member.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>5.1</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="MethodName_Examples">
@@ -1529,13 +1601,15 @@ class MyClass {
 &lt;/module&gt;
         </source>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 class MyClass {
   public void myMethod() {} // OK
   public void MyMethod() {} // violation, name "MyMethod"
                             // should match the pattern "^[a-z](_?[a-zA-Z0-9]+)*$"
 }
-        </pre>
+          </pre>
+        </div>
         <p>
           An example of how to configure the check to allow method names to be equal to the
           residing class name is:
@@ -1547,43 +1621,52 @@ class MyClass {
 &lt;/module&gt;
         </source>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 class MyClass {
   public MyClass() {} // OK
   public void MyClass() {} // OK, method Name 'MyClass' is allowed to be
                            // equal to the enclosing class name
 }
-        </pre>
+          </pre>
+        </div>
         <p>
           An example of how to configure the check to disallow method names to be equal to the
           residing class name is:
         </p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 &lt;module name="MethodName"&gt;
    &lt;property name="format" value="^[a-zA-Z](_?[a-zA-Z0-9]+)*$"/&gt;
    &lt;property name="allowClassName" value="false"/&gt;
 &lt;/module&gt;
-        </pre>
+          </pre>
+        </div>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 class MyClass {
   public MyClass() {} // OK
   public void MyClass() {} // violation,  method Name 'MyClass' must not
                            // equal the enclosing class name
 }
-        </pre>
+          </pre>
+        </div>
         <p>
           An example of how to suppress the check to public and protected methods:
         </p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 &lt;module name="MethodName"&gt;
    &lt;property name="format" value="^[a-z](_?[a-zA-Z0-9]+)*$"/&gt;
    &lt;property name="applyToPublic" value="false"&gt;
    &lt;property name="applyToProtected" value="false"&gt;
 &lt;/module&gt;
-        </pre>
+          </pre>
+        </div>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 class MyClass {
   public void FirstMethod() {} // OK
   protected void SecondMethod() {} // OK
@@ -1592,7 +1675,8 @@ class MyClass {
   void FourthMethod() {} // violation, name 'FourthMethod' must match
                          // pattern '^[a-z](_?[a-zA-Z0-9]+)*$'
 }
-        </pre>
+          </pre>
+        </div>
       </subsection>
 
       <subsection name="Example of Usage" id="MethodName_Example_of_Usage">
@@ -1648,22 +1732,24 @@ class MyClass {
       </subsection>
 
       <subsection name="Properties" id="MethodTypeParameterName_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^[A-Z]$"</code></td>
-            <td>5.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specifies valid identifiers.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^[A-Z]$"</code></td>
+              <td>5.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="MethodTypeParameterName_Examples">
@@ -1674,14 +1760,16 @@ class MyClass {
 &lt;module name=&quot;MethodTypeParameterName&quot;/&gt;
         </source>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 class MyClass {
   public &lt;T&gt; void method1() {} // OK
   public &lt;a&gt; void method2() {} // violation,  name 'a' must match pattern '^[A-Z]$'
   public &lt;K, V&gt; void method3() {} // OK
   public &lt;k, V&gt; void method4() {} // violation, name 'k' must match pattern '^[A-Z]$'
 }
-        </pre>
+          </pre>
+        </div>
         <p>
           An example of how to configure the check for names that are only a single letter is:
         </p>
@@ -1691,14 +1779,16 @@ class MyClass {
 &lt;/module&gt;
         </source>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 class MyClass {
   public &lt;T&gt; void method1() {} // OK
   public &lt;a&gt; void method2() {} // OK
   public &lt;K, V&gt; void method3() {} // OK
   public &lt;k, V&gt; void method4() {} // OK
 }
-        </pre>
+          </pre>
+        </div>
       </subsection>
 
       <subsection name="Example of Usage" id="MethodTypeParameterName_Example_of_Usage">
@@ -1755,22 +1845,24 @@ class MyClass {
       </subsection>
 
       <subsection name="Properties" id="PackageName_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^[a-z]+(\.[a-zA-Z_][a-zA-Z0-9_]*)*$"</code></td>
-            <td>3.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specifies valid identifiers.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^[a-z]+(\.[a-zA-Z_][a-zA-Z0-9_]*)*$"</code></td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="PackageName_Examples">
@@ -1781,7 +1873,8 @@ class MyClass {
 &lt;module name="PackageName"/&gt;
         </source>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 package com; // OK
 package COM; // violation, name 'COM' must match pattern '^[a-z]+(\.[a-zA-Z_][a-zA-Z0-9_]*)*$'
 package com.checkstyle.checks; // OK
@@ -1789,7 +1882,8 @@ package com.A.checkstyle.checks; // OK
 package com.checkstyle1.checks; // OK
 package com.checkSTYLE.checks; // OK
 package com._checkstyle.checks_; // OK
-        </pre>
+          </pre>
+        </div>
         <p>
           An example of how to configure the check to ensure with packages start with a lowercase
           letter and only contains lowercase letters or numbers is:
@@ -1801,7 +1895,8 @@ package com._checkstyle.checks_; // OK
 &lt;/module&gt;
         </source>
         <p>Code Example:</p>
-        <pre>
+        <div class="wrapper">
+          <pre>
 package com; // OK
 package COM; // violation, name 'COM' must match pattern '^[a-z]+(\.[a-z][a-z0-9]*)*$'
 package com.checkstyle.checks; // OK
@@ -1812,7 +1907,8 @@ package com.checkSTYLE.checks; // violation, name 'com.checkSTYLE.checks' must
                                // match pattern '^[a-z]+(\.[a-z][a-z0-9]*)*$'
 package com._checkstyle.checks_; // violation, name 'com._checkstyle.checks_' must match
                                  // pattern '^[a-z]+(\.[a-z][a-z0-9]*)*$'
-        </pre>
+          </pre>
+        </div>
       </subsection>
 
       <subsection name="Example of Usage" id="PackageName_Example_of_Usage">
@@ -1873,46 +1969,50 @@ package com._checkstyle.checks_; // violation, name 'com._checkstyle.checks_' mu
       </subsection>
 
       <subsection name="Properties" id="ParameterName_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>ignoreOverridden</td>
-            <td>
-              Allows to skip methods with Override annotation from validation. For example, the
-              following method's parameter will be skipped from validation, if
-              ignoreOverridden is true:
-              <pre>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specifies valid identifiers.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>ignoreOverridden</td>
+              <td>
+                Allows to skip methods with Override annotation from validation. For example, the
+                following method's parameter will be skipped from validation, if
+                ignoreOverridden is true:
+                <div class="wrapper">
+                  <pre>
 @Override
 public boolean equals(Object o) {
   return super.equals(o);
 }
-              </pre>
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>6.12.1</td>
-          </tr>
-          <tr>
-            <td>accessModifiers</td>
-            <td>Access modifiers of methods where parameters are checked.</td>
-            <td><a href="property_types.html#access_modifiers">Access Modifier Set</a></td>
-            <td><code>public, protected, package, private</code></td>
-            <td>7.5</td>
-          </tr>
-        </table>
+                  </pre>
+                </div>
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>6.12.1</td>
+            </tr>
+            <tr>
+              <td>accessModifiers</td>
+              <td>Access modifiers of methods where parameters are checked.</td>
+              <td><a href="property_types.html#access_modifiers">Access Modifier Set</a></td>
+              <td><code>public, protected, package, private</code></td>
+              <td>7.5</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="ParameterName_Examples">
@@ -2019,52 +2119,54 @@ public boolean equals(Object o) {
       </subsection>
 
       <subsection name="Properties" id="StaticVariableName_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>applyToPublic</td>
-            <td>Controls whether to apply the check to public member.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>applyToProtected</td>
-            <td>Controls whether to apply the check to protected member.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>applyToPackage</td>
-            <td>
-              Controls whether to apply the check to package-private member.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>applyToPrivate</td>
-            <td>Controls whether to apply the check to private member.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>5.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specifies valid identifiers.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>applyToPublic</td>
+              <td>Controls whether to apply the check to public member.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>applyToProtected</td>
+              <td>Controls whether to apply the check to protected member.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>applyToPackage</td>
+              <td>
+                Controls whether to apply the check to package-private member.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>applyToPrivate</td>
+              <td>Controls whether to apply the check to private member.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>5.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="StaticVariableName_Examples">
@@ -2130,78 +2232,80 @@ public boolean equals(Object o) {
       </subsection>
 
       <subsection name="Properties" id="TypeName_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Specifies valid identifiers.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^[A-Z][a-zA-Z0-9]*$"</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>applyToPublic</td>
-            <td>Controls whether to apply the check to public member.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>applyToProtected</td>
-            <td>Controls whether to apply the check to protected member.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>applyToPackage</td>
-            <td>
-              Controls whether to apply the check to package-private member.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>applyToPrivate</td>
-            <td>Controls whether to apply the check to private member.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                ANNOTATION_DEF</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
-                ANNOTATION_DEF</a>.
-            </td>
-            <td>3.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specifies valid identifiers.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^[A-Z][a-zA-Z0-9]*$"</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>applyToPublic</td>
+              <td>Controls whether to apply the check to public member.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>applyToProtected</td>
+              <td>Controls whether to apply the check to protected member.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>applyToPackage</td>
+              <td>
+                Controls whether to apply the check to package-private member.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>applyToPrivate</td>
+              <td>Controls whether to apply the check to private member.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                  CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                  ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                  ANNOTATION_DEF</a>.
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                  CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                  ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
+                  ANNOTATION_DEF</a>.
+              </td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="TypeName_Examples">

--- a/src/xdocs/config_regexp.xml
+++ b/src/xdocs/config_regexp.xml
@@ -73,61 +73,63 @@
       </subsection>
 
       <subsection name="Properties" id="Regexp_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Specify the pattern to match against.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^$"</code> (empty)</td>
-            <td>4.0</td>
-          </tr>
-          <tr>
-            <td>message</td>
-            <td>Specify message which is used to notify about violations,
-              if empty then the default (hard-coded) message is used.</td>
-            <td><a href="property_types.html#string">String</a></td>
-            <td><code>null</code></td>
-            <td>4.0</td>
-          </tr>
-          <tr>
-            <td>illegalPattern</td>
-            <td>Control whether the pattern is required or illegal.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>4.0</td>
-          </tr>
-          <tr>
-            <td>duplicateLimit</td>
-            <td>Control whether to check for duplicates of a required pattern,
-              any negative value means no checking for duplicates, any positive
-              value is used as the maximum number of allowed duplicates, if the
-              limit is exceeded violations will be logged.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>0</code></td>
-            <td>4.0</td>
-          </tr>
-          <tr>
-            <td>errorLimit</td>
-            <td>Specify the maximum number of violations before the check will abort.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>100</code></td>
-            <td>4.0</td>
-          </tr>
-          <tr>
-            <td>ignoreComments</td>
-            <td>Control whether to ignore matches found within comments.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>4.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specify the pattern to match against.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^$"</code> (empty)</td>
+              <td>4.0</td>
+            </tr>
+            <tr>
+              <td>message</td>
+              <td>Specify message which is used to notify about violations,
+                if empty then the default (hard-coded) message is used.</td>
+              <td><a href="property_types.html#string">String</a></td>
+              <td><code>null</code></td>
+              <td>4.0</td>
+            </tr>
+            <tr>
+              <td>illegalPattern</td>
+              <td>Control whether the pattern is required or illegal.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>4.0</td>
+            </tr>
+            <tr>
+              <td>duplicateLimit</td>
+              <td>Control whether to check for duplicates of a required pattern,
+                any negative value means no checking for duplicates, any positive
+                value is used as the maximum number of allowed duplicates, if the
+                limit is exceeded violations will be logged.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>0</code></td>
+              <td>4.0</td>
+            </tr>
+            <tr>
+              <td>errorLimit</td>
+              <td>Specify the maximum number of violations before the check will abort.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>100</code></td>
+              <td>4.0</td>
+            </tr>
+            <tr>
+              <td>ignoreComments</td>
+              <td>Control whether to ignore matches found within comments.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>4.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="Regexp_Examples">
@@ -506,65 +508,67 @@ public static final int A_SETPOINT = 1;
       </subsection>
 
       <subsection name="Properties" id="RegexpMultiline_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Specify the format of the regular expression to match.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>&quot;$.&quot;</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>message</td>
-            <td>Specify the message which is used to notify about violations,
-            if empty then default (hard-coded) message is used.</td>
-            <td><a href="property_types.html#string">String</a></td>
-            <td><code>null</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>ignoreCase</td>
-            <td>Control whether to ignore case when searching.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>minimum</td>
-            <td>Specify the minimum number of matches required in each file.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>0</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>maximum</td>
-            <td>Specify the maximum number of matches required in each file.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>0</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>matchAcrossLines</td>
-            <td>Control whether to match expressions across multiple lines.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>8.25</td>
-          </tr>
-          <tr>
-            <td>fileExtensions</td>
-            <td>Specify the file type extension of files to process.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>all files</code></td>
-            <td>5.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specify the format of the regular expression to match.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>&quot;$.&quot;</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>message</td>
+              <td>Specify the message which is used to notify about violations,
+              if empty then default (hard-coded) message is used.</td>
+              <td><a href="property_types.html#string">String</a></td>
+              <td><code>null</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>ignoreCase</td>
+              <td>Control whether to ignore case when searching.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>minimum</td>
+              <td>Specify the minimum number of matches required in each file.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>0</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>maximum</td>
+              <td>Specify the maximum number of matches required in each file.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>0</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>matchAcrossLines</td>
+              <td>Control whether to match expressions across multiple lines.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>8.25</td>
+            </tr>
+            <tr>
+              <td>fileExtensions</td>
+              <td>Specify the file type extension of files to process.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>all files</code></td>
+              <td>5.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="RegexpMultiline_Examples">
@@ -700,52 +704,54 @@ void method() {
       </subsection>
 
       <subsection name="Properties" id="RegexpOnFilename_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>folderPattern</td>
-            <td>Specify the regular expression to match the folder path against.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>null</code></td>
-            <td>6.15</td>
-          </tr>
-          <tr>
-            <td>fileNamePattern</td>
-            <td>Specify the regular expression to match the file name against.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>null</code></td>
-            <td>6.15</td>
-          </tr>
-          <tr>
-            <td>match</td>
-            <td>Control whether to look for a match or mis-match on the file name, if the
-            fileNamePattern is supplied, otherwise it is applied on the folderPattern.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>6.15</td>
-          </tr>
-          <tr>
-            <td>ignoreFileNameExtensions</td>
-            <td>Control whether to ignore the file extension for the file name match.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>6.15</td>
-          </tr>
-          <tr>
-            <td>fileExtensions</td>
-            <td>Specify the file type extension of files to process. If this is specified, then
-            only files that match these types are examined with the other patterns.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>all files</code></td>
-            <td>6.15</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>folderPattern</td>
+              <td>Specify the regular expression to match the folder path against.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>null</code></td>
+              <td>6.15</td>
+            </tr>
+            <tr>
+              <td>fileNamePattern</td>
+              <td>Specify the regular expression to match the file name against.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>null</code></td>
+              <td>6.15</td>
+            </tr>
+            <tr>
+              <td>match</td>
+              <td>Control whether to look for a match or mis-match on the file name, if the
+              fileNamePattern is supplied, otherwise it is applied on the folderPattern.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>6.15</td>
+            </tr>
+            <tr>
+              <td>ignoreFileNameExtensions</td>
+              <td>Control whether to ignore the file extension for the file name match.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>6.15</td>
+            </tr>
+            <tr>
+              <td>fileExtensions</td>
+              <td>Specify the file type extension of files to process. If this is specified, then
+              only files that match these types are examined with the other patterns.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>all files</code></td>
+              <td>6.15</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="RegexpOnFilename_Examples">
@@ -875,58 +881,60 @@ void method() {
       </subsection>
 
       <subsection name="Properties" id="RegexpSingleline_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Specify the format of the regular expression to match.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>&quot;$.&quot;</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>message</td>
-            <td>Specify the message which is used to notify about violations,
-            if empty then default (hard-coded) message is used.</td>
-            <td><a href="property_types.html#string">String</a></td>
-            <td><code>null</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>ignoreCase</td>
-            <td>Control whether to ignore case when searching.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>minimum</td>
-            <td>Specify the minimum number of matches required in each file.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>0</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>maximum</td>
-            <td>Specify the maximum number of matches required in each file.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>0</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>fileExtensions</td>
-            <td>Specify the file type extension of files to process.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>all files</code></td>
-            <td>5.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specify the format of the regular expression to match.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>&quot;$.&quot;</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>message</td>
+              <td>Specify the message which is used to notify about violations,
+              if empty then default (hard-coded) message is used.</td>
+              <td><a href="property_types.html#string">String</a></td>
+              <td><code>null</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>ignoreCase</td>
+              <td>Control whether to ignore case when searching.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>minimum</td>
+              <td>Specify the minimum number of matches required in each file.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>0</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>maximum</td>
+              <td>Specify the maximum number of matches required in each file.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>0</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>fileExtensions</td>
+              <td>Specify the file type extension of files to process.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>all files</code></td>
+              <td>5.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="RegexpSingleline_Examples">
@@ -1030,58 +1038,60 @@ void method() {
       </subsection>
 
       <subsection name="Properties" id="RegexpSinglelineJava_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>format</td>
-            <td>Specify the format of the regular expression to match.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>&quot;$.&quot;</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>message</td>
-            <td>Specify the message which is used to notify about violations,
-            if empty then default (hard-coded) message is used.</td>
-            <td><a href="property_types.html#string">String</a></td>
-            <td><code>null</code></td>
-            <td>6.0</td>
-          </tr>
-          <tr>
-            <td>ignoreCase</td>
-            <td>Control whether to ignore case when searching.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>minimum</td>
-            <td>Specify the minimum number of matches required in each file.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>0</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>maximum</td>
-            <td>Specify the maximum number of matches required in each file.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>0</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>ignoreComments</td>
-            <td>Control whether to ignore text in comments when searching.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>format</td>
+              <td>Specify the format of the regular expression to match.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>&quot;$.&quot;</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>message</td>
+              <td>Specify the message which is used to notify about violations,
+              if empty then default (hard-coded) message is used.</td>
+              <td><a href="property_types.html#string">String</a></td>
+              <td><code>null</code></td>
+              <td>6.0</td>
+            </tr>
+            <tr>
+              <td>ignoreCase</td>
+              <td>Control whether to ignore case when searching.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>minimum</td>
+              <td>Specify the minimum number of matches required in each file.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>0</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>maximum</td>
+              <td>Specify the maximum number of matches required in each file.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>0</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>ignoreComments</td>
+              <td>Control whether to ignore text in comments when searching.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="RegexpSinglelineJava_Examples">

--- a/src/xdocs/config_sizes.xml
+++ b/src/xdocs/config_sizes.xml
@@ -39,22 +39,24 @@
       </subsection>
 
       <subsection name="Properties" id="AnonInnerLength_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>max</td>
-            <td>Specify the maximum number of lines allowed.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>20</code></td>
-            <td>3.2</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>max</td>
+              <td>Specify the maximum number of lines allowed.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>20</code></td>
+              <td>3.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="AnonInnerLength_Examples">
@@ -118,48 +120,50 @@
       </subsection>
 
       <subsection name="Properties" id="ExecutableStatementCount_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>max</td>
-            <td>Specify the maximum threshold allowed.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>30</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">
-                INSTANCE_INIT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">
-                STATIC_INIT</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">
-                INSTANCE_INIT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">
-                STATIC_INIT</a>.
-            </td>
-            <td>3.2</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>max</td>
+              <td>Specify the maximum threshold allowed.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>30</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">
+                  INSTANCE_INIT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">
+                  STATIC_INIT</a>.
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">
+                  INSTANCE_INIT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">
+                  STATIC_INIT</a>.
+              </td>
+              <td>3.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="ExecutableStatementCount_Examples">
@@ -232,29 +236,31 @@
       </subsection>
 
       <subsection name="Properties" id="FileLength_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>max</td>
-            <td>Specify the maximum number of lines allowed.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>2000</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>fileExtensions</td>
-            <td>Specify the file type extension of files to process.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>all files</code></td>
-            <td>5.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>max</td>
+              <td>Specify the maximum number of lines allowed.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>2000</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>fileExtensions</td>
+              <td>Specify the file type extension of files to process.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>all files</code></td>
+              <td>5.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="FileLength_Examples">
@@ -329,36 +335,38 @@
       </subsection>
 
       <subsection name="Properties" id="LineLength_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>fileExtensions</td>
-            <td>Specify file extensions that are accepted.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>all files</code></td>
-            <td>8.24</td>
-          </tr>
-          <tr>
-            <td>ignorePattern</td>
-            <td>Specify pattern for lines to ignore.</td>
-            <td><a href="property_types.html#regexp">Regular Expression</a></td>
-            <td><code>"^$" (empty)</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>max</td>
-            <td>Specify the maximum line length allowed.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>80</code></td>
-            <td>3.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>fileExtensions</td>
+              <td>Specify file extensions that are accepted.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>all files</code></td>
+              <td>8.24</td>
+            </tr>
+            <tr>
+              <td>ignorePattern</td>
+              <td>Specify pattern for lines to ignore.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^$" (empty)</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>max</td>
+              <td>Specify the maximum line length allowed.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>80</code></td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="LineLength_Examples">
@@ -517,83 +525,85 @@ public class ExampleClass {
       </subsection>
 
       <subsection name="Properties" id="MethodCount_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>maxTotal</td>
-            <td>Specify the maximum number of methods allowed at all scope levels.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>100</code></td>
-            <td>5.3</td>
-          </tr>
-          <tr>
-            <td>maxPrivate</td>
-            <td>Specify the maximum number of <code>private</code> methods allowed.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>100</code></td>
-            <td>5.3</td>
-          </tr>
-          <tr>
-            <td>maxPackage</td>
-            <td>Specify the maximum number of <code>package</code> methods allowed.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>100</code></td>
-            <td>5.3</td>
-          </tr>
-          <tr>
-            <td>maxProtected</td>
-            <td>Specify the maximum number of <code>protected</code> methods allowed.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td>100</td>
-            <td>5.3</td>
-          </tr>
-          <tr>
-            <td>maxPublic</td>
-            <td>Specify the maximum number of <code>public</code> methods allowed.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>100</code></td>
-            <td>5.3</td>
-          </tr>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>maxTotal</td>
+              <td>Specify the maximum number of methods allowed at all scope levels.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>100</code></td>
+              <td>5.3</td>
+            </tr>
+            <tr>
+              <td>maxPrivate</td>
+              <td>Specify the maximum number of <code>private</code> methods allowed.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>100</code></td>
+              <td>5.3</td>
+            </tr>
+            <tr>
+              <td>maxPackage</td>
+              <td>Specify the maximum number of <code>package</code> methods allowed.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>100</code></td>
+              <td>5.3</td>
+            </tr>
+            <tr>
+              <td>maxProtected</td>
+              <td>Specify the maximum number of <code>protected</code> methods allowed.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td>100</td>
+              <td>5.3</td>
+            </tr>
+            <tr>
+              <td>maxPublic</td>
+              <td>Specify the maximum number of <code>public</code> methods allowed.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>100</code></td>
+              <td>5.3</td>
+            </tr>
 
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
 
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
-                ENUM_CONSTANT_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                ANNOTATION_DEF</a>.
-            </td>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                  CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
+                  ENUM_CONSTANT_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                  ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  ANNOTATION_DEF</a>.
+              </td>
 
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
-                ENUM_CONSTANT_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                ANNOTATION_DEF</a>.
-            </td>
-            <td>5.3</td>
-          </tr>
-        </table>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                  CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
+                  ENUM_CONSTANT_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                  ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  INTERFACE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  ANNOTATION_DEF</a>.
+              </td>
+              <td>5.3</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="MethodCount_Examples">
@@ -692,55 +702,57 @@ public class ExampleClass {
       </subsection>
 
       <subsection name="Properties" id="MethodLength_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>max</td>
-            <td>Specify the maximum number of lines allowed.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>150</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>countEmpty</td>
-            <td>
-              Control whether to count empty lines and single line comments of the
-              form <code>//</code>.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>3.2</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>max</td>
+              <td>Specify the maximum number of lines allowed.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>150</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>countEmpty</td>
+              <td>
+                Control whether to count empty lines and single line comments of the
+                form <code>//</code>.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>3.2</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
 
-            <td>
-              subset of tokens <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>.
-            </td>
+              <td>
+                subset of tokens <a
+                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a
+                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>.
+              </td>
 
-            <td>
-              <a
-               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-               <a
-               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>.
-            </td>
-            <td>3.0</td>
-          </tr>
-        </table>
+              <td>
+                <a
+                 href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                 <a
+                 href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>.
+              </td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="MethodLength_Examples">
@@ -829,22 +841,24 @@ public class ExampleClass {
       </subsection>
 
       <subsection name="Properties" id="OuterTypeNumber_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>max</td>
-            <td>Specify the maximum number of outer types allowed.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>1</code></td>
-            <td>5.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>max</td>
+              <td>Specify the maximum number of outer types allowed.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>1</code></td>
+              <td>5.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="OuterTypeNumber_Examples">
@@ -910,54 +924,56 @@ public class ExampleClass {
       </subsection>
 
       <subsection name="Properties" id="ParameterNumber_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>max</td>
-            <td>Specify the maximum number of parameters allowed.</td>
-            <td><a href="property_types.html#integer">Integer</a></td>
-            <td><code>7</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>ignoreOverriddenMethods</td>
-            <td>
-              Ignore number of parameters for methods with <code>@Override</code> annotation.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>6.2</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>max</td>
+              <td>Specify the maximum number of parameters allowed.</td>
+              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><code>7</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>ignoreOverriddenMethods</td>
+              <td>
+                Ignore number of parameters for methods with <code>@Override</code> annotation.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>6.2</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
 
-            <td>
-              subset of tokens <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>.
-            </td>
+              <td>
+                subset of tokens <a
+                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a
+                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>.
+              </td>
 
-            <td>
-              <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a
-              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>.
-            </td>
-            <td>3.0</td>
-          </tr>
-        </table>
+              <td>
+                <a
+                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a
+                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>.
+              </td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="ParameterNumber_Examples">

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -39,22 +39,24 @@ for (
       </subsection>
 
       <subsection name="Properties" id="EmptyForInitializerPad_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>option</td>
-            <td>Specify policy on how to pad an empty for iterator.</td>
-            <td><a href="property_types.html#parenPad">Pad Policy</a></td>
-            <td><code>nospace</code></td>
-            <td>3.4</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>option</td>
+              <td>Specify policy on how to pad an empty for iterator.</td>
+              <td><a href="property_types.html#parenPad">Pad Policy</a></td>
+              <td><code>nospace</code></td>
+              <td>3.4</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="EmptyForInitializerPad_Examples">
@@ -133,24 +135,26 @@ for (Iterator foo = very.long.line.iterator();
         </source>
       </subsection>
 
-      <subsection name="Properties" id="EmptyForIteratorPad_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>option</td>
-            <td>Specify policy on how to pad an empty for iterator.</td>
-            <td><a href="property_types.html#parenPad">Pad Policy</a></td>
-            <td><code>nospace</code></td>
-            <td>3.0</td>
-          </tr>
-        </table>
-      </subsection>
+     <subsection name="Properties" id="EmptyForIteratorPad_Properties">
+       <div class="wrapper">
+         <table>
+           <tr>
+             <th>name</th>
+             <th>description</th>
+             <th>type</th>
+             <th>default value</th>
+             <th>since</th>
+           </tr>
+           <tr>
+             <td>option</td>
+             <td>Specify policy on how to pad an empty for iterator.</td>
+             <td><a href="property_types.html#parenPad">Pad Policy</a></td>
+             <td><code>nospace</code></td>
+             <td>3.0</td>
+           </tr>
+         </table>
+       </div>
+     </subsection>
 
       <subsection name="Examples" id="EmptyForIteratorPad_Examples">
         <p>
@@ -231,89 +235,91 @@ for (Iterator foo = very.long.line.iterator();
       </subsection>
 
       <subsection name="Properties" id="EmptyLineSeparator_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>allowNoEmptyLineBetweenFields</td>
-            <td>Allow no empty line between fields.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>allowNoEmptyLineBetweenFields</td>
+              <td>Allow no empty line between fields.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.8</td>
+            </tr>
+            <tr>
+              <td>allowMultipleEmptyLines</td>
+              <td>Allow multiple empty lines between class members.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>6.3</td>
+            </tr>
+            <tr>
+              <td>allowMultipleEmptyLinesInsideClassMembers</td>
+              <td>Allow multiple empty lines inside class members.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>6.18</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>subset of tokens
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">
+                  PACKAGE_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPORT">
+                  IMPORT</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_IMPORT">
+                  STATIC_IMPORT</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                  CLASS_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  INTERFACE_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                  ENUM_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  STATIC_INIT</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">
+                  INSTANCE_INIT</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                  VARIABLE_DEF</a>.
+            </td>
+            <td>
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">
+                  PACKAGE_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPORT">
+                  IMPORT</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_IMPORT">
+                  STATIC_IMPORT</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                  CLASS_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  INTERFACE_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                  ENUM_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  STATIC_INIT</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">
+                  INSTANCE_INIT</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
+                  VARIABLE_DEF</a>.
+            </td>
             <td>5.8</td>
-          </tr>
-          <tr>
-            <td>allowMultipleEmptyLines</td>
-            <td>Allow multiple empty lines between class members.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>6.3</td>
-          </tr>
-          <tr>
-            <td>allowMultipleEmptyLinesInsideClassMembers</td>
-            <td>Allow multiple empty lines inside class members.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>6.18</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>subset of tokens
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">
-                PACKAGE_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPORT">
-                IMPORT</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_IMPORT">
-                STATIC_IMPORT</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                ENUM_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                STATIC_INIT</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">
-                INSTANCE_INIT</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                VARIABLE_DEF</a>.
-          </td>
-          <td>
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">
-                PACKAGE_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPORT">
-                IMPORT</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_IMPORT">
-                STATIC_IMPORT</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                ENUM_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                STATIC_INIT</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INSTANCE_INIT">
-                INSTANCE_INIT</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
-                VARIABLE_DEF</a>.
-          </td>
-          <td>5.8</td>
-          </tr>
-        </table>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="EmptyLineSeparator_Examples">
@@ -530,31 +536,33 @@ class Foo
       </subsection>
 
       <subsection name="Properties" id="FileTabCharacter_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>eachLine</td>
-            <td>
-              Control whether to report on each line containing a tab, or just the first instance.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.0</td>
-          </tr>
-          <tr>
-            <td>fileExtensions</td>
-            <td>Specify file type extension of files to process.</td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
-            <td><code>all files</code></td>
-            <td>5.0</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>eachLine</td>
+              <td>
+                Control whether to report on each line containing a tab, or just the first instance.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.0</td>
+            </tr>
+            <tr>
+              <td>fileExtensions</td>
+              <td>Specify file type extension of files to process.</td>
+              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><code>all files</code></td>
+              <td>5.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="FileTabCharacter_Examples">
@@ -750,69 +758,71 @@ sort(list, Comparable::&lt;String&gt;compareTo);
       </subsection>
 
       <subsection name="Properties" id="MethodParamPad_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>allowLineBreaks</td>
-            <td>
-              Allow a line break between the identifier and left parenthesis.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>3.4</td>
-          </tr>
-          <tr>
-            <td>option</td>
-            <td>Specify policy on how to pad method parameter.</td>
-            <td>
-              <a href="property_types.html#parenPad">Pad Policy</a>
-            </td>
-            <td><code>nospace</code></td>
-            <td>3.4</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>allowLineBreaks</td>
+              <td>
+                Allow a line break between the identifier and left parenthesis.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>3.4</td>
+            </tr>
+            <tr>
+              <td>option</td>
+              <td>Specify policy on how to pad method parameter.</td>
+              <td>
+                <a href="property_types.html#parenPad">Pad Policy</a>
+              </td>
+              <td><code>nospace</code></td>
+              <td>3.4</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
 
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NEW">
-                LITERAL_NEW</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_CALL">
-                METHOD_CALL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SUPER_CTOR_CALL">
-                SUPER_CTOR_CALL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
-                ENUM_CONSTANT_DEF</a>.
-            </td>
-
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NEW">
-                LITERAL_NEW</a>,
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NEW">
+                  LITERAL_NEW</a>,
                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_CALL">
-                METHOD_CALL</a>,
-                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SUPER_CTOR_CALL">
-                SUPER_CTOR_CALL</a>,
-                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
-                ENUM_CONSTANT_DEF</a>.
-            </td>
-            <td>3.4</td>
-          </tr>
-        </table>
+                  METHOD_CALL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SUPER_CTOR_CALL">
+                  SUPER_CTOR_CALL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
+                  ENUM_CONSTANT_DEF</a>.
+              </td>
+
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NEW">
+                  LITERAL_NEW</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_CALL">
+                  METHOD_CALL</a>,
+                   <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                    <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SUPER_CTOR_CALL">
+                  SUPER_CTOR_CALL</a>,
+                   <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
+                  ENUM_CONSTANT_DEF</a>.
+              </td>
+              <td>3.4</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="MethodParamPad_Examples">
@@ -899,44 +909,46 @@ sort(list, Comparable::&lt;String&gt;compareTo);
       </subsection>
 
       <subsection name="Properties" id="NoLineWrap_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
-            <td>subset of tokens
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
+              <td>subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPORT">
+                  IMPORT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_IMPORT">
+                  STATIC_IMPORT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">
+                  PACKAGE_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
+                  CLASS_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
+                  ENUM_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
+                  INTERFACE_DEF</a>.
+              </td>
+              <td><a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">
+                  PACKAGE_DEF</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPORT">
-                IMPORT</a>,
+                  IMPORT</a>,
               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_IMPORT">
-                STATIC_IMPORT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">
-                PACKAGE_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
-                CLASS_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                ENUM_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
-                INTERFACE_DEF</a>.
-            </td>
-            <td><a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">
-                PACKAGE_DEF</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#IMPORT">
-                IMPORT</a>,
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_IMPORT">
-                STATIC_IMPORT</a>.</td>
-            <td>5.8</td>
-          </tr>
-        </table>
+                  STATIC_IMPORT</a>.</td>
+              <td>5.8</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="NoLineWrap_Examples">
@@ -1048,86 +1060,88 @@ import static java.math.BigInteger.ZERO;
       </subsection>
 
       <subsection name="Properties" id="NoWhitespaceAfter_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>allowLineBreaks</td>
-            <td>
-              Control whether whitespace is allowed if the token is at a linebreak.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>allowLineBreaks</td>
+              <td>
+                Control whether whitespace is allowed if the token is at a linebreak.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
 
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_INIT">
-                ARRAY_INIT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#AT">
-                AT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INC">
-                INC</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DEC">
-                DEC</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_MINUS">
-                UNARY_MINUS</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_PLUS">
-                UNARY_PLUS</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BNOT">
-                BNOT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LNOT">
-                LNOT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">
-                DOT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPECAST">
-                TYPECAST</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_DECLARATOR">
-                ARRAY_DECLARATOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INDEX_OP">
-                INDEX_OP</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">
-                LITERAL_SYNCHRONIZED</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_REF">
-                METHOD_REF</a>.
-            </td>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_INIT">
+                  ARRAY_INIT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#AT">
+                  AT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INC">
+                  INC</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DEC">
+                  DEC</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_MINUS">
+                  UNARY_MINUS</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_PLUS">
+                  UNARY_PLUS</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BNOT">
+                  BNOT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LNOT">
+                  LNOT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">
+                  DOT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPECAST">
+                  TYPECAST</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_DECLARATOR">
+                  ARRAY_DECLARATOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INDEX_OP">
+                  INDEX_OP</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">
+                  LITERAL_SYNCHRONIZED</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_REF">
+                  METHOD_REF</a>.
+              </td>
 
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_INIT">
-                ARRAY_INIT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#AT">
-                AT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INC">
-                INC</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DEC">
-                DEC</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_MINUS">
-                UNARY_MINUS</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_PLUS">
-                UNARY_PLUS</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BNOT">
-                BNOT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LNOT">
-                LNOT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">
-                DOT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_DECLARATOR">
-                ARRAY_DECLARATOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INDEX_OP">
-                INDEX_OP</a>.
-            </td>
-            <td>3.0</td>
-          </tr>
-        </table>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_INIT">
+                  ARRAY_INIT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#AT">
+                  AT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INC">
+                  INC</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DEC">
+                  DEC</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_MINUS">
+                  UNARY_MINUS</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_PLUS">
+                  UNARY_PLUS</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BNOT">
+                  BNOT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LNOT">
+                  LNOT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">
+                  DOT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_DECLARATOR">
+                  ARRAY_DECLARATOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INDEX_OP">
+                  INDEX_OP</a>.
+              </td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="NoWhitespaceAfter_Examples">
@@ -1209,63 +1223,65 @@ public void foo(final char @NotNull [] param) {} // No violation
       </subsection>
 
       <subsection name="Properties" id="NoWhitespaceBefore_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>allowLineBreaks</td>
-            <td>
-              Control whether whitespace is allowed if the token is at a linebreak.
-            </td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>allowLineBreaks</td>
+              <td>
+                Control whether whitespace is allowed if the token is at a linebreak.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
 
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMMA">
-                COMMA</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SEMI">
-                SEMI</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#POST_INC">
-                POST_INC</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#POST_DEC">
-                POST_DEC</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">
-                DOT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GENERIC_START">
-                GENERIC_START</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GENERIC_END">
-                GENERIC_END</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ELLIPSIS">
-                ELLIPSIS</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ELLIPSIS">
-                METHOD_REF</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMMA">
-                COMMA</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SEMI">
-                SEMI</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#POST_INC">
-                POST_INC</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#POST_DEC">
-                POST_DEC</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ELLIPSIS">
-                ELLIPSIS</a>.
-            </td>
-            <td>3.0</td>
-          </tr>
-        </table>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMMA">
+                  COMMA</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SEMI">
+                  SEMI</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#POST_INC">
+                  POST_INC</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#POST_DEC">
+                  POST_DEC</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">
+                  DOT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GENERIC_START">
+                  GENERIC_START</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GENERIC_END">
+                  GENERIC_END</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ELLIPSIS">
+                  ELLIPSIS</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ELLIPSIS">
+                  METHOD_REF</a>.
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMMA">
+                  COMMA</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SEMI">
+                  SEMI</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#POST_INC">
+                  POST_INC</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#POST_DEC">
+                  POST_DEC</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ELLIPSIS">
+                  ELLIPSIS</a>.
+              </td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="NoWhitespaceBefore_Examples">
@@ -1339,154 +1355,156 @@ public void foo(final char @NotNull [] param) {} // No violation
       </subsection>
 
       <subsection name="Properties" id="OperatorWrap_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>option</td>
-            <td>Specify policy on how to wrap lines.</td>
-            <td>
-              <a href="property_types.html#wrapOp">Wrap Operator Policy</a>
-            </td>
-            <td><code>nl</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>option</td>
+              <td>Specify policy on how to wrap lines.</td>
+              <td>
+                <a href="property_types.html#wrapOp">Wrap Operator Policy</a>
+              </td>
+              <td><code>nl</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
 
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">
-                QUESTION</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COLON">
-                COLON</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EQUAL">
-                EQUAL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NOT_EQUAL">
-                NOT_EQUAL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV">
-                DIV</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS">
-                PLUS</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS">
-                MINUS</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR">
-                STAR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD">
-                MOD</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR">
-                SR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR">
-                BSR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GE">
-                GE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GT">
-                GT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL">
-                SL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LE">
-                LE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LT">
-                LT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR">
-                BXOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR">
-                BOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">
-                LOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND">
-                BAND</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">
-                LAND</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_INSTANCEOF">
-                LITERAL_INSTANCEOF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPE_EXTENSION_AND">
-                TYPE_EXTENSION_AND</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">
-                ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV_ASSIGN">
-                DIV_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS_ASSIGN">
-                PLUS_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS_ASSIGN">
-                MINUS_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR_ASSIGN">
-                STAR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD_ASSIGN">
-                MOD_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR_ASSIGN">
-                SR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR_ASSIGN">
-                BSR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL_ASSIGN">
-                SL_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR_ASSIGN">
-                BXOR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR_ASSIGN">
-                BOR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND_ASSIGN">
-                BAND_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_REF">
-                METHOD_REF</a>.
-            </td>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">
+                  QUESTION</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COLON">
+                  COLON</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EQUAL">
+                  EQUAL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NOT_EQUAL">
+                  NOT_EQUAL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV">
+                  DIV</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS">
+                  PLUS</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS">
+                  MINUS</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR">
+                  STAR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD">
+                  MOD</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR">
+                  SR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR">
+                  BSR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GE">
+                  GE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GT">
+                  GT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL">
+                  SL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LE">
+                  LE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LT">
+                  LT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR">
+                  BXOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR">
+                  BOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">
+                  LOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND">
+                  BAND</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">
+                  LAND</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_INSTANCEOF">
+                  LITERAL_INSTANCEOF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPE_EXTENSION_AND">
+                  TYPE_EXTENSION_AND</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">
+                  ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV_ASSIGN">
+                  DIV_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS_ASSIGN">
+                  PLUS_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS_ASSIGN">
+                  MINUS_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR_ASSIGN">
+                  STAR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD_ASSIGN">
+                  MOD_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR_ASSIGN">
+                  SR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR_ASSIGN">
+                  BSR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL_ASSIGN">
+                  SL_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR_ASSIGN">
+                  BXOR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR_ASSIGN">
+                  BOR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND_ASSIGN">
+                  BAND_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_REF">
+                  METHOD_REF</a>.
+              </td>
 
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">
-                QUESTION</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COLON">
-                COLON</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EQUAL">
-                EQUAL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NOT_EQUAL">
-                NOT_EQUAL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV">
-                DIV</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS">
-                PLUS</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS">
-                MINUS</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR">
-                STAR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD">
-                MOD</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR">
-                SR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR">
-                BSR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GE">
-                GE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GT">
-                GT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL">
-                SL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LE">
-                LE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LT">
-                LT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR">
-                BXOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR">
-                BOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">
-                LOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND">
-                BAND</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">
-                LAND</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPE_EXTENSION_AND">
-                TYPE_EXTENSION_AND</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_INSTANCEOF">
-                LITERAL_INSTANCEOF</a>.
-            </td>
-            <td>3.0</td>
-          </tr>
-        </table>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">
+                  QUESTION</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COLON">
+                  COLON</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EQUAL">
+                  EQUAL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NOT_EQUAL">
+                  NOT_EQUAL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV">
+                  DIV</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS">
+                  PLUS</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS">
+                  MINUS</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR">
+                  STAR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD">
+                  MOD</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR">
+                  SR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR">
+                  BSR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GE">
+                  GE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GT">
+                  GT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL">
+                  SL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LE">
+                  LE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LT">
+                  LT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR">
+                  BXOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR">
+                  BOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">
+                  LOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND">
+                  BAND</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">
+                  LAND</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPE_EXTENSION_AND">
+                  TYPE_EXTENSION_AND</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_INSTANCEOF">
+                  LITERAL_INSTANCEOF</a>.
+              </td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="OperatorWrap_Examples">
@@ -1581,118 +1599,120 @@ public void foo(final char @NotNull [] param) {} // No violation
       </subsection>
 
       <subsection name="Properties" id="ParenPad_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>option</td>
-            <td>Specify policy on how to pad parentheses.</td>
-            <td><a href="property_types.html#parenPad">Pad Policy</a></td>
-            <td><code>nospace</code></td>
-            <td>3.0</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>option</td>
+              <td>Specify policy on how to pad parentheses.</td>
+              <td><a href="property_types.html#parenPad">Pad Policy</a></td>
+              <td><code>nospace</code></td>
+              <td>3.0</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
 
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION">
-                ANNOTATION</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
-                ANNOTATION_FIELD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_CALL">
-                CTOR_CALL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">
-                DOT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
-                ENUM_CONSTANT_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EXPR">
-                EXPR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
-                LITERAL_CATCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
-                LITERAL_DO</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
-                LITERAL_FOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
-                LITERAL_IF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NEW">
-                LITERAL_NEW</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">
-                LITERAL_SWITCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">
-                LITERAL_SYNCHRONIZED</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
-                LITERAL_WHILE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_CALL">
-                METHOD_CALL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">
-                QUESTION</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RESOURCE_SPECIFICATION">
-                RESOURCE_SPECIFICATION</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SUPER_CTOR_CALL">
-                SUPER_CTOR_CALL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
-                LAMBDA</a>.
-            </td>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION">
+                  ANNOTATION</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
+                  ANNOTATION_FIELD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_CALL">
+                  CTOR_CALL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">
+                  DOT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
+                  ENUM_CONSTANT_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EXPR">
+                  EXPR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
+                  LITERAL_CATCH</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
+                  LITERAL_DO</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
+                  LITERAL_FOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
+                  LITERAL_IF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NEW">
+                  LITERAL_NEW</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">
+                  LITERAL_SWITCH</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">
+                  LITERAL_SYNCHRONIZED</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
+                  LITERAL_WHILE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_CALL">
+                  METHOD_CALL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">
+                  QUESTION</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RESOURCE_SPECIFICATION">
+                  RESOURCE_SPECIFICATION</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SUPER_CTOR_CALL">
+                  SUPER_CTOR_CALL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
+                  LAMBDA</a>.
+              </td>
 
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION">
-                ANNOTATION</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
-                ANNOTATION_FIELD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_CALL">
-                CTOR_CALL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
-                CTOR_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">
-                DOT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
-                ENUM_CONSTANT_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EXPR">
-                EXPR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
-                LITERAL_CATCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
-                LITERAL_DO</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
-                LITERAL_FOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
-                LITERAL_IF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NEW">
-                LITERAL_NEW</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">
-                LITERAL_SWITCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">
-                LITERAL_SYNCHRONIZED</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
-                LITERAL_WHILE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_CALL">
-                METHOD_CALL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
-                METHOD_DEF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">
-                QUESTION</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RESOURCE_SPECIFICATION">
-                RESOURCE_SPECIFICATION</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SUPER_CTOR_CALL">
-                SUPER_CTOR_CALL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
-                LAMBDA</a>.
-            </td>
-            <td>3.0</td>
-          </tr>
-        </table>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION">
+                  ANNOTATION</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
+                  ANNOTATION_FIELD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_CALL">
+                  CTOR_CALL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
+                  CTOR_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">
+                  DOT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
+                  ENUM_CONSTANT_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EXPR">
+                  EXPR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
+                  LITERAL_CATCH</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
+                  LITERAL_DO</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
+                  LITERAL_FOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
+                  LITERAL_IF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_NEW">
+                  LITERAL_NEW</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">
+                  LITERAL_SWITCH</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">
+                  LITERAL_SYNCHRONIZED</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
+                  LITERAL_WHILE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_CALL">
+                  METHOD_CALL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+                  METHOD_DEF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">
+                  QUESTION</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RESOURCE_SPECIFICATION">
+                  RESOURCE_SPECIFICATION</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SUPER_CTOR_CALL">
+                  SUPER_CTOR_CALL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
+                  LAMBDA</a>.
+              </td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="ParenPad_Examples">
@@ -1790,60 +1810,62 @@ try (Closeable resource = acquire(); ) // no check before right parenthesis
       </subsection>
 
       <subsection name="Properties" id="SeparatorWrap_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>option</td>
-            <td>Specify policy on how to wrap lines.</td>
-            <td>
-              <a href="property_types.html#wrapOp">Wrap Operator Policy</a>
-            </td>
-            <td><code>eol</code></td>
-            <td>5.8</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>option</td>
+              <td>Specify policy on how to wrap lines.</td>
+              <td>
+                <a href="property_types.html#wrapOp">Wrap Operator Policy</a>
+              </td>
+              <td><code>eol</code></td>
+              <td>5.8</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
 
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">
-                DOT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMMA">
-                COMMA</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SEMI">
-                SEMI</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ELLIPSIS">
-                ELLIPSIS</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#AT">
-                AT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LPAREN">
-                LPAREN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RPAREN">
-                RPAREN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_DECLARATOR">
-                ARRAY_DECLARATOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RBRACK">
-                RBRACK</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_REF">
-                METHOD_REF</a>.
-            </td>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">
+                  DOT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMMA">
+                  COMMA</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SEMI">
+                  SEMI</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ELLIPSIS">
+                  ELLIPSIS</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#AT">
+                  AT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LPAREN">
+                  LPAREN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RPAREN">
+                  RPAREN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_DECLARATOR">
+                  ARRAY_DECLARATOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RBRACK">
+                  RBRACK</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_REF">
+                  METHOD_REF</a>.
+              </td>
 
-            <td>
-             <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">
-                DOT</a>,
-             <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMMA">
-                COMMA</a>.
-            </td>
-            <td>5.8</td>
-          </tr>
-        </table>
+              <td>
+               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">
+                  DOT</a>,
+               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMMA">
+                  COMMA</a>.
+              </td>
+              <td>5.8</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="SeparatorWrap_Examples">
@@ -1979,22 +2001,24 @@ public long toMicros(long d) { return d / (C1 / C0); }
       </subsection>
 
       <subsection name="Properties" id="SingleSpaceSeparator_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>validateComments</td>
-            <td>Control whether to validate whitespaces surrounding comments.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>6.19</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>validateComments</td>
+              <td>Control whether to validate whitespaces surrounding comments.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>6.19</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="SingleSpaceSeparator_Examples">
@@ -2063,22 +2087,24 @@ public long toMicros(long d) { return d / (C1 / C0); }
       </subsection>
 
       <subsection name="Properties" id="TypecastParenPad_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>option</td>
-            <td>Specify policy on how to pad parentheses.</td>
-            <td><a href="property_types.html#parenPad">Pad Policy</a></td>
-            <td><code>nospace</code></td>
-            <td>3.2</td>
-          </tr>
-        </table>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>option</td>
+              <td>Specify policy on how to pad parentheses.</td>
+              <td><a href="property_types.html#parenPad">Pad Policy</a></td>
+              <td><code>nospace</code></td>
+              <td>3.2</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="TypecastParenPad_Examples">
@@ -2162,63 +2188,65 @@ public long toMicros(long d) { return d / (C1 / C0); }
       </subsection>
 
       <subsection name="Properties" id="WhitespaceAfter_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
 
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMMA">
-                COMMA</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SEMI">
-                SEMI</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPECAST">
-                TYPECAST</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
-                LITERAL_IF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">
-                LITERAL_ELSE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
-                LITERAL_WHILE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
-                LITERAL_DO</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
-                LITERAL_FOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
-                DO_WHILE</a>.
-            </td>
-
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMMA">
-                COMMA</a>,
-               <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SEMI">
-                SEMI</a>,
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMMA">
+                  COMMA</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SEMI">
+                  SEMI</a>,
                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPECAST">
-                TYPECAST</a>,
+                  TYPECAST</a>,
                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
-                LITERAL_IF</a>,
+                  LITERAL_IF</a>,
                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">
-                LITERAL_ELSE</a>,
+                  LITERAL_ELSE</a>,
                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
-                LITERAL_WHILE</a>,
+                  LITERAL_WHILE</a>,
                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
-                LITERAL_DO</a>,
+                  LITERAL_DO</a>,
                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
-                LITERAL_FOR</a>,
+                  LITERAL_FOR</a>,
                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
-                DO_WHILE</a>.
-            </td>
-            <td>3.0</td>
-          </tr>
-        </table>
+                  DO_WHILE</a>.
+              </td>
+
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMMA">
+                  COMMA</a>,
+                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SEMI">
+                  SEMI</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPECAST">
+                  TYPECAST</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
+                  LITERAL_IF</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">
+                  LITERAL_ELSE</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
+                  LITERAL_WHILE</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
+                  LITERAL_DO</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
+                  LITERAL_FOR</a>,
+                  <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
+                  DO_WHILE</a>.
+              </td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="WhitespaceAfter_Examples">
@@ -2314,19 +2342,23 @@ public @interface Beta {} // empty annotation type
         properties.
         </p>
         <p>This check does not flag as violation double brace initialization like:</p>
-        <pre><code>
+        <div class="wrapper">
+          <pre><code>
 new Properties() {{
     setProperty("key", "value");
 }};
-        </code></pre>
+          </code></pre>
+        </div>
         <p>Parameter allowEmptyCatches allows to suppress violations when token
         list contains SLIST to check if beginning of block is surrounded by
         whitespace and catch block is empty, for example:</p>
-        <pre><code>
+        <div class="wrapper">
+          <pre><code>
 try {
     k = 5 / i;
 } catch (ArithmeticException ex) {}
-        </code></pre>
+          </code></pre>
+        </div>
       <p>
         With this property turned off, this raises violation because the beginning of the
         catch block (left curly bracket) is not separated from the end of the catch
@@ -2335,291 +2367,293 @@ try {
       </subsection>
 
       <subsection name="Properties" id="WhitespaceAround_Properties">
-        <table>
-          <tr>
-            <th>name</th>
-            <th>description</th>
-            <th>type</th>
-            <th>default value</th>
-            <th>since</th>
-          </tr>
-          <tr>
-            <td>allowEmptyConstructors</td>
-            <td>Allow empty constructor bodies.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>4.0</td>
-          </tr>
-          <tr>
-            <td>allowEmptyMethods</td>
-            <td>Allow empty method bodies.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>4.0</td>
-          </tr>
-          <tr>
-            <td>allowEmptyTypes</td>
-            <td>Allow empty class, interface and enum bodies.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.8</td>
-          </tr>
-          <tr>
-            <td>allowEmptyLoops</td>
-            <td>Allow empty loop bodies.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>5.8</td>
-          </tr>
-          <tr>
-            <td>allowEmptyLambdas</td>
-            <td>Allow empty lambda bodies.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>6.14</td>
-          </tr>
-          <tr>
-            <td>allowEmptyCatches</td>
-            <td>Allow empty catch bodies.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>false</code></td>
-            <td>7.6</td>
-          </tr>
-          <tr>
-            <td>ignoreEnhancedForColon</td>
-            <td>Ignore whitespace around colon in
-              <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-14.html#jls-14.14.2">
-                enhanced for</a> loop.</td>
-            <td><a href="property_types.html#boolean">Boolean</a></td>
-            <td><code>true</code></td>
-            <td>5.5</td>
-          </tr>
-          <tr>
-            <td>tokens</td>
-            <td>tokens to check</td>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>allowEmptyConstructors</td>
+              <td>Allow empty constructor bodies.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>4.0</td>
+            </tr>
+            <tr>
+              <td>allowEmptyMethods</td>
+              <td>Allow empty method bodies.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>4.0</td>
+            </tr>
+            <tr>
+              <td>allowEmptyTypes</td>
+              <td>Allow empty class, interface and enum bodies.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.8</td>
+            </tr>
+            <tr>
+              <td>allowEmptyLoops</td>
+              <td>Allow empty loop bodies.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>5.8</td>
+            </tr>
+            <tr>
+              <td>allowEmptyLambdas</td>
+              <td>Allow empty lambda bodies.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>6.14</td>
+            </tr>
+            <tr>
+              <td>allowEmptyCatches</td>
+              <td>Allow empty catch bodies.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>7.6</td>
+            </tr>
+            <tr>
+              <td>ignoreEnhancedForColon</td>
+              <td>Ignore whitespace around colon in
+                <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-14.html#jls-14.14.2">
+                  enhanced for</a> loop.</td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>true</code></td>
+              <td>5.5</td>
+            </tr>
+            <tr>
+              <td>tokens</td>
+              <td>tokens to check</td>
 
-            <td>
-              subset of tokens
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">
-                ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_INIT">
-                ARRAY_INIT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND">
-                BAND</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND_ASSIGN">
-                BAND_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR">
-                BOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR_ASSIGN">
-                BOR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR">
-                BSR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR_ASSIGN">
-                BSR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR">
-                BXOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR_ASSIGN">
-                BXOR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COLON">
-                COLON</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV">
-                DIV</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV_ASSIGN">
-                DIV_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DO_WHILE">
-                DO_WHILE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EQUAL">
-                EQUAL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GE">
-                GE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GT">
-                GT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
-                LAMBDA</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">
-                LAND</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LCURLY">
-                LCURLY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LE">
-                LE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
-                LITERAL_CATCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
-                LITERAL_DO</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">
-                LITERAL_ELSE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">
-                LITERAL_FINALLY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
-                LITERAL_FOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
-                LITERAL_IF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_RETURN">
-                LITERAL_RETURN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">
-                LITERAL_SWITCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">
-                LITERAL_SYNCHRONIZED</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">
-                LITERAL_TRY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
-                LITERAL_WHILE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">
-                LOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LT">
-                LT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS">
-                MINUS</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS_ASSIGN">
-                MINUS_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD">
-                MOD</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD_ASSIGN">
-                MOD_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NOT_EQUAL">
-                NOT_EQUAL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS">
-                PLUS</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS_ASSIGN">
-                PLUS_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">
-                QUESTION</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RCURLY">
-                RCURLY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL">
-                SL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SLIST">
-                SLIST</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL_ASSIGN">
-                SL_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR">
-                SR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR_ASSIGN">
-                SR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR">
-                STAR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR_ASSIGN">
-                STAR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ASSERT">
-                LITERAL_ASSERT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPE_EXTENSION_AND">
-                TYPE_EXTENSION_AND</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#WILDCARD_TYPE">
-                WILDCARD_TYPE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GENERIC_START">
-                GENERIC_START</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GENERIC_END">
-                GENERIC_END</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ELLIPSIS">
-                ELLIPSIS</a>.
-            </td>
-            <td>
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">
-                ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND">
-                BAND</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND_ASSIGN">
-                BAND_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR">
-                BOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR_ASSIGN">
-                BOR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR">
-                BSR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR_ASSIGN">
-                BSR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR">
-                BXOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR_ASSIGN">
-                BXOR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COLON">
-                COLON</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV">
-                DIV</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV_ASSIGN">
-                DIV_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DO_WHILE">
-                DO_WHILE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EQUAL">
-                EQUAL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GE">
-                GE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GT">
-                GT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
-                LAMBDA</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">
-                LAND</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LCURLY">
-                LCURLY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LE">
-                LE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
-                LITERAL_CATCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
-                LITERAL_DO</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">
-                LITERAL_ELSE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">
-                LITERAL_FINALLY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
-                LITERAL_FOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
-                LITERAL_IF</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_RETURN">
-                LITERAL_RETURN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">
-                LITERAL_SWITCH</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">
-                LITERAL_SYNCHRONIZED</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">
-                LITERAL_TRY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
-                LITERAL_WHILE</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">
-                LOR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LT">
-                LT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS">
-                MINUS</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS_ASSIGN">
-                MINUS_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD">
-                MOD</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD_ASSIGN">
-                MOD_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NOT_EQUAL">
-                NOT_EQUAL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS">
-                PLUS</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS_ASSIGN">
-                PLUS_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">
-                QUESTION</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RCURLY">
-                RCURLY</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL">
-                SL</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SLIST">
-                SLIST</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL_ASSIGN">
-                SL_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR">
-                SR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR_ASSIGN">
-                SR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR">
-                STAR</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR_ASSIGN">
-                STAR_ASSIGN</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ASSERT">
-                LITERAL_ASSERT</a>,
-              <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPE_EXTENSION_AND">
-                TYPE_EXTENSION_AND</a>.
-            </td>
-            <td>3.0</td>
-          </tr>
-        </table>
+              <td>
+                subset of tokens
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">
+                  ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ARRAY_INIT">
+                  ARRAY_INIT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND">
+                  BAND</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND_ASSIGN">
+                  BAND_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR">
+                  BOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR_ASSIGN">
+                  BOR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR">
+                  BSR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR_ASSIGN">
+                  BSR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR">
+                  BXOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR_ASSIGN">
+                  BXOR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COLON">
+                  COLON</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV">
+                  DIV</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV_ASSIGN">
+                  DIV_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DO_WHILE">
+                  DO_WHILE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EQUAL">
+                  EQUAL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GE">
+                  GE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GT">
+                  GT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
+                  LAMBDA</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">
+                  LAND</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LCURLY">
+                  LCURLY</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LE">
+                  LE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
+                  LITERAL_CATCH</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
+                  LITERAL_DO</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">
+                  LITERAL_ELSE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">
+                  LITERAL_FINALLY</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
+                  LITERAL_FOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
+                  LITERAL_IF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_RETURN">
+                  LITERAL_RETURN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">
+                  LITERAL_SWITCH</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">
+                  LITERAL_SYNCHRONIZED</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">
+                  LITERAL_TRY</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
+                  LITERAL_WHILE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">
+                  LOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LT">
+                  LT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS">
+                  MINUS</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS_ASSIGN">
+                  MINUS_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD">
+                  MOD</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD_ASSIGN">
+                  MOD_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NOT_EQUAL">
+                  NOT_EQUAL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS">
+                  PLUS</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS_ASSIGN">
+                  PLUS_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">
+                  QUESTION</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RCURLY">
+                  RCURLY</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL">
+                  SL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SLIST">
+                  SLIST</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL_ASSIGN">
+                  SL_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR">
+                  SR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR_ASSIGN">
+                  SR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR">
+                  STAR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR_ASSIGN">
+                  STAR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ASSERT">
+                  LITERAL_ASSERT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPE_EXTENSION_AND">
+                  TYPE_EXTENSION_AND</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#WILDCARD_TYPE">
+                  WILDCARD_TYPE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GENERIC_START">
+                  GENERIC_START</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GENERIC_END">
+                  GENERIC_END</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ELLIPSIS">
+                  ELLIPSIS</a>.
+              </td>
+              <td>
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ASSIGN">
+                  ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND">
+                  BAND</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND_ASSIGN">
+                  BAND_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR">
+                  BOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BOR_ASSIGN">
+                  BOR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR">
+                  BSR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BSR_ASSIGN">
+                  BSR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR">
+                  BXOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BXOR_ASSIGN">
+                  BXOR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COLON">
+                  COLON</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV">
+                  DIV</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DIV_ASSIGN">
+                  DIV_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DO_WHILE">
+                  DO_WHILE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EQUAL">
+                  EQUAL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GE">
+                  GE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GT">
+                  GT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
+                  LAMBDA</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">
+                  LAND</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LCURLY">
+                  LCURLY</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LE">
+                  LE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
+                  LITERAL_CATCH</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_DO">
+                  LITERAL_DO</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ELSE">
+                  LITERAL_ELSE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FINALLY">
+                  LITERAL_FINALLY</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
+                  LITERAL_FOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
+                  LITERAL_IF</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_RETURN">
+                  LITERAL_RETURN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">
+                  LITERAL_SWITCH</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">
+                  LITERAL_SYNCHRONIZED</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">
+                  LITERAL_TRY</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
+                  LITERAL_WHILE</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">
+                  LOR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LT">
+                  LT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS">
+                  MINUS</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MINUS_ASSIGN">
+                  MINUS_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD">
+                  MOD</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#MOD_ASSIGN">
+                  MOD_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NOT_EQUAL">
+                  NOT_EQUAL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS">
+                  PLUS</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PLUS_ASSIGN">
+                  PLUS_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#QUESTION">
+                  QUESTION</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RCURLY">
+                  RCURLY</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL">
+                  SL</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SLIST">
+                  SLIST</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SL_ASSIGN">
+                  SL_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR">
+                  SR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#SR_ASSIGN">
+                  SR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR">
+                  STAR</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STAR_ASSIGN">
+                  STAR_ASSIGN</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_ASSERT">
+                  LITERAL_ASSERT</a>,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPE_EXTENSION_AND">
+                  TYPE_EXTENSION_AND</a>.
+              </td>
+              <td>3.0</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Examples" id="WhitespaceAround_Examples">

--- a/src/xdocs/eclipse.xml
+++ b/src/xdocs/eclipse.xml
@@ -32,7 +32,9 @@
     <section name="Import Checkstyle Project">
       <p>
         Select File > Import > Maven > Existing Maven Projects<br/><br/>
-        <img alt="screenshot" src="images/gui_screenshot_importing_eclipse.png"/>
+        <span class="wrapper">
+          <img alt="screenshot" src="images/gui_screenshot_importing_eclipse.png"/>
+        </span>
       </p>
     </section>
 
@@ -40,8 +42,10 @@
       <p>When you import Checkstyle Project, "Setup maven plugin connectors" window will appear.</p>
       <p>
         Left click on "Finish".<br/><br/>
-        <img alt="screenshot"
-          src="images/gui_screenshot_setup_maven_plugin_connectors_eclipse.png"/>
+        <span class="wrapper">
+          <img alt="screenshot"
+            src="images/gui_screenshot_setup_maven_plugin_connectors_eclipse.png"/>
+        </span>
         <br/><br/>
       </p>
       <p>
@@ -49,26 +53,36 @@
         <br/><br/>
         Left click on Next > Next.
         <br/><br/>
-        <img alt="screenshot" src="images/gui_screenshot_install_connector_eclipse.png"/>
+        <span class="wrapper">
+          <img alt="screenshot" src="images/gui_screenshot_install_connector_eclipse.png"/>
+        </span>
         <br/><br/>
-        <img alt="screenshot" src="images/gui_screenshot_install_connector_details_eclipse.png"/>
+        <span class="wrapper">
+          <img alt="screenshot" src="images/gui_screenshot_install_connector_details_eclipse.png"/>
+        </span>
         <br/><br/>
         Set "I accept the terms of the license agreement" > Finish.
         <br/><br/>
-        <img alt="screenshot" src="images/gui_screenshot_install_connector_license_eclipse.png"/>
+        <span class="wrapper">
+          <img alt="screenshot" src="images/gui_screenshot_install_connector_license_eclipse.png"/>
+        </span>
       </p>
       <p>
         <br/><br/>
         Then "Security Warning" window will appear.
         <br/><br/>
         Left click on "OK", and then restart Eclipse.<br/><br/>
-        <img alt="screenshot"
-          src="images/gui_screenshot_install_connector_security_warning_eclipse.png"/>
+        <span class="wrapper">
+          <img alt="screenshot"
+            src="images/gui_screenshot_install_connector_security_warning_eclipse.png"/>
+        </span>
       </p>
       <p>
         <br/><br/>
         Then target/generated-sources/antlr folder will appear in Package Explorer.<br/><br/>
-        <img alt="screenshot" src="images/gui_screenshot_package_explorer_eclipse.png"/>
+        <span class="wrapper">
+          <img alt="screenshot" src="images/gui_screenshot_package_explorer_eclipse.png"/>
+        </span>
       </p>
     </section>
 
@@ -88,7 +102,9 @@
       <p>
         2) Ignore optional compile problems on resource files:<br/><br/>
         Right click on Checkstyle project > Build Path > Configure Build Path...<br/><br/>
-        <img alt="screenshot" src="images/gui_screenshot_eclipse_build_path.png"/>
+        <span class="wrapper">
+          <img alt="screenshot" src="images/gui_screenshot_eclipse_build_path.png"/>
+        </span>
       </p>
       <p>
         Set "Ignore optional compile problems" to "Yes" for following folders:
@@ -100,7 +116,9 @@
         <li>target/generated-sources/antlr</li>
       </ul>
       <p>
-        <img alt="screenshot" src="images/gui_screenshot_eclipse_ignore_warnings.png"/>
+        <span class="wrapper">
+          <img alt="screenshot" src="images/gui_screenshot_eclipse_ignore_warnings.png"/>
+        </span>
       </p>
     </section>
 
@@ -115,8 +133,10 @@
         picture).<br/>
         Default configuration should look as following (you can also try Restore Defaults
         button):<br/><br/>
-        <img alt="Organize Imports settings in Eclipse"
-          src="images/gui_screenshot_organize_imports_eclipse.png"/>
+        <span class="wrapper">
+          <img alt="Organize Imports settings in Eclipse"
+            src="images/gui_screenshot_organize_imports_eclipse.png"/>
+        </span>
         <br/>
       </p>
     </section>
@@ -124,15 +144,21 @@
     <section name="Debug">
       <p>
         Open the Check's source file by double click on it in a source tree as is shown:<br/><br/>
-        <img alt="screenshot" src="images/gui_screenshot_select_check_eclipse.png"/>
+        <span class="wrapper">
+          <img alt="screenshot" src="images/gui_screenshot_select_check_eclipse.png"/>
+        </span>
         <br/><br/>
         Debug the Check by putting the breakpoint at controversial place (double-click)
         on the left part of line number as it is shown:<br/><br/>
-        <img alt="screenshot" src="images/gui_screenshot_debug_eclipse.png"/>
+        <span class="wrapper">
+          <img alt="screenshot" src="images/gui_screenshot_debug_eclipse.png"/>
+        </span>
         <br/><br/>
         Then right-click the corresponding Unit-test file or class definition > Debug As >
         JUnit Test<br/><br/>
-        <img alt="screenshot" src="images/gui_screenshot_ut_select_eclipse.png"/>
+        <span class="wrapper">
+          <img alt="screenshot" src="images/gui_screenshot_ut_select_eclipse.png"/>
+        </span>
         <br/><br/>
         Then manage you debug operations by F6 (Step Over), F5 (Step Into), F7 (Step Return)
         and F8 (Resume)

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -5,1906 +5,1983 @@
           xsi:schemaLocation="http://maven.apache.org/XDOC/2.0
                               http://maven.apache.org/xsd/xdoc-2.0.xsd">
 
-    <head>
-        <title>Google's Style</title>
-        <script type="text/javascript"
-                src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"/>
-        <script type="text/javascript" src="js/anchors.js"/>
-        <script type="text/javascript" src="js/google-analytics.js"/>
-        <link rel="icon" href="images/favicon.png" type="image/x-icon" />
-        <link rel="shortcut icon" href="images/favicon.ico" type="image/ico" />
-    </head>
+  <head>
+    <title>Google's Style</title>
+    <script type="text/javascript"
+            src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"/>
+    <script type="text/javascript" src="js/anchors.js"/>
+    <script type="text/javascript" src="js/google-analytics.js"/>
+    <link rel="icon" href="images/favicon.png" type="image/x-icon" />
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/ico" />
+  </head>
 
-    <body>
-        <section name="Google's Java Style Checkstyle Coverage ">
-            <subsection name="Useful information" id="Google_Useful_information">
-                <p>
-                    This coverage report was created for
-                    <a href="http://google.github.io/styleguide/javaguide.html">
-                        Google Java Style</a>(
-                    <a href="styleguides/google-java-style-20180523/javaguide.html">
-                    cached page</a>),
-                    version of 23 May 2018, current as of 07 May 2019
-                </p>
+  <body>
+    <section name="Google's Java Style Checkstyle Coverage ">
+      <subsection name="Useful information" id="Google_Useful_information">
+        <p>
+          This coverage report was created for
+          <a href="http://google.github.io/styleguide/javaguide.html">
+            Google Java Style</a>(
+          <a href="styleguides/google-java-style-20180523/javaguide.html">
+            cached page</a>),
+          version of 23 May 2018, current as of 07 May 2019
+        </p>
 
-                <p>
-                    <a href="http://checkstyle.sourceforge.io/reports/google-style/guava/">
-                        Checkstyle's html report for Guava library</a>
-                </p>
-                <p>
-                    <a href="https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/google_checks.xml">
-                    Checkstyle configuration for 'Google Java Style'</a>
-                </p>
-            </subsection>
-            <subsection name="Legend" id="Google_Legend">
-                <p>
-                    "--" - There is no rule in this paragraph.
-                    <br />
-                    "↓" - This paragraph is the high-level point of some group.
-                    <br />
-                    <img
-                        src="images/ok_green.png"
-                        alt="" />
-                    - Existing Check covers all requirements from Google.
-                    <br />
-                    <img
-                        src="images/ok_blue.png"
-                        alt="" />
-                    - Existing Check covers some part of requirements from Google.
-                    <br />
+        <p>
+          <a href="http://checkstyle.sourceforge.io/reports/google-style/guava/">
+            Checkstyle's html report for Guava library</a>
+        </p>
+        <p>
+          <a href="https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/google_checks.xml">
+            Checkstyle configuration for 'Google Java Style'</a>
+        </p>
+      </subsection>
+      <subsection name="Legend" id="Google_Legend">
+        <p>
+          "--" - There is no rule in this paragraph.
+          <br />
+          "↓" - This paragraph is the high-level point of some group.
+          <br />
+          <span class="wrapper">
+            <img
+                src="images/ok_green.png"
+                alt="" />
+          </span>
+          - Existing Check covers all requirements from Google.
+          <br />
+          <span class="wrapper">
+            <img
+                src="images/ok_blue.png"
+                alt="" />
+          </span>
+          - Existing Check covers some part of requirements from Google.
+          <br />
+          <span class="wrapper">
+            <img
+                src="images/ban_red.png"
+                alt="" />
+          </span>
+          - Requirements are not possible to check by Checkstyle at all.
+          <br />
+        </p>
+      </subsection>
+      <subsection name="Coverage table" id="Google_Coverage_table">
+        <div class="wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th/>
+                <th>Google's Java Style Rule</th>
+                <th>Checkstyle Check</th>
+                <th>Applied to config</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <a name="1"/>
+                  <a href="#1">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s1-introduction">
+                    <strong>1 Introduction</strong>
+                  </a>
+                </td>
+                <td>--</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="1.1"/>
+                  <a href="#1.1">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s1.1-terminology">
+                    1.1 Terminology notes</a>
+                </td>
+                <td>--</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="1.2"/>
+                  <a href="#1.2">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s1.2-guide-notes">
+                    1.2 Guide notes</a>
+                </td>
+                <td>--</td>
+                <td>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <a name="2"/>
+                  <a href="#2">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s2-source-file-basics">
+                    <strong>2 Source file basics</strong>
+                  </a>
+                </td>
+                <td>↓</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="2.1"/>
+                  <a href="#2.1">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s2.1-file-name">
+                    2.1 File name</a>
+                </td>
+                <td>
+                  <span class="wrapper">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="config_misc.html#OuterTypeFilename">OuterTypeFilename</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OuterTypeFilename">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule21filename/OuterTypeFilenameTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="2.2"/>
+                  <a href="#2.2">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s2.2-file-encoding">
+                    2.2 File encoding: UTF-8
+                  </a>
+                </td>
+                <td>
+                  <span class="wrapper">
                     <img
                         src="images/ban_red.png"
                         alt="" />
-                    - Requirements are not possible to check by Checkstyle at all.
-                    <br />
-                </p>
-            </subsection>
-            <subsection name="Coverage table" id="Google_Coverage_table">
-                <table>
-                    <thead>
-                        <tr>
-                            <th/>
-                            <th>Google's Java Style Rule</th>
-                            <th>Checkstyle Check</th>
-                            <th>Applied to config</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>
-                                <a name="1"/>
-                                <a href="#1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s1-introduction">
-                                    <strong>1 Introduction</strong>
-                                </a>
-                            </td>
-                            <td>--</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="1.1"/>
-                                <a href="#1.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s1.1-terminology">
-                                    1.1 Terminology notes</a>
-                            </td>
-                            <td>--</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="1.2"/>
-                                <a href="#1.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s1.2-guide-notes">
-                                    1.2 Guide notes</a>
-                            </td>
-                            <td>--</td>
-                            <td>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="2"/>
-                                <a href="#2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s2-source-file-basics">
-                                    <strong>2 Source file basics</strong>
-                                </a>
-                            </td>
-                            <td>↓</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="2.1"/>
-                                <a href="#2.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s2.1-file-name">
-                                    2.1 File name</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_misc.html#OuterTypeFilename">OuterTypeFilename</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OuterTypeFilename">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule21filename/OuterTypeFilenameTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="2.2"/>
-                                <a href="#2.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s2.2-file-encoding">
-                                 2.2 File encoding: UTF-8
-                                </a>
-                            </td>
-                            <td>
-                                <img
-                                src="images/ban_red.png"
-                                alt="" />
-                                <a href="https://github.com/checkstyle/checkstyle/issues/265">
-                                    explanation</a>
-                            </td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="2.3.1"/>
-                                <a href="#2.3.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s2.3.1-whitespace-characters">
-                                    2.3.1 Whitespace characters</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_whitespace.html#FileTabCharacter">
-                                    FileTabCharacter</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+FileTabCharacter">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule231filetab/FileTabCharacterTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="2.3.2"/>
-                                <a href="#2.3.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s2.3.2-special-escape-sequences">
-                                    2.3.2 Special escape sequences</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_coding.html#IllegalTokenText">IllegalTokenText</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+IllegalTokenText">
-                                    config</a><br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/IllegalTokenTextTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="2.3.3"/>
-                                <a href="#2.3.3">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s2.3.3-non-ascii-characters">
-                                    2.3.3 Non-ASCII characters</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_misc.html#AvoidEscapedUnicodeCharacters">
-                                    AvoidEscapedUnicodeCharacters</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidEscapedUnicodeCharacters">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule233nonascii/AvoidEscapedUnicodeCharactersTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="3"/>
-                                <a href="#3">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s3-source-file-structure">
-                                    <strong>3 Source file structure</strong>
-                                </a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_whitespace.html#EmptyLineSeparator">
-                                    EmptyLineSeparator</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+EmptyLineSeparator">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/EmptyLineSeparatorTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="3.1"/>
-                                <a href="#3.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s3.1-copyright-statement">
-                                    3.1 License or copyright information, if present</a>
-                            </td>
-                            <td>--</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="3.2"/>
-                                <a href="#3.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s3.2-package-statement">
-                                    3.2 Package statement</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_sizes.html#LineLength">LineLength</a>
-                                <br />
-                                <br />
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_whitespace.html#NoLineWrap">NoLineWrap</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LineLength">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule32packagestate/LineLengthTest.java">
-                                    test</a>
-                                <br />
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoLineWrap">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/NoLineWrapTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="3.3"/>
-                                <a href="#3.3">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s3.3-import-statements">
-                                    3.3 Import statements
-                                </a>
-                            </td>
-                            <td>↓</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="3.3.1"/>
-                                <a href="#3.3.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s3.3.1-wildcard-imports">
-                                    3.3.1 No wildcard imports</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_imports.html#AvoidStarImport">AvoidStarImport</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidStarImport">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule331nowildcard/AvoidStarImportTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="3.3.2"/>
-                                <a href="#3.3.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s3.3.2-import-line-wrapping">
-                                    3.3.2 No line-wrapping</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_sizes.html#LineLength">LineLength</a>
-                                <br />
-                                <br />
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_whitespace.html#NoLineWrap">NoLineWrap</a>
-                                <br />
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LineLength">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule32packagestate/LineLengthTest.java">
-                                    test</a>
-                                <br />
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoLineWrap">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/NoLineWrapTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="3.3.3"/>
-                                <a href="#3.3.3">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s3.3.3-import-ordering-and-spacing">
-                                    3.3.3 Ordering and spacing</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_imports.html#CustomImportOrder">
-                                    CustomImportOrder</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+CustomImportOrder">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/CustomImportOrderTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="3.3.4"/>
-                                <a href="#3.3.4">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s3.3.4-import-class-not-static">
-                                   3.3.4 No static import for classes</a>
-                            </td>
-                            <td>
-                                <img
-                                    src="images/ban_red.png"
-                                    alt="" />
-                                That validation could not be checked by Checkstyle. It's
-                                need information from another class(java file). But Checkstyle
-                                have no way to open or look at another java file.
-                            </td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="3.4"/>
-                                <a href="#3.4">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s3.4-class-declaration">
-                                    3.4 Class declaration
-                                </a>
-                            </td>
-                            <td>↓</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="3.4.1"/>
-                                <a href="#3.4.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s3.4.1-one-top-level-class">
-                                    3.4.1 Exactly one top-level class declaration</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_design.html#OneTopLevelClass">OneTopLevelClass</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OneTopLevelClass">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/OneTopLevelClassTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="3.4.2"/>
-                                <a href="#3.4.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s3.4.2-class-member-ordering">
-                                    3.4.2 Class member ordering</a>
-                            </td>
-                            <td>--</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="3.4.2.1"/>
-                                <a href="#3.4.2.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s3.4.2.1-overloads-never-split">
-                                    3.4.2.1 Overloads: never split</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_coding.html#OverloadMethodsDeclarationOrder">
-                                    OverloadMethodsDeclarationOrder</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OverloadMethodsDeclarationOrder">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/OverloadMethodsDeclarationOrderTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="4"/>
-                                <a href="#4">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4-formatting">
-                                    <strong>4 Formatting</strong>
-                                </a>
-                            </td>
-                            <td>--</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="4.1"/>
-                                <a href="#4.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.1-braces">
-                                    4.1 Braces
-                                </a>
-                            </td>
-                            <td>↓</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="4.1.1"/>
-                                <a href="#4.1.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.1.1-braces-always-used">
-                                    4.1.1 Braces are used where optional</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_blocks.html#NeedBraces">NeedBraces</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NeedBraces">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule411bracesareused/NeedBracesTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="4.1.2"/>
-                                <a href="#4.1.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.1.2-blocks-k-r-style">
-                                    4.1.2 Nonempty blocks: K &amp; R style</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_blocks.html#LeftCurly">LeftCurly</a>
-                                <br/>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_blocks.html#RightCurly">RightCurly</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LeftCurly">
-                                    config</a>
-                                <br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/LeftCurlyTest.java">
-                                    test</a>
-                                <br/>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+RightCurly">
-                                    config</a>
-                                <br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/RightCurlyTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="4.1.3"/>
-                                <a href="#4.1.3">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.1.3-braces-empty-blocks">
-                                    4.1.3 Empty blocks: may be concise</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_blocks.html#EmptyBlock">EmptyBlock</a>
-                                <br />
-                                <br />
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_blocks.html#EmptyCatchBlock">EmptyCatchBlock</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+EmptyBlock">
-                                    config</a><br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/EmptyBlockTest.java">
-                                    test</a>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+EmptyCatchBlock">
-                                    config</a><br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/EmptyCatchBlockTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="4.2"/>
-                                <a href="#4.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.2-block-indentation">
-                                    4.2 Block indentation: +2 spaces</a>
-                            </td>
-                            <td>
-                                <img
-                                    src="images/ok_blue.png"
-                                    alt="" />
-                                <a href="config_misc.html#Indentation">Indentation</a>
-                                <br />
-                                The rule "A line is never broken adjacent to the arrow in a lambda,
-                                except that a break may come immediately after the arrow if the body
-                                of the lambda consists of a single unbraced expression" will be
-                                addressed in the issue
-                                <a href="https://github.com/checkstyle/checkstyle/issues/4006">
-                                    #4006</a>.
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+Indentation">
-                                    config</a><br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4841indentation/IndentationTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="4.3"/>
-                                <a href="#4.3">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.3-one-statement-per-line">
-                                    4.3 One statement per line</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_coding.html#OneStatementPerLine">
-                                    OneStatementPerLine</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OneStatementPerLine">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule43onestatement/OneStatementPerLineTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="4.4"/>
-                                <a href="#4.4">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.4-column-limit">
-                                    4.4 Column limit: 100</a>
-                            </td>
-                            <td>
-                                <img
-                                    src="images/ok_blue.png"
-                                    alt="" />
-                                <a href="config_sizes.html#LineLength">LineLength</a>
-                                <br />
-                                We can detect URL with protocol type as http://, https:// etc.
-                                <br />
-                                <a href="https://webtoolkit.googleblog.com/2008/07/getting-to-really-know-gwt-part-1-jsni.html">
-                                    JSNI</a>
-                                could not be detected right now, but might be possible after
-                                comments and javadoc support appear in Checkstyle
-                                <br />
-                                Also full-length characters are not counted as one character,
-                                but as multiple and will be addressed in the issue
-                                <a href="https://github.com/checkstyle/checkstyle/issues/5089">
-                                    #5089</a>.
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LineLength">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule32packagestate/LineLengthTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="4.5"/>
-                                <a href="#4.5">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.5-line-wrapping">
-                                    4.5 Line-wrapping
-                                </a>
-                            </td>
-                            <td>--</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="4.5.1"/>
-                                <a href="#4.5.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.5.1-line-wrapping-where-to-break">
-                                    4.5.1 Where to break</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_whitespace.html#OperatorWrap">OperatorWrap</a>
-                                <br />
-                                <br />
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_whitespace.html#SeparatorWrap">SeparatorWrap</a>
-                                <br />
-                                <br />
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_whitespace.html#MethodParamPad">MethodParamPad</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OperatorWrap">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/OperatorWrapTest.java">
-                                    test</a>
-                                <br />
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SeparatorWrap">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/SeparatorWrapTest.java">
-                                    test</a>
-                                <br />
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodParamPad">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/MethodParamPadTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="4.5.2"/>
-                                <a href="#4.5.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.5.2-line-wrapping-indent">
-                                    4.5.2 Indent continuation lines at least +4 spaces</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_misc.html#Indentation">Indentation</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+Indentation">
-                                    config</a><br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4841indentation/IndentationTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="4.6"/>
-                                <a href="#4.6">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.6-whitespace">
-                                    4.6 Whitespace
-                                </a>
-                            </td>
-                            <td>↓</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="4.6.1"/>
-                                <a href="#4.6.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.6.1-vertical-whitespace">
-                                    4.6.1 Vertical Whitespace</a>
-                            </td>
-                            <td>
-                                <img
-                                    src="images/ok_blue.png"
-                                    alt="" />
-                                <a href="config_whitespace.html#EmptyLineSeparator">
-                                    EmptyLineSeparator</a>
-                                <br />Blank lines between two consecutive fields are optional.
-                                This exception is not satisfied
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+EmptyLineSeparator">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/EmptyLineSeparatorTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="4.6.2"/>
-                                <a href="#4.6.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.6.2-horizontal-whitespace">
-                                    4.6.2 Horizontal whitespace</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_whitespace.html#WhitespaceAround">
-                                    WhitespaceAround</a>
-                                <br />
-                                <br />
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_whitespace.html#GenericWhitespace">
-                                    GenericWhitespace</a>
-                                <br />
-                                <br />
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_whitespace.html#MethodParamPad">MethodParamPad</a>
-                                <br />
-                                <br />
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_whitespace.html#ParenPad">ParenPad</a>
+                  </span>
+                  <a href="https://github.com/checkstyle/checkstyle/issues/265">
+                    explanation</a>
+                </td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="2.3.1"/>
+                  <a href="#2.3.1">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s2.3.1-whitespace-characters">
+                    2.3.1 Whitespace characters</a>
+                </td>
+                <td>
+                  <span class="wrapper">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="config_whitespace.html#FileTabCharacter">
+                    FileTabCharacter</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+FileTabCharacter">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule231filetab/FileTabCharacterTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="2.3.2"/>
+                  <a href="#2.3.2">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s2.3.2-special-escape-sequences">
+                    2.3.2 Special escape sequences</a>
+                </td>
+                <td>
+                  <span class="wrapper">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="config_coding.html#IllegalTokenText">IllegalTokenText</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+IllegalTokenText">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule232specialescape/IllegalTokenTextTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="2.3.3"/>
+                  <a href="#2.3.3">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s2.3.3-non-ascii-characters">
+                    2.3.3 Non-ASCII characters</a>
+                </td>
+                <td>
+                  <span class="wrapper">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="config_misc.html#AvoidEscapedUnicodeCharacters">
+                    AvoidEscapedUnicodeCharacters</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidEscapedUnicodeCharacters">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule233nonascii/AvoidEscapedUnicodeCharactersTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="3"/>
+                  <a href="#3">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s3-source-file-structure">
+                    <strong>3 Source file structure</strong>
+                  </a>
+                </td>
+                <td>
+                  <span class="wrapper">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="config_whitespace.html#EmptyLineSeparator">
+                    EmptyLineSeparator</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+EmptyLineSeparator">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/EmptyLineSeparatorTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="3.1"/>
+                  <a href="#3.1">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s3.1-copyright-statement">
+                    3.1 License or copyright information, if present</a>
+                </td>
+                <td>--</td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="3.2"/>
+                  <a href="#3.2">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s3.2-package-statement">
+                    3.2 Package statement</a>
+                </td>
+                <td>
+                  <span class="wrapper">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="config_sizes.html#LineLength">LineLength</a>
+                  <br />
+                  <br />
+                  <span class="wrapper">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="config_whitespace.html#NoLineWrap">NoLineWrap</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LineLength">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule32packagestate/LineLengthTest.java">
+                    test</a>
+                  <br />
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoLineWrap">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/NoLineWrapTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="3.3"/>
+                  <a href="#3.3">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s3.3-import-statements">
+                    3.3 Import statements
+                  </a>
+                </td>
+                <td>↓</td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="3.3.1"/>
+                  <a href="#3.3.1">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s3.3.1-wildcard-imports">
+                    3.3.1 No wildcard imports</a>
+                </td>
+                <td>
+                  <span class="wrapper">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="config_imports.html#AvoidStarImport">AvoidStarImport</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidStarImport">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule331nowildcard/AvoidStarImportTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="3.3.2"/>
+                  <a href="#3.3.2">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s3.3.2-import-line-wrapping">
+                    3.3.2 No line-wrapping</a>
+                </td>
+                <td>
+                  <span class="wrapper">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="config_sizes.html#LineLength">LineLength</a>
+                  <br />
+                  <br />
+                  <span class="wrapper">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="config_whitespace.html#NoLineWrap">NoLineWrap</a>
+                  <br />
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LineLength">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule32packagestate/LineLengthTest.java">
+                    test</a>
+                  <br />
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoLineWrap">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/NoLineWrapTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="3.3.3"/>
+                  <a href="#3.3.3">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s3.3.3-import-ordering-and-spacing">
+                    3.3.3 Ordering and spacing</a>
+                </td>
+                <td>
+                  <span class="wrapper">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="config_imports.html#CustomImportOrder">
+                    CustomImportOrder</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+CustomImportOrder">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/CustomImportOrderTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="3.3.4"/>
+                  <a href="#3.3.4">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s3.3.4-import-class-not-static">
+                    3.3.4 No static import for classes</a>
+                </td>
+                <td>
+                  <span class="wrapper">
+                    <img
+                        src="images/ban_red.png"
+                        alt="" />
+                  </span>
+                  That validation could not be checked by Checkstyle. It's
+                  need information from another class(java file). But Checkstyle
+                  have no way to open or look at another java file.
+                </td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="3.4"/>
+                  <a href="#3.4">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s3.4-class-declaration">
+                    3.4 Class declaration
+                  </a>
+                </td>
+                <td>↓</td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="3.4.1"/>
+                  <a href="#3.4.1">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s3.4.1-one-top-level-class">
+                    3.4.1 Exactly one top-level class declaration</a>
+                </td>
+                <td>
+                  <span class="wrapper">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="config_design.html#OneTopLevelClass">OneTopLevelClass</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OneTopLevelClass">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/OneTopLevelClassTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="3.4.2"/>
+                  <a href="#3.4.2">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s3.4.2-class-member-ordering">
+                    3.4.2 Class member ordering</a>
+                </td>
+                <td>--</td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="3.4.2.1"/>
+                  <a href="#3.4.2.1">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s3.4.2.1-overloads-never-split">
+                    3.4.2.1 Overloads: never split</a>
+                </td>
+                <td>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_coding.html#OverloadMethodsDeclarationOrder">
+                    OverloadMethodsDeclarationOrder</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OverloadMethodsDeclarationOrder">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule3421overloadsplit/OverloadMethodsDeclarationOrderTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="4"/>
+                  <a href="#4">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4-formatting">
+                    <strong>4 Formatting</strong>
+                  </a>
+                </td>
+                <td>--</td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="4.1"/>
+                  <a href="#4.1">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.1-braces">
+                    4.1 Braces
+                  </a>
+                </td>
+                <td>↓</td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="4.1.1"/>
+                  <a href="#4.1.1">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.1.1-braces-always-used">
+                    4.1.1 Braces are used where optional</a>
+                </td>
+                <td>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_blocks.html#NeedBraces">NeedBraces</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NeedBraces">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule411bracesareused/NeedBracesTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="4.1.2"/>
+                  <a href="#4.1.2">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.1.2-blocks-k-r-style">
+                    4.1.2 Nonempty blocks: K &amp; R style</a>
+                </td>
+                <td>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_blocks.html#LeftCurly">LeftCurly</a>
+                  <br/>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_blocks.html#RightCurly">RightCurly</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LeftCurly">
+                    config</a>
+                  <br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/LeftCurlyTest.java">
+                    test</a>
+                  <br/>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+RightCurly">
+                    config</a>
+                  <br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/RightCurlyTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="4.1.3"/>
+                  <a href="#4.1.3">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.1.3-braces-empty-blocks">
+                    4.1.3 Empty blocks: may be concise</a>
+                </td>
+                <td>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_blocks.html#EmptyBlock">EmptyBlock</a>
+                  <br />
+                  <br />
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_blocks.html#EmptyCatchBlock">EmptyCatchBlock</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+EmptyBlock">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/EmptyBlockTest.java">
+                    test</a>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+EmptyCatchBlock">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule413emptyblocks/EmptyCatchBlockTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="4.2"/>
+                  <a href="#4.2">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.2-block-indentation">
+                    4.2 Block indentation: +2 spaces</a>
+                </td>
+                <td>
+                  <img
+                      src="images/ok_blue.png"
+                      alt="" />
+                  <a href="config_misc.html#Indentation">Indentation</a>
+                  <br />
+                  The rule "A line is never broken adjacent to the arrow in a
+                  lambda, except that a break may come immediately after the arrow
+                  if the body of the lambda consists of a single unbraced
+                  expression" will be addressed in the issue
+                  <a href="https://github.com/checkstyle/checkstyle/issues/4006">
+                    #4006</a>.
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+Indentation">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4841indentation/IndentationTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="4.3"/>
+                  <a href="#4.3">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.3-one-statement-per-line">
+                    4.3 One statement per line</a>
+                </td>
+                <td>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_coding.html#OneStatementPerLine">
+                    OneStatementPerLine</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OneStatementPerLine">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule43onestatement/OneStatementPerLineTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="4.4"/>
+                  <a href="#4.4">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.4-column-limit">
+                    4.4 Column limit: 100</a>
+                </td>
+                <td>
+                  <img
+                      src="images/ok_blue.png"
+                      alt="" />
+                  <a href="config_sizes.html#LineLength">LineLength</a>
+                  <br />
+                  We can detect URL with protocol type as http://, https:// etc.
+                  <br />
+                  <a href="https://webtoolkit.googleblog.com/2008/07/getting-to-really-know-gwt-part-1-jsni.html">
+                    JSNI</a>
+                  could not be detected right now, but might be possible after
+                  comments and javadoc support appear in Checkstyle
+                  <br />
+                  Also full-length characters are not counted as one character,
+                  but as multiple and will be addressed in the issue
+                  <a href="https://github.com/checkstyle/checkstyle/issues/5089">
+                    #5089</a>.
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LineLength">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule32packagestate/LineLengthTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="4.5"/>
+                  <a href="#4.5">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.5-line-wrapping">
+                    4.5 Line-wrapping
+                  </a>
+                </td>
+                <td>--</td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="4.5.1"/>
+                  <a href="#4.5.1">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.5.1-line-wrapping-where-to-break">
+                    4.5.1 Where to break</a>
+                </td>
+                <td>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_whitespace.html#OperatorWrap">OperatorWrap</a>
+                  <br />
+                  <br />
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_whitespace.html#SeparatorWrap">SeparatorWrap</a>
+                  <br />
+                  <br />
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_whitespace.html#MethodParamPad">MethodParamPad</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OperatorWrap">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/OperatorWrapTest.java">
+                    test</a>
+                  <br />
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SeparatorWrap">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/SeparatorWrapTest.java">
+                    test</a>
+                  <br />
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodParamPad">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule451wheretobreak/MethodParamPadTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="4.5.2"/>
+                  <a href="#4.5.2">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.5.2-line-wrapping-indent">
+                    4.5.2 Indent continuation lines at least +4 spaces</a>
+                </td>
+                <td>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_misc.html#Indentation">Indentation</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+Indentation">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4841indentation/IndentationTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="4.6"/>
+                  <a href="#4.6">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.6-whitespace">
+                    4.6 Whitespace
+                  </a>
+                </td>
+                <td>↓</td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="4.6.1"/>
+                  <a href="#4.6.1">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.6.1-vertical-whitespace">
+                    4.6.1 Vertical Whitespace</a>
+                </td>
+                <td>
+                  <img
+                      src="images/ok_blue.png"
+                      alt="" />
+                  <a href="config_whitespace.html#EmptyLineSeparator">
+                    EmptyLineSeparator</a>
+                  <br />Blank lines between two consecutive fields are optional.
+                  This exception is not satisfied
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+EmptyLineSeparator">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule461verticalwhitespace/EmptyLineSeparatorTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="4.6.2"/>
+                  <a href="#4.6.2">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.6.2-horizontal-whitespace">
+                    4.6.2 Horizontal whitespace</a>
+                </td>
+                <td>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_whitespace.html#WhitespaceAround">
+                    WhitespaceAround</a>
+                  <br />
+                  <br />
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_whitespace.html#GenericWhitespace">
+                    GenericWhitespace</a>
+                  <br />
+                  <br />
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_whitespace.html#MethodParamPad">MethodParamPad</a>
+                  <br />
+                  <br />
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_whitespace.html#ParenPad">ParenPad</a>
 
-                                <br />
-                                <br />
-                                <img src="images/ok_blue.png" alt="" />
-                                <a href="config_whitespace.html#NoWhitespaceBefore">
-                                    NoWhitespaceBefore</a>
-                                <br />
-                                <br />
-                                Between a type annotation and "[]" or "..." cannot be checked yet
-                                and actually "NoWhitespaceBefore" configuration checks the opposite
-                                for ellipsis. This will be addressed in the issue
-                                <a href="https://github.com/checkstyle/checkstyle/issues/6707">
-                                    #6707</a>.
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+WhitespaceAround">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/WhitespaceAroundTest.java">
-                                    test</a>
-                                <br />
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+GenericWhitespace">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/GenericWhitespaceTest.java">
-                                    test</a>
-                                <br />
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodParamPad">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/MethodParamPadTest.java">
-                                    test</a>
-                                <br />
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ParenPad">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/ParenPadTest.java">
-                                    test</a>
-                                <br />
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoWhitespaceBefore">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/NoWhitespaceBeforeTest.java">
-                                    test</a>
+                  <br />
+                  <br />
+                  <img src="images/ok_blue.png" alt="" />
+                  <a href="config_whitespace.html#NoWhitespaceBefore">
+                    NoWhitespaceBefore</a>
+                  <br />
+                  <br />
+                  Between a type annotation and "[]" or "..." cannot be checked
+                  yet and actually "NoWhitespaceBefore" configuration checks the
+                  opposite for ellipsis. This will be addressed in the issue
+                  <a href="https://github.com/checkstyle/checkstyle/issues/6707">
+                    #6707</a>.
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+WhitespaceAround">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/WhitespaceAroundTest.java">
+                    test</a>
+                  <br />
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+GenericWhitespace">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/GenericWhitespaceTest.java">
+                    test</a>
+                  <br />
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodParamPad">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/MethodParamPadTest.java">
+                    test</a>
+                  <br />
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ParenPad">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/ParenPadTest.java">
+                    test</a>
+                  <br />
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoWhitespaceBefore">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/NoWhitespaceBeforeTest.java">
+                    test</a>
 
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="4.6.3"/>
-                                <a href="#4.6.3">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.6.3-horizontal-alignment">
-                                    4.6.3 Horizontal alignment: never required</a>
-                            </td>
-                            <td>--</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="4.7"/>
-                                <a href="#4.7">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.7-grouping-parentheses">
-                                    4.7 Grouping parentheses: recommended</a>
-                            </td>
-                            <td>--</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="4.8"/>
-                                <a href="#4.8">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8-specific-constructs">
-                                    4.8 Specific constructs
-                                </a>
-                            </td>
-                            <td>↓</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="4.8.1"/>
-                                <a href="#4.8.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.1-enum-classes">
-                                    4.8.1 Enum classes</a>
-                            </td>
-                            <td>--</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="4.8.2"/>
-                                <a href="#4.8.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.2-variable-declarations">
-                                    4.8.2 Variable declarations</a>
-                            </td>
-                            <td>↓</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="4.8.2.1"/>
-                                <a href="#4.8.2.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.2.1-variables-per-declaration">
-                                    4.8.2.1 One variable per declaration</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_coding.html#MultipleVariableDeclarations">
-                                    MultipleVariableDeclarations</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultipleVariableDeclarations">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4821onevariableperline/MultipleVariableDeclarationsTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="4.8.2.2"/>
-                                <a href="#4.8.2.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.2.2-variables-limited-scope">
-                                    4.8.2.2 Declared when needed
-                                </a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_coding.html#VariableDeclarationUsageDistance">
-                                    VariableDeclarationUsageDistance</a>
-                                <br />
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+VariableDeclarationUsageDistance">
-                                    config</a><br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4822variabledistance/VariableDeclarationUsageDistanceTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="4.8.3"/>
-                                <a href="#4.8.3">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.3-arrays">
-                                    4.8.3 Arrays</a>
-                            </td>
-                            <td>↓</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="4.8.3.1"/>
-                                <a href="#4.8.3.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.3.1-array-initializers">
-                                    4.8.3.1 Array initializers: can be "block-like"</a>
-                            </td>
-                            <td>--</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="4.8.3.2"/>
-                                <a href="#4.8.3.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.3.2-array-declarations">
-                                    4.8.3.2 No C-style array declarations</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_misc.html#ArrayTypeStyle">ArrayTypeStyle</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ArrayTypeStyle">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4832nocstylearray/ArrayTypeStyleTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="4.8.4"/>
-                                <a href="#4.8.4">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.4-switch">
-                                    4.8.4 Switch statements</a>
-                            </td>
-                            <td>--</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="4.8.4.1"/>
-                                <a href="#4.8.4.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.4.1-switch-indentation">
-                                    4.8.4.1 Indentation</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_misc.html#Indentation">Indentation</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+Indentation">
-                                    config</a><br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4841indentation/IndentationTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="4.8.4.2"/>
-                                <a href="#4.8.4.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.4.2-switch-fall-through">
-                                    4.8.4.2 Fall-through: commented</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_coding.html#FallThrough">FallThrough</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+FallThrough">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4842fallthrough/FallThroughTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="4.8.4.3"/>
-                                <a href="#4.8.4.3">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.4.3-switch-default">
-                                    4.8.4.3 The default case is present</a>
-                            </td>
-                            <td>
-                                <img
-                                    src="images/ok_blue.png"
-                                    alt="" />
-                                <a href="config_coding.html#MissingSwitchDefault">
-                                    MissingSwitchDefault</a>
-                                <br />
-                                "Exception: enum type may omit the default statement group"
-                                requirement can not be covered as we can not distinguish types,
-                                enum values may look the same as static final String constants.
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingSwitchDefault">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4843defaultcasepresent/MissingSwitchDefaultTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="4.8.5"/>
-                                <a href="#4.8.5">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.5-annotations">
-                                    4.8.5 Annotations</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_annotation.html#AnnotationLocation">
-                                    AnnotationLocation</a>
-                            </td>
-                            <td>
-                              <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AnnotationLocation">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule485annotations/AnnotationLocationTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="4.8.6"/>
-                                <a href="#4.8.6">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.6-comments">
-                                    4.8.6 Comments</a>
-                            </td>
-                            <td>↓</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="4.8.6.1"/>
-                                <a href="#4.8.6.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.6.1-block-comment-style">
-                                    4.8.6.1 Block comment style</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_misc.html#CommentsIndentation">
-                                    CommentsIndentation</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+CommentsIndentation">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/CommentsIndentationTest.java">
-                                    test</a>
-                            </td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="4.8.7"/>
-                                <a href="#4.8.7">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.7-modifiers">
-                                    4.8.7 Modifiers</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_modifier.html#ModifierOrder">ModifierOrder</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ModifierOrder">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule487modifiers/ModifierOrderTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="4.8.8"/>
-                                <a href="#4.8.8">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.8-numeric-literals">
-                                    4.8.8 Numeric Literals</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_misc.html#UpperEll">UpperEll</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+UpperEll">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule488numericliterals/UpperEllTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="5"/>
-                                <a href="#5">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s5-naming">
-                                    <strong>5 Naming</strong>
-                                </a>
-                            </td>
-                            <td>↓</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="5.1"/>
-                                <a href="#5.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s5.1-identifier-names">
-                                    5.1 Rules common to all identifiers</a>
-                            </td>
-                            <td>"5.2 Rules of identifier type" already includes this rule.
-                            </td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="5.2"/>
-                                <a href="#5.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s5.2-specific-identifier-names">
-                                    5.2 Rules by identifier type
-                                </a>
-                            </td>
-                            <td>↓</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="5.2.1"/>
-                                <a href="#5.2.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s5.2.1-package-names">
-                                    5.2.1 Package names</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_naming.html#PackageName">PackageName</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+PackageName">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule521packagenames/PackageNameTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="5.2.2"/>
-                                <a href="#5.2.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s5.2.2-class-names">
-                                    5.2.2 Class names</a>
-                            </td>
-                            <td>
-                                <img
-                                    src="images/ok_blue.png"
-                                    alt="" />
-                                <a href="config_naming.html#TypeName">TypeName</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+TypeName">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule522typenames/TypeNameTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="5.2.3"/>
-                                <a href="#5.2.3">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s5.2.3-method-names">
-                                    5.2.3 Method names</a>
-                            </td>
-                            <td>
-                                <img
-                                    src="images/ok_blue.png"
-                                    alt="" />
-                                <a href="config_naming.html#MethodName">MethodName</a>
-                                <br/> No ability to distinguish verb at the beginning of name, no
-                                way distinguish Test method from others so "_" is allowed in names
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodName">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule523methodnames/MethodNameTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="5.2.4"/>
-                                <a href="#5.2.4">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s5.2.4-constant-names">
-                                    5.2.4 Constant names</a>
-                            </td>
-                            <td>
-                                <img
-                                    src="images/ban_red.png"
-                                    alt="" />
-                                Every constant is a static final field, but not all static final
-                                fields are constants - impossible to check such rule.
-                            </td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="5.2.5"/>
-                                <a href="#5.2.5">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s5.2.5-non-constant-field-names">
-                                    5.2.5 Non-constant field names</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_naming.html#MemberName">MemberName</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MemberName">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/MemberNameTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="5.2.6"/>
-                                <a href="#5.2.6">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s5.2.6-parameter-names">
-                                    5.2.6 Parameter names</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_naming.html#ParameterName">ParameterName</a>
-                                <br/>
-                                <br/>
-                                <img src="images/ok_green.png" alt=""/>
-                                <a href="config_naming.html#CatchParameterName">
-                                    CatchParameterName</a>
-                                <br/>
-                                <br/>
-                                <img src="images/ok_green.png" alt=""/>
-                                <a href="config_naming.html#LambdaParameterName">
-                                    LambdaParameterName</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ParameterName">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/ParameterNameTest.java">
-                                    test</a>
-                                <br/>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+CatchParameterName">
-                                    config
-                                </a>
-                                <br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule51identifiernames/CatchParameterNameTest.java">
-                                    test
-                                </a>
-                                <br/>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LambdaParameterName">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/LambdaParameterNameTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="5.2.7"/>
-                                <a href="#5.2.7">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s5.2.7-local-variable-names">
-                                    5.2.7 Local variable names</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_naming.html#LocalVariableName">LocalVariableName</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LocalVariableName">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNameTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="5.2.8"/>
-                                <a href="#5.2.8">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s5.2.8-type-variable-names">
-                                    5.2.8 Type variable names</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_naming.html#MethodTypeParameterName">
-                                    MethodTypeParameterName</a>
-                                <br/>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_naming.html#ClassTypeParameterName">
-                                    ClassTypeParameterName</a>
-                                <br/>
-                                <img
-                                   src="images/ok_green.png"
-                                   alt="" />
-                                <a href="config_naming.html#InterfaceTypeParameterName">
-                                    InterfaceTypeParameterName</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodTypeParameterName">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/MethodTypeParameterNameTest.java">
-                                    test</a>
-                                <br />
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ClassTypeParameterName">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassTypeParameterNameTest.java">
-                                    test</a>
-                                <br />
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+InterfaceTypeParameterName">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/InterfaceTypeParameterNameTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="5.3"/>
-                                <a href="#5.3">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s5.3-camel-case">
-                                    5.3 Camel case: defined</a>
-                            </td>
-                            <td>
-                                <img
-                                    src="images/ok_blue.png"
-                                    alt="" />
-                                <a href="config_naming.html#AbbreviationAsWordInName">
-                                    AbbreviationAsWordInName</a>
-                                <br />
-                                Non covered: Some words are ambiguously hyphenated in the English
-                                language. No way to distinguish "YouTubeImporter" or
-                                "YoutubeImporter".
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AbbreviationAsWordInName">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule53camelcase/AbbreviationAsWordInNameTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="6"/>
-                                <a href="#6">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s6-programming-practices">
-                                    <strong>6 Programming Practices</strong>
-                                </a>
-                            </td>
-                            <td>↓</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="6.1"/>
-                                <a href="#6.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s6.1-override-annotation">
-                                    6.1 @Override: always used</a>
-                            </td>
-                            <td>
-                                <img
-                                    src="images/ban_red.png"
-                                    alt="" />
-                                That validation could not be checked by Checkstyle. It's
-                                need to
-                                take a look as parent class. But Checkstyle have no way to
-                                open or
-                                look at another Class file.
-                            </td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="6.2"/>
-                                <a href="#6.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s6.2-caught-exceptions">
-                                    6.2 Caught exceptions: not ignored</a>
-                            </td>
-                            <td>
-                                <img
-                                    src="images/ok_blue.png"
-                                    alt="" />
-                                <a href="config_blocks.html#EmptyBlock">EmptyBlock</a>
-                                with option=text.
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+EmptyBlock">
-                                    config</a><br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter6programpractice/rule62donotignoreexceptions/EmptyBlockTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="6.3"/>
-                                <a href="#6.3">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s6.3-static-members">
-                                    6.3 Static members: qualified using class</a>
-                            </td>
-                            <td>
-                                <img
-                                    src="images/ban_red.png"
-                                    alt="" />
-                                    Proper validation require parsing other files, sources
-                                    are not always available.
-                            </td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="6.4"/>
-                                <a href="#6.4">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s6.4-finalizers">
-                                    6.4 Finalizers: not used</a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_coding.html#NoFinalizer">NoFinalizer</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoFinalizer">
-                                    config</a>
-                                <br />
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter6programpractice/rule64finalizers/NoFinalizerTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="7"/>
-                                <a href="#7">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s7-javadoc">
-                                    <strong>7 Javadoc</strong>
-                                </a>
-                            </td>
-                            <td>↓</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="7.1"/>
-                                <a href="#7.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s7.1-javadoc-formatting">
-                                    7.1 Formatting
-                                </a>
-                            </td>
-                            <td>↓</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td><a name="7.1.1"/>
-                                <a href="#7.1.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s7.1.1-javadoc-multi-line">
-                                    7.1.1 General form</a>
-                            </td>
-                            <td>
-                                <img
-                                    src="images/ok_blue.png"
-                                    alt="" />
-                                <br />
-                                <a href="config_javadoc.html#SingleLineJavadoc">
-                                    SingleLineJavadoc</a>
-                                Recent update for guide that clarify requirements will be
-                                addressed at
-                                <a href="https://github.com/checkstyle/checkstyle/issues/4052">
-                                    #4052</a>
-                                <br />
-                                <a href="config_javadoc.html#InvalidJavadocPosition">
-                                    InvalidJavadocPosition</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SingleLineJavadoc">
-                                    config</a><br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule711generalform/SingleLineJavadocTest.java">
-                                    test</a>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+InvalidJavadocPosition">
-                                    config</a><br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InvalidJavadocPositionTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="7.1.2"/>
-                                <a href="#7.1.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s7.1.2-javadoc-paragraphs">
-                                    7.1.2 Paragraphs</a>
-                            </td>
-                            <td>
-                            <img
-                                    src="images/ok_green.png"
-                                    alt="" />
-                                <a href="config_javadoc.html#JavadocParagraph">JavadocParagraph</a>
-                            </td>
-                            <td>
-                            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocParagraph">
-                                    config</a><br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/JavadocParagraphTest.java">
-                                    test</a>
-                                    </td>
-                        </tr>
-                        <tr>
-                            <td><a name="7.1.3"/>
-                                <a href="#7.1.3">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s7.1.3-javadoc-at-clauses">
-                                    7.1.3 Block tags</a>
-                            </td>
-                            <td>
-                            <img
-                                    src="images/ok_green.png"
-                                    alt="" />
-                                <a href="config_javadoc.html#AtclauseOrder">AtclauseOrder</a>
-                                <br/>
-                                <br/>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_javadoc.html#JavadocTagContinuationIndentation">
-                                    JavadocTagContinuationIndentation</a>
-                                <br/>
-                                <br/>
-                                <img src="images/ok_green.png" alt="" />
-                                <a href="config_javadoc.html#NonEmptyAtclauseDescription">
-                                    NonEmptyAtclauseDescription</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AtclauseOrder">
-                                    config</a><br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/AtclauseOrderTest.java">
-                                    test</a><br/>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocTagContinuationIndentation">
-                                    config</a><br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/JavadocTagContinuationIndentationTest.java">
-                                    test</a><br/>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NonEmptyAtclauseDescription">
-                                    config</a><br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/NonEmptyAtclauseDescriptionTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="7.2"/>
-                                <a href="#7.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s7.2-summary-fragment">
-                                    7.2 The summary fragment</a>
-                            </td>
-                            <td>
-                            <img
-                                    src="images/ok_green.png"
-                                    alt="" />
-                                <a href="config_javadoc.html#SummaryJavadoc">SummaryJavadoc</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SummaryJavadoc">
-                                    config</a><br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule72thesummaryfragment/SummaryJavadocTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="7.3"/>
-                                <a href="#7.3">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s7.3-javadoc-where-required">
-                                    7.3 Where Javadoc is used
-                                </a>
-                            </td>
-                            <td>
-                            <img
-                                    src="images/ok_green.png"
-                                    alt="" />
-                                <a href="config_javadoc.html#MissingJavadocMethod">MissingJavadocMethod</a>
-                            <img
-                                    src="images/ok_green.png"
-                                    alt="" />
-                                <a href="config_javadoc.html#JavadocMethod">JavadocMethod</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingJavadocMethod">
-                                    config</a><br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/MissingJavadocMethodTest.java">
-                                    test</a>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocMethod">
-                                    config</a><br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/JavadocMethodTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="7.3.1"/>
-                                <a href="#7.3.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s7.3.1-javadoc-exception-self-explanatory">
-                                    7.3.1 Exception: self-explanatory methods</a>
-                            </td>
-                            <td>
-                            <img
-                                    src="images/ok_green.png"
-                                    alt="" />
-                                <a href="config_javadoc.html#MissingJavadocMethod">MissingJavadocMethod</a>
-                            <img
-                                    src="images/ok_green.png"
-                                    alt="" />
-                                <a href="config_javadoc.html#JavadocMethod">JavadocMethod</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingJavadocMethod">
-                                    config</a><br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/MissingJavadocMethodTest.java">
-                                    test</a>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocMethod">
-                                    config</a><br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/JavadocMethodTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="7.3.2"/>
-                                <a href="#7.3.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s7.3.2-javadoc-exception-overrides">
-                                    7.3.2 Exception: overrides</a>
-                            </td>
-                            <td>
-                            <img
-                                    src="images/ok_green.png"
-                                    alt="" />
-                                <a href="config_javadoc.html#MissingJavadocMethod">MissingJavadocMethod</a>
-                                <img
-                                    src="images/ok_blue.png"
-                                    alt="" />
-                                <a href="config_javadoc.html#JavadocMethod">JavadocMethod</a><br/>
-                                Overrides are checked by presence of "@Override" annotation on
-                                method.
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingJavadocMethod">
-                                    config</a><br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/MissingJavadocMethodTest.java">
-                                    test</a>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocMethod">
-                                    config</a><br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/JavadocMethodTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td><a name="7.3.4"/>
-                                <a href="#7.3.4">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/google-java-style-20180523/javaguide.html#s7.3.4-javadoc-non-required">
-                                    7.3.4 Non-required Javadoc</a>
-                            </td>
-                            <td>
-                                <img
-                                    src="images/ok_blue.png"
-                                    alt="" />
-                                <a href="config_javadoc.html#InvalidJavadocPosition">
-                                    InvalidJavadocPosition</a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+InvalidJavadocPosition">
-                                    config</a><br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule734nonrequiredjavadoc/InvalidJavadocPositionTest.java">
-                                    test</a>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </subsection>
-        </section>
-    </body>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="4.6.3"/>
+                  <a href="#4.6.3">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.6.3-horizontal-alignment">
+                    4.6.3 Horizontal alignment: never required</a>
+                </td>
+                <td>--</td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="4.7"/>
+                  <a href="#4.7">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.7-grouping-parentheses">
+                    4.7 Grouping parentheses: recommended</a>
+                </td>
+                <td>--</td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="4.8"/>
+                  <a href="#4.8">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8-specific-constructs">
+                    4.8 Specific constructs
+                  </a>
+                </td>
+                <td>↓</td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="4.8.1"/>
+                  <a href="#4.8.1">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.1-enum-classes">
+                    4.8.1 Enum classes</a>
+                </td>
+                <td>--</td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="4.8.2"/>
+                  <a href="#4.8.2">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.2-variable-declarations">
+                    4.8.2 Variable declarations</a>
+                </td>
+                <td>↓</td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="4.8.2.1"/>
+                  <a href="#4.8.2.1">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.2.1-variables-per-declaration">
+                    4.8.2.1 One variable per declaration</a>
+                </td>
+                <td>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_coding.html#MultipleVariableDeclarations">
+                    MultipleVariableDeclarations</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultipleVariableDeclarations">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4821onevariableperline/MultipleVariableDeclarationsTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="4.8.2.2"/>
+                  <a href="#4.8.2.2">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.2.2-variables-limited-scope">
+                    4.8.2.2 Declared when needed
+                  </a>
+                </td>
+                <td>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_coding.html#VariableDeclarationUsageDistance">
+                    VariableDeclarationUsageDistance</a>
+                  <br />
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+VariableDeclarationUsageDistance">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4822variabledistance/VariableDeclarationUsageDistanceTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="4.8.3"/>
+                  <a href="#4.8.3">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.3-arrays">
+                    4.8.3 Arrays</a>
+                </td>
+                <td>↓</td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="4.8.3.1"/>
+                  <a href="#4.8.3.1">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.3.1-array-initializers">
+                    4.8.3.1 Array initializers: can be "block-like"</a>
+                </td>
+                <td>--</td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="4.8.3.2"/>
+                  <a href="#4.8.3.2">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.3.2-array-declarations">
+                    4.8.3.2 No C-style array declarations</a>
+                </td>
+                <td>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_misc.html#ArrayTypeStyle">ArrayTypeStyle</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ArrayTypeStyle">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4832nocstylearray/ArrayTypeStyleTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="4.8.4"/>
+                  <a href="#4.8.4">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.4-switch">
+                    4.8.4 Switch statements</a>
+                </td>
+                <td>--</td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="4.8.4.1"/>
+                  <a href="#4.8.4.1">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.4.1-switch-indentation">
+                    4.8.4.1 Indentation</a>
+                </td>
+                <td>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_misc.html#Indentation">Indentation</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+Indentation">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4841indentation/IndentationTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="4.8.4.2"/>
+                  <a href="#4.8.4.2">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.4.2-switch-fall-through">
+                    4.8.4.2 Fall-through: commented</a>
+                </td>
+                <td>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_coding.html#FallThrough">FallThrough</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+FallThrough">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4842fallthrough/FallThroughTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="4.8.4.3"/>
+                  <a href="#4.8.4.3">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.4.3-switch-default">
+                    4.8.4.3 The default case is present</a>
+                </td>
+                <td>
+                  <img
+                      src="images/ok_blue.png"
+                      alt="" />
+                  <a href="config_coding.html#MissingSwitchDefault">
+                    MissingSwitchDefault</a>
+                  <br />
+                  "Exception: enum type may omit the default statement group"
+                  requirement can not be covered as we can not distinguish types,
+                  enum values may look the same as static final String constants.
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingSwitchDefault">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4843defaultcasepresent/MissingSwitchDefaultTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="4.8.5"/>
+                  <a href="#4.8.5">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.5-annotations">
+                    4.8.5 Annotations</a>
+                </td>
+                <td>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_annotation.html#AnnotationLocation">
+                    AnnotationLocation</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AnnotationLocation">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule485annotations/AnnotationLocationTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="4.8.6"/>
+                  <a href="#4.8.6">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.6-comments">
+                    4.8.6 Comments</a>
+                </td>
+                <td>↓</td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="4.8.6.1"/>
+                  <a href="#4.8.6.1">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.6.1-block-comment-style">
+                    4.8.6.1 Block comment style</a>
+                </td>
+                <td>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_misc.html#CommentsIndentation">
+                    CommentsIndentation</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+CommentsIndentation">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4861blockcommentstyle/CommentsIndentationTest.java">
+                    test</a>
+                </td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="4.8.7"/>
+                  <a href="#4.8.7">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.7-modifiers">
+                    4.8.7 Modifiers</a>
+                </td>
+                <td>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_modifier.html#ModifierOrder">ModifierOrder</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ModifierOrder">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule487modifiers/ModifierOrderTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="4.8.8"/>
+                  <a href="#4.8.8">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s4.8.8-numeric-literals">
+                    4.8.8 Numeric Literals</a>
+                </td>
+                <td>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_misc.html#UpperEll">UpperEll</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+UpperEll">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter4formatting/rule488numericliterals/UpperEllTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="5"/>
+                  <a href="#5">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s5-naming">
+                    <strong>5 Naming</strong>
+                  </a>
+                </td>
+                <td>↓</td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="5.1"/>
+                  <a href="#5.1">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s5.1-identifier-names">
+                    5.1 Rules common to all identifiers</a>
+                </td>
+                <td>"5.2 Rules of identifier type" already includes this rule.
+                </td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="5.2"/>
+                  <a href="#5.2">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s5.2-specific-identifier-names">
+                    5.2 Rules by identifier type
+                  </a>
+                </td>
+                <td>↓</td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="5.2.1"/>
+                  <a href="#5.2.1">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s5.2.1-package-names">
+                    5.2.1 Package names</a>
+                </td>
+                <td>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_naming.html#PackageName">PackageName</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+PackageName">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule521packagenames/PackageNameTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="5.2.2"/>
+                  <a href="#5.2.2">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s5.2.2-class-names">
+                    5.2.2 Class names</a>
+                </td>
+                <td>
+                  <img
+                      src="images/ok_blue.png"
+                      alt="" />
+                  <a href="config_naming.html#TypeName">TypeName</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+TypeName">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule522typenames/TypeNameTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="5.2.3"/>
+                  <a href="#5.2.3">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s5.2.3-method-names">
+                    5.2.3 Method names</a>
+                </td>
+                <td>
+                  <img
+                      src="images/ok_blue.png"
+                      alt="" />
+                  <a href="config_naming.html#MethodName">MethodName</a>
+                  <br/> No ability to distinguish verb at the beginning of name,
+                  no way distinguish Test method from others so "_" is allowed in
+                  names
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodName">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule523methodnames/MethodNameTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="5.2.4"/>
+                  <a href="#5.2.4">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s5.2.4-constant-names">
+                    5.2.4 Constant names</a>
+                </td>
+                <td>
+                  <img
+                      src="images/ban_red.png"
+                      alt="" />
+                  Every constant is a static final field, but not all static final
+                  fields are constants - impossible to check such rule.
+                </td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="5.2.5"/>
+                  <a href="#5.2.5">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s5.2.5-non-constant-field-names">
+                    5.2.5 Non-constant field names</a>
+                </td>
+                <td>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_naming.html#MemberName">MemberName</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MemberName">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/MemberNameTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="5.2.6"/>
+                  <a href="#5.2.6">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s5.2.6-parameter-names">
+                    5.2.6 Parameter names</a>
+                </td>
+                <td>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_naming.html#ParameterName">ParameterName</a>
+                  <br/>
+                  <br/>
+                  <img src="images/ok_green.png" alt=""/>
+                  <a href="config_naming.html#CatchParameterName">
+                    CatchParameterName</a>
+                  <br/>
+                  <br/>
+                  <img src="images/ok_green.png" alt=""/>
+                  <a href="config_naming.html#LambdaParameterName">
+                    LambdaParameterName</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ParameterName">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/ParameterNameTest.java">
+                    test</a>
+                  <br/>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+CatchParameterName">
+                    config
+                  </a>
+                  <br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule51identifiernames/CatchParameterNameTest.java">
+                    test
+                  </a>
+                  <br/>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LambdaParameterName">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/LambdaParameterNameTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="5.2.7"/>
+                  <a href="#5.2.7">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s5.2.7-local-variable-names">
+                    5.2.7 Local variable names</a>
+                </td>
+                <td>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_naming.html#LocalVariableName">LocalVariableName</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LocalVariableName">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNameTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="5.2.8"/>
+                  <a href="#5.2.8">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s5.2.8-type-variable-names">
+                    5.2.8 Type variable names</a>
+                </td>
+                <td>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_naming.html#MethodTypeParameterName">
+                    MethodTypeParameterName</a>
+                  <br/>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_naming.html#ClassTypeParameterName">
+                    ClassTypeParameterName</a>
+                  <br/>
+                  <img
+                      src="images/ok_green.png"
+                      alt="" />
+                  <a href="config_naming.html#InterfaceTypeParameterName">
+                    InterfaceTypeParameterName</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodTypeParameterName">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/MethodTypeParameterNameTest.java">
+                    test</a>
+                  <br />
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ClassTypeParameterName">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassTypeParameterNameTest.java">
+                    test</a>
+                  <br />
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+InterfaceTypeParameterName">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/InterfaceTypeParameterNameTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="5.3"/>
+                  <a href="#5.3">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s5.3-camel-case">
+                    5.3 Camel case: defined</a>
+                </td>
+                <td>
+                  <img
+                      src="images/ok_blue.png"
+                      alt="" />
+                  <a href="config_naming.html#AbbreviationAsWordInName">
+                    AbbreviationAsWordInName</a>
+                  <br />
+                  Non covered: Some words are ambiguously hyphenated in the
+                  English language. No way to distinguish "YouTubeImporter" or
+                  "YoutubeImporter".
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AbbreviationAsWordInName">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule53camelcase/AbbreviationAsWordInNameTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="6"/>
+                  <a href="#6">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s6-programming-practices">
+                    <strong>6 Programming Practices</strong>
+                  </a>
+                </td>
+                <td>↓</td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="6.1"/>
+                  <a href="#6.1">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s6.1-override-annotation">
+                    6.1 @Override: always used</a>
+                </td>
+                <td>
+                  <img
+                      src="images/ban_red.png"
+                      alt="" />
+                  That validation could not be checked by Checkstyle. It's
+                  need to
+                  take a look as parent class. But Checkstyle have no way to
+                  open or
+                  look at another Class file.
+                </td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="6.2"/>
+                  <a href="#6.2">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s6.2-caught-exceptions">
+                    6.2 Caught exceptions: not ignored</a>
+                </td>
+                <td>
+                  <img
+                      src="images/ok_blue.png"
+                      alt="" />
+                  <a href="config_blocks.html#EmptyBlock">EmptyBlock</a>
+                  with option=text.
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+EmptyBlock">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter6programpractice/rule62donotignoreexceptions/EmptyBlockTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="6.3"/>
+                  <a href="#6.3">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s6.3-static-members">
+                    6.3 Static members: qualified using class</a>
+                </td>
+                <td>
+                  <img
+                      src="images/ban_red.png"
+                      alt="" />
+                  Proper validation require parsing other files, sources
+                  are not always available.
+                </td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="6.4"/>
+                  <a href="#6.4">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s6.4-finalizers">
+                    6.4 Finalizers: not used</a>
+                </td>
+                <td>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_coding.html#NoFinalizer">NoFinalizer</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoFinalizer">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter6programpractice/rule64finalizers/NoFinalizerTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="7"/>
+                  <a href="#7">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s7-javadoc">
+                    <strong>7 Javadoc</strong>
+                  </a>
+                </td>
+                <td>↓</td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="7.1"/>
+                  <a href="#7.1">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s7.1-javadoc-formatting">
+                    7.1 Formatting
+                  </a>
+                </td>
+                <td>↓</td>
+                <td/>
+              </tr>
+              <tr>
+                <td><a name="7.1.1"/>
+                  <a href="#7.1.1">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s7.1.1-javadoc-multi-line">
+                    7.1.1 General form</a>
+                </td>
+                <td>
+                  <img
+                      src="images/ok_blue.png"
+                      alt="" />
+                  <br />
+                  <a href="config_javadoc.html#SingleLineJavadoc">
+                    SingleLineJavadoc</a>
+                  Recent update for guide that clarify requirements will be
+                  addressed at
+                  <a href="https://github.com/checkstyle/checkstyle/issues/4052">
+                    #4052</a>
+                  <br />
+                  <a href="config_javadoc.html#InvalidJavadocPosition">
+                    InvalidJavadocPosition</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SingleLineJavadoc">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule711generalform/SingleLineJavadocTest.java">
+                    test</a>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+InvalidJavadocPosition">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule711generalform/InvalidJavadocPositionTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="7.1.2"/>
+                  <a href="#7.1.2">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s7.1.2-javadoc-paragraphs">
+                    7.1.2 Paragraphs</a>
+                </td>
+                <td>
+                  <img
+                      src="images/ok_green.png"
+                      alt="" />
+                  <a href="config_javadoc.html#JavadocParagraph">JavadocParagraph</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocParagraph">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/JavadocParagraphTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="7.1.3"/>
+                  <a href="#7.1.3">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s7.1.3-javadoc-at-clauses">
+                    7.1.3 Block tags</a>
+                </td>
+                <td>
+                  <img
+                      src="images/ok_green.png"
+                      alt="" />
+                  <a href="config_javadoc.html#AtclauseOrder">AtclauseOrder</a>
+                  <br/>
+                  <br/>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_javadoc.html#JavadocTagContinuationIndentation">
+                    JavadocTagContinuationIndentation</a>
+                  <br/>
+                  <br/>
+                  <img src="images/ok_green.png" alt="" />
+                  <a href="config_javadoc.html#NonEmptyAtclauseDescription">
+                    NonEmptyAtclauseDescription</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AtclauseOrder">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/AtclauseOrderTest.java">
+                    test</a><br/>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocTagContinuationIndentation">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/JavadocTagContinuationIndentationTest.java">
+                    test</a><br/>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NonEmptyAtclauseDescription">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule713atclauses/NonEmptyAtclauseDescriptionTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="7.2"/>
+                  <a href="#7.2">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s7.2-summary-fragment">
+                    7.2 The summary fragment</a>
+                </td>
+                <td>
+                  <img
+                      src="images/ok_green.png"
+                      alt="" />
+                  <a href="config_javadoc.html#SummaryJavadoc">SummaryJavadoc</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SummaryJavadoc">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule72thesummaryfragment/SummaryJavadocTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="7.3"/>
+                  <a href="#7.3">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s7.3-javadoc-where-required">
+                    7.3 Where Javadoc is used
+                  </a>
+                </td>
+                <td>
+                  <img
+                      src="images/ok_green.png"
+                      alt="" />
+                  <a href="config_javadoc.html#MissingJavadocMethod">MissingJavadocMethod</a>
+                  <img
+                      src="images/ok_green.png"
+                      alt="" />
+                  <a href="config_javadoc.html#JavadocMethod">JavadocMethod</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingJavadocMethod">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/MissingJavadocMethodTest.java">
+                    test</a>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocMethod">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/JavadocMethodTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="7.3.1"/>
+                  <a href="#7.3.1">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s7.3.1-javadoc-exception-self-explanatory">
+                    7.3.1 Exception: self-explanatory methods</a>
+                </td>
+                <td>
+                  <img
+                      src="images/ok_green.png"
+                      alt="" />
+                  <a href="config_javadoc.html#MissingJavadocMethod">MissingJavadocMethod</a>
+                  <img
+                      src="images/ok_green.png"
+                      alt="" />
+                  <a href="config_javadoc.html#JavadocMethod">JavadocMethod</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingJavadocMethod">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/MissingJavadocMethodTest.java">
+                    test</a>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocMethod">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/JavadocMethodTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="7.3.2"/>
+                  <a href="#7.3.2">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s7.3.2-javadoc-exception-overrides">
+                    7.3.2 Exception: overrides</a>
+                </td>
+                <td>
+                  <img
+                      src="images/ok_green.png"
+                      alt="" />
+                  <a href="config_javadoc.html#MissingJavadocMethod">MissingJavadocMethod</a>
+                  <img
+                      src="images/ok_blue.png"
+                      alt="" />
+                  <a href="config_javadoc.html#JavadocMethod">JavadocMethod</a><br/>
+                  Overrides are checked by presence of "@Override" annotation on
+                  method.
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingJavadocMethod">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/MissingJavadocMethodTest.java">
+                    test</a>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocMethod">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/JavadocMethodTest.java">
+                    test</a>
+                </td>
+              </tr>
+              <tr>
+                <td><a name="7.3.4"/>
+                  <a href="#7.3.4">
+                    <img src="images/anchor.png" alt=""/>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s7.3.4-javadoc-non-required">
+                    7.3.4 Non-required Javadoc</a>
+                </td>
+                <td>
+                  <img
+                      src="images/ok_blue.png"
+                      alt="" />
+                  <a href="config_javadoc.html#InvalidJavadocPosition">
+                    InvalidJavadocPosition</a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+InvalidJavadocPosition">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule734nonrequiredjavadoc/InvalidJavadocPositionTest.java">
+                    test</a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </subsection>
+    </section>
+  </body>
 </document>

--- a/src/xdocs/idea.xml
+++ b/src/xdocs/idea.xml
@@ -26,9 +26,13 @@
       <p>
         If no project is currently open in IntelliJ IDEA, click Import Project on the
         Welcome screen. Otherwise, select File > New > Project from Existing Sources<br/><br/>
-        <img alt="screenshot" src="images/gui_screenshot_importing_idea.png"/>
+        <span class="wrapper">
+          <img alt="screenshot" src="images/gui_screenshot_importing_idea.png"/>
+        </span>
         <br/><br/>
-        <img alt="screenshot" src="images/gui_screenshot_importing_idea1.png"/>
+        <span class="wrapper">
+          <img alt="screenshot" src="images/gui_screenshot_importing_idea1.png"/>
+        </span>
         <br/><br/>
         Then Next > Next > ... Until Finish.
       </p>
@@ -36,7 +40,9 @@
         Generate sources that a required by checkstyle
         by right click over pom.xml file and click on menu "Maven / Generate Sources and Update
         Folders"
-        <img alt="screenshot" src="images/gui_screenshot_idea_generate_sources.png"/>
+        <span class="wrapper">
+          <img alt="screenshot" src="images/gui_screenshot_idea_generate_sources.png"/>
+        </span>
         <br/><br/>
       </p>
     </section>
@@ -44,15 +50,21 @@
     <section name="Debug">
       <p>
         Open the Check's source file by double click on it in a source tree as is shown:<br/><br/>
-        <img alt="screenshot" src="images/gui_screenshot_select_check_idea.png"/>
+        <span class="wrapper">
+          <img alt="screenshot" src="images/gui_screenshot_select_check_idea.png"/>
+        </span>
         <br/><br/>
         Debug the Check by putting the breakpoint at controversial place (double-click)
         on the left part of line number as it is shown:<br/><br/>
-        <img alt="screenshot" src="images/gui_screenshot_debug_idea.png"/>
+        <span class="wrapper">
+          <img alt="screenshot" src="images/gui_screenshot_debug_idea.png"/>
+        </span>
         <br/><br/>
         Then right-click the corresponding Unit-test file or class definition > Debug
         &quot;testName&quot;<br/><br/>
-        <img alt="screenshot" src="images/gui_screenshot_ut_select_idea.png"/>
+        <span class="wrapper">
+          <img alt="screenshot" src="images/gui_screenshot_ut_select_idea.png"/>
+        </span>
         <br/><br/>
         Then manage you debug operations F8 (Step Over), Shift+F8 (Step Out),
         F7 (Step Into), Alt+F9 (Run to Cursor)
@@ -67,8 +79,10 @@
         To change formatter settings please go to File->Settings in menu.<br/>
         Then in the tree go to: Editor->Code Style->Java, open Import tab (follow numbers on a
         picture) and apply settings highlighted:<br/><br/>
-        <img alt="Organize Imports settings in IDEA"
-          src="images/gui_screenshot_organize_imports_idea.jpg"/>
+        <span class="wrapper">
+          <img alt="Organize Imports settings in IDEA"
+            src="images/gui_screenshot_organize_imports_idea.jpg"/>
+        </span>
         <br/>
       </p>
     </section>
@@ -80,7 +94,9 @@
         <code>config/intellij-idea-inspections.xml</code>.
         <br/>
         <br/>
-        <img alt="Inspections in IntelliJ IDEA" src="images/gui_screenshot_inspections_idea.png"/>
+        <span class="wrapper">
+          <img alt="Inspections in IntelliJ IDEA" src="images/gui_screenshot_inspections_idea.png"/>
+        </span>
         <br/>
         <br/>
         ATTENTION: Not all files in repository should be analyzed.
@@ -98,7 +114,9 @@
         Now it should be ready to be used in Inspect Code window (Analyse -> Inspect Code):
         <br/>
         <br/>
-        <img alt="Scope for inspections" src="images/gui_screenshot_scope_idea.png"/>
+        <span class="wrapper">
+          <img alt="Scope for inspections" src="images/gui_screenshot_scope_idea.png"/>
+        </span>
       </p>
     </section>
 
@@ -109,8 +127,10 @@
         checkstyle files. A simple solution to this problem is by using the key combinations
         <code>Ctrl + Shift + Alt + V</code> or <code>Edit | Paste Simple</code>. However it is
         recommended that this settings be changed by default as shown below
-        <img alt="Disable Auto Indent on Paste"
-          src="images/gui_screenshot_disable_indent_paste_idea.png"/>
+        <span class="wrapper">
+          <img alt="Disable Auto Indent on Paste"
+            src="images/gui_screenshot_disable_indent_paste_idea.png"/>
+        </span>
       </p>
     </section>
 

--- a/src/xdocs/index.xml.vm
+++ b/src/xdocs/index.xml.vm
@@ -150,270 +150,275 @@
       </p>
 
       <subsection name="Active Tools" >
-          <table>
-              <tr>
-                  <th>IDE / Build tool</th>
-                  <th>Main/Initial Author</th>
-                  <th>Available from</th>
-                  <th>Remarks</th>
-              </tr>
-              <tr>
-                  <td>
-                      <a href="https://www.atlassian.com/software/bitbucket">
-                          Bitbucket Server</a>
-                  </td>
-                  <td>Stephan Bechter</td>
-                  <td>
-                      <a href="https://marketplace.atlassian.com/apps/1214095/checkstyles-for-bitbucket-server">
-                          Checkstyle for Bitbucket Server
-                      </a>
-                  </td>
-                  <td/>
-              </tr>
-              <tr>
-                  <td>
-                      <a href="https://www.codacy.com/">Codacy</a>
-                  </td>
-                  <td>João Machado</td>
-                  <td>
-                      <a href="https://github.com/codacy/codacy-checkstyle/">
-                          codacy-checkstyle
-                      </a>
-                  </td>
-                  <td>
-                      Provides analysis per commit and per pull request. Supports CheckStyle
-                      config files.
-                  </td>
-              </tr>
-              <tr>
-                  <td><a href="https://eclipse.org">Eclipse/RAD/RDz</a></td>
-                  <td>Christian Wulf</td>
-                  <td>
-                     <a href="https://github.com/ChristianWulf/qa-eclipse-plugin">
-                        Lightweight Eclipse Plugin for Quality Assurance Tools
-                     </a>
-                  </td>
-                  <td>Alternative to the Eclipse-CS plugin.
-                     Allows to use custom checks directly without providing
-                     an Eclipse Fragment plugin for that purpose.
-                  </td>
-              </tr>
-              <tr>
-                  <td><a href="https://eclipse.org">Eclipse/RAD/RDz</a></td>
-                  <td>David Schneider</td>
-                  <td>
-                      <a href="http://checkstyle.org/eclipse-cs/">Eclipse-CS Home Page</a>
-                  </td>
-                  <td>
-                      In 2007 was awarded
-                      <a href="https://eclipse.org/org/press-release/20070306eclipsecommunityawards.php">
-                          Best Open Source Eclipse-based Developer tool
-                      </a>.
-                  </td>
-              </tr>
-              <tr>
-                  <td><a href="https://gradle.org">Gradle</a></td>
-                  <td>Hans Dockter (initial author)</td>
-                  <td>Checkstyle supported out of the box</td>
-                  <td><a href="https://docs.gradle.org/current/userguide/checkstyle_plugin.html">
-                      Gradle Checkstyle docs</a></td>
-              </tr>
-              <tr>
-                  <td><a href="http://www.jetbrains.com/idea/">IntelliJ IDEA</a></td>
-                  <td>James Shiell</td>
-                  <td>
-                      <a href="https://github.com/jshiell/checkstyle-idea">
-                          Checkstyle-idea Project Page</a>
-                  </td>
-                  <td>Provides real-time and on-demand scanning.</td>
-              </tr>
-              <tr>
-                  <td><a href="https://www.jgrasp.org/">jGRASP</a></td>
-                  <td>Larry Barowski</td>
-                  <td><a href="https://www.jgrasp.org/">jGRASP Home Page</a></td>
-                  <td/>
-              </tr>
-              <tr>
-                  <td><a href="https://eclipse.org">Eclipse/RAD/RDz</a></td>
-                  <td>Roman Ivanov</td>
-                  <td>
-                      <a href="https://github.com/sevntu-checkstyle">Project Page</a>
-                  </td>
-                  <td>
-                      Extension for Eclipse-CS plugin and also an incubator for
-                      Checkstyle checks that are not present in main stream of
-                      Checkstyle. See the
-                      <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/wiki">Wiki</a>
-                      and
-                      <a href="http://sevntu-checkstyle.github.io/sevntu.checkstyle/">Blog</a>
-                      .
-                  </td>
-              </tr>
-              <tr>
-                  <td><a href="https://eclipse.org">Eclipse/RAD/RDz</a></td>
-                  <td>Jan Burkhardt</td>
-                  <td>
-                      <a href="https://github.com/bjrke/JSR305CheckstylePlugin">Project Page</a>
-                  </td>
-                  <td>
-                      Extension for Eclipse-CS plugin which ensures nullness annotations on methods
-                      and constructors (JSR305).
-                  </td>
-              </tr>
-              <tr>
-                  <td><a href="https://bitbucket.org/atlassian/bamboo-checkstyle-plugin">
-                      Bamboo Checkstyle plug-in</a></td>
-                  <td>Atlassian (formerly by Ross Rowe and Stephan Paulicke)</td>
-                  <td><a href="https://bitbucket.org/atlassian/bamboo-checkstyle-plugin">
-                      Bamboo Checkstyle plug-in Home Page</a></td>
-                  <td>An add-on that will parse and record CheckStyle reports and report your style
-                      violations over time.</td>
-              </tr>
-              <tr>
-                  <td>
-                      <a href="https://codeclimate.com/">Code Climate</a>
-                  </td>
-                  <td>Sivakumar Kailasam</td>
-                  <td>
-                      <a href="https://github.com/sivakumar-kailasam/codeclimate-checkstyle">
-                          codeclimate-checkstyle
-                      </a>
-                  </td>
-                  <td/>
-              </tr>
-              <tr>
-                  <td><a href="https://wiki.jenkins.io/display/JENKINS/Checkstyle+Plugin">Jenkins
-                  Checkstyle plug-in</a></td>
-                  <td/>
-                  <td><a href="https://wiki.jenkins.io/display/JENKINS/Checkstyle+Plugin">Jenkins
-                  Checkstyle plug-in Home Page</a></td>
-                  <td>This plug-in is supported by the Static Analysis Collector plug-in that
-                  collects different analysis results and shows the results in aggregated trend
-                  graphs.</td>
-              </tr>
-              <tr>
-                  <td><a href="http://maven.apache.org/">Maven</a></td>
-                  <td>Vincent Massol</td>
-                  <td>Checkstyle supported out of the box</td>
-                  <td><a href="http://maven.apache.org/plugins/maven-checkstyle-plugin/checkstyle.html">
-                      example report</a></td>
-              </tr>
-              <tr>
-                  <td><a href="http://tide.olympe.in/">tIDE</a></td>
-                  <td/>
-                  <td>Built in</td>
-                  <td/>
-              </tr>
-              <tr>
-                  <td><a href="https://netbeans.org/">NetBeans</a></td>
-                  <td>Petr Hejl</td>
-                  <td>
-                      <a href="https://www.sickboy.cz/checkstyle/">Checkstyle Beans</a>
-                  </td>
-                  <td>
-                      Problems with source code are displayed as annotations of
-                      the source
-                  </td>
-              </tr>
-              <tr>
-                  <td><a href="https://netbeans.org/">NetBeans</a></td>
-                  <td/>
-                  <td>
-                      <a href="http://sqe-team.github.io">Software Quality Environment (SQE)</a>
-                  </td>
-                  <td/>
-              </tr>
-              <tr>
-                  <td><a href="https://www.sonarqube.org/">SonarQube</a></td>
-                  <td>Freddy Mallet (initial author)</td>
-                  <td><a href="https://github.com/checkstyle/sonar-checkstyle">
-                      Checkstyle SonarQube repository</a></td>
-                  <td><a href="https://sonarcloud.io/projects">Demo site of SonarQube</a></td>
-              </tr>
-              <tr>
-                  <td><a href="http://www.jedit.org/">jEdit</a></td>
-                  <td>Todd Papaioannou</td>
-                  <td><a href="http://plugins.jedit.org/plugins/?CheckStylePlugin">
-                      JEdit CheckStylePlugin</a></td>
-                  <td/>
-              </tr>
-              <tr>
-                  <td><a href="https://www.scm-manager.org/">SCM-Manager</a></td>
-                  <td/>
-                  <td><a href="http://plugins.scm-manager.org/scm-plugin-backend/page/index.html">
-                      SCM-Manager Plugin Page</a></td>
-                  <td/>
-              </tr>
-              <tr>
-                  <td><a href="http://www.jetbrains.com/idea/">IntelliJ IDEA</a></td>
-                  <td>Jakub Slawinski</td>
-                  <td>
-                      <a href="https://plugins.jetbrains.com/plugin/4594-qaplug">QAPlug</a>
-                  </td>
-                  <td>Provides quality assurance features.</td>
-              </tr>
-              <tr>
-                  <td><a href="https://www.jarchitect.com">JArchitect</a></td>
-                  <td/>
-                  <td><a href="https://www.jarchitect.com">JArchitect Home Page</a></td>
-                  <td>Imports XML result files from CheckStyle.</td>
-              </tr>
-              <tr>
-                  <td><a href="https://www.scala-sbt.org/">SBT</a></td>
-                  <td>Andrew Johnson</td>
-                  <td><a href="https://github.com/etsy/sbt-checkstyle-plugin">
-                      sbt-checkstyle-plugin Project Page</a></td>
-                  <td>SBT plugin for running Checkstyle on Java source files in an SBT project</td>
-              </tr>
-              <tr>
-                  <td><a href="https://github.com/nidi3/code-assert">code-assert</a></td>
-                  <td>Stefan Niederhauser</td>
-                  <td><a href="https://github.com/nidi3/code-assert#checkstyle-checks">
-                      code-assert</a></td>
-                  <td>Assert that the java code of a project satisfies certain checks. Launch
-                      checkstyle validation from UTs</td>
-              </tr>
-              <tr>
-                  <td><a href="http://jdee.sourceforge.net/">Emacs JDE</a></td>
-                  <td>Markus Mohnen</td>
-                  <td>Part of the standard JDEE distribution -
-                      <a href="https://github.com/jdee-emacs/jdee"/>
-                  </td>
-                  <td><a href="https://github.com/jdee-emacs/jdee/blob/master/jdee-checkstyle.el">
-                      configuration could be seen at jdee-checkstyle.el</a></td>
-              </tr>
-              <tr>
-                  <td><a href="https://code.visualstudio.com/">Visual Studio Code</a></td>
-                  <td>Sheng Chen</td>
-                  <td><a href="https://marketplace.visualstudio.com/items?itemName=shengchen.vscode-checkstyle">
-                      vscode-checkstyle</a></td>
-                  <td>Checkstyle for Microsoft Visual Studio Code</td>
-              </tr>
-          </table>
+          <div class="wrapper">
+              <table>
+                  <tr>
+                      <th>IDE / Build tool</th>
+                      <th>Main/Initial Author</th>
+                      <th>Available from</th>
+                      <th>Remarks</th>
+                  </tr>
+                  <tr>
+                      <td>
+                          <a href="https://www.atlassian.com/software/bitbucket">
+                              Bitbucket Server</a>
+                      </td>
+                      <td>Stephan Bechter</td>
+                      <td>
+                          <a href="https://marketplace.atlassian.com/apps/1214095/checkstyles-for-bitbucket-server">
+                              Checkstyle for Bitbucket Server
+                          </a>
+                      </td>
+                      <td/>
+                  </tr>
+                  <tr>
+                      <td>
+                          <a href="https://www.codacy.com/">Codacy</a>
+                      </td>
+                      <td>João Machado</td>
+                      <td>
+                          <a href="https://github.com/codacy/codacy-checkstyle/">
+                              codacy-checkstyle
+                          </a>
+                      </td>
+                      <td>
+                          Provides analysis per commit and per pull request. Supports CheckStyle
+                          config files.
+                      </td>
+                  </tr>
+                  <tr>
+                      <td><a href="https://eclipse.org">Eclipse/RAD/RDz</a></td>
+                      <td>Christian Wulf</td>
+                      <td>
+                         <a href="https://github.com/ChristianWulf/qa-eclipse-plugin">
+                            Lightweight Eclipse Plugin for Quality Assurance Tools
+                         </a>
+                      </td>
+                      <td>Alternative to the Eclipse-CS plugin.
+                         Allows to use custom checks directly without providing
+                         an Eclipse Fragment plugin for that purpose.
+                      </td>
+                  </tr>
+                  <tr>
+                      <td><a href="https://eclipse.org">Eclipse/RAD/RDz</a></td>
+                      <td>David Schneider</td>
+                      <td>
+                          <a href="http://checkstyle.org/eclipse-cs/">Eclipse-CS Home Page</a>
+                      </td>
+                      <td>
+                          In 2007 was awarded
+                          <a href="https://eclipse.org/org/press-release/20070306eclipsecommunityawards.php">
+                              Best Open Source Eclipse-based Developer tool
+                          </a>.
+                      </td>
+                  </tr>
+                  <tr>
+                      <td><a href="https://gradle.org">Gradle</a></td>
+                      <td>Hans Dockter (initial author)</td>
+                      <td>Checkstyle supported out of the box</td>
+                      <td><a href="https://docs.gradle.org/current/userguide/checkstyle_plugin.html">
+                          Gradle Checkstyle docs</a></td>
+                  </tr>
+                  <tr>
+                      <td><a href="http://www.jetbrains.com/idea/">IntelliJ IDEA</a></td>
+                      <td>James Shiell</td>
+                      <td>
+                          <a href="https://github.com/jshiell/checkstyle-idea">
+                              Checkstyle-idea Project Page</a>
+                      </td>
+                      <td>Provides real-time and on-demand scanning.</td>
+                  </tr>
+                  <tr>
+                      <td><a href="https://www.jgrasp.org/">jGRASP</a></td>
+                      <td>Larry Barowski</td>
+                      <td><a href="https://www.jgrasp.org/">jGRASP Home Page</a></td>
+                      <td/>
+                  </tr>
+                  <tr>
+                      <td><a href="https://eclipse.org">Eclipse/RAD/RDz</a></td>
+                      <td>Roman Ivanov</td>
+                      <td>
+                          <a href="https://github.com/sevntu-checkstyle">Project Page</a>
+                      </td>
+                      <td>
+                          Extension for Eclipse-CS plugin and also an incubator for
+                          Checkstyle checks that are not present in main stream of
+                          Checkstyle. See the
+                          <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/wiki">Wiki</a>
+                          and
+                          <a href="http://sevntu-checkstyle.github.io/sevntu.checkstyle/">Blog</a>
+                          .
+                      </td>
+                  </tr>
+                  <tr>
+                      <td><a href="https://eclipse.org">Eclipse/RAD/RDz</a></td>
+                      <td>Jan Burkhardt</td>
+                      <td>
+                          <a href="https://github.com/bjrke/JSR305CheckstylePlugin">Project Page</a>
+                      </td>
+                      <td>
+                          Extension for Eclipse-CS plugin which ensures nullness annotations on
+                          methods and constructors (JSR305).
+                      </td>
+                  </tr>
+                  <tr>
+                      <td><a href="https://bitbucket.org/atlassian/bamboo-checkstyle-plugin">
+                          Bamboo Checkstyle plug-in</a></td>
+                      <td>Atlassian (formerly by Ross Rowe and Stephan Paulicke)</td>
+                      <td><a href="https://bitbucket.org/atlassian/bamboo-checkstyle-plugin">
+                          Bamboo Checkstyle plug-in Home Page</a></td>
+                      <td>An add-on that will parse and record CheckStyle reports and report your
+                          style violations over time.</td>
+                  </tr>
+                  <tr>
+                      <td>
+                          <a href="https://codeclimate.com/">Code Climate</a>
+                      </td>
+                      <td>Sivakumar Kailasam</td>
+                      <td>
+                          <a href="https://github.com/sivakumar-kailasam/codeclimate-checkstyle">
+                              codeclimate-checkstyle
+                          </a>
+                      </td>
+                      <td/>
+                  </tr>
+                  <tr>
+                      <td><a href="https://wiki.jenkins.io/display/JENKINS/Checkstyle+Plugin">Jenkins
+                      Checkstyle plug-in</a></td>
+                      <td/>
+                      <td><a href="https://wiki.jenkins.io/display/JENKINS/Checkstyle+Plugin">Jenkins
+                      Checkstyle plug-in Home Page</a></td>
+                      <td>This plug-in is supported by the Static Analysis Collector plug-in that
+                      collects different analysis results and shows the results in aggregated trend
+                      graphs.</td>
+                  </tr>
+                  <tr>
+                      <td><a href="http://maven.apache.org/">Maven</a></td>
+                      <td>Vincent Massol</td>
+                      <td>Checkstyle supported out of the box</td>
+                      <td><a href="http://maven.apache.org/plugins/maven-checkstyle-plugin/checkstyle.html">
+                          example report</a></td>
+                  </tr>
+                  <tr>
+                      <td><a href="http://tide.olympe.in/">tIDE</a></td>
+                      <td/>
+                      <td>Built in</td>
+                      <td/>
+                  </tr>
+                  <tr>
+                      <td><a href="https://netbeans.org/">NetBeans</a></td>
+                      <td>Petr Hejl</td>
+                      <td>
+                          <a href="https://www.sickboy.cz/checkstyle/">Checkstyle Beans</a>
+                      </td>
+                      <td>
+                          Problems with source code are displayed as annotations of
+                          the source
+                      </td>
+                  </tr>
+                  <tr>
+                      <td><a href="https://netbeans.org/">NetBeans</a></td>
+                      <td/>
+                      <td>
+                          <a href="http://sqe-team.github.io">Software Quality Environment (SQE)</a>
+                      </td>
+                      <td/>
+                  </tr>
+                  <tr>
+                      <td><a href="https://www.sonarqube.org/">SonarQube</a></td>
+                      <td>Freddy Mallet (initial author)</td>
+                      <td><a href="https://github.com/checkstyle/sonar-checkstyle">
+                          Checkstyle SonarQube repository</a></td>
+                      <td><a href="https://sonarcloud.io/projects">Demo site of SonarQube</a></td>
+                  </tr>
+                  <tr>
+                      <td><a href="http://www.jedit.org/">jEdit</a></td>
+                      <td>Todd Papaioannou</td>
+                      <td><a href="http://plugins.jedit.org/plugins/?CheckStylePlugin">
+                          JEdit CheckStylePlugin</a></td>
+                      <td/>
+                  </tr>
+                  <tr>
+                      <td><a href="https://www.scm-manager.org/">SCM-Manager</a></td>
+                      <td/>
+                      <td><a href="http://plugins.scm-manager.org/scm-plugin-backend/page/index.html">
+                          SCM-Manager Plugin Page</a></td>
+                      <td/>
+                  </tr>
+                  <tr>
+                      <td><a href="http://www.jetbrains.com/idea/">IntelliJ IDEA</a></td>
+                      <td>Jakub Slawinski</td>
+                      <td>
+                          <a href="https://plugins.jetbrains.com/plugin/4594-qaplug">QAPlug</a>
+                      </td>
+                      <td>Provides quality assurance features.</td>
+                  </tr>
+                  <tr>
+                      <td><a href="https://www.jarchitect.com">JArchitect</a></td>
+                      <td/>
+                      <td><a href="https://www.jarchitect.com">JArchitect Home Page</a></td>
+                      <td>Imports XML result files from CheckStyle.</td>
+                  </tr>
+                  <tr>
+                      <td><a href="https://www.scala-sbt.org/">SBT</a></td>
+                      <td>Andrew Johnson</td>
+                      <td><a href="https://github.com/etsy/sbt-checkstyle-plugin">
+                          sbt-checkstyle-plugin Project Page</a></td>
+                      <td>SBT plugin for running Checkstyle on Java source files in an SBT
+                        project</td>
+                  </tr>
+                  <tr>
+                      <td><a href="https://github.com/nidi3/code-assert">code-assert</a></td>
+                      <td>Stefan Niederhauser</td>
+                      <td><a href="https://github.com/nidi3/code-assert#checkstyle-checks">
+                          code-assert</a></td>
+                      <td>Assert that the java code of a project satisfies certain checks. Launch
+                          checkstyle validation from UTs</td>
+                  </tr>
+                  <tr>
+                      <td><a href="http://jdee.sourceforge.net/">Emacs JDE</a></td>
+                      <td>Markus Mohnen</td>
+                      <td>Part of the standard JDEE distribution -
+                          <a href="https://github.com/jdee-emacs/jdee"/>
+                      </td>
+                      <td><a href="https://github.com/jdee-emacs/jdee/blob/master/jdee-checkstyle.el">
+                          configuration could be seen at jdee-checkstyle.el</a></td>
+                  </tr>
+                  <tr>
+                      <td><a href="https://code.visualstudio.com/">Visual Studio Code</a></td>
+                      <td>Sheng Chen</td>
+                      <td><a href="https://marketplace.visualstudio.com/items?itemName=shengchen.vscode-checkstyle">
+                          vscode-checkstyle</a></td>
+                      <td>Checkstyle for Microsoft Visual Studio Code</td>
+                  </tr>
+              </table>
+          </div>
       </subsection>
 
       <subsection name="Inactive / Old Tools" >
-          <table>
-              <tr>
-                  <th>IDE / Build tool</th>
-                  <th>Main/Initial Author</th>
-                  <th>Available from</th>
-                  <th>Remarks</th>
-              </tr>
-              <tr>
-                  <td><a href="http://qalab.sourceforge.net/">QALab</a></td>
-                  <td>Benoit Xhenseval</td>
-                  <td><a href="http://qalab.sourceforge.net/">QALab Home Page</a></td>
-                  <td>Supports tracking Checkstyle statistics over time.</td>
-              </tr>
-              <tr>
-                  <td><a href="https://vim.sourceforge.io/">Vim editor</a></td>
-                  <td>Xandy Johnson</td>
-                  <td><a href="https://vim.sourceforge.io/scripts/script.php?script_id=448">
-                      Plugin Homepage</a></td>
-                  <td>Vim file-type plug-in</td>
-              </tr>
-          </table>
+          <div class="wrapper">
+              <table>
+                  <tr>
+                      <th>IDE / Build tool</th>
+                      <th>Main/Initial Author</th>
+                      <th>Available from</th>
+                      <th>Remarks</th>
+                  </tr>
+                  <tr>
+                      <td><a href="http://qalab.sourceforge.net/">QALab</a></td>
+                      <td>Benoit Xhenseval</td>
+                      <td><a href="http://qalab.sourceforge.net/">QALab Home Page</a></td>
+                      <td>Supports tracking Checkstyle statistics over time.</td>
+                  </tr>
+                  <tr>
+                      <td><a href="https://vim.sourceforge.io/">Vim editor</a></td>
+                      <td>Xandy Johnson</td>
+                      <td><a href="https://vim.sourceforge.io/scripts/script.php?script_id=448">
+                          Plugin Homepage</a></td>
+                      <td>Vim file-type plug-in</td>
+                  </tr>
+              </table>
+          </div>
       </subsection>
 
       <p>

--- a/src/xdocs/netbeans.xml
+++ b/src/xdocs/netbeans.xml
@@ -25,24 +25,34 @@
     <section name="Import Checkstyle Project">
       <p>
         Select File > New Project > Maven > Project with existing POM<br/><br/>
-        <img alt="screenshot" src="images/gui_screenshot_importing_netbeans.png"/>
+        <span class="wrapper">
+          <img alt="screenshot" src="images/gui_screenshot_importing_netbeans.png"/>
+        </span>
         <br/><br/>
-        <img alt="screenshot" src="images/gui_screenshot_importing_netbeans1.png"/>
+        <span class="wrapper">
+          <img alt="screenshot" src="images/gui_screenshot_importing_netbeans1.png"/>
+        </span>
       </p>
     </section>
 
     <section name="Debug">
       <p>
         Open the Check's source file by double click on it in a source tree as is shown:<br/><br/>
-        <img alt="screenshot" src="images/gui_screenshot_select_check_netbeans.png"/>
+        <span class="wrapper">
+          <img alt="screenshot" src="images/gui_screenshot_select_check_netbeans.png"/>
+        </span>
         <br/><br/>
         Debug the Check by putting the breakpoint at controversial place (double-click)
         on the left part of line number as it is shown:<br/><br/>
-        <img alt="screenshot" src="images/gui_screenshot_debug_netbeans.png"/>
+        <span class="wrapper">
+          <img alt="screenshot" src="images/gui_screenshot_debug_netbeans.png"/>
+        </span>
         <br/><br/>
         Then right-click the corresponding Unit-test file or class definition > Debug Test File
         <br/><br/>
-        <img alt="screenshot" src="images/gui_screenshot_ut_select_netbeans.png"/>
+        <span class="wrapper">
+          <img alt="screenshot" src="images/gui_screenshot_ut_select_netbeans.png"/>
+        </span>
         <br/><br/>
         Then manage you debug operations by Ctrl+F7 (Step Out), F7 (Step Into),
         Shift+F8 (Step Over Expression), Step Over (F8)
@@ -57,8 +67,10 @@
         To change formatter settings please go to Tools->Options in menu.<br/>
         On Options page go to Editor->Formatting->Java->Imports (follow numbers on a
         picture) and apply settings highlighted:<br/><br/>
-        <img alt="Organize Imports settings in NetBeans"
-          src="images/gui_screenshot_organize_imports_netbeans.jpg"/>
+        <span class="wrapper">
+          <img alt="Organize Imports settings in NetBeans"
+            src="images/gui_screenshot_organize_imports_netbeans.jpg"/>
+        </span>
         <br/>
       </p>
     </section>

--- a/src/xdocs/property_types.xml
+++ b/src/xdocs/property_types.xml
@@ -125,32 +125,34 @@
         following table describes the valid options:
       </p>
 
-      <table summary="line separator options">
-        <tr>
-          <td>Option</td>
-          <td>Definition</td>
-        </tr>
-        <tr>
-          <td><code>crlf</code></td>
-          <td>Windows-style</td>
-        </tr>
-        <tr>
-          <td><code>cr</code></td>
-          <td>Mac-style</td>
-        </tr>
-        <tr>
-          <td><code>lf</code></td>
-          <td>Unix-style</td>
-        </tr>
-        <tr>
-          <td><code>lf_cr_crlf</code></td>
-          <td>lf, cr or crlf</td>
-        </tr>
-        <tr>
-          <td><code>system</code></td>
-          <td>system default</td>
-        </tr>
-      </table>
+      <div class="wrapper">
+        <table summary="line separator options">
+          <tr>
+            <td>Option</td>
+            <td>Definition</td>
+          </tr>
+          <tr>
+            <td><code>crlf</code></td>
+            <td>Windows-style</td>
+          </tr>
+          <tr>
+            <td><code>cr</code></td>
+            <td>Mac-style</td>
+          </tr>
+          <tr>
+            <td><code>lf</code></td>
+            <td>Unix-style</td>
+          </tr>
+          <tr>
+            <td><code>lf_cr_crlf</code></td>
+            <td>lf, cr or crlf</td>
+          </tr>
+          <tr>
+            <td><code>system</code></td>
+            <td>system default</td>
+          </tr>
+        </table>
+      </div>
     </section>
 
     <section name="parenPad">
@@ -159,25 +161,27 @@
         following table describes the valid options:
       </p>
 
-      <table summary="padding options">
-        <tr>
-          <td>Option</td>
-          <td>Definition</td>
-        </tr>
-        <tr>
-          <td><code>nospace</code></td>
-          <td>
-            Do not pad. For example, <code>method(a, b);</code>
-          </td>
-        </tr>
-        <tr>
-          <td><code>space</code></td>
-          <td>
-            Ensure padding. For example,
-            <code>method( a, b );</code>
-          </td>
-        </tr>
-      </table>
+      <div class="wrapper">
+        <table summary="padding options">
+          <tr>
+            <td>Option</td>
+            <td>Definition</td>
+          </tr>
+          <tr>
+            <td><code>nospace</code></td>
+            <td>
+              Do not pad. For example, <code>method(a, b);</code>
+            </td>
+          </tr>
+          <tr>
+            <td><code>space</code></td>
+            <td>
+              Ensure padding. For example,
+              <code>method( a, b );</code>
+            </td>
+          </tr>
+        </table>
+      </div>
     </section>
 
     <section name="wrapOp">
@@ -186,32 +190,38 @@
         The following table describes the valid options:
       </p>
 
-      <table summary="wrap options">
-        <tr>
-          <td>Option</td>
-          <td>Definition</td>
-        </tr>
-        <tr>
-          <td><code>nl</code></td>
-          <td>
-            The token must be on a new line. For example:
-            <pre>
+      <div class="wrapper">
+        <table summary="wrap options">
+          <tr>
+            <td>Option</td>
+            <td>Definition</td>
+          </tr>
+          <tr>
+            <td><code>nl</code></td>
+            <td>
+              The token must be on a new line. For example:
+              <div class="wrapper">
+                <pre>
     someVariable = aBigVariableNameToMakeThings + "this may work"
                    + lookVeryInteresting;
-            </pre>
-          </td>
-        </tr>
-        <tr>
-          <td><code>eol</code></td>
-          <td>
-            The token must be at the end of the line. For example:
-            <pre>
+                </pre>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td><code>eol</code></td>
+            <td>
+              The token must be at the end of the line. For example:
+              <div class="wrapper">
+                <pre>
     someVariable = aBigVariableNameToMakeThings + "this may work" +
                    lookVeryInteresting;
-            </pre>
-          </td>
-        </tr>
-      </table>
+                </pre>
+              </div>
+            </td>
+          </tr>
+        </table>
+      </div>
     </section>
 
     <section name="block">
@@ -220,34 +230,40 @@
         following table describes the valid options:
       </p>
 
-      <table summary="block options">
-        <tr>
-          <td>Option</td>
-          <td>Definition</td>
-        </tr>
-        <tr>
-          <td><code>text</code></td>
-          <td>
-            Require that there is some text in the block. For example:
-            <pre>
+      <div class="wrapper">
+        <table summary="block options">
+          <tr>
+            <td>Option</td>
+            <td>Definition</td>
+          </tr>
+          <tr>
+            <td><code>text</code></td>
+            <td>
+              Require that there is some text in the block. For example:
+              <div class="wrapper">
+                <pre>
     catch (Exception ex) {
         // This is a bad coding practice
     }
-            </pre>
-          </td>
-        </tr>
-        <tr>
-          <td><code>statement</code></td>
-          <td>
-            Require that there is a statement in the block. For example:
-            <pre>
+                </pre>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td><code>statement</code></td>
+            <td>
+              Require that there is a statement in the block. For example:
+              <div class="wrapper">
+                <pre>
     finally {
         lock.release();
     }
-            </pre>
-          </td>
-        </tr>
-      </table>
+                </pre>
+              </div>
+            </td>
+          </tr>
+        </table>
+      </div>
     </section>
 
     <section name="lcurly">
@@ -257,57 +273,67 @@
         describes the valid options:
       </p>
 
-      <table summary="left curly options">
-        <tr>
-          <td>Option</td>
-          <td>Definition</td>
-        </tr>
+      <div class="wrapper">
+        <table summary="left curly options">
+          <tr>
+            <td>Option</td>
+            <td>Definition</td>
+          </tr>
 
-        <tr>
-          <td><code>eol</code></td>
-          <td>
-            The brace must always be on the end of the line. For example:
-            <pre>
+          <tr>
+            <td><code>eol</code></td>
+            <td>
+              The brace must always be on the end of the line. For example:#
+              <div class="wrapper">
+                <pre>
     if (condition) {
         ...
-            </pre>
-          </td>
-        </tr>
+                </pre>
+              </div>
+            </td>
+          </tr>
 
-        <tr>
-          <td><code>nl</code></td>
-          <td>
-            The brace must always be on a new line. For example:
-            <pre>
+          <tr>
+            <td><code>nl</code></td>
+            <td>
+              The brace must always be on a new line. For example:
+              <div class="wrapper">
+                <pre>
     if (condition)
     {
         ...
-            </pre>
-          </td>
-        </tr>
+                </pre>
+              </div>
+            </td>
+          </tr>
 
-        <tr>
-          <td><code>nlow</code></td>
-          <td>
-            If the statement/expression/declaration connected to the brace spans multiple lines,
-            then apply <code>nl</code> rule. Otherwise apply the <code>eol</code> rule.
-            <code>nlow</code> is a mnemonic for "new line on wrap".
-            For the example above Checkstyle will enforce:
-            <pre>
+          <tr>
+            <td><code>nlow</code></td>
+            <td>
+              If the statement/expression/declaration connected to the brace spans multiple lines,
+              then apply <code>nl</code> rule. Otherwise apply the <code>eol</code> rule.
+              <code>nlow</code> is a mnemonic for "new line on wrap".
+              For the example above Checkstyle will enforce:
+              <div class="wrapper">
+                <pre>
     if (condition) {
         ...
-            </pre>
-            But for a statement spanning multiple lines, Checkstyle will
-            enforce:
-            <pre>
+                </pre>
+             </div>
+              But for a statement spanning multiple lines, Checkstyle will
+              enforce:
+              <div class="wrapper">
+                <pre>
     if (condition1 &amp;&amp; condition2 &amp;&amp;
         condition3 &amp;&amp; condition4)
     {
         ...
-            </pre>
-          </td>
-        </tr>
-      </table>
+                </pre>
+              </div>
+            </td>
+          </tr>
+        </table>
+      </div>
     </section>
 
     <section name="rcurly">
@@ -319,34 +345,38 @@
         table describes the valid options:
       </p>
 
-      <table summary="right curly options">
-        <tr>
-          <td>Option</td>
-          <td>Definition</td>
-        </tr>
+      <div class="wrapper">
+        <table summary="right curly options">
+          <tr>
+            <td>Option</td>
+            <td>Definition</td>
+          </tr>
 
-        <tr>
-          <td><code>alone</code></td>
-          <td>
-            The brace must be alone on the line. For example:
-            <pre>
+          <tr>
+            <td><code>alone</code></td>
+            <td>
+              The brace must be alone on the line. For example:
+              <div class="wrapper">
+                <pre>
     try {
         ...
     <b>}</b>
     finally {
         ...
     <b>}</b>
-            </pre>
-          </td>
-        </tr>
+                </pre>
+              </div>
+            </td>
+          </tr>
 
-        <tr>
-          <td><code>alone_or_singleline</code></td>
-          <td>
-                  The brace must be alone on the line, yet
-                  single-line format of block is allowed.
-                  For example:
-            <pre>
+          <tr>
+            <td><code>alone_or_singleline</code></td>
+            <td>
+                    The brace must be alone on the line, yet
+                    single-line format of block is allowed.
+                    For example:
+              <div class="wrapper">
+                <pre>
     // Brace is alone on the line
     try {
         ...
@@ -357,22 +387,24 @@
 
     // Single-line format of block
     public long getId() { return id; <b>}</b>
-            </pre>
-          </td>
-        </tr>
+                </pre>
+              </div>
+            </td>
+          </tr>
 
-        <tr>
-          <td><code>same</code></td>
-          <td>
-            Works like <code>alone_or_singleline</code> but the brace should be on the same line
-            as the next part of a multi-block statement
-            (one that directly contains multiple blocks: if/else-if/else or try/catch/finally).
-            If no next part of a multi-block statement present, brace must be alone on line.
-            It also allows single-line format of multi-block statements.
+          <tr>
+            <td><code>same</code></td>
+            <td>
+              Works like <code>alone_or_singleline</code> but the brace should be on the same line
+              as the next part of a multi-block statement
+              (one that directly contains multiple blocks: if/else-if/else or try/catch/finally).
+              If no next part of a multi-block statement present, brace must be alone on line.
+              It also allows single-line format of multi-block statements.
 
-            <p>Examples:</p>
+              <p>Examples:</p>
 
-              <pre>
+              <div class="wrapper">
+                <pre>
     public long getId() {return id;<b>}</b> // this is OK, it is single line
 
     // try-catch-finally blocks
@@ -424,11 +456,13 @@
     if (a &#62; 0) {
         ...
     } else { ... <b>}</b> // OK, single-line multi-block statement
-              </pre>
-          </td>
-        </tr>
+                </pre>
+              </div>
+            </td>
+          </tr>
 
-      </table>
+        </table>
+      </div>
     </section>
 
     <section name="scope">
@@ -485,79 +519,91 @@
         The following table describes the valid options:
       </p>
 
-      <table summary="import order options">
-        <tr>
-          <td>Option</td>
-          <td>Definition</td>
-        </tr>
+      <div class="wrapper">
+        <table summary="import order options">
+          <tr>
+            <td>Option</td>
+            <td>Definition</td>
+          </tr>
 
-        <tr>
-          <td><code>top</code></td>
-          <td>All static imports are at the top.
-              Groups for static import are defined by the property 'staticGroups'.
-              The blank line between groups is driven by the property 'separatedStaticGroups'.
-              For example:
-              <pre>
+          <tr>
+            <td><code>top</code></td>
+            <td>All static imports are at the top.
+                Groups for static import are defined by the property 'staticGroups'.
+                The blank line between groups is driven by the property 'separatedStaticGroups'.
+                For example:
+              <div class="wrapper">
+                <pre>
     import static a.b.C.*;
     import static x.y.Z.*;
 
     import a.b.D;
     import x.y.Z;</pre>
-          </td>
-        </tr>
+              </div>
+            </td>
+          </tr>
 
-        <tr>
-          <td><code>above</code></td>
-          <td>All static imports are above the local group. For example:
-            <pre>
+          <tr>
+            <td><code>above</code></td>
+            <td>All static imports are above the local group. For example:
+              <div class="wrapper">
+                <pre>
     import static a.b.C.*;
     import a.b.D;
 
     import static x.y.Z.*;
     import x.y.Z;</pre>
-          </td>
-        </tr>
+              </div>
+            </td>
+          </tr>
 
-        <tr>
-          <td><code>inflow</code></td>
-          <td>All static imports are processed like non static
-              imports. For example:
-              <pre>
+          <tr>
+            <td><code>inflow</code></td>
+            <td>All static imports are processed like non static
+                imports. For example:
+              <div class="wrapper">
+                <pre>
     import static a.b.C.*;
     import a.b.D;
 
     import x.y.Z;
     import static x.y.Z.*;</pre>
-          </td>
-        </tr>
+              </div>
+            </td>
+          </tr>
 
-        <tr>
-          <td><code>under</code></td>
-          <td>All static imports are under the local group. For example:
-              <pre>
+          <tr>
+            <td><code>under</code></td>
+            <td>All static imports are under the local group. For example:
+              <div class="wrapper">
+                <pre>
     import a.b.D;
     import static a.b.C.*;
 
     import x.y.Z;
     import static x.y.Z.*;</pre>
-          </td>
-        </tr>
+              </div>
+            </td>
+          </tr>
 
-        <tr>
-          <td><code>bottom</code></td>
-          <td>All static imports are at the bottom.
-              Groups for static import are defined by the property 'staticGroups'.
-              The blank line between groups is driven by the property 'separatedStaticGroups'.
-              For example:
-              <pre>
+          <tr>
+            <td><code>bottom</code></td>
+            <td>All static imports are at the bottom.
+                Groups for static import are defined by the property 'staticGroups'.
+                The blank line between groups is driven by the property 'separatedStaticGroups'.
+                For example:
+              <div class="wrapper">
+                <pre>
     import a.b.D;
     import x.y.Z;
 
     import static a.b.C.*;
     import static x.y.Z.*;</pre>
-          </td>
-        </tr>
-      </table>
+              </div>
+            </td>
+          </tr>
+        </table>
+      </div>
     </section>
 
     <section name="elementStyle">
@@ -567,69 +613,83 @@
         describes the valid options:
       </p>
 
-      <table summary="elementStyle options">
-        <tr>
-          <td>Option</td>
-          <td>Definition</td>
-        </tr>
+      <div class="wrapper">
+        <table summary="elementStyle options">
+          <tr>
+            <td>Option</td>
+            <td>Definition</td>
+          </tr>
 
-        <tr>
-          <td><code>expanded</code></td>
-          <td>
-            The expanded version is sometimes referred to as "named parameters"
-            in other languages.
-            Example:
-            <pre>@SuppressWarnings(value={"unchecked","unused",})</pre>
-            Example of violation:
-            <pre>@SuppressWarnings({"unchecked","unused",})</pre>
-          </td>
-        </tr>
+          <tr>
+            <td><code>expanded</code></td>
+            <td>
+              The expanded version is sometimes referred to as "named parameters"
+              in other languages.
+              Example:
+              <div class="wrapper">
+                <pre>@SuppressWarnings(value={"unchecked","unused",})</pre>
+              </div>
+              Example of violation:
+              <div class="wrapper">
+                <pre>@SuppressWarnings({"unchecked","unused",})</pre>
+              </div>
+            </td>
+          </tr>
 
-        <tr>
-          <td><code>compact</code></td>
-          <td>
-            This style can only be used when there is an element called 'value'
-            which is either the sole element or all other elements have default
-            values.
-            Example:
-            <pre>
+          <tr>
+            <td><code>compact</code></td>
+            <td>
+              This style can only be used when there is an element called 'value'
+              which is either the sole element or all other elements have default
+              values.
+              Example:
+              <div class="wrapper">
+                <pre>
                 @SuppressWarnings({"unchecked","unused",})
                 @SuppressWarnings("unchecked")
-            </pre>
-            Example of violation:
-            <pre>
+                </pre>
+              </div>
+              Example of violation:
+              <div class="wrapper">
+                <pre>
                 @SuppressWarnings(value = {"unchecked","unused",})
                 @SuppressWarnings(value = "unchecked")
-            </pre>
-          </td>
-        </tr>
+                </pre>
+              </div>
+            </td>
+          </tr>
 
-        <tr>
-          <td><code>compact_no_array</code></td>
-          <td>
-            It is similar to the <code>compact</code> style but
-            single value arrays are flagged. With annotations a single value
-            array does not need to be placed in an array initializer.
-            Example:
-            <pre>
+          <tr>
+            <td><code>compact_no_array</code></td>
+            <td>
+              It is similar to the <code>compact</code> style but
+              single value arrays are flagged. With annotations a single value
+              array does not need to be placed in an array initializer.
+              Example:
+              <div class="wrapper">
+                <pre>
               @SuppressWarnings("unchecked")
               @MyAnnotation(someArray = "some value")
-            </pre>
-            Example of violation:
-            <pre>
+                </pre>
+              </div>
+              Example of violation:
+              <div class="wrapper">
+                <pre>
               @SuppressWarnings({"unchecked"})
               @MyAnnotation(someArray = {"some value"})
-            </pre>
-          </td>
-        </tr>
+                </pre>
+              </div>
+            </td>
+          </tr>
 
-        <tr>
-          <td><code>ignore</code></td>
-          <td>
-            Anything goes.
-          </td>
-        </tr>
-      </table>
+          <tr>
+            <td><code>ignore</code></td>
+            <td>
+              Anything goes.
+            </td>
+          </tr>
+        </table>
+      </div>
     </section>
 
     <section name="closingParens">
@@ -638,35 +698,37 @@
         parenthesis. The following table describes the valid options:
       </p>
 
-      <table summary="closingParens options">
-        <tr>
-          <td>Option</td>
-          <td>Definition</td>
-        </tr>
+      <div class="wrapper">
+        <table summary="closingParens options">
+          <tr>
+            <td>Option</td>
+            <td>Definition</td>
+          </tr>
 
-        <tr>
-          <td><code>always</code></td>
-          <td>
-            Example:
-            <pre>@Deprecated()</pre>
-          </td>
-        </tr>
+          <tr>
+            <td><code>always</code></td>
+            <td>
+              Example:
+              <pre>@Deprecated()</pre>
+            </td>
+          </tr>
 
-        <tr>
-          <td><code>never</code></td>
-          <td>
-            Example:
-            <pre>@Deprecated</pre>
-          </td>
-        </tr>
+          <tr>
+            <td><code>never</code></td>
+            <td>
+              Example:
+              <pre>@Deprecated</pre>
+            </td>
+          </tr>
 
-        <tr>
-          <td><code>ignore</code></td>
-          <td>
-            Anything goes.
-          </td>
-        </tr>
-      </table>
+          <tr>
+            <td><code>ignore</code></td>
+            <td>
+              Anything goes.
+            </td>
+          </tr>
+        </table>
+      </div>
     </section>
 
     <section name="trailingArrayComma">
@@ -675,35 +737,37 @@
         array comma. The following table describes the valid options:
       </p>
 
-      <table summary="trailingArrayComma options">
-        <tr>
-          <td>Option</td>
-          <td>Definition</td>
-        </tr>
+        <div class="wrapper">
+        <table summary="trailingArrayComma options">
+          <tr>
+            <td>Option</td>
+            <td>Definition</td>
+          </tr>
 
-        <tr>
-          <td><code>always</code></td>
-          <td>
-            Example:
-            <pre>@SuppressWarnings(value={"unchecked","unused",})</pre>
-          </td>
-        </tr>
+          <tr>
+            <td><code>always</code></td>
+            <td>
+              Example:
+              <pre>@SuppressWarnings(value={"unchecked","unused",})</pre>
+            </td>
+          </tr>
 
-        <tr>
-          <td><code>never</code></td>
-          <td>
-            Example:
-            <pre>@SuppressWarnings(value={"unchecked","unused"})</pre>
-          </td>
-        </tr>
+          <tr>
+            <td><code>never</code></td>
+            <td>
+              Example:
+              <pre>@SuppressWarnings(value={"unchecked","unused"})</pre>
+            </td>
+          </tr>
 
-        <tr>
-          <td><code>ignore</code></td>
-          <td>
-            Anything goes.
-          </td>
-        </tr>
-      </table>
+          <tr>
+            <td><code>ignore</code></td>
+            <td>
+              Anything goes.
+            </td>
+          </tr>
+        </table>
+      </div>
     </section>
 
     <section name="javadocContentLocation">
@@ -712,46 +776,52 @@
         The following table describes the valid options:
       </p>
 
-      <table summary="javadocContentLocation options">
-        <tr>
-          <td>Option</td>
-          <td>Definition</td>
-        </tr>
+      <div class="wrapper">
+        <table summary="javadocContentLocation options">
+          <tr>
+            <td>Option</td>
+            <td>Definition</td>
+          </tr>
 
-        <tr>
-          <td><code>FIRST_LINE</code></td>
-          <td>
-            Represents the policy for Javadoc content starts from the same line
-            as <code>/**</code>.
-            Example:
-            <pre>
+          <tr>
+            <td><code>FIRST_LINE</code></td>
+            <td>
+              Represents the policy for Javadoc content starts from the same line
+              as <code>/**</code>.
+              Example:
+              <div class="wrapper">
+                <pre>
             &#47;** Summary text.
               * More details.
               *&#47;
             public void method();
-            </pre>
-            This style is also known as "scala" style.
-          </td>
-        </tr>
+                </pre>
+              </div>
+              This style is also known as "scala" style.
+            </td>
+          </tr>
 
-        <tr>
-          <td><code>SECOND_LINE</code></td>
-          <td>
-            Represents the policy for Javadoc content starts from the next line
-            after <code>/**</code>.
-            Example:
-            <pre>
+          <tr>
+            <td><code>SECOND_LINE</code></td>
+            <td>
+              Represents the policy for Javadoc content starts from the next line
+              after <code>/**</code>.
+              Example:
+              <div class="wrapper">
+                <pre>
               &#47;**
               * Summary text.
               * More details.
               *&#47;
               public void method();
-            </pre>
-            This style is common to java projects.
-          </td>
-        </tr>
+                </pre>
+              </div>
+              This style is common to java projects.
+            </td>
+          </tr>
 
-      </table>
+        </table>
+      </div>
     </section>
   </body>
 </document>

--- a/src/xdocs/sponsoring.xml
+++ b/src/xdocs/sponsoring.xml
@@ -24,40 +24,54 @@
       </p>
 
       <p>
-        <a href="https://www.bountysource.com/teams/checkstyle/issues">
-          <img src="https://api.bountysource.com/badge/team?team_id=3568&amp;style=bounties_posted"
-               alt="bountysource" title="bountysource" border="0"/>
-        </a>
+        <span class="wrapper">
+          <a href="https://www.bountysource.com/teams/checkstyle/issues">
+            <img src="https://api.bountysource.com/badge/team?team_id=3568&amp;style=bounties_posted"
+                 alt="bountysource" title="bountysource" border="0"/>
+          </a>
+        </span>
         <br/>
-        <a href="https://salt.bountysource.com/teams/checkstyle">
-          <img src="https://img.shields.io/bountysource/team/checkstyle/activity.svg?label=salt.bountysource"
-               alt="salt.bountysource" title="salt.bountysource" border="0"/>
-        </a>
+        <span class="wrapper">
+          <a href="https://salt.bountysource.com/teams/checkstyle">
+            <img src="https://img.shields.io/bountysource/team/checkstyle/activity.svg?label=salt.bountysource"
+                 alt="salt.bountysource" title="salt.bountysource" border="0"/>
+          </a>
+        </span>
         <br/>
-        <a href="https://flattr.com/submit/auto?fid=g39d10&amp;url=https%3A%2F%2Fcheckstyle.org"
-           target="_blank">
-          <img src="https://button.flattr.com/flattr-badge-large.png"
-               alt="Flattr this" title="Flattr this" border="0"/>
-        </a>
+        <span class="wrapper">
+          <a href="https://flattr.com/submit/auto?fid=g39d10&amp;url=https%3A%2F%2Fcheckstyle.org"
+             target="_blank">
+            <img src="https://button.flattr.com/flattr-badge-large.png"
+                 alt="Flattr this" title="Flattr this" border="0"/>
+          </a>
+        </span>
         <br/>
-        <a href="https://liberapay.com/checkstyle/">
-          <img src="https://liberapay.com/assets/widgets/donate.svg"
-               alt="liberapay" title="liberapay" border="0"/>
-        </a>
+        <span class="wrapper">
+          <a href="https://liberapay.com/checkstyle/">
+            <img src="https://liberapay.com/assets/widgets/donate.svg"
+                 alt="liberapay" title="liberapay" border="0"/>
+          </a>
+        </span>
         <br/>
-        <a href="https://opencollective.com/checkstyle/">
-          <img src="https://opencollective.com/checkstyle/backers/badge.svg"
-               alt="backers.opencollective" title="backers.opencollective" border="0"/>
-        </a>
+        <span class="wrapper">
+          <a href="https://opencollective.com/checkstyle/">
+            <img src="https://opencollective.com/checkstyle/backers/badge.svg"
+                 alt="backers.opencollective" title="backers.opencollective" border="0"/>
+          </a>
+        </span>
         <br/>
-        <a href="https://opencollective.com/checkstyle/">
-          <img src="https://opencollective.com/checkstyle/sponsors/badge.svg"
-               alt="sponsors.opencollective" title="backers.opencollective" border="0"/>
-        </a>
+        <span class="wrapper">
+          <a href="https://opencollective.com/checkstyle/">
+            <img src="https://opencollective.com/checkstyle/sponsors/badge.svg"
+                 alt="sponsors.opencollective" title="backers.opencollective" border="0"/>
+          </a>
+        </span>
         <br/>
-        <object type="image/svg+xml"
-        data="https://opencollective.com/checkstyle/tiers/backer.svg?avatarHeight=76&amp;width=600">
-        </object>
+        <span class="wrapper">
+          <object type="image/svg+xml"
+          data="https://opencollective.com/checkstyle/tiers/backer.svg?avatarHeight=76&amp;width=600">
+          </object>
+        </span>
         <br/>
         <a href="https://freedomsponsors.org/search/?project_name=checkstyle">
           freedomsponsors - checkstyle</a>

--- a/src/xdocs/sun_style.xml
+++ b/src/xdocs/sun_style.xml
@@ -5,882 +5,998 @@
           xsi:schemaLocation="http://maven.apache.org/XDOC/2.0
                               http://maven.apache.org/xsd/xdoc-2.0.xsd">
 
-    <head>
-        <title>Sun's Java Style</title>
-        <script type="text/javascript"
-                src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"/>
-        <script type="text/javascript" src="js/anchors.js"/>
-        <script type="text/javascript" src="js/google-analytics.js"/>
-        <link rel="icon" href="images/favicon.png" type="image/x-icon" />
-        <link rel="shortcut icon" href="images/favicon.ico" type="image/ico" />
-    </head>
+  <head>
+    <title>Sun's Java Style</title>
+    <script type="text/javascript"
+            src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"/>
+    <script type="text/javascript" src="js/anchors.js"/>
+    <script type="text/javascript" src="js/google-analytics.js"/>
+    <link rel="icon" href="images/favicon.png" type="image/x-icon" />
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/ico" />
+  </head>
 
-    <body>
-        <section name="Sun's Java Style Checkstyle Coverage">
-            <subsection name="Useful information" id="Sun_Useful_information">
-                <p>
-                    This coverage report was created for
-                    <a href="https://www.oracle.com/technetwork/java/codeconvtoc-136057.html">
-                        Code Conventions for the Java™ Programming Language</a>(<a
-                        href="styleguides/sun-code-conventions-19990420/CodeConvTOC.doc.html"
-                    >cached page</a>),
-                    version of 20 April 1999, current as of 30 March 2019
-                </p>
+  <body>
+    <section name="Sun's Java Style Checkstyle Coverage">
+      <subsection name="Useful information" id="Sun_Useful_information">
+        <p>
+          This coverage report was created for
+          <a href="https://www.oracle.com/technetwork/java/codeconvtoc-136057.html">
+            Code Conventions for the Java™ Programming Language</a>(<a
+            href="styleguides/sun-code-conventions-19990420/CodeConvTOC.doc.html"
+        >cached page</a>),
+          version of 20 April 1999, current as of 30 March 2019
+        </p>
 
-                <p>
-                    <a href="https://checkstyle.sourceforge.io/reports/javadoc/openjdk8/">
-                        Checkstyle's html report for Open JDK library (javadoc validation)</a>
-                </p>
-                <p>
-                    <a href="https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/sun_checks.xml">
-                    incomplete Checkstyle configuration for 'Sun's Java Style'</a>
-                </p>
-            </subsection>
-            <subsection name="Legend" id="Sun_Legend">
-                <p>
-                    "???" - Report is incomplete in this line.
-                    <br />
-                    "--" - There is no rule in this paragraph.
-                    <br />
-                    "↓" - This paragraph is the high-level point of some group.
-                    <br />
-                    <img
-                        src="images/ok_green.png"
-                        alt="" />
-                    - Existing Check covers all requirements from Sun.
-                    <br />
-                    <img
-                        src="images/ok_blue.png"
-                        alt="" />
-                    - Existing Check covers some part of requirements from Sun.
-                    <br />
-                    <img
-                        src="images/ban_red.png"
-                        alt="" />
-                    - Requirements are not possible to check by Checkstyle at all.
-                    <br />
-                </p>
-            </subsection>
-            <subsection name="Coverage table" id="Sun_Coverage_table">
-                <table>
-                    <thead>
-                        <tr>
-                            <th/>
-                            <th>Sun's Java Style Rule</th>
-                            <th>Checkstyle Check</th>
-                            <th>Applied to config</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>
-                                <a name="1"/>
-                                <a href="#1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc.html#a18407">
-                                    <strong>1 - Introduction</strong>
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="1.1"/>
-                                <a href="#1.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc.html#a16712">
-                                    1.1 Why Have Code Conventions
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="1.2"/>
-                                <a href="#1.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc.html#a16729">
-                                    1.2 Acknowledgments
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="2"/>
-                                <a href="#2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc1.html#a16732">
-                                    <strong>2 - File Names</strong>
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="2.1"/>
-                                <a href="#2.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc1.html#a647">
-                                    2.1 File Suffixes
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="2.2"/>
-                                <a href="#2.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc1.html#a253">
-                                    2.2 Common File Names
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="3"/>
-                                <a href="#3">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc2.html#a3043">
-                                    <strong>3 - File Organization</strong>
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="3.1"/>
-                                <a href="#3.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc2.html#a11684">
-                                    3.1 Java Source Files
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="3.1.1"/>
-                                <a href="#3.1.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc2.html#a3441">
-                                    3.1.1 Beginning Comments
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="3.1.2"/>
-                                <a href="#3.1.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc2.html#a277">
-                                    3.1.2 Package and Import Statements
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="3.1.3"/>
-                                <a href="#3.1.3">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc2.html#a1852">
-                                    3.1.3 Class and Interface Declarations
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="4"/>
-                                <a href="#4">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc3.html#a262">
-                                    <strong>4 - Indentation</strong>
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="4.1"/>
-                                <a href="#4.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc3.html#a313">
-                                    4.1 Line Length
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="4.2"/>
-                                <a href="#4.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc3.html#a248">
-                                    4.2 Wrapping Lines
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="5"/>
-                                <a href="#5">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc4.html#a385">
-                                    <strong>5 - Comments</strong>
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="5.1"/>
-                                <a href="#5.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc4.html#a216">
-                                    5.1 Implementation Comment Formats
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="5.1.1"/>
-                                <a href="#5.1.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc4.html#a680">
-                                    5.1.1 Block Comments
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="5.1.2"/>
-                                <a href="#5.1.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc4.html#a341">
-                                    5.1.2 Single-Line Comments
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="5.1.3"/>
-                                <a href="#5.1.3">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc4.html#a342">
-                                    5.1.3 Trailing Comments
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="5.1.4"/>
-                                <a href="#5.1.4">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc4.html#a286">
-                                    5.1.4 End-Of-Line Comments
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="5.2"/>
-                                <a href="#5.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc4.html#a16838">
-                                    5.2 Documentation Comments
-                                </a>
-                            </td>
-                            <td>
-                                <img src="images/ok_blue.png" alt=""/>
-                                <a href="config_javadoc.html#InvalidJavadocPosition">
-                                    InvalidJavadocPosition
-                                </a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Asun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+InvalidJavadocPosition">
-                                    config
-                                </a>
-                                <br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/sun/checkstyle/test/chapter5comments/rule52documentationcomments/InvalidJavadocPositionTest.java">
-                                    test
-                                </a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="6"/>
-                                <a href="#6">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc5.html#a2991">
-                                    <strong>6 - Declarations</strong>
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="6.1"/>
-                                <a href="#6.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc5.html#a2992">
-                                    6.1 Number Per Line
-                                </a>
-                            </td>
-                            <td>
-                                <img src="images/ok_green.png" alt=""/>
-                                <a href="config_coding.html#MultipleVariableDeclarations">
-                                    MultipleVariableDeclarations
-                                </a>
-                            </td>
-                            <td>
-                                <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Asun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultipleVariableDeclarations">
-                                    config
-                                </a>
-                                <br/>
-                                <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/sun/checkstyle/test/chapter6declarations/rule61numberperline/MultipleVariableDeclarationsTest.java">
-                                    test
-                                </a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="6.2"/>
-                                <a href="#6.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc5.html#a18761">
-                                    6.2 Initialization
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="6.3"/>
-                                <a href="#6.3">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc5.html#a16817">
-                                    6.3 Placement
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="6.4"/>
-                                <a href="#6.4">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc5.html#a381">
-                                    6.4 Class and Interface Declarations
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="7"/>
-                                <a href="#7">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc6.html#a430">
-                                    <strong>7 - Statements</strong>
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="7.1"/>
-                                <a href="#7.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc6.html#a431">
-                                    7.1 Simple Statements
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="7.2"/>
-                                <a href="#7.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc6.html#a15395">
-                                    7.2 Compound Statements
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="7.3"/>
-                                <a href="#7.3">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc6.html#a438">
-                                    7.3 return Statements
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="7.4"/>
-                                <a href="#7.4">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc6.html#a449">
-                                    7.4 if, if-else, if else-if else Statements
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="7.5"/>
-                                <a href="#7.5">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc6.html#a454">
-                                    7.5 for Statements
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="7.6"/>
-                                <a href="#7.6">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc6.html#a460">
-                                    7.6 while Statements
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="7.7"/>
-                                <a href="#7.7">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc6.html#a465">
-                                    7.7 do-while Statements
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="7.8"/>
-                                <a href="#7.8">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc6.html#a468">
-                                    7.8 switch Statements
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="7.9"/>
-                                <a href="#7.9">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc6.html#a472">
-                                    7.9 try-catch Statements
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="8"/>
-                                <a href="#8">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc7.html#a475">
-                                    <strong>8 - White Space</strong>
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="8.1"/>
-                                <a href="#8.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc7.html#a487">
-                                    8.1 Blank Lines
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="8.2"/>
-                                <a href="#8.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc7.html#a682">
-                                    8.2 Blank Spaces
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="9"/>
-                                <a href="#9">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc8.html#a367">
-                                    <strong>9 - Naming Conventions</strong>
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="10"/>
-                                <a href="#10">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc9.html#a529">
-                                    <strong>10 - Programming Practices</strong>
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="10.1"/>
-                                <a href="#10.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc9.html#a177">
-                                    10.1 Providing Access to Instance and Class Variables
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="10.2"/>
-                                <a href="#10.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc9.html#a587">
-                                    10.2 Referring to Class Variables and Methods
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="10.3"/>
-                                <a href="#10.3">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc9.html#a1255">
-                                    10.3 Constants
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="10.4"/>
-                                <a href="#10.4">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc9.html#a547">
-                                    10.4 Variable Assignments
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="10.5"/>
-                                <a href="#10.5">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc9.html#a554">
-                                    10.5 Miscellaneous Practices
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="10.5.1"/>
-                                <a href="#10.5.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc9.html#a331">
-                                    10.5.1 Parentheses
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="10.5.2"/>
-                                <a href="#10.5.2">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc9.html#a333">
-                                    10.5.2 Returning Values
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="10.5.3"/>
-                                <a href="#10.5.3">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc9.html#a353">
-                                    10.5.3 Expressions before `?' in the Conditional Operator
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="10.5.4"/>
-                                <a href="#10.5.4">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc9.html#a395">
-                                    10.5.4 Special Comments
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="11"/>
-                                <a href="#11">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc10.html#a186">
-                                    <strong>11 - Code Examples</strong>
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                        <tr>
-                            <td>
-                                <a name="11.1"/>
-                                <a href="#11.1">
-                                    <img src="images/anchor.png" alt=""/>
-                                </a>
-                            </td>
-                            <td>
-                                <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc10.html#a182">
-                                    11.1 Java Source File Example
-                                </a>
-                            </td>
-                            <td>???</td>
-                            <td/>
-                        </tr>
-                    </tbody>
-                </table>
-            </subsection>
-        </section>
-    </body>
+        <p>
+          <a href="https://checkstyle.sourceforge.io/reports/javadoc/openjdk8/">
+            Checkstyle's html report for Open JDK library (javadoc validation)</a>
+        </p>
+        <p>
+          <a href="https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/sun_checks.xml">
+            incomplete Checkstyle configuration for 'Sun's Java Style'</a>
+        </p>
+      </subsection>
+      <subsection name="Legend" id="Sun_Legend">
+        <p>
+          "???" - Report is incomplete in this line.
+          <br />
+          "--" - There is no rule in this paragraph.
+          <br />
+          "↓" - This paragraph is the high-level point of some group.
+          <br />
+          <span class="wrapper">
+            <img
+                src="images/ok_green.png"
+                alt="" />
+          </span>
+          - Existing Check covers all requirements from Sun.
+          <br />
+          <span class="wrapper">
+            <img
+                src="images/ok_blue.png"
+                alt="" />
+          </span>
+          - Existing Check covers some part of requirements from Sun.
+          <br />
+          <span class="wrapper">
+            <img
+                src="images/ban_red.png"
+                alt="" />
+          </span>
+          - Requirements are not possible to check by Checkstyle at all.
+          <br />
+        </p>
+      </subsection>
+      <subsection name="Coverage table" id="Sun_Coverage_table">
+        <div class="wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th/>
+                <th>Sun's Java Style Rule</th>
+                <th>Checkstyle Check</th>
+                <th>Applied to config</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <a name="1"/>
+                  <a href="#1">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc.html#a18407">
+                    <strong>1 - Introduction</strong>
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="1.1"/>
+                  <a href="#1.1">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc.html#a16712">
+                    1.1 Why Have Code Conventions
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="1.2"/>
+                  <a href="#1.2">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc.html#a16729">
+                    1.2 Acknowledgments
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="2"/>
+                  <a href="#2">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc1.html#a16732">
+                    <strong>2 - File Names</strong>
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="2.1"/>
+                  <a href="#2.1">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc1.html#a647">
+                    2.1 File Suffixes
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="2.2"/>
+                  <a href="#2.2">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc1.html#a253">
+                    2.2 Common File Names
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="3"/>
+                  <a href="#3">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc2.html#a3043">
+                    <strong>3 - File Organization</strong>
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="3.1"/>
+                  <a href="#3.1">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc2.html#a11684">
+                    3.1 Java Source Files
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="3.1.1"/>
+                  <a href="#3.1.1">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc2.html#a3441">
+                    3.1.1 Beginning Comments
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="3.1.2"/>
+                  <a href="#3.1.2">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc2.html#a277">
+                    3.1.2 Package and Import Statements
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="3.1.3"/>
+                  <a href="#3.1.3">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc2.html#a1852">
+                    3.1.3 Class and Interface Declarations
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="4"/>
+                  <a href="#4">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc3.html#a262">
+                    <strong>4 - Indentation</strong>
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="4.1"/>
+                  <a href="#4.1">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc3.html#a313">
+                    4.1 Line Length
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="4.2"/>
+                  <a href="#4.2">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc3.html#a248">
+                    4.2 Wrapping Lines
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="5"/>
+                  <a href="#5">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc4.html#a385">
+                    <strong>5 - Comments</strong>
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="5.1"/>
+                  <a href="#5.1">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc4.html#a216">
+                    5.1 Implementation Comment Formats
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="5.1.1"/>
+                  <a href="#5.1.1">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc4.html#a680">
+                    5.1.1 Block Comments
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="5.1.2"/>
+                  <a href="#5.1.2">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc4.html#a341">
+                    5.1.2 Single-Line Comments
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="5.1.3"/>
+                  <a href="#5.1.3">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc4.html#a342">
+                    5.1.3 Trailing Comments
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="5.1.4"/>
+                  <a href="#5.1.4">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc4.html#a286">
+                    5.1.4 End-Of-Line Comments
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="5.2"/>
+                  <a href="#5.2">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc4.html#a16838">
+                    5.2 Documentation Comments
+                  </a>
+                </td>
+                <td>
+                  <span class="wrapper">
+                    <img src="images/ok_blue.png" alt=""/>
+                  </span>
+                  <a href="config_javadoc.html#InvalidJavadocPosition">
+                    InvalidJavadocPosition
+                  </a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Asun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+InvalidJavadocPosition">
+                    config
+                  </a>
+                  <br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/sun/checkstyle/test/chapter5comments/rule52documentationcomments/InvalidJavadocPositionTest.java">
+                    test
+                  </a>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <a name="6"/>
+                  <a href="#6">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc5.html#a2991">
+                    <strong>6 - Declarations</strong>
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="6.1"/>
+                  <a href="#6.1">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc5.html#a2992">
+                    6.1 Number Per Line
+                  </a>
+                </td>
+                <td>
+                  <span class="wrapper">
+                    <img src="images/ok_green.png" alt=""/>
+                  </span>
+                  <a href="config_coding.html#MultipleVariableDeclarations">
+                    MultipleVariableDeclarations
+                  </a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Asun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultipleVariableDeclarations">
+                    config
+                  </a>
+                  <br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/sun/checkstyle/test/chapter6declarations/rule61numberperline/MultipleVariableDeclarationsTest.java">
+                    test
+                  </a>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <a name="6.2"/>
+                  <a href="#6.2">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc5.html#a18761">
+                    6.2 Initialization
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="6.3"/>
+                  <a href="#6.3">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc5.html#a16817">
+                    6.3 Placement
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="6.4"/>
+                  <a href="#6.4">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc5.html#a381">
+                    6.4 Class and Interface Declarations
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="7"/>
+                  <a href="#7">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc6.html#a430">
+                    <strong>7 - Statements</strong>
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="7.1"/>
+                  <a href="#7.1">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc6.html#a431">
+                    7.1 Simple Statements
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="7.2"/>
+                  <a href="#7.2">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc6.html#a15395">
+                    7.2 Compound Statements
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="7.3"/>
+                  <a href="#7.3">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc6.html#a438">
+                    7.3 return Statements
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="7.4"/>
+                  <a href="#7.4">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc6.html#a449">
+                    7.4 if, if-else, if else-if else Statements
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="7.5"/>
+                  <a href="#7.5">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc6.html#a454">
+                    7.5 for Statements
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="7.6"/>
+                  <a href="#7.6">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc6.html#a460">
+                    7.6 while Statements
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="7.7"/>
+                  <a href="#7.7">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc6.html#a465">
+                    7.7 do-while Statements
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="7.8"/>
+                  <a href="#7.8">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc6.html#a468">
+                    7.8 switch Statements
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="7.9"/>
+                  <a href="#7.9">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc6.html#a472">
+                    7.9 try-catch Statements
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="8"/>
+                  <a href="#8">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc7.html#a475">
+                    <strong>8 - White Space</strong>
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="8.1"/>
+                  <a href="#8.1">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc7.html#a487">
+                    8.1 Blank Lines
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="8.2"/>
+                  <a href="#8.2">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc7.html#a682">
+                    8.2 Blank Spaces
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="9"/>
+                  <a href="#9">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc8.html#a367">
+                    <strong>9 - Naming Conventions</strong>
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="10"/>
+                  <a href="#10">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc9.html#a529">
+                    <strong>10 - Programming Practices</strong>
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="10.1"/>
+                  <a href="#10.1">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc9.html#a177">
+                    10.1 Providing Access to Instance and Class Variables
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="10.2"/>
+                  <a href="#10.2">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc9.html#a587">
+                    10.2 Referring to Class Variables and Methods
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="10.3"/>
+                  <a href="#10.3">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc9.html#a1255">
+                    10.3 Constants
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="10.4"/>
+                  <a href="#10.4">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc9.html#a547">
+                    10.4 Variable Assignments
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="10.5"/>
+                  <a href="#10.5">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc9.html#a554">
+                    10.5 Miscellaneous Practices
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="10.5.1"/>
+                  <a href="#10.5.1">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc9.html#a331">
+                    10.5.1 Parentheses
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="10.5.2"/>
+                  <a href="#10.5.2">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc9.html#a333">
+                    10.5.2 Returning Values
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="10.5.3"/>
+                  <a href="#10.5.3">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc9.html#a353">
+                    10.5.3 Expressions before `?' in the Conditional Operator
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="10.5.4"/>
+                  <a href="#10.5.4">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc9.html#a395">
+                    10.5.4 Special Comments
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="11"/>
+                  <a href="#11">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc10.html#a186">
+                    <strong>11 - Code Examples</strong>
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+              <tr>
+                <td>
+                  <a name="11.1"/>
+                  <a href="#11.1">
+                    <span class="wrapper">
+                      <img src="images/anchor.png" alt=""/>
+                    </span>
+                  </a>
+                </td>
+                <td>
+                  <a href="styleguides/sun-code-conventions-19990420/CodeConventions.doc10.html#a182">
+                    11.1 Java Source File Example
+                  </a>
+                </td>
+                <td>???</td>
+                <td/>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </subsection>
+    </section>
+  </body>
 </document>

--- a/src/xdocs/writingchecks.xml
+++ b/src/xdocs/writingchecks.xml
@@ -130,6 +130,7 @@ public class MyClass {
 
 }
       ]]></source>
+        <div class="wrapper">
           <table style="table-layout: fixed;">
               <tr>
                   <td>
@@ -174,6 +175,7 @@ CLASS_DEF -> CLASS_DEF [5:0]
                   </td>
               </tr>
           </table>
+        </div>
           <p>
             As you can see very small java file transforms to a huge Abstract Syntax Tree, because
             that is the most detailed tree including all components of the java file: object block,
@@ -201,7 +203,9 @@ CLASS_DEF -> CLASS_DEF [5:0]
       </p>
 
       <p>
-        <img alt="screenshot" src="images/gui_screenshot.png"/>
+        <span class="wrapper">
+          <img alt="screenshot" src="images/gui_screenshot.png"/>
+        </span>
       </p>
 
       <p> In the leftmost column you can open and close branches

--- a/src/xdocs/writingfilters.xml
+++ b/src/xdocs/writingfilters.xml
@@ -47,7 +47,9 @@
         and class <code>FilterSet</code>.
       </p>
 
-      <img src="images/Filter.gif" alt="Filter UML diagram" />
+      <div class="wrapper">
+        <img src="images/Filter.gif" alt="Filter UML diagram" />
+      </div>
     </section>
 
     <section name="Writing Filters">

--- a/src/xdocs/writingjavadocchecks.xml.vm
+++ b/src/xdocs/writingjavadocchecks.xml.vm
@@ -667,10 +667,11 @@ JAVADOC -> JAVADOC [0:0]
         Output with <tt>violateExecutionOnNonTightHtml</tt> set to false:
     </p>
 
-    <table>
-      <tr>
-        <td>
-          <source><![CDATA[
+      <div class="wrapper">
+        <table>
+          <tr>
+            <td>
+              <source><![CDATA[
 <!DOCTYPE module PUBLIC
           "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
           "https://checkstyle.org/dtds/configuration_1_3.dtd">
@@ -681,28 +682,30 @@ JAVADOC -> JAVADOC [0:0]
     </module>
   </module>
 </module>
-          ]]></source>
-        </td>
+              ]]></source>
+            </td>
 
-        <td>
-          <source><![CDATA[
+            <td>
+              <source><![CDATA[
 Starting audit...
 [ERROR] Test.java:11: Redundant <p> tag. [JavadocParagraph]
 Audit done.
 Checkstyle ends with 1 errors.
-          ]]></source>
-        </td>
-      </tr>
-    </table>
+              ]]></source>
+            </td>
+          </tr>
+        </table>
+      </div>
 
     <p>
         Output with <tt>violateExecutionOnNonTightHtml</tt> set to true:
     </p>
 
-    <table>
-      <tr>
-        <td>
-          <source><![CDATA[
+      <div class="wrapper">
+        <table>
+          <tr>
+            <td>
+              <source><![CDATA[
 <!DOCTYPE module PUBLIC
           "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
           "https://checkstyle.org/dtds/configuration_1_3.dtd">
@@ -713,11 +716,11 @@ Checkstyle ends with 1 errors.
     </module>
   </module>
 </module>
-          ]]></source>
-        </td>
+              ]]></source>
+            </td>
 
-        <td>
-          <source><![CDATA[
+            <td>
+              <source><![CDATA[
 Starting audit...
 [ERROR] Test.java:4: Unclosed HTML tag found: p [JavadocParagraph]
 [ERROR] Test.java:11: Redundant <p> tag. [JavadocParagraph]
@@ -726,10 +729,11 @@ Starting audit...
 [ERROR] Test.java:23: Unclosed HTML tag found: p [JavadocParagraph]
 Audit done.
 Checkstyle ends with 5 errors.
-          ]]></source>
-        </td>
-      </tr>
-    </table>
+              ]]></source>
+            </td>
+          </tr>
+        </table>
+      </div>
     </section>
 
     <section name="Checkstyle SDK GUI">
@@ -748,7 +752,9 @@ Checkstyle ends with 5 errors.
        Now you can see parsed javadoc tree as child of comment block.
       </p>
       <p>
-        <img alt="screenshot" src="images/gui_javadoc_screenshot.png"/>
+        <span class="wrapper">
+          <img alt="screenshot" src="images/gui_javadoc_screenshot.png"/>
+        </span>
       </p>
       <p>
        Notice that only files with ".java" extension can be opened.
@@ -851,140 +857,144 @@ Checkstyle ends with 5 errors.
       SpecialToken - mean that after parsing there will be special AstToken - PARAGRAPH, .... .
       </p>
       <p><b>Tags with optional (omittable) end tag:</b></p>
-      <table style="table-layout: fixed;">
-        <tr>
-          <th>Input</th>
-          <th>Current standard (HTML4)</th>
-          <th>Current standard with hasUnclosedTag flag</th>
-          <th>After parser update for new standard (HTML5)</th>
-          <th>After parser update for new standard with hasUnclosedTag flag</th>
-        </tr>
-        <tr>
-          <td><![CDATA[<p>text</p>]]></td>
-          <td><![CDATA[No errors, Nested tree, SpecialToken]]></td>
-          <td><![CDATA[No errors, Nested tree, SpecialToken, hasUnclosedTag=false]]></td>
-          <td><![CDATA[No errors, Nested tree, SpecialToken]]></td>
-          <td><![CDATA[No errors, Nested tree, SpecialToken, hasUnclosedTag=false]]></td>
-        </tr>
-        <tr>
-          <td><![CDATA[<p>text]]></td>
-          <td><![CDATA[No errors, Non-nested tree, SpecialToken]]></td>
-          <td><![CDATA[No errors, Non-nested tree, SpecialToken, hasUnclosedTag=true]]></td>
-          <td><![CDATA[No errors, Non-nested tree, SpecialToken]]></td>
-          <td><![CDATA[No errors, Non-nested tree, SpecialToken, hasUnclosedTag=true]]></td>
-        </tr>
-        <tr>
-          <td>
-            <![CDATA[<rb>text</rb>]]>
-            <br/><i>New HTML5 tag with optional (omittable) end tag</i>
-          </td>
-          <td><![CDATA[No errors, Nested tree, GeneralToken]]></td>
-          <td><![CDATA[No errors, Nested tree, GeneralToken, hasUnclosedTag=false]]></td>
-          <td><![CDATA[No errors, Nested tree, SpecialToken]]></td>
-          <td><![CDATA[No errors, Nested tree, SpecialToken, hasUnclosedTag=false]]></td>
-        </tr>
-        <tr>
-          <td>
-            <![CDATA[<rb>text]]>
-            <br/><i>New HTML5 tag with optional (omittable) end tag</i>
-          </td>
-          <td><![CDATA[Parse error]]></td>
-          <td><![CDATA[Parse error]]></td>
-          <td><![CDATA[No errors, Non-nested tree, SpecialToken]]></td>
-          <td><![CDATA[No errors, Non-nested tree, SpecialToken, hasUnclosedTag=true]]></td>
-        </tr>
-        <tr>
-          <td>
-            <![CDATA[<qwerty>text</qwerty>]]>
-            <br/><i>Unknown HTML tag</i>
-          </td>
-          <td><![CDATA[No errors, Nested tree, GeneralToken]]></td>
-          <td><![CDATA[No errors, Nested tree, GeneralToken, hasUnclosedTag=false]]></td>
-          <td><![CDATA[No errors, Nested tree, GeneralToken]]></td>
-          <td><![CDATA[No errors, Nested tree, GeneralToken, hasUnclosedTag=false]]></td>
-        </tr>
-        <tr>
-          <td>
-            <![CDATA[<qwerty>text]]>
-            <br/><i>Unknown HTML tag</i>
-          </td>
-          <td><![CDATA[Parse error]]></td>
-          <td><![CDATA[Parse error]]></td>
-          <td><![CDATA[Parse error]]></td>
-          <td><![CDATA[Parse error]]></td>
-        </tr>
-      </table>
+      <div class="wrapper">
+        <table style="table-layout: fixed;">
+          <tr>
+            <th>Input</th>
+            <th>Current standard (HTML4)</th>
+            <th>Current standard with hasUnclosedTag flag</th>
+            <th>After parser update for new standard (HTML5)</th>
+            <th>After parser update for new standard with hasUnclosedTag flag</th>
+          </tr>
+          <tr>
+            <td><![CDATA[<p>text</p>]]></td>
+            <td><![CDATA[No errors, Nested tree, SpecialToken]]></td>
+            <td><![CDATA[No errors, Nested tree, SpecialToken, hasUnclosedTag=false]]></td>
+            <td><![CDATA[No errors, Nested tree, SpecialToken]]></td>
+            <td><![CDATA[No errors, Nested tree, SpecialToken, hasUnclosedTag=false]]></td>
+          </tr>
+          <tr>
+            <td><![CDATA[<p>text]]></td>
+            <td><![CDATA[No errors, Non-nested tree, SpecialToken]]></td>
+            <td><![CDATA[No errors, Non-nested tree, SpecialToken, hasUnclosedTag=true]]></td>
+            <td><![CDATA[No errors, Non-nested tree, SpecialToken]]></td>
+            <td><![CDATA[No errors, Non-nested tree, SpecialToken, hasUnclosedTag=true]]></td>
+          </tr>
+          <tr>
+            <td>
+              <![CDATA[<rb>text</rb>]]>
+              <br/><i>New HTML5 tag with optional (omittable) end tag</i>
+            </td>
+            <td><![CDATA[No errors, Nested tree, GeneralToken]]></td>
+            <td><![CDATA[No errors, Nested tree, GeneralToken, hasUnclosedTag=false]]></td>
+            <td><![CDATA[No errors, Nested tree, SpecialToken]]></td>
+            <td><![CDATA[No errors, Nested tree, SpecialToken, hasUnclosedTag=false]]></td>
+          </tr>
+          <tr>
+            <td>
+              <![CDATA[<rb>text]]>
+              <br/><i>New HTML5 tag with optional (omittable) end tag</i>
+            </td>
+            <td><![CDATA[Parse error]]></td>
+            <td><![CDATA[Parse error]]></td>
+            <td><![CDATA[No errors, Non-nested tree, SpecialToken]]></td>
+            <td><![CDATA[No errors, Non-nested tree, SpecialToken, hasUnclosedTag=true]]></td>
+          </tr>
+          <tr>
+            <td>
+              <![CDATA[<qwerty>text</qwerty>]]>
+              <br/><i>Unknown HTML tag</i>
+            </td>
+            <td><![CDATA[No errors, Nested tree, GeneralToken]]></td>
+            <td><![CDATA[No errors, Nested tree, GeneralToken, hasUnclosedTag=false]]></td>
+            <td><![CDATA[No errors, Nested tree, GeneralToken]]></td>
+            <td><![CDATA[No errors, Nested tree, GeneralToken, hasUnclosedTag=false]]></td>
+          </tr>
+          <tr>
+            <td>
+              <![CDATA[<qwerty>text]]>
+              <br/><i>Unknown HTML tag</i>
+            </td>
+            <td><![CDATA[Parse error]]></td>
+            <td><![CDATA[Parse error]]></td>
+            <td><![CDATA[Parse error]]></td>
+            <td><![CDATA[Parse error]]></td>
+          </tr>
+        </table>
+      </div>
       <br/>
       <p><b>Void tags:</b></p>
       <p>
       Note: "Nested"/"Non-Nested" is not applicable for this type of tags - all of them are looks
       like Non-Nested. Flas "hasUnclosedTag" is "false" for all cases.
       </p>
-      <table style="table-layout: fixed;">
-        <tr>
-          <th>Input</th>
-          <th>Current standard (HTML4)</th>
-          <th>After parser update for new standard (HTML5)</th>
-        </tr>
-        <tr>
-          <td><![CDATA[<br/>]]></td>
-          <td>No errors, SpecialToken</td>
-          <td>No errors, SpecialToken</td>
-        </tr>
-        <tr>
-          <td><![CDATA[<br>]]></td>
-          <td>No errors, SpecialToken</td>
-          <td>No errors, SpecialToken</td>
-        </tr>
-        <tr>
-          <td>
-            <![CDATA[<embed/>]]>
-            <br/><i>New HTML5 tag</i>
-          </td>
-          <td>No errors, GeneralToken</td>
-          <td>No errors, SpecialToken</td>
-        </tr>
-        <tr>
-          <td>
-            <![CDATA[<embed>]]>
-            <br/><i>New HTML5 tag</i>
-          </td>
-          <td>Parse Error</td>
-          <td>No errors, SpecialToken</td>
-        </tr>
-        <tr>
-          <td>
-            <![CDATA[<basefont/>]]>
-            <br/><i>Supported in HTML4. Not supported tag in HTML5</i>
-          </td>
-          <td>No errors, SpecialToken</td>
-          <td>No errors, SpecialToken</td>
-        </tr>
-        <tr>
-          <td>
-            <![CDATA[<basefont>]]>
-            <br/><i>Supported in HTML4. Not supported tag in HTML5</i>
-          </td>
-          <td>No errors, SpecialToken</td>
-          <td>No errors, SpecialToken</td>
-        </tr>
-        <tr>
-          <td>
-            <![CDATA[<qwerty/>]]>
-            <br/><i>Unknown HTML tag</i>
-          </td>
-          <td>No errors, GeneralToken</td>
-          <td>No errors, GeneralToken</td>
+      <div class="wrapper">
+        <table style="table-layout: fixed;">
+          <tr>
+            <th>Input</th>
+            <th>Current standard (HTML4)</th>
+            <th>After parser update for new standard (HTML5)</th>
           </tr>
-        <tr>
-          <td>
-            <![CDATA[<qwerty>]]>
-            <br/><i>Unknown HTML tag</i>
-          </td>
-          <td>Parse Error</td>
-          <td>Parse Error</td>
-        </tr>
-      </table>
+          <tr>
+            <td><![CDATA[<br/>]]></td>
+            <td>No errors, SpecialToken</td>
+            <td>No errors, SpecialToken</td>
+          </tr>
+          <tr>
+            <td><![CDATA[<br>]]></td>
+            <td>No errors, SpecialToken</td>
+            <td>No errors, SpecialToken</td>
+          </tr>
+          <tr>
+            <td>
+              <![CDATA[<embed/>]]>
+              <br/><i>New HTML5 tag</i>
+            </td>
+            <td>No errors, GeneralToken</td>
+            <td>No errors, SpecialToken</td>
+          </tr>
+          <tr>
+            <td>
+              <![CDATA[<embed>]]>
+              <br/><i>New HTML5 tag</i>
+            </td>
+            <td>Parse Error</td>
+            <td>No errors, SpecialToken</td>
+          </tr>
+          <tr>
+            <td>
+              <![CDATA[<basefont/>]]>
+              <br/><i>Supported in HTML4. Not supported tag in HTML5</i>
+            </td>
+            <td>No errors, SpecialToken</td>
+            <td>No errors, SpecialToken</td>
+          </tr>
+          <tr>
+            <td>
+              <![CDATA[<basefont>]]>
+              <br/><i>Supported in HTML4. Not supported tag in HTML5</i>
+            </td>
+            <td>No errors, SpecialToken</td>
+            <td>No errors, SpecialToken</td>
+          </tr>
+          <tr>
+            <td>
+              <![CDATA[<qwerty/>]]>
+              <br/><i>Unknown HTML tag</i>
+            </td>
+            <td>No errors, GeneralToken</td>
+            <td>No errors, GeneralToken</td>
+            </tr>
+          <tr>
+            <td>
+              <![CDATA[<qwerty>]]>
+              <br/><i>Unknown HTML tag</i>
+            </td>
+            <td>Parse Error</td>
+            <td>Parse Error</td>
+          </tr>
+        </table>
+      </div>
     </section>
 
   </body>

--- a/src/xdocs/writinglisteners.xml.vm
+++ b/src/xdocs/writinglisteners.xml.vm
@@ -69,8 +69,10 @@
         classes <code>AuditListener</code> and <code>AuditEvent</code>.
       </p>
 
-      <img src="images/AuditListener.gif" width="381" height="488"
-             alt="AuditListener UML diagram"/>
+      <span class="wrapper">
+        <img src="images/AuditListener.gif" width="381" height="488"
+               alt="AuditListener UML diagram"/>
+      </span>
 
     </section>
 


### PR DESCRIPTION
Issue: #7083 

This PR contains refactoring of the whole page except for project info and project documentation. Those parts are generated by `maven-project-info-reports-plugin`. For making these responsive the generation of those pages has to be changed. For example the `plugin-management.html` is generated in `PluginManagementReport.java`. The line which would have to be changed is [this](https://github.com/apache/maven-project-info-reports-plugin/blob/a06436366670e7fca7e92b690b2d45d5ada00ebc/src/main/java/org/apache/maven/report/projectinfo/PluginManagementReport.java#L202).

To make tables, images and code blockwise scrollable, those tags have to be surrounded by a `span` or `div` with the class `wrapper`. For example:
```
<img alt="example" src="example/path/image.png"/>
```
becomes
```
<div class="wrapper">
    <img alt="example" src="example/path/image.png"/>
</div>
```
The use of `div` and `span` depends on the block element which contains the image, code or table. In a `p` `span` has to be used, otherwise `div` can be used.