### PR TITLE
Issue #6916: migrate tests to junit5 for imports package

### DIFF
--- a/config/import-control-test.xml
+++ b/config/import-control-test.xml
@@ -20,7 +20,7 @@
 
   <!-- Till https://github.com/checkstyle/checkstyle/issues/6916 -->
   <subpackage name="checks">
-    <subpackage name="(imports|indentation|javadoc)" regex="true">
+    <subpackage name="(indentation|javadoc)" regex="true">
       <allow pkg="org.junit"/>
     </subpackage>
   </subpackage>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AccessResultTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AccessResultTest.java
@@ -19,10 +19,10 @@
 
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class AccessResultTest {
 
@@ -33,7 +33,7 @@ public class AccessResultTest {
     @Test
     public void testAccessResultValueOf() {
         final AccessResult result = AccessResult.valueOf("ALLOWED");
-        assertEquals("Invalid access result", AccessResult.ALLOWED, result);
+        assertEquals(AccessResult.ALLOWED, result, "Invalid access result");
     }
 
     /* Additional test for jacoco, since values()
@@ -48,7 +48,7 @@ public class AccessResultTest {
             AccessResult.DISALLOWED,
             AccessResult.UNKNOWN,
         };
-        assertArrayEquals("Invalid access result values", expected, actual);
+        assertArrayEquals(expected, actual, "Invalid access result values");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheckTest.java
@@ -20,9 +20,9 @@
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
 import static com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck.MSG_KEY;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -101,7 +101,7 @@ public class AvoidStarImportCheckTest
                 new AvoidStarImportCheck();
         final int[] actual = testCheckObject.getAcceptableTokens();
         final int[] expected = {TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT};
-        assertArrayEquals("Default acceptable tokens are invalid", expected, actual);
+        assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
     }
 
     @Test
@@ -111,7 +111,7 @@ public class AvoidStarImportCheckTest
         final int[] actual = testCheckObject.getRequiredTokens();
         final int[] expected = {TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT};
 
-        assertArrayEquals("Default required tokens are invalid", expected, actual);
+        assertArrayEquals(expected, actual, "Default required tokens are invalid");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheckTest.java
@@ -20,9 +20,9 @@
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
 import static com.puppycrawl.tools.checkstyle.checks.imports.AvoidStaticImportCheck.MSG_KEY;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -40,8 +40,8 @@ public class AvoidStaticImportCheckTest
     public void testGetRequiredTokens() {
         final AvoidStaticImportCheck checkObj = new AvoidStaticImportCheck();
         final int[] expected = {TokenTypes.STATIC_IMPORT};
-        assertArrayEquals("Default required tokens are invalid",
-            expected, checkObj.getRequiredTokens());
+        assertArrayEquals(expected, checkObj.getRequiredTokens(),
+                "Default required tokens are invalid");
     }
 
     @Test
@@ -168,7 +168,7 @@ public class AvoidStaticImportCheckTest
         final int[] actual = testCheckObject.getAcceptableTokens();
         final int[] expected = {TokenTypes.STATIC_IMPORT};
 
-        assertArrayEquals("Default acceptable tokens are invalid", expected, actual);
+        assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ClassImportRuleTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ClassImportRuleTest.java
@@ -19,48 +19,48 @@
 
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ClassImportRuleTest {
 
     @Test
     public void testClassImportRule() {
         final ClassImportRule rule = new ClassImportRule(true, false, "pkg.a", false);
-        assertNotNull("Class import rule should not be null", rule);
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("asda"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("p"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("pkga"));
-        assertEquals("Invalid access result", AccessResult.ALLOWED, rule.verifyImport("pkg.a"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("pkg.a.b"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("pkg"));
+        assertNotNull(rule, "Class import rule should not be null");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("asda"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("p"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkga"), "Invalid access result");
+        assertEquals(AccessResult.ALLOWED, rule.verifyImport("pkg.a"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkg.a.b"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkg"), "Invalid access result");
     }
 
     @Test
     public void testClassImportRuleRegexpSimple() {
         final ClassImportRule rule = new ClassImportRule(true, false, "pkg.a", true);
-        assertNotNull("Class import rule should not be null", rule);
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("asda"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("p"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("pkga"));
-        assertEquals("Invalid access result", AccessResult.ALLOWED, rule.verifyImport("pkg.a"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("pkg.a.b"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("pkg"));
+        assertNotNull(rule, "Class import rule should not be null");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("asda"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("p"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkga"), "Invalid access result");
+        assertEquals(AccessResult.ALLOWED, rule.verifyImport("pkg.a"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkg.a.b"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkg"), "Invalid access result");
     }
 
     @Test
     public void testClassImportRuleRegexp() {
         final ClassImportRule rule = new ClassImportRule(true, false, "pk[gx]\\.a", true);
-        assertNotNull("Class import rule should not be null", rule);
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("asda"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("p"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("pkga"));
-        assertEquals("Invalid access result", AccessResult.ALLOWED, rule.verifyImport("pkg.a"));
-        assertEquals("Invalid access result", AccessResult.ALLOWED, rule.verifyImport("pkx.a"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("pkg.a.b"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("pkg"));
+        assertNotNull(rule, "Class import rule should not be null");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("asda"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("p"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkga"), "Invalid access result");
+        assertEquals(AccessResult.ALLOWED, rule.verifyImport("pkg.a"), "Invalid access result");
+        assertEquals(AccessResult.ALLOWED, rule.verifyImport("pkx.a"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkg.a.b"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkg"), "Invalid access result");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -24,14 +24,14 @@ import static com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCh
 import static com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck.MSG_NONGROUP_EXPECTED;
 import static com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck.MSG_NONGROUP_IMPORT;
 import static com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck.MSG_ORDER;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.lang.reflect.Method;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.Checker;
@@ -63,8 +63,8 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
             TokenTypes.STATIC_IMPORT,
             TokenTypes.PACKAGE_DEF,
         };
-        assertArrayEquals("Default required tokens are invalid",
-            expected, checkObj.getRequiredTokens());
+        assertArrayEquals(
+                expected, checkObj.getRequiredTokens(), "Default required tokens are invalid");
     }
 
     @Test
@@ -417,7 +417,7 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
             TokenTypes.PACKAGE_DEF,
         };
 
-        assertArrayEquals("Default acceptable tokens are invalid", expected, actual);
+        assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
     }
 
     @Test
@@ -431,7 +431,7 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
         final Object actual = method.invoke(t, new Object[] {null});
 
         final String expected = "";
-        assertEquals("Invalid getFullImportIdent result", expected, actual);
+        assertEquals(expected, actual, "Invalid getFullImportIdent result");
     }
 
     @Test
@@ -526,16 +526,15 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid exception message",
-                "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+            assertEquals("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                         + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
                         + ".imports.CustomImportOrderCheck - "
                         + "Cannot set property 'customImportOrderRules' to "
                         + "'SAME_PACKAGE(-1)'",
-                ex.getMessage());
-            assertEquals("Invalid exception message",
-                    "SAME_PACKAGE rule parameter should be positive integer: SAME_PACKAGE(-1)",
-                        ex.getCause().getCause().getCause().getCause().getMessage());
+                ex.getMessage(), "Invalid exception message");
+            assertEquals("SAME_PACKAGE rule parameter should be positive integer: SAME_PACKAGE(-1)",
+                        ex.getCause().getCause().getCause().getCause().getMessage(),
+                    "Invalid exception message");
         }
     }
 
@@ -555,16 +554,15 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid exception message",
-                "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+            assertEquals("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                         + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
                         + ".imports.CustomImportOrderCheck - "
                         + "Cannot set property 'customImportOrderRules' to "
                         + "'SAME_PACKAGE(0)'",
-                ex.getMessage());
-            assertEquals("Invalid exception message",
-                    "SAME_PACKAGE rule parameter should be positive integer: SAME_PACKAGE(0)",
-                        ex.getCause().getCause().getCause().getCause().getMessage());
+                ex.getMessage(), "Invalid exception message");
+            assertEquals("SAME_PACKAGE rule parameter should be positive integer: SAME_PACKAGE(0)",
+                        ex.getCause().getCause().getCause().getCause().getMessage(),
+                    "Invalid exception message");
         }
     }
 
@@ -583,15 +581,15 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid exception message",
-                "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+            assertEquals("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                         + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
                         + ".imports.CustomImportOrderCheck - "
                         + "Cannot set property 'customImportOrderRules' to "
                         + "'SAME_PACKAGE(3)###UNSUPPORTED_RULE'",
-                ex.getMessage());
-            assertEquals("Invalid exception message", "Unexpected rule: UNSUPPORTED_RULE", ex
-                    .getCause().getCause().getCause().getCause().getMessage());
+                ex.getMessage(), "Invalid exception message");
+            assertEquals("Unexpected rule: UNSUPPORTED_RULE", ex
+                    .getCause().getCause().getCause().getCause().getMessage(),
+                    "Invalid exception message");
         }
     }
 
@@ -609,16 +607,15 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid exception message",
-                "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+            assertEquals("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                         + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
                         + ".imports.CustomImportOrderCheck - "
                         + "Cannot set property 'customImportOrderRules' to "
                         + "'SAME_PACKAGE(INT_IS_REQUIRED_HERE)'",
-                ex.getMessage());
-            assertEquals("Invalid exception message",
-                    "For input string: \"INT_IS_REQUIRED_HERE\"",
-                    ex.getCause().getCause().getCause().getCause().getMessage());
+                ex.getMessage(), "Invalid exception message");
+            assertEquals("For input string: \"INT_IS_REQUIRED_HERE\"",
+                    ex.getCause().getCause().getCause().getCause().getMessage(),
+                    "Invalid exception message");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/FileImportControlTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/FileImportControlTest.java
@@ -19,10 +19,10 @@
 
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class FileImportControlTest {
 
@@ -34,7 +34,7 @@ public class FileImportControlTest {
     private final FileImportControl fileRegexpNode = new FileImportControl(root, ".*Other.*",
             true);
 
-    @Before
+    @BeforeEach
     public void setUp() {
         root.addChild(fileNode);
         root.addChild(fileRegexpNode);
@@ -49,13 +49,14 @@ public class FileImportControlTest {
 
     @Test
     public void testLocateFinest() {
-        assertEquals("Unexpected response", root, root
-                .locateFinest("com.kazgroup.courtlink.domain", "Random"));
-        assertEquals("Unexpected response", fileNode, root
-                .locateFinest("com.kazgroup.courtlink.common.api", "MyClass"));
-        assertEquals("Unexpected response", fileRegexpNode, root
-                .locateFinest("com.kazgroup.courtlink.common.api", "SomeOtherName"));
-        assertEquals("Unexpected response", root, root
-                .locateFinest("com.kazgroup.courtlink", null));
+        assertEquals(root, root.locateFinest("com.kazgroup.courtlink.domain", "Random"),
+                "Unexpected response");
+        assertEquals(fileNode, root.locateFinest("com.kazgroup.courtlink.common.api", "MyClass"),
+                "Unexpected response");
+        assertEquals(fileRegexpNode, root.locateFinest("com.kazgroup.courtlink.common.api",
+                "SomeOtherName"), "Unexpected response");
+        assertEquals(root, root.locateFinest("com.kazgroup.courtlink", null),
+                "Unexpected response");
     }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheckTest.java
@@ -20,9 +20,9 @@
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
 import static com.puppycrawl.tools.checkstyle.checks.imports.IllegalImportCheck.MSG_KEY;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -39,8 +39,8 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
     public void testGetRequiredTokens() {
         final IllegalImportCheck checkObj = new IllegalImportCheck();
         final int[] expected = {TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT};
-        assertArrayEquals("Default required tokens are invalid",
-            expected, checkObj.getRequiredTokens());
+        assertArrayEquals(expected, checkObj.getRequiredTokens(),
+                "Default required tokens are invalid");
     }
 
     @Test
@@ -76,7 +76,7 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
         final int[] actual = testCheckObject.getAcceptableTokens();
         final int[] expected = {TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT};
 
-        assertArrayEquals("Default acceptable tokens are invalid", expected, actual);
+        assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
@@ -22,17 +22,16 @@ package com.puppycrawl.tools.checkstyle.checks.imports;
 import static com.puppycrawl.tools.checkstyle.checks.imports.ImportControlCheck.MSG_DISALLOWED;
 import static com.puppycrawl.tools.checkstyle.checks.imports.ImportControlCheck.MSG_MISSING_FILE;
 import static com.puppycrawl.tools.checkstyle.checks.imports.ImportControlCheck.MSG_UNKNOWN_PKG;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -43,8 +42,8 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class ImportControlCheckTest extends AbstractModuleTestSupport {
 
-    @Rule
-    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    public File temporaryFolder;
 
     @Override
     protected String getPackageLocation() {
@@ -59,8 +58,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
             TokenTypes.IMPORT,
             TokenTypes.STATIC_IMPORT,
         };
-        assertArrayEquals("Default required tokens are invalid",
-            expected, checkObj.getRequiredTokens());
+        assertArrayEquals(expected, checkObj.getRequiredTokens(),
+                "Default required tokens are invalid");
     }
 
     @Test
@@ -129,8 +128,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
             final String message = getCheckstyleExceptionMessage(ex);
             final String messageStart = "Unable to find: ";
 
-            assertTrue("Invalid message, should start with: " + messageStart,
-                message.startsWith(message));
+            assertTrue(message.startsWith(message),
+                    "Invalid message, should start with: " + messageStart);
         }
     }
 
@@ -147,8 +146,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
             final String message = getCheckstyleExceptionMessage(ex);
             final String messageStart = "Unable to load ";
 
-            assertTrue("Invalid message, should start with: " + messageStart,
-                message.startsWith(message));
+            assertTrue(message.startsWith(message),
+                    "Invalid message, should start with: " + messageStart);
         }
     }
 
@@ -279,7 +278,7 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
             TokenTypes.STATIC_IMPORT,
         };
 
-        assertArrayEquals("Default acceptable tokens are invalid", expected, actual);
+        assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
     }
 
     @Test
@@ -305,8 +304,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
             final String message = getCheckstyleExceptionMessage(ex);
             final String messageStart = "Unable to find: ";
 
-            assertTrue("Invalid message, should start with: " + messageStart,
-                message.startsWith(message));
+            assertTrue(message.startsWith(message),
+                    "Invalid message, should start with: " + messageStart);
         }
     }
 
@@ -333,8 +332,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
             final String message = getCheckstyleExceptionMessage(ex);
             final String messageStart = "Unable to load ";
 
-            assertTrue("Invalid message, should start with: " + messageStart,
-                message.startsWith(message));
+            assertTrue(message.startsWith(message),
+                    "Invalid message, should start with: " + messageStart);
         }
     }
 
@@ -347,19 +346,20 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
         treeWalkerConfig.addChild(checkConfig);
 
         final DefaultConfiguration checkerConfig = createRootConfig(treeWalkerConfig);
-        final File cacheFile = temporaryFolder.newFile();
+        final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
         checkerConfig.addAttribute("cacheFile", cacheFile.getPath());
 
-        final String filePath = temporaryFolder.newFile("EmptyFile.java").getPath();
+        final String filePath = File.createTempFile("empty", ".java", temporaryFolder).getPath();
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
         verify(checkerConfig, filePath, expected);
         // One more time to use cache.
         verify(checkerConfig, filePath, expected);
 
-        assertTrue("External resource is not present in cache",
-                new String(Files.readAllBytes(cacheFile.toPath()),
-                        StandardCharsets.UTF_8).contains("InputImportControlOneRegExp.xml"));
+        final String contents = new String(Files.readAllBytes(cacheFile.toPath()),
+                StandardCharsets.UTF_8);
+        assertTrue(contents.contains("InputImportControlOneRegExp.xml"),
+                "External resource is not present in cache");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoaderTest.java
@@ -19,11 +19,11 @@
 
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
@@ -31,7 +31,7 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URI;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -51,7 +51,7 @@ public class ImportControlLoaderTest {
         final AbstractImportControl root =
                 ImportControlLoader.load(
                 new File(getPath("InputImportControlLoaderComplete.xml")).toURI());
-        assertNotNull("Import root should not be null", root);
+        assertNotNull(root, "Import root should not be null");
     }
 
     @Test
@@ -62,10 +62,10 @@ public class ImportControlLoaderTest {
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            assertSame("Invalid exception class",
-                    MalformedURLException.class, ex.getCause().getClass());
-            assertEquals("Invalid exception message",
-                    "unknown protocol: aaa", ex.getCause().getMessage());
+            assertSame(MalformedURLException.class, ex.getCause().getClass(),
+                    "Invalid exception class");
+            assertEquals("unknown protocol: aaa", ex.getCause().getMessage(),
+                    "Invalid exception message");
         }
     }
 
@@ -74,7 +74,7 @@ public class ImportControlLoaderTest {
         final AbstractImportControl root =
                 ImportControlLoader.load(
                     new File(getPath("InputImportControlLoaderWithNewElement.xml")).toURI());
-        assertNotNull("Import root should not be null", root);
+        assertNotNull(root, "Import root should not be null");
     }
 
     @Test
@@ -95,9 +95,9 @@ public class ImportControlLoaderTest {
             fail("exception expected");
         }
         catch (InvocationTargetException ex) {
-            assertSame("Invalid exception class", SAXException.class, ex.getCause().getClass());
-            assertEquals("Invalid exception message",
-                    "missing attribute you_cannot_find_me", ex.getCause().getMessage());
+            assertSame(SAXException.class, ex.getCause().getClass(), "Invalid exception class");
+            assertEquals("missing attribute you_cannot_find_me", ex.getCause().getMessage(),
+                    "Invalid exception message");
         }
     }
 
@@ -117,10 +117,10 @@ public class ImportControlLoaderTest {
             fail("exception expected");
         }
         catch (InvocationTargetException ex) {
-            assertSame("Invalid exception class",
-                    CheckstyleException.class, ex.getCause().getClass());
-            assertTrue("Invalid exception message: " + ex.getCause().getMessage(),
-                    ex.getCause().getMessage().startsWith("unable to read"));
+            assertSame(CheckstyleException.class, ex.getCause().getClass(),
+                    "Invalid exception class");
+            assertTrue(ex.getCause().getMessage().startsWith("unable to read"),
+                    "Invalid exception message: " + ex.getCause().getMessage());
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -22,11 +22,11 @@ package com.puppycrawl.tools.checkstyle.checks.imports;
 import static com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck.MSG_ORDERING;
 import static com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck.MSG_SEPARATED_IN_GROUP;
 import static com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck.MSG_SEPARATION;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import antlr.CommonHiddenStreamToken;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
@@ -52,7 +52,7 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testImportOrderOptionValueOf() {
         final ImportOrderOption option = ImportOrderOption.valueOf("TOP");
-        assertEquals("Invalid valueOf result", ImportOrderOption.TOP, option);
+        assertEquals(ImportOrderOption.TOP, option, "Invalid valueOf result");
     }
 
     @Test
@@ -219,12 +219,12 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid exception message",
+            assertEquals(
                     "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                         + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
                         + ".imports.ImportOrderCheck - "
                         + "Cannot set property 'option' to 'invalid_option'",
-                    ex.getMessage());
+                    ex.getMessage(), "Invalid exception message");
         }
     }
 
@@ -616,14 +616,14 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
             fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid exception message",
-                    "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
+            assertEquals("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker - "
                         + "cannot initialize module com.puppycrawl.tools.checkstyle.checks"
                         + ".imports.ImportOrderCheck - "
                         + "Cannot set property 'groups' to '/^javax'",
-                    ex.getMessage());
-            assertEquals("Invalid exception message", "Invalid group: /^javax",
-                    ex.getCause().getCause().getCause().getCause().getMessage());
+                    ex.getMessage(), "Invalid exception message");
+            assertEquals("Invalid group: /^javax",
+                    ex.getCause().getCause().getCause().getCause().getMessage(),
+                    "Invalid exception message");
         }
     }
 
@@ -676,7 +676,7 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
             fail("An exception is expected");
         }
         catch (IllegalStateException ex) {
-            assertTrue("invalid exception message", ex.getMessage().endsWith(": null"));
+            assertTrue(ex.getMessage().endsWith(": null"), "invalid exception message");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgImportControlTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgImportControlTest.java
@@ -19,11 +19,11 @@
 
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class PkgImportControlTest {
 
@@ -42,7 +42,7 @@ public class PkgImportControlTest {
     private final PkgImportControl icBootRegexpParen = new PkgImportControl(icRootRegexpParent,
             "bo+t", true, MismatchStrategy.DELEGATE_TO_PARENT);
 
-    @Before
+    @BeforeEach
     public void setUp() {
         icRoot.addChild(icCommon);
         icRoot.addImportRule(
@@ -71,122 +71,130 @@ public class PkgImportControlTest {
 
     @Test
     public void testLocateFinest() {
-        assertEquals("Unexpected response", icRoot, icRoot
-                .locateFinest("com.kazgroup.courtlink.domain", "MyClass"));
-        assertEquals("Unexpected response", icCommon, icRoot
-                .locateFinest("com.kazgroup.courtlink.common.api", "MyClass"));
-        assertNull("Unexpected response", icRoot.locateFinest("com", "MyClass"));
+        assertEquals(icRoot, icRoot.locateFinest("com.kazgroup.courtlink.domain", "MyClass"),
+                "Unexpected response");
+        assertEquals(icCommon, icRoot.locateFinest("com.kazgroup.courtlink.common.api", "MyClass"),
+                "Unexpected response");
+        assertNull(icRoot.locateFinest("com", "MyClass"), "Unexpected response");
     }
 
     @Test
     public void testEnsureTrailingDot() {
-        assertNull("Unexpected response",
-                icRoot.locateFinest("com.kazgroup.courtlinkkk", "MyClass"));
-        assertNull("Unexpected response",
-                icRoot.locateFinest("com.kazgroup.courtlink/common.api", "MyClass"));
+        assertNull(icRoot.locateFinest("com.kazgroup.courtlinkkk", "MyClass"),
+                "Unexpected response");
+        assertNull(icRoot.locateFinest("com.kazgroup.courtlink/common.api", "MyClass"),
+                "Unexpected response");
     }
 
     @Test
     public void testCheckAccess() {
-        assertEquals("Unexpected access result", AccessResult.DISALLOWED, icCommon.checkAccess(
+        assertEquals(AccessResult.DISALLOWED, icCommon.checkAccess(
                 "com.kazgroup.courtlink.common", "MyClass",
-                "org.springframework.something"));
-        assertEquals("Unexpected access result", AccessResult.ALLOWED, icCommon
+                "org.springframework.something"), "Unexpected access result");
+        assertEquals(AccessResult.ALLOWED, icCommon
                 .checkAccess("com.kazgroup.courtlink.common", "MyClass",
-                        "org.apache.commons.something"));
-        assertEquals("Unexpected access result", AccessResult.DISALLOWED, icCommon.checkAccess(
-                "com.kazgroup.courtlink.common", "MyClass", "org.apache.commons"));
-        assertEquals("Unexpected access result", AccessResult.ALLOWED, icCommon.checkAccess(
-                "com.kazgroup.courtlink.common", "MyClass", "org.hibernate.something"));
-        assertEquals("Unexpected access result", AccessResult.DISALLOWED, icCommon.checkAccess(
-                "com.kazgroup.courtlink.common", "MyClass", "com.badpackage.something"));
-        assertEquals("Unexpected access result", AccessResult.DISALLOWED, icRoot.checkAccess(
-                "com.kazgroup.courtlink", "MyClass", "org.hibernate.something"));
+                        "org.apache.commons.something"), "Unexpected access result");
+        assertEquals(AccessResult.DISALLOWED, icCommon.checkAccess(
+                "com.kazgroup.courtlink.common", "MyClass",
+                "org.apache.commons"), "Unexpected access result");
+        assertEquals(AccessResult.ALLOWED, icCommon.checkAccess(
+                "com.kazgroup.courtlink.common", "MyClass",
+                "org.hibernate.something"), "Unexpected access result");
+        assertEquals(AccessResult.DISALLOWED, icCommon.checkAccess(
+                "com.kazgroup.courtlink.common", "MyClass",
+                "com.badpackage.something"), "Unexpected access result");
+        assertEquals(AccessResult.DISALLOWED, icRoot.checkAccess(
+                "com.kazgroup.courtlink", "MyClass",
+                "org.hibernate.something"), "Unexpected access result");
     }
 
     @Test
     public void testUnknownPkg() {
-        assertNull("Unexpected response", icRoot.locateFinest("net.another", "MyClass"));
+        assertNull(icRoot.locateFinest("net.another", "MyClass"), "Unexpected response");
     }
 
     @Test
     public void testRegExpChildLocateFinest() {
-        assertEquals("Unexpected response", icRootRegexpChild, icRootRegexpChild
-                .locateFinest("com.kazgroup.courtlink.domain", "MyClass"));
-        assertEquals("Unexpected response", icCommonRegexpChild, icRootRegexpChild
-                .locateFinest("com.kazgroup.courtlink.common.api", "MyClass"));
-        assertNull("Unexpected response", icRootRegexpChild.locateFinest("com", "MyClass"));
+        assertEquals(icRootRegexpChild,
+                icRootRegexpChild.locateFinest("com.kazgroup.courtlink.domain", "MyClass"),
+                "Unexpected response");
+        assertEquals(icCommonRegexpChild,
+                icRootRegexpChild.locateFinest("com.kazgroup.courtlink.common.api", "MyClass"),
+                "Unexpected response");
+        assertNull(icRootRegexpChild.locateFinest("com", "MyClass"), "Unexpected response");
     }
 
     @Test
     public void testRegExpChildCheckAccess() {
-        assertEquals("Unexpected access result", AccessResult.DISALLOWED,
+        assertEquals(AccessResult.DISALLOWED,
                 icCommonRegexpChild.checkAccess("com.kazgroup.courtlink.common", "MyClass",
-                        "org.springframework.something"));
-        assertEquals("Unexpected access result", AccessResult.DISALLOWED,
+                        "org.springframework.something"), "Unexpected access result");
+        assertEquals(AccessResult.DISALLOWED,
                 icCommonRegexpChild.checkAccess("com.kazgroup.courtlink.common", "MyClass",
-                        "org.luiframework.something"));
-        assertEquals("Unexpected access result", AccessResult.DISALLOWED,
+                        "org.luiframework.something"), "Unexpected access result");
+        assertEquals(AccessResult.DISALLOWED,
                 icCommonRegexpChild.checkAccess("com.kazgroup.courtlink.common", "MyClass",
-                        "de.springframework.something"));
-        assertEquals("Unexpected access result", AccessResult.DISALLOWED,
+                        "de.springframework.something"), "Unexpected access result");
+        assertEquals(AccessResult.DISALLOWED,
                 icCommonRegexpChild.checkAccess("com.kazgroup.courtlink.common", "MyClass",
-                "de.luiframework.something"));
-        assertEquals("Unexpected access result", AccessResult.ALLOWED,
+                "de.luiframework.something"), "Unexpected access result");
+        assertEquals(AccessResult.ALLOWED,
                 icCommonRegexpChild.checkAccess("com.kazgroup.courtlink.common", "MyClass",
-                        "org.apache.commons.something"));
-        assertEquals("Unexpected access result", AccessResult.ALLOWED,
+                        "org.apache.commons.something"), "Unexpected access result");
+        assertEquals(AccessResult.ALLOWED,
                 icCommonRegexpChild.checkAccess("com.kazgroup.courtlink.common", "MyClass",
-                        "org.lui.commons.something"));
-        assertEquals("Unexpected access result", AccessResult.DISALLOWED,
+                        "org.lui.commons.something"), "Unexpected access result");
+        assertEquals(AccessResult.DISALLOWED,
                 icCommonRegexpChild.checkAccess("com.kazgroup.courtlink.common", "MyClass",
-                        "org.apache.commons"));
-        assertEquals("Unexpected access result", AccessResult.DISALLOWED,
+                        "org.apache.commons"), "Unexpected access result");
+        assertEquals(AccessResult.DISALLOWED,
                 icCommonRegexpChild.checkAccess("com.kazgroup.courtlink.common", "MyClass",
-                        "org.lui.commons"));
-        assertEquals("Unexpected access result", AccessResult.ALLOWED,
+                        "org.lui.commons"), "Unexpected access result");
+        assertEquals(AccessResult.ALLOWED,
                 icCommonRegexpChild.checkAccess("com.kazgroup.courtlink.common", "MyClass",
-                        "org.hibernate.something"));
-        assertEquals("Unexpected access result", AccessResult.DISALLOWED,
+                        "org.hibernate.something"), "Unexpected access result");
+        assertEquals(AccessResult.DISALLOWED,
                 icCommonRegexpChild.checkAccess("com.kazgroup.courtlink.common", "MyClass",
-                        "com.badpackage.something"));
-        assertEquals("Unexpected access result", AccessResult.DISALLOWED,
+                        "com.badpackage.something"), "Unexpected access result");
+        assertEquals(AccessResult.DISALLOWED,
                 icRootRegexpChild.checkAccess("com.kazgroup.courtlink", "MyClass",
-                        "org.hibernate.something"));
+                        "org.hibernate.something"), "Unexpected access result");
     }
 
     @Test
     public void testRegExpChildUnknownPkg() {
-        assertNull("Unexpected response", icRootRegexpChild.locateFinest("net.another", "MyClass"));
+        assertNull(icRootRegexpChild.locateFinest("net.another", "MyClass"), "Unexpected response");
     }
 
     @Test
     public void testRegExpParentInRootIsConsidered() {
-        assertNull("Package should not be null", icRootRegexpParent.locateFinest("com", "MyClass"));
-        assertNull("Package should not be null",
-                icRootRegexpParent.locateFinest("com/hurz/courtlink", "MyClass"));
-        assertNull("Package should not be null",
-                icRootRegexpParent.locateFinest("com.hurz.hurz.courtlink", "MyClass"));
-        assertEquals("Invalid package", icRootRegexpParent,
-                icRootRegexpParent.locateFinest("com.hurz.courtlink.domain", "MyClass"));
-        assertEquals("Invalid package", icRootRegexpParent, icRootRegexpParent
-                .locateFinest("com.kazgroup.courtlink.domain", "MyClass"));
+        assertNull(icRootRegexpParent.locateFinest("com", "MyClass"), "Package should not be null");
+        assertNull(icRootRegexpParent.locateFinest("com/hurz/courtlink", "MyClass"),
+                "Package should not be null");
+        assertNull(icRootRegexpParent.locateFinest("com.hurz.hurz.courtlink", "MyClass"),
+                "Package should not be null");
+        assertEquals(icRootRegexpParent,
+                icRootRegexpParent.locateFinest("com.hurz.courtlink.domain", "MyClass"),
+                "Invalid package");
+        assertEquals(icRootRegexpParent,
+                icRootRegexpParent.locateFinest("com.kazgroup.courtlink.domain", "MyClass"),
+                "Invalid package");
     }
 
     @Test
     public void testRegExpParentInSubpackageIsConsidered() {
-        assertEquals("Invalid package", icBootRegexpParen, icRootRegexpParent
-                .locateFinest("com.kazgroup.courtlink.boot.api", "MyClass"));
-        assertEquals("Invalid package", icBootRegexpParen, icRootRegexpParent
-                .locateFinest("com.kazgroup.courtlink.bot.api", "MyClass"));
+        assertEquals(icBootRegexpParen, icRootRegexpParent
+                .locateFinest("com.kazgroup.courtlink.boot.api", "MyClass"), "Invalid package");
+        assertEquals(icBootRegexpParen, icRootRegexpParent
+                .locateFinest("com.kazgroup.courtlink.bot.api", "MyClass"), "Invalid package");
     }
 
     @Test
     public void testRegExpParentEnsureTrailingDot() {
-        assertNull("Invalid package",
-                icRootRegexpParent.locateFinest("com.kazgroup.courtlinkkk", "MyClass"));
-        assertNull("Invalid package",
-                icRootRegexpParent.locateFinest("com.kazgroup.courtlink/common.api", "MyClass"));
+        assertNull(icRootRegexpParent.locateFinest("com.kazgroup.courtlinkkk", "MyClass"),
+                "Invalid package");
+        assertNull(icRootRegexpParent.locateFinest("com.kazgroup.courtlink/common.api", "MyClass"),
+                "Invalid package");
     }
 
     @Test
@@ -197,10 +205,10 @@ public class PkgImportControlTest {
         final PkgImportControl common = new PkgImportControl(root, "common", false,
                 MismatchStrategy.DELEGATE_TO_PARENT);
         root.addChild(common);
-        assertEquals("Invalid package", root, root.locateFinest("com.foo", "MyClass"));
-        assertEquals("Invalid package", common, root.locateFinest("com.foo.common", "MyClass"));
-        assertEquals("Invalid package", root, root.locateFinest("com.bar", "MyClass"));
-        assertEquals("Invalid package", common, root.locateFinest("com.bar.common", "MyClass"));
+        assertEquals(root, root.locateFinest("com.foo", "MyClass"), "Invalid package");
+        assertEquals(common, root.locateFinest("com.foo.common", "MyClass"), "Invalid package");
+        assertEquals(root, root.locateFinest("com.bar", "MyClass"), "Invalid package");
+        assertEquals(common, root.locateFinest("com.bar.common", "MyClass"), "Invalid package");
     }
 
     @Test
@@ -211,10 +219,10 @@ public class PkgImportControlTest {
         final PkgImportControl common = new PkgImportControl(root, "common", false,
                 MismatchStrategy.DELEGATE_TO_PARENT);
         root.addChild(common);
-        assertEquals("Invalid package", root, root.locateFinest("com.foo", "MyClass"));
-        assertEquals("Invalid package", common, root.locateFinest("com.foo.common", "MyClass"));
-        assertEquals("Invalid package", root, root.locateFinest("com.bar", "MyClass"));
-        assertEquals("Invalid package", common, root.locateFinest("com.bar.common", "MyClass"));
+        assertEquals(root, root.locateFinest("com.foo", "MyClass"), "Invalid package");
+        assertEquals(common, root.locateFinest("com.foo.common", "MyClass"), "Invalid package");
+        assertEquals(root, root.locateFinest("com.bar", "MyClass"), "Invalid package");
+        assertEquals(common, root.locateFinest("com.bar.common", "MyClass"), "Invalid package");
     }
 
     @Test
@@ -225,17 +233,17 @@ public class PkgImportControlTest {
         final PkgImportControl subpackages = new PkgImportControl(root, "foo|bar", true,
                 MismatchStrategy.DELEGATE_TO_PARENT);
         root.addChild(subpackages);
-        assertEquals("Invalid package", root, root.locateFinest("org.somewhere", "MyClass"));
-        assertEquals("Invalid package", subpackages,
-                root.locateFinest("org.somewhere.foo", "MyClass"));
-        assertEquals("Invalid package", subpackages,
-                root.locateFinest("org.somewhere.bar", "MyClass"));
+        assertEquals(root, root.locateFinest("org.somewhere", "MyClass"), "Invalid package");
+        assertEquals(subpackages,
+                root.locateFinest("org.somewhere.foo", "MyClass"), "Invalid package");
+        assertEquals(subpackages,
+                root.locateFinest("org.somewhere.bar", "MyClass"), "Invalid package");
     }
 
     @Test
     public void testRegExpParentUnknownPkg() {
-        assertNull("Package should not be null",
-                icRootRegexpParent.locateFinest("net.another", "MyClass"));
+        assertNull(icRootRegexpParent.locateFinest("net.another", "MyClass"),
+                "Package should not be null");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgImportRuleTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgImportRuleTest.java
@@ -19,87 +19,87 @@
 
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PkgImportRuleTest {
 
     @Test
     public void testPkgImportRule() {
         final PkgImportRule rule = new PkgImportRule(true, false, "pkg", false, false);
-        assertNotNull("Rule must not be null", rule);
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("asda"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("p"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("pkga"));
-        assertEquals("Invalid access result", AccessResult.ALLOWED, rule.verifyImport("pkg.a"));
-        assertEquals("Invalid access result", AccessResult.ALLOWED, rule.verifyImport("pkg.a.b"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("pkg"));
+        assertNotNull(rule, "Rule must not be null");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("asda"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("p"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkga"), "Invalid access result");
+        assertEquals(AccessResult.ALLOWED, rule.verifyImport("pkg.a"), "Invalid access result");
+        assertEquals(AccessResult.ALLOWED, rule.verifyImport("pkg.a.b"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkg"), "Invalid access result");
     }
 
     @Test
     public void testPkgImportRuleExactMatch() {
         final PkgImportRule rule = new PkgImportRule(true, false, "pkg", true, false);
-        assertNotNull("Rule must not be null", rule);
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("asda"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("p"));
-        assertEquals("Invalid access result", AccessResult.ALLOWED, rule.verifyImport("pkg.a"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("pkg.a.b"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("pkg"));
+        assertNotNull(rule, "Rule must not be null");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("asda"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("p"), "Invalid access result");
+        assertEquals(AccessResult.ALLOWED, rule.verifyImport("pkg.a"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkg.a.b"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkg"), "Invalid access result");
     }
 
     @Test
     public void testPkgImportRuleRegexpSimple() {
         final PkgImportRule rule = new PkgImportRule(true, false, "pkg", false, true);
-        assertNotNull("Rule must not be null", rule);
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("asda"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("p"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("pkga"));
-        assertEquals("Invalid access result", AccessResult.ALLOWED, rule.verifyImport("pkg.a"));
-        assertEquals("Invalid access result", AccessResult.ALLOWED, rule.verifyImport("pkg.a.b"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("pkg"));
+        assertNotNull(rule, "Rule must not be null");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("asda"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("p"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkga"), "Invalid access result");
+        assertEquals(AccessResult.ALLOWED, rule.verifyImport("pkg.a"), "Invalid access result");
+        assertEquals(AccessResult.ALLOWED, rule.verifyImport("pkg.a.b"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkg"), "Invalid access result");
     }
 
     @Test
     public void testPkgImportRuleExactMatchRegexpSimple() {
         final PkgImportRule rule = new PkgImportRule(true, false, "pkg", true, true);
-        assertNotNull("Rule must not be null", rule);
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("asda"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("p"));
-        assertEquals("Invalid access result", AccessResult.ALLOWED, rule.verifyImport("pkg.a"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("pkg.a.b"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("pkg"));
+        assertNotNull(rule, "Rule must not be null");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("asda"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("p"), "Invalid access result");
+        assertEquals(AccessResult.ALLOWED, rule.verifyImport("pkg.a"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkg.a.b"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkg"), "Invalid access result");
     }
 
     @Test
     public void testPkgImportRuleRegexp() {
         final PkgImportRule rule = new PkgImportRule(true, false, "(pkg|hallo)", false, true);
-        assertNotNull("Rule must not be null", rule);
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("asda"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("p"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("pkga"));
-        assertEquals("Invalid access result", AccessResult.ALLOWED, rule.verifyImport("pkg.a"));
-        assertEquals("Invalid access result", AccessResult.ALLOWED, rule.verifyImport("pkg.a.b"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("pkg"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("halloa"));
-        assertEquals("Invalid access result", AccessResult.ALLOWED, rule.verifyImport("hallo.a"));
-        assertEquals("Invalid access result", AccessResult.ALLOWED, rule.verifyImport("hallo.a.b"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("hallo"));
+        assertNotNull(rule, "Rule must not be null");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("asda"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("p"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkga"), "Invalid access result");
+        assertEquals(AccessResult.ALLOWED, rule.verifyImport("pkg.a"), "Invalid access result");
+        assertEquals(AccessResult.ALLOWED, rule.verifyImport("pkg.a.b"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkg"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("halloa"), "Invalid access result");
+        assertEquals(AccessResult.ALLOWED, rule.verifyImport("hallo.a"), "Invalid access result");
+        assertEquals(AccessResult.ALLOWED, rule.verifyImport("hallo.a.b"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("hallo"), "Invalid access result");
     }
 
     @Test
     public void testPkgImportRuleExactMatchRegexp() {
         final PkgImportRule rule = new PkgImportRule(true, false, "(pkg|hallo)", true, true);
-        assertNotNull("Rule must not be null", rule);
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("asda"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("p"));
-        assertEquals("Invalid access result", AccessResult.ALLOWED, rule.verifyImport("pkg.a"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("pkg.a.b"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("pkg"));
-        assertEquals("Invalid access result", AccessResult.ALLOWED, rule.verifyImport("hallo.a"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("hallo.a.b"));
-        assertEquals("Invalid access result", AccessResult.UNKNOWN, rule.verifyImport("hallo"));
+        assertNotNull(rule, "Rule must not be null");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("asda"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("p"), "Invalid access result");
+        assertEquals(AccessResult.ALLOWED, rule.verifyImport("pkg.a"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkg.a.b"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkg"), "Invalid access result");
+        assertEquals(AccessResult.ALLOWED, rule.verifyImport("hallo.a"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("hallo.a.b"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("hallo"), "Invalid access result");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheckTest.java
@@ -22,13 +22,13 @@ package com.puppycrawl.tools.checkstyle.checks.imports;
 import static com.puppycrawl.tools.checkstyle.checks.imports.RedundantImportCheck.MSG_DUPLICATE;
 import static com.puppycrawl.tools.checkstyle.checks.imports.RedundantImportCheck.MSG_LANG;
 import static com.puppycrawl.tools.checkstyle.checks.imports.RedundantImportCheck.MSG_SAME;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
@@ -52,8 +52,8 @@ public class RedundantImportCheckTest
             TokenTypes.STATIC_IMPORT,
             TokenTypes.PACKAGE_DEF,
         };
-        assertArrayEquals("Default required tokens are invalid",
-            expected, checkObj.getRequiredTokens());
+        assertArrayEquals(expected, checkObj.getRequiredTokens(),
+                "Default required tokens are invalid");
     }
 
     @Test
@@ -117,7 +117,7 @@ public class RedundantImportCheckTest
             TokenTypes.PACKAGE_DEF,
         };
 
-        assertArrayEquals("Default acceptable tokens are invalid", expected, actual);
+        assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
@@ -20,13 +20,13 @@
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
 import static com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck.MSG_KEY;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
@@ -182,7 +182,7 @@ public class UnusedImportsCheckTest extends AbstractModuleTestSupport {
             TokenTypes.VARIABLE_DEF,
         };
 
-        assertArrayEquals("Default required tokens are invalid", expected, actual);
+        assertArrayEquals(expected, actual, "Default required tokens are invalid");
     }
 
     @Test
@@ -207,7 +207,7 @@ public class UnusedImportsCheckTest extends AbstractModuleTestSupport {
             TokenTypes.VARIABLE_DEF,
         };
 
-        assertArrayEquals("Default acceptable tokens are invalid", expected, actual);
+        assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
     }
 
     @Test


### PR DESCRIPTION
Issue #6916

Tests of the `imports` package are migrated to Junit5.