### PR TITLE
Issue #6916: migrate tests to junit5 for annotation package

### DIFF
--- a/config/import-control-test.xml
+++ b/config/import-control-test.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE import-control PUBLIC
-    "-//Checkstyle//DTD ImportControl Configuration 1.3//EN"
-    "https://checkstyle.org/dtds/import_control_1_3.dtd">
+    "-//Checkstyle//DTD ImportControl Configuration 1.4//EN"
+    "https://checkstyle.org/dtds/import_control_1_4.dtd">
 
 <import-control pkg="com.puppycrawl.tools.checkstyle">
 
+  <!-- Disallow obsolete Junit API -->
+  <disallow pkg="org.junit" exact-match="true"/>
   <disallow pkg="junit.framework" />
 
   <!-- Conflicts with normal tests and pitest.
@@ -15,5 +17,22 @@
   <disallow pkg="org\.mockito.*" regex="true" />
 
   <allow pkg=".*" regex="true" />
+
+  <!-- Till https://github.com/checkstyle/checkstyle/issues/6916 -->
+  <subpackage name="checks">
+    <allow pkg="org.junit" local-only="true"/>
+    <subpackage name="(blocks|coding|design|header|imports|indentation|javadoc)" regex="true">
+      <allow pkg="org.junit"/>
+    </subpackage>
+    <subpackage name="(metrics|modifier|naming|regexp|sizes|whitespace)" regex="true">
+      <allow pkg="org.junit"/>
+    </subpackage>
+  </subpackage>
+  <subpackage name="(ant|api|filefilters|filters|grammar|gui|internal|utils|xpath)" regex="true">
+    <allow pkg="org.junit"/>
+  </subpackage>
+  <file name=".*Test(Support)?" regex="true">
+    <allow pkg="org.junit"/>
+  </file>
 
 </import-control>

--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -4599,8 +4599,11 @@
                      enabled_by_default="true"/>
     <inspection_tool class="TestMethodWithoutAssertion" enabled="true" level="ERROR"
                      enabled_by_default="true">
+        <!-- after https://github.com/checkstyle/checkstyle/issues/6916
+             all junit4 methods should be removed -->
         <option name="assertionMethods"
                 value="org.junit.Assert,assert.*|fail.*, ,
+    ,org.junit.jupiter.api.Assertions,assert.*|fail.*, ,
     ,junit.framework.Assert,assert.*|fail.*, ,
     ,org.mockito.Mockito,verify.*, ,
     ,org.mockito.InOrder,verify, ,

--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,7 @@
     <pitest.plugin.timeout.factor>10</pitest.plugin.timeout.factor>
     <pitest.plugin.timeout.constant>50000</pitest.plugin.timeout.constant>
     <pitest.plugin.threads>4</pitest.plugin.threads>
+    <pitest.junit5.plugin.version>0.10</pitest.junit5.plugin.version>
     <sonar.test.exclusions>**/test/resources/**/*,**/it/resources/**/*</sonar.test.exclusions>
     <junit.version>5.5.2</junit.version>
   </properties>
@@ -397,6 +398,13 @@
           <groupId>org.pitest</groupId>
           <artifactId>pitest-maven</artifactId>
           <version>${pitest.plugin.version}</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.pitest</groupId>
+              <artifactId>pitest-junit5-plugin</artifactId>
+              <version>${pitest.junit5.plugin.version}</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
@@ -21,9 +21,9 @@ package com.puppycrawl.tools.checkstyle.checks.annotation;
 
 import static com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocationCheck.MSG_KEY_ANNOTATION_LOCATION;
 import static com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocationCheck.MSG_KEY_ANNOTATION_LOCATION_ALONE;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -40,9 +40,8 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testGetRequiredTokens() {
         final AnnotationLocationCheck checkObj = new AnnotationLocationCheck();
-        assertArrayEquals(
-            "AnnotationLocationCheck#getRequiredTokens should return empty array by default",
-            CommonUtil.EMPTY_INT_ARRAY, checkObj.getRequiredTokens());
+        assertArrayEquals(CommonUtil.EMPTY_INT_ARRAY, checkObj.getRequiredTokens(),
+                "AnnotationLocationCheck#getRequiredTokens should return empty array by default");
     }
 
     @Test
