### PR TITLE
Issue #7340: linkcheck reports that all dtd files are missing

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -114,6 +114,17 @@
     <property name="fileExtensions" value="xml, vm"/>
     <property name="message" value="Line should not be longer than 100 symbols"/>
   </module>
+  <!--
+   Links to .dtd files should start with "/", "http://" or "https://",
+   otherwise they will be broken after archiving the documentation.
+   See https://github.com/checkstyle/checkstyle/issues/7340 for details.
+  -->
+  <module name="RegexpSingleline">
+    <property name="format" value="href=&quot;(?!\/|https?:\/\/).*?\.dtd&quot;"/>
+    <property name="fileExtensions" value="xml, vm"/>
+    <property name="message"
+      value="Relative links to DTD files are prohibited. Please use absolute path or uri instead."/>
+  </module>
   <module name="RegexpSingleline">
     <property name="id" value="noSourceforgeNetLinks"/>
     <property name="format" value="checkstyle\.sourceforge\.net"/>

--- a/pom.xml
+++ b/pom.xml
@@ -1482,6 +1482,21 @@
       </plugin>
 
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>${maven.versions.plugin.version}</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>dependency-updates-report</report>
+              <report>plugin-updates-report</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+
+      <!-- this report should be created last -->
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-linkcheck-plugin</artifactId>
         <version>1.2</version>
@@ -1489,7 +1504,7 @@
           <httpMethod>GET</httpMethod>
           <timeout>6000</timeout>
           <httpFollowRedirect>false</httpFollowRedirect>
-          <forceSite>true</forceSite>
+          <forceSite>false</forceSite>
           <!-- To resolve redirection violation, to find new target url, use:
               URL=https://www.cs.....
               curl -s -I $URL -L | awk '/Location: (.*)/ {print $2}' | tail -n 1
@@ -1516,6 +1531,10 @@
             <excludedLink>reports/javadoc/openjdk8</excludedLink>
             <!-- posting to the mailing list "checkstyle-announce" is private -->
             <excludedLink>privilege of admins</excludedLink>
+            <!-- this page is not yet created when linkcheck executed -->
+            <excludedLink>project-info.html</excludedLink>
+            <!-- this page is not yet created when linkcheck executed -->
+            <excludedLink>project-reports.html</excludedLink>
             <!-- redirects to US page, it is better to stay international -->
             <excludedLink>https://paypal.com/</excludedLink>
             <!-- temporal suppress till plugin update link in his source -->
@@ -1593,20 +1612,6 @@
             <excludedLink>https://www.w3.org/TR/*</excludedLink>
           </excludedLinks>
         </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>versions-maven-plugin</artifactId>
-        <version>${maven.versions.plugin.version}</version>
-        <reportSets>
-          <reportSet>
-            <reports>
-              <report>dependency-updates-report</report>
-              <report>plugin-updates-report</report>
-            </reports>
-          </reportSet>
-        </reportSets>
       </plugin>
 
     </plugins>

--- a/src/xdocs/config.xml
+++ b/src/xdocs/config.xml
@@ -931,8 +931,8 @@
       </p>
 
       <p>
-        Checkstyle also validates the package names XML document structure when it
-        loads the document. DTD is available at <a href="dtds/packages_1_0.dtd">packages_1_0.dtd</a>
+        Checkstyle also validates the package names XML document structure when it loads
+        the document. DTD is available at <a href="/dtds/packages_1_0.dtd">packages_1_0.dtd</a>
       </p>
 
       <p>
@@ -986,7 +986,7 @@
       <p>
         Checkstyle validates the configuration XML document structure when it loads
         the document. To validate against the
-        <a href="dtds/configuration_1_3.dtd">latest DTD</a>,
+        <a href="/dtds/configuration_1_3.dtd">latest DTD</a>,
         include the following document type declaration in your
         configuration XML document:
       </p>

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -437,7 +437,7 @@ public class UserService {
           <p>
             Filter <code>SuppressionFilter</code> rejects
             audit events for Check violations according to
-            a <a href="dtds/suppressions_1_2.dtd">suppressions XML
+            a <a href="/dtds/suppressions_1_2.dtd">suppressions XML
             document</a> in a file. If there is no configured
             suppressions file or the optional is set to true and
             suppressions file was not found the Filter accepts all audit events.
@@ -480,7 +480,7 @@ public class UserService {
       </subsection>
       <subsection name="Notes" id="SuppressionFilter_Notes">
         <p>
-          A <a href="dtds/suppressions_1_2.dtd">suppressions XML
+          A <a href="/dtds/suppressions_1_2.dtd">suppressions XML
           document</a> contains a set of <code>suppress</code> elements, where
           each <code>suppress</code> element can have the following attributes:
         </p>

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -961,7 +961,7 @@ public class InputIllegalImport { }
 
         <p>
           The DTD for a import control XML document is at <a
-          href="dtds/import_control_1_4.dtd">
+          href="/dtds/import_control_1_4.dtd">
           https://checkstyle.org/dtds/import_control_1_4.dtd</a>. It
           contains documentation on each of the elements and attributes.
         </p>


### PR DESCRIPTION
Issue #7340

Solved by reordering reports to execute `linkcheck` last.
Validation of links to `project-reports.html` and `project-info.html` suppressed as they created after **all reports** are generated.

`forcesite` was added at https://github.com/checkstyle/checkstyle/commit/dc3111cb1a2720eb59770756e1afa8d8b9982d8a there is small discussion in commit about such files