### PR TITLE
Issue #6946: add suppression filters to google and sun configs

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -6,7 +6,7 @@
 
 <suppressions>
     <!-- can't split long messages between lines -->
-    <suppress checks="RegexpSingleline" files="google_checks\.xml" lines="48,85"/>
+    <suppress checks="RegexpSingleline" files="google_checks\.xml" lines="56,93"/>
     <!-- don't validate generated files -->
     <suppress checks="RegexpSingleline" files="releasenotes\.xml"/>
 

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -11,6 +11,7 @@
     http://checkstyle.org (or in your downloaded distribution).
 
     To completely disable a check, just comment it out or delete it from the file.
+    To suppress certain violations please review suppression filters.
 
     Authors: Max Vetrenko, Ruslan Diachenko, Roman Ivanov.
  -->
@@ -26,6 +27,13 @@
     <module name="BeforeExecutionExclusionFileFilter">
         <property name="fileNamePattern" value="module\-info\.java$"/>
     </module>
+    <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
+    <module name="SuppressionFilter">
+        <property name="file" value="${org.checkstyle.google.suppressionfilter.config}"
+                  default="checkstyle-suppressions.xml" />
+        <property name="optional" value="true"/>
+    </module>
+
     <!-- Checks for whitespace                               -->
     <!-- See http://checkstyle.org/config_whitespace.html -->
     <module name="FileTabCharacter">
@@ -262,5 +270,11 @@
             <property name="exceptionVariableName" value="expected"/>
         </module>
         <module name="CommentsIndentation"/>
+        <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
+        <module name="SuppressionXpathFilter">
+            <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
+                      default="checkstyle-xpath-suppressions.xml" />
+            <property name="optional" value="true"/>
+        </module>
     </module>
 </module>

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -8,7 +8,7 @@
     that can be found at https://google.github.io/styleguide/javaguide.html
 
     Checkstyle is very configurable. Be sure to read the documentation at
-    http://checkstyle.sf.net (or in your downloaded distribution).
+    http://checkstyle.org (or in your downloaded distribution).
 
     To completely disable a check, just comment it out or delete it from the file.
 
@@ -27,7 +27,7 @@
         <property name="fileNamePattern" value="module\-info\.java$"/>
     </module>
     <!-- Checks for whitespace                               -->
-    <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+    <!-- See http://checkstyle.org/config_whitespace.html -->
     <module name="FileTabCharacter">
         <property name="eachLine" value="true"/>
     </module>

--- a/src/main/resources/sun_checks.xml
+++ b/src/main/resources/sun_checks.xml
@@ -25,6 +25,7 @@
   Most Checks are configurable, be sure to consult the documentation.
 
   To completely disable a check, just comment it out or delete it from the file.
+  To suppress certain violations please review suppression filters.
 
   Finally, it is worth reading the documentation.
 
@@ -46,6 +47,13 @@
     <!-- See https://checkstyle.org/config_filefilters.html -->
     <module name="BeforeExecutionExclusionFileFilter">
         <property name="fileNamePattern" value="module\-info\.java$"/>
+    </module>
+
+    <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
+    <module name="SuppressionFilter">
+        <property name="file" value="${org.checkstyle.sun.suppressionfilter.config}"
+                  default="checkstyle-suppressions.xml" />
+        <property name="optional" value="true"/>
     </module>
 
     <!-- Checks that a package-info.java file exists for each package.     -->
@@ -177,6 +185,13 @@
         <module name="FinalParameters"/>
         <module name="TodoComment"/>
         <module name="UpperEll"/>
+
+        <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
+        <module name="SuppressionXpathFilter">
+            <property name="file" value="${org.checkstyle.sun.suppressionxpathfilter.config}"
+                      default="checkstyle-xpath-suppressions.xml" />
+            <property name="optional" value="true"/>
+        </module>
 
     </module>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -150,6 +150,9 @@ public class MainTest {
             Definitions.CHECKSTYLE_BUNDLE, "DefaultLogger.auditFinished", null, null,
             getClass(), null);
 
