### PR TITLE
Issue #6916: migrate tests to junit5 for package internal

### DIFF
--- a/config/import-control-test.xml
+++ b/config/import-control-test.xml
@@ -18,9 +18,11 @@
 
   <allow pkg=".*" regex="true" />
 
-  <!-- Till https://github.com/checkstyle/checkstyle/issues/6916 -->
+  <!-- Till https://github.com/checkstyle/checkstyle/issues/7368 -->
   <subpackage name="internal">
-    <allow pkg="org.junit"/>
+    <subpackage name="powermock">
+      <allow pkg="org.junit" local-only="true"/>
+    </subpackage>
   </subpackage>
   <file name=".*Test(Support)?" regex="true">
     <allow pkg="org.junit"/>

--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,7 @@
       <version>1.0.3</version>
       <scope>test</scope>
     </dependency>
-    <!-- Junit4 legacy support till https://github.com/checkstyle/checkstyle/issues/6916 -->
+    <!-- till https://github.com/checkstyle/checkstyle/issues/7368 -->
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
@@ -297,6 +297,7 @@
       <version>1.0</version>
       <scope>test</scope>
     </dependency>
+    <!-- till https://github.com/checkstyle/checkstyle/issues/7368 -->
     <dependency>
       <groupId>com.github.stefanbirkner</groupId>
       <artifactId>system-rules</artifactId>
@@ -315,6 +316,7 @@
       <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- till https://github.com/checkstyle/checkstyle/issues/7368 -->
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllTestsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllTestsTest.java
@@ -19,6 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.internal;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -32,8 +35,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * AllTestsTest.
@@ -49,7 +51,7 @@ public class AllTestsTest {
             grabAllTests(allTests, filePath.toFile());
         });
 
