### PR TITLE
Issue #6916: migrate tests to junit5 for package checkstyle

### DIFF
--- a/config/import-control-test.xml
+++ b/config/import-control-test.xml
@@ -24,7 +24,7 @@
       <allow pkg="org.junit" local-only="true"/>
     </subpackage>
   </subpackage>
-  <file name=".*Test(Support)?" regex="true">
+  <file name="(JavadocPropertiesGenerator|Main)Test" regex="true">
     <allow pkg="org.junit"/>
   </file>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractXmlTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractXmlTestSupport.java
@@ -19,6 +19,11 @@
 
 package com.puppycrawl.tools.checkstyle;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
@@ -26,7 +31,6 @@ import java.util.function.BiPredicate;
 
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.junit.Assert;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -60,10 +64,10 @@ public abstract class AbstractXmlTestSupport extends AbstractModuleTestSupport {
                 expectedContents);
         final Document actualDocument = getOutputStreamXml(actualOutputStream);
 
-        Assert.assertEquals("xml encoding should be the same", expectedDocument.getXmlEncoding(),
-                actualDocument.getXmlEncoding());
-        Assert.assertEquals("xml version should be the same", expectedDocument.getXmlVersion(),
-                actualDocument.getXmlVersion());
+        assertEquals(expectedDocument.getXmlEncoding(), actualDocument.getXmlEncoding(),
+                "xml encoding should be the same");
+        assertEquals(expectedDocument.getXmlVersion(), actualDocument.getXmlVersion(),
+                "xml version should be the same");
         verifyXmlNode(expectedDocument, actualDocument, "/", ordered);
     }
 
@@ -73,12 +77,12 @@ public abstract class AbstractXmlTestSupport extends AbstractModuleTestSupport {
         final Node actualFirstChild = actual.getFirstChild();
 
         if (expectedFirstChild == null) {
-            Assert.assertNull("no children nodes should exist: " + path, actualFirstChild);
-            Assert.assertEquals("text should be the same: " + path, expected.getNodeValue(),
-                    actual.getNodeValue());
+            assertNull(actualFirstChild, "no children nodes should exist: " + path);
+            assertEquals(expected.getNodeValue(), actual.getNodeValue(),
+                    "text should be the same: " + path);
         }
         else {
-            Assert.assertNotNull("children nodes should exist: " + path, actualFirstChild);
+            assertNotNull(actualFirstChild, "children nodes should exist: " + path);
 
             if (ordered == null) {
                 Node actualChild = actualFirstChild;
@@ -90,14 +94,14 @@ public abstract class AbstractXmlTestSupport extends AbstractModuleTestSupport {
                     actualChild = actualChild.getNextSibling();
                 }
 
-                Assert.assertNull("node have same number of children: " + path, actualChild);
+                assertNull(actualChild, "node have same number of children: " + path);
             }
             else {
                 final Set<Node> expectedChildren = XmlUtil.getChildrenElements(expected);
                 final Set<Node> actualChildren = XmlUtil.getChildrenElements(actual);
 
-                Assert.assertEquals("node have same number of children: " + path,
-                        expectedChildren.size(), actualChildren.size());
+                assertEquals(expectedChildren.size(), actualChildren.size(),
+                        "node have same number of children: " + path);
 
                 for (Node expectedChild : expectedChildren) {
                     Node foundChild = null;
@@ -109,8 +113,8 @@ public abstract class AbstractXmlTestSupport extends AbstractModuleTestSupport {
                         }
                     }
 
-                    Assert.assertNotNull("node should exist: " + path + expectedChild.getNodeName()
-                            + "/", foundChild);
+                    assertNotNull(foundChild,
+                            "node should exist: " + path + expectedChild.getNodeName() + "/");
 
                     verifyXmlNode(expectedChild, foundChild, path, ordered);
                 }
@@ -122,17 +126,17 @@ public abstract class AbstractXmlTestSupport extends AbstractModuleTestSupport {
             BiPredicate<Node, Node> ordered) {
         if (expected == null) {
             if (actual != null) {
-                Assert.fail("no node should exist: " + path + actual.getNodeName() + "/");
+                fail("no node should exist: " + path + actual.getNodeName() + "/");
             }
         }
         else {
             final String newPath = path + expected.getNodeName() + "/";
 
-            Assert.assertNotNull("node should exist: " + newPath, actual);
-            Assert.assertEquals("node should have same name: " + newPath, expected.getNodeName(),
-                    actual.getNodeName());
-            Assert.assertEquals("node should have same type: " + newPath, expected.getNodeType(),
-                    actual.getNodeType());
+            assertNotNull(actual, "node should exist: " + newPath);
+            assertEquals(expected.getNodeName(), actual.getNodeName(),
+                    "node should have same name: " + newPath);
+            assertEquals(expected.getNodeType(), actual.getNodeType(),
+                    "node should have same type: " + newPath);
 
             verifyXmlAttributes(expected.getAttributes(), actual.getAttributes(), newPath);
 
@@ -143,33 +147,32 @@ public abstract class AbstractXmlTestSupport extends AbstractModuleTestSupport {
     private static void verifyXmlAttributes(NamedNodeMap expected, NamedNodeMap actual,
             String path) {
         if (expected == null) {
-            Assert.assertNull("no attributes should exist: " + path, actual);
+            assertNull(actual, "no attributes should exist: " + path);
         }
         else {
-            Assert.assertNotNull("attributes should exist: " + path, actual);
+            assertNotNull(actual, "attributes should exist: " + path);
 
             for (int i = 0; i < expected.getLength(); i++) {
                 verifyXmlAttribute(expected.item(i), actual.item(i), path);
             }
 
-            Assert.assertEquals("node have same number of attributes: " + path,
-                    expected.getLength(), actual.getLength());
+            assertEquals(expected.getLength(), actual.getLength(),
+                    "node have same number of attributes: " + path);
         }
     }
 
     private static void verifyXmlAttribute(Node expected, Node actual, String path) {
         final String expectedName = expected.getNodeName();
 
-        Assert.assertNotNull("attribute value for '" + expectedName + "' should not be null: "
-                + path, actual);
+        assertNotNull(actual,
+                "attribute value for '" + expectedName + "' should not be null: " + path);
 
-        Assert.assertEquals("attribute name should match: " + path, expectedName,
-                actual.getNodeName());
+        assertEquals(expectedName, actual.getNodeName(), "attribute name should match: " + path);
 
         // ignore checkstyle version in xml as it changes each release
         if (!"/#document/checkstyle".equals(path) && !"version".equals(expectedName)) {
-            Assert.assertEquals("attribute value for '" + expectedName + "' should match: " + path,
-                    expected.getNodeValue(), actual.getNodeValue());
+            assertEquals(expected.getNodeValue(), actual.getNodeValue(),
+                    "attribute value for '" + expectedName + "' should match: " + path);
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
@@ -20,17 +20,19 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import antlr.NoViableAltException;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -46,8 +48,8 @@ public class AstTreeStringPrinterTest extends AbstractTreeTestSupport {
 
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
-        assertTrue("Constructor is not private",
-                isUtilsClassHasPrivateConstructor(AstTreeStringPrinter.class, true));
+        assertTrue(isUtilsClassHasPrivateConstructor(AstTreeStringPrinter.class, true),
+                "Constructor is not private");
     }
 
     @Test
@@ -55,14 +57,12 @@ public class AstTreeStringPrinterTest extends AbstractTreeTestSupport {
         final File input = new File(getNonCompilablePath("InputAstTreeStringPrinter.java"));
         try {
             AstTreeStringPrinter.printFileAst(input, JavaParser.Options.WITHOUT_COMMENTS);
-            Assert.fail("exception expected");
+            fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            Assert.assertSame("Invalid class",
-                    NoViableAltException.class, ex.getCause().getClass());
-            Assert.assertEquals("Invalid exception message",
-                    input.getAbsolutePath() + ":2:1: unexpected token: classD",
-                    ex.getCause().toString());
+            assertSame(NoViableAltException.class, ex.getCause().getClass(), "Invalid class");
+            assertEquals(input.getAbsolutePath() + ":2:1: unexpected token: classD",
+                    ex.getCause().toString(), "Invalid exception message");
         }
     }
 
@@ -97,7 +97,7 @@ public class AstTreeStringPrinterTest extends AbstractTreeTestSupport {
         final String expected = toLfLineEnding(new String(Files.readAllBytes(Paths.get(
                 getPath("ExpectedAstTreeStringPrinter.txt"))), StandardCharsets.UTF_8));
 
-        Assert.assertEquals("Print AST output is invalid", expected, actual);
+        assertEquals(expected, actual, "Print AST output is invalid");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatterTest.java
@@ -19,11 +19,11 @@
 
 package com.puppycrawl.tools.checkstyle;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.lang.reflect.Method;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
@@ -42,7 +42,7 @@ public class AuditEventDefaultFormatterTest {
         final String expected = "[WARN] InputMockFile.java:1:1: Mocked message. "
                 + "[AuditEventDefaultFormatterTest$TestModule]";
 
-        assertEquals("Invalid format", expected, formatter.format(event));
+        assertEquals(expected, formatter.format(event), "Invalid format");
     }
 
     @Test
@@ -55,7 +55,7 @@ public class AuditEventDefaultFormatterTest {
         final String expected = "[WARN] InputMockFile.java:1:1: Mocked message. "
                 + "[AuditEventDefaultFormatterTest$TestModule]";
 
-        assertEquals("Invalid format", expected, formatter.format(event));
+        assertEquals(expected, formatter.format(event), "Invalid format");
     }
 
     @Test
@@ -67,7 +67,7 @@ public class AuditEventDefaultFormatterTest {
 
         final String expected = "[WARN] InputMockFile.java:1:1: Mocked message. [ModuleId]";
 
-        assertEquals("Invalid format", expected, formatter.format(event));
+        assertEquals(expected, formatter.format(event), "Invalid format");
     }
 
     @Test
@@ -82,7 +82,7 @@ public class AuditEventDefaultFormatterTest {
         final int result = (int) calculateBufferLengthMethod.invoke(null,
                 auditEvent, SeverityLevel.ERROR.ordinal());
 
-        assertEquals("Buffer length is not expected", 54, result);
+        assertEquals(54, result, "Buffer length is not expected");
     }
 
     private static class TestModuleCheck {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -24,16 +24,15 @@ import static com.puppycrawl.tools.checkstyle.Checker.EXCEPTION_MSG;
 import static com.puppycrawl.tools.checkstyle.DefaultLogger.AUDIT_FINISHED_MESSAGE;
 import static com.puppycrawl.tools.checkstyle.DefaultLogger.AUDIT_STARTED_MESSAGE;
 import static com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck.MSG_KEY_NO_NEWLINE_EOF;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -59,9 +58,8 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
@@ -98,8 +96,8 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  */
 public class CheckerTest extends AbstractModuleTestSupport {
 
-    @Rule
-    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    public File temporaryFolder;
 
     private static Method getFireAuditFinished() throws NoSuchMethodException {
         final Class<Checker> checkerClass = Checker.class;
@@ -135,16 +133,17 @@ public class CheckerTest extends AbstractModuleTestSupport {
         // should remove all listeners, file sets, and filters
         checker.destroy();
 
-        checker.process(Collections.singletonList(temporaryFolder.newFile()));
+        final File tempFile = File.createTempFile("junit", null, temporaryFolder);
+        checker.process(Collections.singletonList(tempFile));
         final SortedSet<LocalizedMessage> messages = new TreeSet<>();
         messages.add(new LocalizedMessage(1, 0, "a Bundle", "message.key",
                 new Object[] {"arg"}, null, getClass(), null));
         checker.fireErrors("Some File Name", messages);
 
-        assertFalse("Checker.destroy() doesn't remove listeners.", auditAdapter.wasCalled());
-        assertFalse("Checker.destroy() doesn't remove file sets.", fileSet.wasCalled());
-        assertFalse("Checker.destroy() doesn't remove filters.", filter.wasCalled());
-        assertFalse("Checker.destroy() doesn't remove file filters.", fileFilter.wasCalled());
+        assertFalse(auditAdapter.wasCalled(), "Checker.destroy() doesn't remove listeners.");
+        assertFalse(fileSet.wasCalled(), "Checker.destroy() doesn't remove file sets.");
+        assertFalse(filter.wasCalled(), "Checker.destroy() doesn't remove filters.");
+        assertFalse(fileFilter.wasCalled(), "Checker.destroy() doesn't remove file filters.");
     }
 
     @Test
@@ -155,31 +154,31 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
         // Let's try fire some events
         getFireAuditStartedMethod().invoke(checker);
-        assertTrue("Checker.fireAuditStarted() doesn't call listener", auditAdapter.wasCalled());
-        assertTrue("Checker.fireAuditStarted() doesn't pass event", auditAdapter.wasEventPassed());
+        assertTrue(auditAdapter.wasCalled(), "Checker.fireAuditStarted() doesn't call listener");
+        assertTrue(auditAdapter.wasEventPassed(), "Checker.fireAuditStarted() doesn't pass event");
 
         auditAdapter.resetListener();
         getFireAuditFinished().invoke(checker);
-        assertTrue("Checker.fireAuditFinished() doesn't call listener", auditAdapter.wasCalled());
-        assertTrue("Checker.fireAuditFinished() doesn't pass event", auditAdapter.wasEventPassed());
+        assertTrue(auditAdapter.wasCalled(), "Checker.fireAuditFinished() doesn't call listener");
+        assertTrue(auditAdapter.wasEventPassed(), "Checker.fireAuditFinished() doesn't pass event");
 
         auditAdapter.resetListener();
         checker.fireFileStarted("Some File Name");
-        assertTrue("Checker.fireFileStarted() doesn't call listener", auditAdapter.wasCalled());
-        assertTrue("Checker.fireFileStarted() doesn't pass event", auditAdapter.wasEventPassed());
+        assertTrue(auditAdapter.wasCalled(), "Checker.fireFileStarted() doesn't call listener");
+        assertTrue(auditAdapter.wasEventPassed(), "Checker.fireFileStarted() doesn't pass event");
 
         auditAdapter.resetListener();
         checker.fireFileFinished("Some File Name");
-        assertTrue("Checker.fireFileFinished() doesn't call listener", auditAdapter.wasCalled());
-        assertTrue("Checker.fireFileFinished() doesn't pass event", auditAdapter.wasEventPassed());
+        assertTrue(auditAdapter.wasCalled(), "Checker.fireFileFinished() doesn't call listener");
+        assertTrue(auditAdapter.wasEventPassed(), "Checker.fireFileFinished() doesn't pass event");
 
         auditAdapter.resetListener();
         final SortedSet<LocalizedMessage> messages = new TreeSet<>();
         messages.add(new LocalizedMessage(1, 0, "a Bundle", "message.key",
                 new Object[] {"arg"}, null, getClass(), null));
         checker.fireErrors("Some File Name", messages);
-        assertTrue("Checker.fireErrors() doesn't call listener", auditAdapter.wasCalled());
-        assertTrue("Checker.fireErrors() doesn't pass event", auditAdapter.wasEventPassed());
+        assertTrue(auditAdapter.wasCalled(), "Checker.fireErrors() doesn't call listener");
+        assertTrue(auditAdapter.wasEventPassed(), "Checker.fireErrors() doesn't pass event");
     }
 
     @Test
@@ -193,35 +192,35 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
         // Let's try fire some events
         getFireAuditStartedMethod().invoke(checker);
-        assertTrue("Checker.fireAuditStarted() doesn't call listener", aa2.wasCalled());
-        assertFalse("Checker.fireAuditStarted() does call removed listener",
-                auditAdapter.wasCalled());
+        assertTrue(aa2.wasCalled(), "Checker.fireAuditStarted() doesn't call listener");
+        assertFalse(auditAdapter.wasCalled(),
+                "Checker.fireAuditStarted() does call removed listener");
 
         aa2.resetListener();
         getFireAuditFinished().invoke(checker);
-        assertTrue("Checker.fireAuditFinished() doesn't call listener", aa2.wasCalled());
-        assertFalse("Checker.fireAuditFinished() does call removed listener",
-                auditAdapter.wasCalled());
+        assertTrue(aa2.wasCalled(), "Checker.fireAuditFinished() doesn't call listener");
+        assertFalse(auditAdapter.wasCalled(),
+                "Checker.fireAuditFinished() does call removed listener");
 
         aa2.resetListener();
         checker.fireFileStarted("Some File Name");
-        assertTrue("Checker.fireFileStarted() doesn't call listener", aa2.wasCalled());
-        assertFalse("Checker.fireFileStarted() does call removed listener",
-                auditAdapter.wasCalled());
+        assertTrue(aa2.wasCalled(), "Checker.fireFileStarted() doesn't call listener");
+        assertFalse(auditAdapter.wasCalled(),
+                "Checker.fireFileStarted() does call removed listener");
 
         aa2.resetListener();
         checker.fireFileFinished("Some File Name");
-        assertTrue("Checker.fireFileFinished() doesn't call listener", aa2.wasCalled());
-        assertFalse("Checker.fireFileFinished() does call removed listener",
-                auditAdapter.wasCalled());
+        assertTrue(aa2.wasCalled(), "Checker.fireFileFinished() doesn't call listener");
+        assertFalse(auditAdapter.wasCalled(),
+                "Checker.fireFileFinished() does call removed listener");
 
         aa2.resetListener();
         final SortedSet<LocalizedMessage> messages = new TreeSet<>();
         messages.add(new LocalizedMessage(1, 0, "a Bundle", "message.key",
                 new Object[] {"arg"}, null, getClass(), null));
         checker.fireErrors("Some File Name", messages);
-        assertTrue("Checker.fireErrors() doesn't call listener", aa2.wasCalled());
-        assertFalse("Checker.fireErrors() does call removed listener", auditAdapter.wasCalled());
+        assertTrue(aa2.wasCalled(), "Checker.fireErrors() doesn't call listener");
+        assertFalse(auditAdapter.wasCalled(), "Checker.fireErrors() does call removed listener");
     }
 
     @Test
@@ -233,7 +232,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
         filter.resetFilter();
         checker.process(Collections.singletonList(new File("dummy.java")));
-        assertTrue("Checker.acceptFileStarted() doesn't call filter", filter.wasCalled());
+        assertTrue(filter.wasCalled(), "Checker.acceptFileStarted() doesn't call filter");
     }
 
     @Test
@@ -247,8 +246,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
         f2.resetFilter();
         checker.process(Collections.singletonList(new File("dummy.java")));
-        assertTrue("Checker.acceptFileStarted() doesn't call filter", f2.wasCalled());
-        assertFalse("Checker.acceptFileStarted() does call removed filter", filter.wasCalled());
+        assertTrue(f2.wasCalled(), "Checker.acceptFileStarted() doesn't call filter");
+        assertFalse(filter.wasCalled(), "Checker.acceptFileStarted() does call removed filter");
     }
 
     @Test
@@ -263,7 +262,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         messages.add(new LocalizedMessage(1, 0, "a Bundle", "message.key",
                 new Object[] {"arg"}, null, getClass(), null));
         checker.fireErrors("Some File Name", messages);
-        assertTrue("Checker.fireErrors() doesn't call filter", filter.wasCalled());
+        assertTrue(filter.wasCalled(), "Checker.fireErrors() doesn't call filter");
     }
 
     @Test
@@ -280,15 +279,16 @@ public class CheckerTest extends AbstractModuleTestSupport {
         messages.add(new LocalizedMessage(1, 0, "a Bundle", "message.key",
                 new Object[] {"arg"}, null, getClass(), null));
         checker.fireErrors("Some File Name", messages);
-        assertTrue("Checker.fireErrors() doesn't call filter", f2.wasCalled());
-        assertFalse("Checker.fireErrors() does call removed filter", filter.wasCalled());
+        assertTrue(f2.wasCalled(), "Checker.fireErrors() doesn't call filter");
+        assertFalse(filter.wasCalled(), "Checker.fireErrors() does call removed filter");
     }
 
     @Test
     public void testFileExtensions() throws Exception {
         final DefaultConfiguration checkerConfig = new DefaultConfiguration("configuration");
         checkerConfig.addAttribute("charset", StandardCharsets.UTF_8.name());
-        checkerConfig.addAttribute("cacheFile", temporaryFolder.newFile().getPath());
+        checkerConfig.addAttribute("cacheFile",
+                File.createTempFile("junit", null, temporaryFolder).getPath());
 
         final Checker checker = new Checker();
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
@@ -304,27 +304,27 @@ public class CheckerTest extends AbstractModuleTestSupport {
         files.add(otherFile);
         final String[] fileExtensions = {"java", "xml", "properties"};
         checker.setFileExtensions(fileExtensions);
-        checker.setCacheFile(temporaryFolder.newFile().getPath());
+        checker.setCacheFile(File.createTempFile("junit", null, temporaryFolder).getPath());
         final int counter = checker.process(files);
 
         // comparing to 1 as there is only one legal file in input
         final int numLegalFiles = 1;
         final PropertyCacheFile cache = Whitebox.getInternalState(checker, "cacheFile");
-        assertEquals("There were more legal files than expected",
-                numLegalFiles, counter);
-        assertEquals("Audit was started on larger amount of files than expected",
-                numLegalFiles, auditAdapter.getNumFilesStarted());
-        assertEquals("Audit was finished on larger amount of files than expected",
-                numLegalFiles, auditAdapter.getNumFilesFinished());
-        assertNull("Cache shout not contain any file",
-                cache.get(new File("file.java").getCanonicalPath()));
+        assertEquals(numLegalFiles, counter, "There were more legal files than expected");
+        assertEquals(numLegalFiles, auditAdapter.getNumFilesStarted(),
+                "Audit was started on larger amount of files than expected");
+        assertEquals(numLegalFiles, auditAdapter.getNumFilesFinished(),
+                "Audit was finished on larger amount of files than expected");
+        assertNull(cache.get(new File("file.java").getCanonicalPath()),
+                "Cache shout not contain any file");
     }
 
     @Test
     public void testIgnoredFileExtensions() throws Exception {
         final DefaultConfiguration checkerConfig = new DefaultConfiguration("configuration");
         checkerConfig.addAttribute("charset", StandardCharsets.UTF_8.name());
-        checkerConfig.addAttribute("cacheFile", temporaryFolder.newFile().getPath());
+        final File tempFile = File.createTempFile("junit", null, temporaryFolder);
+        checkerConfig.addAttribute("cacheFile", tempFile.getPath());
 
         final Checker checker = new Checker();
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
@@ -338,17 +338,16 @@ public class CheckerTest extends AbstractModuleTestSupport {
         allIgnoredFiles.add(ignoredFile);
         final String[] fileExtensions = {"java", "xml", "properties"};
         checker.setFileExtensions(fileExtensions);
-        checker.setCacheFile(temporaryFolder.newFile().getPath());
+        checker.setCacheFile(File.createTempFile("junit", null, temporaryFolder).getPath());
         final int counter = checker.process(allIgnoredFiles);
 
         // comparing to 0 as there is no legal file in input
         final int numLegalFiles = 0;
-        assertEquals("There were more legal files than expected",
-                numLegalFiles, counter);
-        assertEquals("Audit was started on larger amount of files than expected",
-                numLegalFiles, auditAdapter.getNumFilesStarted());
-        assertEquals("Audit was finished on larger amount of files than expected",
-                numLegalFiles, auditAdapter.getNumFilesFinished());
+        assertEquals(numLegalFiles, counter, "There were more legal files than expected");
+        assertEquals(numLegalFiles, auditAdapter.getNumFilesStarted(),
+                "Audit was started on larger amount of files than expected");
+        assertEquals(numLegalFiles, auditAdapter.getNumFilesFinished(),
+                "Audit was finished on larger amount of files than expected");
     }
 
     @Test
@@ -371,8 +370,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
             fail("Exception is expected");
         }
         catch (UnsupportedEncodingException ex) {
-            assertEquals("Error message is not expected",
-                    "unsupported charset: 'UNKNOWN-CHARSET'", ex.getMessage());
+            assertEquals("unsupported charset: 'UNKNOWN-CHARSET'", ex.getMessage(),
+                    "Error message is not expected");
         }
     }
 
@@ -385,9 +384,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
             fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Error message is not expected",
-                    "if no custom moduleFactory is set, moduleClassLoader must be specified",
-                    ex.getMessage());
+            assertEquals("if no custom moduleFactory is set, moduleClassLoader must be specified",
+                    ex.getMessage(), "Error message is not expected");
         }
     }
 
@@ -400,8 +398,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.finishLocalSetup();
         final Context actualCtx = Whitebox.getInternalState(checker, "childContext");
 
-        assertNotNull("Default module factory should be created when it is not specified",
-            actualCtx.get("moduleFactory"));
+        assertNotNull(actualCtx.get("moduleFactory"),
+                "Default module factory should be created when it is not specified");
     }
 
     @Test
@@ -418,18 +416,15 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.finishLocalSetup();
 
         final Context context = Whitebox.getInternalState(checker, "childContext");
-        assertEquals("Charset was different than expected",
-                System.getProperty("file.encoding", StandardCharsets.UTF_8.name()),
-                context.get("charset"));
-        assertEquals("Severity is set to unexpected value",
-                "error", context.get("severity"));
-        assertEquals("Basedir is set to unexpected value",
-                "testBaseDir", context.get("basedir"));
+        final String encoding = System.getProperty("file.encoding", StandardCharsets.UTF_8.name());
+        assertEquals(encoding, context.get("charset"), "Charset was different than expected");
+        assertEquals("error", context.get("severity"), "Severity is set to unexpected value");
+        assertEquals("testBaseDir", context.get("basedir"), "Basedir is set to unexpected value");
 
         final Field sLocale = LocalizedMessage.class.getDeclaredField("sLocale");
         sLocale.setAccessible(true);
         final Locale locale = (Locale) sLocale.get(null);
-        assertEquals("Locale is set to unexpected value", Locale.ITALY, locale);
+        assertEquals(Locale.ITALY, locale, "Locale is set to unexpected value");
     }
 
     @Test
@@ -445,8 +440,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
             fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Error message is not expected",
-                    "java.lang.String is not allowed as a child in Checker", ex.getMessage());
+            assertEquals("java.lang.String is not allowed as a child in Checker", ex.getMessage(),
+                    "Error message is not expected");
         }
     }
 
