### PR TITLE
Issue #7382: Fix Appveyor junit5 tests

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -386,7 +386,7 @@ public final class Main {
                 }
 
                 listener = new XpathFileGeneratorAuditListener(getOutputStream(options.outputPath),
-                        AutomaticBean.OutputStreamOptions.NONE);
+                        getOutputStreamOptions(options.outputPath));
             }
             else {
                 listener = createListener(options.format, options.outputPath);


### PR DESCRIPTION
Issue #7382 

Blocker for #6916

The '@ TempDir ' annotation from Junit5 works slightly differently than the `@TemporaryFolder` rule from Junit4. This creates a new subdirectory in the $TMP folder, and deletes it when the test completes.

This creates problems when running tests under Windows. If there are unclosed files in the temporary subdirectory, the directory cannot be deleted.