### PR TITLE
Issue #7405: all new checks should have XpathRegressionTest

### DIFF
--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -4610,6 +4610,7 @@
     ,org.mockito.InOrder,verify, ,
     ,org.junit.rules.ExpectedException,expect.*, ,
     ,org.hamcrest.MatcherAssert,assertThat, ,
+    ,com.google.common.truth.Truth,assert.*, ,
     ,com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport,verify.*, ,
     ,com.puppycrawl.tools.checkstyle.AbstractTreeTestSupport,verify.*, ,
     ,com.google.checkstyle.test.base.AbstractModuleTestSupport,verify.*, ,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -40,304 +40,187 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * suppressed nodes inside the AST tree.
  * </p>
  * <p>
- * Currently, filter supports the following checks:
+ * Currently, filter does not support the following checks:
  * </p>
- * <ul>
+ * <ul id="SuppressionXpathFilter_IncompatibleChecks">
  * <li>
- * AbbreviationAsWordInName
+ * AnnotationLocation
  * </li>
  * <li>
- * AbstractClassName
+ * AnnotationOnSameLine
  * </li>
  * <li>
- * AnonInnerLength
+ * AnnotationUseStyle
  * </li>
  * <li>
- * ArrayTypeStyle
+ * ArrayTrailingComma
  * </li>
  * <li>
- * AvoidInlineConditionals
+ * AvoidEscapedUnicodeCharacters
  * </li>
  * <li>
- * AvoidNestedBlocks
+ * AvoidStarImport
  * </li>
  * <li>
- * BooleanExpressionComplexity
+ * AvoidStaticImport
  * </li>
  * <li>
- * CatchParameterName
+ * CommentsIndentation
  * </li>
  * <li>
- * ClassDataAbstractionCoupling
+ * CustomImportOrder
  * </li>
  * <li>
- * ClassFanOutComplexity
+ * EmptyCatchBlock
  * </li>
  * <li>
- * ClassMemberImpliedModifier
+ * EmptyLineSeparator
  * </li>
  * <li>
- * ClassTypeParameterName
+ * FinalClass
  * </li>
  * <li>
- * ConstantName
+ * IllegalCatch
  * </li>
  * <li>
- * CovariantEquals
+ * ImportOrder
  * </li>
  * <li>
- * CyclomaticComplexity
+ * Indentation
  * </li>
  * <li>
- * DeclarationOrder
+ * InterfaceIsType
  * </li>
  * <li>
- * DefaultComesLast
+ * InterfaceMemberImpliedModifier
  * </li>
  * <li>
- * DescendantToken
+ * InvalidJavadocPosition
  * </li>
  * <li>
- * DesignForExtension
+ * JavadocContentLocation
  * </li>
  * <li>
- * EmptyBlock
+ * JavadocMethod
  * </li>
  * <li>
- * EmptyForInitializerPad
+ * JavadocStyle
  * </li>
  * <li>
- * EmptyForIteratorPad
+ * JavadocType
  * </li>
  * <li>
- * EmptyStatement
+ * LambdaParameterName
  * </li>
  * <li>
- * EqualsAvoidNull
+ * MethodCount
  * </li>
  * <li>
- * EqualsHashCode
+ * MissingCtor
  * </li>
  * <li>
- * ExecutableStatementCount
+ * MissingJavadocMethod
  * </li>
  * <li>
- * ExplicitInitialization
+ * MissingJavadocPackage
  * </li>
  * <li>
- * FallThrough
+ * MissingJavadocType
  * </li>
  * <li>
- * FinalLocalVariable
+ * MissingOverride
  * </li>
  * <li>
- * FinalParameters
+ * MissingSwitchDefault
  * </li>
  * <li>
- * GenericWhitespace
+ * NeedBraces
  * </li>
  * <li>
- * HiddenField
+ * NoClone
  * </li>
  * <li>
- * HideUtilityClassConstructor
+ * NoFinalizer
  * </li>
  * <li>
- * IllegalInstantiation
+ * NoLineWrap
  * </li>
  * <li>
- * IllegalToken
+ * OneTopLevelClass
  * </li>
  * <li>
- * IllegalTokenText
+ * OuterTypeFilename
  * </li>
  * <li>
- * IllegalType
+ * OverloadMethodsDeclarationOrder
  * </li>
  * <li>
- * InnerAssignment
+ * PackageAnnotation
  * </li>
  * <li>