@@ -459,11 +454,11 @@ public class CheckerTest extends AbstractModuleTestSupport {
             fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Error message is not expected",
-                    "cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker"
+            assertEquals("cannot initialize module com.puppycrawl.tools.checkstyle.TreeWalker"
                         + " - cannot initialize module " + checkConfig.getName()
                         + " - Property '$$No such property'"
-                        + " does not exist, please check the documentation", ex.getMessage());
+                        + " does not exist, please check the documentation", ex.getMessage(),
+                    "Error message is not expected");
         }
     }
 
@@ -479,8 +474,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.setupChild(config);
 
         final List<AuditListener> listeners = Whitebox.getInternalState(checker, "listeners");
-        assertTrue("Invalid child listener class",
-            listeners.get(listeners.size() - 1) instanceof DebugAuditAdapter);
+        assertTrue(listeners.get(listeners.size() - 1) instanceof DebugAuditAdapter,
+                "Invalid child listener class");
     }
 
     @Test
@@ -499,8 +494,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
             fail("Exception did not happen");
         }
         catch (IllegalStateException ex) {
-            assertTrue("Cause of exception differs from IOException",
-                    ex.getCause() instanceof IOException);
+            assertTrue(ex.getCause() instanceof IOException,
+                    "Cause of exception differs from IOException");
         }
     }
 
@@ -510,8 +505,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
     @Test
     public void testCacheAndCheckWhichDoesNotImplementExternalResourceHolderInterface()
             throws Exception {
-        assertFalse("ExternalResourceHolder has changed his parent",
-                ExternalResourceHolder.class.isAssignableFrom(HiddenFieldCheck.class));
+        assertFalse(ExternalResourceHolder.class.isAssignableFrom(HiddenFieldCheck.class),
+                "ExternalResourceHolder has changed his parent");
         final DefaultConfiguration checkConfig = createModuleConfig(HiddenFieldCheck.class);
 
         final DefaultConfiguration treeWalkerConfig = createModuleConfig(TreeWalker.class);
@@ -520,23 +515,27 @@ public class CheckerTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkerConfig = createRootConfig(treeWalkerConfig);
         checkerConfig.addAttribute("charset", StandardCharsets.UTF_8.name());
 
-        final File cacheFile = temporaryFolder.newFile();
+        final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
         checkerConfig.addAttribute("cacheFile", cacheFile.getPath());
 
-        final File tmpFile = temporaryFolder.newFile("file.java");
+        final File tmpFile = File.createTempFile("file", ".java", temporaryFolder);
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
         verify(checkerConfig, tmpFile.getPath(), expected);
         final Properties cacheAfterFirstRun = new Properties();
-        cacheAfterFirstRun.load(Files.newBufferedReader(cacheFile.toPath()));
+        try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
+            cacheAfterFirstRun.load(reader);
+        }
 
         // one more time to reuse cache
         verify(checkerConfig, tmpFile.getPath(), expected);
         final Properties cacheAfterSecondRun = new Properties();
-        cacheAfterSecondRun.load(Files.newBufferedReader(cacheFile.toPath()));
+        try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
+            cacheAfterSecondRun.load(reader);
+        }
 
-        assertEquals("Cache from first run differs from second run cache",
-                cacheAfterFirstRun, cacheAfterSecondRun);
+        assertEquals(cacheAfterFirstRun, cacheAfterSecondRun,
+                "Cache from first run differs from second run cache");
     }
 
     @Test
@@ -547,11 +546,11 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.setModuleFactory(factory);
         checker.configure(createModuleConfig(TranslationCheck.class));
 
-        final File cacheFile = temporaryFolder.newFile();
+        final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
         checker.setCacheFile(cacheFile.getPath());
 
         checker.setupChild(createModuleConfig(TranslationCheck.class));
-        final File tmpFile = temporaryFolder.newFile("file.java");
+        final File tmpFile = File.createTempFile("file", ".java", temporaryFolder);
         final List<File> files = new ArrayList<>(1);
         files.add(tmpFile);
         checker.process(files);
@@ -560,26 +559,26 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.destroy();
 
         final Properties cache = new Properties();
-        cache.load(Files.newBufferedReader(cacheFile.toPath()));
+        try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
+            cache.load(reader);
+        }
 
         // There should 2 objects in cache: processed file (file.java) and checker configuration.
         final int expectedNumberOfObjectsInCache = 2;
-        assertEquals("Cache has unexpected size",
-                expectedNumberOfObjectsInCache, cache.size());
+        assertEquals(expectedNumberOfObjectsInCache, cache.size(), "Cache has unexpected size");
 
         final String expectedConfigHash = "B8535A811CA90BE8B7A14D40BCA62B4FC2447B46";
-        assertEquals("Cache has unexpected hash",
-                expectedConfigHash, cache.getProperty(PropertyCacheFile.CONFIG_HASH_KEY));
+        assertEquals(expectedConfigHash, cache.getProperty(PropertyCacheFile.CONFIG_HASH_KEY),
+                "Cache has unexpected hash");
 
-        assertNotNull("Cache file has null path",
-                cache.getProperty(tmpFile.getPath()));
+        assertNotNull(cache.getProperty(tmpFile.getPath()), "Cache file has null path");
     }
 
     @Test
     public void testClearExistingCache() throws Exception {
         final DefaultConfiguration checkerConfig = createRootConfig(null);
         checkerConfig.addAttribute("charset", StandardCharsets.UTF_8.name());
-        final File cacheFile = temporaryFolder.newFile();
+        final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
         checkerConfig.addAttribute("cacheFile", cacheFile.getPath());
 
         final Checker checker = new Checker();
@@ -592,30 +591,32 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.destroy();
 
         final Properties cacheAfterClear = new Properties();
-        cacheAfterClear.load(Files.newBufferedReader(cacheFile.toPath()));
+        try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
+            cacheAfterClear.load(reader);
+        }
 
-        assertEquals("Cache has unexpected size",
-                1, cacheAfterClear.size());
-        assertNotNull("Cache has null hash",
-                cacheAfterClear.getProperty(PropertyCacheFile.CONFIG_HASH_KEY));
+        assertEquals(1, cacheAfterClear.size(), "Cache has unexpected size");
+        assertNotNull(cacheAfterClear.getProperty(PropertyCacheFile.CONFIG_HASH_KEY),
+                "Cache has null hash");
 
-        final String pathToEmptyFile = temporaryFolder.newFile("file.java").getPath();
+        final String pathToEmptyFile =
+                File.createTempFile("file", ".java", temporaryFolder).getPath();
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
         // file that should be audited is not in cache
         verify(checker, pathToEmptyFile, pathToEmptyFile, expected);
         final Properties cacheAfterSecondRun = new Properties();
-        cacheAfterSecondRun.load(Files.newBufferedReader(cacheFile.toPath()));
+        try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
+            cacheAfterSecondRun.load(reader);
+        }
 
-        assertNotNull("Cache has null path",
-                cacheAfterSecondRun.getProperty(pathToEmptyFile));
-        assertEquals("Cash have changed it hash",
-            cacheAfterClear.getProperty(PropertyCacheFile.CONFIG_HASH_KEY),
-            cacheAfterSecondRun.getProperty(PropertyCacheFile.CONFIG_HASH_KEY)
-        );
+        assertNotNull(cacheAfterSecondRun.getProperty(pathToEmptyFile), "Cache has null path");
+        final String cacheHash = cacheAfterSecondRun.getProperty(PropertyCacheFile.CONFIG_HASH_KEY);
+        assertEquals(cacheAfterClear.getProperty(PropertyCacheFile.CONFIG_HASH_KEY),
+                cacheHash, "Cash have changed it hash");
         final int expectedNumberOfObjectsInCacheAfterSecondRun = 2;
-        assertEquals("Cache has changed number of items",
-                expectedNumberOfObjectsInCacheAfterSecondRun, cacheAfterSecondRun.size());
+        assertEquals(expectedNumberOfObjectsInCacheAfterSecondRun, cacheAfterSecondRun.size(),
+                "Cache has changed number of items");
     }
 
     @Test
@@ -624,7 +625,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
                 createModuleConfig(DummyFileSetViolationCheck.class);
         final DefaultConfiguration checkerConfig = new DefaultConfiguration("myConfig");
         checkerConfig.addAttribute("charset", "UTF-8");
-        final File cacheFile = temporaryFolder.newFile();
+        final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
         checkerConfig.addAttribute("cacheFile", cacheFile.getPath());
         checkerConfig.addChild(violationCheck);
         final Checker checker = new Checker();
@@ -639,10 +640,11 @@ public class CheckerTest extends AbstractModuleTestSupport {
         cache.persist();
 
         final Properties cacheAfterClear = new Properties();
-        cacheAfterClear.load(Files.newBufferedReader(cacheFile.toPath()));
+        try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
+            cacheAfterClear.load(reader);
+        }
 
-        assertEquals("Cache has unexpected size",
-                1, cacheAfterClear.size());
+        assertEquals(1, cacheAfterClear.size(), "Cache has unexpected size");
     }
 
     @Test
@@ -650,8 +652,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
         final Checker checker = new Checker();
         checker.setFileExtensions(".test1", "test2");
         final String[] actual = Whitebox.getInternalState(checker, "fileExtensions");
-        assertArrayEquals("Extensions are not expected",
-                new String[] {".test1", ".test2"}, actual);
+        assertArrayEquals(new String[] {".test1", ".test2"}, actual,
+                "Extensions are not expected");
     }
 
     @Test
@@ -660,8 +662,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
         // the invocation of clearCache method does not throw an exception.
         final Checker checker = new Checker();
         checker.clearCache();
