### PR TITLE
Config validate since javadoc tag in new modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -311,6 +311,10 @@ matrix:
         - DESC="ensure that no files are in changed state after clone"
         - CMD="./.ci/travis/travis.sh git-status"
 
+    - env:
+        - DESC="validate since javadoc tag if new module is created"
+        - CMD="./.ci/travis/travis.sh check-since-version"
+
 script:
   - SKIP_FILES1=".github|codeship-*|buddy.yml|appveyor.yml|circleci"
   - SKIP_FILES2="|fast-forward-merge.sh|LICENSE|LICENSE.apache20|README.md|release.sh|RIGHTS.antlr"


### PR DESCRIPTION
 It is not very reliable approach(in case of multi commits in PR it will not help) but lets start with some ...

**Testing on my local**:
Tree with merge commit on my local :
```
$ git log --graph
*   commit 7b39f32ec55abfca0ea126d36b19d45dd2c20779
|\  Merge: 10fa74a 47b2c58
| | Author: Roman Ivanov <ivanov-jr@mail.ru>
| | Date:   Tue Dec 24 14:28:57 2019 -0800
| | 
| |     Merge branch 'config-validate-since-in-new-checks'
| |   
| * commit 47b2c58e550f97ee6f94ac788864066e075cde13
| | Author: sd1998 <shashvat51@gmail.com>
| | Date:   Sun Oct 27 12:33:20 2019 +0530
| | 
| |     Issue #6971: NoArrayTrailingCommaCheck added
| |   
| * commit cd2e1f538a5d37917028421070f3c1dc252ce470
|/  Author: Roman Ivanov <ivanov-jr@mail.ru>
|   Date:   Tue Dec 24 14:06:20 2019 -0800
|   
|       config: validate since javadoc tag in new Checks
|  
* commit 10fa74a551d590d45c317a5affb50369014976e5
| Author: pbludov <pbludov@gmail.com>
| Date:   Tue Dec 24 22:13:12 2019 +0300
| 
|     doc: fix treeWithJavadoc command line option

```

```
✔ ~/java/github/romani/checkstyle [master ↑·3|✚ 1] 
$ ./.ci/travis/travis.sh check-since-version
Merge: 10fa74a 47b2c58
Merge detected.
PR commit: 47b2c58e550f97ee6f94ac788864066e075cde13
New files in comit: --- /dev/null
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNoArrayTrailingCommaTest.java
--
--- /dev/null
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/noarraytrailingcomma/SuppressionXpathRegressionNoArrayTrailingCommaOne.java
--
--- /dev/null
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/noarraytrailingcomma/SuppressionXpathRegressionNoArrayTrailingCommaTwo.java
--
--- /dev/null
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoArrayTrailingCommaCheck.java
--
--- /dev/null
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NoArrayTrailingCommaCheckTest.java
--
--- /dev/null
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/noarraytrailingcomma/InputNoArrayTrailingComma.java
New Check file: src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoArrayTrailingCommaCheck.java
New Check detected: src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoArrayTrailingCommaCheck.java
CS Release version: 8.28
Grep for @since 8.28
 * @since 8.28
```

if file have wrong version:
```
✔ ~/java/github/romani/checkstyle [master ↑·3|✚ 1] 
$ git diff src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoArrayTrailingCommaCheck.java
diff --git a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoArrayTrailingCommaCheck.java b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoArrayTrailingCommaCheck.java
index 0e1aee8..afe4796 100644
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoArrayTrailingCommaCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoArrayTrailingCommaCheck.java
@@ -65,7 +65,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * String[] foo4 = { "FOO", "BAR" }; // OK
  * </pre>
  *
- * @since 8.28
+ * @since 8.27
  */
 @StatelessCheck
 public class NoArrayTrailingCommaCheck extends AbstractCheck {

✔ ~/java/github/romani/checkstyle [master ↑·3|✚ 2] 
$ ./.ci/travis/travis.sh check-since-version
Merge: 10fa74a 47b2c58
Merge detected.
PR commit: 47b2c58e550f97ee6f94ac788864066e075cde13
New files in comit: --- /dev/null
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNoArrayTrailingCommaTest.java
--
--- /dev/null
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/noarraytrailingcomma/SuppressionXpathRegressionNoArrayTrailingCommaOne.java
--
--- /dev/null
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/noarraytrailingcomma/SuppressionXpathRegressionNoArrayTrailingCommaTwo.java
--
--- /dev/null
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoArrayTrailingCommaCheck.java
--
--- /dev/null
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NoArrayTrailingCommaCheckTest.java
--
--- /dev/null
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/noarraytrailingcomma/InputNoArrayTrailingComma.java
New Check file: src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoArrayTrailingCommaCheck.java
New Check detected: src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoArrayTrailingCommaCheck.java
CS Release version: 8.28
Grep for @since 8.28
✘-1 
```