### PR TITLE
Issue #7309: fix teamcity inspections issues

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -1335,9 +1335,9 @@
                      enabled_by_default="true"/>
     <!-- we do like constants on the right side, it is more readable,
          placing constant on the left does not give benefit -->
-    <inspection_tool class="ConstantOnRHSOfComparison" enabled="false" level="ERROR"
+    <inspection_tool class="ConstantOnWrongSideOfComparison" enabled="false" level="ERROR"
                      enabled_by_default="false"/>
-    <inspection_tool class="ConstantOnRHSOfComparisonJS" enabled="true" level="ERROR"
+    <inspection_tool class="ConstantOnWrongSideOfComparisonJS" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
     <inspection_tool class="ConstantStringIntern" enabled="true" level="ERROR"
                      enabled_by_default="true"/>
@@ -1614,7 +1614,7 @@
     <inspection_tool class="DuplicatedDataProviderNames" enabled="true" level="WARNING"
                      enabled_by_default="true"/>
     <!-- this duplication algorithm generate too much won't fixes -->
-    <inspection_tool class="Duplicates" enabled="false" level="ERROR" enabled_by_default="true">
+    <inspection_tool class="DuplicatedCode" enabled="false" level="ERROR" enabled_by_default="true">
         <scope name="Tests" level="ERROR" enabled="false"/>
     </inspection_tool>
     <inspection_tool class="DynamicRegexReplaceableByCompiledPattern" enabled="true" level="WARNING"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