-        assertNull("If cache file is not set the cache should default to null",
-            Whitebox.getInternalState(checker, "cacheFile"));
+        assertNull(Whitebox.getInternalState(checker, "cacheFile"),
+                "If cache file is not set the cache should default to null");
     }
 
     /**
@@ -697,12 +699,12 @@ public class CheckerTest extends AbstractModuleTestSupport {
         }
         // -@cs[IllegalCatchExtended] Testing for catch Error is part of 100% coverage.
         catch (Error error) {
-            assertThat("Error cause differs from IOError",
-                    error.getCause(), instanceOf(IOError.class));
-            assertThat("Error cause is not InternalError",
-                    error.getCause().getCause(), instanceOf(InternalError.class));
-            assertEquals("Error message is not expected",
-                    errorMessage, error.getCause().getCause().getMessage());
+            assertWithMessage("Error cause differs from IOError")
+                    .that(error.getCause()).isInstanceOf(IOError.class);
+            assertWithMessage("Error cause is not InternalError")
+                    .that(error.getCause().getCause()).isInstanceOf(InternalError.class);
+            assertEquals(errorMessage, error.getCause().getCause().getMessage(),
+                    "Error message is not expected");
         }
     }
 
@@ -744,12 +746,12 @@ public class CheckerTest extends AbstractModuleTestSupport {
         }
         // -@cs[IllegalCatchExtended] Testing for catch Error is part of 100% coverage.
         catch (Error error) {
-            assertThat("Error cause differs from IOError",
-                    error.getCause(), instanceOf(IOError.class));
-            assertThat("Error cause is not InternalError",
-                    error.getCause().getCause(), instanceOf(InternalError.class));
-            assertEquals("Error message is not expected",
-                    errorMessage, error.getCause().getCause().getMessage());
+            assertWithMessage("Error cause differs from IOError")
+                    .that(error.getCause()).isInstanceOf(IOError.class);
+            assertWithMessage("Error cause is not InternalError")
+                    .that(error.getCause().getCause()).isInstanceOf(InternalError.class);
+            assertEquals(errorMessage, error.getCause().getCause().getMessage(),
+                    "Error message is not expected");
         }
     }
 
@@ -759,41 +761,42 @@ public class CheckerTest extends AbstractModuleTestSupport {
     @Test
     public void testCacheAndFilterWhichDoesNotImplementExternalResourceHolderInterface()
             throws Exception {
-        assertFalse("ExternalResourceHolder has changed its parent",
-                ExternalResourceHolder.class.isAssignableFrom(DummyFilter.class));
+        assertFalse(ExternalResourceHolder.class.isAssignableFrom(DummyFilter.class),
+                "ExternalResourceHolder has changed its parent");
         final DefaultConfiguration filterConfig = createModuleConfig(DummyFilter.class);
 
         final DefaultConfiguration checkerConfig = createRootConfig(filterConfig);
-        final File cacheFile = temporaryFolder.newFile();
+        final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
         checkerConfig.addAttribute("cacheFile", cacheFile.getPath());
 
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        final String pathToEmptyFile = temporaryFolder.newFile("file.java").getPath();
+        final String pathToEmptyFile =
+                File.createTempFile("file", ".java", temporaryFolder).getPath();
 
         verify(checkerConfig, pathToEmptyFile, expected);
         final Properties cacheAfterFirstRun = new Properties();
-        cacheAfterFirstRun.load(Files.newBufferedReader(cacheFile.toPath()));
+        try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
+            cacheAfterFirstRun.load(reader);
+        }
 
         // One more time to use cache.
         verify(checkerConfig, pathToEmptyFile, expected);
         final Properties cacheAfterSecondRun = new Properties();
-        cacheAfterSecondRun.load(Files.newBufferedReader(cacheFile.toPath()));
+        try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
+            cacheAfterSecondRun.load(reader);
+        }
 
-        assertEquals(
-                "Cache file has changed its path",
-            cacheAfterFirstRun.getProperty(pathToEmptyFile),
-            cacheAfterSecondRun.getProperty(pathToEmptyFile)
-        );
-        assertEquals(
-                "Cache has changed its hash",
-            cacheAfterFirstRun.getProperty(PropertyCacheFile.CONFIG_HASH_KEY),
-            cacheAfterSecondRun.getProperty(PropertyCacheFile.CONFIG_HASH_KEY)
-        );
+        final String cacheFilePath = cacheAfterSecondRun.getProperty(pathToEmptyFile);
+        assertEquals(cacheAfterFirstRun.getProperty(pathToEmptyFile),
+                cacheFilePath, "Cache file has changed its path");
+        final String cacheHash = cacheAfterSecondRun.getProperty(PropertyCacheFile.CONFIG_HASH_KEY);
+        assertEquals(cacheAfterFirstRun.getProperty(PropertyCacheFile.CONFIG_HASH_KEY),
+                cacheHash, "Cache has changed its hash");
         final int expectedNumberOfObjectsInCache = 2;
-        assertEquals("Number of items in cache differs from expected",
-                expectedNumberOfObjectsInCache, cacheAfterFirstRun.size());
-        assertEquals("Number of items in cache differs from expected",
-                expectedNumberOfObjectsInCache, cacheAfterSecondRun.size());
+        assertEquals(expectedNumberOfObjectsInCache, cacheAfterFirstRun.size(),
+                "Number of items in cache differs from expected");
+        assertEquals(expectedNumberOfObjectsInCache, cacheAfterSecondRun.size(),
+                "Number of items in cache differs from expected");
     }
 
     /**
@@ -816,7 +819,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         check.setFirstExternalResourceLocation(firstExternalResourceLocation);
 
         final DefaultConfiguration checkerConfig = createRootConfig(null);
-        final File cacheFile = temporaryFolder.newFile();
+        final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
         checkerConfig.addAttribute("cacheFile", cacheFile.getPath());
 
         final Checker checker = new Checker();
@@ -826,16 +829,19 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.configure(checkerConfig);
         checker.addListener(getBriefUtLogger());
 
-        final String pathToEmptyFile = temporaryFolder.newFile("file.java").getPath();
+        final String pathToEmptyFile =
+                File.createTempFile("file", ".java", temporaryFolder).getPath();
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
         verify(checker, pathToEmptyFile, expected);
         final Properties cacheAfterFirstRun = new Properties();
-        cacheAfterFirstRun.load(Files.newBufferedReader(cacheFile.toPath()));
+        try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
+            cacheAfterFirstRun.load(reader);
+        }
 
         final int expectedNumberOfObjectsInCacheAfterFirstRun = 4;
-        assertEquals("Number of items in cache differs from expected",
-                expectedNumberOfObjectsInCacheAfterFirstRun, cacheAfterFirstRun.size());
+        assertEquals(expectedNumberOfObjectsInCacheAfterFirstRun, cacheAfterFirstRun.size(),
+                "Number of items in cache differs from expected");
 
         // Change a list of external resources which are used by the check
         final String secondExternalResourceLocation = "InputCheckerImportControlTwo.xml";
@@ -848,30 +854,28 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
         verify(checker, pathToEmptyFile, expected);
         final Properties cacheAfterSecondRun = new Properties();
-        cacheAfterSecondRun.load(Files.newBufferedReader(cacheFile.toPath()));
+        try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
+            cacheAfterSecondRun.load(reader);
+        }
 
-        assertEquals("Cache file has changed its path",
-            cacheAfterFirstRun.getProperty(pathToEmptyFile),
-            cacheAfterSecondRun.getProperty(pathToEmptyFile)
-        );
-        assertEquals(
-                "Cache has changed its hash",
-            cacheAfterFirstRun.getProperty(PropertyCacheFile.CONFIG_HASH_KEY),
-            cacheAfterSecondRun.getProperty(PropertyCacheFile.CONFIG_HASH_KEY)
-        );
-        assertEquals("Cache has changed its resource key",
-            cacheAfterFirstRun.getProperty(firstExternalResourceKey),
-            cacheAfterSecondRun.getProperty(firstExternalResourceKey)
-        );
-        assertNotNull("Cache has null as a resource key",
-                cacheAfterFirstRun.getProperty(firstExternalResourceKey));
+        final String cacheFilePath = cacheAfterSecondRun.getProperty(pathToEmptyFile);
+        assertEquals(cacheAfterFirstRun.getProperty(pathToEmptyFile),
+                cacheFilePath, "Cache file has changed its path");
+        final String cacheHash = cacheAfterSecondRun.getProperty(PropertyCacheFile.CONFIG_HASH_KEY);
+        assertEquals(cacheAfterFirstRun.getProperty(PropertyCacheFile.CONFIG_HASH_KEY),
+                cacheHash, "Cache has changed its hash");
+        final String resourceKey = cacheAfterSecondRun.getProperty(firstExternalResourceKey);
+        assertEquals(cacheAfterFirstRun.getProperty(firstExternalResourceKey),
+                resourceKey, "Cache has changed its resource key");
+        assertNotNull(cacheAfterFirstRun.getProperty(firstExternalResourceKey),
+                "Cache has null as a resource key");
         final int expectedNumberOfObjectsInCacheAfterSecondRun = 4;
-        assertEquals("Number of items in cache differs from expected",
-                expectedNumberOfObjectsInCacheAfterSecondRun, cacheAfterSecondRun.size());
-        assertNull("Cache has not null as a resource key",
-                cacheAfterFirstRun.getProperty(secondExternalResourceKey));
-        assertNotNull("Cache has null as a resource key",
-                cacheAfterSecondRun.getProperty(secondExternalResourceKey));
+        assertEquals(expectedNumberOfObjectsInCacheAfterSecondRun, cacheAfterSecondRun.size(),
+                "Number of items in cache differs from expected");
+        assertNull(cacheAfterFirstRun.getProperty(secondExternalResourceKey),
+                "Cache has not null as a resource key");
+        assertNotNull(cacheAfterSecondRun.getProperty(secondExternalResourceKey),
+                "Cache has null as a resource key");
     }
 
     @Test
@@ -895,7 +899,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
     @Test
     public void testCacheOnViolationSuppression() throws Exception {
-        final File cacheFile = temporaryFolder.newFile();
+        final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
         final DefaultConfiguration violationCheck =
                 createModuleConfig(DummyFileSetViolationCheck.class);
 
@@ -906,7 +910,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checkerConfig.addAttribute("cacheFile", cacheFile.getPath());
         checkerConfig.addChild(filterConfig);
 
-        final String fileViolationPath = temporaryFolder.newFile("ViolationFile.java").getPath();
+        final String fileViolationPath =
+                File.createTempFile("ViolationFile", ".java", temporaryFolder).getPath();
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
         verify(checkerConfig, fileViolationPath, expected);
@@ -915,8 +920,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
             final Properties details = new Properties();
             details.load(input);
 
-            assertNotNull("suppressed violation file saved in cache",
-                    details.getProperty(fileViolationPath));
+            assertNotNull(details.getProperty(fileViolationPath),
+                    "suppressed violation file saved in cache");
         }
     }
 
@@ -930,14 +935,14 @@ public class CheckerTest extends AbstractModuleTestSupport {
             fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Error message is not expected",
-                    "Exception was thrown while processing " + filePath, ex.getMessage());
+            assertEquals("Exception was thrown while processing " + filePath, ex.getMessage(),
+                    "Error message is not expected");
         }
     }
 
     @Test
     public void testExceptionWithCache() throws Exception {
-        final File cacheFile = temporaryFolder.newFile();
+        final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
 
         final DefaultConfiguration checkConfig =
                 createModuleConfig(CheckWhichThrowsError.class);
@@ -959,19 +964,19 @@ public class CheckerTest extends AbstractModuleTestSupport {
             fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Error message is not expected",
-                    "Exception was thrown while processing " + filePath, ex.getMessage());
+            assertEquals("Exception was thrown while processing " + filePath, ex.getMessage(),
+                    "Error message is not expected");
 
             // destroy is called by Main
             checker.destroy();
 
             final Properties cache = new Properties();
-            cache.load(Files.newBufferedReader(cacheFile.toPath()));
+            try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
+                cache.load(reader);
+            }
 
-            assertEquals("Cache has unexpected size",
-                    1, cache.size());
-            assertNull("testFile is not in cache",
-                    cache.getProperty(filePath));
+            assertEquals(1, cache.size(), "Cache has unexpected size");
+            assertNull(cache.getProperty(filePath), "testFile is not in cache");
         }
     }
 
@@ -981,7 +986,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
      */
     @Test
     public void testCatchErrorWithCache() throws Exception {
-        final File cacheFile = temporaryFolder.newFile();
+        final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
 
         final DefaultConfiguration checkerConfig = new DefaultConfiguration("configuration");
         checkerConfig.addAttribute("charset", StandardCharsets.UTF_8.name());
@@ -1020,21 +1025,21 @@ public class CheckerTest extends AbstractModuleTestSupport {
         }
         // -@cs[IllegalCatchExtended] Testing for catch Error is part of 100% coverage.
         catch (Error error) {
-            assertThat("Error cause differs from IOError",
-                    error.getCause(), instanceOf(IOError.class));
-            assertEquals("Error message is not expected",
-                    errorMessage, error.getCause().getCause().getMessage());
+            assertWithMessage("Error cause differs from IOError")
+                    .that(error.getCause()).isInstanceOf(IOError.class);
+            assertEquals(errorMessage, error.getCause().getCause().getMessage(),
+                    "Error message is not expected");
 
             // destroy is called by Main
             checker.destroy();
 
             final Properties cache = new Properties();
-            cache.load(Files.newBufferedReader(cacheFile.toPath()));
+            try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
+                cache.load(reader);
+            }
 
-            assertEquals("Cache has unexpected size",
-                    1, cache.size());
-            assertNull("testFile is not in cache",
-                    cache.getProperty("testFile"));
+            assertEquals(1, cache.size(), "Cache has unexpected size");
+            assertNull(cache.getProperty("testFile"), "testFile is not in cache");
         }
     }
 
@@ -1044,7 +1049,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
      */
     @Test
     public void testCatchErrorWithCacheWithNoFileName() throws Exception {
-        final File cacheFile = temporaryFolder.newFile();
+        final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
 
         final DefaultConfiguration checkerConfig = new DefaultConfiguration("configuration");
         checkerConfig.addAttribute("charset", StandardCharsets.UTF_8.name());
@@ -1078,19 +1083,20 @@ public class CheckerTest extends AbstractModuleTestSupport {
         }
         // -@cs[IllegalCatchExtended] Testing for catch Error is part of 100% coverage.
         catch (Error error) {
-            assertThat("Error cause differs from IOError",
-                    error.getCause(), instanceOf(IOError.class));
-            assertEquals("Error message is not expected",
-                    errorMessage, error.getCause().getCause().getMessage());
+            assertWithMessage("Error cause differs from IOError")
+                    .that(error.getCause()).isInstanceOf(IOError.class);
+            assertEquals(errorMessage, error.getCause().getCause().getMessage(),
+                    "Error message is not expected");
 
             // destroy is called by Main
             checker.destroy();
 
             final Properties cache = new Properties();
-            cache.load(Files.newBufferedReader(cacheFile.toPath()));
+            try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
+                cache.load(reader);
+            }
 
-            assertEquals("Cache has unexpected size",
-                    1, cache.size());
+            assertEquals(1, cache.size(), "Cache has unexpected size");
         }
     }
 
@@ -1124,10 +1130,10 @@ public class CheckerTest extends AbstractModuleTestSupport {
             fail("SecurityException is expected!");
         }
         catch (CheckstyleException ex) {
-            assertThat("Error cause differs from SecurityException",
-                    ex.getCause(), instanceOf(SecurityException.class));
-            assertEquals("Error message is not expected",
-                    errorMessage, ex.getCause().getMessage());
+            assertWithMessage("Error cause differs from SecurityException")
+                    .that(ex.getCause()).isInstanceOf(SecurityException.class);
+            assertEquals(errorMessage, ex.getCause().getMessage(),
+                    "Error message is not expected");
         }
     }
 
@@ -1137,7 +1143,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
      */
     @Test
     public void testExceptionWithCacheAndNoFileName() throws Exception {
-        final File cacheFile = temporaryFolder.newFile();
+        final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
 
         final DefaultConfiguration checkerConfig = new DefaultConfiguration("configuration");
         checkerConfig.addAttribute("charset", StandardCharsets.UTF_8.name());
@@ -1169,19 +1175,20 @@ public class CheckerTest extends AbstractModuleTestSupport {
             fail("SecurityException is expected!");
         }
         catch (CheckstyleException ex) {
-            assertThat("Error cause differs from SecurityException",
-                    ex.getCause(), instanceOf(SecurityException.class));
-            assertEquals("Error message is not expected",
-                    errorMessage, ex.getCause().getMessage());
+            assertWithMessage("Error cause differs from SecurityException")
+                    .that(ex.getCause()).isInstanceOf(SecurityException.class);
+            assertEquals(errorMessage, ex.getCause().getMessage(),
+                    "Error message is not expected");
 
             // destroy is called by Main
             checker.destroy();
 
             final Properties cache = new Properties();
-            cache.load(Files.newBufferedReader(cacheFile.toPath()));
+            try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
+                cache.load(reader);
+            }
 
-            assertEquals("Cache has unexpected size",
-                    1, cache.size());
+            assertEquals(1, cache.size(), "Cache has unexpected size");
         }
     }
 
@@ -1240,8 +1247,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.process(Collections.singletonList(new File("dummy.java")));
         final List<String> expected =
             Arrays.asList("beginProcessing", "finishProcessing", "destroy");
-        assertArrayEquals("Method calls were not expected",
-                expected.toArray(), fileSet.getMethodCalls().toArray());
+        assertArrayEquals(expected.toArray(), fileSet.getMethodCalls().toArray(),
+                "Method calls were not expected");
     }
 
     @Test
@@ -1249,8 +1256,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
         final DummyFileSet fileSet = new DummyFileSet();
         final Checker checker = new Checker();
         checker.addFileSetCheck(fileSet);
-        assertEquals("Message dispatcher was not expected",
-                checker, fileSet.getInternalMessageDispatcher());
+        assertEquals(checker, fileSet.getInternalMessageDispatcher(),
+                "Message dispatcher was not expected");
     }
 
     @Test
@@ -1272,7 +1279,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.setupChild(createModuleConfig(DebugAuditAdapter.class));
         // Let's try fire some events
         checker.process(Collections.singletonList(new File("dummy.java")));
-        assertTrue("Checker.fireAuditStarted() doesn't call listener", auditAdapter.wasCalled());
+        assertTrue(auditAdapter.wasCalled(), "Checker.fireAuditStarted() doesn't call listener");
     }
 
     @Test
@@ -1293,7 +1300,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.setModuleFactory(factory);
         checker.setupChild(createModuleConfig(TestBeforeExecutionFileFilter.class));
         checker.process(Collections.singletonList(new File("dummy.java")));
-        assertTrue("Checker.acceptFileStarted() doesn't call listener", fileFilter.wasCalled());
+        assertTrue(fileFilter.wasCalled(), "Checker.acceptFileStarted() doesn't call listener");
     }
 
     @Test
@@ -1314,7 +1321,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.setModuleFactory(factory);
         checker.finishLocalSetup();
         checker.setupChild(createModuleConfig(DummyFileSet.class));
-        assertTrue("FileSetCheck.init() wasn't called", fileSet.isInitCalled());
+        assertTrue(fileSet.isInitCalled(), "FileSetCheck.init() wasn't called");
     }
 
     // -@cs[CheckstyleTestMakeup] must use raw class to directly initialize DefaultLogger
@@ -1329,7 +1336,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
             checker.addListener(new DefaultLogger(testInfoOutputStream,
                 OutputStreamOptions.CLOSE, testErrorOutputStream, OutputStreamOptions.CLOSE));
 
-            final File tmpFile = temporaryFolder.newFile("file.java");
+            final File tmpFile = File.createTempFile("file", ".java", temporaryFolder);
             final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
             verify(checker, tmpFile.getPath(), expected);
@@ -1358,7 +1365,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
             checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
             checker.addListener(new XMLLogger(testInfoOutputStream, OutputStreamOptions.CLOSE));
 
-            final File tmpFile = temporaryFolder.newFile("file.java");
+            final File tmpFile = File.createTempFile("file", ".java", temporaryFolder);
             final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
             verify(checker, tmpFile.getPath(), tmpFile.getPath(), expected);
@@ -1393,7 +1400,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
                 OutputStreamOptions.NONE, new AuditEventDefaultFormatter());
         checker.addListener(logger);
 
-        final String path = temporaryFolder.newFile("file.java").getPath();
+        final String path = File.createTempFile("file", ".java", temporaryFolder).getPath();
         final String violationMessage =
                 getCheckMessage(NewlineAtEndOfFileCheck.class, MSG_KEY_NO_NEWLINE_EOF);
         final String[] expected = {
@@ -1419,10 +1426,10 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
             for (int i = 0; i < expected.length; i++) {
                 final String expectedResult = "[ERROR] " + path + ":" + expected[i];
-                assertEquals("error message " + i, expectedResult, actual.get(i));
+                assertEquals(expectedResult, actual.get(i), "error message " + i);
             }
 
-            assertEquals("unexpected output: " + lnr.readLine(), expected.length, errs);
+            assertEquals(expected.length, errs, "unexpected output: " + lnr.readLine());
         }
 
         checker.destroy();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -19,10 +19,10 @@
 
 package com.puppycrawl.tools.checkstyle;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.lang.reflect.Constructor;
@@ -34,7 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -64,12 +64,6 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         return ConfigurationLoader.loadConfiguration(fName, new PropertiesExpander(props));
     }
 
-    /**
-     * Non meaningful javadoc just to contain "noinspection" tag.
-     * Till https://youtrack.jetbrains.com/issue/IDEA-187209
-     * @return method class
-     * @throws Exception if smth wrong
-     */
     private static Method getReplacePropertiesMethod() throws Exception {
         final Class<?>[] params = new Class<?>[3];
         params[0] = String.class;
@@ -115,9 +109,8 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
             fail("An exception is expected");
         }
         catch (IllegalArgumentException ex) {
-            assertEquals("Invalid exception message",
-                "Multi thread mode for Checker module is not implemented",
-                ex.getMessage());
+            assertEquals("Multi thread mode for Checker module is not implemented",
+                ex.getMessage(), "Invalid exception message");
         }
     }
 
@@ -163,12 +156,12 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
             fail("missing property name");
         }
         catch (CheckstyleException ex) {
-            assertTrue("Invalid exception message: " + ex.getMessage(),
-                    ex.getMessage().contains("\"name\""));
-            assertTrue("Invalid exception message: " + ex.getMessage(),
-                    ex.getMessage().contains("\"property\""));
-            assertTrue("Invalid exception message: " + ex.getMessage(),
-                    ex.getMessage().endsWith(":8:41"));
+            assertTrue(ex.getMessage().contains("\"name\""),
+                    "Invalid exception message: " + ex.getMessage());
+            assertTrue(ex.getMessage().contains("\"property\""),
+                    "Invalid exception message: " + ex.getMessage());
+            assertTrue(ex.getMessage().endsWith(":8:41"),
+                    "Invalid exception message: " + ex.getMessage());
         }
     }
 
@@ -182,12 +175,12 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
             fail("missing property name");
         }
         catch (CheckstyleException ex) {
-            assertTrue("Invalid exception message: " + ex.getMessage(),
-                    ex.getMessage().contains("\"name\""));
-            assertTrue("Invalid exception message: " + ex.getMessage(),
-                    ex.getMessage().contains("\"property\""));
-            assertTrue("Invalid exception message: " + ex.getMessage(),
-                    ex.getMessage().endsWith(":8:41"));
+            assertTrue(ex.getMessage().contains("\"name\""),
+                    "Invalid exception message: " + ex.getMessage());
+            assertTrue(ex.getMessage().contains("\"property\""),
+                    "Invalid exception message: " + ex.getMessage());
+            assertTrue(ex.getMessage().endsWith(":8:41"),
+                    "Invalid exception message: " + ex.getMessage());
         }
     }
 
@@ -198,12 +191,12 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
             fail("missing property value");
         }
         catch (CheckstyleException ex) {
-            assertTrue("Invalid exception message: " + ex.getMessage(),
-                    ex.getMessage().contains("\"value\""));
-            assertTrue("Invalid exception message: " + ex.getMessage(),
-                    ex.getMessage().contains("\"property\""));
-            assertTrue("Invalid exception message: " + ex.getMessage(),
-                    ex.getMessage().endsWith(":8:43"));
+            assertTrue(ex.getMessage().contains("\"value\""),
+                    "Invalid exception message: " + ex.getMessage());
+            assertTrue(ex.getMessage().contains("\"property\""),
+                    "Invalid exception message: " + ex.getMessage());
+            assertTrue(ex.getMessage().endsWith(":8:43"),
+                    "Invalid exception message: " + ex.getMessage());
         }
     }
 
@@ -214,12 +207,12 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
             fail("missing module name");
         }
         catch (CheckstyleException ex) {
-            assertTrue("Invalid exception message: " + ex.getMessage(),
-                    ex.getMessage().contains("\"name\""));
-            assertTrue("Invalid exception message: " + ex.getMessage(),
-                    ex.getMessage().contains("\"module\""));
-            assertTrue("Invalid exception message: " + ex.getMessage(),
-                    ex.getMessage().endsWith(":7:23"));
+            assertTrue(ex.getMessage().contains("\"name\""),
+                    "Invalid exception message: " + ex.getMessage());
+            assertTrue(ex.getMessage().contains("\"module\""),
+                    "Invalid exception message: " + ex.getMessage());
+            assertTrue(ex.getMessage().endsWith(":7:23"),
+                    "Invalid exception message: " + ex.getMessage());
         }
     }
 
@@ -230,12 +223,12 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
             fail("missing module parent");
         }
         catch (CheckstyleException ex) {
-            assertTrue("Invalid exception message: " + ex.getMessage(),
-                    ex.getMessage().contains("\"property\""));
-            assertTrue("Invalid exception message: " + ex.getMessage(),
-                    ex.getMessage().contains("\"module\""));
-            assertTrue("Invalid exception message: " + ex.getMessage(),
-                    ex.getMessage().endsWith(":8:38"));
+            assertTrue(ex.getMessage().contains("\"property\""),
+                    "Invalid exception message: " + ex.getMessage());
+            assertTrue(ex.getMessage().contains("\"module\""),
+                    "Invalid exception message: " + ex.getMessage());
+            assertTrue(ex.getMessage().endsWith(":8:38"),
+                    "Invalid exception message: " + ex.getMessage());
         }
     }
 