+    private final String noViolationsOutput = auditStartMessage.getMessage() + EOL
+                    + auditFinishMessage.getMessage() + EOL;
+
     private static String getPath(String filename) {
         return "src/test/resources/com/puppycrawl/tools/checkstyle/main/" + filename;
     }
@@ -415,6 +418,28 @@ public class MainTest {
                     auditFinishMessage.getMessage()),
                 systemOut.getCapturedData(), "Unexpected output log");
         assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
+    }
+
+    @Test
+    public void testViolationsByGoogleAndXpathSuppressions(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws Exception {
+        System.setProperty("org.checkstyle.google.suppressionxpathfilter.config",
+                getPath("InputMainViolationsForGoogleXpathSuppressions.xml"));
+        Main.main("-c", "/google_checks.xml",
+                getPath("InputMainViolationsForGoogle.java"));
+        assertThat("Unexpected output log", systemOut.getCapturedData(), is(noViolationsOutput));
+        assertThat("Unexpected system error log", systemErr.getCapturedData(), is(""));
+    }
+
+    @Test
+    public void testViolationsByGoogleAndSuppressions(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws Exception {
+        System.setProperty("org.checkstyle.google.suppressionfilter.config",
+                getPath("InputMainViolationsForGoogleSuppressions.xml"));
+        Main.main("-c", "/google_checks.xml",
+                getPath("InputMainViolationsForGoogle.java"));
+        assertThat("Unexpected output log", systemOut.getCapturedData(), is(noViolationsOutput));
+        assertThat("Unexpected system error log", systemErr.getCapturedData(), is(""));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -1475,6 +1475,8 @@ public class XdocsPagesTest {
 
             // these modules aren't documented, but are added to the config
             styleChecks.remove("BeforeExecutionExclusionFileFilter");
+            styleChecks.remove("SuppressionFilter");
+            styleChecks.remove("SuppressionXpathFilter");
             styleChecks.remove("TreeWalker");
             styleChecks.remove("Checker");
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainViolationsForGoogle.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainViolationsForGoogle.java
@@ -1,0 +1,9 @@
+package com.puppycrawl.tools.checkstyle.main;
+
+public class InputMainViolationsForGoogle {
+  private String m_field; // violation
+
+  private void _method() { // violation
+      // no code
+  }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainViolationsForGoogleSuppressions.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainViolationsForGoogleSuppressions.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suppressions PUBLIC
+  "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+  "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+<suppressions>
+  <suppress
+         files="InputMainViolationsForGoogle.java"
+         checks="MemberNameCheck"
+         lines="4"
+  />
+  <suppress
+         files="InputMainViolationsForGoogle.java"
+         checks="MethodNameCheck"
+         lines="6"
+  />
+</suppressions>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainViolationsForGoogleXpathSuppressions.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainViolationsForGoogleXpathSuppressions.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suppressions PUBLIC
+    "-//Checkstyle//DTD SuppressionXpathFilter Experimental Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2_xpath_experimental.dtd">
+<suppressions>
+  <suppress-xpath
+         files="InputMainViolationsForGoogle.java"
+         checks="MemberNameCheck"
+         query="/CLASS_DEF[./IDENT[@text='InputMainViolationsForGoogle']]/
+                  OBJBLOCK/VARIABLE_DEF/IDENT[@text='m_field']"
+  />
+  <suppress-xpath
+         files="InputMainViolationsForGoogle.java"
+         checks="MethodNameCheck"
+         query="/CLASS_DEF[./IDENT[@text='InputMainViolationsForGoogle']]/
+                  OBJBLOCK/METHOD_DEF/IDENT[@text='_method']"
+  />
+</suppressions>

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -654,6 +654,14 @@ public class UserService {
       <subsection name="Example of Usage" id="SuppressionFilter_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionFilter">
+              Google Style</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Asun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionFilter">
+              Sun Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig+filename%3Acheckstyle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionFilter">
             Checkstyle Style</a>
           </li>
@@ -1391,6 +1399,14 @@ CLASS_DEF -> CLASS_DEF [1:0]
       </subsection>
       <subsection name="Example of Usage" id="SuppressionXpathFilter_Example_of_Usage">
         <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionXpathFilter">
+              Google Style</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Asun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionXpathFilter">
+              Sun Style</a>
+          </li>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig+filename%3Acheckstyle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionXpathFilter">
               Checkstyle Style</a>

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -2222,6 +2222,30 @@
           </table>
         </div>
       </subsection>
+      <subsection name="Suppressions" id="Google_Suppressions">
+        <p>
+          It is possible to suppress some violations by embeded filters
+          <a href="config_filters.html#SuppressionFilter">
+            SuppressionFilter</a>
+          and
+          <a href="config_filters.html#SuppressionXpathFilter">
+            SuppressionXpathFilter</a>.
+          Location of config file for <i>SuppressionFilter</i> can be defined by system property
+          <i>org.checkstyle.google.suppressionfilter.config</i> (default value is
+          <i>checkstyle-suppressions.xml</i>).
+          Location of config file for <i>SuppressionXpathFilter</i>
+          can be defined by system property
+          <i>org.checkstyle.google.suppressionxpathfilter.config</i> (default value is
+          <i>checkstyle-xpath-suppressions.xml</i>).
+        </p>
+        <p>
+          For more details please review exact configuration of Filters in google_checks.xml:
+          <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionFilter">
+                    SuppressionFilter</a>,
+          <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionXpathFilter">
+                    SuppressionXpathFilter</a>.
+        </p>
+      </subsection>
     </section>
   </body>
 </document>

--- a/src/xdocs/sun_style.xml
+++ b/src/xdocs/sun_style.xml
@@ -997,6 +997,30 @@
           </table>
         </div>
       </subsection>
+      <subsection name="Suppressions" id="Sun_Suppressions">
+        <p>
+          It is possible to suppress some violations by embeded filters
+          <a href="config_filters.html#SuppressionFilter">
+            SuppressionFilter</a>
+          and
+          <a href="config_filters.html#SuppressionXpathFilter">
+            SuppressionXpathFilter</a>.
+          Location of config file for <i>SuppressionFilter</i> can be defined by system property
+          <i>org.checkstyle.sun.suppressionfilter.config</i> (default value is
+          <i>checkstyle-suppressions.xml</i>).
+          Location of config file for <i>SuppressionXpathFilter</i>
+          can be defined by system property
+          <i>org.checkstyle.sun.suppressionxpathfilter.config</i> (default value is
+          <i>checkstyle-xpath-suppressions.xml</i>).
+        </p>
+        <p>
+          For more details please review exact configuration of Filters in sun_checks.xml:
+          <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Asun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionFilter">
+                    SuppressionFilter</a>,
+          <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Asun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionXpathFilter">
+                    SuppressionXpathFilter</a>.
+        </p>
+      </subsection>
     </section>
   </body>
 </document>


### PR DESCRIPTION
Issue #6946

Examples of execution by CLI:
```
java -Dorg.checkstyle.google.suppressionxpathfilter.config="/var/tmp/xpath-suppressions.xml" \
  -jar /var/tmp/checkstyle-8.28-all.jar \
  -c google_checks.xml \
  Test.java
Starting audit...
Audit done.
```
```
java -Dorg.checkstyle.google.suppressionfilter.config="/var/tmp/suppressions.xml" \
  -jar /var/tmp/checkstyle-8.28-all.jar \
  -c google_checks.xml \
  Test.java
Starting audit...
Audit done.
```

Tested at https://github.com/sevntu-checkstyle/checkstyle-samples/pull/23