### PR TITLE
Issue #6916: migrate tests to junit5 for {Main,JavadocPropertiesenerator}Test

### DIFF
--- a/config/import-control-test.xml
+++ b/config/import-control-test.xml
@@ -24,8 +24,5 @@
       <allow pkg="org.junit" local-only="true"/>
     </subpackage>
   </subpackage>
-  <file name="(JavadocPropertiesGenerator|Main)Test" regex="true">
-    <allow pkg="org.junit"/>
-  </file>
 
 </import-control>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGeneratorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGeneratorTest.java
@@ -19,9 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -30,32 +30,32 @@ import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.contrib.java.lang.system.SystemErrRule;
-import org.junit.contrib.java.lang.system.SystemOutRule;
+import org.itsallcode.io.Capturable;
+import org.itsallcode.junit.sysextensions.SystemErrGuard;
+import org.itsallcode.junit.sysextensions.SystemErrGuard.SysErr;
+import org.itsallcode.junit.sysextensions.SystemOutGuard;
+import org.itsallcode.junit.sysextensions.SystemOutGuard.SysOut;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import antlr.MismatchedTokenException;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
+@ExtendWith({SystemErrGuard.class, SystemOutGuard.class})
 public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
 
     private static final String EOL = System.lineSeparator();
     private static final String USAGE = String.format(Locale.ROOT,
-          "Usage: java com.puppycrawl.tools.checkstyle.JavadocPropertiesGenerator [-hV]%n"
-          + "       --destfile=<outputFile> <inputFile>%n"
-          + "      <inputFile>   The input file.%n"
-          + "      --destfile=<outputFile>%n"
-          + "                    The output file.%n"
-          + "  -h, --help        Show this help message and exit.%n"
-          + "  -V, --version     Print version information and exit.%n");
+            "Usage: java com.puppycrawl.tools.checkstyle.JavadocPropertiesGenerator [-hV]%n"
+                    + "       --destfile=<outputFile> <inputFile>%n"
+                    + "      <inputFile>   The input file.%n"
+                    + "      --destfile=<outputFile>%n"
+                    + "                    The output file.%n"
+                    + "  -h, --help        Show this help message and exit.%n"
+                    + "  -V, --version     Print version information and exit.%n");
     private static final File DESTFILE = new File("target/tokentypes.properties");
-
-    @Rule
-    public final SystemErrRule systemErr = new SystemErrRule().enableLog().mute();
-    @Rule
-    public final SystemOutRule systemOut = new SystemOutRule().enableLog().mute();
 
     @Override
     protected String getPackageLocation() {
@@ -67,6 +67,7 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
      * The path is formed base on the non-compilable resources location.
      * This implementation uses 'src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/'
      * as a non-compilable resource location.
+     *
      * @param filename file name.
      * @return canonical path for the file with the given file name.
      * @throws IOException if I/O exception occurs while forming the path.
@@ -76,75 +77,95 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
                 + filename).getCanonicalPath();
     }
 