@@ -305,28 +298,24 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         final Configuration[] grandchildren = children[0].getChildren();
 
         final String expectedKey = "name.invalidPattern";
-        assertTrue("Messages should contain key: " + expectedKey,
-            grandchildren[0].getMessages()
-            .containsKey(expectedKey));
+        assertTrue(grandchildren[0].getMessages().containsKey(expectedKey),
+                "Messages should contain key: " + expectedKey);
     }
 
     private static void verifyConfigNode(
         DefaultConfiguration config, String name, int childrenLength,
         Properties atts) throws Exception {
-        assertEquals("name.", name, config.getName());
+        assertEquals(name, config.getName(), "name.");
         assertEquals(
-            "children.length.",
-            childrenLength,
-            config.getChildren().length);
+                childrenLength,
+            config.getChildren().length, "children.length.");
 
         final String[] attNames = config.getAttributeNames();
-        assertEquals("attributes.length", atts.size(), attNames.length);
+        assertEquals(atts.size(), attNames.length, "attributes.length");
 
         for (String attName : attNames) {
-            assertEquals(
-                "attribute[" + attName + "]",
-                atts.getProperty(attName),
-                config.getAttribute(attName));
+            final String attribute = config.getAttribute(attName);
+            assertEquals(atts.getProperty(attName), attribute, "attribute[" + attName + "]");
         }
     }
 
@@ -338,7 +327,7 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         for (String testValue : testValues) {
             final String value = (String) getReplacePropertiesMethod().invoke(
                 null, testValue, new PropertiesExpander(props), null);
-            assertEquals("\"" + testValue + "\"", value, testValue);
+            assertEquals(value, testValue, "\"" + testValue + "\"");
         }
     }
 
@@ -351,8 +340,8 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
             fail("expected to fail, instead got: " + value);
         }
         catch (InvocationTargetException ex) {
-            assertEquals("Invalid exception cause message",
-                "Syntax error in property: ${a", ex.getCause().getMessage());
+            assertEquals("Syntax error in property: ${a", ex.getCause().getMessage(),
+                    "Invalid exception cause message");
         }
     }
 
@@ -365,8 +354,8 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
             fail("expected to fail, instead got: " + value);
         }
         catch (InvocationTargetException ex) {
-            assertEquals("Invalid exception cause message",
-                "Property ${c} has not been set", ex.getCause().getMessage());
+            assertEquals("Property ${c} has not been set", ex.getCause().getMessage(),
+                    "Invalid exception cause message");
         }
     }
 
@@ -390,8 +379,7 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         for (String[] testValue : testValues) {
             final String value = (String) getReplacePropertiesMethod().invoke(
                 null, testValue[0], new PropertiesExpander(props), null);
-            assertEquals("\"" + testValue[0] + "\"",
-                testValue[1], value);
+            assertEquals(testValue[1], value, "\"" + testValue[0] + "\"");
         }
     }
 
@@ -479,8 +467,8 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
             fail("Exception is expected");
         }
         catch (IllegalStateException ex) {
-            assertEquals("Invalid exception cause message",
-                "Unknown name:" + "hello" + ".", ex.getMessage());
+            assertEquals("Unknown name:" + "hello" + ".", ex.getMessage(),
+                    "Invalid exception cause message");
         }
     }
 
@@ -491,15 +479,14 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
             fail("exception in expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid exception message",
-                "unable to parse configuration stream", ex.getMessage());
-            assertSame("Expected cause of type SAXException",
-                SAXException.class, ex.getCause().getClass());
-            assertSame("Expected cause of type CheckstyleException",
-                CheckstyleException.class, ex.getCause().getCause().getClass());
-            assertEquals("Invalid exception cause message",
-                "Property ${nonexistent} has not been set",
-                ex.getCause().getCause().getMessage());
+            assertEquals("unable to parse configuration stream", ex.getMessage(),
+                    "Invalid exception message");
+            assertSame(SAXException.class, ex.getCause().getClass(),
+                    "Expected cause of type SAXException");
+            assertSame(CheckstyleException.class, ex.getCause().getCause().getClass(),
+                    "Expected cause of type CheckstyleException");
+            assertEquals("Property ${nonexistent} has not been set",
+                ex.getCause().getCause().getMessage(), "Invalid exception cause message");
         }
     }
 
@@ -511,7 +498,8 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
                         new PropertiesExpander(new Properties()), IgnoredModulesOptions.OMIT);
 
         final Configuration[] children = config.getChildren();
-        assertEquals("Invalid children count", 0, children[0].getChildren().length);
+        final int length = children[0].getChildren().length;
+        assertEquals(0, length, "Invalid children count");
     }
 
     @Test
@@ -523,7 +511,8 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
                         new PropertiesExpander(new Properties()), IgnoredModulesOptions.OMIT);
 
         final Configuration[] children = config.getChildren();
-        assertEquals("Invalid children count", 0, children[0].getChildren().length);
+        final int length = children[0].getChildren().length;
+        assertEquals(0, length, "Invalid children count");
     }
 
     @Test
@@ -534,7 +523,7 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
                         new PropertiesExpander(new Properties()), IgnoredModulesOptions.OMIT);
 
         final Configuration[] children = config.getChildren();
-        assertEquals("Invalid children count", 0, children.length);
+        assertEquals(0, children.length, "Invalid children count");
     }
 
     @Test
@@ -546,13 +535,13 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
                             new PropertiesExpander(new Properties()), IgnoredModulesOptions.OMIT);
 
             final Configuration[] children = config.getChildren();
-            assertEquals("Invalid children count", 0, children[0].getChildren().length);
+            final int length = children[0].getChildren().length;
+            assertEquals(0, length, "Invalid children count");
             fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid exception message",
-                    "Unable to find: ;InputConfigurationLoaderModuleIgnoreSeverity.xml",
-                    ex.getMessage());
+            assertEquals("Unable to find: ;InputConfigurationLoaderModuleIgnoreSeverity.xml",
+                    ex.getMessage(), "Invalid exception message");
         }
     }
 
@@ -565,8 +554,8 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
                         new PropertiesExpander(new Properties()), IgnoredModulesOptions.OMIT);
 
         final Configuration[] children = config.getChildren();
-        assertEquals("Invalid children count",
-            0, children[0].getChildren().length);
+        final int length = children[0].getChildren().length;
+        assertEquals(0, length, "Invalid children count");
     }
 
     @Test
@@ -577,7 +566,7 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         final String value = (String) getReplacePropertiesMethod().invoke(
             null, "${checkstyle.basedir}", new PropertiesExpander(props), defaultValue);
 
-        assertEquals("Invalid property value", defaultValue, value);
+        assertEquals(defaultValue, value, "Invalid property value");
     }
 
     @Test
@@ -588,8 +577,8 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
                         new PropertiesExpander(new Properties()), IgnoredModulesOptions.OMIT);
 
         final Configuration[] children = config.getChildren();
-        assertEquals("Invalid children count",
-            0, children[0].getChildren().length);
+        final int length = children[0].getChildren().length;
+        assertEquals(0, length, "Invalid children count");
     }
 
     @Test
@@ -600,8 +589,7 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         Whitebox.invokeMethod(ConfigurationLoader.class,
                 "parsePropertyString", "$",
                fragments, propertyRefs);
-        assertEquals("Fragments list has unexpected amount of items",
-                1, fragments.size());
+        assertEquals(1, fragments.size(), "Fragments list has unexpected amount of items");
     }
 
     @Test
@@ -612,7 +600,7 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
 
         final Configuration configuration = ConfigurationLoader.loadConfiguration(fName,
                 new PropertiesExpander(props), ConfigurationLoader.IgnoredModulesOptions.OMIT);
-        assertEquals("Name is not expected", "Checker", configuration.getName());
+        assertEquals("Checker", configuration.getName(), "Name is not expected");
 
         final DefaultConfiguration configuration1 =
                 (DefaultConfiguration) ConfigurationLoader.loadConfiguration(
@@ -622,7 +610,8 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
                         ConfigurationLoader.IgnoredModulesOptions.EXECUTE);
 
         final Configuration[] children = configuration1.getChildren();
-        assertEquals("Unexpected children size", 1, children[0].getChildren().length);
+        final int length = children[0].getChildren().length;
+        assertEquals(1, length, "Unexpected children size");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DefaultConfigurationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DefaultConfigurationTest.java
@@ -19,14 +19,14 @@
 
 package com.puppycrawl.tools.checkstyle;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Map;
 import java.util.TreeMap;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 
@@ -38,33 +38,33 @@ public class DefaultConfigurationTest {
         config.addAttribute("attribute", "value");
         final String[] actual = config.getAttributeNames();
         final String[] expected = {"attribute"};
-        assertArrayEquals("Invalid attribute names", expected, actual);
+        assertArrayEquals(expected, actual, "Invalid attribute names");
     }
 
     @Test
     public void testAddAttributeAndGetAttribute() throws CheckstyleException {
         final DefaultConfiguration config = new DefaultConfiguration("MyConfig");
         config.addAttribute("attribute", "first");
-        assertEquals("Invalid attribute value", "first", config.getAttribute("attribute"));
+        assertEquals("first", config.getAttribute("attribute"), "Invalid attribute value");
         config.addAttribute("attribute", "second");
-        assertEquals("Invalid attribute value", "first,second", config.getAttribute("attribute"));
+        assertEquals("first,second", config.getAttribute("attribute"), "Invalid attribute value");
     }
 
     @Test
     public void testGetName() {
         final DefaultConfiguration config = new DefaultConfiguration("MyConfig");
-        assertEquals("Invalid configuration name", "MyConfig", config.getName());
+        assertEquals("MyConfig", config.getName(), "Invalid configuration name");
     }
 
     @Test
     public void testRemoveChild() {
         final DefaultConfiguration config = new DefaultConfiguration("MyConfig");
         final DefaultConfiguration configChild = new DefaultConfiguration("childConfig");
-        assertEquals("Invalid children count", 0, config.getChildren().length);
+        assertEquals(0, config.getChildren().length, "Invalid children count");
         config.addChild(configChild);
-        assertEquals("Invalid children count", 1, config.getChildren().length);
+        assertEquals(1, config.getChildren().length, "Invalid children count");
         config.removeChild(configChild);
-        assertEquals("Invalid children count", 0, config.getChildren().length);
+        assertEquals(0, config.getChildren().length, "Invalid children count");
     }
 
     @Test
@@ -73,7 +73,7 @@ public class DefaultConfigurationTest {
         config.addMessage("key", "value");
         final Map<String, String> expected = new TreeMap<>();
         expected.put("key", "value");
-        assertEquals("Invalid message map", expected, config.getMessages());
+        assertEquals(expected, config.getMessages(), "Invalid message map");
     }
 
     @Test
@@ -86,9 +86,9 @@ public class DefaultConfigurationTest {
             fail("Exception is expected");
         }
         catch (CheckstyleException expected) {
-            assertEquals("Invalid exception message",
+            assertEquals(
                     "missing key '" + attributeName + "' in " + name,
-                    expected.getMessage());
+                    expected.getMessage(), "Invalid exception message");
         }
     }
 
@@ -98,7 +98,7 @@ public class DefaultConfigurationTest {
         final DefaultConfiguration config = new DefaultConfiguration(name);
         final ThreadModeSettings singleThreadMode =
                 ThreadModeSettings.SINGLE_THREAD_MODE_INSTANCE;
-        assertEquals("Invalid thread mode", singleThreadMode, config.getThreadModeSettings());
+        assertEquals(singleThreadMode, config.getThreadModeSettings(), "Invalid thread mode");
     }
 
     @Test
@@ -107,7 +107,7 @@ public class DefaultConfigurationTest {
         final ThreadModeSettings multiThreadMode =
                 new ThreadModeSettings(4, 2);
         final DefaultConfiguration config = new DefaultConfiguration(name, multiThreadMode);
-        assertEquals("Invalid thread mode", multiThreadMode, config.getThreadModeSettings());
+        assertEquals(multiThreadMode, config.getThreadModeSettings(), "Invalid thread mode");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
@@ -19,17 +19,17 @@
 
 package com.puppycrawl.tools.checkstyle;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
@@ -60,9 +60,9 @@ public class DefaultLoggerTest {
                 new String[] {"myfile"}, null,
                 getClass(), null);
 
-        assertTrue("Invalid exception", output.contains(addExceptionMessage.getMessage()));
-        assertTrue("Invalid exception class",
-            output.contains("java.lang.IllegalStateException: upsss"));
+        assertTrue(output.contains(addExceptionMessage.getMessage()), "Invalid exception");
+        assertTrue(output.contains("java.lang.IllegalStateException: upsss"),
+                "Invalid exception class");
     }
 
     @Test
@@ -72,8 +72,8 @@ public class DefaultLoggerTest {
         dl.addException(new AuditEvent(5000, "myfile"), new IllegalStateException("upsss"));
         dl.auditFinished(new AuditEvent(6000, "myfile"));
         final String output = infoStream.toString();
-        assertTrue("Message should contain exception info, but was " + output,
-                output.contains("java.lang.IllegalStateException: upsss"));
+        assertTrue(output.contains("java.lang.IllegalStateException: upsss"),
+                "Message should contain exception info, but was " + output);
     }
 
     @Test
@@ -83,8 +83,8 @@ public class DefaultLoggerTest {
                 AutomaticBean.OutputStreamOptions.NONE);
         dl.addException(new AuditEvent(5000, "myfile"), new IllegalStateException("upsss"));
         dl.auditFinished(new AuditEvent(6000, "myfile"));
-        assertTrue("Message should contain exception info, but was " + infoStream,
-                infoStream.toString().contains("java.lang.IllegalStateException: upsss"));
+        assertTrue(infoStream.toString().contains("java.lang.IllegalStateException: upsss"),
+                "Message should contain exception info, but was " + infoStream);
     }
 
     @Test
@@ -92,12 +92,12 @@ public class DefaultLoggerTest {
         try {
             final DefaultLogger logger = new DefaultLogger(new ByteArrayOutputStream(), null);
             // assert required to calm down eclipse's 'The allocated object is never used' violation
-            assertNotNull("Null instance", logger);
+            assertNotNull(logger, "Null instance");
             fail("Exception was expected");
         }
         catch (IllegalArgumentException exception) {
-            assertEquals("Invalid error message", "Parameter infoStreamOptions can not be null",
-                    exception.getMessage());
+            assertEquals("Parameter infoStreamOptions can not be null",
+                    exception.getMessage(), "Invalid error message");
         }
     }
 
@@ -107,12 +107,12 @@ public class DefaultLoggerTest {
             final DefaultLogger logger = new DefaultLogger(new ByteArrayOutputStream(),
                 AutomaticBean.OutputStreamOptions.CLOSE, new ByteArrayOutputStream(), null);
             // assert required to calm down eclipse's 'The allocated object is never used' violation
-            assertNotNull("Null instance", logger);
+            assertNotNull(logger, "Null instance");
             fail("Exception was expected");
         }
         catch (IllegalArgumentException exception) {
-            assertEquals("Invalid error message", "Parameter errorStreamOptions can not be null",
-                    exception.getMessage());
+            assertEquals("Parameter errorStreamOptions can not be null",
+                    exception.getMessage(), "Invalid error message");
         }
     }
 
@@ -128,10 +128,11 @@ public class DefaultLoggerTest {
         dl.addError(new AuditEvent(this, "fileName", new LocalizedMessage(1, 2, "bundle", "key",
                 null, null, getClass(), "customMessage")));
         dl.auditFinished(null);
-        assertEquals("expected output", auditStartMessage.getMessage() + System.lineSeparator()
-                + auditFinishMessage.getMessage() + System.lineSeparator(), infoStream.toString());
-        assertEquals("expected output", "[ERROR] fileName:1:2: customMessage [DefaultLoggerTest]"
-                + System.lineSeparator(), errorStream.toString());
+        assertEquals(auditStartMessage.getMessage() + System.lineSeparator()
+                + auditFinishMessage.getMessage() + System.lineSeparator(), infoStream.toString(),
+                "expected output");
+        assertEquals("[ERROR] fileName:1:2: customMessage [DefaultLoggerTest]"
+                + System.lineSeparator(), errorStream.toString(), "expected output");
     }
 
     @Test
@@ -145,10 +146,11 @@ public class DefaultLoggerTest {
         dl.addError(new AuditEvent(this, "fileName", new LocalizedMessage(1, 2, "bundle", "key",
                 null, "moduleId", getClass(), "customMessage")));
         dl.auditFinished(null);
-        assertEquals("expected output", auditStartMessage.getMessage() + System.lineSeparator()
-                + auditFinishMessage.getMessage() + System.lineSeparator(), infoStream.toString());
-        assertEquals("expected output", "[ERROR] fileName:1:2: customMessage [moduleId]"
-                + System.lineSeparator(), errorStream.toString());
+        assertEquals(auditStartMessage.getMessage() + System.lineSeparator()
+                + auditFinishMessage.getMessage() + System.lineSeparator(), infoStream.toString(),
+                "expected output");
+        assertEquals("[ERROR] fileName:1:2: customMessage [moduleId]"
+                + System.lineSeparator(), errorStream.toString(), "expected output");
     }
 
     @Test
@@ -159,7 +161,7 @@ public class DefaultLoggerTest {
         dl.finishLocalSetup();
         dl.auditStarted(null);
         dl.auditFinished(null);
-        assertNotNull("instance should not be null", dl);
+        assertNotNull(dl, "instance should not be null");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DefinitionsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DefinitionsTest.java
@@ -20,16 +20,16 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DefinitionsTest {
 
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
-        assertTrue("Constructor is not private",
-                isUtilsClassHasPrivateConstructor(Definitions.class, true));
+        assertTrue(isUtilsClassHasPrivateConstructor(Definitions.class, true),
+                "Constructor is not private");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
@@ -19,12 +19,12 @@
 
 package com.puppycrawl.tools.checkstyle;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.Writer;
@@ -39,9 +39,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.function.Consumer;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.powermock.reflect.Whitebox;
 
 import antlr.CommonHiddenStreamToken;
@@ -55,8 +54,8 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  */
 public class DetailAstImplTest extends AbstractModuleTestSupport {
 
-    @Rule
-    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    public File temporaryFolder;
 
     @Override
     protected String getPackageLocation() {
@@ -82,10 +81,10 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
         final DetailAstImpl copy = new DetailAstImpl();
         copy.initialize(ast);
 
-        assertEquals("Invalid text", "test", copy.getText());
-        assertEquals("Invalid type", 1, copy.getType());
-        assertEquals("Invalid line number", 2, copy.getLineNo());
-        assertEquals("Invalid column number", 3, copy.getColumnNo());
+        assertEquals("test", copy.getText(), "Invalid text");
+        assertEquals(1, copy.getType(), "Invalid type");
+        assertEquals(2, copy.getLineNo(), "Invalid line number");
+        assertEquals(3, copy.getColumnNo(), "Invalid column number");
     }
 
     @Test
@@ -99,10 +98,10 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
         final DetailAstImpl ast = new DetailAstImpl();
         ast.initialize(token);
 
-        assertEquals("Invalid text", "test", ast.getText());
-        assertEquals("Invalid type", 1, ast.getType());
-        assertEquals("Invalid line number", 2, ast.getLineNo());
-        assertEquals("Invalid column number", 3, ast.getColumnNo());
+        assertEquals("test", ast.getText(), "Invalid text");
+        assertEquals(1, ast.getType(), "Invalid type");
+        assertEquals(2, ast.getLineNo(), "Invalid line number");
+        assertEquals(3, ast.getColumnNo(), "Invalid column number");
     }
 
     @Test
@@ -123,16 +122,16 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
 
         setParentMethod.invoke(secondLevelA, root);
 
-        assertEquals("Invalid child count", 0, secondLevelA.getChildCount());
-        assertEquals("Invalid child count", 0, firstLevelB.getChildCount());
-        assertEquals("Invalid child count", 1, firstLevelA.getChildCount());
-        assertEquals("Invalid child count", 2, root.getChildCount());
-        assertEquals("Invalid child count", 2, root.getChildCount());
+        assertEquals(0, secondLevelA.getChildCount(), "Invalid child count");
+        assertEquals(0, firstLevelB.getChildCount(), "Invalid child count");
+        assertEquals(1, firstLevelA.getChildCount(), "Invalid child count");
+        assertEquals(2, root.getChildCount(), "Invalid child count");
+        assertEquals(2, root.getChildCount(), "Invalid child count");
 
-        assertNull("Previous sibling should be null", root.getPreviousSibling());
-        assertNull("Previous sibling should be null", firstLevelA.getPreviousSibling());
-        assertNull("Previous sibling should be null", secondLevelA.getPreviousSibling());
-        assertEquals("Invalid previous sibling", firstLevelA, firstLevelB.getPreviousSibling());
+        assertNull(root.getPreviousSibling(), "Previous sibling should be null");
+        assertNull(firstLevelA.getPreviousSibling(), "Previous sibling should be null");
+        assertNull(secondLevelA.getPreviousSibling(), "Previous sibling should be null");
+        assertEquals(firstLevelA, firstLevelB.getPreviousSibling(), "Invalid previous sibling");
     }
 
     @Test
@@ -152,11 +151,16 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
 
         setParentMethod.invoke(firstLevelB, root);
 
-        assertEquals("Invalid child count", 0, firstLevelB.getChildCount(0));
-        assertEquals("Invalid child count", 0, firstLevelA.getChildCount(TokenTypes.EXPR));
-        assertEquals("Invalid child count", 1, root.getChildCount(TokenTypes.IDENT));
-        assertEquals("Invalid child count", 1, root.getChildCount(TokenTypes.EXPR));
-        assertEquals("Invalid child count", 0, root.getChildCount(0));
+        final int childCountLevelB = firstLevelB.getChildCount(0);
+        assertEquals(0, childCountLevelB, "Invalid child count");
+        final int childCountLevelA = firstLevelA.getChildCount(TokenTypes.EXPR);
+        assertEquals(0, childCountLevelA, "Invalid child count");
+        final int identTypeCount = root.getChildCount(TokenTypes.IDENT);
+        assertEquals(1, identTypeCount, "Invalid child count");
+        final int exprTypeCount = root.getChildCount(TokenTypes.EXPR);
+        assertEquals(1, exprTypeCount, "Invalid child count");
+        final int invalidTypeCount = root.getChildCount(0);
+        assertEquals(0, invalidTypeCount, "Invalid child count");
     }
 
     @Test