@@ -201,8 +201,7 @@ public class JavadocDetailNodeParser {
         while (currentJavadocParent != null) {
             // remove unnecessary children tokens
             if (currentJavadocParent.getType() == JavadocTokenTypes.TEXT) {
-                currentJavadocParent
-                        .setChildren((DetailNode[]) JavadocNodeImpl.EMPTY_DETAIL_NODE_ARRAY);
+                currentJavadocParent.setChildren(JavadocNodeImpl.EMPTY_DETAIL_NODE_ARRAY);
             }
 
             final JavadocNodeImpl[] children =
@@ -254,7 +253,7 @@ public class JavadocDetailNodeParser {
             final ParseTree currentParseTreeNodeChild = parseTreeParent.getChild(i);
             final JavadocNodeImpl[] subChildren =
                     createChildrenNodes(currentJavadocNode, currentParseTreeNodeChild);
-            currentJavadocNode.setChildren((DetailNode[]) subChildren);
+            currentJavadocNode.setChildren(subChildren);
         }
     }
 
@@ -320,7 +319,7 @@ public class JavadocDetailNodeParser {
         node.setIndex(index);
         node.setType(getTokenType(parseTree));
         node.setParent(parent);
-        node.setChildren((DetailNode[]) new JavadocNodeImpl[parseTree.getChildCount()]);
+        node.setChildren(new JavadocNodeImpl[parseTree.getChildCount()]);
         return node;
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XmlLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XmlLoader.java
@@ -88,7 +88,7 @@ public class XmlLoader
     public InputSource resolveEntity(String publicId, String systemId)
             throws SAXException, IOException {
         final InputSource inputSource;
-        if (publicIdToResourceNameMap.keySet().contains(publicId)) {
+        if (publicIdToResourceNameMap.containsKey(publicId)) {
             final String dtdResourceName =
                     publicIdToResourceNameMap.get(publicId);
             final ClassLoader loader =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
@@ -291,7 +291,7 @@ public abstract class AutomaticBean
     /** A converter that converts strings to patterns. */
     private static class PatternConverter implements Converter {
 
-        @SuppressWarnings({"unchecked", "rawtypes"})
+        @SuppressWarnings("unchecked")
         @Override
         public Object convert(Class type, Object value) {
             return CommonUtil.createPattern(value.toString());
@@ -302,7 +302,7 @@ public abstract class AutomaticBean
     /** A converter that converts strings to severity level. */
     private static class SeverityLevelConverter implements Converter {
 
-        @SuppressWarnings({"unchecked", "rawtypes"})
+        @SuppressWarnings("unchecked")
         @Override
         public Object convert(Class type, Object value) {
             return SeverityLevel.getInstance(value.toString());
@@ -313,7 +313,7 @@ public abstract class AutomaticBean
     /** A converter that converts strings to scope. */
     private static class ScopeConverter implements Converter {
 
-        @SuppressWarnings({"unchecked", "rawtypes"})
+        @SuppressWarnings("unchecked")
         @Override
         public Object convert(Class type, Object value) {
             return Scope.getInstance(value.toString());
@@ -324,7 +324,7 @@ public abstract class AutomaticBean
     /** A converter that converts strings to uri. */
     private static class UriConverter implements Converter {
 
-        @SuppressWarnings({"unchecked", "rawtypes"})
+        @SuppressWarnings("unchecked")
         @Override
         public Object convert(Class type, Object value) {
             final String url = value.toString();
@@ -351,7 +351,7 @@ public abstract class AutomaticBean
      */
     private static class RelaxedStringArrayConverter implements Converter {
 
-        @SuppressWarnings({"unchecked", "rawtypes"})
+        @SuppressWarnings("unchecked")
         @Override
         public Object convert(Class type, Object value) {
             // Convert to a String and trim it for the tokenizer.
@@ -379,7 +379,7 @@ public abstract class AutomaticBean
         /** Constant for optimization. */
         private static final AccessModifier[] EMPTY_MODIFIER_ARRAY = new AccessModifier[0];
 
-        @SuppressWarnings({"unchecked", "rawtypes"})
+        @SuppressWarnings("unchecked")
         @Override
         public Object convert(Class type, Object value) {
             // Converts to a String and trims it for the tokenizer.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -163,7 +163,7 @@ public class AvoidEscapedUnicodeCharactersCheck
     /** Regular expression for all escaped chars. */
     private static final Pattern ALL_ESCAPED_CHARS = Pattern.compile("^((\\\\u)[a-fA-F0-9]{4}"
             + "|\""
-            + "|\'"
+            + "|'"
             + "|\\\\"
             + "|\\\\b"
             + "|\\\\f"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -69,7 +69,6 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
      * Till https://youtrack.jetbrains.com/issue/IDEA-187209
      * @return method class
      * @throws Exception if smth wrong
-     * @noinspection JavaReflectionMemberAccess
      */
     private static Method getReplacePropertiesMethod() throws Exception {
         final Class<?>[] params = new Class<?>[3];

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -1976,16 +1976,18 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
      */
     @Test
     public void testArgumentOrderOfErrorMessages() {
-        final String[] arguments = {"##0##", "##1##", "##2##"};
+        final Object[] arguments = {"##0##", "##1##", "##2##"};
         final String[] messages = {
-            getCheckMessage(MSG_ERROR, (Object[]) arguments),
-            getCheckMessage(MSG_CHILD_ERROR, (Object[]) arguments),
-            getCheckMessage(MSG_ERROR_MULTI, (Object[]) arguments),
-            getCheckMessage(MSG_CHILD_ERROR_MULTI, (Object[]) arguments),
+            getCheckMessage(MSG_ERROR, arguments),
+            getCheckMessage(MSG_CHILD_ERROR, arguments),
+            getCheckMessage(MSG_ERROR_MULTI, arguments),
+            getCheckMessage(MSG_CHILD_ERROR_MULTI, arguments),
         };
         final boolean isInOrder = Arrays.stream(messages).allMatch(msg -> {
-            final int indexOfArgumentZero = msg.indexOf(arguments[0]);
-            return Arrays.stream(arguments).mapToInt(msg::indexOf)
+            final int indexOfArgumentZero = msg.indexOf((String) arguments[0]);
+            return Arrays.stream(arguments)
+                    .map(String.class::cast)
+                    .mapToInt(msg::indexOf)
                     .allMatch(index -> index >= indexOfArgumentZero);
         });
         assertTrue(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -979,7 +979,7 @@ public class XdocsPagesTest {
      * @param fieldClass The bean property's type.
      * @param instance The class instance to work with.
      * @return String form of property's default value.
-     * @noinspection ReuseOfLocalVariable, OverlyNestedMethod
+     * @noinspection OverlyNestedMethod
      */
     private static String getModulePropertyExpectedValue(String sectionName, String propertyName,
             Field field, Class<?> fieldClass, Object instance) throws Exception {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
@@ -125,9 +125,9 @@ public class TokenUtilTest {
             TokenUtil.getTokenName(nextAfterMaxId);
             fail("IllegalArgumentException is expected");
         }
-        catch (IllegalArgumentException expected) {
+        catch (IllegalArgumentException expectedException) {
             assertEquals("Invalid exception message",
-                    "given id " + nextAfterMaxId, expected.getMessage());
+                    "given id " + nextAfterMaxId, expectedException.getMessage());
         }
     }
 


### PR DESCRIPTION
Issue #7309

Fixed in code:
*    Redundant suppression (Errors) (8)
*    Misordered 'assertEquals()' arguments (Errors) (1)
*    Redundant Collection operation (1)
*    Redundant type cast (Errors) (7)
*    Unnecessarily escaped character (1)

Fixed in config:
*    Constant on the wrong side of comparison (Errors) (2247)
*    Duplicated code fragment (30)
