### PR TITLE
Issue #6916: migrate tests to junit5 for checks package

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -265,6 +265,8 @@
     <module name="DesignForExtension">
       <property name="ignoredAnnotations"
                 value="Override, Test, Before, After, BeforeClass, AfterClass"/>
+      <property name="ignoredAnnotations"
+                value="BeforeAll, AfterAll, BeforeEach, AfterEach"/>
     </module>
     <module name="FinalClass"/>
     <module name="HideUtilityClassConstructor"/>
@@ -275,7 +277,10 @@
     <module name="ThrowsCount">
       <property name="max" value="2"/>
     </module>
-    <module name="VisibilityModifier"/>
+    <module name="VisibilityModifier">
+      <property name="ignoreAnnotationCanonicalNames"
+                value="org.junit.Rule, org.junit.jupiter.api.io.TempDir"/>
+    </module>
 
     <!-- Coding -->
     <module name="ArrayTrailingComma"/>

--- a/config/import-control-test.xml
+++ b/config/import-control-test.xml
@@ -20,7 +20,6 @@
 
   <!-- Till https://github.com/checkstyle/checkstyle/issues/6916 -->
   <subpackage name="checks">
-    <allow pkg="org.junit" local-only="true"/>
     <subpackage name="(blocks|coding|design|header|imports|indentation|javadoc)" regex="true">
       <allow pkg="org.junit"/>
     </subpackage>

--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -3647,6 +3647,7 @@
             <value>
                 <item value="org.junit.Rule"/>
                 <item value="org.junit.ClassRule"/>
+                <item value="org.junit.jupiter.api.io.TempDir"/>
             </value>
         </option>
     </inspection_tool>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheckTest.java
@@ -20,10 +20,10 @@
 package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.puppycrawl.tools.checkstyle.checks.ArrayTypeStyleCheck.MSG_KEY;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -41,8 +41,8 @@ public class ArrayTypeStyleCheckTest
     public void testGetRequiredTokens() {
         final ArrayTypeStyleCheck checkObj = new ArrayTypeStyleCheck();
         final int[] expected = {TokenTypes.ARRAY_DECLARATOR};
-        assertArrayEquals("Required tokens differs from expected",
-                expected, checkObj.getRequiredTokens());
+        assertArrayEquals(expected, checkObj.getRequiredTokens(),
+                "Required tokens differs from expected");
     }
 
     @Test
@@ -84,10 +84,8 @@ public class ArrayTypeStyleCheckTest
         final int[] expected = {TokenTypes.ARRAY_DECLARATOR };
         final ArrayTypeStyleCheck check = new ArrayTypeStyleCheck();
         final int[] actual = check.getAcceptableTokens();
-        assertEquals("Amount of acceptable tokens differs from expected",
-                1, actual.length);
-        assertArrayEquals("Acceptable tokens differs from expected",
-                expected, actual);
+        assertEquals(1, actual.length, "Amount of acceptable tokens differs from expected");
+        assertArrayEquals(expected, actual, "Acceptable tokens differs from expected");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
@@ -20,9 +20,9 @@
 package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck.MSG_KEY;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -31,7 +31,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
@@ -162,8 +162,8 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
             TokenTypes.STRING_LITERAL,
             TokenTypes.CHAR_LITERAL,
         };
-        assertArrayEquals("Required tokens differ from expected",
-                expected, checkObj.getRequiredTokens());
+        assertArrayEquals(expected, checkObj.getRequiredTokens(),
+                "Required tokens differ from expected");
     }
 
     @Test
@@ -340,8 +340,7 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
         final AvoidEscapedUnicodeCharactersCheck check = new AvoidEscapedUnicodeCharactersCheck();
         final int[] actual = check.getAcceptableTokens();
         final int[] expected = {TokenTypes.STRING_LITERAL, TokenTypes.CHAR_LITERAL };
-        assertArrayEquals("Acceptable tokens differ from expected",
-                expected, actual);
+        assertArrayEquals(expected, actual, "Acceptable tokens differ from expected");
     }
 
     @Test
@@ -379,7 +378,7 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
         final AvoidEscapedUnicodeCharactersCheck check = new AvoidEscapedUnicodeCharactersCheck();
         final int actual = (int) countMatches.invoke(check,
                 Pattern.compile("\\\\u[a-fA-F0-9]{4}"), "\\u1234");
