### PR TITLE
Issue #6916: migrate tests to junit5 for regexp package

### DIFF
--- a/config/import-control-test.xml
+++ b/config/import-control-test.xml
@@ -23,7 +23,7 @@
     <subpackage name="(design|header|imports|indentation|javadoc)" regex="true">
       <allow pkg="org.junit"/>
     </subpackage>
-    <subpackage name="(regexp|sizes|whitespace)" regex="true">
+    <subpackage name="(sizes|whitespace)" regex="true">
       <allow pkg="org.junit"/>
     </subpackage>
   </subpackage>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheckTest.java
@@ -22,9 +22,9 @@ package com.puppycrawl.tools.checkstyle.checks.regexp;
 import static com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck.MSG_DUPLICATE_REGEXP;
 import static com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck.MSG_ILLEGAL_REGEXP;
 import static com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck.MSG_REQUIRED_REGEXP;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -40,17 +40,15 @@ public class RegexpCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testGetAcceptableTokens() {
         final RegexpCheck regexpCheck = new RegexpCheck();
-        assertArrayEquals(
-                "RegexpCheck#getAcceptableTokens should return empty array by default",
-                CommonUtil.EMPTY_INT_ARRAY, regexpCheck.getAcceptableTokens());
+        assertArrayEquals(CommonUtil.EMPTY_INT_ARRAY, regexpCheck.getAcceptableTokens(),
+                "RegexpCheck#getAcceptableTokens should return empty array by default");
     }
 
     @Test
     public void testGetRequiredTokens() {
         final RegexpCheck checkObj = new RegexpCheck();
-        assertArrayEquals(
-            "RegexpCheck#getRequiredTokens should return empty array by default",
-            CommonUtil.EMPTY_INT_ARRAY, checkObj.getRequiredTokens());
+        assertArrayEquals(CommonUtil.EMPTY_INT_ARRAY, checkObj.getRequiredTokens(),
+                "RegexpCheck#getRequiredTokens should return empty array by default");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckTest.java
@@ -23,15 +23,14 @@ import static com.puppycrawl.tools.checkstyle.checks.regexp.MultilineDetector.MS
 import static com.puppycrawl.tools.checkstyle.checks.regexp.MultilineDetector.MSG_REGEXP_EXCEEDED;
 import static com.puppycrawl.tools.checkstyle.checks.regexp.MultilineDetector.MSG_REGEXP_MINIMUM;
 import static com.puppycrawl.tools.checkstyle.checks.regexp.MultilineDetector.MSG_STACKOVERFLOW;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -41,8 +40,8 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class RegexpMultilineCheckTest extends AbstractModuleTestSupport {
 
-    @Rule
-    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    public File temporaryFolder;
 
     @Override
     protected String getPackageLocation() {
@@ -113,7 +112,7 @@ public class RegexpMultilineCheckTest extends AbstractModuleTestSupport {
             "3: " + getCheckMessage(MSG_REGEXP_EXCEEDED, "\\r"),
         };
 
-        final File file = temporaryFolder.newFile();
+        final File file = File.createTempFile("junit", null, temporaryFolder);
         Files.write(file.toPath(),
             "first line \r\n second line \n\r third line".getBytes(StandardCharsets.UTF_8));
 
@@ -129,7 +128,7 @@ public class RegexpMultilineCheckTest extends AbstractModuleTestSupport {
             "3: " + getCheckMessage(MSG_REGEXP_EXCEEDED, "\\r"),
         };
 
-        final File file = temporaryFolder.newFile();
+        final File file = File.createTempFile("junit", null, temporaryFolder);
         Files.write(file.toPath(),
                 "first line \r\n second line \n\r third line".getBytes(StandardCharsets.UTF_8));
 
@@ -151,14 +150,13 @@ public class RegexpMultilineCheckTest extends AbstractModuleTestSupport {
 
         final MultilineDetector detector =
                 new MultilineDetector(detectorOptions);
-        final File file = temporaryFolder.newFile();
+        final File file = File.createTempFile("junit", null, temporaryFolder);
         Files.write(file.toPath(),
                 "first line \r\n second line \n\r third line".getBytes(StandardCharsets.UTF_8));
 
         detector.processLines(new FileText(file, StandardCharsets.UTF_8.name()));
         detector.processLines(new FileText(file, StandardCharsets.UTF_8.name()));
-        Assert.assertEquals("Logged unexpected amount of issues",
-                2, reporter.getLogCount());
+        assertEquals(2, reporter.getLogCount(), "Logged unexpected amount of issues");
     }
 
     @Test
@@ -198,7 +196,7 @@ public class RegexpMultilineCheckTest extends AbstractModuleTestSupport {
             "1: " + getCheckMessage(MSG_STACKOVERFLOW),
         };
 
-        final File file = temporaryFolder.newFile();
+        final File file = File.createTempFile("junit", null, temporaryFolder);
         Files.write(file.toPath(), makeLargeXyString().toString().getBytes(StandardCharsets.UTF_8));
 
         verify(checkConfig, file.getPath(), expected);
@@ -213,7 +211,7 @@ public class RegexpMultilineCheckTest extends AbstractModuleTestSupport {
             "1: " + getCheckMessage(MSG_REGEXP_MINIMUM, "5", "\\r"),
         };
 
-        final File file = temporaryFolder.newFile();
+        final File file = File.createTempFile("junit", null, temporaryFolder);
         Files.write(file.toPath(), "".getBytes(StandardCharsets.UTF_8));
 
         verify(checkConfig, file.getPath(), expected);
@@ -229,7 +227,7 @@ public class RegexpMultilineCheckTest extends AbstractModuleTestSupport {
             "1: some message",
         };
 
-        final File file = temporaryFolder.newFile();
+        final File file = File.createTempFile("junit", null, temporaryFolder);
         Files.write(file.toPath(), "".getBytes(StandardCharsets.UTF_8));
 
         verify(checkConfig, file.getPath(), expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheckTest.java
@@ -21,14 +21,14 @@ package com.puppycrawl.tools.checkstyle.checks.regexp;
 
 import static com.puppycrawl.tools.checkstyle.checks.regexp.RegexpOnFilenameCheck.MSG_MATCH;
 import static com.puppycrawl.tools.checkstyle.checks.regexp.RegexpOnFilenameCheck.MSG_MISMATCH;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.util.Collections;
 import java.util.regex.Pattern;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -249,9 +249,8 @@ public class RegexpOnFilenameCheckTest extends AbstractModuleTestSupport {
             fail("CheckstyleException expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid exception message",
-                "unable to create canonical path names for " + file.getAbsolutePath(),
-                ex.getMessage());
+            assertEquals("unable to create canonical path names for " + file.getAbsolutePath(),
+                ex.getMessage(), "Invalid exception message");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheckTest.java
@@ -21,12 +21,12 @@ package com.puppycrawl.tools.checkstyle.checks.regexp;
 
 import static com.puppycrawl.tools.checkstyle.checks.regexp.SinglelineDetector.MSG_REGEXP_EXCEEDED;
 import static com.puppycrawl.tools.checkstyle.checks.regexp.SinglelineDetector.MSG_REGEXP_MINIMUM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -140,8 +140,7 @@ public class RegexpSinglelineCheckTest extends AbstractModuleTestSupport {
 
         detector.processLines(new FileText(file, StandardCharsets.UTF_8.name()));
         detector.processLines(new FileText(file, StandardCharsets.UTF_8.name()));
-        Assert.assertEquals("Logged unexpected amount of issues",
-                0, reporter.getLogCount());
+        assertEquals(0, reporter.getLogCount(), "Logged unexpected amount of issues");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheckTest.java
@@ -21,9 +21,9 @@ package com.puppycrawl.tools.checkstyle.checks.regexp;
 
 import static com.puppycrawl.tools.checkstyle.checks.regexp.MultilineDetector.MSG_REGEXP_EXCEEDED;
 import static com.puppycrawl.tools.checkstyle.checks.regexp.MultilineDetector.MSG_REGEXP_MINIMUM;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -40,15 +40,16 @@ public class RegexpSinglelineJavaCheckTest extends AbstractModuleTestSupport {
     public void testGetAcceptableTokens() {
         final RegexpSinglelineJavaCheck regexpSinglelineJavaCheck =
             new RegexpSinglelineJavaCheck();
-        assertArrayEquals("Default acceptable tokens are invalid",
-            CommonUtil.EMPTY_INT_ARRAY, regexpSinglelineJavaCheck.getAcceptableTokens());
+        assertArrayEquals(CommonUtil.EMPTY_INT_ARRAY,
+                regexpSinglelineJavaCheck.getAcceptableTokens(),
+                "Default acceptable tokens are invalid");
     }
 
     @Test
     public void testGetRequiredTokens() {
         final RegexpSinglelineJavaCheck checkObj = new RegexpSinglelineJavaCheck();
-        assertArrayEquals("Default required tokens are invalid",
-            CommonUtil.EMPTY_INT_ARRAY, checkObj.getRequiredTokens());
+        assertArrayEquals(CommonUtil.EMPTY_INT_ARRAY, checkObj.getRequiredTokens(),
+                "Default required tokens are invalid");
     }
 
     @Test


### PR DESCRIPTION
Issue #6916

Tests of the `regexp` package are migrated to Junit5.