@@ -166,13 +170,13 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
 
         root.setFirstChild(firstLevelA);
 
-        assertEquals("Invalid child count", 1, root.getChildCount());
+        assertEquals(1, root.getChildCount(), "Invalid child count");
 
         getSetParentMethod().invoke(firstLevelA, root);
         firstLevelA.addPreviousSibling(null);
         firstLevelA.addNextSibling(null);
 
-        assertEquals("Invalid child count", 1, root.getChildCount());
+        assertEquals(1, root.getChildCount(), "Invalid child count");
     }
 
     @Test
@@ -185,17 +189,17 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
 
         instance.addPreviousSibling(previousSibling);
 
-        assertEquals("unexpected result", previousSibling, instance.getPreviousSibling());
-        assertEquals("unexpected result", previousSibling, parent.getFirstChild());
+        assertEquals(previousSibling, instance.getPreviousSibling(), "unexpected result");
+        assertEquals(previousSibling, parent.getFirstChild(), "unexpected result");
 
         final DetailAST newPreviousSibling = new DetailAstImpl();
 
         instance.addPreviousSibling(newPreviousSibling);
 
-        assertEquals("unexpected result", newPreviousSibling, instance.getPreviousSibling());
-        assertEquals("unexpected result", previousSibling, newPreviousSibling.getPreviousSibling());
-        assertEquals("unexpected result", newPreviousSibling, previousSibling.getNextSibling());
-        assertEquals("unexpected result", previousSibling, parent.getFirstChild());
+        assertEquals(newPreviousSibling, instance.getPreviousSibling(), "unexpected result");
+        assertEquals(previousSibling, newPreviousSibling.getPreviousSibling(), "unexpected result");
+        assertEquals(newPreviousSibling, previousSibling.getNextSibling(), "unexpected result");
+        assertEquals(previousSibling, parent.getFirstChild(), "unexpected result");
     }
 
     @Test
@@ -205,8 +209,8 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
 
         child.addPreviousSibling(newSibling);
 
-        assertEquals("Invalid child token", child, newSibling.getNextSibling());
-        assertEquals("Invalid child token", newSibling, child.getPreviousSibling());
+        assertEquals(child, newSibling.getNextSibling(), "Invalid child token");
+        assertEquals(newSibling, child.getPreviousSibling(), "Invalid child token");
     }
 
     @Test
@@ -216,23 +220,23 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
         final DetailAST firstLevelB = new DetailAstImpl();
         final DetailAST firstLevelC = new DetailAstImpl();
 
-        assertEquals("Invalid child count", 0, root.getChildCount());
+        assertEquals(0, root.getChildCount(), "Invalid child count");
 
         root.setFirstChild(firstLevelA);
         final Method setParentMethod = getSetParentMethod();
         setParentMethod.invoke(firstLevelA, root);
 
-        assertEquals("Invalid child count", 1, root.getChildCount());
+        assertEquals(1, root.getChildCount(), "Invalid child count");
 
         firstLevelA.addNextSibling(firstLevelB);
         setParentMethod.invoke(firstLevelB, root);
 
-        assertEquals("Invalid next sibling", firstLevelB, firstLevelA.getNextSibling());
+        assertEquals(firstLevelB, firstLevelA.getNextSibling(), "Invalid next sibling");
 
         firstLevelA.addNextSibling(firstLevelC);
         setParentMethod.invoke(firstLevelC, root);
 
-        assertEquals("Invalid next sibling", firstLevelC, firstLevelA.getNextSibling());
+        assertEquals(firstLevelC, firstLevelA.getNextSibling(), "Invalid next sibling");
     }
 
     @Test
@@ -241,8 +245,8 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
         final DetailAstImpl modifiers = createToken(root, TokenTypes.MODIFIERS);
         createToken(modifiers, TokenTypes.LITERAL_PUBLIC);
 
-        assertTrue("invalid result", root.branchContains(TokenTypes.LITERAL_PUBLIC));
-        assertFalse("invalid result", root.branchContains(TokenTypes.OBJBLOCK));
+        assertTrue(root.branchContains(TokenTypes.LITERAL_PUBLIC), "invalid result");
+        assertFalse(root.branchContains(TokenTypes.OBJBLOCK), "invalid result");
     }
 
     private static DetailAstImpl createToken(DetailAstImpl root, int type) {
@@ -281,9 +285,9 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
             final BitSet branchTokenTypes = Whitebox.invokeMethod(parent, "getBranchTokenTypes");
             method.accept(null);
             final BitSet branchTokenTypes2 = Whitebox.invokeMethod(parent, "getBranchTokenTypes");
-            assertEquals("Branch token types are not equal", branchTokenTypes, branchTokenTypes2);
-            assertNotSame("Branch token types should not be the same",
-                    branchTokenTypes, branchTokenTypes2);
+            assertEquals(branchTokenTypes, branchTokenTypes2, "Branch token types are not equal");
+            assertNotSame(branchTokenTypes, branchTokenTypes2,
+                    "Branch token types should not be the same");
         }
     }
 
@@ -294,7 +298,7 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
         bitSet.set(999);
 
         Whitebox.setInternalState(root, "branchTokenTypes", bitSet);
-        assertTrue("Branch tokens has changed", root.branchContains(999));
+        assertTrue(root.branchContains(999), "Branch tokens has changed");
     }
 
     @Test
@@ -314,16 +318,16 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
             method.accept(null);
             final int intermediateCount = Whitebox.getInternalState(parent, "childCount");
             final int finishCount = parent.getChildCount();
-            assertEquals("Child count has changed", startCount, finishCount);
-            assertEquals("Invalid child count", Integer.MIN_VALUE, intermediateCount);
+            assertEquals(startCount, finishCount, "Child count has changed");
+            assertEquals(Integer.MIN_VALUE, intermediateCount, "Invalid child count");
         }
 
         final int startCount = child.getChildCount();
         child.addChild(null);
         final int intermediateCount = Whitebox.getInternalState(child, "childCount");
         final int finishCount = child.getChildCount();
-        assertEquals("Child count has changed", startCount, finishCount);
-        assertEquals("Invalid child count", Integer.MIN_VALUE, intermediateCount);
+        assertEquals(startCount, finishCount, "Child count has changed");
+        assertEquals(Integer.MIN_VALUE, intermediateCount, "Invalid child count");
     }
 
     @Test
@@ -331,7 +335,7 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
         final DetailAST root = new DetailAstImpl();
 
         Whitebox.setInternalState(root, "childCount", 999);
-        assertEquals("Child count has changed", 999, root.getChildCount());
+        assertEquals(999, root.getChildCount(), "Child count has changed");
     }
 
     @Test
@@ -344,9 +348,9 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
         child.setNextSibling(sibling);
         child.addNextSibling(newSibling);
 
-        assertEquals("Invalid parent", parent, newSibling.getParent());
-        assertEquals("Invalid next sibling", sibling, newSibling.getNextSibling());
-        assertEquals("Invalid child", newSibling, child.getNextSibling());
+        assertEquals(parent, newSibling.getParent(), "Invalid parent");
+        assertEquals(sibling, newSibling.getNextSibling(), "Invalid next sibling");
+        assertEquals(newSibling, child.getNextSibling(), "Invalid child");
     }
 
     @Test
@@ -357,61 +361,61 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
         oldParent.addChild(newSibling);
         child.addNextSibling(newSibling);
 
-        assertEquals("Invalid parent", oldParent, newSibling.getParent());
-        assertNull("Invalid next sibling", newSibling.getNextSibling());
-        assertEquals("Invalid child", newSibling, child.getNextSibling());
+        assertEquals(oldParent, newSibling.getParent(), "Invalid parent");
+        assertNull(newSibling.getNextSibling(), "Invalid next sibling");
+        assertEquals(newSibling, child.getNextSibling(), "Invalid child");
     }
 
     @Test
     public void testGetLineNo() {
         final DetailAstImpl root1 = new DetailAstImpl();
         root1.setLineNo(1);
-        assertEquals("Invalid line number", 1, root1.getLineNo());
+        assertEquals(1, root1.getLineNo(), "Invalid line number");
 
         final DetailAstImpl root2 = new DetailAstImpl();
         final DetailAstImpl firstChild = new DetailAstImpl();
         firstChild.setLineNo(2);
         root2.setFirstChild(firstChild);
-        assertEquals("Invalid line number", 2, root2.getLineNo());
+        assertEquals(2, root2.getLineNo(), "Invalid line number");
 
         final DetailAstImpl root3 = new DetailAstImpl();
         final DetailAstImpl nextSibling = new DetailAstImpl();
         nextSibling.setLineNo(3);
         root3.setNextSibling(nextSibling);
-        assertEquals("Invalid line number", 3, root3.getLineNo());
+        assertEquals(3, root3.getLineNo(), "Invalid line number");
 
         final DetailAstImpl root4 = new DetailAstImpl();
         final DetailAstImpl comment = new DetailAstImpl();
         comment.setType(TokenTypes.SINGLE_LINE_COMMENT);
         comment.setLineNo(3);
         root4.setFirstChild(comment);
-        assertEquals("Invalid line number", Integer.MIN_VALUE, root4.getLineNo());
+        assertEquals(Integer.MIN_VALUE, root4.getLineNo(), "Invalid line number");
     }
 
     @Test
     public void testGetColumnNo() {
         final DetailAstImpl root1 = new DetailAstImpl();
         root1.setColumnNo(1);
-        assertEquals("Invalid column number", 1, root1.getColumnNo());
+        assertEquals(1, root1.getColumnNo(), "Invalid column number");
 
         final DetailAstImpl root2 = new DetailAstImpl();
         final DetailAstImpl firstChild = new DetailAstImpl();
         firstChild.setColumnNo(2);
         root2.setFirstChild(firstChild);
-        assertEquals("Invalid column number", 2, root2.getColumnNo());
+        assertEquals(2, root2.getColumnNo(), "Invalid column number");
 
         final DetailAstImpl root3 = new DetailAstImpl();
         final DetailAstImpl nextSibling = new DetailAstImpl();
         nextSibling.setColumnNo(3);
         root3.setNextSibling(nextSibling);
-        assertEquals("Invalid column number", 3, root3.getColumnNo());
+        assertEquals(3, root3.getColumnNo(), "Invalid column number");
 
         final DetailAstImpl root4 = new DetailAstImpl();
         final DetailAstImpl comment = new DetailAstImpl();
         comment.setType(TokenTypes.SINGLE_LINE_COMMENT);
         comment.setColumnNo(3);
         root4.setFirstChild(comment);
-        assertEquals("Invalid column number", Integer.MIN_VALUE, root4.getColumnNo());
+        assertEquals(Integer.MIN_VALUE, root4.getColumnNo(), "Invalid column number");
     }
 
     @Test
@@ -428,15 +432,17 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
         root.addChild(secondChild);
         root.addChild(thirdChild);
 
-        assertNull("Invalid result", firstChild.findFirstToken(TokenTypes.IDENT));
-        assertEquals("Invalid result", firstChild, root.findFirstToken(TokenTypes.IDENT));
-        assertEquals("Invalid result", secondChild, root.findFirstToken(TokenTypes.EXPR));
-        assertNull("Invalid result", root.findFirstToken(0));
+        assertNull(firstChild.findFirstToken(TokenTypes.IDENT), "Invalid result");
+        final DetailAST ident = root.findFirstToken(TokenTypes.IDENT);
+        assertEquals(firstChild, ident, "Invalid result");
+        final DetailAST expr = root.findFirstToken(TokenTypes.EXPR);
+        assertEquals(secondChild, expr, "Invalid result");
+        assertNull(root.findFirstToken(0), "Invalid result");
     }
 
     @Test
     public void testManyComments() throws Exception {
-        final File file = temporaryFolder.newFile("InputDetailASTManyComments.java");
+        final File file = new File(temporaryFolder, "InputDetailASTManyComments.java");
 
         try (Writer bw = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8)) {
             bw.write("class C {\n");
@@ -462,9 +468,9 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
             final DetailAST rootAST = JavaParser.parseFile(new File(fileName),
                     JavaParser.Options.WITHOUT_COMMENTS);
 
-            assertNotNull("file must return a root node: " + fileName, rootAST);
+            assertNotNull(rootAST, "file must return a root node: " + fileName);
 
-            assertTrue("tree is valid", checkTree(fileName, rootAST));
+            assertTrue(checkTree(fileName, rootAST), "tree is valid");
         }
     }
 
@@ -474,7 +480,7 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
         ast.setText("text");
         ast.setColumnNo(0);
         ast.setLineNo(0);
-        assertEquals("Invalid text", "text[0x0]", ast.toString());
+        assertEquals("text[0x0]", ast.toString(), "Invalid text");
     }
 
     private static List<File> getAllFiles(File dir) {
@@ -542,11 +548,11 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
         final MessageFormat badParentFormatter = new MessageFormat(
                 "Bad parent node={0} parent={1} filename={3} root={4}", Locale.ROOT);
         final String badParentMsg = badParentFormatter.format(params);
-        assertEquals(badParentMsg, parent, node.getParent());
+        assertEquals(parent, node.getParent(), badParentMsg);
         final MessageFormat badPrevFormatter = new MessageFormat(
                 "Bad prev node={0} prev={2} parent={1} filename={3} root={4}", Locale.ROOT);
         final String badPrevMsg = badPrevFormatter.format(params);
-        assertEquals(badPrevMsg, prev, node.getPreviousSibling());
+        assertEquals(prev, node.getPreviousSibling(), badPrevMsg);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
@@ -23,14 +23,14 @@ import static com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.MSG_JAVADO
 import static com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.MSG_JAVADOC_PARSE_RULE_ERROR;
 import static com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.MSG_JAVADOC_WRONG_SINGLETON_TAG;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.lang.reflect.Method;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.ParseErrorMessage;
@@ -51,8 +51,8 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
 
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
-        assertTrue("Constructor is not private",
-                isUtilsClassHasPrivateConstructor(DetailNodeTreeStringPrinter.class, true));
+        assertTrue(isUtilsClassHasPrivateConstructor(DetailNodeTreeStringPrinter.class, true),
+                "Constructor is not private");
     }
 
     @Test
@@ -66,13 +66,13 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
         try {
             DetailNodeTreeStringPrinter.printFileAst(
                     new File(getPath("InputDetailNodeTreeStringPrinterJavadocWithError.javadoc")));
-            Assert.fail("Javadoc parser didn't fail on missing end tag");
+            fail("Javadoc parser didn't fail on missing end tag");
         }
         catch (IllegalArgumentException ex) {
             final String expected = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
                     new ParseErrorMessage(0, MSG_JAVADOC_MISSED_HTML_CLOSE, 1, "qwe"));
-            assertEquals("Generated and expected parse error messages don't match",
-                    expected, ex.getMessage());
+            assertEquals(expected, ex.getMessage(),
+                    "Generated and expected parse error messages don't match");
         }
     }
 
@@ -96,8 +96,8 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
                 DetailNodeTreeStringPrinter.class,
                 null);
         final String expected = "[ERROR:35] " + localizedMessage.getMessage();
-        assertEquals("Javadoc parse error message for missed HTML tag doesn't meet expectations",
-                expected, actual);
+        assertEquals(expected, actual,
+                "Javadoc parse error message for missed HTML tag doesn't meet expectations");
     }
 
     @Test
@@ -114,7 +114,7 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
                 DetailNodeTreeStringPrinter.class,
                 null);
         final String expected = "[ERROR:10] " + localizedMessage.getMessage();
-        assertEquals("Javadoc parse error message doesn't meet expectations", expected, actual);
+        assertEquals(expected, actual, "Javadoc parse error message doesn't meet expectations");
     }
 
     @Test
@@ -131,8 +131,9 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
                 DetailNodeTreeStringPrinter.class,
                 null);
         final String expected = "[ERROR:100] " + localizedMessage.getMessage();
-        assertEquals("Javadoc parse error message for void elements with close tag "
-                + "doesn't meet expectations", expected, actual);
+        assertEquals(expected, actual,
+                "Javadoc parse error message for void elements with close tag "
+                    + "doesn't meet expectations");
     }
 
     @Test
@@ -141,13 +142,13 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             DetailNodeTreeStringPrinter.printFileAst(new File(
                     getPath("InputDetailNodeTreeStringPrinter"
                             + "UnescapedJavaCodeWithGenericsInJavadoc.javadoc")));
-            Assert.fail("Exception is expected");
+            fail("Exception is expected");
         }
         catch (IllegalArgumentException ex) {
             final String expected = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
                     new ParseErrorMessage(35, MSG_JAVADOC_MISSED_HTML_CLOSE, 7, "parsing"));
-            assertEquals("Generated and expected parse error messages don't match",
-                    expected, ex.getMessage());
+            assertEquals(expected, ex.getMessage(),
+                    "Generated and expected parse error messages don't match");
         }
     }
 
@@ -156,14 +157,14 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
         try {
             DetailNodeTreeStringPrinter.printFileAst(new File(getPath(
                     "InputDetailNodeTreeStringPrinterNoViableAltException.javadoc")));
-            Assert.fail("Exception is expected");
+            fail("Exception is expected");
         }
         catch (IllegalArgumentException ex) {
             final String expected = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
                     new ParseErrorMessage(0, MSG_JAVADOC_PARSE_RULE_ERROR,
                             9, "no viable alternative at input '<<'", "HTML_ELEMENT"));
-            assertEquals("Generated and expected parse error messages don't match",
-                    expected, ex.getMessage());
+            assertEquals(expected, ex.getMessage(),
+                    "Generated and expected parse error messages don't match");
         }
     }
 
@@ -173,14 +174,14 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             DetailNodeTreeStringPrinter.printFileAst(new File(getPath(
                     "InputDetailNodeTreeStringPrinterHtmlTagCloseBeforeTagOpen.javadoc"
             )));
-            Assert.fail("Exception is expected");
+            fail("Exception is expected");
         }
         catch (IllegalArgumentException ex) {
             final String expected = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
                     new ParseErrorMessage(0, MSG_JAVADOC_PARSE_RULE_ERROR,
                             4, "no viable alternative at input '</tag'", "HTML_ELEMENT"));
-            assertEquals("Generated and expected parse error messages don't match",
-                    expected, ex.getMessage());
+            assertEquals(expected, ex.getMessage(),
+                    "Generated and expected parse error messages don't match");
         }
     }
 
@@ -190,13 +191,13 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             DetailNodeTreeStringPrinter.printFileAst(new File(getPath(
                     "InputDetailNodeTreeStringPrinterWrongHtmlTagOrder.javadoc"
             )));
-            Assert.fail("Exception is expected");
+            fail("Exception is expected");
         }
         catch (IllegalArgumentException ex) {
             final String expected = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
                     new ParseErrorMessage(0, MSG_JAVADOC_MISSED_HTML_CLOSE, 10, "tag2"));
-            assertEquals("Generated and expected parse error messages don't match",
-                    expected, ex.getMessage());
+            assertEquals(expected, ex.getMessage(),
+                    "Generated and expected parse error messages don't match");
         }
     }
 
@@ -206,13 +207,13 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             DetailNodeTreeStringPrinter.printFileAst(new File(getPath(
                     "InputDetailNodeTreeStringPrinterOmittedStartTagForHtmlElement.javadoc"
             )));