@@ -136,7 +135,7 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
             TokenTypes.ANNOTATION_DEF,
             TokenTypes.ANNOTATION_FIELD_DEF,
             };
-        assertArrayEquals("Default acceptable tokens are invalid", expected, actual);
+        assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationOnSameLineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationOnSameLineCheckTest.java
@@ -20,9 +20,9 @@
 package com.puppycrawl.tools.checkstyle.checks.annotation;
 
 import static com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationOnSameLineCheck.MSG_KEY_ANNOTATION_ON_SAME_LINE;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -39,9 +39,8 @@ public class AnnotationOnSameLineCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testGetRequiredTokens() {
         final AnnotationOnSameLineCheck check = new AnnotationOnSameLineCheck();
-        assertArrayEquals(
-            "AnnotationOnSameLineCheck#getRequiredTokens should return empty array by default",
-            CommonUtil.EMPTY_INT_ARRAY, check.getRequiredTokens());
+        assertArrayEquals(CommonUtil.EMPTY_INT_ARRAY, check.getRequiredTokens(),
+                "AnnotationOnSameLineCheck#getRequiredTokens should return empty array by default");
     }
 
     @Test
@@ -65,7 +64,7 @@ public class AnnotationOnSameLineCheckTest extends AbstractModuleTestSupport {
             TokenTypes.DOT,
             TokenTypes.ANNOTATION_FIELD_DEF,
         };
