### PR TITLE
Issue #6916: migrate tests to junit5 for javadoc package

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -620,6 +620,7 @@ issuehunt
 itemvalue
 ith
 itr
+itsallcode
 ivanov
 ivanovjr
 IVersion
@@ -1235,6 +1236,7 @@ suppresswithplaintextcommentfilter
 svg
 svn
 sxpath
+sysextensions
 sysprop
 systemout
 systemtests

--- a/config/import-control-test.xml
+++ b/config/import-control-test.xml
@@ -19,11 +19,6 @@
   <allow pkg=".*" regex="true" />
 
   <!-- Till https://github.com/checkstyle/checkstyle/issues/6916 -->
-  <subpackage name="checks">
-    <subpackage name="javadoc">
-      <allow pkg="org.junit"/>
-    </subpackage>
-  </subpackage>
   <subpackage name="internal">
     <allow pkg="org.junit"/>
   </subpackage>

--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,12 @@
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.itsallcode</groupId>
+      <artifactId>junit5-system-extensions</artifactId>
+      <version>1.0.3</version>
+      <scope>test</scope>
+    </dependency>
     <!-- Junit4 legacy support till https://github.com/checkstyle/checkstyle/issues/6916 -->
     <dependency>
       <groupId>org.junit.vintage</groupId>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckTest.java
@@ -20,9 +20,9 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.AtclauseOrderCheck.MSG_KEY;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -40,16 +40,16 @@ public class AtclauseOrderCheckTest extends AbstractModuleTestSupport {
     public void testGetAcceptableTokens() {
         final AtclauseOrderCheck checkObj = new AtclauseOrderCheck();
         final int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN};
-        assertArrayEquals("Default acceptable tokens are invalid",
-            expected, checkObj.getAcceptableTokens());
+        assertArrayEquals(expected, checkObj.getAcceptableTokens(),
+                "Default acceptable tokens are invalid");
     }
 
     @Test
     public void testGetRequiredTokens() {
         final AtclauseOrderCheck checkObj = new AtclauseOrderCheck();
         final int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN};
-        assertArrayEquals("Default required tokens are invalid",
-            expected, checkObj.getRequiredTokens());
+        assertArrayEquals(expected, checkObj.getRequiredTokens(),
+                "Default required tokens are invalid");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/ClassResolverTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/ClassResolverTest.java
@@ -19,14 +19,14 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ClassResolverTest {
 
@@ -35,14 +35,14 @@ public class ClassResolverTest {
         final Set<String> imports = new HashSet<>();
         final ClassResolver classResolver = new ClassResolver(
                 Thread.currentThread().getContextClassLoader(), "java.util", imports);
-        assertNotNull("Class should be resolved", classResolver.resolve("List", ""));
+        assertNotNull(classResolver.resolve("List", ""), "Class should be resolved");
         try {
             classResolver.resolve("NoSuchClass", "");
             fail("ClassNotFoundException is expected");
         }
         catch (ClassNotFoundException ex) {
             // exception is expected
-            assertEquals("Invalid exception message", "NoSuchClass", ex.getMessage());
+            assertEquals("NoSuchClass", ex.getMessage(), "Invalid exception message");
         }
     }
 
@@ -53,7 +53,7 @@ public class ClassResolverTest {
         imports.add("no.such.package.ChoiceFormat");
         final ClassResolver classResolver = new ClassResolver(
                 Thread.currentThread().getContextClassLoader(), null, imports);
-        assertNotNull("Class should be resolved", classResolver.resolve("ChoiceFormat", ""));
+        assertNotNull(classResolver.resolve("ChoiceFormat", ""), "Class should be resolved");
     }
 
     @Test
@@ -62,7 +62,7 @@ public class ClassResolverTest {
         imports.add("no.such.package.*");
         final ClassResolver classResolver = new ClassResolver(
                 Thread.currentThread().getContextClassLoader(), null, imports);
-        assertNotNull("Class should be resolved", classResolver.resolve("StringBuffer", ""));
+        assertNotNull(classResolver.resolve("StringBuffer", ""), "Class should be resolved");
     }
 
     @Test
@@ -79,7 +79,7 @@ public class ClassResolverTest {
         }
         catch (ClassNotFoundException ex) {
             // exception is expected
-            assertEquals("Invalid exception message", "someClass", ex.getMessage());
+            assertEquals("someClass", ex.getMessage(), "Invalid exception message");
         }
     }
 
@@ -91,7 +91,7 @@ public class ClassResolverTest {
                 "java.util", imports);
 
         final Class<?> entry = classResolver.resolve("Entry", "Map");
-        assertEquals("Invalid resolve result", "java.util.Map$Entry", entry.getName());
+        assertEquals("java.util.Map$Entry", entry.getName(), "Invalid resolve result");
     }
 
     @Test