-            Assert.fail("Exception is expected");
+            fail("Exception is expected");
         }
         catch (IllegalArgumentException ex) {
             final String expected = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
                     new ParseErrorMessage(0, MSG_JAVADOC_MISSED_HTML_CLOSE, 3, "a"));
-            assertEquals("Generated and expected parse error messages don't match",
-                    expected, ex.getMessage());
+            assertEquals(expected, ex.getMessage(),
+                    "Generated and expected parse error messages don't match");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavaParserTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavaParserTest.java
@@ -19,11 +19,13 @@
 
 package com.puppycrawl.tools.checkstyle;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -31,8 +33,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import antlr.NoViableAltException;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -49,13 +50,13 @@ public class JavaParserTest extends AbstractModuleTestSupport {
 
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
-        assertTrue("Constructor is not private", TestUtil.isUtilsClassHasPrivateConstructor(
-            JavaParser.class, false));
+        assertTrue(TestUtil.isUtilsClassHasPrivateConstructor(
+            JavaParser.class, false), "Constructor is not private");
     }
 
     @Test
     public void testNullRootWithComments() {
-        assertNull("Invalid return root", JavaParser.appendHiddenCommentNodes(null));
+        assertNull(JavaParser.appendHiddenCommentNodes(null), "Invalid return root");
     }
 
     @Test
@@ -67,21 +68,21 @@ public class JavaParserTest extends AbstractModuleTestSupport {
         final Optional<DetailAST> blockComment = TestUtil.findTokenInAstByPredicate(root,
             ast -> ast.getType() == TokenTypes.BLOCK_COMMENT_BEGIN);
 
-        assertTrue("Block comment should be present", blockComment.isPresent());
+        assertTrue(blockComment.isPresent(), "Block comment should be present");
 
         final DetailAST comment = blockComment.get();
 
-        assertEquals("Unexpected line number", 3, comment.getLineNo());
-        assertEquals("Unexpected column number", 0, comment.getColumnNo());
-        assertEquals("Unexpected comment content", "/*", comment.getText());
+        assertEquals(3, comment.getLineNo(), "Unexpected line number");
+        assertEquals(0, comment.getColumnNo(), "Unexpected column number");
+        assertEquals("/*", comment.getText(), "Unexpected comment content");
 
         final DetailAST commentContent = comment.getFirstChild();
         final DetailAST commentEnd = comment.getLastChild();
 
-        assertEquals("Unexpected line number", 3, commentContent.getLineNo());
-        assertEquals("Unexpected column number", 2, commentContent.getColumnNo());
-        assertEquals("Unexpected line number", 9, commentEnd.getLineNo());
-        assertEquals("Unexpected column number", 1, commentEnd.getColumnNo());
+        assertEquals(3, commentContent.getLineNo(), "Unexpected line number");
+        assertEquals(2, commentContent.getColumnNo(), "Unexpected column number");
+        assertEquals(9, commentEnd.getLineNo(), "Unexpected line number");
+        assertEquals(1, commentEnd.getColumnNo(), "Unexpected column number");
     }
 
     @Test
@@ -92,21 +93,21 @@ public class JavaParserTest extends AbstractModuleTestSupport {
 
         final Optional<DetailAST> singleLineComment = TestUtil.findTokenInAstByPredicate(root,
             ast -> ast.getType() == TokenTypes.SINGLE_LINE_COMMENT);
-        assertTrue("Single line comment should be present", singleLineComment.isPresent());
+        assertTrue(singleLineComment.isPresent(), "Single line comment should be present");
 
         final DetailAST comment = singleLineComment.get();
 
-        assertEquals("Unexpected line number", 13, comment.getLineNo());
-        assertEquals("Unexpected column number", 0, comment.getColumnNo());
-        assertEquals("Unexpected comment content", "//", comment.getText());
+        assertEquals(13, comment.getLineNo(), "Unexpected line number");
+        assertEquals(0, comment.getColumnNo(), "Unexpected column number");
+        assertEquals("//", comment.getText(), "Unexpected comment content");
 
         final DetailAST commentContent = comment.getFirstChild();
 
-        assertEquals("Unexpected token type", TokenTypes.COMMENT_CONTENT, commentContent.getType());
-        assertEquals("Unexpected line number", 13, commentContent.getLineNo());
-        assertEquals("Unexpected column number", 2, commentContent.getColumnNo());
-        assertTrue("Unexpected comment content",
-            commentContent.getText().startsWith(" inline comment"));
+        assertEquals(TokenTypes.COMMENT_CONTENT, commentContent.getType(), "Unexpected token type");
+        assertEquals(13, commentContent.getLineNo(), "Unexpected line number");
+        assertEquals(2, commentContent.getColumnNo(), "Unexpected column number");
+        assertTrue(commentContent.getText().startsWith(" inline comment"),
+                "Unexpected comment content");
     }
 
     @Test
@@ -117,21 +118,21 @@ public class JavaParserTest extends AbstractModuleTestSupport {
 
         final Optional<DetailAST> singleLineComment = TestUtil.findTokenInAstByPredicate(root,
             ast -> ast.getType() == TokenTypes.SINGLE_LINE_COMMENT);
-        assertTrue("Single line comment should be present", singleLineComment.isPresent());
+        assertTrue(singleLineComment.isPresent(), "Single line comment should be present");
 
         final DetailAST comment = singleLineComment.get();
 
-        assertEquals("Unexpected line number", 1, comment.getLineNo());
-        assertEquals("Unexpected column number", 4, comment.getColumnNo());
-        assertEquals("Unexpected comment content", "//", comment.getText());
+        assertEquals(1, comment.getLineNo(), "Unexpected line number");
+        assertEquals(4, comment.getColumnNo(), "Unexpected column number");
+        assertEquals("//", comment.getText(), "Unexpected comment content");
 
         final DetailAST commentContent = comment.getFirstChild();
 
-        assertEquals("Unexpected token type", TokenTypes.COMMENT_CONTENT, commentContent.getType());
-        assertEquals("Unexpected line number", 1, commentContent.getLineNo());
-        assertEquals("Unexpected column number", 6, commentContent.getColumnNo());
-        assertTrue("Unexpected comment content",
-            commentContent.getText().startsWith(" indented comment"));
+        assertEquals(TokenTypes.COMMENT_CONTENT, commentContent.getType(), "Unexpected token type");
+        assertEquals(1, commentContent.getLineNo(), "Unexpected line number");
+        assertEquals(6, commentContent.getColumnNo(), "Unexpected column number");
+        assertTrue(commentContent.getText().startsWith(" indented comment"),
+                "Unexpected comment content");
     }
 
     @Test
@@ -142,7 +143,7 @@ public class JavaParserTest extends AbstractModuleTestSupport {
 
         final Optional<DetailAST> singleLineComment = TestUtil.findTokenInAstByPredicate(root,
             ast -> ast.getType() == TokenTypes.SINGLE_LINE_COMMENT);
-        assertFalse("Single line comment should be present", singleLineComment.isPresent());
+        assertFalse(singleLineComment.isPresent(), "Single line comment should be present");
     }
 
     @Test
@@ -150,19 +151,17 @@ public class JavaParserTest extends AbstractModuleTestSupport {
         final File input = new File(getNonCompilablePath("InputJavaParser.java"));
         try {
             JavaParser.parseFile(input, JavaParser.Options.WITH_COMMENTS);
-            Assert.fail("exception expected");
+            fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid exception message",
+            assertEquals(
                     CheckstyleException.class.getName()
                             + ": NoViableAltException occurred while parsing file "
                             + input.getAbsolutePath() + ".",
-                    ex.toString());
-            Assert.assertSame("Invalid class",
-                    NoViableAltException.class, ex.getCause().getClass());
-            assertEquals("Invalid exception message",
-                    input.getAbsolutePath() + ":2:1: unexpected token: classD",
-                    ex.getCause().toString());
+                    ex.toString(), "Invalid exception message");
+            assertSame(NoViableAltException.class, ex.getCause().getClass(), "Invalid class");
+            assertEquals(input.getAbsolutePath() + ":2:1: unexpected token: classD",
+                    ex.getCause().toString(), "Invalid exception message");
         }
     }
 
@@ -173,12 +172,12 @@ public class JavaParserTest extends AbstractModuleTestSupport {
                 JavaParser.Options.WITH_COMMENTS);
         final CountComments counter = new CountComments(root);
 
-        assertArrayEquals("Invalid line comments",
+        assertArrayEquals(
                 Arrays.asList("1,4", "6,4", "9,0").toArray(),
-                counter.lineComments.toArray());
-        assertArrayEquals("Invalid block comments",
+                counter.lineComments.toArray(), "Invalid line comments");
+        assertArrayEquals(
                 Arrays.asList("5,4", "8,0").toArray(),
-                counter.blockComments.toArray());
+                counter.blockComments.toArray(), "Invalid block comments");
     }
 
     private static final class CountComments {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParserTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParserTest.java
@@ -19,14 +19,14 @@
 
 package com.puppycrawl.tools.checkstyle;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 
@@ -50,7 +50,7 @@ public class JavadocDetailNodeParserTest extends AbstractModuleTestSupport {
         final String expected = toLfLineEnding(new String(Files.readAllBytes(Paths.get(
                 getPath("ExpectedJavadocDetailNodeParser.txt"))),
                 StandardCharsets.UTF_8));
-        assertEquals("Invalid parse result", expected, actual);
+        assertEquals(expected, actual, "Invalid parse result");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
@@ -19,10 +19,10 @@
 
 package com.puppycrawl.tools.checkstyle;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -36,7 +36,7 @@ import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
 
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -60,8 +60,7 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
         final Set<String> packageNames = PackageNamesLoader
                 .getPackageNames(Thread.currentThread()
                         .getContextClassLoader());
-        assertEquals("pkgNames.length.", 0,
-                packageNames.size());
+        assertEquals(0, packageNames.size(), "pkgNames.length.");
     }
 
     @Test
@@ -69,7 +68,7 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
         final Set<String> actualPackageNames = PackageNamesLoader
                 .getPackageNames(new TestUrlsClassLoader(Collections.emptyEnumeration()));
 
-        assertEquals("Invalid package names length.", 0, actualPackageNames.size());
+        assertEquals(0, actualPackageNames.size(), "Invalid package names length.");
     }
 
     @Test
@@ -100,11 +99,11 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
             "com.puppycrawl.tools.checkstyle.filters",
         };
 
-        assertEquals("Invalid package names length.", expectedPackageNames.length,
-            actualPackageNames.size());
+        assertEquals(expectedPackageNames.length,
+            actualPackageNames.size(), "Invalid package names length.");
         final Set<String> checkstylePackagesSet =
                 new HashSet<>(Arrays.asList(expectedPackageNames));
-        assertEquals("Invalid names set.", checkstylePackagesSet, actualPackageNames);
+        assertEquals(checkstylePackagesSet, actualPackageNames, "Invalid names set.");
     }
 
     @Test
@@ -118,11 +117,11 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
             "coding.",
         };
 
-        assertEquals("Invalid package names length.", expectedPackageNames.length,
-            actualPackageNames.size());
+        assertEquals(expectedPackageNames.length,
+            actualPackageNames.size(), "Invalid package names length.");
         final Set<String> checkstylePackagesSet =
                 new HashSet<>(Arrays.asList(expectedPackageNames));
-        assertEquals("Invalid names set.", checkstylePackagesSet, actualPackageNames);
+        assertEquals(checkstylePackagesSet, actualPackageNames, "Invalid names set.");
     }
 
     @Test
@@ -137,11 +136,11 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
             "coding.",
         };
 
-        assertEquals("Invalid package names length.", expectedPackageNames.length,
-            actualPackageNames.size());
+        assertEquals(expectedPackageNames.length, actualPackageNames.size(),
+                "Invalid package names length.");
         final Set<String> checkstylePackagesSet =
                 new HashSet<>(Arrays.asList(expectedPackageNames));
-        assertEquals("Invalid names set.", checkstylePackagesSet, actualPackageNames);
+        assertEquals(checkstylePackagesSet, actualPackageNames, "Invalid names set.");
     }
 
     @Test
@@ -154,7 +153,7 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
             fail("CheckstyleException is expected");
         }
         catch (CheckstyleException ex) {
-            assertTrue("Invalid exception cause class", ex.getCause() instanceof SAXException);
+            assertTrue(ex.getCause() instanceof SAXException, "Invalid exception cause class");
         }
     }
 
@@ -185,9 +184,9 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
             fail("CheckstyleException is expected");
         }
         catch (CheckstyleException ex) {
-            assertTrue("Invalid exception cause class", ex.getCause() instanceof IOException);
-            assertNotEquals("Invalid exception message",
-                    "unable to get package file resources", ex.getMessage());
+            assertTrue(ex.getCause() instanceof IOException, "Invalid exception cause class");
+            assertNotEquals("unable to get package file resources", ex.getMessage(),
+                    "Invalid exception message");
         }
     }
 
@@ -198,9 +197,9 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
             fail("CheckstyleException is expected");
         }
         catch (CheckstyleException ex) {
-            assertTrue("Invalid exception cause class", ex.getCause() instanceof IOException);
-            assertEquals("Invalid exception message",
-                    "unable to get package file resources", ex.getMessage());
+            assertTrue(ex.getCause() instanceof IOException, "Invalid exception cause class");
+            assertEquals("unable to get package file resources", ex.getMessage(),
+                    "Invalid exception message");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
@@ -28,9 +28,9 @@ import static com.puppycrawl.tools.checkstyle.PackageObjectFactory.NULL_PACKAGE_
 import static com.puppycrawl.tools.checkstyle.PackageObjectFactory.PACKAGE_SEPARATOR;
 import static com.puppycrawl.tools.checkstyle.PackageObjectFactory.STRING_SEPARATOR;
 import static com.puppycrawl.tools.checkstyle.PackageObjectFactory.UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.lang.reflect.Field;
@@ -44,7 +44,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -69,7 +69,7 @@ public class PackageObjectFactoryTest {
             fail("Exception is expected but got " + test);
         }
         catch (IllegalArgumentException ex) {
-            assertEquals("Invalid exception message", NULL_LOADER_MESSAGE, ex.getMessage());
+            assertEquals(NULL_LOADER_MESSAGE, ex.getMessage(), "Invalid exception message");
         }
     }
 
@@ -80,7 +80,7 @@ public class PackageObjectFactoryTest {
             fail("Exception is expected but got " + test);
         }
         catch (IllegalArgumentException ex) {
-            assertEquals("Invalid exception message", NULL_LOADER_MESSAGE, ex.getMessage());
+            assertEquals(NULL_LOADER_MESSAGE, ex.getMessage(), "Invalid exception message");
         }
     }
 
@@ -92,7 +92,7 @@ public class PackageObjectFactoryTest {
             fail("Exception is expected but got " + test);
         }
         catch (IllegalArgumentException ex) {
-            assertEquals("Invalid exception message", NULL_PACKAGE_MESSAGE, ex.getMessage());
+            assertEquals(NULL_PACKAGE_MESSAGE, ex.getMessage(), "Invalid exception message");
         }
     }
 
@@ -104,7 +104,7 @@ public class PackageObjectFactoryTest {
             fail("Exception is expected but got " + test);
         }
         catch (IllegalArgumentException ex) {
-            assertEquals("Invalid exception message", NULL_PACKAGE_MESSAGE, ex.getMessage());
+            assertEquals(NULL_PACKAGE_MESSAGE, ex.getMessage(), "Invalid exception message");
         }
     }
 
@@ -117,7 +117,7 @@ public class PackageObjectFactoryTest {
             fail("Exception is expected but got " + test);
         }
         catch (IllegalArgumentException ex) {
-            assertEquals("Invalid exception message", NULL_PACKAGE_MESSAGE, ex.getMessage());
+            assertEquals(NULL_PACKAGE_MESSAGE, ex.getMessage(), "Invalid exception message");
         }
     }
 
@@ -127,7 +127,7 @@ public class PackageObjectFactoryTest {
         final Checker checker =
             (Checker) factory.createModule(
                         "com.puppycrawl.tools.checkstyle.Checker");
-        assertNotNull("Checker should not be null when creating module from name", checker);
+        assertNotNull(checker, "Checker should not be null when creating module from name");
     }
 
     @Test
@@ -141,8 +141,8 @@ public class PackageObjectFactoryTest {
             final LocalizedMessage exceptionMessage = new LocalizedMessage(1,
                     Definitions.CHECKSTYLE_BUNDLE, UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE,
                     new String[] {name, null}, null, factory.getClass(), null);
-            assertEquals("Invalid exception message",
-                    exceptionMessage.getMessage(), ex.getMessage());
+            assertEquals(exceptionMessage.getMessage(), ex.getMessage(),
+                    "Invalid exception message");
         }
     }
 
@@ -161,8 +161,8 @@ public class PackageObjectFactoryTest {
                 final LocalizedMessage exceptionMessage = new LocalizedMessage(1,
                     Definitions.CHECKSTYLE_BUNDLE, UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE,
                     new String[] {name, attemptedNames}, null, factory.getClass(), null);
-                assertEquals("Invalid exception message",
-                    exceptionMessage.getMessage(), ex.getMessage());
+                assertEquals(exceptionMessage.getMessage(), ex.getMessage(),
+                        "Invalid exception message");
             }
         }
     }
@@ -177,9 +177,9 @@ public class PackageObjectFactoryTest {
         final PackageObjectFactory objectFactory =
                 new PackageObjectFactory(packageName, classLoader);
         final Object instance1 = objectFactory.createModule(name);
-        assertEquals("Invalid canonical name", fullName, instance1.getClass().getCanonicalName());
+        assertEquals(fullName, instance1.getClass().getCanonicalName(), "Invalid canonical name");
         final Object instance2 = objectFactory.createModule(moduleName);
-        assertEquals("Invalid canonical name", fullName, instance2.getClass().getCanonicalName());
+        assertEquals(fullName, instance2.getClass().getCanonicalName(), "Invalid canonical name");
     }
 
     @Test
@@ -191,7 +191,7 @@ public class PackageObjectFactoryTest {
         final PackageObjectFactory objectFactory =
                 new PackageObjectFactory(packageName, classLoader);
         final Object instance = objectFactory.createModule(moduleName);
-        assertEquals("Invalid canonical name", fullName, instance.getClass().getCanonicalName());
+        assertEquals(fullName, instance.getClass().getCanonicalName(), "Invalid canonical name");
     }
 
     @Test
@@ -204,7 +204,7 @@ public class PackageObjectFactoryTest {
         final PackageObjectFactory objectFactory =
                 new PackageObjectFactory(packageName, classLoader);
         final Object instance = objectFactory.createModule(moduleName);
-        assertEquals("Invalid canonical name", fullName, instance.getClass().getCanonicalName());
+        assertEquals(fullName, instance.getClass().getCanonicalName(), "Invalid canonical name");
     }
 
     @Test
@@ -225,8 +225,8 @@ public class PackageObjectFactoryTest {
             final LocalizedMessage exceptionMessage = new LocalizedMessage(1,
                     Definitions.CHECKSTYLE_BUNDLE, AMBIGUOUS_MODULE_NAME_EXCEPTION_MESSAGE,
                     new String[] {name, optionalNames}, null, getClass(), null);
-            assertEquals("Invalid exception message",
-                    exceptionMessage.getMessage(), ex.getMessage());
+            assertEquals(
+                    exceptionMessage.getMessage(), ex.getMessage(), "Invalid exception message");
         }
     }
 
@@ -252,8 +252,8 @@ public class PackageObjectFactoryTest {
             final LocalizedMessage exceptionMessage = new LocalizedMessage(1,
                     Definitions.CHECKSTYLE_BUNDLE, UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE,
                     new String[] {name, attemptedNames}, null, getClass(), null);
-            assertEquals("Invalid exception message",
-                    exceptionMessage.getMessage(), ex.getMessage());
+            assertEquals(
+                    exceptionMessage.getMessage(), ex.getMessage(), "Invalid exception message");
         }
     }
 
@@ -280,8 +280,8 @@ public class PackageObjectFactoryTest {
             final LocalizedMessage exceptionMessage = new LocalizedMessage(1,
                     Definitions.CHECKSTYLE_BUNDLE, UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE,
                     new String[] {name, attemptedNames}, null, getClass(), null);
-            assertEquals("Invalid exception message",
-                    exceptionMessage.getMessage(), ex.getMessage());
+            assertEquals(
+                    exceptionMessage.getMessage(), ex.getMessage(), "Invalid exception message");
         }
     }
 
@@ -292,7 +292,7 @@ public class PackageObjectFactoryTest {
                 "createModuleByTryInEachPackage", String.class);
         createModuleByBruteForce.setAccessible(true);
         final Checker checker = (Checker) createModuleByBruteForce.invoke(factory, className);
-        assertNotNull("Checker should not be null when creating module from name", checker);
+        assertNotNull(checker, "Checker should not be null when creating module from name");
     }
 
     @Test
