### PR TITLE
Issue #7423: provide organization/projectKey name as checkstyle for sonar

### DIFF
--- a/.ci/travis/travis.sh
+++ b/.ci/travis/travis.sh
@@ -189,6 +189,8 @@ sonarqube)
   mvn -e clean package sonar:sonar \
        -Dsonar.host.url=https://sonarcloud.io \
        -Dsonar.login=$SONAR_TOKEN \
+       -Dsonar.projectKey=com.puppycrawl.tools:checkstyle \
+       -Dsonar.organization=checkstyle \
        -Dmaven.test.failure.ignore=true \
        -Dcheckstyle.skip=true -Dpmd.skip=true -Dcheckstyle.ant.skip=true
   ;;


### PR DESCRIPTION
Issue #7423

it executes only from master build, not PR.

for some reason I can not run it from local, as it is hanging at `[INFO] User cache: /home/rivanov/.sonar/cache`
probably this PR should be just merged.
On remote it passed in master https://travis-ci.org/checkstyle/checkstyle/jobs/631080595#L1215 looks like this line is instant action and sonarqube server info should be printed immediately.