@@ -107,7 +107,7 @@ public class ClassResolverTest {
         }
         catch (ClassNotFoundException ex) {
             // exception is expected
-            assertEquals("Invalid exception message", "Entry", ex.getMessage());
+            assertEquals("Entry", ex.getMessage(), "Invalid exception message");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/InvalidJavadocPositionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/InvalidJavadocPositionCheckTest.java
@@ -20,9 +20,9 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.InvalidJavadocPositionCheck.MSG_KEY;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
@@ -43,7 +43,7 @@ public class InvalidJavadocPositionCheckTest extends AbstractModuleTestSupport {
         final InvalidJavadocPositionCheck check = new InvalidJavadocPositionCheck();
         final int[] actual = check.getAcceptableTokens();
 
-        assertArrayEquals("Acceptable tokens differs from expected", expected, actual);
+        assertArrayEquals(expected, actual, "Acceptable tokens differs from expected");
     }
 
     @Test
@@ -54,7 +54,7 @@ public class InvalidJavadocPositionCheckTest extends AbstractModuleTestSupport {
         final InvalidJavadocPositionCheck check = new InvalidJavadocPositionCheck();
         final int[] actual = check.getRequiredTokens();
 
-        assertArrayEquals("Required tokens differ from expected", expected, actual);
+        assertArrayEquals(expected, actual, "Required tokens differ from expected");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheckTest.java
@@ -20,9 +20,9 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocBlockTagLocationCheck.MSG_BLOCK_TAG_LOCATION;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -42,8 +42,8 @@ public class JavadocBlockTagLocationCheckTest extends AbstractModuleTestSupport 
         final int[] expected = {
             JavadocTokenTypes.TEXT,
         };
-        assertArrayEquals("Default acceptable tokens are invalid",
-            expected, checkObj.getAcceptableJavadocTokens());
+        assertArrayEquals(expected, checkObj.getAcceptableJavadocTokens(),
+                "Default acceptable tokens are invalid");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheckTest.java
@@ -21,9 +21,9 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck.MSG_JAVADOC_CONTENT_FIRST_LINE;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck.MSG_JAVADOC_CONTENT_SECOND_LINE;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -41,16 +41,15 @@ public class JavadocContentLocationCheckTest extends AbstractModuleTestSupport {
     public void testGetAcceptableTokens() {
         final JavadocContentLocationCheck checkObj = new JavadocContentLocationCheck();
         final int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN };
-        assertArrayEquals("Acceptable tokens are invalid",
-            expected, checkObj.getAcceptableTokens());
+        assertArrayEquals(expected, checkObj.getAcceptableTokens(),
+                "Acceptable tokens are invalid");
     }
 
     @Test
     public void testGetDefaultTokens() {
         final JavadocContentLocationCheck checkObj = new JavadocContentLocationCheck();
         final int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN };
-        assertArrayEquals("Default tokens are invalid",
-            expected, checkObj.getDefaultTokens());
+        assertArrayEquals(expected, checkObj.getDefaultTokens(), "Default tokens are invalid");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -25,18 +25,18 @@ import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_RETURN_EXPECTED;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_UNUSED_TAG;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_UNUSED_TAG_GENERAL;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -67,7 +67,7 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
             TokenTypes.ANNOTATION_FIELD_DEF,
         };
 
-        assertArrayEquals("Default acceptable tokens are invalid", expected, actual);
+        assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
     }
 
     @Test
@@ -501,8 +501,8 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
         final Method method = check.getClass()
                 .getDeclaredMethod("isSubclass", Class.class, Class.class);
         method.setAccessible(true);
-        assertFalse("Should return false if at least one of the params is null",
-            (boolean) method.invoke(check, null, null));
+        assertFalse((boolean) method.invoke(check, null, null),
+                "Should return false if at least one of the params is null");
     }
 
     @Test
@@ -516,7 +516,7 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
         };
         final JavadocMethodCheck check = new JavadocMethodCheck();
         final int[] actual = check.getRequiredTokens();
-        assertArrayEquals("Required tokens differ from expected", expected, actual);
+        assertArrayEquals(expected, actual, "Required tokens differ from expected");
     }
 
     @Test
@@ -528,7 +528,7 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
         final Object token = tokenConstructor.newInstance("blablabla", 1, 1);
         final Method toString = token.getClass().getDeclaredMethod("toString");
         final String result = (String) toString.invoke(token);
-        assertEquals("Invalid toString result", "Token[blablabla(1x1)]", result);
+        assertEquals("Token[blablabla(1x1)]", result, "Invalid toString result");
     }
 
     @Test
@@ -548,10 +548,10 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
             fail("Exception is expected");
         }
         catch (InvocationTargetException ex) {
-            assertTrue("Invalid exception class, expected: IllegalArgumentException.class",
-                ex.getCause() instanceof IllegalArgumentException);
-            assertEquals("Invalid exception message",
-                "ClassInfo's name should be non-null", ex.getCause().getMessage());
+            assertTrue(ex.getCause() instanceof IllegalArgumentException,
+                    "Invalid exception class, expected: IllegalArgumentException.class");
+            assertEquals("ClassInfo's name should be non-null", ex.getCause().getMessage(),
+                    "Invalid exception message");
         }
 
         final Constructor<?> tokenConstructor = tokenType.getDeclaredConstructor(String.class,
@@ -568,7 +568,7 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
         final String expected = "RegularClass[name=Token[blablabla(1x1)], in class='sur', check="
                 + methodCheck.hashCode() + "," + " loadable=true, class=null]";
 
-        assertEquals("Invalid toString result", expected, result);
+        assertEquals(expected, result, "Invalid toString result");
 
         final Method setClazz = regularClass.getClass().getDeclaredMethod("setClazz", Class.class);
         setClazz.setAccessible(true);
@@ -577,7 +577,7 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
 
         final Method getClazz = regularClass.getClass().getDeclaredMethod("getClazz");
         getClazz.setAccessible(true);
-        assertNull("Expected null", getClazz.invoke(regularClass));
+        assertNull(getClazz.invoke(regularClass), "Expected null");
     }
 
     @Test
@@ -613,8 +613,8 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
         final Method toString = classAlias.getClass().getDeclaredMethod("toString");
         toString.setAccessible(true);
         final String result = (String) toString.invoke(classAlias);
-        assertEquals("Invalid toString result",
-            "ClassAlias[alias Token[blablabla(1x1)] for Token[blablabla(1x1)]]", result);
+        assertEquals("ClassAlias[alias Token[blablabla(1x1)] for Token[blablabla(1x1)]]", result,
+                "Invalid toString result");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImplTest.java
@@ -19,9 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
 
@@ -36,9 +36,8 @@ public class JavadocNodeImplTest {
 
         final String result = javadocNode.toString();
 
-        assertEquals("Invalid toString result",
-                "JavadocNodeImpl[index=0, type=CODE_LITERAL, text='null', lineNumber=1,"
-                + " columnNumber=2, children=0, parent=null]", result);
+        assertEquals("JavadocNodeImpl[index=0, type=CODE_LITERAL, text='null', lineNumber=1,"
+                + " columnNumber=2, children=0, parent=null]", result, "Invalid toString result");
     }
 
     @Test