@@ -306,7 +306,7 @@ public class PackageObjectFactoryTest {
         createModuleByBruteForce.setAccessible(true);
         final AnnotationLocationCheck check = (AnnotationLocationCheck) createModuleByBruteForce
                 .invoke(packageObjectFactory, checkName);
-        assertNotNull("Check should not be null when creating module from name", check);
+        assertNotNull(check, "Check should not be null when creating module from name");
     }
 
     @Test
@@ -317,7 +317,7 @@ public class PackageObjectFactoryTest {
             Thread.currentThread().getContextClassLoader(), TRY_IN_ALL_REGISTERED_PACKAGES);
         final AnnotationLocationCheck check = (AnnotationLocationCheck) packageObjectFactory
                 .createModule(checkName);
-        assertNotNull("Check should not be null when creating module from name", check);
+        assertNotNull(check, "Check should not be null when creating module from name");
     }
 
     @Test
@@ -330,7 +330,7 @@ public class PackageObjectFactoryTest {
         final String className = "SomeClass";
         final String actual =
             String.valueOf(method.invoke(PackageObjectFactory.class, className, packages));
-        assertEquals("Invalid class name", "test." + className, actual);
+        assertEquals("test." + className, actual, "Invalid class name");
     }
 
     @Test
@@ -363,12 +363,11 @@ public class PackageObjectFactoryTest {
             fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid exception message",
-                    "Unable to instantiate com.puppycrawl.tools.checkstyle."
-                    + "PackageObjectFactoryTest$FailConstructorFileSet", ex.getMessage());
-            assertEquals("Invalid exception cause class",
-                    "IllegalArgumentException", ex.getCause().getCause().getClass()
-                    .getSimpleName());
+            assertEquals("Unable to instantiate com.puppycrawl.tools.checkstyle."
+                    + "PackageObjectFactoryTest$FailConstructorFileSet", ex.getMessage(),
+                    "Invalid exception message");
+            assertEquals("IllegalArgumentException", ex.getCause().getCause().getClass()
+                    .getSimpleName(), "Invalid exception cause class");
         }
     }
 
@@ -377,9 +376,9 @@ public class PackageObjectFactoryTest {
         final String fullName =
                 "com.puppycrawl.tools.checkstyle.checks.coding.DefaultComesLastCheck";
 
-        assertEquals("Invalid simple check name",
-                "DefaultComesLastCheck",
-                PackageObjectFactory.getShortFromFullModuleNames(fullName));
+        assertEquals("DefaultComesLastCheck",
+                PackageObjectFactory.getShortFromFullModuleNames(fullName),
+                "Invalid simple check name");
     }
 
     @Test
@@ -387,9 +386,8 @@ public class PackageObjectFactoryTest {
         final String fullName =
                 "java.util.stream.Collectors";
 
-        assertEquals("Invalid simple check name",
-                fullName,
-                PackageObjectFactory.getShortFromFullModuleNames(fullName));
+        assertEquals(fullName, PackageObjectFactory.getShortFromFullModuleNames(fullName),
+                "Invalid simple check name");
     }
 
     private static final class FailConstructorFileSet extends AbstractFileSetCheck {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertiesExpanderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertiesExpanderTest.java
@@ -19,10 +19,12 @@
 
 package com.puppycrawl.tools.checkstyle;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.Properties;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PropertiesExpanderTest {
 
@@ -30,10 +32,10 @@ public class PropertiesExpanderTest {
     public void testCtorException() {
         try {
             final Object test = new PropertiesExpander(null);
-            Assert.fail("exception expected but got " + test);
+            fail("exception expected but got " + test);
         }
         catch (IllegalArgumentException ex) {
-            Assert.assertEquals("Invalid exception message", "cannot pass null", ex.getMessage());
+            assertEquals("cannot pass null", ex.getMessage(), "Invalid exception message");
         }
     }
 
@@ -41,16 +43,18 @@ public class PropertiesExpanderTest {
     public void testDefaultProperties() {
         final Properties properties = new Properties(System.getProperties());
         properties.setProperty("test", "checkstyle");
-        Assert.assertEquals("Invalid user.home property",
-                System.getProperty("user.home"), properties.getProperty("user.home"));
-        Assert.assertEquals("Invalid checkstyle property",
-                "checkstyle", properties.getProperty("test"));
+        final String propertiesUserHome = properties.getProperty("user.home");
+        assertEquals(System.getProperty("user.home"), propertiesUserHome,
+                "Invalid user.home property");
+        assertEquals("checkstyle", properties.getProperty("test"),
+                "Invalid checkstyle property");
 
         final PropertiesExpander expander = new PropertiesExpander(properties);
-        Assert.assertEquals("Invalid user.home property",
-                System.getProperty("user.home"), expander.resolve("user.home"));
-        Assert.assertEquals("Invalid checkstyle property",
-                "checkstyle", expander.resolve("test"));
+        final String expanderUserHome = expander.resolve("user.home");
+        assertEquals(System.getProperty("user.home"), expanderUserHome,
+                "Invalid user.home property");
+        assertEquals("checkstyle", expander.resolve("test"),
+                "Invalid checkstyle property");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/SuppressionsStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SuppressionsStringPrinterTest.java
@@ -20,12 +20,14 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import antlr.NoViableAltException;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -41,8 +43,9 @@ public class SuppressionsStringPrinterTest extends AbstractTreeTestSupport {
 
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
-        assertTrue("Constructor is not private",
-                isUtilsClassHasPrivateConstructor(SuppressionsStringPrinter.class, true));
+        assertTrue(
+                isUtilsClassHasPrivateConstructor(SuppressionsStringPrinter.class, true),
+                "Constructor is not private");
     }
 
     @Test
@@ -58,8 +61,7 @@ public class SuppressionsStringPrinterTest extends AbstractTreeTestSupport {
         final String result = SuppressionsStringPrinter.printSuppressions(input,
                 lineAndColumnNumber, tabWidth);
 
-        Assert.assertEquals("Invalid xpath queries",
-                expected, result);
+        assertEquals(expected, result, "Invalid xpath queries");
     }
 
     @Test
@@ -77,8 +79,7 @@ public class SuppressionsStringPrinterTest extends AbstractTreeTestSupport {
         final String result = SuppressionsStringPrinter.printSuppressions(input,
                 lineAndColumnNumber, tabWidth);
 
-        Assert.assertEquals("Invalid xpath queries",
-                expected, result);
+        assertEquals(expected, result, "Invalid xpath queries");
     }
 
     @Test
@@ -88,8 +89,7 @@ public class SuppressionsStringPrinterTest extends AbstractTreeTestSupport {
         final int tabWidth = 6;
         final String result = SuppressionsStringPrinter.printSuppressions(input,
                 lineAndColumnNumber, tabWidth);
-        Assert.assertEquals("Invalid xpath queries",
-                EOL, result);
+        assertEquals(EOL, result, "Invalid xpath queries");
     }
 
     @Test
@@ -100,12 +100,11 @@ public class SuppressionsStringPrinterTest extends AbstractTreeTestSupport {
         try {
             SuppressionsStringPrinter.printSuppressions(input,
                     invalidLineAndColumnNumber, tabWidth);
-            Assert.fail("exception expected");
+            fail("exception expected");
         }
         catch (IllegalStateException ex) {
-            Assert.assertEquals("Invalid exception message",
-                    "abc-432 does not match valid format 'line:column'.",
-                    ex.getMessage());
+            assertEquals("abc-432 does not match valid format 'line:column'.",
+                    ex.getMessage(), "Invalid exception message");
         }
     }
 
@@ -117,14 +116,13 @@ public class SuppressionsStringPrinterTest extends AbstractTreeTestSupport {
         try {
             SuppressionsStringPrinter.printSuppressions(input,
                     lineAndColumnNumber, tabWidth);
-            Assert.fail("exception expected");
+            fail("exception expected");
         }
         catch (CheckstyleException ex) {
-            Assert.assertSame("Invalid class",
-                    NoViableAltException.class, ex.getCause().getClass());
-            Assert.assertEquals("Invalid exception message",
-                    input.getAbsolutePath() + ":2:1: unexpected token: classD",
-                    ex.getCause().toString());
+            assertSame(NoViableAltException.class, ex.getCause().getClass(), "Invalid class");
+            assertEquals(input.getAbsolutePath() + ":2:1: unexpected token: classD",
+                    ex.getCause().toString(), "Invalid exception message");
         }
     }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ThreadModeSettingsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ThreadModeSettingsTest.java
@@ -19,14 +19,14 @@
 
 package com.puppycrawl.tools.checkstyle;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
 
@@ -35,8 +35,8 @@ public class ThreadModeSettingsTest {
     @Test
     public void testProperties() {
         final ThreadModeSettings config = new ThreadModeSettings(1, 2);
-        assertEquals("Invalid checker threads number", 1, config.getCheckerThreadsNumber());
-        assertEquals("Invalid treewalker threads number", 2, config.getTreeWalkerThreadsNumber());
+        assertEquals(1, config.getCheckerThreadsNumber(), "Invalid checker threads number");
+        assertEquals(2, config.getTreeWalkerThreadsNumber(), "Invalid treewalker threads number");
     }
 
     @Test
@@ -48,9 +48,8 @@ public class ThreadModeSettingsTest {
             fail("An exception is expected");
         }
         catch (IllegalArgumentException ex) {
-            assertEquals("Invalid exception message",
-                    "Multi thread mode for Checker module is not implemented",
-                    ex.getMessage());
+            assertEquals("Multi thread mode for Checker module is not implemented",
+                    ex.getMessage(), "Invalid exception message");
         }
     }
 
@@ -58,8 +57,8 @@ public class ThreadModeSettingsTest {
     public void testResolveCheckerInSingleThreadMode() {
         final ThreadModeSettings singleThreadMode = ThreadModeSettings.SINGLE_THREAD_MODE_INSTANCE;
 
-        assertEquals("Invalid name resolved", ThreadModeSettings.CHECKER_MODULE_NAME,
-                singleThreadMode.resolveName(ThreadModeSettings.CHECKER_MODULE_NAME));
+        final String name = singleThreadMode.resolveName(ThreadModeSettings.CHECKER_MODULE_NAME);
+        assertEquals(ThreadModeSettings.CHECKER_MODULE_NAME, name, "Invalid name resolved");
     }
 
     @Test
@@ -71,9 +70,8 @@ public class ThreadModeSettingsTest {
             fail("Exception is expected");
         }
         catch (IllegalArgumentException ex) {
-            assertEquals("Invalid exception message",
-                    "Multi thread mode for TreeWalker module is not implemented",
-                    ex.getMessage());
+            assertEquals("Multi thread mode for TreeWalker module is not implemented",
+                    ex.getMessage(), "Invalid exception message");
         }
     }
 
@@ -82,8 +80,8 @@ public class ThreadModeSettingsTest {
         final ThreadModeSettings singleThreadMode = ThreadModeSettings.SINGLE_THREAD_MODE_INSTANCE;
         final String actual =
                 singleThreadMode.resolveName(ThreadModeSettings.TREE_WALKER_MODULE_NAME);
-        assertThat("Invalid name resolved: " + actual,
-                actual, is(ThreadModeSettings.TREE_WALKER_MODULE_NAME));
+        assertThat("Invalid name resolved: " + actual, actual,
+                is(ThreadModeSettings.TREE_WALKER_MODULE_NAME));
     }
 
     @Test
@@ -101,10 +99,10 @@ public class ThreadModeSettingsTest {
             }
 
             final String moduleName = module.getSimpleName();
-            assertThat("Invalid name resolved",
-                    singleThreadModeSettings.resolveName(moduleName), is(moduleName));
-            assertThat("Invalid name resolved",
-                    multiThreadModeSettings.resolveName(moduleName), is(moduleName));
+            assertThat("Invalid name resolved", singleThreadModeSettings.resolveName(moduleName),
+                    is(moduleName));
+            assertThat("Invalid name resolved", multiThreadModeSettings.resolveName(moduleName),
+                    is(moduleName));
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -20,9 +20,9 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.Writer;
@@ -37,9 +37,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.internal.util.Checks;
 import org.powermock.reflect.Whitebox;
 
@@ -66,8 +65,8 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class TreeWalkerTest extends AbstractModuleTestSupport {
 
-    @Rule
-    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    public File temporaryFolder;
 
     @Override
     protected String getPackageLocation() {
@@ -78,7 +77,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
     public void testProperFileExtension() throws Exception {
         final DefaultConfiguration checkConfig =
                 createModuleConfig(ConstantNameCheck.class);
-        final File file = temporaryFolder.newFile("file.java");
+        final File file = new File(temporaryFolder, "file.java");
         try (Writer writer = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8)) {
             final String content = "public class Main { public static final int k = 5 + 4; }";
             writer.write(content);
@@ -94,7 +93,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
     public void testImproperFileExtension() throws Exception {
         final DefaultConfiguration checkConfig =
                 createModuleConfig(ConstantNameCheck.class);
-        final File file = temporaryFolder.newFile("file.pdf");
+        final File file = new File(temporaryFolder, "file.pdf");
         try (Writer writer = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8)) {
             final String content = "public class Main { public static final int k = 5 + 4; }";
             writer.write(content);
@@ -124,14 +123,15 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
                     + " com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck"));
 
             final Matcher errorMsgMatcher = expected.matcher(errorMsg);
-            assertTrue("Failure for: " + errorMsg, errorMsgMatcher.matches());
+            assertTrue(errorMsgMatcher.matches(), "Failure for: " + errorMsg);
         }
     }
 
     @Test
     public void testOnEmptyFile() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(HiddenFieldCheck.class);
-        final String pathToEmptyFile = temporaryFolder.newFile("file.java").getPath();
+        final String pathToEmptyFile =
+                File.createTempFile("file", ".java", temporaryFolder).getPath();
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
         verify(checkConfig, pathToEmptyFile, expected);
@@ -144,12 +144,12 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         try {
             final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
             verify(createChecker(checkConfig, ModuleCreationOption.IN_TREEWALKER),
-                    temporaryFolder.newFile().getPath(), expected);
+                    File.createTempFile("junit", null, temporaryFolder).getPath(), expected);
             fail("CheckstyleException is expected");
         }
         catch (CheckstyleException exception) {
-            assertTrue("Error message is unexpected",
-                    exception.getMessage().contains("TreeWalker is not allowed as a parent of"));
+            assertTrue(exception.getMessage().contains("TreeWalker is not allowed as a parent of"),
+                    "Error message is unexpected");
         }
     }
 
@@ -166,10 +166,9 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
             fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Error message is not expected",
-                    "TreeWalker is not allowed as a parent of java.lang.String Please review "
-                            + "'Parent Module' section for this Check in web documentation if "
-                            + "Check is standard.", ex.getMessage());
+            assertEquals("TreeWalker is not allowed as a parent of java.lang.String Please review "
+                    + "'Parent Module' section for this Check in web documentation if "
+                    + "Check is standard.", ex.getMessage(), "Error message is not expected");
         }
     }
 
@@ -180,16 +179,17 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         treeWalker.setTabWidth(1);
         treeWalker.configure(config);
 
-        assertEquals("Invalid setter result", 1,
-                (int) Whitebox.getInternalState(treeWalker, "tabWidth"));
-        assertEquals("Invalid configuration", config,
-            Whitebox.getInternalState(treeWalker, "configuration"));
+        final int tabWidth = Whitebox.getInternalState(treeWalker, "tabWidth");
+        assertEquals(1, tabWidth, "Invalid setter result");
+        final Object configuration = Whitebox.getInternalState(treeWalker, "configuration");
+        assertEquals(config, configuration, "Invalid configuration");
     }
 
     @Test
     public void testForInvalidCheckImplementation() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(BadJavaDocCheck.class);
-        final String pathToEmptyFile = temporaryFolder.newFile("file.java").getPath();
+        final String pathToEmptyFile =
+                File.createTempFile("file", ".java", temporaryFolder).getPath();
 
         try {
             final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
@@ -197,8 +197,8 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
             fail("Exception is expected");
         }
         catch (CheckstyleException ex) {
-            assertTrue("Error message is unexpected",
-                    ex.getMessage().contains("isCommentNodesRequired"));
+            assertTrue(ex.getMessage().contains("isCommentNodesRequired"),
+                    "Error message is unexpected");
         }
     }
 
@@ -222,9 +222,8 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
             fail("Exception expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid exception message",
-                "MismatchedTokenException occurred while parsing file input.java.",
-                ex.getMessage());
+            assertEquals("MismatchedTokenException occurred while parsing file input.java.",
+                ex.getMessage(), "Invalid exception message");
         }
     }
 
@@ -237,7 +236,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         final FileText fileText = new FileText(file, StandardCharsets.ISO_8859_1.name());
         treeWalker.processFiltered(file, fileText);
         final Collection<Checks> checks = Whitebox.getInternalState(treeWalker, "ordinaryChecks");
-        assertTrue("No checks -> No parsing", checks.isEmpty());
+        assertTrue(checks.isEmpty(), "No checks -> No parsing");
     }
 
     @Test
@@ -247,7 +246,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         final PackageObjectFactory factory = new PackageObjectFactory(
             new HashSet<>(), Thread.currentThread().getContextClassLoader());
         checker.setModuleFactory(factory);
-        final File file = temporaryFolder.newFile("file.java");
+        final File file = File.createTempFile("file", ".java", temporaryFolder);
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
         verify(checker, file.getPath(), expected);
@@ -261,7 +260,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
             new HashSet<>(), Thread.currentThread().getContextClassLoader());
         treeWalker.setModuleFactory(factory);
         treeWalker.setupChild(createModuleConfig(TypeNameCheck.class));
-        final File file = temporaryFolder.newFile("file.java");
+        final File file = new File(temporaryFolder, "file.java");
         final List<String> lines = new ArrayList<>();
         lines.add(" classD a {} ");
         final FileText fileText = new FileText(file, lines);
@@ -271,9 +270,8 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
             fail("Exception is expected");
         }
         catch (CheckstyleException exception) {
-            assertTrue("Error message is unexpected",
-                    exception.getMessage().contains(
-                    "occurred while parsing file"));
+            assertTrue(exception.getMessage().contains("occurred while parsing file"),
+                    "Error message is unexpected");
         }
     }
 
@@ -285,7 +283,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
             new HashSet<>(), Thread.currentThread().getContextClassLoader());
         treeWalker.setModuleFactory(factory);
         treeWalker.setupChild(createModuleConfig(TypeNameCheck.class));
-        final File file = temporaryFolder.newFile("file.java");
+        final File file = new File(temporaryFolder, "file.java");
         final List<String> lines = new ArrayList<>();
         lines.add(" class a%$# {} ");
         final FileText fileText = new FileText(file, lines);
@@ -295,9 +293,9 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
             fail("Exception is expected");
         }
         catch (CheckstyleException exception) {
-            assertTrue("Error message is unexpected",
-                    exception.getMessage().contains(
-                    "TokenStreamRecognitionException occurred while parsing file"));
+            assertTrue(exception.getMessage().contains(
+                    "TokenStreamRecognitionException occurred while parsing file"),
+                    "Error message is unexpected");
         }
     }
 
@@ -305,7 +303,8 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
     public void testRequiredTokenIsEmptyIntArray() throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(RequiredTokenIsEmptyIntArray.class);
-        final String pathToEmptyFile = temporaryFolder.newFile("file.java").getPath();
+        final String pathToEmptyFile =
+                File.createTempFile("file", ".java", temporaryFolder).getPath();
 
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig, pathToEmptyFile, expected);
@@ -318,12 +317,12 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
                 new HashSet<>(), Thread.currentThread().getContextClassLoader());
         treeWalker.setModuleFactory(factory);
         // create file that should throw exception
-        final File file = temporaryFolder.newFile("file.java");
+        final File file = new File(temporaryFolder, "file.java");
         final FileText fileText = new FileText(file, new ArrayList<>());
 
         treeWalker.processFiltered(file, fileText);
         final Collection<Checks> checks = Whitebox.getInternalState(treeWalker, "ordinaryChecks");
-        assertTrue("No checks -> No parsing", checks.isEmpty());
+        assertTrue(checks.isEmpty(), "No checks -> No parsing");
     }
 
     @Test
@@ -336,7 +335,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         treeWalker.setModuleFactory(factory);
         treeWalker.setupChild(createModuleConfig(TypeNameCheck.class));
         treeWalker.setupChild(createModuleConfig(CommentsIndentationCheck.class));
-        final File file = temporaryFolder.newFile("file.java");
+        final File file = new File(temporaryFolder, "file.java");
         final List<String> lines = new ArrayList<>();
         lines.add(" class a%$# {} ");
         final FileText fileText = new FileText(file, lines);