-        Assert.assertTrue("found tests", !allTests.keySet().isEmpty());
+        assertFalse(allTests.keySet().isEmpty(), "found tests");
 
         walk(Paths.get("src/test/resources/com/puppycrawl"), filePath -> {
             verifyInputFile(allTests, filePath.toFile());
@@ -67,7 +69,7 @@ public class AllTestsTest {
             grabAllFiles(allTests, filePath.toFile());
         });
 
-        Assert.assertTrue("found tests", !allTests.keySet().isEmpty());
+        assertFalse(allTests.keySet().isEmpty(), "found tests");
 
         walk(Paths.get("src/test/java"), filePath -> {
             verifyHasProductionFile(allTests, filePath.toFile());
@@ -99,14 +101,7 @@ public class AllTestsTest {
 
             final int slash = path.lastIndexOf(File.separatorChar);
             final String packge = path.substring(0, slash);
-
-            List<String> classes = allTests.get(packge);
-
-            if (classes == null) {
-                classes = new ArrayList<>();
-
-                allTests.put(packge, classes);
-            }
+            final List<String> classes = allTests.computeIfAbsent(packge, key -> new ArrayList<>());
 
             classes.add(path.substring(slash + 1));
         }
@@ -125,14 +120,7 @@ public class AllTestsTest {
 
             final int slash = path.lastIndexOf(File.separatorChar);
             final String packge = path.substring(0, slash);
-
-            List<String> classes = allTests.get(packge);
-
-            if (classes == null) {
-                classes = new ArrayList<>();
-
-                allTests.put(packge, classes);
-            }
+            final List<String> classes = allTests.computeIfAbsent(packge, key -> new ArrayList<>());
 
             classes.add(path.substring(slash + 1));
         }
@@ -157,8 +145,8 @@ public class AllTestsTest {
                 final boolean skipFileNaming = shouldSkipInputFileNameCheck(path, fileName);
 
                 if (!skipFileNaming) {
-                    Assert.assertTrue("Resource must start with 'Input' or 'Expected': " + path,
-                            fileName.startsWith("Input") || fileName.startsWith("Expected"));
+                    assertTrue(fileName.startsWith("Input") || fileName.startsWith("Expected"),
+                            "Resource must start with 'Input' or 'Expected': " + path);
 
                     if (fileName.startsWith("Input")) {
                         fileName = fileName.substring(5);
@@ -202,9 +190,9 @@ public class AllTestsTest {
             }
         }
 
-        Assert.assertTrue("Resource must be named after a Test like 'InputMyCustomCase.java' "
+        assertTrue(found, "Resource must be named after a Test like 'InputMyCustomCase.java' "
                 + "and be in the sub-package of the test like 'mycustom' "
-                + "for test 'MyCustomCheckTest': " + path, found);
+                + "for test 'MyCustomCheckTest': " + path);
     }
 
     private static void verifyHasProductionFile(Map<String, List<String>> allTests, File file) {
@@ -229,9 +217,9 @@ public class AllTestsTest {
                     final String packge = path.substring(0, slash);
                     final List<String> classes = allTests.get(packge);
 
-                    Assert.assertTrue("Test must be named after a production class "
-                            + "and must be in the same package of the production class: " + path,
-                            classes != null && classes.contains(fileName));
+                    assertTrue(classes != null && classes.contains(fileName),
+                            "Test must be named after a production class "
+                            + "and must be in the same package of the production class: " + path);
                 }
             }
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
@@ -19,9 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.internal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -43,8 +43,8 @@ import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Validate commit message has proper structure.
@@ -96,44 +96,44 @@ public class CommitValidationTest {
 
     private static List<RevCommit> lastCommits;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() throws Exception {
         lastCommits = getCommitsToCheck();
     }
 
     @Test
     public void testHasCommits() {
-        assertTrue("must have at least one commit to validate",
-                lastCommits != null && !lastCommits.isEmpty());
+        assertTrue(lastCommits != null && !lastCommits.isEmpty(),
+                "must have at least one commit to validate");
     }
 
     @Test
     public void testCommitMessage() {
-        assertEquals("should not accept commit message with periods on end", 3,
-                validateCommitMessage("minor: Test. Test."));
-        assertEquals("should not accept commit message with spaces on end", 3,
-                validateCommitMessage("minor: Test. "));
-        assertEquals("should not accept commit message with tabs on end", 3,
-                validateCommitMessage("minor: Test.\t"));
-        assertEquals("should not accept commit message with period on end, ignoring new line",
-                3, validateCommitMessage("minor: Test.\n"));
-        assertEquals("should not accept commit message with missing prefix", 1,
-                validateCommitMessage("Test. Test"));
-        assertEquals("should not accept commit message with missing prefix", 1,
-                validateCommitMessage("Test. Test\n"));
-        assertEquals("should not accept commit message with multiple lines with text", 2,
-                validateCommitMessage("minor: Test.\nTest"));
-        assertEquals("should accept commit message with a new line on end", 0,
-                validateCommitMessage("minor: Test\n"));
-        assertEquals("should accept commit message with multiple new lines on end", 0,
-                validateCommitMessage("minor: Test\n\n"));
-        assertEquals("should accept commit message that ends properly", 0,
-                validateCommitMessage("minor: Test. Test"));
-        assertEquals("should accept commit message with less than or equal to 200 characters",
-                4, validateCommitMessage("minor: Test Test Test Test Test"
+        assertEquals(3, validateCommitMessage("minor: Test. Test."),
+                "should not accept commit message with periods on end");
+        assertEquals(3, validateCommitMessage("minor: Test. "),
+                "should not accept commit message with spaces on end");
+        assertEquals(3, validateCommitMessage("minor: Test.\t"),
+                "should not accept commit message with tabs on end");
+        assertEquals(3, validateCommitMessage("minor: Test.\n"),
+                "should not accept commit message with period on end, ignoring new line");
+        assertEquals(1, validateCommitMessage("Test. Test"),
+                "should not accept commit message with missing prefix");
+        assertEquals(1, validateCommitMessage("Test. Test\n"),
+                "should not accept commit message with missing prefix");
+        assertEquals(2, validateCommitMessage("minor: Test.\nTest"),
+                "should not accept commit message with multiple lines with text");
+        assertEquals(0, validateCommitMessage("minor: Test\n"),
+                "should accept commit message with a new line on end");
+        assertEquals(0, validateCommitMessage("minor: Test\n\n"),
+                "should accept commit message with multiple new lines on end");
+        assertEquals(0, validateCommitMessage("minor: Test. Test"),
+                "should accept commit message that ends properly");
+        assertEquals(4, validateCommitMessage("minor: Test Test Test Test Test"
                 + "Test Test Test Test Test Test Test Test Test Test Test Test Test Test "
                 + "Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test "
-                + "Test Test Test Test Test Test Test  Test Test Test Test Test Test"));
+                + "Test Test Test Test Test Test Test  Test Test Test Test Test Test"),
+                "should accept commit message with less than or equal to 200 characters");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -20,7 +20,9 @@
 package com.puppycrawl.tools.checkstyle.internal;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -33,9 +35,8 @@ import java.util.regex.Pattern;
 
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -72,7 +73,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
         return "com.puppycrawl.tools.checkstyle.internal";
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         final DefaultConfiguration checkConfig = new DefaultConfiguration(
                 JavaDocCapture.class.getName());
@@ -370,8 +371,8 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
             if ("a".equals(nodeName) && "href".equals(attrName)) {
                 String value = attribute.getNodeValue();
 
-                assertNotEquals("links starting with '#' aren't supported: " + value,
-                        '#', value.charAt(0));
+                assertNotEquals('#', value.charAt(0),
+                        "links starting with '#' aren't supported: " + value);
 
                 if (value.contains("://")) {
                     attrValue = value;
@@ -448,7 +449,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
                         // ignore
                         break;
                     default:
-                        Assert.fail("Unknown token '" + TokenUtil.getTokenName(parentNode.getType())
+                        fail("Unknown token '" + TokenUtil.getTokenName(parentNode.getType())
                                 + "': " + ast.getLineNo());
                         break;
                 }
@@ -469,14 +470,13 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
 
         private static void visitClass(DetailAST node) {
             if (ScopeUtil.isInScope(node, Scope.PUBLIC)) {
-                Assert.assertEquals(
-                        checkName + "'s class-level JavaDoc",
-                        CHECK_TEXT.get("Description")
-                                + CHECK_TEXT.computeIfAbsent("Rule Description", unused -> "")
-                                + CHECK_TEXT.computeIfAbsent("Notes", unused -> "")
-                                + CHECK_TEXT.computeIfAbsent("Properties", unused -> "")
-                                + CHECK_TEXT.get("Examples") + " @since "
-                                + CHECK_TEXT.get("since"), getJavaDocText(node));
+                assertEquals(CHECK_TEXT.get("Description")
+                        + CHECK_TEXT.computeIfAbsent("Rule Description", unused -> "")
+                        + CHECK_TEXT.computeIfAbsent("Notes", unused -> "")
+                        + CHECK_TEXT.computeIfAbsent("Properties", unused -> "")
+                        + CHECK_TEXT.get("Examples") + " @since "
+                        + CHECK_TEXT.get("since"), getJavaDocText(node),
+                        checkName + "'s class-level JavaDoc");
             }
         }
 
@@ -486,9 +486,8 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
                 final String propertyDoc = CHECK_PROPERTY_DOC.get(propertyName);
 
                 if (propertyDoc != null) {
-                    Assert.assertEquals(checkName + "'s class field-level JavaDoc for "
-                                    + propertyName, makeFirstUpper(propertyDoc),
-                            getJavaDocText(node));
+                    assertEquals(makeFirstUpper(propertyDoc), getJavaDocText(node),
+                            checkName + "'s class field-level JavaDoc for " + propertyName);
                 }
             }
         }
@@ -503,10 +502,9 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
                 if (propertyDoc != null) {
                     final String javaDoc = getJavaDocText(node);
 
-                    Assert.assertEquals(checkName + "'s class method-level JavaDoc for "
-                            + propertyName,
-                            "Setter to " + makeFirstLower(propertyDoc),
-                            javaDoc.substring(0, javaDoc.indexOf(" @param")));
+                    assertEquals("Setter to " + makeFirstLower(propertyDoc),
+                            javaDoc.substring(0, javaDoc.indexOf(" @param")),
+                            checkName + "'s class method-level JavaDoc for " + propertyName);
                 }
             }
         }
@@ -551,7 +549,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
                         .replace("\r", "");
             }
             catch (ParserConfigurationException ex) {
-                Assert.fail("Exception: " + ex.getClass() + " - " + ex.getMessage());
+                fail("Exception: " + ex.getClass() + " - " + ex.getMessage());
             }
 
             return result;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsMobileWrapperTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsMobileWrapperTest.java
@@ -20,6 +20,9 @@
 package com.puppycrawl.tools.checkstyle.internal;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -27,9 +30,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -41,7 +43,7 @@ public class XdocsMobileWrapperTest {
 
     private static final List<String> NODES_TO_WRAP = new ArrayList<>();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         NODES_TO_WRAP.add("pre");
         NODES_TO_WRAP.add("table");
@@ -56,8 +58,7 @@ public class XdocsMobileWrapperTest {
             final String fileName = file.getName();
 
             final String input = new String(Files.readAllBytes(path), UTF_8);
-            Assert.assertNotEquals(fileName + ": input file cannot be empty", "",
-                    input);
+            assertNotEquals("", input, fileName + ": input file cannot be empty");
             final Document document = XmlUtil.getRawXml(fileName, input, input);
             final NodeList sources = document.getElementsByTagName("section");
 
@@ -81,13 +82,12 @@ public class XdocsMobileWrapperTest {
                 final String wrapperMessage = fileName + "/" + sectionName + ": Tag '"
                         + child.getNodeName() + "' in '" + node.getNodeName()
                         + "' needs a wrapping <span> or <div> with the class 'wrapper'.";
-                Assert.assertTrue(wrapperMessage, "div".equals(node.getNodeName())
-                        || "span".equals(node.getNodeName()));
-                Assert.assertTrue(wrapperMessage, node.hasAttributes());
-                Assert.assertNotNull(wrapperMessage, node.getAttributes().getNamedItem("class"));
-                Assert.assertTrue(wrapperMessage,
-                        node.getAttributes().getNamedItem("class").getNodeValue()
-                                .contains("wrapper"));
+                assertTrue("div".equals(node.getNodeName())
+                        || "span".equals(node.getNodeName()), wrapperMessage);
+                assertTrue(node.hasAttributes(), wrapperMessage);
+                assertNotNull(node.getAttributes().getNamedItem("class"), wrapperMessage);
+                assertTrue(node.getAttributes().getNamedItem("class").getNodeValue()
+                                .contains("wrapper"), wrapperMessage);
 
                 if ("table".equals(child.getNodeName())) {
                     iterateNode(child, fileName, sectionName);
@@ -96,9 +96,8 @@ public class XdocsMobileWrapperTest {
                     final String dataImageInlineMessage = fileName + "/" + sectionName + ": img "
                             + "needs the additional class inline if it should be displayed inline "
                             + "or block if scrolling in mobile view should be enabled.";
-                    Assert.assertTrue(dataImageInlineMessage,
-                            node.getAttributes().getNamedItem("class").getNodeValue()
-                                    .matches(".*(block|inline).*"));
+                    assertTrue(node.getAttributes().getNamedItem("class").getNodeValue()
+                                    .matches(".*(block|inline).*"), dataImageInlineMessage);
                 }
             }
             else {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -23,6 +23,14 @@ import static java.lang.Integer.parseInt;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.describedAs;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.beans.PropertyDescriptor;
 import java.io.File;
@@ -54,8 +62,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.apache.commons.beanutils.PropertyUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -239,7 +246,7 @@ public class XdocsPagesTest {
         CheckUtil.getSimpleNames(CheckUtil.getCheckstyleChecks())
             .forEach(checkName -> {
                 if (!isPresent(availableChecks, checkName)) {
-                    Assert.fail(checkName + " is not correctly listed on Available Checks page"
+                    fail(checkName + " is not correctly listed on Available Checks page"
                         + " - add it to " + AVAILABLE_CHECKS_PATH);
                 }
             });
@@ -263,12 +270,11 @@ public class XdocsPagesTest {
                 final Node subSection = subSections.item(position);
                 final Node name = subSection.getAttributes().getNamedItem("name");
 
-                Assert.assertNotNull("All sub-sections in '" + fileName + "' must have a name",
-                        name);
+                assertNotNull(name, "All sub-sections in '" + fileName + "' must have a name");
 
                 final Node id = subSection.getAttributes().getNamedItem("id");
 
-                Assert.assertNotNull("All sub-sections in '" + fileName + "' must have an id", id);
+                assertNotNull(id, "All sub-sections in '" + fileName + "' must have an id");
 
                 final String sectionName;
 
@@ -286,9 +292,9 @@ public class XdocsPagesTest {
                 final String nameString = name.getNodeValue();
                 final String idString = id.getNodeValue();
 
-                Assert.assertEquals(fileName + " sub-section " + nameString + " for section "
-                        + sectionName + " must match",
-                        (sectionName + " " + nameString).replace(' ', '_'), idString);
+                assertEquals((sectionName + " " + nameString).replace(' ', '_'), idString,
+                        fileName + " sub-section " + nameString + " for section "
+                        + sectionName + " must match");
             }
         }
     }
@@ -318,10 +324,10 @@ public class XdocsPagesTest {
                 XmlUtil.getRawXml(fileName, code, unserializedSource);
 
                 // can't test ant structure, or old and outdated checks
-                Assert.assertTrue("Xml is invalid, old or has outdated structure",
-                        fileName.startsWith("anttask")
+                assertTrue(fileName.startsWith("anttask")
                         || fileName.startsWith("releasenotes")
-                        || isValidCheckstyleXml(fileName, code, unserializedSource));
+                        || isValidCheckstyleXml(fileName, code, unserializedSource),
+                        "Xml is invalid, old or has outdated structure");
             }
         }
     }
@@ -424,19 +430,18 @@ public class XdocsPagesTest {
                         .getNodeValue();
 
                 if ("Content".equals(sectionName) || "Overview".equals(sectionName)) {
-                    Assert.assertNull(fileName + " section '" + sectionName + "' should be first",
-                            lastSectionName);
+                    assertNull(lastSectionName,
+                            fileName + " section '" + sectionName + "' should be first");
                     continue;
                 }
 
-                Assert.assertTrue(fileName + " section '" + sectionName
-                        + "' shouldn't end with 'Check'", !sectionName.endsWith("Check"));
+                assertFalse(sectionName.endsWith("Check"),
+                        fileName + " section '" + sectionName + "' shouldn't end with 'Check'");
                 if (lastSectionName != null) {
-                    Assert.assertTrue(
+                    assertTrue(sectionName.toLowerCase(Locale.ENGLISH).compareTo(
+                            lastSectionName.toLowerCase(Locale.ENGLISH)) >= 0,
                             fileName + " section '" + sectionName
-                                    + "' is out of order compared to '" + lastSectionName + "'",
-                            sectionName.toLowerCase(Locale.ENGLISH).compareTo(
-                                    lastSectionName.toLowerCase(Locale.ENGLISH)) >= 0);
+                                + "' is out of order compared to '" + lastSectionName + "'");
                 }
 
                 validateCheckSection(moduleFactory, fileName, sectionName, section);
@@ -512,9 +517,8 @@ public class XdocsPagesTest {
                 subSectionPos++;
             }
 
-            Assert.assertEquals(fileName + " section '" + sectionName
-                    + "' should be in order", getSubSectionName(subSectionPos),
-                    subSectionName);
+            assertEquals(getSubSectionName(subSectionPos), subSectionName,
+                    fileName + " section '" + sectionName + "' should be in order");
 
             switch (subSectionPos) {
                 case 1:
@@ -542,21 +546,21 @@ public class XdocsPagesTest {
         }
 
         if ("Checker".equals(sectionName)) {
-            Assert.assertTrue(fileName + " section '" + sectionName
-                    + "' should contain up to 'Package' sub-section", subSectionPos >= 6);
+            assertTrue(subSectionPos >= 6, fileName + " section '" + sectionName
+                    + "' should contain up to 'Package' sub-section");
         }
         else {
-            Assert.assertTrue(fileName + " section '" + sectionName
-                    + "' should contain up to 'Parent' sub-section", subSectionPos >= 7);
+            assertTrue(subSectionPos >= 7, fileName + " section '" + sectionName
+                    + "' should contain up to 'Parent' sub-section");
         }
     }
 
     private static void validateSinceDescriptionSection(String fileName, String sectionName,
             Node subSection) {
-        Assert.assertTrue(fileName + " section '" + sectionName
-                + "' should have a valid version at the start of the description like:\n"
-                + DESCRIPTION_VERSION.pattern(),
-                DESCRIPTION_VERSION.matcher(subSection.getTextContent().trim()).find());
+        assertTrue(DESCRIPTION_VERSION.matcher(subSection.getTextContent().trim()).find(),
+                fileName + " section '" + sectionName
+                        + "' should have a valid version at the start of the description like:\n"
+                        + DESCRIPTION_VERSION.pattern());
     }
 
     private static Object getSubSectionName(int subSectionPos) {
@@ -600,38 +604,34 @@ public class XdocsPagesTest {
         fixCapturedProperties(sectionName, instance, clss, properties);
 
         if (subSection != null) {
-            Assert.assertTrue(fileName + " section '" + sectionName
-                    + "' should have no properties to show", !properties.isEmpty());
+            assertFalse(properties.isEmpty(), fileName + " section '" + sectionName
+                    + "' should have no properties to show");
 
             final Set<Node> nodes = XmlUtil.getChildrenElements(subSection);
-            Assert.assertEquals(fileName + " section '" + sectionName
-                    + "' subsection 'Properties' should have one child node",
-                1, nodes.size());
+            assertEquals(1, nodes.size(), fileName + " section '" + sectionName
+                    + "' subsection 'Properties' should have one child node");
 
             final Node div = nodes.iterator().next();
-            Assert.assertEquals(fileName + " section '" + sectionName
-                    + "' subsection 'Properties' has unexpected child node",
-                "div", div.getNodeName());
+            assertEquals("div", div.getNodeName(), fileName + " section '" + sectionName
+                        + "' subsection 'Properties' has unexpected child node");
             final String wrapperMessage = fileName + " section '" + sectionName
                     + "' subsection 'Properties' wrapping div for table needs the"
                     + " class 'wrapper'";
-            Assert.assertTrue(wrapperMessage, div.hasAttributes());
-            Assert.assertNotNull(wrapperMessage,
-                    div.getAttributes().getNamedItem("class").getNodeValue());
-            Assert.assertTrue(wrapperMessage,
-                    div.getAttributes().getNamedItem("class").getNodeValue().contains("wrapper"));
+            assertTrue(div.hasAttributes(), wrapperMessage);
+            assertNotNull(div.getAttributes().getNamedItem("class").getNodeValue(), wrapperMessage);
+            assertTrue(div.getAttributes().getNamedItem("class").getNodeValue().contains("wrapper"),
+                    wrapperMessage);
 
             final Node table = XmlUtil.getFirstChildElement(div);
-            Assert.assertEquals(fileName + " section '" + sectionName
-                            + "' subsection 'Properties' has unexpected child node",
-                    "table", table.getNodeName());
+            assertEquals("table", table.getNodeName(), fileName + " section '" + sectionName
+                    + "' subsection 'Properties' has unexpected child node");
 
             validatePropertySectionProperties(fileName, sectionName, table, instance,
                     properties);
         }
 
-        Assert.assertTrue(fileName + " section '" + sectionName + "' should show properties: "
-                + properties, properties.isEmpty());
+        assertTrue(properties.isEmpty(),
+                fileName + " section '" + sectionName + "' should show properties: " + properties);
     }
 
     private static void fixCapturedProperties(String sectionName, Object instance, Class<?> clss,
@@ -702,37 +702,36 @@ public class XdocsPagesTest {
         for (Node row : XmlUtil.getChildrenElements(table)) {
             final List<Node> columns = new ArrayList<>(XmlUtil.getChildrenElements(row));
 
-            Assert.assertEquals(fileName + " section '" + sectionName
-                    + "' should have the requested columns", 5, columns.size());
+            assertEquals(5, columns.size(), fileName + " section '" + sectionName
+                    + "' should have the requested columns");
 
             if (skip) {
-                Assert.assertEquals(fileName + " section '" + sectionName
-                        + "' should have the specific title", "name", columns.get(0)
-                        .getTextContent());
-                Assert.assertEquals(fileName + " section '" + sectionName
-                        + "' should have the specific title", "description", columns.get(1)
-                        .getTextContent());
-                Assert.assertEquals(fileName + " section '" + sectionName
-                        + "' should have the specific title", "type", columns.get(2)
-                        .getTextContent());
-                Assert.assertEquals(fileName + " section '" + sectionName
-                        + "' should have the specific title", "default value", columns.get(3)
-                        .getTextContent());
-                Assert.assertEquals(fileName + " section '" + sectionName
-                        + "' should have the specific title", "since", columns.get(4)
-                        .getTextContent());
+                assertEquals("name", columns.get(0).getTextContent(),
+                        fileName + " section '" + sectionName
+                                + "' should have the specific title");
+                assertEquals("description", columns.get(1).getTextContent(),
+                        fileName + " section '" + sectionName
+                                + "' should have the specific title");
+                assertEquals("type", columns.get(2).getTextContent(),
+                        fileName + " section '" + sectionName
+                                + "' should have the specific title");
+                assertEquals("default value", columns.get(3).getTextContent(),
+                        fileName + " section '" + sectionName
+                                + "' should have the specific title");
+                assertEquals("since", columns.get(4).getTextContent(),
+                        fileName + " section '" + sectionName
+                                + "' should have the specific title");
 
                 skip = false;
                 continue;
             }
 
-            Assert.assertFalse(fileName + " section '" + sectionName
-                    + "' should have token properties last", didTokens);
+            assertFalse(didTokens, fileName + " section '" + sectionName
+                    + "' should have token properties last");
 
             final String propertyName = columns.get(0).getTextContent();
-            Assert.assertTrue(fileName + " section '" + sectionName
-                    + "' should not contain the property: " + propertyName,
-                    properties.remove(propertyName));
+            assertTrue(properties.remove(propertyName), fileName + " section '" + sectionName
+                    + "' should not contain the property: " + propertyName);
 
             if ("tokens".equals(propertyName)) {
                 final AbstractCheck check = (AbstractCheck) instance;
@@ -745,34 +744,33 @@ public class XdocsPagesTest {
                 didJavadocTokens = true;
             }
             else {
-                Assert.assertFalse(fileName + " section '" + sectionName
-                        + "' should have javadoc token properties next to last, before tokens",
-                        didJavadocTokens);
+                assertFalse(didJavadocTokens, fileName + " section '" + sectionName
+                            + "' should have javadoc token properties next to last, before tokens");
 
                 validatePropertySectionPropertyEx(fileName, sectionName, instance, columns,
                         propertyName);
             }
 
-            Assert.assertFalse(fileName + " section '" + sectionName
-                    + "' should have a version for " + propertyName, columns.get(4)
-                    .getTextContent().trim().isEmpty());
-            Assert.assertTrue(fileName + " section '" + sectionName
-                    + "' should have a valid version for " + propertyName,
-                    VERSION.matcher(columns.get(4).getTextContent().trim()).matches());
+            assertFalse(columns.get(4).getTextContent().trim().isEmpty(),
+                    fileName + " section '" + sectionName
+                            + "' should have a version for " + propertyName);
+            assertTrue(VERSION.matcher(columns.get(4).getTextContent().trim()).matches(),
+                    fileName + " section '" + sectionName
+                            + "' should have a valid version for " + propertyName);
         }
     }
 
     private static void validatePropertySectionPropertyEx(String fileName, String sectionName,
             Object instance, List<Node> columns, String propertyName) throws Exception {
-        Assert.assertFalse(fileName + " section '" + sectionName
-                + "' should have a description for " + propertyName, columns.get(1)
-                .getTextContent().trim().isEmpty());
+        assertFalse(columns.get(1).getTextContent().trim().isEmpty(),
+                fileName + " section '" + sectionName
+                        + "' should have a description for " + propertyName);
 
         final String actualTypeName = columns.get(2).getTextContent().replace("\n", "")
                 .replace("\r", "").replaceAll(" +", " ").trim();
 
-        Assert.assertFalse(fileName + " section '" + sectionName + "' should have a type for "
-                + propertyName, actualTypeName.isEmpty());
+        assertFalse(actualTypeName.isEmpty(),
+                fileName + " section '" + sectionName + "' should have a type for " + propertyName);
 
         final Field field = getField(instance.getClass(), propertyName);
         final Class<?> fieldClss = getFieldClass(fileName, sectionName, instance, field,
@@ -783,55 +781,50 @@ public class XdocsPagesTest {
         final String expectedValue = getModulePropertyExpectedValue(sectionName, propertyName,
                 field, fieldClss, instance);
 
-        Assert.assertEquals(fileName + " section '" + sectionName
-                + "' should have the type for " + propertyName, expectedTypeName,
-                actualTypeName);
+        assertEquals(expectedTypeName, actualTypeName,
+                fileName + " section '" + sectionName
+                        + "' should have the type for " + propertyName);
 
         if (expectedValue != null) {
             final String actualValue = columns.get(3).getTextContent().replace("\n", "")
                     .replace("\r", "").replaceAll(" +", " ").trim();
 
-            Assert.assertEquals(fileName + " section '" + sectionName
-                    + "' should have the value for " + propertyName, expectedValue,
-                    actualValue);
+            assertEquals(expectedValue, actualValue,
+                    fileName + " section '" + sectionName
+                            + "' should have the value for " + propertyName);
         }
     }
 
     private static void validatePropertySectionPropertyTokens(String fileName, String sectionName,
             AbstractCheck check, List<Node> columns) {
-        Assert.assertEquals(fileName + " section '" + sectionName
-                + "' should have the basic token description", "tokens to check", columns.get(1)
-                .getTextContent());
-        Assert.assertEquals(
-                fileName + " section '" + sectionName + "' should have all the acceptable tokens",
-                "subset of tokens "
-                        + CheckUtil.getTokenText(check.getAcceptableTokens(),
-                                check.getRequiredTokens()), columns.get(2).getTextContent()
-                        .replaceAll("\\s+", " ").trim());
-        Assert.assertEquals(fileName + " section '" + sectionName
-                + "' should have all the default tokens",
+        assertEquals("tokens to check", columns.get(1).getTextContent(),
+                fileName + " section '" + sectionName
+                        + "' should have the basic token description");
+        assertEquals("subset of tokens " + CheckUtil.getTokenText(check.getAcceptableTokens(),
+                check.getRequiredTokens()),
+                columns.get(2).getTextContent().replaceAll("\\s+", " ").trim(),
+                fileName + " section '" + sectionName + "' should have all the acceptable tokens");
+        assertEquals(
                 CheckUtil.getTokenText(check.getDefaultTokens(), check.getRequiredTokens()),
-                columns.get(3).getTextContent().replaceAll("\\s+", " ").trim());
+                columns.get(3).getTextContent().replaceAll("\\s+", " ").trim(),
+                fileName + " section '" + sectionName + "' should have all the default tokens");
     }
 
     private static void validatePropertySectionPropertyJavadocTokens(String fileName,
             String sectionName, AbstractJavadocCheck check, List<Node> columns) {
-        Assert.assertEquals(fileName + " section '" + sectionName
-                + "' should have the basic token javadoc description", "javadoc tokens to check",
-                columns.get(1).getTextContent());
-        Assert.assertEquals(
-                fileName + " section '" + sectionName
-                        + "' should have all the acceptable javadoc tokens",
-                "subset of javadoc tokens "
+        assertEquals("javadoc tokens to check",
+                columns.get(1).getTextContent(), fileName + " section '" + sectionName
+                        + "' should have the basic token javadoc description");
+        assertEquals("subset of javadoc tokens "
                         + CheckUtil.getJavadocTokenText(check.getAcceptableJavadocTokens(),
                                 check.getRequiredJavadocTokens()), columns.get(2).getTextContent()
-                        .replaceAll("\\s+", " ").trim());
-        Assert.assertEquals(
-                fileName + " section '" + sectionName
-                        + "' should have all the default javadoc tokens",
+                        .replaceAll("\\s+", " ").trim(), fileName + " section '" + sectionName
+                                + "' should have all the acceptable javadoc tokens");
+        assertEquals(
                 CheckUtil.getJavadocTokenText(check.getDefaultJavadocTokens(),
                         check.getRequiredJavadocTokens()), columns.get(3).getTextContent()
-                        .replaceAll("\\s+", " ").trim());
+                        .replaceAll("\\s+", " ").trim(), fileName + " section '" + sectionName
+                                + "' should have all the default javadoc tokens");
     }
 
     /**
@@ -960,7 +953,7 @@ public class XdocsPagesTest {
             result = "File";
         }
         else {
-            Assert.fail("Unknown property type: " + fieldClass.getSimpleName());
+            fail("Unknown property type: " + fieldClass.getSimpleName());
         }
 
         if ("SuppressWarningsHolder".equals(instanceName)) {
@@ -1173,7 +1166,7 @@ public class XdocsPagesTest {
                 result = Arrays.toString((Object[]) value).replace("[", "").replace("]", "");
             }
             else {
-                Assert.fail("Unknown property type: " + fieldClass.getSimpleName());
+                fail("Unknown property type: " + fieldClass.getSimpleName());
             }
 
             if (result == null) {
@@ -1225,11 +1218,11 @@ public class XdocsPagesTest {
             result = field.getType();
         }
         if (result == null) {
-            Assert.assertTrue(
-                    fileName + " section '" + sectionName + "' could not find field "
-                            + propertyName,
+            assertTrue(
                     PROPERTIES_ALLOWED_GET_TYPES_FROM_METHOD.contains(sectionName + "."
-                            + propertyName));
+                            + propertyName),
+                    fileName + " section '" + sectionName + "' could not find field "
+                            + propertyName);
 
             final PropertyDescriptor descriptor = PropertyUtils.getPropertyDescriptor(instance,
                     propertyName);
@@ -1249,7 +1242,7 @@ public class XdocsPagesTest {
                 result = Pattern[].class;
             }
             else {
-                Assert.fail("Unknown parameterized type: " + parameterClass.getSimpleName());
+                fail("Unknown parameterized type: " + parameterClass.getSimpleName());
             }
         }
         else if (result == BitSet.class) {
@@ -1288,13 +1281,14 @@ public class XdocsPagesTest {
         }
 
         if (subSection == null) {
-            Assert.assertEquals(fileName + " section '" + sectionName
-                    + "' should have the expected error keys", "", expectedText.toString());
+            assertEquals("", expectedText.toString(), fileName + " section '" + sectionName
+                    + "' should have the expected error keys");
         }
         else {
-            Assert.assertEquals(fileName + " section '" + sectionName
-                    + "' should have the expected error keys", expectedText.toString().trim(),
-                    subSection.getTextContent().replaceAll("\n\\s+", "\n").trim());
+            assertEquals(expectedText.toString().trim(),
+                    subSection.getTextContent().replaceAll("\n\\s+", "\n").trim(),
+                    fileName + " section '" + sectionName
+                            + "' should have the expected error keys");
 
             for (Node node : XmlUtil.findChildElementsByTag(subSection, "a")) {
                 final String url = node.getAttributes().getNamedItem("href").getTextContent();
@@ -1312,8 +1306,8 @@ public class XdocsPagesTest {
                             + linkText + "%22";
                 }
 
-                Assert.assertEquals(fileName + " section '" + sectionName
-                        + "' should have matching url for '" + linkText + "'", expectedUrl, url);
+                assertEquals(expectedUrl, url, fileName + " section '" + sectionName
+                        + "' should have matching url for '" + linkText + "'");
             }
         }
     }
@@ -1322,8 +1316,8 @@ public class XdocsPagesTest {
         final String text = subSection.getTextContent().replace("Checkstyle Style", "")
                 .replace("Google Style", "").replace("Sun Style", "").trim();
 
-        Assert.assertTrue(fileName + " section '" + sectionName
-                + "' has unknown text in 'Example of Usage': " + text, text.isEmpty());
+        assertTrue(text.isEmpty(), fileName + " section '" + sectionName
+                + "' has unknown text in 'Example of Usage': " + text);
 
         boolean hasCheckstyle = false;
         boolean hasGoogle = false;
@@ -1347,9 +1341,9 @@ public class XdocsPagesTest {
                         + "repo%3Acheckstyle%2Fcheckstyle+"
                         + sectionName;
 
-                Assert.assertTrue(fileName + " section '" + sectionName
-                        + "' should be in google_checks.xml or not reference 'Google Style'",
-                        GOOGLE_MODULES.contains(sectionName));
+                assertTrue(
+                        GOOGLE_MODULES.contains(sectionName), fileName + " section '" + sectionName
+                            + "' should be in google_checks.xml or not reference 'Google Style'");
             }
             else if ("Sun Style".equals(linkText)) {
                 hasSun = true;
@@ -1358,30 +1352,30 @@ public class XdocsPagesTest {
                         + "repo%3Acheckstyle%2Fcheckstyle+"
                         + sectionName;
 
-                Assert.assertTrue(fileName + " section '" + sectionName
-                        + "' should be in sun_checks.xml or not reference 'Sun Style'",
-                        SUN_MODULES.contains(sectionName));
+                assertTrue(
+                        SUN_MODULES.contains(sectionName), fileName + " section '" + sectionName
+                                + "' should be in sun_checks.xml or not reference 'Sun Style'");
             }
 
-            Assert.assertEquals(fileName + " section '" + sectionName
-                    + "' should have matching url", expectedUrl, url);
+            assertEquals(expectedUrl, url, fileName + " section '" + sectionName
+                    + "' should have matching url");
         }
 
-        Assert.assertTrue(fileName + " section '" + sectionName
-                + "' should have a checkstyle section", hasCheckstyle);
-        Assert.assertTrue(fileName + " section '" + sectionName
-                + "' should have a google section since it is in it's config", hasGoogle
-                || !GOOGLE_MODULES.contains(sectionName));
-        Assert.assertTrue(fileName + " section '" + sectionName
-                + "' should have a sun section since it is in it's config",
-                hasSun || !SUN_MODULES.contains(sectionName));
+        assertTrue(hasCheckstyle, fileName + " section '" + sectionName
+                + "' should have a checkstyle section");
+        assertTrue(hasGoogle
+                || !GOOGLE_MODULES.contains(sectionName), fileName + " section '" + sectionName
+                        + "' should have a google section since it is in it's config");
+        assertTrue(hasSun || !SUN_MODULES.contains(sectionName),
+                fileName + " section '" + sectionName
+                        + "' should have a sun section since it is in it's config");
     }
 
     private static void validatePackageSection(String fileName, String sectionName,
             Node subSection, Object instance) {
-        Assert.assertEquals(fileName + " section '" + sectionName
-                + "' should have matching package", instance.getClass().getPackage().getName(),
-                subSection.getTextContent().trim());
+        assertEquals(instance.getClass().getPackage().getName(),
+                subSection.getTextContent().trim(), fileName + " section '" + sectionName
+                        + "' should have matching package");
     }
 
     private static void validateParentSection(String fileName, String sectionName,
@@ -1395,10 +1389,8 @@ public class XdocsPagesTest {
             expected = "Checker";
         }
 
-        Assert.assertEquals(
-                fileName + " section '" + sectionName + "' should have matching parent",
-                expected, subSection
-                        .getTextContent().trim());
+        assertEquals(expected, subSection.getTextContent().trim(),
+                fileName + " section '" + sectionName + "' should have matching parent");
     }
 
     private static boolean hasParentModule(String sectionName) {
@@ -1449,7 +1441,7 @@ public class XdocsPagesTest {
                     break;
 
                 default:
-                    Assert.fail("Missing modules list for style file '" + fileName + "'");
+                    fail("Missing modules list for style file '" + fileName + "'");
                     styleChecks = null;
             }
 
@@ -1486,8 +1478,8 @@ public class XdocsPagesTest {
             styleChecks.remove("TreeWalker");
             styleChecks.remove("Checker");
 
-            Assert.assertTrue(fileName + " requires the following check(s) to appear: "
-                    + styleChecks, styleChecks.isEmpty());
+            assertTrue(styleChecks.isEmpty(),
+                    fileName + " requires the following check(s) to appear: " + styleChecks);
         }
     }
 
@@ -1519,16 +1511,14 @@ public class XdocsPagesTest {
                 if (ruleNumberPartsAreNumeric) {
                     final int numericRuleNumberPart = parseInt(ruleNumberPart);
                     final int numericLastRuleNumberPart = parseInt(lastRuleNumberPart);
-                    Assert.assertThat(
-                            outOfOrderReason,
+                    assertThat(outOfOrderReason,
                             numericRuleNumberPart < numericLastRuleNumberPart,
                             describedAs("'%0' should not be less than '%1'",
                                     is(false),
                                     numericRuleNumberPart, numericLastRuleNumberPart));
                 }
                 else {
-                    Assert.assertThat(
-                            outOfOrderReason,
+                    assertThat(outOfOrderReason,
                             ruleNumberPart.compareToIgnoreCase(lastRuleNumberPart) < 0,
                             describedAs("'%0' should not be less than '%1'",
                                     is(false),
@@ -1543,11 +1533,11 @@ public class XdocsPagesTest {
             }
             if (ruleNumberPartsAmount == partIndex && lastRuleNumberPartWasEqual) {
                 if (lastRuleNumberPartsAmount == partIndex) {
-                    Assert.fail(fileName + " rule '" + ruleName + "' and rule '"
+                    fail(fileName + " rule '" + ruleName + "' and rule '"
                             + lastRuleName + "' have the same rule number");
                 }
                 else {
-                    Assert.fail(outOfOrderReason);
+                    fail(outOfOrderReason);
                 }
             }
         }
@@ -1556,13 +1546,13 @@ public class XdocsPagesTest {
     }
 
     private static void validateStyleAnchors(Set<Node> anchors, String fileName, String ruleName) {
-        Assert.assertEquals(fileName + " rule '" + ruleName + "' must have two row anchors", 2,
-                anchors.size());
+        assertEquals(2,
+                anchors.size(), fileName + " rule '" + ruleName + "' must have two row anchors");
 
         final int space = ruleName.indexOf(' ');
-        Assert.assertTrue(fileName + " rule '" + ruleName
-                + "' must have have a space between the rule's number and the rule's name",
-                space != -1);
+        assertNotEquals(-1, space,
+                fileName + " rule '" + ruleName
+                        + "' must have have a space between the rule's number and the rule's name");
 
         final String ruleNumber = ruleName.substring(0, space);
 
@@ -1581,8 +1571,8 @@ public class XdocsPagesTest {
                 expectedUrl = "#" + ruleNumber;
             }
 
-            Assert.assertEquals(fileName + " rule '" + ruleName + "' anchor " + position
-                    + " should have matching name/url", expectedUrl, actualUrl);
+            assertEquals(expectedUrl, actualUrl, fileName + " rule '" + ruleName + "' anchor "
+                    + position + " should have matching name/url");
 
             position++;
         }
@@ -1602,8 +1592,9 @@ public class XdocsPagesTest {
                 continue;
             }
 
-            Assert.assertTrue(styleName + "_style.xml rule '" + ruleName + "' module '" + moduleName
-                    + "' shouldn't end with 'Check'", !moduleName.endsWith("Check"));
+            assertFalse(moduleName.endsWith("Check"),
+                    styleName + "_style.xml rule '" + ruleName + "' module '" + moduleName
+                        + "' shouldn't end with 'Check'");
 
             styleChecks.remove(moduleName);
 
@@ -1614,13 +1605,13 @@ public class XdocsPagesTest {
                     config = itrConfigs.next();
                 }
                 catch (NoSuchElementException ignore) {
-                    Assert.fail(styleName + "_style.xml rule '" + ruleName + "' module '"
+                    fail(styleName + "_style.xml rule '" + ruleName + "' module '"
                             + moduleName + "' is missing the config link: " + configName);
                 }
 
-                Assert.assertEquals(styleName + "_style.xml rule '" + ruleName + "' module '"
-                        + moduleName + "' has mismatched config/test links", configName,
-                        config.getTextContent().trim());
+                assertEquals(configName, config.getTextContent().trim(),
+                        styleName + "_style.xml rule '" + ruleName + "' module '"
+                                + moduleName + "' has mismatched config/test links");
 
                 final String configUrl = config.getAttributes().getNamedItem("href")
                         .getTextContent();
@@ -1630,30 +1621,32 @@ public class XdocsPagesTest {
                             + "path%3Asrc%2Fmain%2Fresources+filename%3A" + styleName
                             + "_checks.xml+repo%3Acheckstyle%2Fcheckstyle+" + moduleName;
 
-                    Assert.assertEquals(styleName + "_style.xml rule '" + ruleName + "' module '"
-                                    + moduleName + "' should have matching " + configName + " url",
-                            expectedUrl, configUrl);
+                    assertEquals(expectedUrl, configUrl,
+                            styleName + "_style.xml rule '" + ruleName + "' module '"
+                                    + moduleName + "' should have matching " + configName + " url");
                 }
                 else if ("test".equals(configName)) {
-                    Assert.assertTrue(styleName + "_style.xml rule '" + ruleName + "' module '"
-                                    + moduleName + "' should have matching " + configName + " url",
+                    assertTrue(
                             configUrl.startsWith("https://github.com/checkstyle/checkstyle/"
                                     + "blob/master/src/it/java/com/" + styleName
-                                    + "/checkstyle/test/"));
-                    Assert.assertTrue(styleName + "_style.xml rule '" + ruleName + "' module '"
-                                    + moduleName + "' should have matching " + configName + " url",
-                            configUrl.endsWith("/" + moduleName + "Test.java"));
+                                    + "/checkstyle/test/"),
+                            styleName + "_style.xml rule '" + ruleName + "' module '"
+                                    + moduleName + "' should have matching " + configName + " url");
+                    assertTrue(configUrl.endsWith("/" + moduleName + "Test.java"),
+                            styleName + "_style.xml rule '" + ruleName + "' module '"
+                                    + moduleName + "' should have matching " + configName + " url");
 
-                    Assert.assertTrue(styleName + "_style.xml rule '" + ruleName + "' module '"
-                            + moduleName + "' should have a test that exists",
+                    assertTrue(
                             new File(configUrl.substring(53)
-                                    .replace('/', File.separatorChar)).exists());
+                                    .replace('/', File.separatorChar)).exists(),
+                            styleName + "_style.xml rule '" + ruleName + "' module '"
+                                    + moduleName + "' should have a test that exists");
                 }
             }
         }
 
-        Assert.assertFalse(styleName + "_style.xml rule '" + ruleName + "' has too many configs",
-                itrConfigs.hasNext());
+        assertFalse(itrConfigs.hasNext(),
+                styleName + "_style.xml rule '" + ruleName + "' has too many configs");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -19,8 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.internal;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
@@ -36,9 +36,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
@@ -112,7 +112,7 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
     private Path javaDir;
     private Path inputDir;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpBeforeClass() throws IOException {
         simpleCheckNames = CheckUtil.getSimpleNames(CheckUtil.getCheckstyleChecks());
 
@@ -121,7 +121,7 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
                 .collect(Collectors.toMap(id -> id.toLowerCase(Locale.ENGLISH), id -> id));
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         javaDir = Paths.get("src/it/java/" + getPackageLocation());
         inputDir = Paths.get(getPath(""));
@@ -142,23 +142,23 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
         final Pattern pattern = Pattern.compile("^XpathRegression(.+)Test\\.java$");
         try (DirectoryStream<Path> javaPaths = Files.newDirectoryStream(javaDir)) {
             for (Path path : javaPaths) {
-                assertTrue(path + " is not a regular file", Files.isRegularFile(path));
+                assertTrue(Files.isRegularFile(path), path + " is not a regular file");
                 final String filename = path.toFile().getName();
                 if (filename.startsWith("Abstract")) {
                     continue;
                 }
 
                 final Matcher matcher = pattern.matcher(filename);
-                assertTrue("Invalid test file: " + filename + ", expected pattern: " + pattern,
-                        matcher.matches());
+                assertTrue(matcher.matches(),
+                        "Invalid test file: " + filename + ", expected pattern: " + pattern);
 
                 final String check = matcher.group(1);
-                assertTrue("Unknown check '" + check + "' in test file: " + filename,
-                        simpleCheckNames.contains(check));
+                assertTrue(simpleCheckNames.contains(check),
+                        "Unknown check '" + check + "' in test file: " + filename);
 
-                assertFalse("Check '" + check + "' is now tested. Please update the todo list in"
-                        + " XpathRegressionTest.MISSING_CHECK_NAMES",
-                        MISSING_CHECK_NAMES.contains(check));
+                assertFalse(MISSING_CHECK_NAMES.contains(check),
+                        "Check '" + check + "' is now tested. Please update the todo list in"
+                                + " XpathRegressionTest.MISSING_CHECK_NAMES");
             }
         }
     }
@@ -168,16 +168,17 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
         try (DirectoryStream<Path> dirs = Files.newDirectoryStream(inputDir)) {
             for (Path dir : dirs) {
                 // input directory must be named in lower case
-                assertTrue(dir + " is not a directory", Files.isDirectory(dir));
+                assertTrue(Files.isDirectory(dir), dir + " is not a directory");
                 final String dirName = dir.toFile().getName();
-                assertTrue("Invalid directory name: " + dirName,
-                        allowedDirectoryAndChecks.containsKey(dirName));
+                assertTrue(allowedDirectoryAndChecks.containsKey(dirName),
+                        "Invalid directory name: " + dirName);
 
                 // input directory must be connected to an existing test
                 final String check = allowedDirectoryAndChecks.get(dirName);
                 final Path javaPath = javaDir.resolve("XpathRegression" + check + "Test.java");
-                assertTrue("Input directory '" + dir + "' is not connected to Java test case: "
-                        + javaPath, Files.exists(javaPath));
+                assertTrue(Files.exists(javaPath),
+                        "Input directory '" + dir + "' is not connected to Java test case: "
+                                + javaPath);
 
                 // input files should named correctly
                 validateInputDirectory(dir);
@@ -194,12 +195,13 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
                 final String filename = inputPath.toFile().getName();
                 if (filename.endsWith("java")) {
                     final Matcher matcher = pattern.matcher(filename);
-                    assertTrue("Invalid input file '" + inputPath + "', expected pattern:"
-                            + pattern, matcher.matches());
+                    assertTrue(matcher.matches(),
+                            "Invalid input file '" + inputPath + "', expected pattern:" + pattern);
 
                     final String remaining = matcher.group(1);
-                    assertTrue("Check name '" + check + "' should be included in input file: "
-                            + inputPath, remaining.startsWith(check));
+                    assertTrue(remaining.startsWith(check),
+                            "Check name '" + check + "' should be included in input file: "
+                            + inputPath);
                 }
             }
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XmlUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XmlUtil.java
@@ -19,6 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.internal.utils;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.LinkedHashSet;
@@ -28,7 +30,6 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.junit.Assert;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
@@ -61,7 +62,7 @@ public final class XmlUtil {
             rawXml = builder.parse(new InputSource(new StringReader(code)));
         }
         catch (IOException | SAXException ex) {
-            Assert.fail(fileName + " has invalid xml (" + ex.getMessage() + "): "
+            fail(fileName + " has invalid xml (" + ex.getMessage() + "): "
                     + unserializedSource);
         }
 


### PR DESCRIPTION
Issue #6916

Tests of the `internal` package are migrated to Junit5, except of `powermock`