@@ -48,7 +47,7 @@ public class JavadocNodeImplTest {
 
         final int result = javadocNode.getColumnNumber();
 
-        assertEquals("Invalid column number", 1, result);
+        assertEquals(1, result, "Invalid column number");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheckTest.java
@@ -21,13 +21,13 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocPackageCheck.MSG_LEGACY_PACKAGE_HTML;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocPackageCheck.MSG_PACKAGE_INFO;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.util.Collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -146,8 +146,8 @@ public class JavadocPackageCheckTest
             fail("CheckstyleException expected to be thrown");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid exception message. Expected: " + expectedExceptionMessage,
-                    expectedExceptionMessage, ex.getMessage());
+            assertEquals(expectedExceptionMessage, ex.getMessage(),
+                    "Invalid exception message. Expected: " + expectedExceptionMessage);
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheckTest.java
@@ -23,9 +23,9 @@ import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphChe
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck.MSG_MISPLACED_TAG;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck.MSG_REDUNDANT_PARAGRAPH;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocParagraphCheck.MSG_TAG_AFTER;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -43,8 +43,8 @@ public class JavadocParagraphCheckTest extends AbstractModuleTestSupport {
     public void testGetRequiredTokens() {
         final JavadocParagraphCheck checkObj = new JavadocParagraphCheck();
         final int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN};
-        assertArrayEquals("Default required tokens are invalid",
-            expected, checkObj.getRequiredTokens());
+        assertArrayEquals(expected, checkObj.getRequiredTokens(),
+                "Default required tokens are invalid");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
@@ -25,12 +25,12 @@ import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck.M
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck.MSG_JAVADOC_MISSING;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck.MSG_NO_PERIOD;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck.MSG_UNCLOSED_HTML;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -63,7 +63,7 @@ public class JavadocStyleCheckTest
             TokenTypes.VARIABLE_DEF,
         };
 
-        assertArrayEquals("Default acceptable tokens are invalid", expected, actual);
+        assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
     }
 
     @Test
@@ -418,9 +418,9 @@ public class JavadocStyleCheckTest
     @Test
     public void testHtmlTagToString() {
         final HtmlTag tag = new HtmlTag("id", 3, 5, true, false, "<a href=\"URL\"/>");
-        assertEquals("Invalid toString result",
-                "HtmlTag[id='id', lineNo=3, position=5, text='<a href=\"URL\"/>', "
-                + "closedTag=true, incompleteTag=false]", tag.toString());
+        assertEquals("HtmlTag[id='id', lineNo=3, position=5, text='<a href=\"URL\"/>', "
+                + "closedTag=true, incompleteTag=false]", tag.toString(),
+                "Invalid toString result");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
@@ -20,9 +20,9 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTagContinuationIndentationCheck.MSG_KEY;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -42,8 +42,8 @@ public class JavadocTagContinuationIndentationCheckTest
         final JavadocTagContinuationIndentationCheck checkObj =
             new JavadocTagContinuationIndentationCheck();
         final int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN };
-        assertArrayEquals("Default required tokens are invalid",
-            expected, checkObj.getRequiredTokens());
+        assertArrayEquals(expected, checkObj.getRequiredTokens(),
+                "Default required tokens are invalid");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfoTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfoTest.java
@@ -19,15 +19,15 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Method;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -41,7 +41,7 @@ public class JavadocTagInfoTest {
     @Test
     public void testJavadocTagInfoValueOf() {
         final JavadocTagInfo tag = JavadocTagInfo.valueOf("AUTHOR");
-        assertEquals("Invalid valueOf result", JavadocTagInfo.AUTHOR, tag);
+        assertEquals(JavadocTagInfo.AUTHOR, tag, "Invalid valueOf result");
     }
 
     /* Additional test for jacoco, since valueOf()
@@ -51,7 +51,7 @@ public class JavadocTagInfoTest {
     @Test
     public void testTypeValueOf() {
         final JavadocTagInfo.Type type = JavadocTagInfo.Type.valueOf("BLOCK");
-        assertEquals("Invalid valueOf result", JavadocTagInfo.Type.BLOCK, type);
+        assertEquals(JavadocTagInfo.Type.BLOCK, type, "Invalid valueOf result");
     }
 
     /* Additional test for jacoco, since values()
@@ -65,7 +65,7 @@ public class JavadocTagInfoTest {
             JavadocTagInfo.Type.INLINE,
         };
         final JavadocTagInfo.Type[] actual = JavadocTagInfo.Type.values();
-        assertArrayEquals("Invalid Type values", expected, actual);
+        assertArrayEquals(expected, actual, "Invalid Type values");
     }
 
     @Test
@@ -81,13 +81,13 @@ public class JavadocTagInfoTest {
         };
         for (int type: validTypes) {
             ast.setType(type);
-            assertTrue("Invalid ast type for current tag: " + ast.getType(),
-                    JavadocTagInfo.AUTHOR.isValidOn(ast));
+            assertTrue(JavadocTagInfo.AUTHOR.isValidOn(ast),
+                    "Invalid ast type for current tag: " + ast.getType());
         }
 
         ast.setType(TokenTypes.LAMBDA);
-        assertFalse("Should return false when ast type is invalid for current tag",
-                JavadocTagInfo.AUTHOR.isValidOn(ast));
+        assertFalse(JavadocTagInfo.AUTHOR.isValidOn(ast),
+                "Should return false when ast type is invalid for current tag");
     }
 
     @Test
@@ -124,18 +124,18 @@ public class JavadocTagInfoTest {
             };
             for (int type: validTypes) {
                 ast.setType(type);
-                assertTrue("Invalid ast type for current tag: " + ast.getType(),
-                        tagInfo.isValidOn(ast));
+                assertTrue(tagInfo.isValidOn(ast),
+                        "Invalid ast type for current tag: " + ast.getType());
             }
 
             astParent.setType(TokenTypes.SLIST);
             ast.setType(TokenTypes.VARIABLE_DEF);
-            assertFalse("Should return false when ast type is invalid for current tag",
-                    tagInfo.isValidOn(ast));
+            assertFalse(tagInfo.isValidOn(ast),
+                    "Should return false when ast type is invalid for current tag");
 
             ast.setType(TokenTypes.PARAMETER_DEF);
-            assertFalse("Should return false when ast type is invalid for current tag",
-                    tagInfo.isValidOn(ast));
+            assertFalse(tagInfo.isValidOn(ast),
+                    "Should return false when ast type is invalid for current tag");
         }
     }
 
@@ -161,18 +161,18 @@ public class JavadocTagInfoTest {
         };
         for (int type: validTypes) {
             ast.setType(type);
-            assertTrue("Invalid ast type for current tag: " + ast.getType(),
-                    JavadocTagInfo.DEPRECATED.isValidOn(ast));
+            assertTrue(JavadocTagInfo.DEPRECATED.isValidOn(ast),
+                    "Invalid ast type for current tag: " + ast.getType());
         }
 
         astParent.setType(TokenTypes.SLIST);
         ast.setType(TokenTypes.VARIABLE_DEF);
-        assertFalse("Should return false when ast type is invalid for current tag",
-                JavadocTagInfo.DEPRECATED.isValidOn(ast));
+        assertFalse(JavadocTagInfo.DEPRECATED.isValidOn(ast),
+                "Should return false when ast type is invalid for current tag");
 
         ast.setType(TokenTypes.PARAMETER_DEF);
-        assertFalse("Should return false when ast type is invalid for current tag",
-                JavadocTagInfo.DEPRECATED.isValidOn(ast));
+        assertFalse(JavadocTagInfo.DEPRECATED.isValidOn(ast),
+                "Should return false when ast type is invalid for current tag");
     }
 
     @Test
@@ -189,18 +189,18 @@ public class JavadocTagInfoTest {
         };
         for (int type: validTypes) {
             ast.setType(type);
-            assertTrue("Invalid ast type for current tag: " + ast.getType(),
-                    JavadocTagInfo.SERIAL.isValidOn(ast));
+            assertTrue(JavadocTagInfo.SERIAL.isValidOn(ast),
+                    "Invalid ast type for current tag: " + ast.getType());
         }
 
         astParent.setType(TokenTypes.SLIST);
         ast.setType(TokenTypes.VARIABLE_DEF);
-        assertFalse("Should return false when ast type is invalid for current tag",
-                JavadocTagInfo.SERIAL.isValidOn(ast));
+        assertFalse(JavadocTagInfo.SERIAL.isValidOn(ast),
+                "Should return false when ast type is invalid for current tag");
 
         ast.setType(TokenTypes.PARAMETER_DEF);
-        assertFalse("Should return false when ast type is invalid for current tag",
-                JavadocTagInfo.SERIAL.isValidOn(ast));
+        assertFalse(JavadocTagInfo.SERIAL.isValidOn(ast),
+                "Should return false when ast type is invalid for current tag");
     }
 
     @Test
@@ -213,13 +213,13 @@ public class JavadocTagInfoTest {
         };
         for (int type: validTypes) {
             ast.setType(type);
-            assertTrue("Invalid ast type for current tag: " + ast.getType(),
-                    JavadocTagInfo.EXCEPTION.isValidOn(ast));
+            assertTrue(JavadocTagInfo.EXCEPTION.isValidOn(ast),
+                    "Invalid ast type for current tag: " + ast.getType());
         }
 
         ast.setType(TokenTypes.LAMBDA);
-        assertFalse("Should return false when ast type is invalid for current tag",
-                JavadocTagInfo.EXCEPTION.isValidOn(ast));
+        assertFalse(JavadocTagInfo.EXCEPTION.isValidOn(ast),
+                "Should return false when ast type is invalid for current tag");
     }
 
     @Test
@@ -232,13 +232,13 @@ public class JavadocTagInfoTest {
         };
         for (int type: validTypes) {
             ast.setType(type);
-            assertTrue("Invalid ast type for current tag: " + ast.getType(),
-                    JavadocTagInfo.THROWS.isValidOn(ast));
+            assertTrue(JavadocTagInfo.THROWS.isValidOn(ast),
+                    "Invalid ast type for current tag: " + ast.getType());
         }
 
         ast.setType(TokenTypes.LAMBDA);
-        assertFalse("Should return false when ast type is invalid for current tag",
-                JavadocTagInfo.THROWS.isValidOn(ast));
+        assertFalse(JavadocTagInfo.THROWS.isValidOn(ast),
+                "Should return false when ast type is invalid for current tag");
     }
 
     @Test
@@ -254,13 +254,13 @@ public class JavadocTagInfoTest {
         };
         for (int type: validTypes) {
             ast.setType(type);
-            assertTrue("Invalid ast type for current tag: " + ast.getType(),
-                    JavadocTagInfo.VERSION.isValidOn(ast));
+            assertTrue(JavadocTagInfo.VERSION.isValidOn(ast),
+                    "Invalid ast type for current tag: " + ast.getType());
         }
 
         ast.setType(TokenTypes.LAMBDA);
-        assertFalse("Should return false when ast type is invalid for current tag",
-                JavadocTagInfo.VERSION.isValidOn(ast));
+        assertFalse(JavadocTagInfo.VERSION.isValidOn(ast),
+                "Should return false when ast type is invalid for current tag");
     }
 
     @Test
@@ -275,13 +275,13 @@ public class JavadocTagInfoTest {
         };
         for (int type: validTypes) {
             ast.setType(type);
-            assertTrue("Invalid ast type for current tag: " + ast.getType(),
-                    JavadocTagInfo.PARAM.isValidOn(ast));
+            assertTrue(JavadocTagInfo.PARAM.isValidOn(ast),
+                    "Invalid ast type for current tag: " + ast.getType());
         }
 
         ast.setType(TokenTypes.LAMBDA);
-        assertFalse("Should return false when ast type is invalid for current tag",
-                JavadocTagInfo.PARAM.isValidOn(ast));
+        assertFalse(JavadocTagInfo.PARAM.isValidOn(ast),
+                "Should return false when ast type is invalid for current tag");
     }
 
     @Test
@@ -299,17 +299,17 @@ public class JavadocTagInfoTest {
         };
         for (int type: validTypes) {
             ast.setType(type);
-            assertTrue("Invalid ast type for current tag: " + ast.getType(),
-                    JavadocTagInfo.RETURN.isValidOn(ast));
+            assertTrue(JavadocTagInfo.RETURN.isValidOn(ast),
+                    "Invalid ast type for current tag: " + ast.getType());
         }
 
         astChild2.setType(TokenTypes.LITERAL_VOID);
-        assertFalse("Should return false when ast type is invalid for current tag",
-                JavadocTagInfo.RETURN.isValidOn(ast));
+        assertFalse(JavadocTagInfo.RETURN.isValidOn(ast),
+                "Should return false when ast type is invalid for current tag");
 
         ast.setType(TokenTypes.LAMBDA);
-        assertFalse("Should return false when ast type is invalid for current tag",
-                JavadocTagInfo.RETURN.isValidOn(ast));
+        assertFalse(JavadocTagInfo.RETURN.isValidOn(ast),
+                "Should return false when ast type is invalid for current tag");
     }
 
     @Test
@@ -328,21 +328,21 @@ public class JavadocTagInfoTest {
         };
         for (int type: validTypes) {
             ast.setType(type);
-            assertTrue("Invalid ast type for current tag: " + ast.getType(),
-                    JavadocTagInfo.SERIAL_FIELD.isValidOn(ast));
+            assertTrue(JavadocTagInfo.SERIAL_FIELD.isValidOn(ast),
+                    "Invalid ast type for current tag: " + ast.getType());
         }
 
         astChild2.setText("1111");
-        assertFalse("Should return false when ast type is invalid for current tag",
-                JavadocTagInfo.SERIAL_FIELD.isValidOn(ast));
+        assertFalse(JavadocTagInfo.SERIAL_FIELD.isValidOn(ast),
+                "Should return false when ast type is invalid for current tag");
 
         astChild2.setType(TokenTypes.LITERAL_VOID);
-        assertFalse("Should return false when ast type is invalid for current tag",
-                JavadocTagInfo.SERIAL_FIELD.isValidOn(ast));
+        assertFalse(JavadocTagInfo.SERIAL_FIELD.isValidOn(ast),
+                "Should return false when ast type is invalid for current tag");
 
         ast.setType(TokenTypes.LAMBDA);
-        assertFalse("Should return false when ast type is invalid for current tag",
-                JavadocTagInfo.SERIAL_FIELD.isValidOn(ast));
+        assertFalse(JavadocTagInfo.SERIAL_FIELD.isValidOn(ast),
+                "Should return false when ast type is invalid for current tag");
     }
 
     @Test
@@ -364,33 +364,33 @@ public class JavadocTagInfoTest {
         };
         for (String name: validNames) {
             astChild.setText(name);
-            assertTrue("Invalid ast type for current tag: " + ast.getType(),
-                    JavadocTagInfo.SERIAL_DATA.isValidOn(ast));
+            assertTrue(JavadocTagInfo.SERIAL_DATA.isValidOn(ast),
+                    "Invalid ast type for current tag: " + ast.getType());
         }
 
         astChild.setText("1111");
-        assertFalse("Should return false when ast type is invalid for current tag",
-                JavadocTagInfo.SERIAL_DATA.isValidOn(ast));
+        assertFalse(JavadocTagInfo.SERIAL_DATA.isValidOn(ast),
+                "Should return false when ast type is invalid for current tag");
 
         ast.setType(TokenTypes.LAMBDA);
-        assertFalse("Should return false when ast type is invalid for current tag",
-                JavadocTagInfo.SERIAL_DATA.isValidOn(ast));
+        assertFalse(JavadocTagInfo.SERIAL_DATA.isValidOn(ast),
+                "Should return false when ast type is invalid for current tag");
     }
 
     @Test
     public void testCoverage() {
-        assertEquals("Invalid type", JavadocTagInfo.Type.BLOCK, JavadocTagInfo.VERSION.getType());
+        assertEquals(JavadocTagInfo.Type.BLOCK, JavadocTagInfo.VERSION.getType(), "Invalid type");
 
-        assertEquals("Invalid toString result", "text [@version] name [version] type [BLOCK]",
-            JavadocTagInfo.VERSION.toString());
+        assertEquals("text [@version] name [version] type [BLOCK]",
+            JavadocTagInfo.VERSION.toString(), "Invalid toString result");
 
         try {
             JavadocTagInfo.fromName(null);
             fail("IllegalArgumentException is expected");
         }
         catch (IllegalArgumentException ex) {
-            assertEquals("Invalid exception message",
-                    "the name is null", ex.getMessage());
+            assertEquals("the name is null", ex.getMessage(),
+                    "Invalid exception message");
         }
 
         try {
@@ -398,8 +398,8 @@ public class JavadocTagInfoTest {
             fail("IllegalArgumentException is expected");
         }
         catch (IllegalArgumentException ex) {
-            assertEquals("Invalid exception message",
-                    "the name [myname] is not a valid Javadoc tag name", ex.getMessage());
+            assertEquals("the name [myname] is not a valid Javadoc tag name", ex.getMessage(),
+                    "Invalid exception message");
         }
 
         try {
@@ -407,7 +407,7 @@ public class JavadocTagInfoTest {
             fail("IllegalArgumentException is expected");
         }
         catch (IllegalArgumentException ex) {
-            assertEquals("Invalid exception message", "the text is null", ex.getMessage());
+            assertEquals("the text is null", ex.getMessage(), "Invalid exception message");
         }
 
         try {
@@ -415,12 +415,13 @@ public class JavadocTagInfoTest {
             fail("IllegalArgumentException is expected");
         }
         catch (IllegalArgumentException ex) {
-            assertEquals("Invalid exception message",
-                    "the text [myname] is not a valid Javadoc tag text", ex.getMessage());
+            assertEquals(
+                    "the text [myname] is not a valid Javadoc tag text", ex.getMessage(),
+                    "Invalid exception message");
         }
 
-        assertEquals("Invalid fromText result",
-                JavadocTagInfo.VERSION, JavadocTagInfo.fromText("@version"));
+        assertEquals(JavadocTagInfo.VERSION, JavadocTagInfo.fromText("@version"),
+                "Invalid fromText result");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagTest.java
@@ -19,12 +19,12 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 
@@ -38,7 +38,7 @@ public class JavadocTagTest {
     public void testJavadocTagTypeValueOf() {
         final JavadocUtil.JavadocTagType enumConst =
             JavadocUtil.JavadocTagType.valueOf("ALL");
-        assertEquals("Invalid enum valueOf result", JavadocUtil.JavadocTagType.ALL, enumConst);
+        assertEquals(JavadocUtil.JavadocTagType.ALL, enumConst, "Invalid enum valueOf result");
     }
 
     /* Additional test for jacoco, since values()
@@ -54,7 +54,7 @@ public class JavadocTagTest {
             JavadocUtil.JavadocTagType.INLINE,
             JavadocUtil.JavadocTagType.ALL,
         };
-        assertArrayEquals("Invalid enum constants", expected, enumConstants);
+        assertArrayEquals(expected, enumConstants, "Invalid enum constants");
     }
 
     @Test
@@ -63,23 +63,24 @@ public class JavadocTagTest {
 
         final String result = javadocTag.toString();
 
-        assertEquals("Invalid toString result",
-                "JavadocTag[tag='author' lineNo=0, columnNo=1, firstArg='firstArg']", result);
+        assertEquals(
+                "JavadocTag[tag='author' lineNo=0, columnNo=1, firstArg='firstArg']", result,
+                "Invalid toString result");
     }
 
     @Test
     public void testJavadocTagReferenceImports() {
-        assertTrue("", new JavadocTag(0, 0, "see", null).canReferenceImports());
-        assertTrue("", new JavadocTag(0, 0, "link", null).canReferenceImports());
-        assertTrue("", new JavadocTag(0, 0, "value", null).canReferenceImports());
-        assertTrue("", new JavadocTag(0, 0, "linkplain", null).canReferenceImports());
-        assertTrue("", new JavadocTag(0, 0, "throws", null).canReferenceImports());
-        assertTrue("", new JavadocTag(0, 0, "exception", null).canReferenceImports());
+        assertTrue(new JavadocTag(0, 0, "see", null).canReferenceImports(), "");
+        assertTrue(new JavadocTag(0, 0, "link", null).canReferenceImports(), "");
+        assertTrue(new JavadocTag(0, 0, "value", null).canReferenceImports(), "");
+        assertTrue(new JavadocTag(0, 0, "linkplain", null).canReferenceImports(), "");
+        assertTrue(new JavadocTag(0, 0, "throws", null).canReferenceImports(), "");
+        assertTrue(new JavadocTag(0, 0, "exception", null).canReferenceImports(), "");
     }
 
     @Test
     public void testJavadocTagReferenceImportsInvalid() {
-        assertFalse("", new JavadocTag(0, 0, "author", null).canReferenceImports());
+        assertFalse(new JavadocTag(0, 0, "author", null).canReferenceImports(), "");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -23,9 +23,9 @@ import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MS
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_TAG_FORMAT;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_UNKNOWN_TAG;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.MSG_UNUSED_TAG;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -43,9 +43,8 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testGetRequiredTokens() {
         final JavadocTypeCheck javadocTypeCheck = new JavadocTypeCheck();
-        assertArrayEquals(
-            "JavadocTypeCheck#getRequiredTokens should return empty array by default",
-            CommonUtil.EMPTY_INT_ARRAY, javadocTypeCheck.getRequiredTokens());
+        assertArrayEquals(CommonUtil.EMPTY_INT_ARRAY, javadocTypeCheck.getRequiredTokens(),
+                "JavadocTypeCheck#getRequiredTokens should return empty array by default");
     }
 
     @Test
@@ -60,7 +59,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
             TokenTypes.ANNOTATION_DEF,
         };
 
-        assertArrayEquals("Default acceptable tokens are invalid", expected, actual);
+        assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
@@ -20,9 +20,9 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocVariableCheck.MSG_JAVADOC_MISSING;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -45,7 +45,7 @@ public class JavadocVariableCheckTest
         final int[] expected = {
             TokenTypes.VARIABLE_DEF,
         };
-        assertArrayEquals("Default required tokens are invalid", expected, actual);
+        assertArrayEquals(expected, actual, "Default required tokens are invalid");
     }
 
     @Test
@@ -58,7 +58,7 @@ public class JavadocVariableCheckTest
             TokenTypes.ENUM_CONSTANT_DEF,
         };
 
-        assertArrayEquals("Default acceptable tokens are invalid", expected, actual);
+        assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
@@ -20,9 +20,9 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck.MSG_JAVADOC_MISSING;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -48,7 +48,7 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
             TokenTypes.ANNOTATION_FIELD_DEF,
         };
 
-        assertArrayEquals("Default acceptable tokens are invalid", expected, actual);
+        assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
     }
 
     @Test
@@ -56,7 +56,7 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
         final MissingJavadocMethodCheck missingJavadocMethodCheck = new MissingJavadocMethodCheck();
         final int[] actual = missingJavadocMethodCheck.getRequiredTokens();
         final int[] expected = CommonUtil.EMPTY_INT_ARRAY;
-        assertArrayEquals("Required tokens are invalid", expected, actual);
+        assertArrayEquals(expected, actual, "Required tokens are invalid");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocPackageCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocPackageCheckTest.java
@@ -20,9 +20,9 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocPackageCheck.MSG_PKG_JAVADOC_MISSING;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -149,11 +149,11 @@ public class MissingJavadocPackageCheckTest extends AbstractModuleTestSupport {
         final int[] expected = {
             TokenTypes.PACKAGE_DEF,
         };
-        Assert.assertArrayEquals("Acceptable required tokens are invalid",
-            expected, check.getAcceptableTokens());
-        Assert.assertArrayEquals("Default required tokens are invalid",
-            expected, check.getDefaultTokens());
-        Assert.assertArrayEquals("Required required tokens are invalid",
-            expected, check.getRequiredTokens());
+        assertArrayEquals(expected, check.getAcceptableTokens(),
+                "Acceptable required tokens are invalid");
+        assertArrayEquals(expected, check.getDefaultTokens(),
+                "Default required tokens are invalid");
+        assertArrayEquals(expected, check.getRequiredTokens(),
+                "Required required tokens are invalid");
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckTest.java
@@ -20,9 +20,9 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck.MSG_JAVADOC_MISSING;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -40,9 +40,8 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testGetRequiredTokens() {
         final MissingJavadocTypeCheck missingJavadocTypeCheck = new MissingJavadocTypeCheck();
-        assertArrayEquals(
-            "MissingJavadocTypeCheck#getRequiredTokens should return empty array by default",
-            CommonUtil.EMPTY_INT_ARRAY, missingJavadocTypeCheck.getRequiredTokens());
+        assertArrayEquals(CommonUtil.EMPTY_INT_ARRAY, missingJavadocTypeCheck.getRequiredTokens(),
+                "MissingJavadocTypeCheck#getRequiredTokens should return empty array by default");
     }
 
     @Test
@@ -57,7 +56,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
             TokenTypes.ANNOTATION_DEF,
         };
 
-        assertArrayEquals("Default acceptable tokens are invalid", expected, actual);
+        assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheckTest.java
@@ -20,9 +20,9 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.NonEmptyAtclauseDescriptionCheck.MSG_KEY;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -41,8 +41,8 @@ public class NonEmptyAtclauseDescriptionCheckTest
         final NonEmptyAtclauseDescriptionCheck checkObj =
             new NonEmptyAtclauseDescriptionCheck();
         final int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN};
-        assertArrayEquals("Default acceptable tokens are invalid",
-            expected, checkObj.getAcceptableTokens());
+        assertArrayEquals(expected, checkObj.getAcceptableTokens(),
+                "Default acceptable tokens are invalid");
     }
 
     @Test
@@ -50,8 +50,8 @@ public class NonEmptyAtclauseDescriptionCheckTest
         final NonEmptyAtclauseDescriptionCheck checkObj =
             new NonEmptyAtclauseDescriptionCheck();
         final int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN};
-        assertArrayEquals("Default required tokens are invalid",
-            expected, checkObj.getRequiredTokens());
+        assertArrayEquals(expected, checkObj.getRequiredTokens(),
+                "Default required tokens are invalid");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheckTest.java
@@ -20,9 +20,9 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.SingleLineJavadocCheck.MSG_KEY;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -39,16 +39,16 @@ public class SingleLineJavadocCheckTest extends AbstractModuleTestSupport {
     public void testAcceptableTokens() {
         final SingleLineJavadocCheck checkObj = new SingleLineJavadocCheck();
         final int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN };
-        assertArrayEquals("Default acceptable tokens are invalid",
-            expected, checkObj.getAcceptableTokens());
+        assertArrayEquals(expected, checkObj.getAcceptableTokens(),
+                "Default acceptable tokens are invalid");
     }
 
     @Test
     public void testGetRequiredTokens() {
         final SingleLineJavadocCheck checkObj = new SingleLineJavadocCheck();
         final int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN };
-        assertArrayEquals("Default required tokens are invalid",
-            expected, checkObj.getRequiredTokens());
+        assertArrayEquals(expected, checkObj.getRequiredTokens(),
+                "Default required tokens are invalid");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
@@ -22,9 +22,9 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck.MSG_SUMMARY_FIRST_SENTENCE;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck.MSG_SUMMARY_JAVADOC;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck.MSG_SUMMARY_JAVADOC_MISSING;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -42,8 +42,8 @@ public class SummaryJavadocCheckTest extends AbstractModuleTestSupport {
     public void testGetRequiredTokens() {
         final SummaryJavadocCheck checkObj = new SummaryJavadocCheck();
         final int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN };
-        assertArrayEquals("Default required tokens are invalid",
-            expected, checkObj.getRequiredTokens());
+        assertArrayEquals(expected, checkObj.getRequiredTokens(),
+                "Default required tokens are invalid");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
@@ -22,8 +22,8 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.WriteTagCheck.MSG_MISSING_TAG;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.WriteTagCheck.MSG_TAG_FORMAT;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.WriteTagCheck.MSG_WRITE_TAG;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -34,7 +34,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.Checker;
@@ -232,11 +232,10 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
             for (int i = 0; i < expected.length; i++) {
                 final String expectedResult = messageFileName + ":" + expected[i];
                 final String actual = lnr.readLine();
-                assertEquals("error message " + i, expectedResult, actual);
+                assertEquals(expectedResult, actual, "error message " + i);
             }
 
-            assertTrue("unexpected output: " + lnr.readLine(),
-                    expected.length >= errs);
+            assertTrue(expected.length >= errs, "unexpected output: " + lnr.readLine());
         }
         checker.destroy();
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/BlockTagUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/BlockTagUtilTest.java
@@ -19,12 +19,12 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.utils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
@@ -32,8 +32,8 @@ public class BlockTagUtilTest {
 
     @Test
     public void testHasPrivateConstructor() throws Exception {
-        assertTrue("Constructor is not private",
-                TestUtil.isUtilsClassHasPrivateConstructor(BlockTagUtil.class, true));
+        assertTrue(TestUtil.isUtilsClassHasPrivateConstructor(BlockTagUtil.class, true),
+                "Constructor is not private");
     }
 
     @Test
@@ -47,7 +47,7 @@ public class BlockTagUtilTest {
         };
 
         final List<TagInfo> tags = BlockTagUtil.extractBlockTags(text);
-        assertEquals("Invalid tags size", 4, tags.size());
+        assertEquals(4, tags.size(), "Invalid tags size");
 
         final TagInfo tag1 = tags.get(0);
         assertTagEquals(tag1, "foo", "abc", 1, 4);
@@ -70,9 +70,9 @@ public class BlockTagUtilTest {
             " */",
         };
         final List<TagInfo> tags = BlockTagUtil.extractBlockTags(text);
