### PR TITLE
Issue #6916: migrate tests to junit5 for packages filefilters, filters

### DIFF
--- a/config/import-control-test.xml
+++ b/config/import-control-test.xml
@@ -27,7 +27,7 @@
       <allow pkg="org.junit"/>
     </subpackage>
   </subpackage>
-  <subpackage name="(filefilters|filters|grammar|gui|internal|utils|xpath)" regex="true">
+  <subpackage name="(grammar|gui|internal|utils|xpath)" regex="true">
     <allow pkg="org.junit"/>
   </subpackage>
   <file name=".*Test(Support)?" regex="true">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filefilters/BeforeExecutionExclusionFileFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filefilters/BeforeExecutionExclusionFileFilterTest.java
@@ -19,12 +19,12 @@
 
 package com.puppycrawl.tools.checkstyle.filefilters;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.regex.Pattern;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -45,7 +45,7 @@ public class BeforeExecutionExclusionFileFilterTest extends AbstractModuleTestSu
         final BeforeExecutionExclusionFileFilter filter =
                 createExclusionBeforeExecutionFileFilter(fileName);
 
-        assertTrue("Should accept if file does not exist", filter.accept("ATest.java"));
+        assertTrue(filter.accept("ATest.java"), "Should accept if file does not exist");
     }
 
     @Test
@@ -54,7 +54,7 @@ public class BeforeExecutionExclusionFileFilterTest extends AbstractModuleTestSu
         final BeforeExecutionExclusionFileFilter filter =
                 createExclusionBeforeExecutionFileFilter(fileName);
 
-        assertTrue("Should accept if file is null", filter.accept("AnyJava.java"));
+        assertTrue(filter.accept("AnyJava.java"), "Should accept if file is null");
     }
 
     @Test
@@ -63,7 +63,7 @@ public class BeforeExecutionExclusionFileFilterTest extends AbstractModuleTestSu
         final BeforeExecutionExclusionFileFilter filter =
                 createExclusionBeforeExecutionFileFilter(fileName);
 