-    @Test
-    public void testIsProperUtilsClass() throws ReflectiveOperationException {
-        assertTrue("Constructor is not private", TestUtil.isUtilsClassHasPrivateConstructor(
-            JavadocPropertiesGenerator.class, false));
+    /**
+     * <p>Configures the environment for each test.</p>
+     * <ul>
+     * <li>Start output capture for {@link System#err} and {@link System#out}</li>
+     * </ul>
+     *
+     * @param systemErr wrapper for {@code System.err}
+     * @param systemOut wrapper for {@code System.out}
+     */
+    @BeforeEach
+    public void setUp(@SysErr Capturable systemErr, @SysOut Capturable systemOut) {
+        systemErr.capture();
+        systemOut.capture();
     }
 
     @Test
-    public void testNonExistentArgument() throws Exception {
+    public void testIsProperUtilsClass() throws ReflectiveOperationException {
+        assertTrue(TestUtil.isUtilsClassHasPrivateConstructor(
+            JavadocPropertiesGenerator.class, false), "Constructor is not private");
+    }
+
+    @Test
+    public void testNonExistentArgument(@SysErr Capturable systemErr, @SysOut Capturable systemOut)
+            throws Exception {
         JavadocPropertiesGenerator.main("--nonexistent-argument");
 
         final String expected = String.format(Locale.ROOT, "Missing required options "
                 + "[--destfile=<outputFile>, params[0]=<inputFile>]%n")
                 + USAGE;
-        assertEquals("Unexpected error log", expected, systemErr.getLog());
-        assertEquals("Unexpected output log", "", systemOut.getLog());
+        assertEquals(expected, systemErr.getCapturedData(), "Unexpected error log");
+        assertEquals("", systemOut.getCapturedData(), "Unexpected output log");
     }
 
     @Test
-    public void testNoDestfileSpecified() throws Exception {
+    public void testNoDestfileSpecified(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws Exception {
         JavadocPropertiesGenerator.main(getPath("InputMain.java"));
 
         final String expected = String.format(Locale.ROOT,
                 "Missing required option '--destfile=<outputFile>'%n") + USAGE;
-        assertEquals("Unexpected error log", expected, systemErr.getLog());
-        assertEquals("Unexpected output log", "", systemOut.getLog());
+        assertEquals(expected, systemErr.getCapturedData(), "Unexpected error log");
+        assertEquals("", systemOut.getCapturedData(), "Unexpected output log");
     }
 
     @Test
-    public void testNoInputSpecified() throws Exception {
+    public void testNoInputSpecified(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws Exception {
         JavadocPropertiesGenerator.main("--destfile", DESTFILE.getAbsolutePath());
 
         final String expected = String.format(Locale.ROOT,
                 "Missing required parameter: <inputFile>%n") + USAGE;
-        assertEquals("Unexpected error log", expected, systemErr.getLog());
-        assertEquals("Unexpected output log", "", systemOut.getLog());
+        assertEquals(expected, systemErr.getCapturedData(), "Unexpected error log");
+        assertEquals("", systemOut.getCapturedData(), "Unexpected output log");
     }
 
     @Test
-    public void testNotClass() throws Exception {
+    public void testNotClass(@SysErr Capturable systemErr, @SysOut Capturable systemOut)
+            throws Exception {
         JavadocPropertiesGenerator.main("--destfile", DESTFILE.getAbsolutePath(),
             getPath("InputJavadocPropertiesGeneratorNotClass.java"));
-        assertEquals("Unexpected error log", "", systemErr.getLog());
-        assertEquals("Unexpected output log", "", systemOut.getLog());
+        assertEquals("", systemErr.getCapturedData(), "Unexpected error log");
+        assertEquals("", systemOut.getCapturedData(), "Unexpected output log");
     }
 
     @Test
-    public void testNotExistentInputSpecified() {
+    public void testNotExistentInputSpecified(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) {
         try {
             JavadocPropertiesGenerator.main(
                 "--destfile", DESTFILE.getAbsolutePath(), "NotExistent.java");
             fail("Exception was expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid error message",
-                "Failed to write javadoc properties of 'NotExistent.java' to '"
+            assertEquals(
+                    "Failed to write javadoc properties of 'NotExistent.java' to '"
                     + DESTFILE.getAbsolutePath() + "'",
-                ex.getMessage());
+                ex.getMessage(), "Invalid error message");
 
             final Throwable cause = ex.getCause();
-            assertTrue("Invalid error message", cause instanceof FileNotFoundException);
-            assertTrue("Invalid error message", cause.getMessage().contains("NotExistent.java"));
+            assertTrue(cause instanceof FileNotFoundException, "Invalid error message");
+            assertTrue(cause.getMessage().contains("NotExistent.java"), "Invalid error message");
         }
-        assertEquals("Unexpected error log", "", systemErr.getLog());
-        assertEquals("Unexpected output log", "", systemOut.getLog());
+        assertEquals("", systemErr.getCapturedData(), "Unexpected error log");
+        assertEquals("", systemOut.getCapturedData(), "Unexpected output log");
     }
 
     @Test
-    public void testInvalidDestinationSpecified() throws Exception {
-
+    public void testInvalidDestinationSpecified(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws Exception {
         try {
             // Passing a folder name will cause the FileNotFoundException.
             JavadocPropertiesGenerator.main("--destfile", "..",
@@ -154,18 +175,19 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
         catch (CheckstyleException ex) {
             final String expectedError = "Failed to write javadoc properties of '"
                 + getPath("InputJavadocPropertiesGeneratorCorrect.java") + "' to '..'";
-            assertEquals("Invalid error message", expectedError, ex.getMessage());
+            assertEquals(expectedError, ex.getMessage(), "Invalid error message");
 
             final Throwable cause = ex.getCause();
-            assertTrue("Invalid error message", cause instanceof FileNotFoundException);
-            assertTrue("Invalid error message", cause.getMessage().contains(".."));
+            assertTrue(cause instanceof FileNotFoundException, "Invalid error message");
+            assertTrue(cause.getMessage().contains(".."), "Invalid error message");
         }
-        assertEquals("Unexpected error log", "", systemErr.getLog());
-        assertEquals("Unexpected output log", "", systemOut.getLog());
+        assertEquals("", systemErr.getCapturedData(), "Unexpected error log");
+        assertEquals("", systemOut.getCapturedData(), "Unexpected output log");
     }
 
     @Test
-    public void testCorrect() throws Exception {
+    public void testCorrect(@SysErr Capturable systemErr, @SysOut Capturable systemOut)
+            throws Exception {
         final String expectedContent = "EOF1=The end of file token." + EOL
             + "EOF2=The end of file token." + EOL
             + "TYPE_EXTENSION_AND='&amp;' symbol when used in a generic upper or lower bounds"
@@ -176,35 +198,40 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
 
         JavadocPropertiesGenerator.main(getPath("InputJavadocPropertiesGeneratorCorrect.java"),
             "--destfile", DESTFILE.getAbsolutePath());
-        assertEquals("Unexpected error log", "", systemErr.getLog());
-        assertEquals("Unexpected output log", "", systemOut.getLog());
+        assertEquals("", systemErr.getCapturedData(), "Unexpected error log");
+        assertEquals("", systemOut.getCapturedData(), "Unexpected output log");
         final String fileContent = FileUtils.readFileToString(DESTFILE, StandardCharsets.UTF_8);
-        assertEquals("File content is not expected", expectedContent, fileContent);
+        assertEquals(expectedContent, fileContent, "File content is not expected");
     }
 
     @Test
-    public void testEmptyJavadoc() throws Exception {
+    public void testEmptyJavadoc(@SysErr Capturable systemErr, @SysOut Capturable systemOut)
+            throws Exception {
         JavadocPropertiesGenerator.main(getPath("InputJavadocPropertiesGeneratorEmptyJavadoc.java"),
             "--destfile", DESTFILE.getAbsolutePath());
-        assertEquals("Unexpected error log", "", systemErr.getLog());
-        assertEquals("Unexpected output log", "", systemOut.getLog());
-        assertEquals("File '" + DESTFILE + "' must be empty", 0, FileUtils.sizeOf(DESTFILE));
+        assertEquals("", systemErr.getCapturedData(), "Unexpected error log");
+        assertEquals("", systemOut.getCapturedData(), "Unexpected output log");
+        final long size = FileUtils.sizeOf(DESTFILE);
+        assertEquals(0, size, "File '" + DESTFILE + "' must be empty");
     }
 
     @Test
-    public void testNotConstants() throws Exception {
+    public void testNotConstants(@SysErr Capturable systemErr, @SysOut Capturable systemOut)
+            throws Exception {
         JavadocPropertiesGenerator.main(getPath("InputJavadocPropertiesGeneratorNotConstants.java"),
             "--destfile", DESTFILE.getAbsolutePath());
-        assertEquals("Unexpected error log", "", systemErr.getLog());
-        assertEquals("Unexpected output log", "", systemOut.getLog());
-        assertEquals("File '" + DESTFILE + "' must be empty", 0, FileUtils.sizeOf(DESTFILE));
+        assertEquals("", systemErr.getCapturedData(), "Unexpected error log");
+        assertEquals("", systemOut.getCapturedData(), "Unexpected output log");
+        final long size = FileUtils.sizeOf(DESTFILE);
+        assertEquals(0, size, "File '" + DESTFILE + "' must be empty");
     }
 
     @Test
-    public void testHelp() throws Exception {
+    public void testHelp(@SysErr Capturable systemErr, @SysOut Capturable systemOut)
+            throws Exception {
         JavadocPropertiesGenerator.main("-h");
-        assertEquals("Unexpected error log", "", systemErr.getLog());
-        assertEquals("Unexpected output log", USAGE, systemOut.getLog());
+        assertEquals("", systemErr.getCapturedData(), "Unexpected error log");
+        assertEquals(USAGE, systemOut.getCapturedData(), "Unexpected output log");
     }
 
     @Test
@@ -216,10 +243,12 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
             fail("Exception was expected");
         }
         catch (IllegalArgumentException ex) {
-            assertTrue("Invalid error message", ex.getMessage().contains(
-                "mismatched input '<EOF>' expecting JAVADOC_INLINE_TAG_END"));
+            assertTrue(ex.getMessage()
+                            .contains("mismatched input '<EOF>' expecting JAVADOC_INLINE_TAG_END"),
+                    "Invalid error message");
         }
-        assertEquals("File '" + DESTFILE + "' must be empty", 0, FileUtils.sizeOf(DESTFILE));
+        final long size = FileUtils.sizeOf(DESTFILE);
+        assertEquals(0, size, "File '" + DESTFILE + "' must be empty");
     }
 
     @Test
@@ -231,10 +260,11 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
             fail("Exception was expected");
         }
         catch (CheckstyleException ex) {
-            assertEquals("Invalid error message", "Unsupported inline tag LINK_LITERAL",
-                ex.getMessage());
+            assertEquals("Unsupported inline tag LINK_LITERAL",
+                ex.getMessage(), "Invalid error message");
         }
-        assertEquals("File '" + DESTFILE + "' must be empty", 0, FileUtils.sizeOf(DESTFILE));
+        final long size = FileUtils.sizeOf(DESTFILE);
+        assertEquals(0, size, "File '" + DESTFILE + "' must be empty");
     }
 
     @Test
@@ -246,13 +276,13 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
             fail("Exception was expected");
         }
         catch (CheckstyleException ex) {
-            assertTrue("Invalid error message",
-                ex.getMessage().contains("InputJavadocPropertiesGeneratorParseError.java"));
+            assertTrue(ex.getMessage().contains("InputJavadocPropertiesGeneratorParseError.java"),
+                    "Invalid error message");
 
             final Throwable cause = ex.getCause().getCause();
-            assertTrue("Invalid error message", cause instanceof MismatchedTokenException);
-            assertTrue("Invalid error message",
-                cause.getMessage().contains("expecting RCURLY, found '!'"));
+            assertTrue(cause instanceof MismatchedTokenException, "Invalid error message");
+            assertTrue(cause.getMessage().contains("expecting RCURLY, found '!'"),
+                    "Invalid error message");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -23,11 +23,13 @@ import static com.puppycrawl.tools.checkstyle.AbstractPathTestSupport.addEndOfLi
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.itsallcode.junit.sysextensions.AssertExit.assertExitWithStatus;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -48,14 +50,16 @@ import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.contrib.java.lang.system.ExpectedSystemExit;
-import org.junit.contrib.java.lang.system.SystemErrRule;
-import org.junit.contrib.java.lang.system.SystemOutRule;
-import org.junit.rules.TemporaryFolder;
+import org.itsallcode.io.Capturable;
+import org.itsallcode.junit.sysextensions.ExitGuard;
+import org.itsallcode.junit.sysextensions.SystemErrGuard;
+import org.itsallcode.junit.sysextensions.SystemErrGuard.SysErr;
+import org.itsallcode.junit.sysextensions.SystemOutGuard;
+import org.itsallcode.junit.sysextensions.SystemOutGuard.SysOut;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.api.AuditListener;
@@ -66,6 +70,7 @@ import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.internal.testmodules.TestRootModuleChecker;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
+@ExtendWith({ExitGuard.class, SystemErrGuard.class, SystemOutGuard.class})
 public class MainTest {
 
     private static final String SHORT_USAGE = String.format(Locale.ROOT,
@@ -134,14 +139,8 @@ public class MainTest {
 
     private static final String EOL = System.lineSeparator();
 
-    @Rule
-    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
-    @Rule
-    public final ExpectedSystemExit exit = ExpectedSystemExit.none();
-    @Rule
-    public final SystemErrRule systemErr = new SystemErrRule().enableLog().mute();
-    @Rule
-    public final SystemOutRule systemOut = new SystemOutRule().enableLog().mute();
+    @TempDir
+    public File temporaryFolder;
 
     private final LocalizedMessage auditStartMessage = new LocalizedMessage(1,
             Definitions.CHECKSTYLE_BUNDLE, "DefaultLogger.auditStarted", null, null,
@@ -163,9 +162,20 @@ public class MainTest {
         return new File(getPath(filename)).getCanonicalPath();
     }
 
-    @Before
-    public void setUp() {
-        // restore original logging level and HANDLERS to prevent bleeding into other tests
+    /**
+     * <p>Configures the environment for each test.</p>
+     * <ul>
+     * <li>Restore original logging level and HANDLERS to prevent bleeding into other tests;</li>
+     * <li>Start output capture for {@link System#err} and {@link System#out}</li>
+     * </ul>
+     *
+     * @param systemErr wrapper for {@code System.err}
+     * @param systemOut wrapper for {@code System.out}
+     */
+    @BeforeEach
+    public void setUp(@SysErr Capturable systemErr, @SysOut Capturable systemOut) {
+        systemErr.capture();
+        systemOut.capture();
 
         LOG.setLevel(ORIGINAL_LOG_LEVEL);
 
@@ -187,176 +197,145 @@ public class MainTest {
 
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
-        assertTrue("Constructor is not private",
-                isUtilsClassHasPrivateConstructor(Main.class, false));
+        assertTrue(
+                isUtilsClassHasPrivateConstructor(Main.class, false), "Constructor is not private");
     }
 
     @Test
-    public void testVersionPrint()
-            throws Exception {
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log",
-                    "Checkstyle version: null" + System.lineSeparator(),
-                    systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-        });
+    public void testVersionPrint(@SysErr Capturable systemErr, @SysOut Capturable systemOut)
+            throws IOException {
         Main.main("-V");
+        assertEquals("Checkstyle version: null" + System.lineSeparator(),
+                systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testUsageHelpPrint()
-            throws Exception {
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log",
-                    USAGE,
-                    systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-        });
+    public void testUsageHelpPrint(@SysErr Capturable systemErr, @SysOut Capturable systemOut)
+            throws IOException {
         Main.main("-h");
+        assertEquals(USAGE, systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testWrongArgument()
-            throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            final String usage = "Unknown option: '-q'" + EOL
-                    + SHORT_USAGE;
-            assertEquals("Unexpected output log", "", systemOut.getLog());
-            assertEquals("Unexpected system error log", usage, systemErr.getLog());
-        });
+    public void testWrongArgument(@SysErr Capturable systemErr, @SysOut Capturable systemOut) {
         // need to specify a file:
         // <files> is defined as a required positional param;
         // picocli verifies required parameters before checking unknown options
-        Main.main("-q", "file");
+        assertExitWithStatus(-1, () -> invokeMain("-q", "file"));
+        final String usage = "Unknown option: '-q'" + EOL + SHORT_USAGE;
+        assertEquals("", systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals(usage, systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testWrongArgumentMissingFiles()
-            throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            // files is defined as a required positional param;
-            // picocli verifies required parameters before checking unknown options
-            final String usage = "Missing required parameter: <files>" + EOL
-                    + SHORT_USAGE;
-            assertEquals("Unexpected output log", "", systemOut.getLog());
-            assertEquals("Unexpected system error log", usage, systemErr.getLog());
+    public void testWrongArgumentMissingFiles(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) {
+        assertExitWithStatus(-1, () -> invokeMain("-q"));
+        // files is defined as a required positional param;
+        // picocli verifies required parameters before checking unknown options
+        final String usage = "Missing required parameter: <files>" + EOL + SHORT_USAGE;
+        assertEquals("", systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals(usage, systemErr.getCapturedData(), "Unexpected system error log");
+    }
+
+    @Test
+    public void testNoConfigSpecified(@SysErr Capturable systemErr, @SysOut Capturable systemOut) {
+        assertExitWithStatus(-1, () -> invokeMain(getPath("InputMain.java")));
+        assertEquals("Must specify a config XML file." + System.lineSeparator(),
+                systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
+    }
+
+    @Test
+    public void testNonExistentTargetFile(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) {
+        assertExitWithStatus(-1, () -> {
+            invokeMain("-c", "/google_checks.xml", "NonExistentFile.java");
         });
-        Main.main("-q");
+        assertEquals("Files to process must be specified, found 0."
+            + System.lineSeparator(), systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testNoConfigSpecified()
-            throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log",
-                    "Must specify a config XML file." + System.lineSeparator(),
-                    systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-        });
-        Main.main(getPath("InputMain.java"));
-    }
-
-    @Test
-    public void testNonExistentTargetFile()
-            throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "Files to process must be specified, found 0."
-                + System.lineSeparator(), systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-        });
-        Main.main("-c", "/google_checks.xml", "NonExistentFile.java");
-    }
-
-    @Test
-    public void testExistingTargetFileButWithoutReadAccess() throws Exception {
-        final File file = temporaryFolder.newFile("testExistingTargetFileButWithoutReadAccess");
-        final boolean isSuccessfulChange = file.setReadable(false);
+    public void testExistingTargetFileButWithoutReadAccess(
+            @SysErr Capturable systemErr, @SysOut Capturable systemOut) throws IOException {
+        final File file = File.createTempFile(
+                "testExistingTargetFileButWithoutReadAccess", null, temporaryFolder);
         // skip execution if file is still readable, it is possible on some windows machines
         // see https://github.com/checkstyle/checkstyle/issues/7032 for details
-        if (isSuccessfulChange) {
-            exit.expectSystemExitWithStatus(-1);
-            exit.checkAssertionAfterwards(() -> {
-                assertEquals("Unexpected output log", "Files to process must be specified, found 0."
-                    + System.lineSeparator(), systemOut.getLog());
-                assertEquals("Unexpected system error log", "", systemErr.getLog());
-            });
-            Main.main("-c", "/google_checks.xml", file.getCanonicalPath());
-        }
+        assumeTrue(file.setReadable(false), "file is still readable");
+
+        final String canonicalPath = file.getCanonicalPath();
+        assertExitWithStatus(-1, () -> {
+            invokeMain("-c", "/google_checks.xml", canonicalPath);
+        });
+        assertEquals("Files to process must be specified, found 0."
+            + System.lineSeparator(), systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testNonExistentConfigFile()
-            throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "Could not find config XML file "
-                        + "'src/main/resources/non_existent_config.xml'." + EOL,
-                    systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
+    public void testNonExistentConfigFile(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) {
+        assertExitWithStatus(-1, () -> {
+            invokeMain("-c", "src/main/resources/non_existent_config.xml",
+                    getPath("InputMain.java"));
         });
-        Main.main("-c", "src/main/resources/non_existent_config.xml",
+        assertEquals(addEndOfLine("Could not find config XML file "
+                    + "'src/main/resources/non_existent_config.xml'."),
+                systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
+    }
+
+    @Test
+    public void testNonExistentOutputFormat(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) {
+        assertExitWithStatus(-1, () -> {
+            invokeMain("-c", "/google_checks.xml", "-f", "xmlp", getPath("InputMain.java"));
+        });
+        assertEquals("", systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("Invalid value for option '-f': expected one of [XML, PLAIN]"
+                    + " (case-insensitive) but was 'xmlp'" + EOL + SHORT_USAGE,
+                systemErr.getCapturedData(), "Unexpected system error log");
+    }
+
+    @Test
+    public void testNonExistentClass(@SysErr Capturable systemErr) {
+        assertExitWithStatus(-2, () -> {
+            invokeMain("-c", getPath("InputMainConfig-non-existent-classname.xml"),
+                    getPath("InputMain.java"));
+        });
+        final String cause = "com.puppycrawl.tools.checkstyle.api.CheckstyleException:"
+                + " cannot initialize module TreeWalker - ";
+        assertTrue(systemErr.getCapturedData().startsWith(cause), "Unexpected system error log");
+    }
+
+    @Test
+    public void testExistingTargetFile(@SysErr Capturable systemErr, @SysOut Capturable systemOut)
+            throws IOException {
+        Main.main("-c", getPath("InputMainConfig-classname.xml"), getPath("InputMain.java"));
+        assertEquals(addEndOfLine(auditStartMessage.getMessage(), auditFinishMessage.getMessage()),
+                systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
+    }
+
+    @Test
+    public void testExistingTargetFileXmlOutput(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws IOException {
+        Main.main("-c", getPath("InputMainConfig-classname.xml"), "-f", "xml",
                 getPath("InputMain.java"));
-    }
-
-    @Test
-    public void testNonExistentOutputFormat() throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "", systemOut.getLog());
-            assertEquals("Unexpected system error log",
-                    "Invalid value for option '-f': expected one of [XML, PLAIN]"
-                        + " (case-insensitive) but was 'xmlp'"
-                    + EOL + SHORT_USAGE, systemErr.getLog());
-        });
-        Main.main("-c", "/google_checks.xml", "-f", "xmlp",
-                getPath("InputMain.java"));
-    }
-
-    @Test
-    public void testNonExistentClass() throws Exception {
-        exit.expectSystemExitWithStatus(-2);
-        exit.checkAssertionAfterwards(() -> {
-            final String cause = "com.puppycrawl.tools.checkstyle.api.CheckstyleException:"
-                    + " cannot initialize module TreeWalker - ";
-            assertTrue("Unexpected system error log", systemErr.getLog().startsWith(cause));
-        });
-
-        Main.main("-c", getPath("InputMainConfig-non-existent-classname.xml"),
-            getPath("InputMain.java"));
-    }
-
-    @Test
-    public void testExistingTargetFile() throws Exception {
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", auditStartMessage.getMessage() + EOL
-                    + auditFinishMessage.getMessage() + EOL,
-                    systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-        });
-        Main.main("-c", getPath("InputMainConfig-classname.xml"),
-                getPath("InputMain.java"));
-    }
-
-    @Test
-    public void testExistingTargetFileXmlOutput() throws Exception {
-        exit.checkAssertionAfterwards(() -> {
-            final String expectedPath = getFilePath("InputMain.java");
-            final String version = Main.class.getPackage().getImplementationVersion();
-            assertEquals("Unexpected output log", addEndOfLine(
-                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
-                    "<checkstyle version=\"" + version + "\">",
-                    "<file name=\"" + expectedPath + "\">",
-                    "</file>",
-                    "</checkstyle>"), systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-        });
-        Main.main("-c", getPath("InputMainConfig-classname.xml"),
-                "-f", "xml",
-                getPath("InputMain.java"));
+        final String expectedPath = getFilePath("InputMain.java");
+        final String version = Main.class.getPackage().getImplementationVersion();
+        assertEquals(addEndOfLine(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+                "<checkstyle version=\"" + version + "\">",
+                "<file name=\"" + expectedPath + "\">",
+                "</file>",
+                "</checkstyle>"), systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     /**
@@ -371,8 +350,7 @@ public class MainTest {
      */
     @Test
     public void testNonClosedSystemStreams() throws Exception {
-        Main.main("-c", getPath("InputMainConfig-classname.xml"),
-                "-f", "xml",
+        Main.main("-c", getPath("InputMainConfig-classname.xml"), "-f", "xml",
                 getPath("InputMain.java"));
 
         final Boolean closedOut = (Boolean) TestUtil
@@ -404,72 +382,70 @@ public class MainTest {
     }
 
     @Test
-    public void testExistingTargetFilePlainOutput() throws Exception {
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", auditStartMessage.getMessage() + EOL
-                    + auditFinishMessage.getMessage() + EOL, systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-        });
-        Main.main("-c", getPath("InputMainConfig-classname.xml"),
-                "-f", "plain",
+    public void testExistingTargetFilePlainOutput(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws IOException {
+        Main.main("-c", getPath("InputMainConfig-classname.xml"), "-f", "plain",
                 getPath("InputMain.java"));
+        assertEquals(addEndOfLine(auditStartMessage.getMessage(), auditFinishMessage.getMessage()),
+                systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testExistingTargetFileWithViolations() throws Exception {
-        exit.checkAssertionAfterwards(() -> {
-            final LocalizedMessage invalidPatternMessageMain = new LocalizedMessage(1,
-                    "com.puppycrawl.tools.checkstyle.checks.naming.messages",
-                    "name.invalidPattern", new String[] {"InputMain", "^[a-z0-9]*$"},
-                    null, getClass(), null);
-            final LocalizedMessage invalidPatternMessageMainInner = new LocalizedMessage(1,
-                    "com.puppycrawl.tools.checkstyle.checks.naming.messages",
-                    "name.invalidPattern", new String[] {"InputMainInner", "^[a-z0-9]*$"},
-                    null, getClass(), null);
-            final String expectedPath = getFilePath("InputMain.java");
-            assertEquals("Unexpected output log", auditStartMessage.getMessage() + EOL
-                            + "[WARN] " + expectedPath + ":3:14: "
-                            + invalidPatternMessageMain.getMessage()
-                            + " [TypeName]" + EOL
-                            + "[WARN] " + expectedPath + ":5:7: "
-                            + invalidPatternMessageMainInner.getMessage()
-                            + " [TypeName]" + EOL
-                            + auditFinishMessage.getMessage() + EOL, systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-        });
-        Main.main("-c", getPath("InputMainConfig-classname2.xml"),
-                getPath("InputMain.java"));
+    public void testExistingTargetFileWithViolations(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws IOException {
+        Main.main("-c", getPath("InputMainConfig-classname2.xml"), getPath("InputMain.java"));
+        final LocalizedMessage invalidPatternMessageMain = new LocalizedMessage(1,
+                "com.puppycrawl.tools.checkstyle.checks.naming.messages",
+                "name.invalidPattern", new String[] {"InputMain", "^[a-z0-9]*$"},
+                null, getClass(), null);
+        final LocalizedMessage invalidPatternMessageMainInner = new LocalizedMessage(1,
+                "com.puppycrawl.tools.checkstyle.checks.naming.messages",
+                "name.invalidPattern", new String[] {"InputMainInner", "^[a-z0-9]*$"},
+                null, getClass(), null);
+        final String expectedPath = getFilePath("InputMain.java");
+        assertEquals(
+                addEndOfLine(auditStartMessage.getMessage(),
+                    "[WARN] " + expectedPath + ":3:14: "
+                        + invalidPatternMessageMain.getMessage()
+                        + " [TypeName]",
+                    "[WARN] " + expectedPath + ":5:7: "
+                        + invalidPatternMessageMainInner.getMessage()
+                        + " [TypeName]",
+                    auditFinishMessage.getMessage()),
+                systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testExistingTargetFileWithError()
-            throws Exception {
-        exit.expectSystemExitWithStatus(2);
-        exit.checkAssertionAfterwards(() -> {
-            final LocalizedMessage errorCounterTwoMessage = new LocalizedMessage(1,
-                    Definitions.CHECKSTYLE_BUNDLE, Main.ERROR_COUNTER,
-                    new String[] {String.valueOf(2)}, null, getClass(), null);
-            final LocalizedMessage invalidPatternMessageMain = new LocalizedMessage(1,
-                    "com.puppycrawl.tools.checkstyle.checks.naming.messages",
-                    "name.invalidPattern", new String[] {"InputMain", "^[a-z0-9]*$"},
-                    null, getClass(), null);
-            final LocalizedMessage invalidPatternMessageMainInner = new LocalizedMessage(1,
-                    "com.puppycrawl.tools.checkstyle.checks.naming.messages",
-                    "name.invalidPattern", new String[] {"InputMainInner", "^[a-z0-9]*$"},
-                    null, getClass(), null);
-            final String expectedPath = getFilePath("InputMain.java");
-            assertEquals("Unexpected output log", auditStartMessage.getMessage() + EOL
-                    + "[ERROR] " + expectedPath + ":3:14: "
-                    + invalidPatternMessageMain.getMessage() + " [TypeName]" + EOL
-                    + "[ERROR] " + expectedPath + ":5:7: "
-                    + invalidPatternMessageMainInner.getMessage() + " [TypeName]" + EOL
-                    + auditFinishMessage.getMessage() + EOL, systemOut.getLog());
-            assertEquals("Unexpected system error log",
-                    errorCounterTwoMessage.getMessage() + EOL, systemErr.getLog());
+    public void testExistingTargetFileWithError(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws Exception {
+        assertExitWithStatus(2, () -> {
+            invokeMain("-c", getPath("InputMainConfig-classname2-error.xml"),
+                    getPath("InputMain.java"));
         });
-        Main.main("-c",
-                getPath("InputMainConfig-classname2-error.xml"),
-                getPath("InputMain.java"));
+        final LocalizedMessage errorCounterTwoMessage = new LocalizedMessage(1,
+                Definitions.CHECKSTYLE_BUNDLE, Main.ERROR_COUNTER,
+                new String[] {String.valueOf(2)}, null, getClass(), null);
+        final LocalizedMessage invalidPatternMessageMain = new LocalizedMessage(1,
+                "com.puppycrawl.tools.checkstyle.checks.naming.messages",
+                "name.invalidPattern", new String[] {"InputMain", "^[a-z0-9]*$"},
+                null, getClass(), null);
+        final LocalizedMessage invalidPatternMessageMainInner = new LocalizedMessage(1,
+                "com.puppycrawl.tools.checkstyle.checks.naming.messages",
+                "name.invalidPattern", new String[] {"InputMainInner", "^[a-z0-9]*$"},
+                null, getClass(), null);
+        final String expectedPath = getFilePath("InputMain.java");
+        assertEquals(
+                addEndOfLine(auditStartMessage.getMessage(),
+                    "[ERROR] " + expectedPath + ":3:14: "
+                        + invalidPatternMessageMain.getMessage() + " [TypeName]",
+                    "[ERROR] " + expectedPath + ":5:7: "
+                        + invalidPatternMessageMainInner.getMessage() + " [TypeName]",
+                    auditFinishMessage.getMessage()),
+                systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals(addEndOfLine(errorCounterTwoMessage.getMessage()),
+                systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     /**
@@ -479,159 +455,140 @@ public class MainTest {
      * @throws Exception should not throw anything
      */
     @Test
-    public void testExistingTargetFileWithOneError()
-            throws Exception {
-        exit.expectSystemExitWithStatus(1);
-        exit.checkAssertionAfterwards(() -> {
-            final LocalizedMessage errorCounterTwoMessage = new LocalizedMessage(1,
-                    Definitions.CHECKSTYLE_BUNDLE, Main.ERROR_COUNTER,
-                    new String[] {String.valueOf(1)}, null, getClass(), null);
-            final LocalizedMessage invalidPatternMessageMain = new LocalizedMessage(1,
-                    "com.puppycrawl.tools.checkstyle.checks.naming.messages",
-                    "name.invalidPattern", new String[] {"InputMain1", "^[a-z0-9]*$"},
-                    null, getClass(), null);
-            final String expectedPath = getFilePath("InputMain1.java");
-            assertEquals("Unexpected output log", auditStartMessage.getMessage() + EOL
-                    + "[ERROR] " + expectedPath + ":3:14: "
-                    + invalidPatternMessageMain.getMessage() + " [TypeName]" + EOL
-                    + auditFinishMessage.getMessage() + EOL, systemOut.getLog());
-            assertEquals("Unexpected system error log",
-                    errorCounterTwoMessage.getMessage() + EOL, systemErr.getLog());
+    public void testExistingTargetFileWithOneError(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws Exception {
+        assertExitWithStatus(1, () -> {
+            invokeMain("-c", getPath("InputMainConfig-classname2-error.xml"),
+                    getPath("InputMain1.java"));
         });
-        Main.main("-c",
-                getPath("InputMainConfig-classname2-error.xml"),
-                getPath("InputMain1.java"));
+        final LocalizedMessage errorCounterTwoMessage = new LocalizedMessage(1,
+                Definitions.CHECKSTYLE_BUNDLE, Main.ERROR_COUNTER,
+                new String[] {String.valueOf(1)}, null, getClass(), null);
+        final LocalizedMessage invalidPatternMessageMain = new LocalizedMessage(1,
+                "com.puppycrawl.tools.checkstyle.checks.naming.messages",
+                "name.invalidPattern", new String[] {"InputMain1", "^[a-z0-9]*$"},
+                null, getClass(), null);
+        final String expectedPath = getFilePath("InputMain1.java");
+        assertEquals(
+                addEndOfLine(auditStartMessage.getMessage(),
+                    "[ERROR] " + expectedPath + ":3:14: "
+                        + invalidPatternMessageMain.getMessage() + " [TypeName]",
+                    auditFinishMessage.getMessage()),
+                systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals(addEndOfLine(errorCounterTwoMessage.getMessage()),
+                systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testExistingTargetFileWithOneErrorAgainsSunCheck()
-            throws Exception {
-        exit.expectSystemExitWithStatus(1);
-        exit.checkAssertionAfterwards(() -> {
-            final LocalizedMessage errorCounterTwoMessage = new LocalizedMessage(1,
-                    Definitions.CHECKSTYLE_BUNDLE, Main.ERROR_COUNTER,
-                    new String[] {String.valueOf(1)}, null, getClass(), null);
-            final LocalizedMessage message = new LocalizedMessage(1,
-                    "com.puppycrawl.tools.checkstyle.checks.javadoc.messages",
-                    "javadoc.packageInfo", new String[] {},
-                    null, getClass(), null);
-            final String expectedPath = getFilePath("InputMain1.java");
-            assertEquals("Unexpected output log", auditStartMessage.getMessage() + EOL
-                    + "[ERROR] " + expectedPath + ":1: "
-                    + message.getMessage() + " [JavadocPackage]" + EOL
-                    + auditFinishMessage.getMessage() + EOL, systemOut.getLog());
-            assertEquals("Unexpected system error log",
-                    errorCounterTwoMessage.getMessage() + EOL, systemErr.getLog());
+    public void testExistingTargetFileWithOneErrorAgainstSunCheck(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws Exception {
+        assertExitWithStatus(1, () -> {
+            invokeMain("-c", "/sun_checks.xml", getPath("InputMain1.java"));
         });
-        Main.main("-c", "/sun_checks.xml",
-                getPath("InputMain1.java"));
+        final LocalizedMessage errorCounterTwoMessage = new LocalizedMessage(1,
+                Definitions.CHECKSTYLE_BUNDLE, Main.ERROR_COUNTER,
+                new String[] {String.valueOf(1)}, null, getClass(), null);
+        final LocalizedMessage message = new LocalizedMessage(1,
+                "com.puppycrawl.tools.checkstyle.checks.javadoc.messages",
+                "javadoc.packageInfo", new String[] {},
+                null, getClass(), null);
+        final String expectedPath = getFilePath("InputMain1.java");
+        assertEquals(addEndOfLine(auditStartMessage.getMessage(),
+                "[ERROR] " + expectedPath + ":1: " + message.getMessage() + " [JavadocPackage]",
+                auditFinishMessage.getMessage()),
+                systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals(addEndOfLine(errorCounterTwoMessage.getMessage()),
+                systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testExistentTargetFilePlainOutputToNonExistentFile()
-            throws Exception {
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "", systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-        });
-        Main.main("-c", getPath("InputMainConfig-classname.xml"),
-                "-f", "plain",
-                "-o", temporaryFolder.getRoot() + "/output.txt",
-                getPath("InputMain.java"));
+    public void testExistentTargetFilePlainOutputToNonExistentFile(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws IOException {
+        Main.main("-c", getPath("InputMainConfig-classname.xml"), "-f", "plain",
+                "-o", temporaryFolder + "/output.txt", getPath("InputMain.java"));
+        assertEquals("", systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testExistingTargetFilePlainOutputToFile()
-            throws Exception {
-        final File file = temporaryFolder.newFile("file.output");
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "", systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-        });
-        Main.main("-c", getPath("InputMainConfig-classname.xml"),
-                "-f", "plain",
-                "-o", file.getCanonicalPath(),
-                getPath("InputMain.java"));
+    public void testExistingTargetFilePlainOutputToFile(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws Exception {
+        final String outputFile =
+                File.createTempFile("file", ".output", temporaryFolder).getCanonicalPath();
+        assertTrue(new File(outputFile).exists(), "File must exist");
+        Main.main("-c", getPath("InputMainConfig-classname.xml"), "-f", "plain",
+                "-o", outputFile, getPath("InputMain.java"));
+        assertEquals("", systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testCreateNonExistentOutputFile() throws Exception {
-        final String outputFile = temporaryFolder.getRoot().getCanonicalPath() + "nonexistent.out";
-        assertFalse("File must not exist", new File(outputFile).exists());
-        Main.main("-c", getPath("InputMainConfig-classname.xml"),
-                "-f", "plain",
-                "-o", outputFile,
-                getPath("InputMain.java"));
-        assertTrue("File must exist", new File(outputFile).exists());
+    public void testCreateNonExistentOutputFile() throws IOException {
+        final String outputFile = new File(temporaryFolder, "nonexistent.out").getCanonicalPath();
+        assertFalse(new File(outputFile).exists(), "File must not exist");
+        Main.main("-c", getPath("InputMainConfig-classname.xml"), "-f", "plain",
+                "-o", outputFile, getPath("InputMain.java"));
+        assertTrue(new File(outputFile).exists(), "File must exist");
     }
 
     @Test
-    public void testExistingTargetFilePlainOutputProperties() throws Exception {
-        //exit.expectSystemExitWithStatus(0);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", auditStartMessage.getMessage() + EOL
-                    + auditFinishMessage.getMessage() + EOL, systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-        });
+    public void testExistingTargetFilePlainOutputProperties(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws IOException {
         Main.main("-c", getPath("InputMainConfig-classname-prop.xml"),
-                "-p", getPath("InputMainMycheckstyle.properties"),
-                getPath("InputMain.java"));
+                "-p", getPath("InputMainMycheckstyle.properties"), getPath("InputMain.java"));
+        assertEquals(addEndOfLine(auditStartMessage.getMessage(), auditFinishMessage.getMessage()),
+                systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testExistingTargetFilePlainOutputNonexistentProperties()
-            throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "Could not find file 'nonexistent.properties'."
-                    + System.lineSeparator(), systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
+    public void testExistingTargetFilePlainOutputNonexistentProperties(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) {
+        assertExitWithStatus(-1, () -> {
+            invokeMain("-c", getPath("InputMainConfig-classname-prop.xml"),
+                    "-p", "nonexistent.properties", getPath("InputMain.java"));
         });
-        Main.main("-c", getPath("InputMainConfig-classname-prop.xml"),
-                "-p", "nonexistent.properties",
-                getPath("InputMain.java"));
+        assertEquals("Could not find file 'nonexistent.properties'."
+                + System.lineSeparator(), systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testExistingIncorrectConfigFile()
-            throws Exception {
-        exit.expectSystemExitWithStatus(-2);
-        exit.checkAssertionAfterwards(() -> {
-            final String errorOutput = "com.puppycrawl.tools.checkstyle.api."
-                + "CheckstyleException: unable to parse configuration stream - ";
-            assertTrue("Unexpected system error log", systemErr.getLog().startsWith(errorOutput));
+    public void testExistingIncorrectConfigFile(@SysErr Capturable systemErr) {
+        assertExitWithStatus(-2, () -> {
+            invokeMain("-c", getPath("InputMainConfig-Incorrect.xml"), getPath("InputMain.java"));
         });
-        Main.main("-c", getPath("InputMainConfig-Incorrect.xml"),
-            getPath("InputMain.java"));
+        final String errorOutput = "com.puppycrawl.tools.checkstyle.api."
+            + "CheckstyleException: unable to parse configuration stream - ";
+        assertTrue(systemErr.getCapturedData().startsWith(errorOutput),
+                "Unexpected system error log");
     }
 
     @Test
-    public void testExistingIncorrectChildrenInConfigFile()
-            throws Exception {
-        exit.expectSystemExitWithStatus(-2);
-        exit.checkAssertionAfterwards(() -> {
-            final String errorOutput = "com.puppycrawl.tools.checkstyle.api."
-                    + "CheckstyleException: cannot initialize module RegexpSingleline"
-                    + " - RegexpSingleline is not allowed as a child in RegexpSingleline";
-            assertTrue("Unexpected system error log", systemErr.getLog().startsWith(errorOutput));
+    public void testExistingIncorrectChildrenInConfigFile(@SysErr Capturable systemErr) {
+        assertExitWithStatus(-2, () -> {
+            invokeMain("-c", getPath("InputMainConfig-incorrectChildren.xml"),
+                    getPath("InputMain.java"));
         });
-        Main.main("-c", getPath("InputMainConfig-incorrectChildren.xml"),
-            getPath("InputMain.java"));
+        final String errorOutput = "com.puppycrawl.tools.checkstyle.api."
+                + "CheckstyleException: cannot initialize module RegexpSingleline"
+                + " - RegexpSingleline is not allowed as a child in RegexpSingleline";
+        assertTrue(systemErr.getCapturedData().startsWith(errorOutput),
+                "Unexpected system error log");
     }
 
     @Test
-    public void testExistingIncorrectChildrenInConfigFile2()
-            throws Exception {
-        exit.expectSystemExitWithStatus(-2);
-        exit.checkAssertionAfterwards(() -> {
-            final String errorOutput = "com.puppycrawl.tools.checkstyle.api."
-                    + "CheckstyleException: cannot initialize module TreeWalker - "
-                    + "cannot initialize module JavadocMethod - "
-                    + "JavadocVariable is not allowed as a child in JavadocMethod";
-            assertTrue("Unexpected system error log", systemErr.getLog().startsWith(errorOutput));
+    public void testExistingIncorrectChildrenInConfigFile2(@SysErr Capturable systemErr) {
+        assertExitWithStatus(-2, () -> {
+            invokeMain("-c", getPath("InputMainConfig-incorrectChildren2.xml"),
+                    getPath("InputMain.java"));
         });
-        Main.main("-c", getPath("InputMainConfig-incorrectChildren2.xml"),
-            getPath("InputMain.java"));
+        final String errorOutput = "com.puppycrawl.tools.checkstyle.api."
+                + "CheckstyleException: cannot initialize module TreeWalker - "
+                + "cannot initialize module JavadocMethod - "
+                + "JavadocVariable is not allowed as a child in JavadocMethod";
+        assertTrue(systemErr.getCapturedData().startsWith(errorOutput),
+                "Unexpected system error log");
     }
 
     @Test
@@ -646,8 +603,8 @@ public class MainTest {
             fail("Exception was expected");
         }
         catch (InvocationTargetException ex) {
-            assertTrue("Invalid error cause",
-                    ex.getCause() instanceof CheckstyleException);
+            assertTrue(
+                    ex.getCause() instanceof CheckstyleException, "Invalid error cause");
             // We do separate validation for message as in Windows
             // disk drive letter appear in message,
             // so we skip that drive letter for compatibility issues
@@ -663,13 +620,14 @@ public class MainTest {
                     causeMessage.substring(causeMessage.lastIndexOf(' '))
                     .equals(localizedMessage
                             .substring(localizedMessage.lastIndexOf(' ')));
-            assertTrue("Invalid error message", samePrefix || sameSuffix);
-            assertTrue("Invalid error message", causeMessage.contains(".'"));
+            assertTrue(samePrefix || sameSuffix, "Invalid error message");
+            assertTrue(causeMessage.contains(".'"), "Invalid error message");
         }
     }
 
     @Test
-    public void testExistingDirectoryWithViolations() throws Exception {
+    public void testExistingDirectoryWithViolations(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws IOException {
         // we just reference there all violations
         final String[][] outputValues = {
                 {"InputMainComplexityOverflow", "1", "172"},
@@ -679,28 +637,25 @@ public class MainTest {
         final String msgKey = "maxLen.file";
         final String bundle = "com.puppycrawl.tools.checkstyle.checks.sizes.messages";
 
-        exit.checkAssertionAfterwards(() -> {
-            final String expectedPath = getFilePath("") + File.separator;
-            final StringBuilder sb = new StringBuilder(28);
-            sb.append(auditStartMessage.getMessage())
-                    .append(EOL);
-            final String format = "[WARN] " + expectedPath + outputValues[0][0] + ".java:"
-                    + outputValues[0][1] + ": ";
-            for (String[] outputValue : outputValues) {
-                final String localizedMessage = new LocalizedMessage(1, bundle,
-                        msgKey, new Integer[] {Integer.valueOf(outputValue[2]), allowedLength},
-                        null, getClass(), null).getMessage();
-                final String line = format + localizedMessage + " [FileLength]";
-                sb.append(line).append(EOL);
-            }
-            sb.append(auditFinishMessage.getMessage())
-                    .append(EOL);
-            assertEquals("Unexpected output log", sb.toString(), systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-        });
-
         Main.main("-c", getPath("InputMainConfig-filelength.xml"),
                 getPath(""));
+        final String expectedPath = getFilePath("") + File.separator;
+        final StringBuilder sb = new StringBuilder(28);
+        sb.append(auditStartMessage.getMessage())
+                .append(EOL);
+        final String format = "[WARN] " + expectedPath + outputValues[0][0] + ".java:"
+                + outputValues[0][1] + ": ";
+        for (String[] outputValue : outputValues) {
+            final String localizedMessage = new LocalizedMessage(1, bundle,
+                    msgKey, new Integer[] {Integer.valueOf(outputValue[2]), allowedLength},
+                    null, getClass(), null).getMessage();
+            final String line = format + localizedMessage + " [FileLength]";
+            sb.append(line).append(EOL);
+        }
+        sb.append(auditFinishMessage.getMessage())
+                .append(EOL);
+        assertEquals(sb.toString(), systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     /**
@@ -730,7 +685,7 @@ public class MainTest {
 
         final List<File> result = Whitebox.invokeMethod(Main.class, "listFiles",
                 fileMock, new ArrayList<Pattern>());
-        assertEquals("Invalid result size", 0, result.size());
+        assertEquals(0, result.size(), "Invalid result size");
     }
 
     /**
@@ -761,40 +716,35 @@ public class MainTest {
 
         final List<File> result = Whitebox.invokeMethod(Main.class, "listFiles",
                 fileMock, new ArrayList<Pattern>());
-        assertEquals("Invalid result size", 0, result.size());
+        assertEquals(0, result.size(), "Invalid result size");
     }
 
     @Test
-    public void testFileReferenceDuringException() throws Exception {
-        exit.expectSystemExitWithStatus(-2);
-        exit.checkAssertionAfterwards(() -> {
-            final String exceptionFirstLine = "com.puppycrawl.tools.checkstyle.api."
-                    + "CheckstyleException: Exception was thrown while processing "
-                    + new File(getNonCompilablePath("InputMainIncorrectClass.java")).getPath()
-                    + EOL;
-            assertTrue("Unexpected system error log",
-                    systemErr.getLog().startsWith(exceptionFirstLine));
-        });
-
+    public void testFileReferenceDuringException(@SysErr Capturable systemErr) {
         // We put xml as source to cause parse exception
-        Main.main("-c", getPath("InputMainConfig-classname.xml"),
-                getNonCompilablePath("InputMainIncorrectClass.java"));
-    }
-
-    @Test
-    public void testPrintTreeOnMoreThanOneFile() throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "Printing AST is allowed for only one file."
-                + System.lineSeparator(), systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
+        assertExitWithStatus(-2, () -> {
+            invokeMain("-c", getPath("InputMainConfig-classname.xml"),
+                    getNonCompilablePath("InputMainIncorrectClass.java"));
         });
-
-        Main.main("-t", getPath(""));
+        final String exceptionFirstLine = addEndOfLine("com.puppycrawl.tools.checkstyle.api."
+                + "CheckstyleException: Exception was thrown while processing "
+                + new File(getNonCompilablePath("InputMainIncorrectClass.java")).getPath());
+        assertTrue(systemErr.getCapturedData().startsWith(exceptionFirstLine),
+                "Unexpected system error log");
     }
 
     @Test
-    public void testPrintTreeOption() throws Exception {
+    public void testPrintTreeOnMoreThanOneFile(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) {
+        assertExitWithStatus(-1, () -> invokeMain("-t", getPath("")));
+        assertEquals("Printing AST is allowed for only one file."
+            + System.lineSeparator(), systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
+    }
+
+    @Test
+    public void testPrintTreeOption(@SysErr Capturable systemErr, @SysOut Capturable systemOut)
+            throws IOException {
         final String expected = addEndOfLine(
             "PACKAGE_DEF -> package [1:0]",
             "|--ANNOTATIONS -> ANNOTATIONS [1:39]",
@@ -824,15 +774,14 @@ public class MainTest {
             "    |--LCURLY -> { [5:21]",
             "    `--RCURLY -> } [6:0]");
 
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", expected, systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-        });
         Main.main("-t", getPath("InputMain.java"));
+        assertEquals(expected, systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testPrintXpathOption() throws Exception {
+    public void testPrintXpathOption(@SysErr Capturable systemErr, @SysOut Capturable systemOut)
+            throws IOException {
         final String expected = addEndOfLine(
             "CLASS_DEF -> CLASS_DEF [3:0]",
             "`--OBJBLOCK -> OBJBLOCK [3:28]",
@@ -840,41 +789,37 @@ public class MainTest {
             "    |   `--SLIST -> { [4:20]",
             "    |       |--VARIABLE_DEF -> VARIABLE_DEF [5:8]",
             "    |       |   |--IDENT -> a [5:12]");
-        exit.checkAssertionAfterwards(() -> {
-            Assert.assertThat("Unexpected output log", systemOut.getLog(), is(expected));
-            Assert.assertThat("Unexpected system error log", systemErr.getLog(), is(""));
-        });
         Main.main("-b", "/CLASS_DEF//METHOD_DEF[./IDENT[@text='methodOne']]//VARIABLE_DEF/IDENT",
-            getPath("InputMainXPath.java"));
+                getPath("InputMainXPath.java"));
+        assertThat("Unexpected output log", systemOut.getCapturedData(), is(expected));
+        assertThat("Unexpected system error log", systemErr.getCapturedData(), is(""));
     }
 
     @Test
-    public void testPrintXpathCommentNode() throws Exception {
+    public void testPrintXpathCommentNode(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws IOException {
         final String expected = addEndOfLine(
             "CLASS_DEF -> CLASS_DEF [17:0]",
             "`--OBJBLOCK -> OBJBLOCK [17:19]",
             "    |--CTOR_DEF -> CTOR_DEF [19:4]",
             "    |   |--BLOCK_COMMENT_BEGIN -> /* [18:4]");
-        exit.checkAssertionAfterwards(() -> {
-            Assert.assertThat("Unexpected output log", systemOut.getLog(), is(expected));
-            Assert.assertThat("Unexpected system error log", systemErr.getLog(), is(""));
-        });
-        Main.main("-b", "/CLASS_DEF//BLOCK_COMMENT_BEGIN",
-            getPath("InputMainXPath.java"));
+        Main.main("-b", "/CLASS_DEF//BLOCK_COMMENT_BEGIN", getPath("InputMainXPath.java"));
+        assertThat("Unexpected output log", systemOut.getCapturedData(), is(expected));
+        assertThat("Unexpected system error log", systemErr.getCapturedData(), is(""));
     }
 
     @Test
-    public void testPrintXpathNodeParentNull() throws Exception {
-        final String expected = "PACKAGE_DEF -> package [1:0]" + EOL;
-        exit.checkAssertionAfterwards(() -> {
-            Assert.assertThat("Unexpected output log", systemOut.getLog(), is(expected));
-            Assert.assertThat("Unexpected system error log", systemErr.getLog(), is(""));
-        });
+    public void testPrintXpathNodeParentNull(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws IOException {
+        final String expected = addEndOfLine("PACKAGE_DEF -> package [1:0]");
         Main.main("-b", "/PACKAGE_DEF", getPath("InputMainXPath.java"));
+        assertThat("Unexpected output log", systemOut.getCapturedData(), is(expected));
+        assertThat("Unexpected system error log", systemErr.getCapturedData(), is(""));
     }
 
     @Test
-    public void testPrintXpathFullOption() throws Exception {
+    public void testPrintXpathFullOption(@SysErr Capturable systemErr, @SysOut Capturable systemOut)
+            throws IOException {
         final String expected = addEndOfLine(
             "CLASS_DEF -> CLASS_DEF [3:0]",
             "`--OBJBLOCK -> OBJBLOCK [3:28]",
@@ -882,16 +827,15 @@ public class MainTest {
             "    |   `--SLIST -> { [8:26]",
             "    |       |--VARIABLE_DEF -> VARIABLE_DEF [9:8]",
             "    |       |   |--IDENT -> a [9:12]");
-        exit.checkAssertionAfterwards(() -> {
-            Assert.assertThat("Unexpected output log", systemOut.getLog(), is(expected));
-            Assert.assertThat("Unexpected system error log", systemErr.getLog(), is(""));
-        });
         final String xpath = "/CLASS_DEF//METHOD_DEF[./IDENT[@text='method']]//VARIABLE_DEF/IDENT";
         Main.main("--branch-matching-xpath", xpath, getPath("InputMainXPath.java"));
+        assertThat("Unexpected output log", systemOut.getCapturedData(), is(expected));
+        assertThat("Unexpected system error log", systemErr.getCapturedData(), is(""));
     }
 
     @Test
-    public void testPrintXpathTwoResults() throws Exception {
+    public void testPrintXpathTwoResults(@SysErr Capturable systemErr, @SysOut Capturable systemOut)
+            throws IOException {
         final String expected = addEndOfLine(
             "CLASS_DEF -> CLASS_DEF [12:0]",
             "`--OBJBLOCK -> OBJBLOCK [12:10]",
@@ -900,31 +844,29 @@ public class MainTest {
             "CLASS_DEF -> CLASS_DEF [12:0]",
             "`--OBJBLOCK -> OBJBLOCK [12:10]",
             "    |--METHOD_DEF -> METHOD_DEF [14:4]");
-        exit.checkAssertionAfterwards(() -> {
-            Assert.assertThat("Unexpected output log", systemOut.getLog(), is(expected));
-            Assert.assertThat("Unexpected system error log", systemErr.getLog(), is(""));
-        });
         Main.main("--branch-matching-xpath", "/CLASS_DEF[./IDENT[@text='Two']]//METHOD_DEF",
-            getPath("InputMainXPath.java"));
+                getPath("InputMainXPath.java"));
+        assertThat("Unexpected output log", systemOut.getCapturedData(), is(expected));
+        assertThat("Unexpected system error log", systemErr.getCapturedData(), is(""));
     }
 
     @Test
-    public void testPrintXpathInvalidXpath() throws Exception {
+    public void testPrintXpathInvalidXpath(@SysErr Capturable systemErr) throws Exception {
         final String invalidXpath = "\\/CLASS_DEF[./IDENT[@text='Two']]//METHOD_DEF";
         final String filePath = getFilePath("InputMainXPath.java");
-        exit.expectSystemExitWithStatus(-2);
-        exit.checkAssertionAfterwards(() -> {
-            final String exceptionFirstLine = "com.puppycrawl.tools.checkstyle.api."
-                + "CheckstyleException: Error during evaluation for xpath: " + invalidXpath
-                + ", file: " + filePath + EOL;
-            assertThat("Unexpected system error log",
-                systemErr.getLog().startsWith(exceptionFirstLine), is(true));
+        assertExitWithStatus(-2, () -> {
+            invokeMain("--branch-matching-xpath", invalidXpath, filePath);
         });
-        Main.main("--branch-matching-xpath", invalidXpath, filePath);
+        final String exceptionFirstLine = addEndOfLine("com.puppycrawl.tools.checkstyle.api."
+            + "CheckstyleException: Error during evaluation for xpath: " + invalidXpath
+            + ", file: " + filePath);
+        assertThat("Unexpected system error log",
+            systemErr.getCapturedData().startsWith(exceptionFirstLine), is(true));
     }
 
     @Test
-    public void testPrintTreeCommentsOption() throws Exception {
+    public void testPrintTreeCommentsOption(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws IOException {
         final String expected = addEndOfLine(
             "PACKAGE_DEF -> package [1:0]",
             "|--ANNOTATIONS -> ANNOTATIONS [1:39]",
@@ -957,48 +899,40 @@ public class MainTest {
             "    |--LCURLY -> { [5:21]",
             "    `--RCURLY -> } [6:0]");
 
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", expected, systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-        });
         Main.main("-T", getPath("InputMain.java"));
+        assertEquals(expected, systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testPrintTreeJavadocOption() throws Exception {
+    public void testPrintTreeJavadocOption(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws Exception {
         final String expected = new String(Files.readAllBytes(Paths.get(
             getPath("InputMainExpectedInputJavadocComment.txt"))), StandardCharsets.UTF_8)
             .replaceAll("\\\\r\\\\n", "\\\\n").replaceAll("\r\n", "\n");
 
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log",
-                    expected, systemOut.getLog().replaceAll("\\\\r\\\\n", "\\\\n")
-                            .replaceAll("\r\n", "\n"));
-            assertEquals("Unexpected system error log",
-                    "", systemErr.getLog());
-        });
         Main.main("-j", getPath("InputMainJavadocComment.javadoc"));
+        assertEquals(expected, systemOut.getCapturedData().replaceAll("\\\\r\\\\n", "\\\\n")
+                        .replaceAll("\r\n", "\n"), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testPrintSuppressionOption() throws Exception {
+    public void testPrintSuppressionOption(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws IOException {
         final String expected = addEndOfLine(
             "/CLASS_DEF[./IDENT[@text='InputMainSuppressionsStringPrinter']]",
                 "/CLASS_DEF[./IDENT[@text='InputMainSuppressionsStringPrinter']]/MODIFIERS",
                 "/CLASS_DEF[./IDENT[@text='InputMainSuppressionsStringPrinter']]/LITERAL_CLASS");
 
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log",
-                    expected, systemOut.getLog());
-            assertEquals("Unexpected system error log",
-                    "", systemErr.getLog());
-        });
-        Main.main(getPath("InputMainSuppressionsStringPrinter.java"),
-                "-s", "3:1");
+        Main.main(getPath("InputMainSuppressionsStringPrinter.java"), "-s", "3:1");
+        assertEquals(expected, systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testPrintSuppressionAndTabWidthOption() throws Exception {
+    public void testPrintSuppressionAndTabWidthOption(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws IOException {
         final String expected = addEndOfLine(
             "/CLASS_DEF[./IDENT[@text='InputMainSuppressionsStringPrinter']]/OBJBLOCK"
                     + "/METHOD_DEF[./IDENT[@text='getName']]"
@@ -1013,82 +947,66 @@ public class MainTest {
                     + "/METHOD_DEF[./IDENT[@text='getName']]/SLIST"
                     + "/VARIABLE_DEF[./IDENT[@text='var']]/TYPE/LITERAL_INT");
 
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log",
-                    expected, systemOut.getLog());
-            assertEquals("Unexpected system error log",
-                    "", systemErr.getLog());
-        });
         Main.main(getPath("InputMainSuppressionsStringPrinter.java"),
                 "-s", "7:9", "--tabWidth", "2");
+        assertEquals(expected, systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testPrintSuppressionConflictingOptionsTvsC() throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "Option '-s' cannot be used with other options."
-                    + System.lineSeparator(), systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
+    public void testPrintSuppressionConflictingOptionsTvsC(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) {
+        assertExitWithStatus(-1, () -> {
+            invokeMain("-c", "/google_checks.xml", getPath(""), "-s", "2:4");
         });
-
-        Main.main("-c", "/google_checks.xml",
-                getPath(""), "-s", "2:4");
+        assertEquals("Option '-s' cannot be used with other options."
+                + System.lineSeparator(), systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testPrintSuppressionConflictingOptionsTvsP() throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "Option '-s' cannot be used with other options."
-                    + System.lineSeparator(), systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
+    public void testPrintSuppressionConflictingOptionsTvsP(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) {
+        assertExitWithStatus(-1, () -> {
+            invokeMain("-p", getPath("InputMainMycheckstyle.properties"), "-s", "2:4", getPath(""));
         });
-
-        Main.main("-p", getPath("InputMainMycheckstyle.properties"), "-s", "2:4", getPath(""));
+        assertEquals("Option '-s' cannot be used with other options."
+                + System.lineSeparator(), systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testPrintSuppressionConflictingOptionsTvsF() throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "Option '-s' cannot be used with other options."
-                    + System.lineSeparator(), systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-        });
-
-        Main.main("-f", "plain", "-s", "2:4", getPath(""));
+    public void testPrintSuppressionConflictingOptionsTvsF(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) {
+        assertExitWithStatus(-1, () -> invokeMain("-f", "plain", "-s", "2:4", getPath("")));
+        assertEquals("Option '-s' cannot be used with other options."
+                + System.lineSeparator(), systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testPrintSuppressionConflictingOptionsTvsO() throws Exception {
-        final File file = temporaryFolder.newFile("file.output");
+    public void testPrintSuppressionConflictingOptionsTvsO(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws IOException {
+        final String outputPath = new File(temporaryFolder, "file.output").getCanonicalPath();
 
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "Option '-s' cannot be used with other options."
-                    + System.lineSeparator(), systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-        });
-
-        Main.main("-o", file.getCanonicalPath(), "-s", "2:4", getPath(""));
+        assertExitWithStatus(-1, () -> invokeMain("-o", outputPath, "-s", "2:4", getPath("")));
+        assertEquals("Option '-s' cannot be used with other options."
+                + System.lineSeparator(), systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testPrintSuppressionOnMoreThanOneFile() throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "Printing xpath suppressions is allowed for "
-                    + "only one file."
-                    + System.lineSeparator(), systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-        });
-
-        Main.main("-s", "2:4", getPath(""), getPath(""));
+    public void testPrintSuppressionOnMoreThanOneFile(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) {
+        assertExitWithStatus(-1, () -> invokeMain("-s", "2:4", getPath(""), getPath("")));
+        assertEquals("Printing xpath suppressions is allowed for only one file."
+                + System.lineSeparator(), systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testGenerateXpathSuppressionOptionOne() throws Exception {
+    public void testGenerateXpathSuppressionOptionOne(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws IOException {
         final String expected = addEndOfLine(
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
                 "<!DOCTYPE suppressions PUBLIC",
@@ -1178,18 +1096,15 @@ public class MainTest {
                     + "/LITERAL_IF/SLIST/LITERAL_IF/SLIST/LITERAL_IF/SLIST\"/>",
                 "</suppressions>");
 
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log",
-                    expected, systemOut.getLog());
-            assertEquals("Unexpected system error log",
-                    "", systemErr.getLog());
-        });
         Main.main("-c", "/google_checks.xml", "--generate-xpath-suppression",
                 getPath("InputMainComplexityOverflow.java"));
+        assertEquals(expected, systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testGenerateXpathSuppressionOptionTwo() throws Exception {
+    public void testGenerateXpathSuppressionOptionTwo(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws IOException {
         final String expected = addEndOfLine(
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
             "<!DOCTYPE suppressions PUBLIC",
@@ -1216,33 +1131,27 @@ public class MainTest {
                 + "/LITERAL_FOR/SLIST/LITERAL_FOR\"/>",
             "</suppressions>");
 
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log",
-                    expected, systemOut.getLog());
-            assertEquals("Unexpected system error log",
-                    "", systemErr.getLog());
-        });
         Main.main("-c", getPath("InputMainConfig-xpath-suppressions.xml"),
                 "--generate-xpath-suppression",
                 getPath("InputMainGenerateXpathSuppressions.java"));
+        assertEquals(expected, systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testGenerateXpathSuppressionOptionEmptyConfig() throws Exception {
+    public void testGenerateXpathSuppressionOptionEmptyConfig(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws IOException {
         final String expected = "";
 
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log",
-                    expected, systemOut.getLog());
-            assertEquals("Unexpected system error log",
-                    "", systemErr.getLog());
-        });
         Main.main("-c", getPath("InputMainConfig-empty.xml"), "--generate-xpath-suppression",
                 getPath("InputMainComplexityOverflow.java"));
+        assertEquals(expected, systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testGenerateXpathSuppressionOptionCustomOutput() throws Exception {
+    public void testGenerateXpathSuppressionOptionCustomOutput(@SysErr Capturable systemErr)
+            throws IOException {
         final String expected = addEndOfLine(
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
                 "<!DOCTYPE suppressions PUBLIC",
@@ -1257,24 +1166,20 @@ public class MainTest {
                     + "@text='InputMainGenerateXpathSuppressionsTabWidth']]"
                     + "/OBJBLOCK/VARIABLE_DEF/IDENT[@text='low']\"/>",
                 "</suppressions>");
-        final File file = temporaryFolder.newFile();
-        exit.checkAssertionAfterwards(() -> {
-            try (BufferedReader br = Files.newBufferedReader(file.toPath())) {
-                final String fileContent = br.lines().collect(Collectors.joining(EOL, "", EOL));
-                assertEquals("Unexpected output log",
-                        expected, fileContent);
-                assertEquals("Unexpected system error log",
-                        "", systemErr.getLog());
-            }
-        });
-        Main.main("-c", getPath("InputMainConfig-xpath-suppressions.xml"),
-                "-o", file.getPath(),
+        final File file = new File(temporaryFolder, "file.output");
+        Main.main("-c", getPath("InputMainConfig-xpath-suppressions.xml"), "-o", file.getPath(),
                 "--generate-xpath-suppression",
                 getPath("InputMainGenerateXpathSuppressionsTabWidth.java"));
+        try (BufferedReader br = Files.newBufferedReader(file.toPath())) {
+            final String fileContent = br.lines().collect(Collectors.joining(EOL, "", EOL));
+            assertEquals(expected, fileContent, "Unexpected output log");
+            assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
+        }
     }
 
     @Test
-    public void testGenerateXpathSuppressionOptionDefaultTabWidth() throws Exception {
+    public void testGenerateXpathSuppressionOptionDefaultTabWidth(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws IOException {
         final String expected = addEndOfLine(
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
                 "<!DOCTYPE suppressions PUBLIC",
@@ -1290,163 +1195,144 @@ public class MainTest {
                     + "/OBJBLOCK/VARIABLE_DEF/IDENT[@text='low']\"/>",
                 "</suppressions>");
 
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log",
-                    expected, systemOut.getLog());
-            assertEquals("Unexpected system error log",
-                    "", systemErr.getLog());
-        });
         Main.main("-c", getPath("InputMainConfig-xpath-suppressions.xml"),
                 "--generate-xpath-suppression",
                 getPath("InputMainGenerateXpathSuppressionsTabWidth.java"));
+        assertEquals(
+                expected, systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals(
+                "", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testGenerateXpathSuppressionOptionCustomTabWidth() throws Exception {
+    public void testGenerateXpathSuppressionOptionCustomTabWidth(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws IOException {
         final String expected = "";
 
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log",
-                    expected, systemOut.getLog());
-            assertEquals("Unexpected system error log",
-                    "", systemErr.getLog());
-        });
         Main.main("-c", getPath("InputMainConfig-xpath-suppressions.xml"),
-                "--generate-xpath-suppression",
-                "--tabWidth", "20",
+                "--generate-xpath-suppression", "--tabWidth", "20",
                 getPath("InputMainGenerateXpathSuppressionsTabWidth.java"));
+        assertEquals(expected, systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testPrintFullTreeOption() throws Exception {
+    public void testPrintFullTreeOption(@SysErr Capturable systemErr, @SysOut Capturable systemOut)
+            throws IOException {
         final String expected = new String(Files.readAllBytes(Paths.get(
             getPath("InputMainExpectedInputAstTreeStringPrinterJavadoc.txt"))),
             StandardCharsets.UTF_8).replaceAll("\\\\r\\\\n", "\\\\n")
                 .replaceAll("\r\n", "\n");
 
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log",
-                    expected, systemOut.getLog().replaceAll("\\\\r\\\\n", "\\\\n")
-                            .replaceAll("\r\n", "\n"));
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-        });
         Main.main("-J", getPath("InputMainAstTreeStringPrinterJavadoc.java"));
+        assertEquals(expected, systemOut.getCapturedData().replaceAll("\\\\r\\\\n", "\\\\n")
+                        .replaceAll("\r\n", "\n"), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testConflictingOptionsTvsC() throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "Option '-t' cannot be used with other options."
-                + System.lineSeparator(), systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
+    public void testConflictingOptionsTvsC(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) {
+        assertExitWithStatus(-1, () -> invokeMain("-c", "/google_checks.xml", "-t", getPath("")));
+        assertEquals("Option '-t' cannot be used with other options."
+            + System.lineSeparator(), systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
+    }
+
+    @Test
+    public void testConflictingOptionsTvsP(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) {
+        assertExitWithStatus(-1, () -> {
+            invokeMain("-p", getPath("InputMainMycheckstyle.properties"), "-t", getPath(""));
         });
-
-        Main.main("-c", "/google_checks.xml", "-t", getPath(""));
+        assertEquals("Option '-t' cannot be used with other options."
+            + System.lineSeparator(), systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testConflictingOptionsTvsP() throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "Option '-t' cannot be used with other options."
-                + System.lineSeparator(), systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-        });
-
-        Main.main("-p", getPath("InputMainMycheckstyle.properties"), "-t", getPath(""));
+    public void testConflictingOptionsTvsF(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) {
+        assertExitWithStatus(-1, () -> invokeMain("-f", "plain", "-t", getPath("")));
+        assertEquals("Option '-t' cannot be used with other options."
+            + System.lineSeparator(), systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testConflictingOptionsTvsF() throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "Option '-t' cannot be used with other options."
-                + System.lineSeparator(), systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-        });
+    public void testConflictingOptionsTvsS(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws IOException {
+        final String outputPath = new File(temporaryFolder, "file.output").getCanonicalPath();
 
-        Main.main("-f", "plain", "-t", getPath(""));
+        assertExitWithStatus(-1, () -> invokeMain("-s", outputPath, "-t", getPath("")));
+        assertEquals("Option '-t' cannot be used with other options."
+                + System.lineSeparator(), systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testConflictingOptionsTvsS() throws Exception {
-        final File file = temporaryFolder.newFile("file.output");
+    public void testConflictingOptionsTvsO(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws IOException {
+        final String outputPath = new File(temporaryFolder, "file.output").getCanonicalPath();
 
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "Option '-t' cannot be used with other options."
-                    + System.lineSeparator(), systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-        });
-
-        Main.main("-s", file.getCanonicalPath(), "-t", getPath(""));
+        assertExitWithStatus(-1, () -> invokeMain("-o", outputPath, "-t", getPath("")));
+        assertEquals("Option '-t' cannot be used with other options."
+            + System.lineSeparator(), systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testConflictingOptionsTvsO() throws Exception {
-        final File file = temporaryFolder.newFile("file.output");
-
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "Option '-t' cannot be used with other options."
-                + System.lineSeparator(), systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-        });
-
-        Main.main("-o", file.getCanonicalPath(), "-t", getPath(""));
-    }
-
-    @Test
-    public void testDebugOption() throws Exception {
-        exit.checkAssertionAfterwards(
-            () -> assertNotEquals("Unexpected system error log", "", systemErr.getLog()));
+    public void testDebugOption(@SysErr Capturable systemErr) throws IOException {
         Main.main("-c", "/google_checks.xml", getPath("InputMain.java"), "-d");
+        assertNotEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testExcludeOption() throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "Files to process must be specified, found 0."
-                + System.lineSeparator(), systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
+    public void testExcludeOption(@SysErr Capturable systemErr, @SysOut Capturable systemOut)
+            throws IOException {
+        final String filePath = getFilePath("");
+        assertExitWithStatus(-1, () -> {
+            invokeMain("-c", "/google_checks.xml", filePath, "-e", filePath);
         });
-        Main.main("-c", "/google_checks.xml", getFilePath(""), "-e", getFilePath(""));
+        assertEquals("Files to process must be specified, found 0."
+            + System.lineSeparator(), systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testExcludeOptionFile() throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "Files to process must be specified, found 0."
-                + System.lineSeparator(), systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
+    public void testExcludeOptionFile(@SysErr Capturable systemErr, @SysOut Capturable systemOut)
+            throws IOException {
+        final String filePath = getFilePath("InputMain.java");
+        assertExitWithStatus(-1, () -> {
+            invokeMain("-c", "/google_checks.xml", filePath, "-e", filePath);
         });
-        Main.main("-c", "/google_checks.xml", getFilePath("InputMain.java"), "-e",
-                getFilePath("InputMain.java"));
+        assertEquals("Files to process must be specified, found 0."
+            + System.lineSeparator(), systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testExcludeRegexpOption() throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "Files to process must be specified, found 0."
-                + System.lineSeparator(), systemOut.getLog());
-            assertEquals("Unexpected output log", "", systemErr.getLog());
+    public void testExcludeRegexpOption(@SysErr Capturable systemErr, @SysOut Capturable systemOut)
+            throws IOException {
+        final String filePath = getFilePath("");
+        assertExitWithStatus(-1, () -> {
+            invokeMain("-c", "/google_checks.xml", filePath, "-x", ".");
         });
-        Main.main("-c", "/google_checks.xml", getFilePath(""), "-x", ".");
+        assertEquals("Files to process must be specified, found 0."
+            + System.lineSeparator(), systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected output log");
     }
 
     @Test
-    public void testExcludeRegexpOptionFile() throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "Files to process must be specified, found 0."
-                + System.lineSeparator(), systemOut.getLog());
-            assertEquals("Unexpected output log", "", systemErr.getLog());
+    public void testExcludeRegexpOptionFile(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws IOException {
+        final String filePath = getFilePath("InputMain.java");
+        assertExitWithStatus(-1, () -> {
+            invokeMain("-c", "/google_checks.xml", filePath, "-x", ".");
         });
-        Main.main("-c", "/google_checks.xml", getFilePath("InputMain.java"), "-x", ".");
+        assertEquals("Files to process must be specified, found 0."
+            + System.lineSeparator(), systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected output log");
     }
 
     @Test
@@ -1460,231 +1346,217 @@ public class MainTest {
 
         final List<File> result = (List<File>) method.invoke(null, new File(getFilePath("")),
                 list);
-        assertNotEquals("Invalid result size", 0, result.size());
+        assertNotEquals(0, result.size(), "Invalid result size");
     }
 
     @Test
-    public void testCustomRootModule() throws Exception {
+    public void testCustomRootModule(@SysErr Capturable systemErr, @SysOut Capturable systemOut)
+            throws IOException {
         TestRootModuleChecker.reset();
 
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "", systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-            assertTrue("Invalid Checker state", TestRootModuleChecker.isProcessed());
-        });
         Main.main("-c", getPath("InputMainConfig-custom-root-module.xml"),
                 getPath("InputMain.java"));
-        assertTrue("RootModule should be destroyed", TestRootModuleChecker.isDestroyed());
+        assertEquals("", systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
+        assertTrue(TestRootModuleChecker.isProcessed(), "Invalid Checker state");
+        assertTrue(TestRootModuleChecker.isDestroyed(), "RootModule should be destroyed");
     }
 
     @Test
-    public void testCustomSimpleRootModule() throws Exception {
+    public void testCustomSimpleRootModule(@SysErr Capturable systemErr) {
         TestRootModuleChecker.reset();
-        exit.expectSystemExitWithStatus(-2);
-        exit.checkAssertionAfterwards(() -> {
-            final String checkstylePackage = "com.puppycrawl.tools.checkstyle.";
-            final LocalizedMessage unableToInstantiateExceptionMessage = new LocalizedMessage(1,
-                    Definitions.CHECKSTYLE_BUNDLE,
-                    "PackageObjectFactory.unableToInstantiateExceptionMessage",
-                    new String[] {"TestRootModuleChecker", checkstylePackage
-                            + "TestRootModuleChecker, "
-                            + "TestRootModuleCheckerCheck, " + checkstylePackage
-                            + "TestRootModuleCheckerCheck"},
-                    null, getClass(), null);
-            assertTrue("Unexpected system error log",
-                    systemErr.getLog().startsWith(checkstylePackage + "api.CheckstyleException: "
-                    + unableToInstantiateExceptionMessage.getMessage()));
-            assertFalse("Invalid checker state", TestRootModuleChecker.isProcessed());
-        });
-        Main.main("-c", getPath("InputMainConfig-custom-simple-root-module.xml"),
+        assertExitWithStatus(-2, () -> {
+            invokeMain("-c", getPath("InputMainConfig-custom-simple-root-module.xml"),
                 getPath("InputMain.java"));
+        });
+        final String checkstylePackage = "com.puppycrawl.tools.checkstyle.";
+        final LocalizedMessage unableToInstantiateExceptionMessage = new LocalizedMessage(1,
+                Definitions.CHECKSTYLE_BUNDLE,
+                "PackageObjectFactory.unableToInstantiateExceptionMessage",
+                new String[] {"TestRootModuleChecker", checkstylePackage
+                        + "TestRootModuleChecker, "
+                        + "TestRootModuleCheckerCheck, " + checkstylePackage
+                        + "TestRootModuleCheckerCheck"},
+                null, getClass(), null);
+        assertTrue(systemErr.getCapturedData().startsWith(checkstylePackage
+                + "api.CheckstyleException: " + unableToInstantiateExceptionMessage.getMessage()),
+                "Unexpected system error log");
+        assertFalse(TestRootModuleChecker.isProcessed(), "Invalid checker state");
     }
 
     @Test
-    public void testExceptionOnExecuteIgnoredModuleWithUnknownModuleName() throws Exception {
-        exit.expectSystemExitWithStatus(-2);
-        exit.checkAssertionAfterwards(() -> {
-            final String cause = "com.puppycrawl.tools.checkstyle.api.CheckstyleException:"
-                    + " cannot initialize module TreeWalker - ";
-            assertTrue("Unexpected system error log", systemErr.getLog().startsWith(cause));
+    public void testExceptionOnExecuteIgnoredModuleWithUnknownModuleName(
+            @SysErr Capturable systemErr) {
+        assertExitWithStatus(-2, () -> {
+            invokeMain("-c", getPath("InputMainConfig-non-existent-classname-ignore.xml"),
+                    "--executeIgnoredModules", getPath("InputMain.java"));
         });
-
-        Main.main("-c", getPath("InputMainConfig-non-existent-classname-ignore.xml"),
-                "--executeIgnoredModules",
-                getPath("InputMain.java"));
+        final String cause = "com.puppycrawl.tools.checkstyle.api.CheckstyleException:"
+                + " cannot initialize module TreeWalker - ";
+        assertTrue(systemErr.getCapturedData().startsWith(cause), "Unexpected system error log");
     }
 
     @Test
-    public void testExceptionOnExecuteIgnoredModuleWithBadPropertyValue() throws Exception {
-        exit.expectSystemExitWithStatus(-2);
-        exit.checkAssertionAfterwards(() -> {
-            final String cause = "com.puppycrawl.tools.checkstyle.api.CheckstyleException:"
-                    + " cannot initialize module TreeWalker - ";
-            final String causeDetail = "it is not a boolean";
-            assertTrue("Unexpected system error log", systemErr.getLog().startsWith(cause));
-            assertTrue("Unexpected system error log", systemErr.getLog().contains(causeDetail));
+    public void testExceptionOnExecuteIgnoredModuleWithBadPropertyValue(
+            @SysErr Capturable systemErr) {
+        assertExitWithStatus(-2, () -> {
+            invokeMain("-c", getPath("InputMainConfig-TypeName-bad-value.xml"),
+                    "--executeIgnoredModules", getPath("InputMain.java"));
         });
+        final String cause = "com.puppycrawl.tools.checkstyle.api.CheckstyleException:"
+                + " cannot initialize module TreeWalker - ";
+        final String causeDetail = "it is not a boolean";
+        assertTrue(systemErr.getCapturedData().startsWith(cause), "Unexpected system error log");
+        assertTrue(systemErr.getCapturedData().contains(causeDetail),
+                "Unexpected system error log");
+    }
 
+    @Test
+    public void testNoProblemOnExecuteIgnoredModuleWithBadPropertyValue(
+            @SysErr Capturable systemErr) throws IOException {
         Main.main("-c", getPath("InputMainConfig-TypeName-bad-value.xml"),
-                "--executeIgnoredModules",
-                getPath("InputMain.java"));
+                    "", getPath("InputMain.java"));
+        assertTrue(systemErr.getCapturedData().isEmpty(), "Unexpected system error log");
     }
 
     @Test
-    public void testNoProblemOnExecuteIgnoredModuleWithBadPropertyValue() throws Exception {
-        exit.checkAssertionAfterwards(() -> {
-            assertTrue("Unexpected system error log", systemErr.getLog().isEmpty());
+    public void testInvalidCheckerThreadsNumber(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) {
+        assertExitWithStatus(-1, () -> {
+            invokeMain("-C", "invalid", "-c", "/google_checks.xml", getPath("InputMain.java"));
         });
-
-        Main.main("-c", getPath("InputMainConfig-TypeName-bad-value.xml"),
-                "",
-                getPath("InputMain.java"));
+        assertEquals("", systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("Invalid value for option '--checker-threads-number': 'invalid' is not an int"
+                + EOL + SHORT_USAGE, systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testInvalidCheckerThreadsNumber() throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "", systemOut.getLog());
-            assertEquals("Unexpected system error log",
-                    "Invalid value for option '--checker-threads-number': 'invalid' is not an int"
-                    + EOL + SHORT_USAGE, systemErr.getLog());
+    public void testInvalidTreeWalkerThreadsNumber(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) {
+        assertExitWithStatus(-1, () -> {
+            invokeMain("-W", "invalid", "-c", "/google_checks.xml", getPath("InputMain.java"));
         });
-        Main.main("-C", "invalid", "-c", "/google_checks.xml", getPath("InputMain.java"));
+        assertEquals("", systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("Invalid value for option '--tree-walker-threads-number': "
+                + "'invalid' is not an int" + EOL + SHORT_USAGE, systemErr.getCapturedData(),
+                "Unexpected system error log");
     }
 
     @Test
-    public void testInvalidTreeWalkerThreadsNumber() throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "", systemOut.getLog());
-            assertEquals("Unexpected system error log",
-                    "Invalid value for option '--tree-walker-threads-number': "
-                    + "'invalid' is not an int" + EOL + SHORT_USAGE, systemErr.getLog());
+    public void testZeroCheckerThreadsNumber(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) {
+        assertExitWithStatus(-1, () -> {
+            invokeMain("-C", "0", "-c", "/google_checks.xml", getPath("InputMain.java"));
         });
-        Main.main("-W", "invalid", "-c", "/google_checks.xml", getPath("InputMain.java"));
+        assertEquals("Checker threads number must be greater than zero"
+            + System.lineSeparator(), systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testZeroCheckerThreadsNumber() throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "Checker threads number must be greater than zero"
-                + System.lineSeparator(), systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
+    public void testZeroTreeWalkerThreadsNumber(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) {
+        assertExitWithStatus(-1, () -> {
+            invokeMain("-W", "0", "-c", "/google_checks.xml", getPath("InputMain.java"));
         });
-        Main.main("-C", "0", "-c", "/google_checks.xml", getPath("InputMain.java"));
+        assertEquals(
+                "TreeWalker threads number must be greater than zero"
+            + System.lineSeparator(), systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
-    public void testZeroTreeWalkerThreadsNumber() throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log",
-                    "TreeWalker threads number must be greater than zero"
-                + System.lineSeparator(), systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-        });
-        Main.main("-W", "0", "-c", "/google_checks.xml", getPath("InputMain.java"));
-    }
-
-    @Test
-    public void testCheckerThreadsNumber() throws Exception {
+    public void testCheckerThreadsNumber(@SysErr Capturable systemErr, @SysOut Capturable systemOut)
+            throws IOException {
         TestRootModuleChecker.reset();
 
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "", systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-            assertTrue("Invalid checker state", TestRootModuleChecker.isProcessed());
-            final DefaultConfiguration config =
-                    (DefaultConfiguration) TestRootModuleChecker.getConfig();
-            final ThreadModeSettings multiThreadModeSettings = config.getThreadModeSettings();
-            assertEquals("Invalid checker thread number",
-                    4, multiThreadModeSettings.getCheckerThreadsNumber());
-            assertEquals("Invalid checker thread number",
-                    1, multiThreadModeSettings.getTreeWalkerThreadsNumber());
-        });
         Main.main("-C", "4", "-c", getPath("InputMainConfig-custom-root-module.xml"),
-            getPath("InputMain.java"));
+                getPath("InputMain.java"));
+        assertEquals("", systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
+        assertTrue(TestRootModuleChecker.isProcessed(), "Invalid checker state");
+        final DefaultConfiguration config =
+                (DefaultConfiguration) TestRootModuleChecker.getConfig();
+        final ThreadModeSettings multiThreadModeSettings = config.getThreadModeSettings();
+        assertEquals(4, multiThreadModeSettings.getCheckerThreadsNumber(),
+                "Invalid checker thread number");
+        assertEquals(1, multiThreadModeSettings.getTreeWalkerThreadsNumber(),
+                "Invalid checker thread number");
     }
 
     @Test
-    public void testTreeWalkerThreadsNumber() throws Exception {
+    public void testTreeWalkerThreadsNumber(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws IOException {
         TestRootModuleChecker.reset();
 
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "", systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-            assertTrue("Invalid checker state", TestRootModuleChecker.isProcessed());
-            final DefaultConfiguration config =
-                    (DefaultConfiguration) TestRootModuleChecker.getConfig();
-            final ThreadModeSettings multiThreadModeSettings = config.getThreadModeSettings();
-            assertEquals("Invalid checker thread number",
-                    1, multiThreadModeSettings.getCheckerThreadsNumber());
-            assertEquals("Invalid checker thread number",
-                    4, multiThreadModeSettings.getTreeWalkerThreadsNumber());
-        });
         Main.main("-W", "4", "-c", getPath("InputMainConfig-custom-root-module.xml"),
-            getPath("InputMain.java"));
+                getPath("InputMain.java"));
+        assertEquals("", systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
+        assertTrue(TestRootModuleChecker.isProcessed(), "Invalid checker state");
+        final DefaultConfiguration config =
+                (DefaultConfiguration) TestRootModuleChecker.getConfig();
+        final ThreadModeSettings multiThreadModeSettings = config.getThreadModeSettings();
+        assertEquals(1, multiThreadModeSettings.getCheckerThreadsNumber(),
+                "Invalid checker thread number");
+        assertEquals(4, multiThreadModeSettings.getTreeWalkerThreadsNumber(),
+                "Invalid checker thread number");
     }
 
     @Test
-    public void testModuleNameInSingleThreadMode() throws Exception {
+    public void testModuleNameInSingleThreadMode(@SysErr Capturable systemErr,
+            @SysOut Capturable systemOut) throws IOException {
         TestRootModuleChecker.reset();
 
-        exit.checkAssertionAfterwards(() -> {
-            assertEquals("Unexpected output log", "", systemOut.getLog());
-            assertEquals("Unexpected system error log", "", systemErr.getLog());
-            assertTrue("Invalid checker state", TestRootModuleChecker.isProcessed());
-            final DefaultConfiguration config =
-                    (DefaultConfiguration) TestRootModuleChecker.getConfig();
-            final ThreadModeSettings multiThreadModeSettings =
-                config.getThreadModeSettings();
-            assertEquals("Invalid checker thread number",
-                    1, multiThreadModeSettings.getCheckerThreadsNumber());
-            assertEquals("Invalid checker thread number",
-                    1, multiThreadModeSettings.getTreeWalkerThreadsNumber());
-            final Configuration checkerConfiguration = config
-                .getChildren()[0];
-            assertEquals("Invalid checker name", "Checker", checkerConfiguration.getName());
-            final Configuration treeWalkerConfig = checkerConfiguration.getChildren()[0];
-            assertEquals("Invalid checker children name", "TreeWalker", treeWalkerConfig.getName());
-        });
         Main.main("-C", "1", "-W", "1", "-c", getPath("InputMainConfig-multi-thread-mode.xml"),
-            getPath("InputMain.java"));
+                getPath("InputMain.java"));
+        assertEquals("", systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals("", systemErr.getCapturedData(), "Unexpected system error log");
+        assertTrue(TestRootModuleChecker.isProcessed(), "Invalid checker state");
+        final DefaultConfiguration config =
+                (DefaultConfiguration) TestRootModuleChecker.getConfig();
+        final ThreadModeSettings multiThreadModeSettings =
+            config.getThreadModeSettings();
+        assertEquals(1, multiThreadModeSettings.getCheckerThreadsNumber(),
+                "Invalid checker thread number");
+        assertEquals(1, multiThreadModeSettings.getTreeWalkerThreadsNumber(),
+                "Invalid checker thread number");
+        final Configuration checkerConfiguration = config.getChildren()[0];
+        assertEquals("Checker", checkerConfiguration.getName(), "Invalid checker name");
+        final Configuration treeWalkerConfig = checkerConfiguration.getChildren()[0];
+        assertEquals("TreeWalker", treeWalkerConfig.getName(), "Invalid checker children name");
     }
 
     @Test
-    public void testModuleNameInMultiThreadMode() throws Exception {
+    public void testModuleNameInMultiThreadMode() {
         TestRootModuleChecker.reset();
 
         try {
-            Main.main("-C", "4", "-W", "4", "-c", getPath("InputMainConfig-multi-thread-mode.xml"),
-                getPath("InputMain.java"));
+            assertExitWithStatus(-1, () -> {
+                invokeMain("-C", "4", "-W", "4", "-c",
+                        getPath("InputMainConfig-multi-thread-mode.xml"),
+                        getPath("InputMain.java"));
+            });
             fail("An exception is expected");
         }
         catch (IllegalArgumentException ex) {
-            assertEquals("Invalid error message",
-                    "Multi thread mode for Checker module is not implemented",
-                ex.getMessage());
+            assertEquals("Multi thread mode for Checker module is not implemented",
+                ex.getMessage(), "Invalid error message");
         }
     }
 
     @Test
-    public void testMissingFiles() throws Exception {
-        exit.expectSystemExitWithStatus(-1);
-        exit.checkAssertionAfterwards(() -> {
-            final String usage = "Missing required parameter: <files>" + EOL + SHORT_USAGE;
-            assertEquals("Unexpected output log", "", systemOut.getLog());
-            assertEquals("Unexpected system error log", usage, systemErr.getLog());
-        });
-        Main.main();
+    public void testMissingFiles(@SysErr Capturable systemErr, @SysOut Capturable systemOut) {
+        assertExitWithStatus(-1, MainTest::invokeMain);
+        final String usage = "Missing required parameter: <files>" + EOL + SHORT_USAGE;
+        assertEquals("", systemOut.getCapturedData(), "Unexpected output log");
+        assertEquals(usage, systemErr.getCapturedData(), "Unexpected system error log");
     }
 
     @Test
     public void testOutputFormatToStringLowercase() {
-        assertEquals("expected xml", "xml", Main.OutputFormat.XML.toString());
-        assertEquals("expected plain", "plain", Main.OutputFormat.PLAIN.toString());
+        assertEquals("xml", Main.OutputFormat.XML.toString(), "expected xml");
+        assertEquals("plain", Main.OutputFormat.PLAIN.toString(), "expected plain");
     }
 
     @Test
@@ -1692,7 +1564,7 @@ public class MainTest {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         final AuditListener listener = Main.OutputFormat.XML.createListener(out,
                 AutomaticBean.OutputStreamOptions.CLOSE);
-        assertTrue("listener is XMLLogger", listener instanceof XMLLogger);
+        assertTrue(listener instanceof XMLLogger, "listener is XMLLogger");
     }
 
     @Test
@@ -1700,7 +1572,21 @@ public class MainTest {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         final AuditListener listener = Main.OutputFormat.PLAIN.createListener(out,
                 AutomaticBean.OutputStreamOptions.CLOSE);
-        assertTrue("listener is DefaultLogger", listener instanceof DefaultLogger);
+        assertTrue(listener instanceof DefaultLogger, "listener is DefaultLogger");
+    }
+
+    /**
+     * Helper method to run {@link Main#main(String...)} as {@link Runnable}.
+     *
+     * @param arguments the command line arguments
+     */
+    private static void invokeMain(String... arguments) {
+        try {
+            Main.main(arguments);
+        }
+        catch (IOException exception) {
+            fail("Unexpected exception: " + exception);
+        }
     }
 
 }


### PR DESCRIPTION
Issue #6916

Tests of the ` {Main,JavadocPropertiesenerator}Test` are migrated to Junit5.