-        assertEquals("Invalid tags size", 1, tags.size());
-        assertEquals("Invalid tag name", "version", tags.get(0).getName());
-        assertEquals("Invalid tag value", "1.0", tags.get(0).getValue());
+        assertEquals(1, tags.size(), "Invalid tags size");
+        assertEquals("version", tags.get(0).getName(), "Invalid tag name");
+        assertEquals("1.0", tags.get(0).getValue(), "Invalid tag value");
     }
 
     @Test
@@ -83,17 +83,17 @@ public class BlockTagUtilTest {
             " * @version 1.0 */"};
 
         final List<TagInfo> tags = BlockTagUtil.extractBlockTags(text);
-        assertEquals("Invalid tags size", 1, tags.size());
-        assertEquals("Invalid tag name", "version", tags.get(0).getName());
-        assertEquals("Invalid tag value", "1.0", tags.get(0).getValue());
+        assertEquals(1, tags.size(), "Invalid tags size");
+        assertEquals("version", tags.get(0).getName(), "Invalid tag name");
+        assertEquals("1.0", tags.get(0).getValue(), "Invalid tag value");
     }
 
     private static void assertTagEquals(TagInfo tag, String name, String value,
             int line, int column) {
-        assertEquals("Invalid tag name", name, tag.getName());
-        assertEquals("Invalid tag value", value, tag.getValue());
-        assertEquals("Invalid tag line", line, tag.getPosition().getLine());
-        assertEquals("Invalid tag column", column, tag.getPosition().getColumn());
+        assertEquals(name, tag.getName(), "Invalid tag name");
+        assertEquals(value, tag.getValue(), "Invalid tag value");
+        assertEquals(line, tag.getPosition().getLine(), "Invalid tag line");
+        assertEquals(column, tag.getPosition().getColumn(), "Invalid tag column");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/InlineTagUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/InlineTagUtilTest.java
@@ -19,13 +19,13 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.utils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
@@ -33,8 +33,8 @@ public class InlineTagUtilTest {
 
     @Test
     public void testHasPrivateConstructor() throws Exception {
-        assertTrue("Constructor is not private",
-                TestUtil.isUtilsClassHasPrivateConstructor(InlineTagUtil.class, true));
+        assertTrue(TestUtil.isUtilsClassHasPrivateConstructor(InlineTagUtil.class, true),
+                "Constructor is not private");
     }
 
     @Test
@@ -47,7 +47,7 @@ public class InlineTagUtilTest {
             " */"};
         final List<TagInfo> tags = InlineTagUtil.extractInlineTags(text);
 
-        assertEquals("Unexpected tags size", 4, tags.size());
+        assertEquals(4, tags.size(), "Unexpected tags size");
 
         assertTag(tags.get(0), "link", "List", 2, 4);
         assertTag(tags.get(1), "link", "List link text", 2, 19);
@@ -65,7 +65,7 @@ public class InlineTagUtilTest {
 
         final List<TagInfo> tags = InlineTagUtil.extractInlineTags(text);
 
-        assertEquals("Unexpected tags size", 1, tags.size());
+        assertEquals(1, tags.size(), "Unexpected tags size");
         assertTag(tags.get(0), "link", "foo bar baz", 2, 4);
     }
 
@@ -78,7 +78,7 @@ public class InlineTagUtilTest {
 
         final List<TagInfo> tags = InlineTagUtil.extractInlineTags(text);
 
-        assertEquals("Unexpected tags size", 1, tags.size());
+        assertEquals(1, tags.size(), "Unexpected tags size");
         assertTag(tags.get(0), "code", "foo bar baz", 2, 4);
     }
 
@@ -90,7 +90,7 @@ public class InlineTagUtilTest {
 
         final List<TagInfo> tags = InlineTagUtil.extractInlineTags(source);
 
-        assertEquals("Unexpected tags size", 1, tags.size());
+        assertEquals(1, tags.size(), "Unexpected tags size");
 
         final TagInfo tag = tags.get(0);
         assertTag(tag, "link", "foo", 1, 3);
@@ -103,7 +103,7 @@ public class InlineTagUtilTest {
             fail("IllegalArgumentException expected");
         }
         catch (IllegalArgumentException ex) {
-            assertTrue("Unexpected error message", ex.getMessage().contains("newline"));
+            assertTrue(ex.getMessage().contains("newline"), "Unexpected error message");
         }
     }
 
@@ -114,15 +114,15 @@ public class InlineTagUtilTest {
             fail("IllegalArgumentException expected");
         }
         catch (IllegalArgumentException ex) {
-            assertTrue("Invalid error message", ex.getMessage().contains("newline"));
+            assertTrue(ex.getMessage().contains("newline"), "Invalid error message");
         }
     }
 
     private static void assertTag(TagInfo tag, String name, String value, int line, int col) {
-        assertEquals("Unexpected tags name", name, tag.getName());
-        assertEquals("Unexpected tags value", value, tag.getValue());
-        assertEquals("Unexpected tags position", line, tag.getPosition().getLine());
-        assertEquals("Unexpected tags position", col, tag.getPosition().getColumn());
+        assertEquals(name, tag.getName(), "Unexpected tags name");
+        assertEquals(value, tag.getValue(), "Unexpected tags value");
+        assertEquals(line, tag.getPosition().getLine(), "Unexpected tags position");
+        assertEquals(col, tag.getPosition().getColumn(), "Unexpected tags position");
     }
 
 }


### PR DESCRIPTION
Issue #6916

Tests of the `javadoc` package are migrated to Junit5.

This PR introduces new dependency: https://github.com/itsallcode/junit5-system-extensions
This is replacement for [SystemRules ](https://github.com/stefanbirkner/system-rules)

See changes in AbstractJavadocCheckTest.java