### PR TITLE
Issue #7299: remove build for old non-LTS releases

### DIFF
--- a/.ci/travis/travis.sh
+++ b/.ci/travis/travis.sh
@@ -106,7 +106,7 @@ javac9)
       mkdir -p target
       for file in "${files[@]}"
       do
-        javac -d target "${file}"
+        javac --release 9 -d target "${file}"
       done
   fi
   ;;

--- a/.travis.yml
+++ b/.travis.yml
@@ -273,8 +273,8 @@ matrix:
         - USE_MAVEN_REPO="true"
         - CMD="./.ci/travis/travis.sh jdk13-verify-limited"
 
-    # OpenJDK9 compile input files with jdk9 specific syntax
-    - jdk: openjdk9
+    # OpenJDK11 compile input files with jdk9 specific syntax
+    - jdk: openjdk11
       env:
         - DESC="compile input files with jdk9 specific syntax"
         - CMD="./.ci/travis/travis.sh javac9"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,14 +69,6 @@ environment:
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
       DESC: "verify without checkstyle (JDK8)"
       CMD: "./.ci/appveyor.bat verify_without_checkstyle"
-    # verify without checkstyle (JDK9)
-    - JAVA_HOME: C:\Program Files\Java\jdk9
-      DESC: "verify without checkstyle (JDK9)"
-      CMD: "./.ci/appveyor.bat verify_without_checkstyle"
-    # verify without checkstyle (JDK10)
-    - JAVA_HOME: C:\Program Files\Java\jdk10
-      DESC: "verify without checkstyle (JDK10)"
-      CMD: "./.ci/appveyor.bat verify_without_checkstyle"
     # verify without checkstyle (JDK11)
     - JAVA_HOME: C:\Program Files\Java\jdk11
       DESC: "verify without checkstyle (JDK11)"
@@ -88,14 +80,6 @@ environment:
     # site, without verify (JDK8)
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
       DESC: "site, without verify (JDK8)"
-      CMD: "./.ci/appveyor.bat site_without_verify"
-    # site, without verify (JDK9)
-    - JAVA_HOME: C:\Program Files\Java\jdk9
-      DESC: "site, without verify (JDK9)"
-      CMD: "./.ci/appveyor.bat site_without_verify"
-    # site, without verify (JDK10)
-    - JAVA_HOME: C:\Program Files\Java\jdk10
-      DESC: "site, without verify (JDK10)"
       CMD: "./.ci/appveyor.bat site_without_verify"
     # site, without verify (JDK11)
     - JAVA_HOME: C:\Program Files\Java\jdk11


### PR DESCRIPTION
Issue #7299

JDK 9 and JDK 10 build removed.
Java 9 specific syntax verified with JDK 11 in `--release 9` mode