-        assertArrayEquals("Default acceptable tokens are invalid", expected, actual);
+        assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckTest.java
@@ -24,11 +24,12 @@ import static com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseSty
 import static com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck.MSG_KEY_ANNOTATION_PARENS_PRESENT;
 import static com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck.MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING;
 import static com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck.MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -50,8 +51,8 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
     public void testElementStyleValueOf() {
         final AnnotationUseStyleCheck.ElementStyle option =
             AnnotationUseStyleCheck.ElementStyle.valueOf("COMPACT");
-        assertEquals("Invalid valueOf result",
-            AnnotationUseStyleCheck.ElementStyle.COMPACT, option);
+        assertEquals(AnnotationUseStyleCheck.ElementStyle.COMPACT, option,
+                "Invalid valueOf result");
     }
 
     /* Additional test for jacoco, since valueOf()
@@ -62,8 +63,8 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
     public void testTrailingArrayCommaValueOf() {
         final AnnotationUseStyleCheck.TrailingArrayComma option =
             AnnotationUseStyleCheck.TrailingArrayComma.valueOf("ALWAYS");
-        assertEquals("Invalid valueOf result",
-            AnnotationUseStyleCheck.TrailingArrayComma.ALWAYS, option);
+        assertEquals(AnnotationUseStyleCheck.TrailingArrayComma.ALWAYS, option,
+                "Invalid valueOf result");
     }
 
     /* Additional test for jacoco, since valueOf()
@@ -74,8 +75,8 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
     public void testClosingParensValueOf() {
         final AnnotationUseStyleCheck.ClosingParens option =
             AnnotationUseStyleCheck.ClosingParens.valueOf("ALWAYS");
-        assertEquals("Invalid valueOf result",
-            AnnotationUseStyleCheck.ClosingParens.ALWAYS, option);
+        assertEquals(AnnotationUseStyleCheck.ClosingParens.ALWAYS, option,
+                "Invalid valueOf result");
     }
 
     @Test
@@ -337,7 +338,7 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
         final AnnotationUseStyleCheck constantNameCheckObj = new AnnotationUseStyleCheck();
         final int[] actual = constantNameCheckObj.getAcceptableTokens();
         final int[] expected = {TokenTypes.ANNOTATION };
-        Assert.assertArrayEquals("Invalid acceptable tokens", expected, actual);
+        assertArrayEquals(expected, actual, "Invalid acceptable tokens");
     }
 
     @Test
@@ -345,13 +346,13 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
         final AnnotationUseStyleCheck check = new AnnotationUseStyleCheck();
         try {
             check.setElementStyle("SHOULD_PRODUCE_ERROR");
-            Assert.fail("ConversionException is expected");
+            fail("ConversionException is expected");
         }
         catch (IllegalArgumentException ex) {
             final String messageStart = "unable to parse";
 
-            assertTrue("Invalid exception message, should start with: " + messageStart,
-                ex.getMessage().startsWith(messageStart));
+            assertTrue(ex.getMessage().startsWith(messageStart),
+                    "Invalid exception message, should start with: " + messageStart);
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheckTest.java
@@ -21,9 +21,9 @@ package com.puppycrawl.tools.checkstyle.checks.annotation;
 
 import static com.puppycrawl.tools.checkstyle.checks.annotation.MissingDeprecatedCheck.MSG_KEY_ANNOTATION_MISSING_DEPRECATED;
 import static com.puppycrawl.tools.checkstyle.checks.annotation.MissingDeprecatedCheck.MSG_KEY_JAVADOC_DUPLICATE_TAG;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -45,8 +45,8 @@ public class MissingDeprecatedCheckTest extends AbstractModuleTestSupport {
             JavadocTokenTypes.JAVADOC,
         };
 
-        assertArrayEquals("Default javadoc tokens are invalid",
-                expected, missingDeprecatedCheck.getDefaultJavadocTokens());
+        assertArrayEquals(expected, missingDeprecatedCheck.getDefaultJavadocTokens(),
+                "Default javadoc tokens are invalid");
     }
 
     @Test
@@ -55,8 +55,8 @@ public class MissingDeprecatedCheckTest extends AbstractModuleTestSupport {
         final int[] expected = {
             JavadocTokenTypes.JAVADOC,
         };
-        assertArrayEquals("Default required javadoc tokens are invalid",
-            expected, checkObj.getRequiredJavadocTokens());
+        assertArrayEquals(expected, checkObj.getRequiredJavadocTokens(),
+                "Default required javadoc tokens are invalid");
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheckTest.java
@@ -21,10 +21,10 @@ package com.puppycrawl.tools.checkstyle.checks.annotation;
 
 import static com.puppycrawl.tools.checkstyle.checks.annotation.MissingOverrideCheck.MSG_KEY_ANNOTATION_MISSING_OVERRIDE;
 import static com.puppycrawl.tools.checkstyle.checks.annotation.MissingOverrideCheck.MSG_KEY_TAG_NOT_VALID_ON;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -238,8 +238,8 @@ public class MissingOverrideCheckTest extends AbstractModuleTestSupport {
         final int[] expectedTokens = {TokenTypes.METHOD_DEF };
         final MissingOverrideCheck check = new MissingOverrideCheck();
         final int[] actual = check.getAcceptableTokens();
-        assertEquals("Invalid acceptable token size", 1, actual.length);
-        Assert.assertArrayEquals("Default required tokens are invalid", expectedTokens, actual);
+        assertEquals(1, actual.length, "Invalid acceptable token size");
+        assertArrayEquals(expectedTokens, actual, "Default required tokens are invalid");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationCheckTest.java
@@ -20,9 +20,9 @@
 package com.puppycrawl.tools.checkstyle.checks.annotation;
 
 import static com.puppycrawl.tools.checkstyle.checks.annotation.PackageAnnotationCheck.MSG_KEY;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -53,7 +53,7 @@ public class PackageAnnotationCheckTest extends AbstractModuleTestSupport {
         final PackageAnnotationCheck constantNameCheckObj = new PackageAnnotationCheck();
         final int[] actual = constantNameCheckObj.getAcceptableTokens();
         final int[] expected = {TokenTypes.PACKAGE_DEF };
-        Assert.assertArrayEquals("Invalid acceptable tokens", expected, actual);
+        assertArrayEquals(expected, actual, "Invalid acceptable tokens");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheckTest.java
@@ -21,7 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.annotation;
 
 import static com.puppycrawl.tools.checkstyle.checks.annotation.SuppressWarningsCheck.MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;


### PR DESCRIPTION
Issue #6916

Auto converted to Junit5 with IDEA inspections.
As a side effect, some imports replaced with static imports.