### PR TITLE
Issue #6916: migrate tests to junit5 for modifier package

### DIFF
--- a/config/import-control-test.xml
+++ b/config/import-control-test.xml
@@ -23,7 +23,7 @@
     <subpackage name="(blocks|coding|design|header|imports|indentation|javadoc)" regex="true">
       <allow pkg="org.junit"/>
     </subpackage>
-    <subpackage name="(modifier|naming|regexp|sizes|whitespace)" regex="true">
+    <subpackage name="(naming|regexp|sizes|whitespace)" regex="true">
       <allow pkg="org.junit"/>
     </subpackage>
   </subpackage>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheckTest.java
@@ -20,11 +20,11 @@
 package com.puppycrawl.tools.checkstyle.checks.modifier;
 
 import static com.puppycrawl.tools.checkstyle.checks.modifier.InterfaceMemberImpliedModifierCheck.MSG_KEY;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -64,7 +64,7 @@ public class ClassMemberImpliedModifierCheckTest
             TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,
         };
-        assertArrayEquals("Required tokens are invalid", expected, actual);
+        assertArrayEquals(expected, actual, "Required tokens are invalid");
     }
 
     @Test
@@ -136,10 +136,10 @@ public class ClassMemberImpliedModifierCheckTest
             new ClassMemberImpliedModifierCheck();
         try {
             check.visitToken(init);
-            Assert.fail("IllegalStateException is expected");
+            fail("IllegalStateException is expected");
         }
         catch (IllegalStateException ex) {
-            assertEquals("Error message is unexpected", init.toString(), ex.getMessage());
+            assertEquals(init.toString(), ex.getMessage(), "Error message is unexpected");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheckTest.java
@@ -20,11 +20,11 @@
 package com.puppycrawl.tools.checkstyle.checks.modifier;
 
 import static com.puppycrawl.tools.checkstyle.checks.modifier.InterfaceMemberImpliedModifierCheck.MSG_KEY;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -67,7 +67,7 @@ public class InterfaceMemberImpliedModifierCheckTest
             TokenTypes.CLASS_DEF,
             TokenTypes.ENUM_DEF,
         };
-        assertArrayEquals("Required tokens are invalid", expected, actual);
+        assertArrayEquals(expected, actual, "Required tokens are invalid");
     }
 
     @Test
@@ -418,10 +418,10 @@ public class InterfaceMemberImpliedModifierCheckTest
             new InterfaceMemberImpliedModifierCheck();
         try {
             check.visitToken(init);
-            Assert.fail("IllegalStateException is expected");
+            fail("IllegalStateException is expected");
         }
         catch (IllegalStateException ex) {
-            assertEquals("Error message is unexpected", init.toString(), ex.getMessage());
+            assertEquals(init.toString(), ex.getMessage(), "Error message is unexpected");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckTest.java
@@ -21,10 +21,11 @@ package com.puppycrawl.tools.checkstyle.checks.modifier;
 
 import static com.puppycrawl.tools.checkstyle.checks.modifier.ModifierOrderCheck.MSG_ANNOTATION_ORDER;
 import static com.puppycrawl.tools.checkstyle.checks.modifier.ModifierOrderCheck.MSG_MODIFIER_ORDER;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -43,8 +44,8 @@ public class ModifierOrderCheckTest
     public void testGetRequiredTokens() {
         final ModifierOrderCheck checkObj = new ModifierOrderCheck();
         final int[] expected = {TokenTypes.MODIFIERS};
-        assertArrayEquals("Default required tokens are invalid",
-            expected, checkObj.getRequiredTokens());
+        assertArrayEquals(expected, checkObj.getRequiredTokens(),
+                "Default required tokens are invalid");
     }
 
     @Test
@@ -81,12 +82,11 @@ public class ModifierOrderCheckTest
             TokenTypes.MODIFIERS,
             TokenTypes.OBJBLOCK,
         };
-        assertArrayEquals("Default tokens are invalid", expected, actual);
+        assertArrayEquals(expected, actual, "Default tokens are invalid");
         final int[] unexpectedEmptyArray = CommonUtil.EMPTY_INT_ARRAY;
-        Assert.assertNotSame("Default tokens should not be empty array",
-                unexpectedEmptyArray, actual);
-        Assert.assertNotSame("Invalid default tokens", unexpectedArray, actual);
-        Assert.assertNotNull("Default tokens should not be null", actual);
+        assertNotSame(unexpectedEmptyArray, actual, "Default tokens should not be empty array");
+        assertNotSame(unexpectedArray, actual, "Invalid default tokens");
+        assertNotNull(actual, "Default tokens should not be null");
     }
 
     @Test
@@ -98,12 +98,12 @@ public class ModifierOrderCheckTest
             TokenTypes.MODIFIERS,
             TokenTypes.OBJBLOCK,
         };
-        assertArrayEquals("Default acceptable tokens are invalid", expected, actual);
+        assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
         final int[] unexpectedEmptyArray = CommonUtil.EMPTY_INT_ARRAY;
-        Assert.assertNotSame("Default tokens should not be empty array",
-                unexpectedEmptyArray, actual);
-        Assert.assertNotSame("Invalid acceptable tokens", unexpectedArray, actual);
-        Assert.assertNotNull("Acceptable tokens should not be null", actual);
+        assertNotSame(
+                unexpectedEmptyArray, actual, "Default tokens should not be empty array");
+        assertNotSame(unexpectedArray, actual, "Invalid acceptable tokens");
+        assertNotNull(actual, "Acceptable tokens should not be null");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheckTest.java
@@ -20,9 +20,9 @@
 package com.puppycrawl.tools.checkstyle.checks.modifier;
 
 import static com.puppycrawl.tools.checkstyle.checks.modifier.RedundantModifierCheck.MSG_KEY;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -160,7 +160,7 @@ public class RedundantModifierCheckTest
             TokenTypes.ENUM_DEF,
             TokenTypes.RESOURCE,
         };
-        Assert.assertArrayEquals("Invalid acceptable tokens", expected, actual);
+        assertArrayEquals(expected, actual, "Invalid acceptable tokens");
     }
 
     @Test
@@ -168,7 +168,7 @@ public class RedundantModifierCheckTest
         final RedundantModifierCheck redundantModifierCheckObj = new RedundantModifierCheck();
         final int[] actual = redundantModifierCheckObj.getRequiredTokens();
         final int[] expected = CommonUtil.EMPTY_INT_ARRAY;
-        Assert.assertArrayEquals("Invalid required tokens", expected, actual);
+        assertArrayEquals(expected, actual, "Invalid required tokens");
     }
 
     @Test


### PR DESCRIPTION
Issue #6916

Tests of the `modifier` package are migrated to Junit5.