### PR TITLE
Issue #5234: remove DetailAST.branchContains

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java
@@ -19,8 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle;
 
-import java.util.BitSet;
-
 import antlr.CommonASTWithHiddenTokens;
 import antlr.Token;
 import antlr.collections.AST;
@@ -51,13 +49,6 @@ public final class DetailAstImpl extends CommonASTWithHiddenTokens implements De
     /** Previous sibling. */
     private DetailAstImpl previousSibling;
 
-    /**
-     * All token types in this branch.
-     * Token 'x' (where x is an int) is in this branch
-     * if branchTokenTypes.get(x) is true.
-     */
-    private BitSet branchTokenTypes;
-
     @Override
     public void initialize(Token tok) {
         super.initialize(tok);
@@ -80,7 +71,6 @@ public final class DetailAstImpl extends CommonASTWithHiddenTokens implements De
 
     @Override
     public void setFirstChild(AST ast) {
-        clearBranchTokenTypes();
         clearChildCountCache(this);
         super.setFirstChild(ast);
         if (ast != null) {
@@ -90,7 +80,6 @@ public final class DetailAstImpl extends CommonASTWithHiddenTokens implements De
 
     @Override
     public void setNextSibling(AST ast) {
-        clearBranchTokenTypes();
         clearChildCountCache(parent);
         super.setNextSibling(ast);
         if (ast != null && parent != null) {
@@ -107,7 +96,6 @@ public final class DetailAstImpl extends CommonASTWithHiddenTokens implements De
      *        DetailAST object.
      */
     public void addPreviousSibling(DetailAST ast) {
-        clearBranchTokenTypes();
         clearChildCountCache(parent);
         if (ast != null) {
             //parent is set in setNextSibling or parent.setFirstChild
@@ -133,7 +121,6 @@ public final class DetailAstImpl extends CommonASTWithHiddenTokens implements De
      *        DetailAST object.
      */
     public void addNextSibling(DetailAST ast) {
-        clearBranchTokenTypes();
         clearChildCountCache(parent);
         if (ast != null) {
             //parent is set in setNextSibling
@@ -152,7 +139,6 @@ public final class DetailAstImpl extends CommonASTWithHiddenTokens implements De
 
     @Override
     public void addChild(AST ast) {
-        clearBranchTokenTypes();
         clearChildCountCache(this);
         if (ast != null) {
             final DetailAstImpl astImpl = (DetailAstImpl) ast;
@@ -195,7 +181,6 @@ public final class DetailAstImpl extends CommonASTWithHiddenTokens implements De
     private void setParent(DetailAstImpl parent) {
         DetailAstImpl instance = this;
         do {
-            instance.clearBranchTokenTypes();
             instance.parent = parent;
             instance = instance.getNextSibling();
         } while (instance != null);
@@ -315,33 +300,6 @@ public final class DetailAstImpl extends CommonASTWithHiddenTokens implements De
         return resultNo;
     }
 
-    /**
-     * Returns token type with branch.
-     * @return the token types that occur in the branch as a sorted set.
-     */
-    private BitSet getBranchTokenTypes() {
-        // lazy init
-        if (branchTokenTypes == null) {
-            branchTokenTypes = new BitSet();
-            branchTokenTypes.set(getType());
-
-            // add union of all children
-            DetailAstImpl child = getFirstChild();
-            while (child != null) {
-                final BitSet childTypes = child.getBranchTokenTypes();
-                branchTokenTypes.or(childTypes);
-
-                child = child.getNextSibling();
-            }
-        }
-        return branchTokenTypes;
-    }
-
-    @Override
-    public boolean branchContains(int type) {
-        return getBranchTokenTypes().get(type);
-    }
-
     @Override
     public DetailAST getPreviousSibling() {
         return previousSibling;
@@ -381,18 +339,6 @@ public final class DetailAstImpl extends CommonASTWithHiddenTokens implements De
     private static void clearChildCountCache(DetailAstImpl ast) {
         if (ast != null) {
             ast.childCount = NOT_INITIALIZED;
-        }
-    }
-
-    /**
-     * Clears branchTokenTypes cache for all parents of the current DetailAST instance, and the
-     * child count for the current DetailAST instance.
-     */
-    private void clearBranchTokenTypes() {
-        DetailAstImpl prevParent = parent;
-        while (prevParent != null) {
-            prevParent.branchTokenTypes = null;
-            prevParent = prevParent.parent;
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -79,15 +79,6 @@ public interface DetailAST {
     DetailAST getLastChild();
 
     /**
-     * Checks if this branch of the parse tree contains a token
-     * of the provided type.
-     * @param type a TokenType
-     * @return true if and only if this branch (including this node)
-     *     contains a token of type {@code type}.
-     */
-    boolean branchContains(int type);
-
-    /**
      * Returns the previous sibling or null if no such sibling exists.
      * @return the previous sibling or null if no such sibling exists.
      */

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
@@ -20,9 +20,7 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -34,7 +32,6 @@ import java.nio.file.Files;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.BitSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.Consumer;
@@ -237,68 +234,6 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
         setParentMethod.invoke(firstLevelC, root);
 
         assertEquals(firstLevelC, firstLevelA.getNextSibling(), "Invalid next sibling");
-    }
-
-    @Test
-    public void testBranchContains() {
-        final DetailAstImpl root = createToken(null, TokenTypes.CLASS_DEF);
-        final DetailAstImpl modifiers = createToken(root, TokenTypes.MODIFIERS);
-        createToken(modifiers, TokenTypes.LITERAL_PUBLIC);
-
-        assertTrue(root.branchContains(TokenTypes.LITERAL_PUBLIC), "invalid result");
-        assertFalse(root.branchContains(TokenTypes.OBJBLOCK), "invalid result");
-    }
-
-    private static DetailAstImpl createToken(DetailAstImpl root, int type) {
-        final DetailAstImpl result = new DetailAstImpl();
-        result.setType(type);
-        if (root != null) {
-            root.addChild(result);
-        }
-        return result;
-    }
-
-    @Test
-    public void testClearBranchTokenTypes() throws Exception {
-        final DetailAstImpl parent = new DetailAstImpl();
-        final DetailAstImpl child = new DetailAstImpl();
-        parent.setFirstChild(child);
-
-        final List<Consumer<DetailAstImpl>> clearBranchTokenTypesMethods = Arrays.asList(
-                child::setFirstChild,
-                child::setNextSibling,
-                child::addPreviousSibling,
-                child::addNextSibling,
-                child::addChild,
-            ast -> {
-                try {
-                    Whitebox.invokeMethod(child, "setParent", ast);
-                }
-                // -@cs[IllegalCatch] Cannot avoid catching it.
-                catch (Exception exception) {
-                    throw new IllegalStateException(exception);
-                }
-            }
-        );
-
-        for (Consumer<DetailAstImpl> method : clearBranchTokenTypesMethods) {
-            final BitSet branchTokenTypes = Whitebox.invokeMethod(parent, "getBranchTokenTypes");
-            method.accept(null);
-            final BitSet branchTokenTypes2 = Whitebox.invokeMethod(parent, "getBranchTokenTypes");
-            assertEquals(branchTokenTypes, branchTokenTypes2, "Branch token types are not equal");
-            assertNotSame(branchTokenTypes, branchTokenTypes2,
-                    "Branch token types should not be the same");
-        }
-    }
-
-    @Test
-    public void testCacheBranchTokenTypes() {
-        final DetailAST root = new DetailAstImpl();
-        final BitSet bitSet = new BitSet();
-        bitSet.set(999);
-
-        Whitebox.setInternalState(root, "branchTokenTypes", bitSet);
-        assertTrue(root.branchContains(999), "Branch tokens has changed");
     }
 
     @Test


### PR DESCRIPTION
Issue #5234

This removes `DetailAST.branchContains`.

@romani I am not seeing this method deprecated, but it has been removed from checkstyle for a few versions. Do you still want to deprecate this first before removing it?