### PR TITLE
Issue #7436: avoid using Locale.setDefault in tests

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -722,6 +722,7 @@ JToggle
 JTool
 jtree
 junit
+junitpioneer
 jvm
 jxr
 kailasam

--- a/pom.xml
+++ b/pom.xml
@@ -274,6 +274,12 @@
       <version>1.1.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit-pioneer</groupId>
+      <artifactId>junit-pioneer</artifactId>
+      <version>0.4.2</version>
+      <scope>test</scope>
+    </dependency>
     <!-- till https://github.com/checkstyle/checkstyle/issues/7368 -->
     <dependency>
       <groupId>org.junit.vintage</groupId>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.DefaultLocale;
 import org.powermock.reflect.Whitebox;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -262,36 +263,36 @@ public class LocalizedMessageTest {
         assertEquals("Instruction vide.", localizedMessage.getMessage(), "Invalid message");
     }
 
+    @DefaultLocale("fr")
     @Test
     public void testEnforceEnglishLanguageBySettingUnitedStatesLocale() {
-        Locale.setDefault(Locale.FRENCH);
         LocalizedMessage.setLocale(Locale.US);
         final LocalizedMessage localizedMessage = createSampleLocalizedMessage();
 
         assertEquals("Empty statement.", localizedMessage.getMessage(), "Invalid message");
     }
 
+    @DefaultLocale("fr")
     @Test
     public void testEnforceEnglishLanguageBySettingRootLocale() {
-        Locale.setDefault(Locale.FRENCH);
         LocalizedMessage.setLocale(Locale.ROOT);
         final LocalizedMessage localizedMessage = createSampleLocalizedMessage();
 
         assertEquals("Empty statement.", localizedMessage.getMessage(), "Invalid message");
     }
 
+    @DefaultLocale("fr")
     @Test
     public void testGetKey() {
-        Locale.setDefault(Locale.FRENCH);
         LocalizedMessage.setLocale(Locale.US);
         final LocalizedMessage localizedMessage = createSampleLocalizedMessage();
 
         assertEquals("empty.statement", localizedMessage.getKey(), "Invalid message key");
     }
 
+    @DefaultLocale("fr")
     @Test
     public void testCleatBundleCache() {
-        Locale.setDefault(Locale.FRENCH);
         LocalizedMessage.setLocale(Locale.ROOT);
         final LocalizedMessage localizedMessage = createSampleLocalizedMessage();
 
@@ -386,7 +387,6 @@ public class LocalizedMessageTest {
 
     @AfterEach
     public void tearDown() {
-        Locale.setDefault(DEFAULT_LOCALE);
         LocalizedMessage.clearCache();
         LocalizedMessage.setLocale(DEFAULT_LOCALE);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/ScopeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/ScopeTest.java
@@ -25,9 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import java.util.Locale;
-
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.DefaultLocale;
 
 /**
  * Test cases for {@link Scope} enumeration.
@@ -72,24 +71,15 @@ public class ScopeTest {
         assertEquals(Scope.ANONINNER, Scope.getInstance("AnonInner"), "Invalid scope");
     }
 
+    @DefaultLocale(language = "tr", country = "TR")
     @Test
-    public void testMixedCaseSpacesWithDifferentLocales() {
-        final Locale[] differentLocales = {new Locale("TR", "tr") };
-        final Locale defaultLocale = Locale.getDefault();
-        try {
-            for (Locale differentLocale : differentLocales) {
-                Locale.setDefault(differentLocale);
-                assertEquals(Scope.NOTHING, Scope.getInstance("NothinG "), "Invalid scope");
-                assertEquals(Scope.PUBLIC, Scope.getInstance(" PuBlic"), "Invalid scope");
-                assertEquals(Scope.PROTECTED, Scope.getInstance(" ProteCted"), "Invalid scope");
-                assertEquals(Scope.PACKAGE, Scope.getInstance("    PackAge "), "Invalid scope");
-                assertEquals(Scope.PRIVATE, Scope.getInstance("privaTe   "), "Invalid scope");
-                assertEquals(Scope.ANONINNER, Scope.getInstance("AnonInner"), "Invalid scope");
-            }
-        }
-        finally {
-            Locale.setDefault(defaultLocale);
-        }
+    public void testMixedCaseSpacesWithDifferentLocale() {
+        assertEquals(Scope.NOTHING, Scope.getInstance("NothinG "), "Invalid scope");
+        assertEquals(Scope.PUBLIC, Scope.getInstance(" PuBlic"), "Invalid scope");
+        assertEquals(Scope.PROTECTED, Scope.getInstance(" ProteCted"), "Invalid scope");
+        assertEquals(Scope.PACKAGE, Scope.getInstance("    PackAge "), "Invalid scope");
+        assertEquals(Scope.PRIVATE, Scope.getInstance("privaTe   "), "Invalid scope");
+        assertEquals(Scope.ANONINNER, Scope.getInstance("AnonInner"), "Invalid scope");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelTest.java
@@ -23,9 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import java.util.Locale;
-
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.DefaultLocale;
 
 /**
  * Test cases for {@link SeverityLevel} enumeration.
@@ -72,26 +71,17 @@ public class SeverityLevelTest {
                 "Invalid getInstance result");
     }
 
+    @DefaultLocale(language = "tr", country = "TR")
     @Test
     public void testMixedCaseSpacesWithDifferentLocales() {
-        final Locale[] differentLocales = {new Locale("TR", "tr") };
-        final Locale defaultLocale = Locale.getDefault();
-        try {
-            for (Locale differentLocale : differentLocales) {
-                Locale.setDefault(differentLocale);
-                assertEquals(SeverityLevel.IGNORE, SeverityLevel.getInstance("IgnoRe "),
-                        "Invalid getInstance result");
-                assertEquals(SeverityLevel.INFO, SeverityLevel.getInstance(" iNfo"),
-                        "Invalid getInstance result");
-                assertEquals(SeverityLevel.WARNING, SeverityLevel.getInstance(" WarniNg"),
-                        "Invalid getInstance result");
-                assertEquals(SeverityLevel.ERROR, SeverityLevel.getInstance("    ERROR "),
-                        "Invalid getInstance result");
-            }
-        }
-        finally {
-            Locale.setDefault(defaultLocale);
-        }
+        assertEquals(SeverityLevel.IGNORE, SeverityLevel.getInstance("IgnoRe "),
+                "Invalid getInstance result");
+        assertEquals(SeverityLevel.INFO, SeverityLevel.getInstance(" iNfo"),
+                "Invalid getInstance result");
+        assertEquals(SeverityLevel.WARNING, SeverityLevel.getInstance(" WarniNg"),
+                "Invalid getInstance result");
+        assertEquals(SeverityLevel.ERROR, SeverityLevel.getInstance("    ERROR "),
+                "Invalid getInstance result");
     }
 
 }


### PR DESCRIPTION
Issue #7436

Small step to run tests in parallel. We need to get rid of the global state change in the tests.