### PR TITLE
Issue #7174: ENUM_CONSTANT_DEF token support for RightCurlyCheck

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -267,6 +267,7 @@
       <property name="tokens" value="LITERAL_TRY"/>
       <property name="tokens" value="ANNOTATION_DEF"/>
       <property name="tokens" value="ENUM_DEF"/>
+      <property name="tokens" value="ENUM_CONSTANT_DEF"/>
       <property name="option" value="alone"/>
     </module>
     <module name="RightCurly">

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/RightCurlyTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/RightCurlyTest.java
@@ -95,6 +95,9 @@ public class RightCurlyTest extends AbstractGoogleModuleTestSupport {
             "163:16: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 16),
             "165:30: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 30),
             "168:16: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 16),
+            "187:28: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 28),
+            "191:30: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 30),
+            "195:14: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 14),
         };
 
         final Configuration checkConfig = getModuleConfig("RightCurly", "RightCurlyAlone");

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyOtherAlone.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlyOtherAlone.java
@@ -173,3 +173,30 @@ enum TestEnum3 {
 
 enum TestEnum4 { SOME_VALUE;
 }
+
+class EnumConstDefs {
+
+    public enum Temp {
+        FOO {
+            int someValue;
+        }
+    }
+
+    public enum Temp1 {
+        FOO {
+            int someValue; } //warn
+    }
+
+    public enum Temp2 {
+        FOO { int someValue; } //warn
+    }
+
+    public enum Temp3 {
+        FOO {} //warn
+    }
+
+    public enum Temp4 {
+        FOO { int someValue;
+        }
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -35,7 +35,8 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * Checks the placement of right curly braces (<code>'}'</code>)
  * for if-else, try-catch-finally blocks, while-loops, for-loops,
  * method definitions, class definitions, constructor definitions,
- * instance, static initialization blocks, annotation definitions and enum definitions.
+ * instance, static initialization blocks, annotation definitions,
+ * enum definitions and enum constant definitions.
  * For right curly brace of expression blocks please follow issue
  * <a href="https://github.com/checkstyle/checkstyle/issues/5945">#5945</a>.
  * </p>
@@ -145,6 +146,7 @@ public class RightCurlyCheck extends AbstractCheck {
             TokenTypes.INSTANCE_INIT,
             TokenTypes.ANNOTATION_DEF,
             TokenTypes.ENUM_DEF,
+            TokenTypes.ENUM_CONSTANT_DEF,
         };
     }
 
@@ -345,6 +347,7 @@ public class RightCurlyCheck extends AbstractCheck {
         private static final int[] TOKENS_WITH_NO_CHILD_SLIST = {
             TokenTypes.CLASS_DEF,
             TokenTypes.ENUM_DEF,
+            TokenTypes.ENUM_CONSTANT_DEF,
             TokenTypes.ANNOTATION_DEF,
         };
 
@@ -466,7 +469,7 @@ public class RightCurlyCheck extends AbstractCheck {
 
         /**
          * Collects validation details for CLASS_DEF, METHOD DEF, CTOR_DEF, STATIC_INIT,
-         * INSTANCE_INIT, ANNOTATION_DEF and ENUM_DEF.
+         * INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF and ENUM_CONSTANT_DEF.
          * @param ast a {@code DetailAST} value
          * @return an object containing all details to make a validation
          */

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -93,7 +93,7 @@
             <property name="option" value="alone"/>
             <property name="tokens"
              value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
-                    INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF"/>
+                    INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, ENUM_CONSTANT_DEF"/>
         </module>
         <module name="WhitespaceAround">
             <property name="allowEmptyConstructors" value="true"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
@@ -614,4 +614,89 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         verify(checkConfig, getPath("InputRightCurlySameNewTokens.java"), expected);
     }
 
+    @Test
+    public void testEnumConstDefTokenSame() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
+        checkConfig.addAttribute("option", RightCurlyOption.SAME.toString());
+        checkConfig.addAttribute("tokens", "ENUM_CONSTANT_DEF");
+        final String[] expected = {
+            "19:41: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 41),
+        };
+        verify(checkConfig,
+                getPath("InputRightCurlySameEnumConstDefToken.java"), expected);
+    }
+
+    @Test
+    public void testEnumConstDefTokenAlone() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
+        checkConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
+        checkConfig.addAttribute("tokens", "ENUM_CONSTANT_DEF");
+        final String[] expected = {
+            "19:41: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 41),
+            "23:43: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 43),
+            "27:14: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 14),
+        };
+        verify(checkConfig,
+                getPath("InputRightCurlyAloneEnumConstDefToken.java"), expected);
+    }
+
+    @Test
+    public void testEnumConstDefTokenAloneOrSingleLine() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
+        checkConfig.addAttribute("option",
+                RightCurlyOption.ALONE_OR_SINGLELINE.toString());
+        checkConfig.addAttribute("tokens", "ENUM_CONSTANT_DEF");
+        final String[] expected = {
+            "19:41: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 41),
+        };
+        verify(checkConfig,
+                getPath("InputRightCurlyAloneOrSingleLineEnumConstDefToken.java"),
+                expected);
+    }
+
+    @Test
+    public void testEnumConstDefTokenSameWithSemi() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
+        checkConfig.addAttribute("option", RightCurlyOption.SAME.toString());
+        checkConfig.addAttribute("tokens", "ENUM_CONSTANT_DEF");
+        final String[] expected = {
+            "14:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "19:41: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 41),
+            "32:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+        };
+        verify(checkConfig,
+                getPath("InputRightCurlySameEnumConstDefTokensWithSemi.java"), expected);
+    }
+
+    @Test
+    public void testEnumConstDefTokenAloneWithSemi() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
+        checkConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
+        checkConfig.addAttribute("tokens", "ENUM_CONSTANT_DEF");
+        final String[] expected = {
+            "14:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "19:41: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 41),
+            "23:43: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 43),
+            "27:14: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 14),
+            "32:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+        };
+        verify(checkConfig,
+                getPath("InputRightCurlyAloneEnumConstDefTokenWithSemi.java"), expected);
+    }
+
+    @Test
+    public void testEnumConstDefTokenAloneOrSingleLineWithSemi() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
+        checkConfig.addAttribute("option",
+                RightCurlyOption.ALONE_OR_SINGLELINE.toString());
+        checkConfig.addAttribute("tokens", "ENUM_CONSTANT_DEF");
+        final String[] expected = {
+            "14:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "19:41: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 41),
+            "32:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+        };
+        verify(checkConfig,
+                getPath("InputRightCurlyAloneOrSingleLineEnumConstDefTokenWithSemi.java"),
+                expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneEnumConstDefToken.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneEnumConstDefToken.java
@@ -1,0 +1,34 @@
+/*
+ * Config:
+ * option = alone
+ * tokens = ENUM_CONSTANT_DEF
+ */
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyAloneEnumConstDefToken {
+
+    public enum Temp {
+        FOO {
+            public void doSomething(){}
+        }
+    }
+
+    public enum Temp1 {
+        FOO {
+            public void doSomething(){} } //violation
+    }
+
+    public enum Temp2 {
+        FOO { public void doSomething(){} } //violation
+    }
+
+    public enum Temp3 {
+        FOO {} //violation
+    }
+
+    public enum Temp4 {
+        FOO { public void doSomething(){}
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneEnumConstDefTokenWithSemi.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneEnumConstDefTokenWithSemi.java
@@ -1,0 +1,34 @@
+/*
+ * Config:
+ * option = alone
+ * tokens = ENUM_CONSTANT_DEF
+ */
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyAloneEnumConstDefTokenWithSemi {
+
+    public enum Temp {
+        FOO {
+            public void doSomething(){}
+        }; //violation
+    }
+
+    public enum Temp1 {
+        FOO {
+            public void doSomething(){} }; //violation
+    }
+
+    public enum Temp2 {
+        FOO { public void doSomething(){} }; //violation
+    }
+
+    public enum Temp3 {
+        FOO {}; //violation
+    }
+
+    public enum Temp4 {
+        FOO { public void doSomething(){}
+        }; //violation
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneOrSingleLineEnumConstDefToken.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneOrSingleLineEnumConstDefToken.java
@@ -1,0 +1,34 @@
+/*
+ * Config:
+ * option = alone_or_singleline
+ * tokens = ENUM_CONSTANT_DEF
+ */
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyAloneOrSingleLineEnumConstDefToken {
+
+    public enum Temp {
+        FOO {
+            public void doSomething(){}
+        }
+    }
+
+    public enum Temp1 {
+        FOO {
+            public void doSomething(){} } //violation
+    }
+
+    public enum Temp2 {
+        FOO { public void doSomething(){} }
+    }
+
+    public enum Temp3 {
+        FOO {}
+    }
+
+    public enum Temp4 {
+        FOO { public void doSomething(){}
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneOrSingleLineEnumConstDefTokenWithSemi.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyAloneOrSingleLineEnumConstDefTokenWithSemi.java
@@ -1,0 +1,34 @@
+/*
+ * Config:
+ * option = alone_or_singleline
+ * tokens = ENUM_CONSTANT_DEF
+ */
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyAloneOrSingleLineEnumConstDefTokenWithSemi {
+
+    public enum Temp {
+        FOO {
+            public void doSomething(){}
+        }; //violation
+    }
+
+    public enum Temp1 {
+        FOO {
+            public void doSomething(){} }; //violation
+    }
+
+    public enum Temp2 {
+        FOO { public void doSomething(){} };
+    }
+
+    public enum Temp3 {
+        FOO {};
+    }
+
+    public enum Temp4 {
+        FOO { public void doSomething(){}
+        }; //violation
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlySameEnumConstDefToken.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlySameEnumConstDefToken.java
@@ -1,0 +1,34 @@
+/*
+ * Config:
+ * option = same
+ * tokens = ENUM_CONSTANT_DEF
+ */
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlySameEnumConstDefToken {
+
+    public enum Temp {
+        FOO {
+            public void doSomething(){}
+        }
+    }
+
+    public enum Temp1 {
+        FOO {
+            public void doSomething(){} } //violation
+    }
+
+    public enum Temp2 {
+        FOO { public void doSomething(){} }
+    }
+
+    public enum Temp3 {
+        FOO {}
+    }
+
+    public enum Temp4 {
+        FOO { public void doSomething(){}
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlySameEnumConstDefTokensWithSemi.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlySameEnumConstDefTokensWithSemi.java
@@ -1,0 +1,34 @@
+/*
+ * Config:
+ * option = same
+ * tokens = ENUM_CONSTANT_DEF
+ */
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlySameEnumConstDefTokensWithSemi {
+
+    public enum Temp {
+        FOO {
+            public void doSomething(){}
+        }; //violation
+    }
+
+    public enum Temp1 {
+        FOO {
+            public void doSomething(){} }; //violation
+    }
+
+    public enum Temp2 {
+        FOO { public void doSomething(){} };
+    }
+
+    public enum Temp3 {
+        FOO {};
+    }
+
+    public enum Temp4 {
+        FOO { public void doSomething(){}
+        }; //violation
+    }
+}

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -944,7 +944,8 @@ allowedFuture.addCallback(result -> {
           Checks the placement of right curly braces (<code>'}'</code>)
           for if-else, try-catch-finally blocks, while-loops, for-loops,
           method definitions, class definitions, constructor definitions,
-          instance, static initialization blocks, annotation definitions and enum definitions.
+          instance, static initialization blocks, annotation definitions,
+          enum definitions and enum constant definitions.
           For right curly brace of expression blocks please follow issue
           <a href="https://github.com/checkstyle/checkstyle/issues/5945">#5945</a>.
         </p>
@@ -1014,7 +1015,10 @@ allowedFuture.addCallback(result -> {
                   ANNOTATION_DEF</a>,
               <a
                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
-                  ENUM_DEF</a>.</td>
+                  ENUM_DEF</a>,
+              <a
+               href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
+                  ENUM_CONSTANT_DEF</a>.</td>
               <td><a
                href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">
                   LITERAL_TRY</a>,


### PR DESCRIPTION
`ENUM_CONSTANT_DEF` support added in RightCurlyCheck. Fix #7174.

Regression Report:
https://sd1998.github.io/checkstyle-regression/Fix-7174/index.html

Base config:
https://sd1998.github.io/checkstyle-regression/Fix-7174/base_config.xml

Patch config:
https://sd1998.github.io/checkstyle-regression/Fix-7174/patch_config.xml

Regression Repo:
https://github.com/sd1998/checkstyle-regression/tree/master/Fix-7174