@@ -349,8 +348,8 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         catch (CheckstyleException exception) {
             final String message =
                     "TokenStreamRecognitionException occurred while parsing file";
-            assertTrue("Error message is unexpected",
-                    exception.getMessage().contains(message));
+            assertTrue(exception.getMessage().contains(message),
+                    "Error message is unexpected");
         }
     }
 
@@ -371,7 +370,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         final Set<TreeWalkerFilter> filters = Whitebox.getInternalState(treeWalker, "filters");
         final int tabWidth = Whitebox.getInternalState(filters.iterator().next(), "tabWidth");
 
-        assertEquals("expected tab width", 99, tabWidth);
+        assertEquals(99, tabWidth, "expected tab width");
     }
 
     @Test
@@ -410,20 +409,19 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         treeWalker.finishLocalSetup();
 
         final Context context = Whitebox.getInternalState(treeWalker, "childContext");
-        assertEquals("Severity differs from expected",
-                "error", context.get("severity"));
-        assertEquals("Tab width differs from expected",
-                String.valueOf(100), context.get("tabWidth"));
+        assertEquals("error", context.get("severity"), "Severity differs from expected");
+        assertEquals(String.valueOf(100), context.get("tabWidth"),
+                "Tab width differs from expected");
     }
 
     @Test
     public void testCheckInitIsCalledInTreeWalker() throws Exception {
         final DefaultConfiguration checkConfig =
                 createModuleConfig(VerifyInitCheck.class);
-        final File file = temporaryFolder.newFile("file.pdf");
+        final File file = File.createTempFile("file", ".pdf", temporaryFolder);
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig, file.getPath(), expected);
-        assertTrue("Init was not called", VerifyInitCheck.isInitWasCalled());
+        assertTrue(VerifyInitCheck.isInitWasCalled(), "Init was not called");
     }
 
     @Test
@@ -431,10 +429,10 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         VerifyDestroyCheck.resetDestroyWasCalled();
         final DefaultConfiguration checkConfig =
                 createModuleConfig(VerifyDestroyCheck.class);
-        final File file = temporaryFolder.newFile("file.pdf");
+        final File file = File.createTempFile("file", ".pdf", temporaryFolder);
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig, file.getPath(), expected);
-        assertTrue("Destroy was not called", VerifyDestroyCheck.isDestroyWasCalled());
+        assertTrue(VerifyDestroyCheck.isDestroyWasCalled(), "Destroy was not called");
     }
 
     @Test
@@ -442,10 +440,10 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         VerifyDestroyCheck.resetDestroyWasCalled();
         final DefaultConfiguration checkConfig =
                 createModuleConfig(VerifyDestroyCommentCheck.class);
-        final File file = temporaryFolder.newFile("file.pdf");
+        final File file = File.createTempFile("file", ".pdf", temporaryFolder);
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig, file.getPath(), expected);
-        assertTrue("Destroy was not called", VerifyDestroyCheck.isDestroyWasCalled());
+        assertTrue(VerifyDestroyCheck.isDestroyWasCalled(), "Destroy was not called");
     }
 
     @Test
@@ -456,20 +454,19 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         treeWalkerConfig.addChild(filterConfig);
 
         final DefaultConfiguration checkerConfig = createRootConfig(treeWalkerConfig);
-        final File cacheFile = temporaryFolder.newFile();
+        final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
         checkerConfig.addAttribute("cacheFile", cacheFile.getPath());
 
-        final String filePath = temporaryFolder.newFile("file.java").getPath();
+        final String filePath = File.createTempFile("file", ".java", temporaryFolder).getPath();
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
         verify(checkerConfig, filePath, expected);
         // One more time to use cache.
         verify(checkerConfig, filePath, expected);
 
-        assertTrue("External resource is not present in cache",
-                new String(Files.readAllBytes(cacheFile.toPath()),
-                        StandardCharsets.UTF_8).contains(
-                                "InputTreeWalkerSuppressionXpathFilter.xml"));
+        assertTrue(new String(Files.readAllBytes(cacheFile.toPath()), StandardCharsets.UTF_8)
+                        .contains("InputTreeWalkerSuppressionXpathFilter.xml"),
+                "External resource is not present in cache");
     }
 
     @Test
@@ -503,10 +500,10 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         treeWalkerConfig.addChild(filterConfig);
 
         final DefaultConfiguration checkerConfig = createRootConfig(treeWalkerConfig);
-        final File cacheFile = temporaryFolder.newFile();
+        final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
         checkerConfig.addAttribute("cacheFile", cacheFile.getPath());
 
-        final String filePath = temporaryFolder.newFile("file.java").getPath();
+        final String filePath = File.createTempFile("file", ".java", temporaryFolder).getPath();
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
         verify(checkerConfig, filePath, expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XMLLoggerTest.java
@@ -19,16 +19,16 @@
 
 package com.puppycrawl.tools.checkstyle;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
@@ -60,7 +60,7 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
     public void testEncode()
             throws IOException {
         final XMLLogger test = new XMLLogger(outStream, OutputStreamOptions.NONE);
-        assertNotNull("should be able to create XMLLogger without issue", test);
+        assertNotNull(test, "should be able to create XMLLogger without issue");
         final String[][] encodings = {
             {"<", "&lt;"},
             {">", "&gt;"},
@@ -77,7 +77,7 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
         };
         for (String[] encoding : encodings) {
             final String encoded = XMLLogger.encode(encoding[0]);
-            assertEquals("\"" + encoding[0] + "\"", encoding[1], encoded);
+            assertEquals(encoding[1], encoded, "\"" + encoding[0] + "\"");
         }
         outStream.close();
     }
@@ -86,7 +86,7 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
     public void testIsReference()
             throws IOException {
         final XMLLogger test = new XMLLogger(outStream, OutputStreamOptions.NONE);
-        assertNotNull("should be able to create XMLLogger without issue", test);
+        assertNotNull(test, "should be able to create XMLLogger without issue");
         final String[] references = {
             "&#0;",
             "&#x0;",
@@ -97,8 +97,8 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
             "&amp;",
         };
         for (String reference : references) {
-            assertTrue("reference: " + reference,
-                    XMLLogger.isReference(reference));
+            assertTrue(
+                    XMLLogger.isReference(reference), "reference: " + reference);
         }
         final String[] noReferences = {
             "&",
@@ -112,8 +112,7 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
             "ref",
         };
         for (String noReference : noReferences) {
-            assertFalse("no reference: " + noReference,
-                    XMLLogger.isReference(noReference));
+            assertFalse(XMLLogger.isReference(noReference), "no reference: " + noReference);
         }
 
         outStream.close();
@@ -127,7 +126,7 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
         logger.auditStarted(null);
         logger.auditFinished(null);
 
-        assertEquals("Invalid close count", 1, outStream.getCloseCount());
+        assertEquals(1, outStream.getCloseCount(), "Invalid close count");
 
         verifyXml(getPath("ExpectedXMLLoggerEmpty.xml"), outStream);
     }
@@ -140,7 +139,7 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
         logger.auditStarted(null);
         logger.auditFinished(null);
 
-        assertEquals("Invalid close count", 0, outStream.getCloseCount());
+        assertEquals(0, outStream.getCloseCount(), "Invalid close count");
 
         outStream.close();
         verifyXml(getPath("ExpectedXMLLoggerEmpty.xml"), outStream);
@@ -257,7 +256,7 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
         logger.addException(ev, new TestException("msg", new RuntimeException("msg")));
         logger.auditFinished(null);
         verifyXml(getPath("ExpectedXMLLoggerException.xml"), outStream);
-        assertEquals("Invalid close count", 1, outStream.getCloseCount());
+        assertEquals(1, outStream.getCloseCount(), "Invalid close count");
     }
 
     @Test
@@ -272,7 +271,7 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
         logger.addException(ev, new TestException("msg", new RuntimeException("msg")));
         logger.auditFinished(null);
         verifyXml(getPath("ExpectedXMLLoggerExceptionNullFileName.xml"), outStream);
-        assertEquals("Invalid close count", 1, outStream.getCloseCount());
+        assertEquals(1, outStream.getCloseCount(), "Invalid close count");
     }
 
     @Test
@@ -293,7 +292,7 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
         logger.fileFinished(ev);
         logger.auditFinished(null);
         verifyXml(getPath("ExpectedXMLLoggerException2.xml"), outStream);
-        assertEquals("Invalid close count", 1, outStream.getCloseCount());
+        assertEquals(1, outStream.getCloseCount(), "Invalid close count");
     }
 
     @Test
@@ -310,7 +309,7 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
         logger.fileFinished(fileFinishedEvent);
         logger.auditFinished(null);
         verifyXml(getPath("ExpectedXMLLoggerException3.xml"), outStream);
-        assertEquals("Invalid close count", 1, outStream.getCloseCount());
+        assertEquals(1, outStream.getCloseCount(), "Invalid close count");
     }
 
     @Test
@@ -329,7 +328,7 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
         logger.fileFinished(fileFinishedEvent);
         logger.auditFinished(null);
         verifyXml(getPath("ExpectedXMLLoggerException2.xml"), outStream);
-        assertEquals("Invalid close count", 1, outStream.getCloseCount());
+        assertEquals(1, outStream.getCloseCount(), "Invalid close count");
     }
 
     @Test
@@ -356,12 +355,12 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
         try {
             final XMLLogger logger = new XMLLogger(outStream, null);
             // assert required to calm down eclipse's 'The allocated object is never used' violation
-            assertNotNull("Null instance", logger);
+            assertNotNull(logger, "Null instance");
             fail("Exception was expected");
         }
         catch (IllegalArgumentException exception) {
-            assertEquals("Invalid error message", "Parameter outputStreamOptions can not be null",
-                    exception.getMessage());
+            assertEquals("Parameter outputStreamOptions can not be null",
+                    exception.getMessage(), "Invalid error message");
         }
     }
 
@@ -371,7 +370,7 @@ public class XMLLoggerTest extends AbstractXmlTestSupport {
         logger.finishLocalSetup();
         logger.auditStarted(null);
         logger.auditFinished(null);
-        assertNotNull("instance should not be null", logger);
+        assertNotNull(logger, "instance should not be null");
     }
 
     private static class TestException extends RuntimeException {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XmlLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XmlLoaderTest.java
@@ -20,17 +20,17 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
@@ -41,13 +41,14 @@ public class XmlLoaderTest {
     public void testParserConfiguredSuccessfully() throws Exception {
         final DummyLoader dummyLoader = new DummyLoader(new HashMap<>(1));
         final XMLReader parser = Whitebox.getInternalState(dummyLoader, "parser");
-        assertEquals("Invalid entity resolver", dummyLoader, parser.getEntityResolver());
+        assertEquals(dummyLoader, parser.getEntityResolver(), "Invalid entity resolver");
     }
 
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
-        assertTrue("Constructor is not private", isUtilsClassHasPrivateConstructor(
-                XmlLoader.LoadExternalDtdFeatureProvider.class, true));
+        assertTrue(isUtilsClassHasPrivateConstructor(
+                XmlLoader.LoadExternalDtdFeatureProvider.class, true),
+                "Constructor is not private");
     }
 
     @Test
@@ -55,7 +56,7 @@ public class XmlLoaderTest {
         final Map<String, String> map = new HashMap<>();
         map.put("predefined", "/google.xml");
         final DummyLoader dummyLoader = new DummyLoader(map);
-        assertNull("Invalid entity", dummyLoader.resolveEntity("notPredefined", "BAD"));
+        assertNull(dummyLoader.resolveEntity("notPredefined", "BAD"), "Invalid entity");
     }
 
     @Test
@@ -63,7 +64,7 @@ public class XmlLoaderTest {
         final Map<String, String> map = new HashMap<>();
         map.put("predefined", "/google.xml");
         final DummyLoader dummyLoader = new DummyLoader(map);
-        assertNotNull("Invalid entity", dummyLoader.resolveEntity("predefined", "BAD"));
+        assertNotNull(dummyLoader.resolveEntity("predefined", "BAD"), "Invalid entity");
     }
 
     private static final class DummyLoader extends XmlLoader {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAstFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAstFilterTest.java
@@ -19,12 +19,15 @@
 
 package com.puppycrawl.tools.checkstyle;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -45,12 +48,12 @@ public class XpathFileGeneratorAstFilterTest {
         final TreeWalkerAuditEvent event = new TreeWalkerAuditEvent(null, null, message, null);
         final XpathFileGeneratorAstFilter filter = new XpathFileGeneratorAstFilter();
 
-        Assert.assertTrue("filter accepted", filter.accept(event));
+        assertTrue(filter.accept(event), "filter accepted");
 
         final AuditEvent auditEvent = new AuditEvent(this, "Test.java", message);
 
-        Assert.assertNull("filter has no queries",
-                XpathFileGeneratorAstFilter.findCorrespondingXpathQuery(auditEvent));
+        assertNull(XpathFileGeneratorAstFilter.findCorrespondingXpathQuery(auditEvent),
+                "filter has no queries");
     }
 
     @Test
@@ -62,14 +65,15 @@ public class XpathFileGeneratorAstFilterTest {
                 "InputXpathFileGeneratorAstFilter.java", message);
         final XpathFileGeneratorAstFilter filter = new XpathFileGeneratorAstFilter();
 
-        Assert.assertTrue("filter accepted", filter.accept(event));
+        assertTrue(filter.accept(event), "filter accepted");
 
         final AuditEvent auditEvent = new AuditEvent(this,
                 getPath("InputXpathFileGeneratorAstFilter.java"), message);
 
-        Assert.assertEquals("expected xpath",
+        assertEquals(
                 "/CLASS_DEF[./IDENT[@text='InputXpathFileGeneratorAstFilter']]/OBJBLOCK/LCURLY",
-                XpathFileGeneratorAstFilter.findCorrespondingXpathQuery(auditEvent));
+                XpathFileGeneratorAstFilter.findCorrespondingXpathQuery(auditEvent),
+                "expected xpath");
     }
 
     @Test
@@ -81,13 +85,13 @@ public class XpathFileGeneratorAstFilterTest {
                 "InputXpathFileGeneratorAstFilter.java", message);
         final XpathFileGeneratorAstFilter filter = new XpathFileGeneratorAstFilter();
 
-        Assert.assertTrue("filter accepted", filter.accept(event));
+        assertTrue(filter.accept(event), "filter accepted");
 
         final AuditEvent auditEvent = new AuditEvent(this,
                 getPath("InputXpathFileGeneratorAstFilter.java"), message);
 
-        Assert.assertNull("expected null",
-                XpathFileGeneratorAstFilter.findCorrespondingXpathQuery(auditEvent));
+        assertNull(XpathFileGeneratorAstFilter.findCorrespondingXpathQuery(auditEvent),
+                "expected null");
     }
 
     @Test
@@ -100,15 +104,16 @@ public class XpathFileGeneratorAstFilterTest {
         final XpathFileGeneratorAstFilter filter = new XpathFileGeneratorAstFilter();
         filter.setTabWidth(6);
 
-        Assert.assertTrue("filter accepted", filter.accept(event));
+        assertTrue(filter.accept(event), "filter accepted");
 
         final AuditEvent auditEvent = new AuditEvent(this,
                 getPath("InputXpathFileGeneratorAstFilter.java"), message);
 
-        Assert.assertEquals("expected xpath",
+        assertEquals(
                 "/CLASS_DEF[./IDENT[@text='InputXpathFileGeneratorAstFilter']]/OBJBLOCK"
                         + "/METHOD_DEF[./IDENT[@text='tabMethod']]/SLIST/LITERAL_RETURN",
-                XpathFileGeneratorAstFilter.findCorrespondingXpathQuery(auditEvent));
+                XpathFileGeneratorAstFilter.findCorrespondingXpathQuery(auditEvent),
+                "expected xpath");
     }
 
     /**
@@ -129,9 +134,10 @@ public class XpathFileGeneratorAstFilterTest {
 
         final XpathFileGeneratorAstFilter filter = new XpathFileGeneratorAstFilter();
 
-        Assert.assertTrue("State is not cleared on finishLocalSetup", TestUtil
+        assertTrue(TestUtil
                 .isStatefulFieldClearedDuringLocalSetup(filter, event, "MESSAGE_QUERY_MAP",
-                    variableStack -> ((Map<LocalizedMessage, String>) variableStack).isEmpty()));
+                    variableStack -> ((Map<LocalizedMessage, String>) variableStack).isEmpty()),
+                "State is not cleared on finishLocalSetup");
     }
 
     private static TreeWalkerAuditEvent createTreeWalkerAuditEvent(String fileName,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListenerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListenerTest.java
@@ -20,17 +20,17 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static com.google.common.truth.Truth.assertWithMessage;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
@@ -67,7 +67,7 @@ public class XpathFileGeneratorAuditListenerTest {
     private final CloseAndFlushTestByteArrayOutputStream outStream =
             new CloseAndFlushTestByteArrayOutputStream();
 
-    @BeforeClass
+    @BeforeAll
     public static void constructEvents() throws Exception {
         final TreeWalkerAuditEvent event1 = createTreeWalkerAuditEvent(
                 "InputXpathFileGeneratorAuditListener.java", FIRST_MESSAGE);
@@ -98,7 +98,7 @@ public class XpathFileGeneratorAuditListenerTest {
         listener.auditStarted(null);
         listener.auditFinished(null);
         final String actual = out.toString();
-        assertTrue("Output should be empty", actual.isEmpty());
+        assertTrue(actual.isEmpty(), "Output should be empty");
     }
 
     @Test
@@ -110,7 +110,7 @@ public class XpathFileGeneratorAuditListenerTest {
         listener.fileStarted(ev);
         listener.auditFinished(null);
         final String actual = out.toString();
-        assertTrue("Output should be empty", actual.isEmpty());
+        assertTrue(actual.isEmpty(), "Output should be empty");
     }
 
     @Test
@@ -122,7 +122,7 @@ public class XpathFileGeneratorAuditListenerTest {
         listener.fileFinished(ev);
         listener.auditFinished(null);
         final String actual = out.toString();
-        assertTrue("Output should be empty", actual.isEmpty());
+        assertTrue(actual.isEmpty(), "Output should be empty");
     }
 
     @Test
@@ -141,9 +141,8 @@ public class XpathFileGeneratorAuditListenerTest {
             fail("Exception is excepted");
         }
         catch (UnsupportedOperationException ex) {
-            assertEquals("Invalid exception message",
-                    "Operation is not supported",
-                    ex.getMessage());
+            assertEquals("Operation is not supported",
+                    ex.getMessage(), "Invalid exception message");
         }
     }
 
@@ -238,7 +237,7 @@ public class XpathFileGeneratorAuditListenerTest {
         listener.auditStarted(null);
         listener.auditFinished(null);
 
-        assertEquals("Invalid close count", 1, outStream.getCloseCount());
+        assertEquals(1, outStream.getCloseCount(), "Invalid close count");
     }
 
     @Test
@@ -250,7 +249,7 @@ public class XpathFileGeneratorAuditListenerTest {
         listener.auditStarted(null);
         listener.auditFinished(null);
 
-        assertEquals("Invalid close count", 0, outStream.getCloseCount());
+        assertEquals(0, outStream.getCloseCount(), "Invalid close count");
     }
 
     private AuditEvent createAuditEvent(String fileName, int lineNumber, int columnNumber,
@@ -316,7 +315,7 @@ public class XpathFileGeneratorAuditListenerTest {
                 .isEqualTo(1);
 
         final String actual = out.toString();
-        assertEquals("Invalid suppressions file content", expected, actual);
+        assertEquals(expected, actual, "Invalid suppressions file content");
     }
 
     private static class TestByteArrayOutputStream extends ByteArrayOutputStream {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/PropertyCacheFilePowerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/PropertyCacheFilePowerTest.java
@@ -30,6 +30,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 import java.io.BufferedInputStream;
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
@@ -172,7 +173,9 @@ public class PropertyCacheFilePowerTest extends AbstractPathTestSupport {
             cache.persist();
 
             final Properties cacheDetails = new Properties();
-            cacheDetails.load(Files.newBufferedReader(cacheFile.toPath()));
+            try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
+                cacheDetails.load(reader);
+            }
 
             final int expectedNumberOfObjectsInCacheFile = 2;
             assertEquals("Unexpected number of objects in cache",
@@ -226,7 +229,9 @@ public class PropertyCacheFilePowerTest extends AbstractPathTestSupport {
             cache.persist();
 
             final Properties cacheDetails = new Properties();
-            cacheDetails.load(Files.newBufferedReader(cacheFile.toPath()));
+            try (BufferedReader reader = Files.newBufferedReader(cacheFile.toPath())) {
+                cacheDetails.load(reader);
+            }
 
             final int expectedNumberOfObjectsInCacheFile = 2;
             assertEquals("Unexpected number of objects in cache",


### PR DESCRIPTION
Issue #6916

Tests of the checkstyle package are migrated to Junit5, except `MainTest` and `JavadocPropertiesGeneratorTest` which will be submitted in separate PR.