- * InnerTypeLast
+ * PackageDeclaration
  * </li>
  * <li>
- * InterfaceTypeParameterName
+ * Regexp
  * </li>
  * <li>
- * JavadocVariable
+ * RegexpSinglelineJava
  * </li>
  * <li>
- * JavaNCSS
+ * SuppressWarningsHolder
  * </li>
  * <li>
- * IllegalImport
+ * TodoComment
  * </li>
  * <li>
- * IllegalThrows
+ * TrailingComment
  * </li>
  * <li>
- * ImportControl
+ * UncommentedMain
  * </li>
  * <li>
- * LeftCurly
+ * UnnecessaryParentheses
  * </li>
  * <li>
- * LocalFinalVariableName
+ * VariableDeclarationUsageDistance
  * </li>
  * <li>
- * LocalVariableName
- * </li>
- * <li>
- * MagicNumber
- * </li>
- * <li>
- * MemberName
- * </li>
- * <li>
- * MethodLength
- * </li>
- * <li>
- * MethodName
- * </li>
- * <li>
- * MethodParamPad
- * </li>
- * <li>
- * MethodTypeParameterName
- * </li>
- * <li>
- * ModifiedControlVariable
- * </li>
- * <li>
- * ModifierOrder
- * </li>
- * <li>
- * MultipleStringLiterals
- * </li>
- * <li>
- * MultipleVariableDeclarations
- * </li>
- * <li>
- * MutableException
- * </li>
- * <li>
- * NestedForDepth
- * </li>
- * <li>
- * NestedIfDepth
- * </li>
- * <li>
- * NestedTryDepth
- * </li>
- * <li>
- * NoWhitespaceAfter
- * </li>
- * <li>
- * NoWhitespaceBefore
- * </li>
- * <li>
- * NPathComplexity
- * </li>
- * <li>
- * OneStatementPerLine
- * </li>
- * <li>
- * OperatorWrap
- * </li>
- * <li>
- * OuterTypeNumber
- * </li>
- * <li>
- * PackageName
- * </li>
- * <li>
- * ParameterAssignment
- * </li>
- * <li>
- * ParameterName
- * </li>
- * <li>
- * ParameterNumber
- * </li>
- * <li>
- * ParenPad
- * </li>
- * <li>
- * RedundantImport
- * </li>
- * <li>
- * RedundantModifier
- * </li>
- * <li>
- * RequireThis
- * </li>
- * <li>
- * ReturnCount
- * </li>
- * <li>
- * RightCurly
- * </li>
- * <li>
- * SeparatorWrap
- * </li>
- * <li>
- * SimplifyBooleanExpression
- * </li>
- * <li>
- * SimplifyBooleanReturn
- * </li>
- * <li>
- * SingleSpaceSeparator
- * </li>
- * <li>
- * StaticVariableName
- * </li>
- * <li>
- * StringLiteralEquality
- * </li>
- * <li>
- * SuperClone
- * </li>
- * <li>
- * SuperFinalize
- * </li>
- * <li>
- * SuppressWarnings
- * </li>
- * <li>
- * ThrowsCount
- * </li>
- * <li>
- * TypecastParenPad
- * </li>
- * <li>
- * TypeName
- * </li>
- * <li>
- * UnnecessarySemicolonInEnumeration
- * </li>
- * <li>
- * UnnecessarySemicolonInTryWithResources
- * </li>
- * <li>
- * UnusedImports
- * </li>
- * <li>
- * UpperEll
- * </li>
- * <li>
- * VisibilityModifier
- * </li>
- * <li>
- * WhitespaceAfter
- * </li>
- * <li>
- * WhitespaceAround
+ * WriteTag
  * </li>
  * </ul>
  * <p>
- * Note, that support for other Checks will be available after resolving
- * <a href="https://github.com/checkstyle/checkstyle/issues/4830">issue 4830</a>.
+ * Also, the filter does not support Javadoc checks:
+ * </p>
+ * <ul id="SuppressionXpathFilter_JavadocChecks">
+ * <li>
+ * AtclauseOrder
+ * </li>
+ * <li>
+ * JavadocBlockTagLocation
+ * </li>
+ * <li>
+ * JavadocParagraph
+ * </li>
+ * <li>
+ * JavadocTagContinuationIndentation
+ * </li>
+ * <li>
+ * MissingDeprecated
+ * </li>
+ * <li>
+ * NonEmptyAtclauseDescription
+ * </li>
+ * <li>
+ * SingleLineJavadoc
+ * </li>
+ * <li>
+ * SummaryJavadoc
+ * </li>
+ * </ul>
+ * <p>
+ * Note, that support for these Checks will be available after resolving issues
+ * <a href="https://github.com/checkstyle/checkstyle/issues/5770">#5770</a> and
+ * <a href="https://github.com/checkstyle/checkstyle/issues/5777">#5777</a>.
  * </p>
  * <p>
  * Currently, filter supports the following xpath axes:

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.internal;
 
