### PR TITLE
minor: remove obsolete jacoco suppression

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -823,10 +823,6 @@
                 </exclude>
                 <!-- Swing related classes -->
                 <exclude>com/puppycrawl/tools/checkstyle/gui/*.class</exclude>
-                <!-- Suppressed till https://github.com/jacoco/jacoco/issues/660 -->
-                <exclude>
-                  com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck$1.class
-                </exclude>
               </excludes>
             </configuration>
           </execution>


### PR DESCRIPTION
Issue https://github.com/jacoco/jacoco/issues/660 is resolved.

Local run of
`mvn clean test jacoco:restore-instrumented-classes  jacoco:report@default-report jacoco:check@default-check`
shows 100% coverage on my PC.