### PR TITLE
Issue #7301: fix source display for firefox

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -54,12 +54,13 @@ h2:hover .anchor, h3:hover .anchor {
 .source {
   white-space: nowrap;
   padding: 0;
+  overflow-x: auto;
 }
 
 .source > pre {
   margin: 0;
   padding: 12px;
-  overflow-x: auto;
+  width: max-content;
 }
 
 .wrap-content pre {

--- a/src/xdocs/writingjavadocchecks.xml.vm
+++ b/src/xdocs/writingjavadocchecks.xml.vm
@@ -752,7 +752,7 @@ Checkstyle ends with 5 errors.
        Now you can see parsed javadoc tree as child of comment block.
       </p>
       <p>
-        <span class="wrapper">
+        <span class="wrapper block">
           <img alt="screenshot" src="images/gui_javadoc_screenshot.png"/>
         </span>
       </p>


### PR DESCRIPTION
Issue #7301:
* Fix source display in firefox

how it was before:
![image](https://user-images.githubusercontent.com/7516893/70549564-b67ca600-1b74-11ea-8db8-94a7616f9c44.png)
according to @rnveach there should be some space between the text of the code snippet and its border. This already works in chrome (merged in https://github.com/checkstyle/checkstyle/pull/7302) and this pr fixes that for firefox.

![image](https://user-images.githubusercontent.com/7516893/70550592-466f1f80-1b76-11ea-9d17-db29c06c4dbf.png)
