### PR TITLE
Issue #7276: Fix OutputStream flush count on JDK 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -205,24 +205,23 @@ matrix:
         - CMD2="./.ci/travis/travis.sh osx-assembly"
         - CMD="$CMD1 && $CMD2"
 
-#         disable Mac JDK11+ until https://github.com/checkstyle/checkstyle/issues/7276
-#    # MacOS JDK11 verify (till cache is not working, we can not do verify)
-#    - os: osx
-#      osx_image: xcode10.1
-#      env:
-#        - DESC="MacOS JDK11 verify, site, assembly
-#        - CMD1="./.ci/travis/travis.sh osx-package"
-#        - CMD2="./.ci/travis/travis.sh osx-assembly"
-#        - CMD="$CMD1 && $CMD2"
-#
-#    # MacOS JDK12 verify (till cache is not working, we can not do verify)
-#    - os: osx
-#      osx_image: xcode10.2
-#      env:
-#        - DESC="MacOS JDK12 verify, site, assembly
-#        - CMD1="./.ci/travis/travis.sh osx-jdk12-package"
-#        - CMD2="./.ci/travis/travis.sh osx-jdk12-assembly"
-#        - CMD="$CMD1 && $CMD2"
+    # MacOS JDK11 verify (till cache is not working, we can not do verify)
+    - os: osx
+      osx_image: xcode10.1
+      env:
+        - DESC="MacOS JDK11 verify, site, assembly
+        - CMD1="./.ci/travis/travis.sh osx-package"
+        - CMD2="./.ci/travis/travis.sh osx-assembly"
+        - CMD="$CMD1 && $CMD2"
+
+    # MacOS JDK12 verify (till cache is not working, we can not do verify)
+    - os: osx
+      osx_image: xcode10.2
+      env:
+        - DESC="MacOS JDK12 verify, site, assembly
+        - CMD1="./.ci/travis/travis.sh osx-jdk12-package"
+        - CMD2="./.ci/travis/travis.sh osx-jdk12-assembly"
+        - CMD="$CMD1 && $CMD2"
 
     # https://sonarcloud.io (openjdk8)
     - jdk: openjdk8

--- a/pom.xml
+++ b/pom.xml
@@ -271,6 +271,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+    <groupId>com.google.truth</groupId>
+    <artifactId>truth</artifactId>
+      <version>1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.github.stefanbirkner</groupId>
       <artifactId>system-rules</artifactId>
       <version>1.19.0</version>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle;
 
+import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.Checker.EXCEPTION_MSG;
 import static com.puppycrawl.tools.checkstyle.DefaultLogger.AUDIT_FINISHED_MESSAGE;
 import static com.puppycrawl.tools.checkstyle.DefaultLogger.AUDIT_STARTED_MESSAGE;
@@ -88,6 +89,7 @@ import com.puppycrawl.tools.checkstyle.internal.testmodules.DebugFilter;
 import com.puppycrawl.tools.checkstyle.internal.testmodules.TestBeforeExecutionFileFilter;
 import com.puppycrawl.tools.checkstyle.internal.testmodules.TestFileSetCheck;
 import com.puppycrawl.tools.checkstyle.internal.utils.CloseAndFlushTestByteArrayOutputStream;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
@@ -1332,14 +1334,18 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
             verify(checker, tmpFile.getPath(), expected);
 
-            assertEquals("Close count was not expected",
-                    1, testInfoOutputStream.getCloseCount());
-            assertEquals("Flush count was not expected",
-                    3, testInfoOutputStream.getFlushCount());
-            assertEquals("Close count was not expected",
-                    1, testErrorOutputStream.getCloseCount());
-            assertEquals("Flush count was not expected",
-                    1, testErrorOutputStream.getFlushCount());
+            assertWithMessage("Output stream close count")
+                    .that(testInfoOutputStream.getCloseCount())
+                    .isEqualTo(1);
+            assertWithMessage("Output stream flush count")
+                    .that(testInfoOutputStream.getFlushCount())
+                    .isEqualTo(TestUtil.adjustFlushCountForOutputStreamClose(3));
+            assertWithMessage("Error stream close count")
+                    .that(testErrorOutputStream.getCloseCount())
+                    .isEqualTo(1);
+            assertWithMessage("Error stream flush count")
+                    .that(testErrorOutputStream.getFlushCount())
+                    .isEqualTo(TestUtil.adjustFlushCountForOutputStreamClose(1));
         }
     }
 
