### PR TITLE
config: add .ci/bump-license-year-in-all-projects.sh

### DIFF
--- a/.ci/bump-license-year-in-all-projects.sh
+++ b/.ci/bump-license-year-in-all-projects.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -e
+
+CURR_YEAR=$(date +"%Y")
+JAVA_FILE=$(find ./src/main -type f -name *.java -print -quit)
+echo "Current year will be taken from $JAVA_FILE"
+PREV_YEAR=$(grep "Copyright" $JAVA_FILE | cut -d " " -f 4 | cut -d '-' -f 2)
+echo "CURR_YEAR=$CURR_YEAR"
+echo "PREV_YEAR=$PREV_YEAR"
+
+./.ci/bump-license-year.sh $PREV_YEAR $CURR_YEAR .
+git add . && git commit -m "minor: bump year to $CURR_YEAR" && git push origin master
+
+mkdir -p .ci-temp/bump-year
+cd .ci-temp/bump-year
+
+git clone git@github.com:checkstyle/contribution.git
+git clone git@github.com:checkstyle/sonar-checkstyle.git
+git clone git@github.com:checkstyle/regression-tool.git
+git clone git@github.com:sevntu-checkstyle/sevntu.checkstyle.git
+git clone git@github.com:sevntu-checkstyle/methods-distance.git
+
+./../../.ci/bump-license-year.sh $PREV_YEAR $CURR_YEAR contribution
+./../../.ci/bump-license-year.sh $PREV_YEAR $CURR_YEAR sonar-checkstyle
+./../../.ci/bump-license-year.sh $PREV_YEAR $CURR_YEAR regression-tool
+./../../.ci/bump-license-year.sh $PREV_YEAR $CURR_YEAR sevntu.checkstyle
+./../../.ci/bump-license-year.sh $PREV_YEAR $CURR_YEAR methods-distance
+
+cd contribution
+git add . && git commit -m "minor: bump year to $CURR_YEAR" && git push origin master
+cd ../
+cd sonar-checkstyle
+git add . && git commit -m "minor: bump year to $CURR_YEAR" && git push origin master
+cd ../
+cd regression-tool
+git add . && git commit -m "minor: bump year to $CURR_YEAR" && git push origin master
+cd ../
+cd sevntu.checkstyle
+git add . && git commit -m "minor: bump year to $CURR_YEAR" && git push origin master
+cd ../
+cd methods-distance
+git add . && git commit -m "minor: bump year to $CURR_YEAR" && git push origin master
+cd ../

--- a/.ci/bump-license-year.sh
+++ b/.ci/bump-license-year.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+PREV_YEAR=$1
+CURR_YEAR=$2
+DIR=$3
+
+OLD_VALUE="// Copyright (C) 2001-$PREV_YEAR the original author or authors."
+NEW_VALUE="// Copyright (C) 2001-$CURR_YEAR the original author or authors."
+
+find $DIR -type f \( -name *.java -o -name *.header -o -name *.g \) \
+  -exec sed -i "s|$OLD_VALUE|$NEW_VALUE|g" {} +
+
+BASEDIR=$(pwd)
+echo "Distinct Diff in $DIR is:"
+cd $DIR
+git diff | grep -Eh "^\+"  | grep -v "+++ b" | sort | uniq
+cd $BASEDIR


### PR DESCRIPTION
based on mess of today in CI with year bump ....
https://github.com/checkstyle/checkstyle/pull/7433
https://github.com/checkstyle/checkstyle/pull/7434

from https://github.com/checkstyle/checkstyle/wiki/How-to-make-a-release#before-starting

ones merged, wiki should be updated.
such file should be copied to all other repositories (or use some wrapper with wget/curl of such script and execution of it)

Probably updates like this are not required for review/CI so we cn make script that clone all dependent repositories and make changes in them and push. So some maintainer will launch one script and it will do all required updates.