### PR TITLE
config: update wercker build of hibernate to skip elaticsearch

### DIFF
--- a/.ci/wercker.sh
+++ b/.ci/wercker.sh
@@ -94,7 +94,7 @@ no-error-hibernate-search)
   echo CS_version: ${CS_POM_VERSION}
   checkout_from https://github.com/hibernate/hibernate-search.git
   cd .ci-temp/hibernate-search
-  mvn -e clean install -DskipTests=true -Dtest.elasticsearch.host.provided=true \
+  mvn -e clean install -DskipTests=true -Dtest.elasticsearch.run.skip=true \
      -Dcheckstyle.skip=true -Dforbiddenapis.skip=true \
      -Dpuppycrawl.checkstyle.version=${CS_POM_VERSION}
   mvn -e checkstyle:check  -Dpuppycrawl.checkstyle.version=${CS_POM_VERSION}


### PR DESCRIPTION
Fix for build problem
https://app.wercker.com/checkstyle/checkstyle/runs/build/5dd4cb4b8e18590008b09d9a?step=5dd4cb9ef947d10009282aa1

Root cause: https://github.com/hibernate/hibernate-search/commit/170491f69d89a723fc1c7a1c4744f2a026933f32 see changes at bottom