-        assertFalse("Should reject file, but did not", filter.accept("ATest.java"));
+        assertFalse(filter.accept("ATest.java"), "Should reject file, but did not");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/CsvFilterElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/CsvFilterElementTest.java
@@ -19,11 +19,11 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.EqualsVerifierReport;
@@ -33,62 +33,62 @@ public class CsvFilterElementTest {
     @Test
     public void testDecideSingle() {
         final IntFilterElement filter = new CsvFilterElement("0");
-        assertFalse("less than", filter.accept(-1));
-        assertTrue("equal", filter.accept(0));
-        assertFalse("greater than", filter.accept(1));
+        assertFalse(filter.accept(-1), "less than");
+        assertTrue(filter.accept(0), "equal");
+        assertFalse(filter.accept(1), "greater than");
     }
 
     @Test
     public void testDecidePair() {
         final IntFilterElement filter = new CsvFilterElement("0, 2");
-        assertFalse("less than", filter.accept(-1));
-        assertTrue("equal 0", filter.accept(0));
-        assertFalse("greater than", filter.accept(1));
-        assertTrue("equal 2", filter.accept(2));
+        assertFalse(filter.accept(-1), "less than");
+        assertTrue(filter.accept(0), "equal 0");
+        assertFalse(filter.accept(1), "greater than");
+        assertTrue(filter.accept(2), "equal 2");
     }
 
     @Test
     public void testDecideRange() {
         final IntFilterElement filter = new CsvFilterElement("0-2");
-        assertFalse("less than", filter.accept(-1));
-        assertTrue("equal 0", filter.accept(0));
-        assertTrue("equal 1", filter.accept(1));
-        assertTrue("equal 2", filter.accept(2));
-        assertFalse("greater than", filter.accept(3));
+        assertFalse(filter.accept(-1), "less than");
+        assertTrue(filter.accept(0), "equal 0");
+        assertTrue(filter.accept(1), "equal 1");
+        assertTrue(filter.accept(2), "equal 2");
+        assertFalse(filter.accept(3), "greater than");
     }
 
     @Test
     public void testDecideEmptyRange() {
         final IntFilterElement filter = new CsvFilterElement("2-0");
-        assertFalse("less than", filter.accept(-1));
-        assertFalse("equal 0", filter.accept(0));
-        assertFalse("equal 1", filter.accept(1));
-        assertFalse("equal 2", filter.accept(2));
-        assertFalse("greater than", filter.accept(3));
+        assertFalse(filter.accept(-1), "less than");
+        assertFalse(filter.accept(0), "equal 0");
+        assertFalse(filter.accept(1), "equal 1");
+        assertFalse(filter.accept(2), "equal 2");
+        assertFalse(filter.accept(3), "greater than");
     }
 
     @Test
     public void testDecideRangePlusValue() {
         final IntFilterElement filter = new CsvFilterElement("0-2, 10");
-        assertFalse("less than", filter.accept(-1));
-        assertTrue("equal 0", filter.accept(0));
-        assertTrue("equal 1", filter.accept(1));
-        assertTrue("equal 2", filter.accept(2));
-        assertFalse("greater than", filter.accept(3));
-        assertTrue("equal 10", filter.accept(10));
+        assertFalse(filter.accept(-1), "less than");
+        assertTrue(filter.accept(0), "equal 0");
+        assertTrue(filter.accept(1), "equal 1");
+        assertTrue(filter.accept(2), "equal 2");
+        assertFalse(filter.accept(3), "greater than");
+        assertTrue(filter.accept(10), "equal 10");
     }
 
     @Test
     public void testEmptyChain() {
         final CsvFilterElement filter = new CsvFilterElement("");
-        assertFalse("0", filter.accept(0));
+        assertFalse(filter.accept(0), "0");
     }
 
     @Test
     public void testEqualsAndHashCode() {
         final EqualsVerifierReport ev = EqualsVerifier.forClass(CsvFilterElement.class)
                 .usingGetClass().report();
-        assertEquals("Error: " + ev.getMessage(), EqualsVerifierReport.SUCCESS, ev);
+        assertEquals(EqualsVerifierReport.SUCCESS, ev, "Error: " + ev.getMessage());
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilterElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilterElementTest.java
@@ -19,11 +19,11 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.EqualsVerifierReport;
@@ -33,22 +33,22 @@ public class IntMatchFilterElementTest {
     @Test
     public void testDecide() {
         final IntFilterElement filter = new IntMatchFilterElement(0);
-        assertFalse("less than", filter.accept(-1));
-        assertTrue("equal", filter.accept(0));
-        assertFalse("greater than", filter.accept(1));
+        assertFalse(filter.accept(-1), "less than");
+        assertTrue(filter.accept(0), "equal");
+        assertFalse(filter.accept(1), "greater than");
     }
 
     @Test
     public void testEqualsAndHashCode() {
         final EqualsVerifierReport ev = EqualsVerifier.forClass(IntMatchFilterElement.class)
                 .report();
-        assertEquals("Error: " + ev.getMessage(), EqualsVerifierReport.SUCCESS, ev);
+        assertEquals(EqualsVerifierReport.SUCCESS, ev, "Error: " + ev.getMessage());
     }
 
     @Test
     public void testToString() {
         final IntFilterElement filter = new IntMatchFilterElement(6);
-        assertEquals("Invalid toString result", "IntMatchFilterElement[6]", filter.toString());
+        assertEquals("IntMatchFilterElement[6]", filter.toString(), "Invalid toString result");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilterElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilterElementTest.java
@@ -19,11 +19,11 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.EqualsVerifierReport;
@@ -33,36 +33,36 @@ public class IntRangeFilterElementTest {
     @Test
     public void testDecide() {
         final IntFilterElement filter = new IntRangeFilterElement(0, 10);
-        assertFalse("less than", filter.accept(-1));
-        assertTrue("in range", filter.accept(0));
-        assertTrue("in range", filter.accept(5));
-        assertTrue("in range", filter.accept(10));
-        assertFalse("greater than", filter.accept(11));
+        assertFalse(filter.accept(-1), "less than");
+        assertTrue(filter.accept(0), "in range");
+        assertTrue(filter.accept(5), "in range");
+        assertTrue(filter.accept(10), "in range");
+        assertFalse(filter.accept(11), "greater than");
     }
 
     @Test
     public void testDecideSingle() {
         final IntFilterElement filter = new IntRangeFilterElement(0, 0);
-        assertFalse("less than", filter.accept(-1));
-        assertTrue("in range", filter.accept(0));
-        assertFalse("greater than", filter.accept(1));
+        assertFalse(filter.accept(-1), "less than");
+        assertTrue(filter.accept(0), "in range");
+        assertFalse(filter.accept(1), "greater than");
     }
 
     @Test
     public void testDecideEmpty() {
         final IntFilterElement filter = new IntRangeFilterElement(10, 0);
-        assertFalse("out", filter.accept(-1));
-        assertFalse("out", filter.accept(0));
-        assertFalse("out", filter.accept(5));
-        assertFalse("out", filter.accept(10));
-        assertFalse("out", filter.accept(11));
+        assertFalse(filter.accept(-1), "out");
+        assertFalse(filter.accept(0), "out");
+        assertFalse(filter.accept(5), "out");
+        assertFalse(filter.accept(10), "out");
+        assertFalse(filter.accept(11), "out");
     }
 
     @Test
     public void testEqualsAndHashCode() {
         final EqualsVerifierReport ev = EqualsVerifier.forClass(IntRangeFilterElement.class)
                 .usingGetClass().report();
-        assertEquals("Error: " + ev.getMessage(), EqualsVerifierReport.SUCCESS, ev);
+        assertEquals(EqualsVerifierReport.SUCCESS, ev, "Error: " + ev.getMessage());
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilterTest.java
@@ -19,11 +19,11 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
@@ -38,18 +38,18 @@ public class SeverityMatchFilterTest {
     @Test
     public void testDefault() {
         final AuditEvent ev = new AuditEvent(this, "Test.java");
-        assertFalse("no message", filter.accept(ev));
+        assertFalse(filter.accept(ev), "no message");
         final SeverityLevel errorLevel = SeverityLevel.ERROR;
         final LocalizedMessage errorMessage =
             new LocalizedMessage(1, 0, "", "", null,
                 errorLevel, null, getClass(), null);
         final AuditEvent ev2 = new AuditEvent(this, "ATest.java", errorMessage);
-        assertTrue("level:" + errorLevel, filter.accept(ev2));
+        assertTrue(filter.accept(ev2), "level:" + errorLevel);
         final SeverityLevel infoLevel = SeverityLevel.INFO;
         final LocalizedMessage infoMessage =
                 new LocalizedMessage(1, 0, "", "", null, infoLevel, null, getClass(), null);
         final AuditEvent ev3 = new AuditEvent(this, "ATest.java", infoMessage);
-        assertFalse("level:" + infoLevel, filter.accept(ev3));
+        assertFalse(filter.accept(ev3), "level:" + infoLevel);
     }
 
     @Test
@@ -57,18 +57,18 @@ public class SeverityMatchFilterTest {
         filter.setSeverity(SeverityLevel.INFO);
         final AuditEvent ev = new AuditEvent(this, "Test.java");
         // event with no message has severity level INFO
-        assertTrue("no message", filter.accept(ev));
+        assertTrue(filter.accept(ev), "no message");
         final SeverityLevel errorLevel = SeverityLevel.ERROR;
         final LocalizedMessage errorMessage =
             new LocalizedMessage(1, 0, "", "", null,
                 errorLevel, null, getClass(), null);
         final AuditEvent ev2 = new AuditEvent(this, "ATest.java", errorMessage);
-        assertFalse("level:" + errorLevel, filter.accept(ev2));
+        assertFalse(filter.accept(ev2), "level:" + errorLevel);
         final SeverityLevel infoLevel = SeverityLevel.INFO;
         final LocalizedMessage infoMessage =
                 new LocalizedMessage(1, 0, "", "", null, infoLevel, null, getClass(), null);
         final AuditEvent ev3 = new AuditEvent(this, "ATest.java", infoMessage);
-        assertTrue("level:" + infoLevel, filter.accept(ev3));
+        assertTrue(filter.accept(ev3), "level:" + infoLevel);
     }
 
     @Test
@@ -77,24 +77,24 @@ public class SeverityMatchFilterTest {
         filter.setAcceptOnMatch(false);
         final AuditEvent ev = new AuditEvent(this, "Test.java");
         // event with no message has severity level INFO
-        assertFalse("no message", filter.accept(ev));
+        assertFalse(filter.accept(ev), "no message");
         final SeverityLevel errorLevel = SeverityLevel.ERROR;
         final LocalizedMessage errorMessage =
             new LocalizedMessage(1, 0, "", "", null,
                 errorLevel, null, getClass(), null);
         final AuditEvent ev2 = new AuditEvent(this, "ATest.java", errorMessage);
-        assertTrue("level:" + errorLevel, filter.accept(ev2));
+        assertTrue(filter.accept(ev2), "level:" + errorLevel);
         final SeverityLevel infoLevel = SeverityLevel.INFO;
         final LocalizedMessage infoMessage = new LocalizedMessage(1, 0, "", "", null, infoLevel,
             null, getClass(), null);
         final AuditEvent ev3 = new AuditEvent(this, "ATest.java", infoMessage);
-        assertFalse("level:" + infoLevel, filter.accept(ev3));
+        assertFalse(filter.accept(ev3), "level:" + infoLevel);
     }
 
     @Test
     public void testConfigure() throws CheckstyleException {
         filter.configure(new DefaultConfiguration("test"));
-        assertNotNull("object exists", filter);
+        assertNotNull(filter, "object exists");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElementTest.java
@@ -19,13 +19,13 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.TreeWalkerTest;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
@@ -38,7 +38,7 @@ public class SuppressFilterElementTest {
 
     private SuppressFilterElement filter;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         filter = new SuppressFilterElement("Test", "Test", null, null, null, null);
     }
@@ -46,7 +46,7 @@ public class SuppressFilterElementTest {
     @Test
     public void testDecideDefault() {
         final AuditEvent ev = new AuditEvent(this, "Test.java");
-        assertTrue(ev.getFileName(), filter.accept(ev));
+        assertTrue(filter.accept(ev), ev.getFileName());
     }
 
     @Test
@@ -55,7 +55,7 @@ public class SuppressFilterElementTest {
             new LocalizedMessage(1, 0, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
         //deny because there are matches on file and check names
-        assertFalse("Names match", filter.accept(ev));
+        assertFalse(filter.accept(ev), "Names match");
     }
 
     @Test
@@ -67,8 +67,8 @@ public class SuppressFilterElementTest {
                 new SuppressFilterElement(null, null, "Test", null, null, null);
         final SuppressFilterElement filter2 =
                 new SuppressFilterElement(null, null, "Bad", null, null, null);
-        assertFalse("Message match", filter1.accept(ev));
-        assertTrue("Message not match", filter2.accept(ev));
+        assertFalse(filter1.accept(ev), "Message match");
+        assertTrue(filter2.accept(ev), "Message not match");
     }
 
     @Test
@@ -83,9 +83,9 @@ public class SuppressFilterElementTest {
         final SuppressFilterElement filter3 =
                 new SuppressFilterElement("Test", "Test", null, null, null, null);
         //deny because there are matches on file name, check name, and line
-        assertFalse("In range 1-10", filter1.accept(ev));
-        assertTrue("Not in 1-9, 11", filter2.accept(ev));
-        assertFalse("none", filter3.accept(ev));
+        assertFalse(filter1.accept(ev), "In range 1-10");
+        assertTrue(filter2.accept(ev), "Not in 1-9, 11");
+        assertFalse(filter3.accept(ev), "none");
     }
 
     @Test
@@ -99,8 +99,8 @@ public class SuppressFilterElementTest {
                 new SuppressFilterElement("Test", "Test", null, null, null, "1-9, 11");
 
         //deny because there are matches on file name, check name, and column
-        assertFalse("In range 1-10", filter1.accept(ev));
-        assertTrue("Not in 1-9, 1)", filter2.accept(ev));
+        assertFalse(filter1.accept(ev), "In range 1-10");
+        assertTrue(filter2.accept(ev), "Not in 1-9, 1)");
     }
 
     @Test
@@ -108,13 +108,13 @@ public class SuppressFilterElementTest {
         final LocalizedMessage message =
                 new LocalizedMessage(10, 10, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, null, message);
-        assertTrue("Filter should accept valid event", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Filter should accept valid event");
     }
 
     @Test
     public void testDecideByFileNameAndModuleMatchingMessageNull() {
         final AuditEvent ev = new AuditEvent(this, "ATest.java", null);
-        assertTrue("Filter should accept valid event", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Filter should accept valid event");
     }
 
     @Test
@@ -122,7 +122,7 @@ public class SuppressFilterElementTest {
         final LocalizedMessage message =
                 new LocalizedMessage(10, 10, "", "", null, "MyModule", getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
-        assertFalse("Filter should not accept invalid event", filter.accept(ev));
+        assertFalse(filter.accept(ev), "Filter should not accept invalid event");
     }
 
     @Test
@@ -133,7 +133,7 @@ public class SuppressFilterElementTest {
         final SuppressFilterElement myFilter =
                 new SuppressFilterElement("Test", "Test", null, "MyModule", null, null);
 
-        assertFalse("Filter should not accept invalid event", myFilter.accept(ev));
+        assertFalse(myFilter.accept(ev), "Filter should not accept invalid event");
     }
 
     @Test
@@ -144,7 +144,7 @@ public class SuppressFilterElementTest {
         final SuppressFilterElement myFilter =
                 new SuppressFilterElement("Test", "Test", null, "MyModule", null, null);
 
-        assertTrue("Filter should accept valid event", myFilter.accept(ev));
+        assertTrue(myFilter.accept(ev), "Filter should accept valid event");
     }
 
     @Test
@@ -152,7 +152,7 @@ public class SuppressFilterElementTest {
         final LocalizedMessage message =
                 new LocalizedMessage(10, 10, "", "", null, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "T1est", message);
-        assertTrue("Filter should accept valid event", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Filter should accept valid event");
     }
 
     @Test
@@ -162,7 +162,7 @@ public class SuppressFilterElementTest {
         final AuditEvent ev = new AuditEvent(this, "TestSUFFIX", message);
         final SuppressFilterElement myFilter =
                 new SuppressFilterElement("Test", null, null, null, null, null);
-        assertFalse("Filter should not accept invalid event", myFilter.accept(ev));
+        assertFalse(myFilter.accept(ev), "Filter should not accept invalid event");
     }
 
     @Test
@@ -172,7 +172,7 @@ public class SuppressFilterElementTest {
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
         final SuppressFilterElement myFilter = new SuppressFilterElement("Test",
                 "NON_EXISTENT_CHECK", null, "MyModule", null, null);
-        assertTrue("Filter should accept valid event", myFilter.accept(ev));
+        assertTrue(myFilter.accept(ev), "Filter should accept valid event");
     }
 
     @Test
@@ -183,7 +183,7 @@ public class SuppressFilterElementTest {
         final SuppressFilterElement myFilter = new SuppressFilterElement("Test",
                 getClass().getCanonicalName(), null, null, null, null);
 
-        assertFalse("Filter should not accept invalid event", myFilter.accept(ev));
+        assertFalse(myFilter.accept(ev), "Filter should not accept invalid event");
     }
 
     @Test
@@ -195,7 +195,7 @@ public class SuppressFilterElementTest {
                 new SuppressFilterElement("Test", TreeWalkerTest.class.getCanonicalName(),
                         null, null, null, null);
 
-        assertTrue("Filter should not accept invalid event", myFilter.accept(ev));
+        assertTrue(myFilter.accept(ev), "Filter should not accept invalid event");
     }
 
     @Test
@@ -207,26 +207,26 @@ public class SuppressFilterElementTest {
 
         final SuppressFilterElement filter2 =
                 new SuppressFilterElement("Test", "Test", null, null, null, null);
-        assertEquals("filter, filter2", filterBased, filter2);
+        assertEquals(filterBased, filter2, "filter, filter2");
         final SuppressFilterElement filter3 =
                 new SuppressFilterElement("Test", "Test3", null, null, null, null);
-        assertNotEquals("filter, filter3", filterBased, filter3);
+        assertNotEquals(filterBased, filter3, "filter, filter3");
         final SuppressFilterElement filterBased1 =
                 new SuppressFilterElement("Test", "Test", null, null, null, "1-10");
 
-        assertNotEquals("filter, filter2", filterBased1, filter2);
+        assertNotEquals(filterBased1, filter2, "filter, filter2");
         final SuppressFilterElement filter22 =
                 new SuppressFilterElement("Test", "Test", null, null, null, "1-10");
-        assertEquals("filter, filter2", filterBased1, filter22);
-        assertNotEquals("filter, filter2", filterBased1, filter2);
+        assertEquals(filterBased1, filter22, "filter, filter2");
+        assertNotEquals(filterBased1, filter2, "filter, filter2");
         final SuppressFilterElement filterBased2 =
                 new SuppressFilterElement("Test", "Test", null, null, "3,4", null);
-        assertNotEquals("filter, filter2", filterBased2, filter2);
+        assertNotEquals(filterBased2, filter2, "filter, filter2");
         final SuppressFilterElement filter23 =
                 new SuppressFilterElement("Test", "Test", null, null, "3,4", null);
-        assertEquals("filter, filter2", filterBased2, filter23);
-        assertNotEquals("filter, filter2", filterBased2, filter2);
-        assertEquals("filter, filter2", filterBased2, filter23);
+        assertEquals(filterBased2, filter23, "filter, filter2");
+        assertNotEquals(filterBased2, filter2, "filter, filter2");
+        assertEquals(filterBased2, filter23, "filter, filter2");
     }
 
     @Test
@@ -237,7 +237,7 @@ public class SuppressFilterElementTest {
                         "lineFilter")
                 .suppress(Warning.NONFINAL_FIELDS)
                 .report();
-        assertEquals("Error: " + ev.getMessage(), EqualsVerifierReport.SUCCESS, ev);
+        assertEquals(EqualsVerifierReport.SUCCESS, ev, "Error: " + ev.getMessage());
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilterTest.java
@@ -26,7 +26,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -20,9 +20,9 @@
 package com.puppycrawl.tools.checkstyle.filters;
 
 import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.util.Arrays;
@@ -31,7 +31,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
@@ -307,7 +307,7 @@ public class SuppressWithNearbyCommentFilterTest
                 getTagsAfterExecution(filter, "filename", "//SUPPRESS CHECKSTYLE ignore").get(0);
         final EqualsVerifierReport ev = EqualsVerifier
                 .forClass(tag.getClass()).usingGetClass().report();
-        assertEquals("Error: " + ev.getMessage(), EqualsVerifierReport.SUCCESS, ev);
+        assertEquals(EqualsVerifierReport.SUCCESS, ev, "Error: " + ev.getMessage());
     }
 
     private void verifySuppressed(Configuration moduleConfig,
@@ -362,8 +362,9 @@ public class SuppressWithNearbyCommentFilterTest
         }
         catch (CheckstyleException ex) {
             final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();
-            assertEquals("Invalid exception message", "unable to parse influence"
-                + " from 'SUPPRESS CHECKSTYLE MemberNameCheck' using a", cause.getMessage());
+            assertEquals("unable to parse influence"
+                + " from 'SUPPRESS CHECKSTYLE MemberNameCheck' using a", cause.getMessage(),
+                    "Invalid exception message");
         }
     }
 
@@ -415,8 +416,8 @@ public class SuppressWithNearbyCommentFilterTest
         }
         catch (CheckstyleException ex) {
             final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();
-            assertEquals("Invalid exception message",
-                "unable to parse expanded comment a[l", cause.getMessage());
+            assertEquals("unable to parse expanded comment a[l", cause.getMessage(),
+                    "Invalid exception message");
         }
     }
 
@@ -428,7 +429,7 @@ public class SuppressWithNearbyCommentFilterTest
         contents.reportSingleLineComment(1, 0);
         final TreeWalkerAuditEvent auditEvent =
                 new TreeWalkerAuditEvent(contents, null, null, null);
-        assertTrue("Filter should accept null localized message", filter.accept(auditEvent));
+        assertTrue(filter.accept(auditEvent), "Filter should accept null localized message");
     }
 
     @Test
@@ -437,7 +438,7 @@ public class SuppressWithNearbyCommentFilterTest
         final FileContents contents = null;
         final TreeWalkerAuditEvent auditEvent = new TreeWalkerAuditEvent(contents, null,
                 new LocalizedMessage(1, null, null, null, null, Object.class, null), null);
-        assertTrue("Filter should accept audit event", filter.accept(auditEvent));
+        assertTrue(filter.accept(auditEvent), "Filter should accept audit event");
     }
 
     @Test
@@ -445,10 +446,10 @@ public class SuppressWithNearbyCommentFilterTest
         final SuppressWithNearbyCommentFilter filter = new SuppressWithNearbyCommentFilter();
         final Object tag =
                 getTagsAfterExecution(filter, "filename", "//SUPPRESS CHECKSTYLE ignore").get(0);
-        assertEquals("Invalid toString result",
-            "Tag[text='SUPPRESS CHECKSTYLE ignore', firstLine=1, lastLine=1, "
+        assertEquals(
+                "Tag[text='SUPPRESS CHECKSTYLE ignore', firstLine=1, lastLine=1, "
                     + "tagCheckRegexp=.*, tagMessageRegexp=null, tagIdRegexp=null]",
-                    tag.toString());
+                    tag.toString(), "Invalid toString result");
     }
 
     @Test
@@ -457,10 +458,10 @@ public class SuppressWithNearbyCommentFilterTest
         filter.setIdFormat(".*");
         final Object tag =
                 getTagsAfterExecution(filter, "filename", "//SUPPRESS CHECKSTYLE ignore").get(0);
-        assertEquals("Invalid toString result",
-            "Tag[text='SUPPRESS CHECKSTYLE ignore', firstLine=1, lastLine=1, "
+        assertEquals(
+                "Tag[text='SUPPRESS CHECKSTYLE ignore', firstLine=1, lastLine=1, "
                     + "tagCheckRegexp=.*, tagMessageRegexp=null, tagIdRegexp=.*]",
-                    tag.toString());
+                    tag.toString(), "Invalid toString result");
     }
 
     @Test
@@ -726,10 +727,10 @@ public class SuppressWithNearbyCommentFilterTest
                 new SuppressWithNearbyCommentFilter();
         final List<?> tags1 = getTagsAfterExecution(suppressionCommentFilter,
                 "filename1", "//SUPPRESS CHECKSTYLE ignore this");
-        assertEquals("Invalid tags size", 1, tags1.size());
+        assertEquals(1, tags1.size(), "Invalid tags size");
         final List<?> tags2 = getTagsAfterExecution(suppressionCommentFilter,
                 "filename2", "No comments in this file");
-        assertEquals("Invalid tags size", 0, tags2.size());
+        assertEquals(0, tags2.size(), "Invalid tags size");
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterTest.java
@@ -21,9 +21,10 @@ package com.puppycrawl.tools.checkstyle.filters;
 
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheck.MSG_CONTAINS_TAB;
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheck.MSG_FILE_CONTAINS_TAB;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -31,8 +32,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
@@ -251,8 +251,8 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
         }
         catch (CheckstyleException ex) {
             final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();
-            assertEquals("Invalid exception message",
-                "unable to parse expanded comment e[l", cause.getMessage());
+            assertEquals("unable to parse expanded comment e[l", cause.getMessage(),
+                    "Invalid exception message");
         }
     }
 
@@ -276,8 +276,8 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
         }
         catch (CheckstyleException ex) {
             final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();
-            assertEquals("Invalid exception message",
-                "unable to parse expanded comment e[l", cause.getMessage());
+            assertEquals("unable to parse expanded comment e[l", cause.getMessage(),
+                    "Invalid exception message");
         }
     }
 
@@ -310,8 +310,8 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
         }
         catch (CheckstyleException ex) {
             final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();
-            assertEquals("Invalid exception message",
-                "unable to parse expanded comment e[l", cause.getMessage());
+            assertEquals("unable to parse expanded comment e[l", cause.getMessage(),
+                    "Invalid exception message");
         }
     }
 