+import static com.google.common.truth.Truth.assertWithMessage;
 import static java.lang.Integer.parseInt;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.describedAs;
@@ -521,6 +522,9 @@ public class XdocsPagesTest {
                     fileName + " section '" + sectionName + "' should be in order");
 
             switch (subSectionPos) {
+                case 0:
+                    validateDescriptionSection(fileName, sectionName, subSection);
+                    break;
                 case 1:
                     validatePropertySection(fileName, sectionName, subSection, instance);
                     break;
@@ -536,7 +540,6 @@ public class XdocsPagesTest {
                 case 6:
                     validateParentSection(fileName, sectionName, subSection);
                     break;
-                case 0:
                 case 2:
                 default:
                     break;
@@ -594,6 +597,26 @@ public class XdocsPagesTest {
         }
 
         return result;
+    }
+
+    private static void validateDescriptionSection(String fileName, String sectionName,
+            Node subSection) {
+        // Till https://github.com/checkstyle/checkstyle/issues/5777
+        if ("config_filters.xml".equals(fileName) && "SuppressionXpathFilter".equals(sectionName)) {
+            validateListOfSuppressionXpathFilterIncompatibleChecks(subSection);
+        }
+    }
+
+    private static void validateListOfSuppressionXpathFilterIncompatibleChecks(Node subSection) {
+        assertWithMessage(
+            "Incompatible check list should match XpathRegressionTest.INCOMPATIBLE_CHECK_NAMES")
+            .that(getListById(subSection, "SuppressionXpathFilter_IncompatibleChecks"))
+            .isEqualTo(XpathRegressionTest.INCOMPATIBLE_CHECK_NAMES);
+
+        assertWithMessage(
+            "Javadoc check list should match XpathRegressionTest.INCOMPATIBLE_JAVADOC_CHECK_NAMES")
+            .that(getListById(subSection, "SuppressionXpathFilter_JavadocChecks"))
+            .isEqualTo(XpathRegressionTest.INCOMPATIBLE_JAVADOC_CHECK_NAMES);
     }
 
     private static void validatePropertySection(String fileName, String sectionName,
@@ -1249,6 +1272,18 @@ public class XdocsPagesTest {
             result = int[].class;
         }
 
+        return result;
+    }
+
+    private static Set<String> getListById(Node subSection, String id) {
+        Set<String> result = null;
+        final Node node = XmlUtil.findChildElementById(subSection, id);
+        if (node != null) {
+            result = XmlUtil.getChildrenElements(node)
+                    .stream()
+                    .map(Node::getTextContent)
+                    .collect(Collectors.toSet());
+        }
         return result;
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.internal;
 
+import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -28,6 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
@@ -41,12 +43,83 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck;
 import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
 
 public class XpathRegressionTest extends AbstractModuleTestSupport {
 
-    // Temporal Checks that allowed to have no XPath IT Regression Testing
-    // https://github.com/checkstyle/checkstyle/issues/6207
+    // Checks that not compatible with SuppressionXpathFilter
+    // till https://github.com/checkstyle/checkstyle/issues/5777
+    public static final Set<String> INCOMPATIBLE_CHECK_NAMES =
+        Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            "AnnotationLocation",
+            "AnnotationOnSameLine",
+            "AnnotationUseStyle",
+            "ArrayTrailingComma",
+            "AvoidEscapedUnicodeCharacters",
+            "AvoidStarImport",
+            "AvoidStaticImport",
+            "CommentsIndentation",
+            "CustomImportOrder",
+            "EmptyCatchBlock",
+            "EmptyLineSeparator",
+            "FinalClass",
+            "IllegalCatch",
+            "ImportOrder",
+            "Indentation",
+            "InterfaceIsType",
+            "InterfaceMemberImpliedModifier",
+            "InvalidJavadocPosition",
+            "JavadocContentLocation",
+            "JavadocMethod",
+            "JavadocStyle",
+            "JavadocType",
+            "LambdaParameterName",
+            "MethodCount",
+            "MissingCtor",
+            "MissingJavadocMethod",
+            "MissingJavadocPackage",
+            "MissingJavadocType",
+            "MissingOverride",
+            "MissingSwitchDefault",
+            "NeedBraces",
+            "NoClone",
+            "NoFinalizer",
+            "NoLineWrap",
+            "OneTopLevelClass",
+            "OuterTypeFilename",
+            "OverloadMethodsDeclarationOrder",
+            "PackageAnnotation",
+            "PackageDeclaration",
+            "Regexp",
+            "RegexpSinglelineJava",
+            "SuppressWarningsHolder",
+            "TodoComment",
+            "TrailingComment",
+            "UncommentedMain",
+            "UnnecessaryParentheses",
+            "VariableDeclarationUsageDistance",
+            "WriteTag"
+    )));
+
+    // Javadoc checks are not compatible with SuppressionXpathFilter
+    // till https://github.com/checkstyle/checkstyle/issues/5770
+    // then all of them should be added to the list of incompatible checks
+    // and this field should be removed
+    public static final Set<String> INCOMPATIBLE_JAVADOC_CHECK_NAMES =
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+                    "AtclauseOrder",
+                    "JavadocBlockTagLocation",
+                    "JavadocParagraph",
+                    "JavadocTagContinuationIndentation",
+                    "MissingDeprecated",
+                    "NonEmptyAtclauseDescription",
+                    "SingleLineJavadoc",
+                    "SummaryJavadoc"
+    )));
+
+    // Checks that allowed to have no XPath IT Regression Testing
+    // till https://github.com/checkstyle/checkstyle/issues/6207
     private static final Set<String> MISSING_CHECK_NAMES = new HashSet<>(Arrays.asList(
             "BooleanExpressionComplexity",
             "CatchParameterName",
@@ -138,7 +211,20 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void validateIncompatibleJavadocCheckNames() throws IOException {
+        final Set<Class<?>> abstractJavadocCheckNames = CheckUtil.getCheckstyleChecks()
+                .stream()
+                .filter(AbstractJavadocCheck.class::isAssignableFrom)
+                .collect(Collectors.toSet());
+        assertWithMessage("INCOMPATIBLE_JAVADOC_CHECK_NAMES should contains all descendants "
+                    + "of AbstractJavadocCheck")
+            .that(CheckUtil.getSimpleNames(abstractJavadocCheckNames))
+            .isEqualTo(INCOMPATIBLE_JAVADOC_CHECK_NAMES);
+    }
+
+    @Test
     public void validateIntegrationTestClassNames() throws Exception {
+        final Set<String> compatibleChecks = new HashSet<>();
         final Pattern pattern = Pattern.compile("^XpathRegression(.+)Test\\.java$");
         try (DirectoryStream<Path> javaPaths = Files.newDirectoryStream(javaDir)) {
             for (Path path : javaPaths) {
@@ -159,8 +245,24 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
                 assertFalse(MISSING_CHECK_NAMES.contains(check),
                         "Check '" + check + "' is now tested. Please update the todo list in"
                                 + " XpathRegressionTest.MISSING_CHECK_NAMES");
+                assertFalse(INCOMPATIBLE_CHECK_NAMES.contains(check),
+                        "Check '" + check + "' is now compatible with SuppressionXpathFilter."
+                                + " Please update the todo list in"
+                                + " XpathRegressionTest.INCOMPATIBLE_CHECK_NAMES");
+                compatibleChecks.add(check);
             }
         }
+
+        // Ensure that all lists are up to date
+        final Set<String> allChecks = new HashSet<>(simpleCheckNames);
+        allChecks.removeAll(INCOMPATIBLE_JAVADOC_CHECK_NAMES);
+        allChecks.removeAll(INCOMPATIBLE_CHECK_NAMES);
+        allChecks.removeAll(MISSING_CHECK_NAMES);
+        allChecks.removeAll(compatibleChecks);
+
+        assertTrue(allChecks.isEmpty(), "XpathRegressionTest is missing for ["
+                + String.join(", ", allChecks)
+                + "]. Please add them to src/it/java/org/checkstyle/suppressionxpathfilter");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XmlUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XmlUtil.java
@@ -31,6 +31,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -91,6 +92,29 @@ public final class XmlUtil {
         }
 
         return firstChildElement;
+    }
+
+    /**
+     * Returns the {@code Node} that has an id attribute with the given value.
+     * The id should be unique within the Xml Document.
+     *
+     * @param id the unique {@code id} value for a node.
+     * @return the matching node or {@code null} if none matches.
+     */
+    public static Node findChildElementById(Node node, String id) {
+        Node childElement = null;
+        for (Node child = node.getFirstChild(); child != null; child = child.getNextSibling()) {
+            final NamedNodeMap attributes = child.getAttributes();
+            if (attributes != null) {
+                final Node attribute = attributes.getNamedItem("id");
+                if (attribute != null && id.equals(attribute.getNodeValue())) {
+                    childElement = child;
+                    break;
+                }
+            }
+        }
+
+        return childElement;
     }
 
     public static Set<Node> findChildElementsByTag(Node node, String tag) {

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -899,111 +899,75 @@ public class UserService {
           are queries for suppressed nodes inside the AST tree.
         </p>
         <p>
-          Currently, filter supports the following
-          checks:
+          Currently, filter does not support the following checks:
         </p>
-        <ul>
-          <li>AbbreviationAsWordInName</li>
-          <li>AbstractClassName</li>
-          <li>AnonInnerLength</li>
-          <li>ArrayTypeStyle</li>
-          <li>AvoidInlineConditionals</li>
-          <li>AvoidNestedBlocks</li>
-          <li>BooleanExpressionComplexity</li>
-          <li>CatchParameterName</li>
-          <li>ClassDataAbstractionCoupling</li>
-          <li>ClassFanOutComplexity</li>
-          <li>ClassMemberImpliedModifier</li>
-          <li>ClassTypeParameterName</li>
-          <li>ConstantName</li>
-          <li>CovariantEquals</li>
-          <li>CyclomaticComplexity</li>
-          <li>DeclarationOrder</li>
-          <li>DefaultComesLast</li>
-          <li>DescendantToken</li>
-          <li>DesignForExtension</li>
-          <li>EmptyBlock</li>
-          <li>EmptyForInitializerPad</li>
-          <li>EmptyForIteratorPad</li>
-          <li>EmptyStatement</li>
-          <li>EqualsAvoidNull</li>
-          <li>EqualsHashCode</li>
-          <li>ExecutableStatementCount</li>
-          <li>ExplicitInitialization</li>
-          <li>FallThrough</li>
-          <li>FinalLocalVariable</li>
-          <li>FinalParameters</li>
-          <li>GenericWhitespace</li>
-          <li>HiddenField</li>
-          <li>HideUtilityClassConstructor</li>
-          <li>IllegalInstantiation</li>
-          <li>IllegalToken</li>
-          <li>IllegalTokenText</li>
-          <li>IllegalType</li>
-          <li>InnerAssignment</li>
-          <li>InnerTypeLast</li>
-          <li>InterfaceTypeParameterName</li>
-          <li>JavadocVariable</li>
-          <li>JavaNCSS</li>
-          <li>IllegalImport</li>
-          <li>IllegalThrows</li>
-          <li>ImportControl</li>
-          <li>LeftCurly</li>
-          <li>LocalFinalVariableName</li>
-          <li>LocalVariableName</li>
-          <li>MagicNumber</li>
-          <li>MemberName</li>
-          <li>MethodLength</li>
-          <li>MethodName</li>
-          <li>MethodParamPad</li>
-          <li>MethodTypeParameterName</li>
-          <li>ModifiedControlVariable</li>
-          <li>ModifierOrder</li>
-          <li>MultipleStringLiterals</li>
-          <li>MultipleVariableDeclarations</li>
-          <li>MutableException</li>
-          <li>NestedForDepth</li>
-          <li>NestedIfDepth</li>
-          <li>NestedTryDepth</li>
-          <li>NoWhitespaceAfter</li>
-          <li>NoWhitespaceBefore</li>
-          <li>NPathComplexity</li>
-          <li>OneStatementPerLine</li>
-          <li>OperatorWrap</li>
-          <li>OuterTypeNumber</li>
-          <li>PackageName</li>
-          <li>ParameterAssignment</li>
-          <li>ParameterName</li>
-          <li>ParameterNumber</li>
-          <li>ParenPad</li>
-          <li>RedundantImport</li>
-          <li>RedundantModifier</li>
-          <li>RequireThis</li>
-          <li>ReturnCount</li>
-          <li>RightCurly</li>
-          <li>SeparatorWrap</li>
-          <li>SimplifyBooleanExpression</li>
-          <li>SimplifyBooleanReturn</li>
-          <li>SingleSpaceSeparator</li>
-          <li>StaticVariableName</li>
-          <li>StringLiteralEquality</li>
-          <li>SuperClone</li>
-          <li>SuperFinalize</li>
-          <li>SuppressWarnings</li>
-          <li>ThrowsCount</li>
-          <li>TypecastParenPad</li>
-          <li>TypeName</li>
-          <li>UnnecessarySemicolonInEnumeration</li>
-          <li>UnnecessarySemicolonInTryWithResources</li>
-          <li>UnusedImports</li>
-          <li>UpperEll</li>
-          <li>VisibilityModifier</li>
-          <li>WhitespaceAfter</li>
-          <li>WhitespaceAround</li>
+        <ul id="SuppressionXpathFilter_IncompatibleChecks">
+          <li>AnnotationLocation</li>
+          <li>AnnotationOnSameLine</li>
+          <li>AnnotationUseStyle</li>
+          <li>ArrayTrailingComma</li>
+          <li>AvoidEscapedUnicodeCharacters</li>
+          <li>AvoidStarImport</li>
+          <li>AvoidStaticImport</li>
+          <li>CommentsIndentation</li>
+          <li>CustomImportOrder</li>
+          <li>EmptyCatchBlock</li>
+          <li>EmptyLineSeparator</li>
+          <li>FinalClass</li>
+          <li>IllegalCatch</li>
+          <li>ImportOrder</li>
+          <li>Indentation</li>
+          <li>InterfaceIsType</li>
+          <li>InterfaceMemberImpliedModifier</li>
+          <li>InvalidJavadocPosition</li>
+          <li>JavadocContentLocation</li>
+          <li>JavadocMethod</li>
+          <li>JavadocStyle</li>
+          <li>JavadocType</li>
+          <li>LambdaParameterName</li>
+          <li>MethodCount</li>
+          <li>MissingCtor</li>
+          <li>MissingJavadocMethod</li>
+          <li>MissingJavadocPackage</li>
+          <li>MissingJavadocType</li>
+          <li>MissingOverride</li>
+          <li>MissingSwitchDefault</li>
+          <li>NeedBraces</li>
+          <li>NoClone</li>
+          <li>NoFinalizer</li>
+          <li>NoLineWrap</li>
+          <li>OneTopLevelClass</li>
+          <li>OuterTypeFilename</li>
+          <li>OverloadMethodsDeclarationOrder</li>
+          <li>PackageAnnotation</li>
+          <li>PackageDeclaration</li>
+          <li>Regexp</li>
+          <li>RegexpSinglelineJava</li>
+          <li>SuppressWarningsHolder</li>
+          <li>TodoComment</li>
+          <li>TrailingComment</li>
+          <li>UncommentedMain</li>
+          <li>UnnecessaryParentheses</li>
+          <li>VariableDeclarationUsageDistance</li>
+          <li>WriteTag</li>
         </ul>
         <p>
-          Note, that support for other Checks will be available after resolving
-          <a href="https://github.com/checkstyle/checkstyle/issues/4830">issue 4830</a>.
+          Also, the filter does not support Javadoc checks:
+        </p>
+        <ul id="SuppressionXpathFilter_JavadocChecks">
+          <li>AtclauseOrder</li>
+          <li>JavadocBlockTagLocation</li>
+          <li>JavadocParagraph</li>
+          <li>JavadocTagContinuationIndentation</li>
+          <li>MissingDeprecated</li>
+          <li>NonEmptyAtclauseDescription</li>
+          <li>SingleLineJavadoc</li>
+          <li>SummaryJavadoc</li>
+        </ul>
+        <p>
+          Note, that support for these Checks will be available after resolving issues
+          <a href="https://github.com/checkstyle/checkstyle/issues/5770">#5770</a> and
+          <a href="https://github.com/checkstyle/checkstyle/issues/5777">#5777</a>.
         </p>
         <p>
           Currently, filter supports the following


### PR DESCRIPTION
Issue #7405 

Now all checks are split into three sets:

* incompatible with SuppressionXpathFilter (#5770, #5777)
* compatible with SuppressionXpathFilter, but missing XPath IT Regression Testing (#6207)
* compatible with SuppressionXpathFilter and with XPath IT Regression Testing

After adding a new check, it must have xpath regression tests, or if this is not possible, it must be included in the list of incompatible checks.