-        assertEquals("Unexpected matches count", 1, actual);
+        assertEquals(1, actual, "Unexpected matches count");
     }
 
     /**
@@ -423,12 +422,12 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
             if (!matcher.matches()) {
                 final String message = "Character '" + currentChar + "' (at position " + i
                         + ") doesn't match the pattern";
-                assertTrue(message, matcher.matches());
+                assertTrue(matcher.matches(), message);
             }
             if (lastChar != null) {
                 final String message = "Character '" + lastChar + "' should be after '"
                         + currentChar + "', position: " + i;
-                assertTrue(message, lastChar.compareTo(currentChar) < 0);
+                assertTrue(lastChar.compareTo(currentChar) < 0, message);
             }
             lastChar = currentChar;
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheckTest.java
@@ -24,7 +24,7 @@ import static com.puppycrawl.tools.checkstyle.checks.DescendantTokenCheck.MSG_KE
 import static com.puppycrawl.tools.checkstyle.checks.DescendantTokenCheck.MSG_KEY_SUM_MAX;
 import static com.puppycrawl.tools.checkstyle.checks.DescendantTokenCheck.MSG_KEY_SUM_MIN;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheckTest.java
@@ -21,7 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.puppycrawl.tools.checkstyle.checks.FinalParametersCheck.MSG_KEY;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
@@ -21,8 +21,8 @@ package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck.MSG_KEY_NO_NEWLINE_EOF;
 import static com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck.MSG_KEY_UNABLE_OPEN;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -33,7 +33,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
@@ -146,11 +146,10 @@ public class NewlineAtEndOfFileCheckTest
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Error message is unexpected",
-                    "cannot initialize module com.puppycrawl.tools.checkstyle."
+            assertEquals("cannot initialize module com.puppycrawl.tools.checkstyle."
                             + "checks.NewlineAtEndOfFileCheck - "
                             + "Cannot set property 'lineSeparator' to 'ct'",
-                    ex.getMessage());
+                    ex.getMessage(), "Error message is unexpected");
         }
     }
 
@@ -202,11 +201,10 @@ public class NewlineAtEndOfFileCheckTest
         final File impossibleFile = new File("");
         final FileText fileText = new FileText(impossibleFile, lines);
         final Set<LocalizedMessage> messages = check.process(impossibleFile, fileText);
-        assertEquals("Amount of messages is unexpected",
-                1, messages.size());
+        assertEquals(1, messages.size(), "Amount of messages is unexpected");
         final Iterator<LocalizedMessage> iterator = messages.iterator();
-        assertEquals("Violation message differs from expected",
-                getCheckMessage(MSG_KEY_UNABLE_OPEN, ""), iterator.next().getMessage());
+        assertEquals(getCheckMessage(MSG_KEY_UNABLE_OPEN, ""), iterator.next().getMessage(),
+                "Violation message differs from expected");
     }
 
     @Test
@@ -217,8 +215,8 @@ public class NewlineAtEndOfFileCheckTest
             fail("Exception is expected");
         }
         catch (IOException ex) {
-            assertEquals("Error message is unexpected",
-                    "Unable to read 1 bytes, got 0", ex.getMessage());
+            assertEquals("Unable to read 1 bytes, got 0", ex.getMessage(),
+                    "Error message is unexpected");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheckTest.java
@@ -21,7 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck.MSG_IO_EXCEPTION_KEY;
 import static com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck.MSG_KEY;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,7 +31,7 @@ import java.nio.file.NoSuchFileException;
 import java.util.Collections;
 import java.util.SortedSet;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -131,16 +131,14 @@ public class OrderedPropertiesCheckTest extends AbstractModuleTestSupport {
         final FileText fileText = new FileText(file, Collections.emptyList());
         final SortedSet<LocalizedMessage> messages =
                 check.process(file, fileText);
-        assertEquals("Wrong messages count: " + messages.size(),
-                1, messages.size());
+        assertEquals(1, messages.size(), "Wrong messages count: " + messages.size());
         final LocalizedMessage message = messages.iterator().next();
         final String retrievedMessage = messages.iterator().next().getKey();
-        assertEquals("Message key '" + retrievedMessage
-                        + "' is not valid", "unable.open.cause",
-                retrievedMessage);
-        assertEquals("Message '" + message.getMessage()
-                        + "' is not valid", message.getMessage(),
-                getCheckMessage(MSG_IO_EXCEPTION_KEY, fileName, getFileNotFoundDetail(file)));
+        assertEquals("unable.open.cause", retrievedMessage,
+                "Message key '" + retrievedMessage + "' is not valid");
+        assertEquals(message.getMessage(),
+                getCheckMessage(MSG_IO_EXCEPTION_KEY, fileName, getFileNotFoundDetail(file)),
+                "Message '" + message.getMessage() + "' is not valid");
     }
 
     /**
@@ -165,15 +163,14 @@ public class OrderedPropertiesCheckTest extends AbstractModuleTestSupport {
         final FileText fileText = new FileText(file, Collections.emptyList());
         final SortedSet<LocalizedMessage> messages = check.process(file, fileText);
 
-        assertEquals("Wrong messages count: " + messages.size(),
-                1, messages.size());
+        assertEquals(1, messages.size(), "Wrong messages count: " + messages.size());
     }
 
     @Test
     public void testFileExtension() {
 
         final OrderedPropertiesCheck check = new OrderedPropertiesCheck();
-        assertEquals("File extension should be set", ".properties", check.getFileExtensions()[0]);
+        assertEquals(".properties", check.getFileExtensions()[0], "File extension should be set");
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheckTest.java
@@ -20,9 +20,9 @@
 package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck.MSG_KEY;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -45,8 +45,8 @@ public class OuterTypeFilenameCheckTest extends AbstractModuleTestSupport {
             TokenTypes.ENUM_DEF,
             TokenTypes.ANNOTATION_DEF,
         };
-        assertArrayEquals("Required tokens array differs from expected",
-                expected, checkObj.getRequiredTokens());
+        assertArrayEquals(expected, checkObj.getRequiredTokens(),
+                "Required tokens array differs from expected");
     }
 
     @Test
@@ -75,8 +75,7 @@ public class OuterTypeFilenameCheckTest extends AbstractModuleTestSupport {
             TokenTypes.ENUM_DEF,
             TokenTypes.ANNOTATION_DEF,
         };
-        assertArrayEquals("Acceptable tokens array differs from expected",
-                expected, actual);
+        assertArrayEquals(expected, actual, "Acceptable tokens array differs from expected");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -19,11 +19,11 @@
 
 package com.puppycrawl.tools.checkstyle.checks;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.lang.reflect.Constructor;
@@ -33,8 +33,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
@@ -62,7 +62,7 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
         return "com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder";
     }
 
-    @After
+    @AfterEach
     public void cleanUp() {
         // clear cache that may have been set by tests
 
@@ -77,10 +77,10 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
     public void testGet() {
         final SuppressWarningsHolder checkObj = new SuppressWarningsHolder();
         final int[] expected = {TokenTypes.ANNOTATION};
-        assertArrayEquals("Required token array differs from expected",
-                expected, checkObj.getRequiredTokens());
-        assertArrayEquals("Required token array differs from expected",
-                expected, checkObj.getAcceptableTokens());
+        assertArrayEquals(expected, checkObj.getRequiredTokens(),
+                "Required token array differs from expected");
+        assertArrayEquals(expected, checkObj.getAcceptableTokens(),
+                "Required token array differs from expected");
     }
 
     @Test
@@ -136,26 +136,25 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
 
     @Test
     public void testGetDefaultAlias() {
-        assertEquals("Default alias differs from expected",
-                "somename", SuppressWarningsHolder.getDefaultAlias("SomeName"));
-        assertEquals("Default alias differs from expected",
-                "somename", SuppressWarningsHolder.getDefaultAlias("SomeNameCheck"));
+        assertEquals("somename", SuppressWarningsHolder.getDefaultAlias("SomeName"),
+                "Default alias differs from expected");
+        assertEquals("somename", SuppressWarningsHolder.getDefaultAlias("SomeNameCheck"),
+                "Default alias differs from expected");
     }
 
     @Test
     public void testSetAliasListEmpty() {
         final SuppressWarningsHolder holder = new SuppressWarningsHolder();
         holder.setAliasList("");
-        assertEquals("Empty alias list should not be set", "",
-            SuppressWarningsHolder.getAlias(""));
+        assertEquals("", SuppressWarningsHolder.getAlias(""), "Empty alias list should not be set");
     }
 
     @Test
     public void testSetAliasListCorrect() {
         final SuppressWarningsHolder holder = new SuppressWarningsHolder();
         holder.setAliasList("alias=value");
-        assertEquals("Alias differs from expected",
-                "value", SuppressWarningsHolder.getAlias("alias"));
+        assertEquals("value", SuppressWarningsHolder.getAlias("alias"),
+                "Alias differs from expected");
     }
 
     @Test
@@ -167,8 +166,8 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
             fail("Exception expected");
         }
         catch (IllegalArgumentException ex) {
-            assertEquals("Error message is unexpected",
-                    "'=' expected in alias list item: =SomeAlias", ex.getMessage());
+            assertEquals("'=' expected in alias list item: =SomeAlias", ex.getMessage(),
+                    "Error message is unexpected");
         }
     }
 
@@ -177,7 +176,7 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
         populateHolder("MockEntry", 100, 100, 350, 350);
         final AuditEvent event = createAuditEvent("check", 100, 10);
 
-        assertFalse("Event is not suppressed", SuppressWarningsHolder.isSuppressed(event));
+        assertFalse(SuppressWarningsHolder.isSuppressed(event), "Event is not suppressed");
     }
 
     @Test
@@ -187,7 +186,7 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
         final AuditEvent event = createAuditEvent("id", 110, 10);
         holder.setAliasList(MemberNameCheck.class.getName() + "=check");
 
-        assertTrue("Event is not suppressed", SuppressWarningsHolder.isSuppressed(event));
+        assertTrue(SuppressWarningsHolder.isSuppressed(event), "Event is not suppressed");
     }
 
     @Test
@@ -195,7 +194,7 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
         populateHolder("check", 100, 100, 350, 350);
         final AuditEvent event = createAuditEvent("check", 350, 350);
 
-        assertTrue("Event is not suppressed", SuppressWarningsHolder.isSuppressed(event));
+        assertTrue(SuppressWarningsHolder.isSuppressed(event), "Event is not suppressed");
     }
 
     @Test
@@ -203,7 +202,7 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
         populateHolder("check", 100, 100, 350, 350);
         final AuditEvent event = createAuditEvent("check", 350, 352);
 
-        assertFalse("Event is not suppressed", SuppressWarningsHolder.isSuppressed(event));
+        assertFalse(SuppressWarningsHolder.isSuppressed(event), "Event is not suppressed");
     }
 
     @Test
@@ -211,7 +210,7 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
         populateHolder("check", 100, 100, 350, 350);
         final AuditEvent event = createAuditEvent("check", 400, 10);
 
-        assertFalse("Event is not suppressed", SuppressWarningsHolder.isSuppressed(event));
+        assertFalse(SuppressWarningsHolder.isSuppressed(event), "Event is not suppressed");
     }
 
     @Test
@@ -219,7 +218,7 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
         populateHolder("check", 100, 100, 350, 350);
         final AuditEvent event = createAuditEvent("check", 100, 100);
 
-        assertTrue("Event is not suppressed", SuppressWarningsHolder.isSuppressed(event));
+        assertTrue(SuppressWarningsHolder.isSuppressed(event), "Event is not suppressed");
     }
 
     @Test
@@ -231,22 +230,21 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
             new LocalizedMessage(100, 10, null, null, null, "id", MemberNameCheck.class, "msg");
         final AuditEvent firstEventForTest =
             new AuditEvent(source, "fileName", firstMessageForTest);
-        assertFalse("Event is suppressed",
-                SuppressWarningsHolder.isSuppressed(firstEventForTest));
+        assertFalse(SuppressWarningsHolder.isSuppressed(firstEventForTest), "Event is suppressed");
 
         final LocalizedMessage secondMessageForTest =
             new LocalizedMessage(100, 150, null, null, null, "id", MemberNameCheck.class, "msg");
         final AuditEvent secondEventForTest =
             new AuditEvent(source, "fileName", secondMessageForTest);
-        assertTrue("Event is not suppressed",
-                SuppressWarningsHolder.isSuppressed(secondEventForTest));
+        assertTrue(SuppressWarningsHolder.isSuppressed(secondEventForTest),
+                "Event is not suppressed");
 
         final LocalizedMessage thirdMessageForTest =
             new LocalizedMessage(200, 1, null, null, null, "id", MemberNameCheck.class, "msg");
         final AuditEvent thirdEventForTest =
             new AuditEvent(source, "fileName", thirdMessageForTest);
-        assertTrue("Event is not suppressed",
-                SuppressWarningsHolder.isSuppressed(thirdEventForTest));
+        assertTrue(SuppressWarningsHolder.isSuppressed(thirdEventForTest),
+                "Event is not suppressed");
     }
 
     @Test
@@ -294,10 +292,10 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
             fail("Exception expected");
         }
         catch (InvocationTargetException ex) {
-            assertTrue("Error type is unexpected",
-                    ex.getCause() instanceof IllegalArgumentException);
-            assertEquals("Error message is unexpected",
-                    "Unexpected AST: Method Def[0x0]", ex.getCause().getMessage());
+            assertTrue(ex.getCause() instanceof IllegalArgumentException,
+                    "Error type is unexpected");
+            assertEquals("Unexpected AST: Method Def[0x0]", ex.getCause().getMessage(),
+                    "Error message is unexpected");
         }
     }
 
@@ -319,11 +317,10 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
             fail("Exception expected");
         }
         catch (InvocationTargetException ex) {
-            assertTrue("Error type is unexpected",
-                    ex.getCause() instanceof IllegalArgumentException);
-            assertEquals("Error message is unexpected",
-                    "Expression or annotation array"
-                    + " initializer AST expected: Method Def[0x0]", ex.getCause().getMessage());
+            assertTrue(ex.getCause() instanceof IllegalArgumentException,
+                    "Error type is unexpected");
+            assertEquals("Expression or annotation array initializer AST expected: Method Def[0x0]",
+                    ex.getCause().getMessage(), "Error message is unexpected");
         }
     }
 
@@ -350,10 +347,10 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
             fail("Exception expected");
         }
         catch (InvocationTargetException ex) {
-            assertTrue("Error type is unexpected",
-                    ex.getCause() instanceof IllegalArgumentException);
-            assertEquals("Error message is unexpected",
-                    "Unexpected container AST: Parent ast[0x0]", ex.getCause().getMessage());
+            assertTrue(ex.getCause() instanceof IllegalArgumentException,
+                    "Error type is unexpected");
+            assertEquals("Unexpected container AST: Parent ast[0x0]", ex.getCause().getMessage(),
+                    "Error message is unexpected");
         }
     }
 
@@ -368,8 +365,8 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
             fail("Exception expected");
         }
         catch (IllegalArgumentException ex) {
-            assertEquals("Error message is unexpected",
-                    "Identifier AST expected, but get null.", ex.getMessage());
+            assertEquals("Identifier AST expected, but get null.", ex.getMessage(),
+                    "Error message is unexpected");
         }
     }
 
@@ -393,11 +390,12 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
                     JavaParser.Options.WITHOUT_COMMENTS),
             ast -> ast.getType() == TokenTypes.ANNOTATION);
 
-        assertTrue("Ast should contain ANNOTATION", annotationDef.isPresent());
-        assertTrue("State is not cleared on beginTree",
+        assertTrue(annotationDef.isPresent(), "Ast should contain ANNOTATION");
+        assertTrue(
             TestUtil.isStatefulFieldClearedDuringBeginTree(check, annotationDef.get(),
                 "ENTRIES",
-                entries -> ((ThreadLocal<List<Object>>) entries).get().isEmpty()));
+                entries -> ((ThreadLocal<List<Object>>) entries).get().isEmpty()),
+                "State is not cleared on beginTree");
     }
 
     private static void populateHolder(String checkName, int firstLine,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheckTest.java
@@ -20,10 +20,10 @@
 package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck.MSG_KEY;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -41,8 +41,8 @@ public class TodoCommentCheckTest
     public void testGetRequiredTokens() {
         final TodoCommentCheck checkObj = new TodoCommentCheck();
         final int[] expected = {TokenTypes.COMMENT_CONTENT};
-        assertArrayEquals("Required tokens differs from expected",
-                expected, checkObj.getRequiredTokens());
+        assertArrayEquals(expected, checkObj.getRequiredTokens(),
+                "Required tokens differs from expected");
     }
 
     @Test
@@ -64,10 +64,8 @@ public class TodoCommentCheckTest
         final int[] expected = {TokenTypes.COMMENT_CONTENT };
         final TodoCommentCheck check = new TodoCommentCheck();
         final int[] actual = check.getAcceptableTokens();
-        assertEquals("Amount of acceptable tokens differs from expected",
-                1, actual.length);
-        assertArrayEquals("Acceptable tokens differs from expected",
-                expected, actual);
+        assertEquals(1, actual.length, "Amount of acceptable tokens differs from expected");
+        assertArrayEquals(expected, actual, "Acceptable tokens differs from expected");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckTest.java
@@ -20,11 +20,11 @@
 package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck.MSG_KEY;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -41,15 +41,15 @@ public class TrailingCommentCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testGetRequiredTokens() {
         final TrailingCommentCheck checkObj = new TrailingCommentCheck();
-        assertArrayEquals("Required tokens array is not empty",
-                CommonUtil.EMPTY_INT_ARRAY, checkObj.getRequiredTokens());
+        assertArrayEquals(CommonUtil.EMPTY_INT_ARRAY, checkObj.getRequiredTokens(),
+                "Required tokens array is not empty");
     }
 
     @Test
     public void testGetAcceptableTokens() {
         final TrailingCommentCheck checkObj = new TrailingCommentCheck();
-        assertArrayEquals("Acceptable tokens array is not empty",
-                CommonUtil.EMPTY_INT_ARRAY, checkObj.getAcceptableTokens());
+        assertArrayEquals(CommonUtil.EMPTY_INT_ARRAY, checkObj.getAcceptableTokens(),
+                "Acceptable tokens array is not empty");
     }
 
     @Test
@@ -111,11 +111,11 @@ public class TrailingCommentCheckTest extends AbstractModuleTestSupport {
         final TrailingCommentCheck check = new TrailingCommentCheck();
         try {
             check.visitToken(new DetailAstImpl());
-            Assert.fail("IllegalStateException is expected");
+            fail("IllegalStateException is expected");
         }
         catch (IllegalStateException ex) {
-            assertEquals("Error message is unexpected",
-                    "visitToken() shouldn't be called.", ex.getMessage());
+            assertEquals("visitToken() shouldn't be called.", ex.getMessage(),
+                    "Error message is unexpected");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
@@ -23,10 +23,10 @@ import static com.puppycrawl.tools.checkstyle.checks.TranslationCheck.MSG_KEY;
 import static com.puppycrawl.tools.checkstyle.checks.TranslationCheck.MSG_KEY_MISSING_TRANSLATION_FILE;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.endsWith;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -41,9 +41,8 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.powermock.reflect.Whitebox;
 
 import com.google.common.collect.ImmutableMap;
@@ -62,8 +61,8 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class TranslationCheckTest extends AbstractXmlTestSupport {
 
-    @Rule
-    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    public File temporaryFolder;
 
     @Override
     protected String getPackageLocation() {
@@ -108,7 +107,7 @@ public class TranslationCheckTest extends AbstractXmlTestSupport {
 
     @Test
     public void testDifferentPaths() throws Exception {
-        final File file = temporaryFolder.newFile("messages_test_de.properties");
+        final File file = new File(temporaryFolder, "messages_test_de.properties");
         try (Writer writer = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8)) {
             final String content = "hello=Hello\ncancel=Cancel";
             writer.write(content);
@@ -151,8 +150,8 @@ public class TranslationCheckTest extends AbstractXmlTestSupport {
         final Field field = check.getClass().getDeclaredField("filesToProcess");
         field.setAccessible(true);
 
-        assertTrue("Stateful field is not cleared on beginProcessing",
-            ((Collection<File>) field.get(check)).isEmpty());
+        assertTrue(((Collection<File>) field.get(check)).isEmpty(),
+                "Stateful field is not cleared on beginProcessing");
     }
 
     @Test
@@ -238,14 +237,14 @@ public class TranslationCheckTest extends AbstractXmlTestSupport {
 
         final Set<String> keys = Whitebox.invokeMethod(check, "getTranslationKeys",
                 new File(".no.such.file"));
-        assertTrue("Translation keys should be empty when File is not found", keys.isEmpty());
+        assertTrue(keys.isEmpty(), "Translation keys should be empty when File is not found");
 
-        assertEquals("expected number of errors to fire", 1, dispatcher.savedErrors.size());
+        assertEquals(1, dispatcher.savedErrors.size(), "expected number of errors to fire");
         final LocalizedMessage localizedMessage = new LocalizedMessage(1,
                 Definitions.CHECKSTYLE_BUNDLE, "general.fileNotFound",
                 null, null, getClass(), null);
-        assertEquals("Invalid message", localizedMessage.getMessage(),
-                dispatcher.savedErrors.iterator().next().getMessage());
+        assertEquals(localizedMessage.getMessage(),
+                dispatcher.savedErrors.iterator().next().getMessage(), "Invalid message");
     }
 
     @Test
@@ -262,12 +261,12 @@ public class TranslationCheckTest extends AbstractXmlTestSupport {
         final Exception exception = new IOException("test exception");
         Whitebox.invokeMethod(check, "logException", exception, new File(""));
 
-        assertEquals("expected number of errors to fire", 1, dispatcher.savedErrors.size());
+        assertEquals(1, dispatcher.savedErrors.size(), "expected number of errors to fire");
         final LocalizedMessage localizedMessage = new LocalizedMessage(1,
                 Definitions.CHECKSTYLE_BUNDLE, "general.exception",
                 new String[] {exception.getMessage()}, null, getClass(), null);
-        assertEquals("Invalid message", localizedMessage.getMessage(),
-                dispatcher.savedErrors.iterator().next().getMessage());
+        assertEquals(localizedMessage.getMessage(),
+                dispatcher.savedErrors.iterator().next().getMessage(), "Invalid message");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheckTest.java
@@ -20,10 +20,12 @@
 package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.puppycrawl.tools.checkstyle.checks.UncommentedMainCheck.MSG_KEY;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import antlr.CommonHiddenStreamToken;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
@@ -71,12 +73,12 @@ public class UncommentedMainCheckTest
     @Test
     public void testTokens() {
         final UncommentedMainCheck check = new UncommentedMainCheck();
-        Assert.assertNotNull("Required tokens should not be null", check.getRequiredTokens());
-        Assert.assertNotNull("Acceptable tokens should not be null", check.getAcceptableTokens());
-        Assert.assertArrayEquals("Invalid default tokens", check.getDefaultTokens(),
-                check.getAcceptableTokens());
-        Assert.assertArrayEquals("Invalid acceptable tokens", check.getDefaultTokens(),
-                check.getRequiredTokens());
+        assertNotNull(check.getRequiredTokens(), "Required tokens should not be null");
+        assertNotNull(check.getAcceptableTokens(), "Acceptable tokens should not be null");
+        assertArrayEquals(check.getDefaultTokens(),
+                check.getAcceptableTokens(), "Invalid default tokens");
+        assertArrayEquals(check.getDefaultTokens(),
+                check.getRequiredTokens(), "Invalid acceptable tokens");
     }
 
     @Test
@@ -117,11 +119,10 @@ public class UncommentedMainCheckTest
         ast.initialize(new CommonHiddenStreamToken(TokenTypes.CTOR_DEF, "ctor"));
         try {
             check.visitToken(ast);
-            Assert.fail("IllegalStateException is expected");
+            fail("IllegalStateException is expected");
         }
         catch (IllegalStateException ex) {
-            assertEquals("Error message is unexpected",
-                    ast.toString(), ex.getMessage());
+            assertEquals(ast.toString(), ex.getMessage(), "Error message is unexpected");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
@@ -21,7 +21,8 @@ package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.puppycrawl.tools.checkstyle.checks.UniquePropertiesCheck.MSG_IO_EXCEPTION_KEY;
 import static com.puppycrawl.tools.checkstyle.checks.UniquePropertiesCheck.MSG_KEY;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,8 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -60,7 +60,7 @@ public class UniquePropertiesCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testLineSeparatorOptionValueOf() {
         final LineSeparatorOption option = LineSeparatorOption.valueOf("CR");
-        assertEquals("Invalid valueOf result", LineSeparatorOption.CR, option);
+        assertEquals(LineSeparatorOption.CR, option, "Invalid valueOf result");
     }
 
     /**
@@ -90,7 +90,7 @@ public class UniquePropertiesCheckTest extends AbstractModuleTestSupport {
         final List<String> testStrings = new ArrayList<>(3);
         final Method getLineNumber = UniquePropertiesCheck.class.getDeclaredMethod(
             "getLineNumber", FileText.class, String.class);
-        Assert.assertNotNull("Get line number method should be present", getLineNumber);
+        assertNotNull(getLineNumber, "Get line number method should be present");
         getLineNumber.setAccessible(true);
         testStrings.add("");
         testStrings.add("0 = 0");
@@ -98,8 +98,8 @@ public class UniquePropertiesCheckTest extends AbstractModuleTestSupport {
         final FileText fileText = new FileText(new File("some.properties"), testStrings);
         final Object lineNumber = getLineNumber.invoke(UniquePropertiesCheck.class,
                 fileText, "some key");
-        Assert.assertNotNull("Line number should not be null", lineNumber);
-        assertEquals("Invalid line number", 1, lineNumber);
+        assertNotNull(lineNumber, "Line number should not be null");
+        assertEquals(1, lineNumber, "Invalid line number");
     }
 
     @Test
@@ -132,16 +132,14 @@ public class UniquePropertiesCheckTest extends AbstractModuleTestSupport {
         final FileText fileText = new FileText(file, Collections.emptyList());
         final SortedSet<LocalizedMessage> messages =
                 check.process(file, fileText);
-        assertEquals("Wrong messages count: " + messages.size(),
-                1, messages.size());
+        assertEquals(1, messages.size(), "Wrong messages count: " + messages.size());
         final LocalizedMessage message = messages.iterator().next();
         final String retrievedMessage = messages.iterator().next().getKey();
-        assertEquals("Message key '" + retrievedMessage
-                        + "' is not valid", "unable.open.cause",
-                retrievedMessage);
-        assertEquals("Message '" + message.getMessage()
-                        + "' is not valid", message.getMessage(),
-                getCheckMessage(MSG_IO_EXCEPTION_KEY, fileName, getFileNotFoundDetail(file)));
+        assertEquals("unable.open.cause", retrievedMessage,
+                "Message key '" + retrievedMessage + "' is not valid");
+        assertEquals(message.getMessage(),
+                getCheckMessage(MSG_IO_EXCEPTION_KEY, fileName, getFileNotFoundDetail(file)),
+                "Message '" + message.getMessage() + "' is not valid");
     }
 
     @Test
@@ -157,11 +155,11 @@ public class UniquePropertiesCheckTest extends AbstractModuleTestSupport {
         final Object result = method.invoke(uniqueProperties, 1, "value");
         final Map<Object, Object> table = new HashMap<>();
         final Object expected = table.put(1, "value");
-        assertEquals("Invalid result of put method", expected, result);
+        assertEquals(expected, result, "Invalid result of put method");
 
         final Object result2 = method.invoke(uniqueProperties, 1, "value");
         final Object expected2 = table.put(1, "value");
-        assertEquals("Value should be substituted", expected2, result2);
+        assertEquals(expected2, result2, "Value should be substituted");
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UpperEllCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UpperEllCheckTest.java
@@ -20,10 +20,10 @@
 package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.puppycrawl.tools.checkstyle.checks.UpperEllCheck.MSG_KEY;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -41,8 +41,8 @@ public class UpperEllCheckTest
     public void testGetRequiredTokens() {
         final UpperEllCheck checkObj = new UpperEllCheck();
         final int[] expected = {TokenTypes.NUM_LONG};
-        assertArrayEquals("Default required tokens are invalid",
-            expected, checkObj.getRequiredTokens());
+        assertArrayEquals(expected, checkObj.getRequiredTokens(),
+                "Default required tokens are invalid");
     }
 
     @Test
@@ -61,8 +61,8 @@ public class UpperEllCheckTest
         final int[] expected = {TokenTypes.NUM_LONG };
         final UpperEllCheck check = new UpperEllCheck();
         final int[] actual = check.getAcceptableTokens();
-        assertEquals("Invalid size of tokens", 1, actual.length);
-        assertArrayEquals("Default acceptable tokens are invalid", expected, actual);
+        assertEquals(1, actual.length, "Invalid size of tokens");
+        assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
     }
 
 }


### PR DESCRIPTION
Issue #6916

Tests of the `checks` (misc) package are migrated to Junit5.

Changes in the config:
Junit5 annotations `BeforeAll, AfterAll, BeforeEach, AfterEach` added to `DesignForExtension`;
annotation `TempDir` to `VisibilityModifier`.