@@ -342,8 +342,8 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
         }
         catch (CheckstyleException ex) {
             final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();
-            assertEquals("Invalid exception message",
-                "unable to parse expanded comment e[l", cause.getMessage());
+            assertEquals("unable to parse expanded comment e[l", cause.getMessage(),
+                    "Invalid exception message");
         }
     }
 
@@ -351,8 +351,8 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
     public void testAcceptNullLocalizedMessage() {
         final SuppressWithPlainTextCommentFilter filter = new SuppressWithPlainTextCommentFilter();
         final AuditEvent auditEvent = new AuditEvent(this);
-        assertTrue("Filter should accept audit event", filter.accept(auditEvent));
-        Assert.assertNull("File name should not be null", auditEvent.getFileName());
+        assertTrue(filter.accept(auditEvent), "Filter should accept audit event");
+        assertNull(auditEvent.getFileName(), "File name should not be null");
     }
 
     /**
@@ -367,7 +367,7 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
         final EqualsVerifierReport ev = EqualsVerifier
                 .forClass(suppressionClass).usingGetClass()
                 .report();
-        assertEquals("Error: " + ev.getMessage(), EqualsVerifierReport.SUCCESS, ev);
+        assertEquals(EqualsVerifierReport.SUCCESS, ev, "Error: " + ev.getMessage());
     }
 
     @Test
@@ -594,14 +594,13 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
             fail(IllegalStateException.class.getSimpleName() + " is expected");
         }
         catch (IllegalStateException ex) {
-            assertEquals("Invalid exception message",
-                "Cannot read source file: " + fileName, ex.getMessage());
+            assertEquals("Cannot read source file: " + fileName, ex.getMessage(),
+                    "Invalid exception message");
 
             final Throwable cause = ex.getCause();
-            assertTrue("Exception cause has invalid type",
-                cause instanceof FileNotFoundException);
-            assertEquals("Invalid exception message",
-                fileName + " (No such file or directory)", cause.getMessage());
+            assertTrue(cause instanceof FileNotFoundException, "Exception cause has invalid type");
+            assertEquals(fileName + " (No such file or directory)", cause.getMessage(),
+                    "Invalid exception message");
         }
     }
 
@@ -720,7 +719,7 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
                 "bundle", "key", null, SeverityLevel.ERROR, "moduleId", getClass(),
                 "customMessage"));
 
-        assertTrue("filter should accept directory", filter.accept(event));
+        assertTrue(filter.accept(event), "filter should accept directory");
     }
 
     private void verifySuppressed(String fileNameWithExtension, String[] violationMessages,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -20,11 +20,11 @@
 package com.puppycrawl.tools.checkstyle.filters;
 
 import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.util.Arrays;
@@ -32,7 +32,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
@@ -306,16 +306,16 @@ public class SuppressionCommentFilterTest
         final Object tag = getTagsAfterExecutionOnDefaultFilter("//CHECKSTYLE:OFF").get(0);
         final EqualsVerifierReport ev = EqualsVerifier.forClass(tag.getClass())
                 .usingGetClass().report();
-        assertEquals("Error: " + ev.getMessage(), EqualsVerifierReport.SUCCESS, ev);
+        assertEquals(EqualsVerifierReport.SUCCESS, ev, "Error: " + ev.getMessage());
     }
 
     @Test
     public void testToStringOfTagClass() {
         final Object tag = getTagsAfterExecutionOnDefaultFilter("//CHECKSTYLE:OFF").get(0);
-        assertEquals("Invalid toString result",
-            "Tag[text='CHECKSTYLE:OFF', line=1, column=0, type=OFF,"
+        assertEquals(
+                "Tag[text='CHECKSTYLE:OFF', line=1, column=0, type=OFF,"
                     + " tagCheckRegexp=.*, tagMessageRegexp=null, tagIdRegexp=null]",
-                    tag.toString());
+                    tag.toString(), "Invalid toString result");
     }
 
     @Test
@@ -324,9 +324,10 @@ public class SuppressionCommentFilterTest
         filter.setMessageFormat(".*");
         final Object tag =
                 getTagsAfterExecution(filter, "filename", "//CHECKSTYLE:ON").get(0);
-        assertEquals("Invalid toString result",
-            "Tag[text='CHECKSTYLE:ON', line=1, column=0, type=ON,"
-                + " tagCheckRegexp=.*, tagMessageRegexp=.*, tagIdRegexp=null]", tag.toString());
+        assertEquals(
+                "Tag[text='CHECKSTYLE:ON', line=1, column=0, type=ON,"
+                + " tagCheckRegexp=.*, tagMessageRegexp=.*, tagIdRegexp=null]", tag.toString(),
+                "Invalid toString result");
     }
 
     @Test
@@ -344,11 +345,12 @@ public class SuppressionCommentFilterTest
                 getTagsAfterExecutionOnDefaultFilter("//CHECKSTYLE:ON");
         final Comparable<Object> tag4 = tags3.get(0);
 
-        assertTrue("Invalid comparing result", tag1.compareTo(tag2) < 0);
-        assertTrue("Invalid comparing result", tag2.compareTo(tag1) > 0);
-        assertTrue("Invalid comparing result", tag1.compareTo(tag3) < 0);
-        assertTrue("Invalid comparing result", tag3.compareTo(tag1) > 0);
-        assertEquals("Invalid comparing result", 0, tag1.compareTo(tag4));
+        assertTrue(tag1.compareTo(tag2) < 0, "Invalid comparing result");
+        assertTrue(tag2.compareTo(tag1) > 0, "Invalid comparing result");
+        assertTrue(tag1.compareTo(tag3) < 0, "Invalid comparing result");
+        assertTrue(tag3.compareTo(tag1) > 0, "Invalid comparing result");
+        final int actual = tag1.compareTo(tag4);
+        assertEquals(0, actual, "Invalid comparing result");
     }
 
     @Test
@@ -364,8 +366,8 @@ public class SuppressionCommentFilterTest
         }
         catch (CheckstyleException ex) {
             final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();
-            assertEquals("Invalid exception message",
-                "unable to parse expanded comment e[l", cause.getMessage());
+            assertEquals("unable to parse expanded comment e[l", cause.getMessage(),
+                    "Invalid exception message");
         }
     }
 
@@ -382,8 +384,8 @@ public class SuppressionCommentFilterTest
         }
         catch (CheckstyleException ex) {
             final IllegalArgumentException cause = (IllegalArgumentException) ex.getCause();
-            assertEquals("Invalid exception message",
-                "unable to parse expanded comment e[l", cause.getMessage());
+            assertEquals("unable to parse expanded comment e[l", cause.getMessage(),
+                    "Invalid exception message");
         }
     }
 
@@ -395,8 +397,8 @@ public class SuppressionCommentFilterTest
         contents.reportSingleLineComment(1, 0);
         final TreeWalkerAuditEvent auditEvent =
                 new TreeWalkerAuditEvent(contents, null, null, null);
-        assertTrue("Filter should accept audit event", filter.accept(auditEvent));
-        assertNull("File name should not be null", auditEvent.getFileName());
+        assertTrue(filter.accept(auditEvent), "Filter should accept audit event");
+        assertNull(auditEvent.getFileName(), "File name should not be null");
     }
 
     @Test
@@ -405,7 +407,7 @@ public class SuppressionCommentFilterTest
         final FileContents contents = null;
         final TreeWalkerAuditEvent auditEvent = new TreeWalkerAuditEvent(contents, null,
                 new LocalizedMessage(1, null, null, null, null, Object.class, null), null);
-        assertTrue("Filter should accept audit event", filter.accept(auditEvent));
+        assertTrue(filter.accept(auditEvent), "Filter should accept audit event");
     }
 
     @Test
@@ -614,7 +616,7 @@ public class SuppressionCommentFilterTest
         final TreeWalkerAuditEvent dummyEvent = new TreeWalkerAuditEvent(contents, "filename",
                 new LocalizedMessage(1, null, null, null, null, Object.class, null), null);
         final boolean result = suppressionCommentFilter.accept(dummyEvent);
-        assertFalse("Filter should not accept event", result);
+        assertFalse(result, "Filter should not accept event");
     }
 
     @Test
@@ -622,10 +624,10 @@ public class SuppressionCommentFilterTest
         final SuppressionCommentFilter suppressionCommentFilter = new SuppressionCommentFilter();
         final List<?> tags1 = getTagsAfterExecution(suppressionCommentFilter,
                 "filename1", "//CHECKSTYLE:OFF", "line2");
-        assertEquals("Invalid tags size", 1, tags1.size());
+        assertEquals(1, tags1.size(), "Invalid tags size");
         final List<?> tags2 = getTagsAfterExecution(suppressionCommentFilter,
                 "filename2", "No comments in this file");
-        assertEquals("Invalid tags size", 0, tags2.size());
+        assertEquals(0, tags2.size(), "Invalid tags size");
     }
 
     private static List<Comparable<Object>> getTagsAfterExecutionOnDefaultFilter(String... lines) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
@@ -19,10 +19,10 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -30,9 +30,8 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -44,8 +43,8 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class SuppressionFilterTest extends AbstractModuleTestSupport {
 
-    @Rule
-    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    public File temporaryFolder;
 
     @Override
     protected String getPackageLocation() {
@@ -60,8 +59,8 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
 
         final AuditEvent ev = new AuditEvent(this, "ATest.java", null);
 
-        assertTrue("Audit event should be excepted when there are no suppressions",
-            filter.accept(ev));
+        assertTrue(filter.accept(ev),
+                "Audit event should be excepted when there are no suppressions");
     }
 
     @Test
@@ -74,8 +73,8 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
                 SeverityLevel.ERROR, null, getClass(), null);
         final AuditEvent ev = new AuditEvent(this, "ATest.java", message);
 
-        assertFalse("Audit event should be rejected when there is a matching suppression",
-            filter.accept(ev));
+        assertFalse(filter.accept(ev),
+                "Audit event should be rejected when there is a matching suppression");
     }
 
     @Test
@@ -85,7 +84,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
         final SuppressionFilter filter = createSuppressionFilter(fileName, optional);
 
         final AuditEvent ev = new AuditEvent(this, "AnyJava.java", null);
-        assertTrue("Audit event on null file should be excepted, but was not", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Audit event on null file should be excepted, but was not");
     }
 
     @Test
@@ -97,8 +96,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
             fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid error message",
-                "Unable to find: " + fileName, ex.getMessage());
+            assertEquals("Unable to find: " + fileName, ex.getMessage(), "Invalid error message");
         }
     }
 
@@ -111,9 +109,9 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
             fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid error message",
-                "Unable to parse " + fileName + " - invalid files or checks or message format",
-                ex.getMessage());
+            assertEquals(
+                    "Unable to parse " + fileName + " - invalid files or checks or message format",
+                ex.getMessage(), "Invalid error message");
         }
     }
 
@@ -125,8 +123,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
 
         final AuditEvent ev = new AuditEvent(this, "AnyFile.java", null);
 
-        assertTrue("Suppression file with true optional was not accepted",
-            filter.accept(ev));
+        assertTrue(filter.accept(ev), "Suppression file with true optional was not accepted");
     }
 
     @Test
@@ -137,8 +134,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
 
         final AuditEvent ev = new AuditEvent(this, "AnyFile.java", null);
 
-        assertTrue("Should except event when suppression file does not exist",
-            filter.accept(ev));
+        assertTrue(filter.accept(ev), "Should except event when suppression file does not exist");
     }
 
     @Test
@@ -150,8 +146,8 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
 
         final AuditEvent ev = new AuditEvent(this, "AnyFile.java", null);
 
-        assertTrue("Should except event when suppression file url does not exist",
-            filter.accept(ev));
+        assertTrue(filter.accept(ev),
+                "Should except event when suppression file url does not exist");
     }
 
     @Test
@@ -160,10 +156,10 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
         filterConfig.addAttribute("file", getPath("InputSuppressionFilterNone.xml"));
 
         final DefaultConfiguration checkerConfig = createRootConfig(filterConfig);
-        final File cacheFile = temporaryFolder.newFile();
+        final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
         checkerConfig.addAttribute("cacheFile", cacheFile.getPath());
 
-        final String filePath = temporaryFolder.newFile("file.java").getPath();
+        final String filePath = File.createTempFile("file", ".java", temporaryFolder).getPath();
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
         verify(checkerConfig, filePath, expected);
@@ -198,10 +194,11 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
             firstFilterConfig.addAttribute("file", urlForTest);
 
             final DefaultConfiguration firstCheckerConfig = createRootConfig(firstFilterConfig);
-            final File cacheFile = temporaryFolder.newFile();
+            final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
             firstCheckerConfig.addAttribute("cacheFile", cacheFile.getPath());
 
-            final String pathToEmptyFile = temporaryFolder.newFile("file.java").getPath();
+            final String pathToEmptyFile =
+                    File.createTempFile("file", ".java", temporaryFolder).getPath();
             final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
             verify(firstCheckerConfig, pathToEmptyFile, expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilterTest.java
@@ -19,7 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilterTest.java
@@ -19,17 +19,16 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.Set;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.JavaParser;
@@ -42,9 +41,6 @@ import nl.jqno.equalsverifier.EqualsVerifierReport;
 import nl.jqno.equalsverifier.Warning;
 
 public class SuppressionXpathFilterTest extends AbstractModuleTestSupport {
-
-    @Rule
-    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Override
     protected String getPackageLocation() {
@@ -60,8 +56,8 @@ public class SuppressionXpathFilterTest extends AbstractModuleTestSupport {
 
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(null, "ATest.java", null, null);
 
-        assertTrue("TreeWalker audit event should be accepted when there are no suppressions",
-                filter.accept(ev));
+        assertTrue(filter.accept(ev),
+                "TreeWalker audit event should be accepted when there are no suppressions");
     }
 
     @Test
@@ -71,8 +67,7 @@ public class SuppressionXpathFilterTest extends AbstractModuleTestSupport {
                 getPath("InputSuppressionXpathFilterIdAndQuery.xml"), optional);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(null, "file1.java", null, null);
 
-        assertTrue("TreeWalker audit event should be accepted",
-                filter.accept(ev));
+        assertTrue(filter.accept(ev), "TreeWalker audit event should be accepted");
     }
 
     @Test
@@ -82,8 +77,8 @@ public class SuppressionXpathFilterTest extends AbstractModuleTestSupport {
         final SuppressionXpathFilter filter = createSuppressionXpathFilter(fileName, optional);
 
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(null, "AnyJava.java", null, null);
-        assertTrue("TreeWalker audit event on null file should be accepted, but was not",
-                filter.accept(ev));
+        assertTrue(filter.accept(ev),
+                "TreeWalker audit event on null file should be accepted, but was not");
     }
 
     @Test
@@ -95,8 +90,7 @@ public class SuppressionXpathFilterTest extends AbstractModuleTestSupport {
             fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid error message",
-                    "Unable to find: " + fileName, ex.getMessage());
+            assertEquals("Unable to find: " + fileName, ex.getMessage(), "Invalid error message");
         }
     }
 
@@ -109,9 +103,9 @@ public class SuppressionXpathFilterTest extends AbstractModuleTestSupport {
             fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid error message", "Unable to parse " + fileName
+            assertEquals("Unable to parse " + fileName
                     + " - invalid files or checks or message format for suppress-xpath",
-                    ex.getMessage());
+                    ex.getMessage(), "Invalid error message");
         }
     }
 
@@ -124,8 +118,7 @@ public class SuppressionXpathFilterTest extends AbstractModuleTestSupport {
 
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(null, "AnyJava.java", null, null);
 
-        assertTrue("Suppression file with true optional was not accepted",
-                filter.accept(ev));
+        assertTrue(filter.accept(ev), "Suppression file with true optional was not accepted");
     }
 
     @Test
@@ -137,8 +130,7 @@ public class SuppressionXpathFilterTest extends AbstractModuleTestSupport {
 
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(null, "AnyFile.java", null, null);
 
-        assertTrue("Should except event when suppression file does not exist",
-                filter.accept(ev));
+        assertTrue(filter.accept(ev), "Should except event when suppression file does not exist");
     }
 
     @Test
@@ -152,8 +144,7 @@ public class SuppressionXpathFilterTest extends AbstractModuleTestSupport {
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(null, "file1.java",
                 message, JavaParser.parseFile(file, JavaParser.Options.WITHOUT_COMMENTS));
 
-        assertFalse("TreeWalker audit event should be rejected",
-                filter.accept(ev));
+        assertFalse(filter.accept(ev), "TreeWalker audit event should be rejected");
     }
 
     @Test
@@ -162,7 +153,7 @@ public class SuppressionXpathFilterTest extends AbstractModuleTestSupport {
                 .usingGetClass()
                 .withIgnoredFields("file", "optional", "configuration")
                 .suppress(Warning.NONFINAL_FIELDS).report();
-        assertEquals("Error: " + ev.getMessage(), EqualsVerifierReport.SUCCESS, ev);
+        assertEquals(EqualsVerifierReport.SUCCESS, ev, "Error: " + ev.getMessage());
     }
 
     @Test
@@ -170,9 +161,9 @@ public class SuppressionXpathFilterTest extends AbstractModuleTestSupport {
         final boolean optional = false;
         final String fileName = getPath("InputSuppressionXpathFilterIdAndQuery.xml");
         final SuppressionXpathFilter filter = createSuppressionXpathFilter(fileName, optional);
-        assertEquals("Invalid external resource",
-                Collections.singleton(fileName),
-                filter.getExternalResourceLocations());
+        final Set<String> expected = Collections.singleton(fileName);
+        final Set<String> actual = filter.getExternalResourceLocations();
+        assertEquals(expected, actual, "Invalid external resource");
     }
 
     private static SuppressionXpathFilter createSuppressionXpathFilter(String fileName,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilterTest.java
@@ -19,16 +19,16 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.regex.PatternSyntaxException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.JavaParser;
@@ -44,7 +44,7 @@ public class SuppressionXpathSingleFilterTest
     private File file;
     private FileContents fileContents;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         file = new File(getPath("InputSuppressionXpathSingleFilter.java"));
         fileContents = new FileContents(new FileText(file,
@@ -64,7 +64,7 @@ public class SuppressionXpathSingleFilterTest
                         null, null, xpath);
         final TreeWalkerAuditEvent ev = createEvent(3, 0,
                 TokenTypes.CLASS_DEF);
-        assertFalse("Event should be rejected", filter.accept(ev));
+        assertFalse(filter.accept(ev), "Event should be rejected");
     }
 
     @Test
@@ -75,7 +75,7 @@ public class SuppressionXpathSingleFilterTest
                         null, null, xpath);
         final TreeWalkerAuditEvent ev = createEvent(3, 0,
                 TokenTypes.CLASS_DEF);
-        assertTrue("Event should be accepted", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Event should be accepted");
     }
 
     @Test
@@ -86,7 +86,7 @@ public class SuppressionXpathSingleFilterTest
                         null, null, xpath);
         final TreeWalkerAuditEvent ev = createEvent(100, 0,
                 TokenTypes.CLASS_DEF);
-        assertTrue("Event should be accepted", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Event should be accepted");
     }
 
     @Test
@@ -97,7 +97,7 @@ public class SuppressionXpathSingleFilterTest
                         null, null, xpath);
         final TreeWalkerAuditEvent ev = createEvent(3, 100,
                 TokenTypes.CLASS_DEF);
-        assertTrue("Event should be accepted", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Event should be accepted");
     }
 
     @Test
@@ -114,9 +114,9 @@ public class SuppressionXpathSingleFilterTest
                 TokenTypes.VARIABLE_DEF);
         final TreeWalkerAuditEvent eventThree = createEvent(15, 8,
                 TokenTypes.VARIABLE_DEF);
-        assertFalse("Event should be rejected", filter.accept(eventOne));
-        assertTrue("Event should be accepted", filter.accept(eventTwo));
-        assertFalse("Event should be rejected", filter.accept(eventThree));
+        assertFalse(filter.accept(eventOne), "Event should be rejected");
+        assertTrue(filter.accept(eventTwo), "Event should be accepted");
+        assertFalse(filter.accept(eventThree), "Event should be rejected");
     }
 
     @Test
@@ -129,8 +129,8 @@ public class SuppressionXpathSingleFilterTest
             fail("Exception was expected but got " + test);
         }
         catch (IllegalArgumentException ex) {
-            assertTrue("Message should be: Unexpected xpath query",
-                    ex.getMessage().contains("Incorrect xpath query"));
+            assertTrue(ex.getMessage().contains("Incorrect xpath query"),
+                    "Message should be: Unexpected xpath query");
         }
     }
 
@@ -141,7 +141,7 @@ public class SuppressionXpathSingleFilterTest
         final SuppressionXpathSingleFilter filter =
                 createSuppressionXpathSingleFilter("InputSuppressionXpathSingleFilter", "Test",
                         null, null, null);
-        assertFalse("Event should be accepted", filter.accept(event));
+        assertFalse(filter.accept(event), "Event should be accepted");
     }
 
     @Test
@@ -152,7 +152,7 @@ public class SuppressionXpathSingleFilterTest
                         null, null, xpath);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(null,
                 null, null, null);
-        assertTrue("Event should be accepted", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Event should be accepted");
     }
 
     @Test
@@ -163,7 +163,7 @@ public class SuppressionXpathSingleFilterTest
                         null, null, xpath);
         final TreeWalkerAuditEvent ev = createEvent(3, 0,
                 TokenTypes.CLASS_DEF);
-        assertTrue("Event should be accepted", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Event should be accepted");
     }
 
     @Test
@@ -174,8 +174,8 @@ public class SuppressionXpathSingleFilterTest
             fail("PatternSyntaxException is expected");
         }
         catch (PatternSyntaxException ex) {
-            assertTrue("Message should be: Unclosed character class",
-                    ex.getMessage().contains("Unclosed character class"));
+            assertTrue(ex.getMessage().contains("Unclosed character class"),
+                    "Message should be: Unclosed character class");
         }
     }
 
@@ -187,8 +187,8 @@ public class SuppressionXpathSingleFilterTest
             fail("PatternSyntaxException is expected");
         }
         catch (PatternSyntaxException ex) {
-            assertTrue("Message should be: Unclosed character class",
-                    ex.getMessage().contains("Unclosed character class"));
+            assertTrue(ex.getMessage().contains("Unclosed character class"),
+                    "Message should be: Unclosed character class");
         }
     }
 
@@ -200,7 +200,7 @@ public class SuppressionXpathSingleFilterTest
                         null, null, xpath);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(null,
                 file.getName(), null, null);
-        assertTrue("Event should be accepted", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Event should be accepted");
     }
 
     @Test
@@ -215,7 +215,7 @@ public class SuppressionXpathSingleFilterTest
                         getClass(), null);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(fileContents, file.getName(),
                 message, JavaParser.parseFile(file, JavaParser.Options.WITHOUT_COMMENTS));
-        assertTrue("Event should be accepted", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Event should be accepted");
     }
 
     @Test
@@ -230,7 +230,7 @@ public class SuppressionXpathSingleFilterTest
                         getClass(), null);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(fileContents, file.getName(),
                 message, JavaParser.parseFile(file, JavaParser.Options.WITHOUT_COMMENTS));
-        assertFalse("Event should be rejected", filter.accept(ev));
+        assertFalse(filter.accept(ev), "Event should be rejected");
     }
 
     @Test
@@ -245,7 +245,7 @@ public class SuppressionXpathSingleFilterTest
                         getClass(), null);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(fileContents, file.getName(),
                 message, JavaParser.parseFile(file, JavaParser.Options.WITHOUT_COMMENTS));
-        assertTrue("Event should be accepted", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Event should be accepted");
     }
 
     @Test
@@ -256,7 +256,7 @@ public class SuppressionXpathSingleFilterTest
                         null, null, null, xpath);
         final TreeWalkerAuditEvent ev = createEvent(3, 0,
                 TokenTypes.CLASS_DEF);
-        assertTrue("Event should be accepted", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Event should be accepted");
     }
 
     @Test
@@ -266,7 +266,7 @@ public class SuppressionXpathSingleFilterTest
                 "InputSuppressionXpathSingleFilter", "NonMatchingRegexp", null, null, xpath);
         final TreeWalkerAuditEvent ev = createEvent(3, 0,
                 TokenTypes.CLASS_DEF);
-        assertTrue("Event should be accepted", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Event should be accepted");
     }
 
     @Test
@@ -280,8 +280,8 @@ public class SuppressionXpathSingleFilterTest
                 null, null, "Test", null, null);
         final SuppressionXpathSingleFilter filter2 = createSuppressionXpathSingleFilter(
                 null, null, "Bad", null, null);
-        assertFalse("Message match", filter1.accept(ev));
-        assertTrue("Message not match", filter2.accept(ev));
+        assertFalse(filter1.accept(ev), "Message match");
+        assertTrue(filter2.accept(ev), "Message not match");
     }
 
     @Test
@@ -301,8 +301,8 @@ public class SuppressionXpathSingleFilterTest
             fail("Exception is expected");
         }
         catch (IllegalStateException ex) {
-            assertTrue("Exception message does not match expected one",
-                    ex.getMessage().contains("Cannot initialize context and evaluate query"));
+            assertTrue(ex.getMessage().contains("Cannot initialize context and evaluate query"),
+                    "Exception message does not match expected one");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -19,9 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -29,7 +29,7 @@ import java.net.URL;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 import org.xml.sax.InputSource;
 
@@ -53,8 +53,8 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         final FilterSet fc =
             SuppressionsLoader.loadSuppressions(getPath("InputSuppressionsLoaderNone.xml"));
         final FilterSet fc2 = new FilterSet();
-        assertEquals("No suppressions should be loaded, but found: " + fc.getFilters().size(),
-            fc2.getFilters(), fc.getFilters());
+        assertEquals(fc2.getFilters(), fc.getFilters(),
+                "No suppressions should be loaded, but found: " + fc.getFilters().size());
     }
 
     @Test
@@ -77,8 +77,8 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         // when https://github.com/jayway/powermock/issues/428 will be fixed
         if (actualFilterSet != null) {
             final FilterSet expectedFilterSet = new FilterSet();
-            assertEquals("Failed to load from url", expectedFilterSet.getFilters(),
-                    actualFilterSet.getFilters());
+            assertEquals(expectedFilterSet.getFilters(),
+                    actualFilterSet.getFilters(), "Failed to load from url");
         }
     }
 
@@ -89,7 +89,7 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid error message", "Unable to find: http", ex.getMessage());
+            assertEquals("Unable to find: http", ex.getMessage(), "Invalid error message");
         }
     }
 
@@ -100,8 +100,8 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid error message",
-                "Unable to find: http://^%$^* %&% %^&", ex.getMessage());
+            assertEquals("Unable to find: http://^%$^* %&% %^&", ex.getMessage(),
+                    "Invalid error message");
         }
     }
 
@@ -126,8 +126,8 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         final SuppressFilterElement se4 =
                 new SuppressFilterElement(null, null, "message0", null, null, null);
         fc2.addFilter(se4);
-        assertEquals("Multiple suppressions were loaded incorrectly", fc2.getFilters(),
-                fc.getFilters());
+        assertEquals(fc2.getFilters(), fc.getFilters(),
+                "Multiple suppressions were loaded incorrectly");
     }
 
     @Test
@@ -139,12 +139,12 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         }
         catch (CheckstyleException ex) {
             final String messageStart = "Unable to parse " + fn;
-            assertTrue("Exception message should start with: " + messageStart,
-                ex.getMessage().startsWith("Unable to parse " + fn));
-            assertTrue("Exception message should contain \"files\"",
-                ex.getMessage().contains("\"files\""));
-            assertTrue("Exception message should contain \"suppress\"",
-                ex.getMessage().contains("\"suppress\""));
+            assertTrue(ex.getMessage().startsWith("Unable to parse " + fn),
+                    "Exception message should start with: " + messageStart);
+            assertTrue(ex.getMessage().contains("\"files\""),
+                    "Exception message should contain \"files\"");
+            assertTrue(ex.getMessage().contains("\"suppress\""),
+                    "Exception message should contain \"suppress\"");
         }
     }
 
@@ -157,12 +157,12 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         }
         catch (CheckstyleException ex) {
             final String messageStart = "Unable to parse " + fn;
-            assertTrue("Exception message should start with: " + messageStart,
-                ex.getMessage().startsWith(messageStart));
-            assertTrue("Exception message should contain \"checks\"",
-                ex.getMessage().contains("\"checks\""));
-            assertTrue("Exception message should contain \"suppress\"",
-                ex.getMessage().contains("\"suppress\""));
+            assertTrue(ex.getMessage().startsWith(messageStart),
+                    "Exception message should start with: " + messageStart);
+            assertTrue(ex.getMessage().contains("\"checks\""),
+                    "Exception message should contain \"checks\"");
+            assertTrue(ex.getMessage().contains("\"suppress\""),
+                    "Exception message should contain \"suppress\"");
         }
     }
 
@@ -174,9 +174,8 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
             fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
-            assertTrue(
-                ex.getMessage(),
-                ex.getMessage().startsWith("Number format exception " + fn + " - "));
+            assertTrue(ex.getMessage().startsWith("Number format exception " + fn + " - "),
+                    ex.getMessage());
         }
     }
 
@@ -231,8 +230,8 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
             fail("CheckstyleException is expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid exception message", "Unable to find: " + sourceName,
-                    ex.getMessage());
+            assertEquals("Unable to find: " + sourceName,
+                    ex.getMessage(), "Invalid exception message");
         }
     }
 
@@ -246,8 +245,8 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
             fail("CheckstyleException is expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid exception message", "Unable to read " + sourceName,
-                    ex.getMessage());
+            assertEquals("Unable to read " + sourceName,
+                    ex.getMessage(), "Invalid exception message");
         }
     }
 
@@ -259,9 +258,9 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
             fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid error message",
-                "Unable to parse " + fn + " - missing checks or id or message attribute",
-                ex.getMessage());
+            assertEquals(
+                    "Unable to parse " + fn + " - missing checks or id or message attribute",
+                ex.getMessage(), "Invalid error message");
         }
     }
 
@@ -270,7 +269,7 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         final String fn = getPath("InputSuppressionsLoaderId.xml");
         final FilterSet set = SuppressionsLoader.loadSuppressions(fn);
 
-        assertEquals("Invalid number of filters", 1, set.getFilters().size());
+        assertEquals(1, set.getFilters().size(), "Invalid number of filters");
     }
 
     @Test
@@ -281,9 +280,9 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
             fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid error message",
-                "Unable to parse " + fn + " - invalid files or checks or message format",
-                ex.getMessage());
+            assertEquals(
+                    "Unable to parse " + fn + " - invalid files or checks or message format",
+                ex.getMessage(), "Invalid error message");
         }
     }
 
@@ -292,7 +291,7 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         final FilterSet fc =
             SuppressionsLoader.loadSuppressions(getPath("InputSuppressionsLoaderNone.xml"));
         final FilterSet fc2 = new FilterSet();
-        assertEquals("Suppressions were not loaded", fc2.getFilters(), fc.getFilters());
+        assertEquals(fc2.getFilters(), fc.getFilters(), "Suppressions were not loaded");
     }
 
     @Test
@@ -303,7 +302,7 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
                 .toArray()[0];
 
         final String id = Whitebox.getInternalState(suppressElement, "moduleId");
-        assertEquals("Id has to be defined", "someId", id);
+        assertEquals("someId", id, "Id has to be defined");
     }
 
     @Test
@@ -318,8 +317,8 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         final XpathFilterElement xf1 =
                 new XpathFilterElement(null, null, "message1", null, "/CLASS_DEF");
         expectedFilterSet.add(xf1);
-        assertEquals("Multiple xpath suppressions were loaded incorrectly", expectedFilterSet,
-                filterSet);
+        assertEquals(expectedFilterSet,
+                filterSet, "Multiple xpath suppressions were loaded incorrectly");
     }
 
     @Test
@@ -330,10 +329,10 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
             fail("Exception should be thrown");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid error message",
+            assertEquals(
                     "Unable to parse " + fn + " - invalid files or checks or message format for "
                             + "suppress-xpath",
-                    ex.getMessage());
+                    ex.getMessage(), "Invalid error message");
         }
     }
 
@@ -346,10 +345,10 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
             fail("Exception should be thrown");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid error message",
+            assertEquals(
                     "Unable to parse " + fn + " - missing checks or id or message attribute for "
                             + "suppress-xpath",
-                    ex.getMessage());
+                    ex.getMessage(), "Invalid error message");
         }
     }
 
@@ -358,7 +357,7 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         final String fn = getPath("InputSuppressionsLoaderXpathId.xml");
         final Set<TreeWalkerFilter> filterSet = SuppressionsLoader.loadXpathSuppressions(fn);
 
-        assertEquals("Invalid number of filters", 1, filterSet.size());
+        assertEquals(1, filterSet.size(), "Invalid number of filters");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElementTest.java
@@ -19,17 +19,17 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.regex.Pattern;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.JavaParser;
@@ -48,7 +48,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
     private File file;
     private FileContents fileContents;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         file = new File(getPath("InputXpathFilterElementSuppressByXpath.java"));
         fileContents = new FileContents(new FileText(file,
@@ -67,7 +67,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                 "InputXpathFilterElementSuppressByXpath", "Test", null, null, xpath);
         final TreeWalkerAuditEvent ev = getEvent(3, 0,
                 TokenTypes.CLASS_DEF);
-        assertFalse("Event should be rejected", filter.accept(ev));
+        assertFalse(filter.accept(ev), "Event should be rejected");
     }
 
     @Test
@@ -77,7 +77,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                 "InputXpathFilterElementSuppressByXpath", "Test", null, null, xpath);
         final TreeWalkerAuditEvent ev = getEvent(4, 4,
                 TokenTypes.CLASS_DEF);
-        assertTrue("Event should be accepted", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Event should be accepted");
     }
 
     @Test
@@ -87,7 +87,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                 "InputXpathFilterElementSuppressByXpath", "Test", null, null, xpath);
         final TreeWalkerAuditEvent ev = getEvent(100, 0,
                 TokenTypes.CLASS_DEF);
-        assertTrue("Event should be accepted", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Event should be accepted");
     }
 
     @Test
@@ -97,7 +97,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                 "InputXpathFilterElementSuppressByXpath", "Test", null, null, xpath);
         final TreeWalkerAuditEvent ev = getEvent(3, 100,
                 TokenTypes.CLASS_DEF);
-        assertTrue("Event should be accepted", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Event should be accepted");
     }
 
     @Test
@@ -113,9 +113,9 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                 TokenTypes.VARIABLE_DEF);
         final TreeWalkerAuditEvent eventThree = getEvent(15, 8,
                 TokenTypes.VARIABLE_DEF);
-        assertFalse("Event should be rejected", filter.accept(eventOne));
-        assertTrue("Event should be accepted", filter.accept(eventTwo));
-        assertFalse("Event should be rejected", filter.accept(eventThree));
+        assertFalse(filter.accept(eventOne), "Event should be rejected");
+        assertTrue(filter.accept(eventTwo), "Event should be accepted");
+        assertFalse(filter.accept(eventThree), "Event should be rejected");
     }
 
     @Test
@@ -126,8 +126,8 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
             fail("Exception is expected but got " + test);
         }
         catch (IllegalArgumentException ex) {
-            assertTrue("Message should be: Failed to initialise regular expression",
-                    ex.getMessage().contains("Failed to initialise regular expression"));
+            assertTrue(ex.getMessage().contains("Failed to initialise regular expression"),
+                    "Message should be: Failed to initialise regular expression");
         }
     }
 
@@ -140,8 +140,8 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
             fail("Exception is expected but got " + test);
         }
         catch (IllegalArgumentException ex) {
-            assertTrue("Message should be: Unexpected xpath query",
-                    ex.getMessage().contains("Unexpected xpath query"));
+            assertTrue(ex.getMessage().contains("Unexpected xpath query"),
+                    "Message should be: Unexpected xpath query");
         }
     }
 
@@ -151,7 +151,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                 TokenTypes.VARIABLE_DEF);
         final XpathFilterElement filter = new XpathFilterElement(
                 "InputXpathFilterElementSuppressByXpath", "Test", null, null, null);
-        assertFalse("Event should be accepted", filter.accept(event));
+        assertFalse(filter.accept(event), "Event should be accepted");
     }
 
     @Test
@@ -160,7 +160,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                 "InputXpathFilterElementSuppressByXpath", "Test", null, null, null);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(null,
                 null, null, null);
-        assertTrue("Event should be accepted", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Event should be accepted");
     }
 
     @Test
@@ -169,7 +169,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                 new XpathFilterElement("NonMatchingRegexp", "Test", null, null, null);
         final TreeWalkerAuditEvent ev = getEvent(3, 0,
                 TokenTypes.CLASS_DEF);
-        assertTrue("Event should be accepted", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Event should be accepted");
     }
 
     @Test
@@ -179,7 +179,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                 new XpathFilterElement(pattern, null, null, null, null);
         final TreeWalkerAuditEvent ev = getEvent(3, 0,
                 TokenTypes.CLASS_DEF);
-        assertTrue("Event should be accepted", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Event should be accepted");
     }
 
     @Test
@@ -188,7 +188,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                 new XpathFilterElement(null, "NonMatchingRegexp", null, null, null);
         final TreeWalkerAuditEvent ev = getEvent(3, 0,
                 TokenTypes.CLASS_DEF);
-        assertTrue("Event should be accepted", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Event should be accepted");
     }
 
     @Test
@@ -198,7 +198,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                 new XpathFilterElement(null, pattern, null, null, null);
         final TreeWalkerAuditEvent ev = getEvent(3, 0,
                 TokenTypes.CLASS_DEF);
-        assertTrue("Event should be accepted", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Event should be accepted");
     }
 
     @Test
@@ -207,7 +207,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                 "InputXpathFilterElementSuppressByXpath", "Test", null, null, null);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(null,
                 file.getName(), null, null);
-        assertTrue("Event should be accepted", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Event should be accepted");
     }
 
     @Test
@@ -219,7 +219,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                         getClass(), null);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(fileContents, file.getName(),
                 message, JavaParser.parseFile(file, JavaParser.Options.WITHOUT_COMMENTS));
-        assertTrue("Event should be accepted", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Event should be accepted");
     }
 
     @Test
@@ -232,7 +232,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                         getClass(), null);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(fileContents, file.getName(),
                 message, JavaParser.parseFile(file, JavaParser.Options.WITHOUT_COMMENTS));
-        assertFalse("Event should be rejected", filter.accept(ev));
+        assertFalse(filter.accept(ev), "Event should be rejected");
     }
 
     @Test
@@ -245,7 +245,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                         getClass(), null);
         final TreeWalkerAuditEvent ev = new TreeWalkerAuditEvent(fileContents, file.getName(),
                 message, JavaParser.parseFile(file, JavaParser.Options.WITHOUT_COMMENTS));
-        assertTrue("Event should be accepted", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Event should be accepted");
     }
 
     @Test
@@ -255,7 +255,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                 "InputXpathFilterElementSuppressByXpath", null, null, null, xpath);
         final TreeWalkerAuditEvent ev = getEvent(3, 0,
                 TokenTypes.CLASS_DEF);
-        assertTrue("Event should be accepted", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Event should be accepted");
     }
 
     @Test
@@ -265,7 +265,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                 "InputXpathFilterElementSuppressByXpath", "NonMatchingRegexp", null, null, xpath);
         final TreeWalkerAuditEvent ev = getEvent(3, 0,
                 TokenTypes.CLASS_DEF);
-        assertTrue("Event should be accepted", filter.accept(ev));
+        assertTrue(filter.accept(ev), "Event should be accepted");
     }
 
     @Test
@@ -276,8 +276,8 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                 message, JavaParser.parseFile(file, JavaParser.Options.WITHOUT_COMMENTS));
         final XpathFilterElement filter1 = new XpathFilterElement(null, null, "Test", null, null);
         final XpathFilterElement filter2 = new XpathFilterElement(null, null, "Bad", null, null);
-        assertFalse("Message match", filter1.accept(ev));
-        assertTrue("Message not match", filter2.accept(ev));
+        assertFalse(filter1.accept(ev), "Message match");
+        assertTrue(filter2.accept(ev), "Message not match");
     }
 
     @Test
@@ -295,8 +295,8 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
             fail("Exception is expected");
         }
         catch (IllegalStateException ex) {
-            assertTrue("Exception message does not match expected one",
-                    ex.getMessage().contains("Cannot initialize context and evaluate query"));
+            assertTrue(ex.getMessage().contains("Cannot initialize context and evaluate query"),
+                    "Exception message does not match expected one");
         }
     }
 
@@ -310,7 +310,7 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
                 .usingGetClass()
                 .withIgnoredFields("fileRegexp", "checkRegexp", "messageRegexp", "xpathExpression")
                 .report();
-        assertEquals("Error: " + ev.getMessage(), EqualsVerifierReport.SUCCESS, ev);
+        assertEquals(EqualsVerifierReport.SUCCESS, ev, "Error: " + ev.getMessage());
     }
 
     private TreeWalkerAuditEvent getEvent(int line, int column, int tokenType)


### PR DESCRIPTION
Issue #6916

Tests of the 'filters' and 'filefilters` packages are migrated to Junit5.