### PR TITLE
Issue #7341: fix javadoc links to non-public members

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
@@ -684,10 +684,12 @@ public class JavadocDetailNodeParser {
         }
 
         /**
-         * Getter for {@link #firstNonTightHtmlTag}.
+         * Getter for the first non-tight HTML tag encountered while parsing javadoc.
          *
          * @return the first non-tight HTML tag that is encountered while parsing Javadoc,
          *     if one exists
+         * @see <a href="https://checkstyle.org/writingjavadocchecks.html#Tight-HTML_rules">
+         *     Tight HTML rules</a>
          */
         public Token getFirstNonTightHtmlTag() {
             return firstNonTightHtmlTag;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -158,7 +158,7 @@ public class SuppressWarningsHolder
 
     /**
      * Returns the alias for the source name of a check. If an alias has been
-     * explicitly registered via {@link #registerAlias(String, String)}, that
+     * explicitly registered via {@link #setAliasList(String...)}, that
      * alias is returned; otherwise, the default alias is used.
      * @param sourceName the source name of the check (generally the class
      *        name)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
@@ -65,7 +65,7 @@ import com.puppycrawl.tools.checkstyle.utils.AnnotationUtil;
  * </pre>
  * <ul>
  * <li>
- * Property {@code violateExecutionOnNonTightHtml} - If turned on, will
+ * Property {@code violateExecutionOnNonTightHtml} - Control when to
  * print violations if the Javadoc being examined by this check violates the
  * tight html rules defined at
  * <a href="https://checkstyle.org/writingjavadocchecks.html#Tight-HTML_rules">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -147,10 +147,12 @@ public abstract class AbstractJavadocCheck extends AbstractCheck {
     }
 
     /**
-     * Setter for {@link #violateExecutionOnNonTightHtml}.
+     * Setter to control when to print violations if the Javadoc being examined by this check
+     * violates the tight html rules defined at
+     * <a href="https://checkstyle.org/writingjavadocchecks.html#Tight-HTML_rules">
+     *     Tight-HTML Rules</a>.
+     *
      * @param shouldReportViolation value to which the field shall be set to
-     * @see <a href="https://checkstyle.org/writingjavadocchecks.html#Tight-HTML_rules">
-     *     Tight HTML rules</a>
      */
     public final void setViolateExecutionOnNonTightHtml(boolean shouldReportViolation) {
         violateExecutionOnNonTightHtml = shouldReportViolation;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
@@ -43,7 +43,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *
  * <ul>
  * <li>
- * Property {@code violateExecutionOnNonTightHtml} - If turned on, will print violations if the
+ * Property {@code violateExecutionOnNonTightHtml} - Control when to print violations if the
  * Javadoc being examined by this check violates the tight html rules defined at
  * <a href="https://checkstyle.org/writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.
  * Default value is {@code false}.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/XpathUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/XpathUtil.java
@@ -137,7 +137,7 @@ public final class XpathUtil {
      *
      * @param xpath query to evaluate
      * @param file file to run on
-     * @return all results as string separated by {@link XpathUtil#DELIMITER}
+     * @return all results as string separated by delimiter
      * @throws CheckstyleException if some parsing error happens
      * @throws IOException if an error occurs
      */

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -601,7 +601,7 @@ public int foo() { ... }
             <tr>
               <td>violateExecutionOnNonTightHtml</td>
               <td>
-                If turned on, will print violations if the Javadoc being examined by this check
+                Control when to print violations if the Javadoc being examined by this check
                 violates the tight html rules defined at
                 <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
               <td><a href="property_types.html#boolean">Boolean</a></td>

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -48,7 +48,7 @@
             <tr>
               <td>violateExecutionOnNonTightHtml</td>
               <td>
-                If turned on, will print violations if the Javadoc being examined by this check
+                Control when to print violations if the Javadoc being examined by this check
                 violates the tight html rules defined at
                 <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
               <td><a href="property_types.html#boolean">Boolean</a></td>

--- a/src/xdocs/writingchecks.xml
+++ b/src/xdocs/writingchecks.xml
@@ -687,7 +687,7 @@ public class MethodLimitCheck extends AbstractCheck
       <a href="apidocs/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.html">
               AbstractFileSetCheck</a>
       and override the abstract
-      <a href="apidocs/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.html#processFiltered-java.io.File-java.util.List-">
+      <a href="apidocs/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.html#processFiltered-java.io.File-com.puppycrawl.tools.checkstyle.api.FileText-">
               <code>processFiltered(java.io.File, java.util.List)</code></a> method and you&#39;re
       done. A very simple example could fire a violation if the number of files
       exceeds a certain limit. Here is a FileSetCheck that does just that:</p>


### PR DESCRIPTION
Issue #7341

This PR fixes links to non-public members and links to methods with changed signatures.