### PR TITLE
Issue #7446: ensure all checks summaries in sync with checks.xml

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
@@ -203,8 +203,8 @@ public class TranslationCheckTest extends AbstractXmlTestSupport {
             // This ensures we pick up the correct file based on its name and the
             // number of children it has.
             return !"file".equals(expected.getNodeName())
-                    || expected.getAttributes().getNamedItem("name").getNodeValue()
-                            .equals(actual.getAttributes().getNamedItem("name").getNodeValue())
+                    || XmlUtil.getNameAttributeOfNode(expected)
+                        .equals(XmlUtil.getNameAttributeOfNode(actual))
                     && XmlUtil.getChildrenElements(expected).size() == XmlUtil
                             .getChildrenElements(actual).size();
         }, firstErrorMessage, secondErrorMessage);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -102,8 +102,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
 
             for (int position = 0; position < sources.getLength(); position++) {
                 final Node section = sources.item(position);
-                final String sectionName = section.getAttributes().getNamedItem("name")
-                        .getNodeValue();
+                final String sectionName = XmlUtil.getNameAttributeOfNode(section);
 
                 if ("Content".equals(sectionName) || "Overview".equals(sectionName)) {
                     continue;
@@ -149,8 +148,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
                 continue;
             }
 
-            final String subSectionName = subSection.getAttributes().getNamedItem("name")
-                    .getNodeValue();
+            final String subSectionName = XmlUtil.getNameAttributeOfNode(subSection);
 
             examineCheckSubSection(subSection, subSectionName);
         }
@@ -303,7 +301,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
         }
 
         if (sanitize) {
-            result.append(sanitizeXml(node.getTextContent()));
+            result.append(XmlUtil.sanitizeXml(node.getTextContent()));
         }
         else {
             result.append(getNodeText(node));
@@ -396,11 +394,6 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
         }
 
         return result.toString();
-    }
-
-    private static String sanitizeXml(String nodeValue) {
-        return nodeValue.replaceAll("^[\\r\\n\\s]+", "").replaceAll("[\\r\\n\\s]+$", "")
-                .replace("<", "&lt;").replace(">", "&gt;");
     }
 
     private static class JavaDocCapture extends AbstractCheck {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsMobileWrapperTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsMobileWrapperTest.java
@@ -64,8 +64,7 @@ public class XdocsMobileWrapperTest {
 
             for (int position = 0; position < sources.getLength(); position++) {
                 final Node section = sources.item(position);
-                final String sectionName = section.getAttributes().getNamedItem("name")
-                        .getNodeValue();
+                final String sectionName = XmlUtil.getNameAttributeOfNode(section);
 
                 if ("Content".equals(sectionName) || "Overview".equals(sectionName)) {
                     continue;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XmlUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XmlUtil.java
@@ -132,4 +132,33 @@ public final class XmlUtil {
         return result;
     }
 
+    /**
+     * Returns the value of the "name" attribute for the given node.
+     *
+     * @param node to retrieve the name
+     * @return the value of the attribute "name"
+     */
+    public static String getNameAttributeOfNode(Node node) {
+        return node.getAttributes().getNamedItem("name").getNodeValue();
+    }
+
+    /**
+     * <p>Sanitizes the given string for safe use in XML documents.</p>
+     * <ul>
+     * <li>Removes all whitespaces at the beginning and at the end of the string;</li>
+     * <li>Replaces repeated whitespaces in the middle of the string with a single space;</li>
+     * <li>Replaces XML entities with escaped values.</li>
+     * </ul>
+     *
+     * @param rawXml the text to sanitize
+     * @return the sanitized text
+     */
+    public static String sanitizeXml(String rawXml) {
+        return rawXml
+                .replaceAll("(^\\s+|\\s+$)", "")
+                .replaceAll("\\s+", " ")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;");
+    }
+
 }


### PR DESCRIPTION
Issue #7446

`Node.getAttributes().getNamedItem("name").getNodeValue()` extracted to an utility method.

Method `sanitizeXml` moved to the class `XmlUtil`.