@@ -1357,10 +1363,12 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
             verify(checker, tmpFile.getPath(), tmpFile.getPath(), expected);
 
-            assertEquals("Close count was not expected",
-                    1, testInfoOutputStream.getCloseCount());
-            assertEquals("Flush count was not expected",
-                    0, testInfoOutputStream.getFlushCount());
+            assertWithMessage("Output stream close count")
+                    .that(testInfoOutputStream.getCloseCount())
+                    .isEqualTo(1);
+            assertWithMessage("Output stream flush count")
+                    .that(testInfoOutputStream.getFlushCount())
+                    .isEqualTo(TestUtil.adjustFlushCountForOutputStreamClose(0));
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListenerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListenerTest.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle;
 
+import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -44,6 +45,7 @@ import com.puppycrawl.tools.checkstyle.checks.coding.NestedForDepthCheck;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocVariableCheck;
 import com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCheck;
 import com.puppycrawl.tools.checkstyle.internal.utils.CloseAndFlushTestByteArrayOutputStream;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 public class XpathFileGeneratorAuditListenerTest {
 
@@ -306,8 +308,12 @@ public class XpathFileGeneratorAuditListenerTest {
 
         listener.auditFinished(null);
 
-        assertEquals("expected number of flushes", 1, out.flushCount);
-        assertEquals("expected number of closes", 1, out.closeCount);
+        assertWithMessage("Output stream flush count")
+                .that(out.flushCount)
+                .isEqualTo(TestUtil.adjustFlushCountForOutputStreamClose(1));
+        assertWithMessage("Output stream close count")
+                .that(out.closeCount)
+                .isEqualTo(1);
 
         final String actual = out.toString();
         assertEquals("Invalid suppressions file content", expected, actual);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.internal.utils;
 
+import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -193,6 +194,44 @@ public final class TestUtil {
             curNode = toVisit;
         }
         return Optional.ofNullable(curNode);
+    }
+
+    /**
+     * <p>
+     * Returns the JDK version as a number that is easy to compare.
+     * </p>
+     * <p>
+     * For JDK "1.8" it will be 8; for JDK "11" it will be 11.
+     * </p>
+     *
+     * @return JDK version as integer
+     */
+    public static int getJdkVersion() {
+        String version = System.getProperty("java.specification.version");
+        if (version.startsWith("1.")) {
+            version = version.substring(2);
+        }
+        return Integer.parseInt(version);
+    }
+
+    /**
+     * <p>
+     * Adjusts the expected number of flushes for tests that call {@link OutputStream#close} method.
+     * </p>
+     * <p>
+     * After <a href="https://bugs.openjdk.java.net/browse/JDK-8220477">JDK-8220477</a>
+     * there is one additional flush from {@code sun.nio.cs.StreamEncoder#implClose}.
+     * </p>
+     *
+     * @param flushCount flush count to adjust
+     * @return adjusted flush count
+     */
+    public static int adjustFlushCountForOutputStreamClose(int flushCount) {
+        int result = flushCount;
+        if (getJdkVersion() >= 13) {
+            ++result;
+        }
+        return result;
     }
 
 }


### PR DESCRIPTION
Issue #7276

In JDK-13 there is one more call to `out.flush` from `implClose`:
```
-            else
-                out.close();
+            else {
+                try {
+                    out.flush();
+                } finally {
+                    out.close();
+                }
+            }
```
See https://bugs.openjdk.java.net/browse/JDK-8220477">JDK-8220477