### PR TITLE
doc: extend Indentation Check explanation of line wrap

### DIFF
--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -1084,6 +1084,30 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
           times it is practical experience. In any case, this check should
           just ensure that a minimal set of indentation rules is followed.
         </p>
+        <p>
+          Basic offset indentation is used for indentation inside code blocks.
+          For any lines that span more than 1, line wrapping indentation is used for those
+          lines after the first.
+          Brace adjustment, case, and throws indentations are all used only if those specific
+          identifiers start the line. If, for example, a brace is used in the middle of the line,
+          its indentation will not take effect.
+          All indentations have an accumulative/recursive effect when they are triggered. If
+          during a line wrapping, another code block is found and it doesn't end on that same
+          line, then the subsequent lines afterwards, in that new code block, are increased on
+          top of the line wrap and any indentations above it.
+        </p>
+        <p>Example:</p>
+        <source>
+if ((condition1 &amp;&amp; condition2)
+        || (condition3 &amp;&amp; condition4)    // line wrap with bigger indentation
+        ||!(condition5 &amp;&amp; condition6)) { // line wrap with bigger indentation
+  field.doSomething()                    // basic offset
+      .doSomething()                     // line wrap
+      .doSomething( c -> {               // line wrap
+        return c.doSome();               // basic offset
+      });
+}
+        </source>
       </subsection>
 
       <subsection name="Properties" id="Indentation_Properties">
@@ -1157,12 +1181,44 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
 
       <subsection name="Examples" id="Indentation_Examples">
         <p>
-          To configure the check:
+          To configure the check for default behavior:
         </p>
         <source>
 &lt;module name=&quot;Indentation&quot;/&gt;
         </source>
-
+        <p>
+          Example of Compliant code for default configuration
+          (in comment name of property that controls indentations):
+        </p>
+        <source>
+class Test {
+    String field;               // basicOffset
+    int[] arr = {               // basicOffset
+        5,                      // arrayInitIndent
+        6 };                    // arrayInitIndent
+    void bar() throws Exception // basicOffset
+    {                           // braceAdjustment
+        foo();                  // basicOffset
+    }                           // braceAdjustment
+    void foo() {                // basicOffset
+        if ((cond1 &amp;&amp; cond2)    // basicOffset
+                  || (cond3 &amp;&amp; cond4)    // lineWrappingIndentation, forceStrictCondition
+                  ||!(cond5 &amp;&amp; cond6)) { // lineWrappingIndentation, forceStrictCondition
+            field.doSomething()          // basicOffset
+                .doSomething()           // lineWrappingIndentation and forceStrictCondition
+                .doSomething( c -> {     // lineWrappingIndentation and forceStrictCondition
+                    return c.doSome();   // basicOffset
+                });
+        }
+    }
+    void fooCase()                // basicOffset
+        throws Exception {        // throwsIndent
+        switch (field) {          // basicOffset
+            case "value" : bar(); // caseIndent
+        }
+    }
+}
+        </source>
         <p>
           To configure the check to enforce the indentation style recommended by
           Oracle:
@@ -1174,6 +1230,17 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
 &lt;/module&gt;
         </source>
         <p>
+          Example of Compliant code for default configuration
+          (in comment name of property that controls indentation):
+        </p>
+        <source>
+void fooCase() {          // basicOffset
+    switch (field) {      // basicOffset
+    case "value" : bar(); // caseIndent
+    }
+}
+        </source>
+        <p>
           To configure the Check to enforce strict condition in line-wrapping validation.
         </p>
         <source>
@@ -1182,18 +1249,49 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
 &lt;/module&gt;
         </source>
         <p>
-          Such config doesn't allow next cases:
+          Such config doesn't allow next cases
+          even code is aligned further to the right for better reading:
         </p>
         <source>
 void foo(String aFooString,
-        int aFooInt) {} // indent:8 ; expected: 4; warn, because 8 != 4
+        int aFooInt) { // indent:8 ; expected: 4; violation, because 8 != 4
+    if (cond1
+        || cond2) {
+        field.doSomething()
+            .doSomething();
+    }
+    if ((cond1 &amp;&amp; cond2)
+              || (cond3 &amp;&amp; cond4)    // violation
+              ||!(cond5 &amp;&amp; cond6)) { // violation
+        field.doSomething()
+             .doSomething()          // violation
+             .doSomething( c -> {    // violation
+                 return c.doSome();
+            });
+    }
+}
         </source>
         <p>
           But if forceStrictCondition = false, this code is valid:
         </p>
         <source>
 void foo(String aFooString,
-        int aFooInt) {} // indent:8 ; expected: > 4; ok, because 8 > 4
+        int aFooInt) { // indent:8 ; expected: > 4; ok, because 8 > 4
+    if (cond1
+        || cond2) {
+        field.doSomething()
+            .doSomething();
+    }
+    if ((cond1 &amp;&amp; cond2)
+              || (cond3 &amp;&amp; cond4)
+              ||!(cond5 &amp;&amp; cond6)) {
+        field.doSomething()
+             .doSomething()
+             .doSomething( c -> {
+                 return c.doSome();
+            });
+    }
+}
         </source>
       </subsection>
 


### PR DESCRIPTION
based on discussion at https://github.com/checkstyle/checkstyle/pull/7238#discussion_r360711145

It is not very concise doc, but good step forward to unblock #7238 .

I did simple `// violation` on purpose to not bother user with too much details like `// indent:8 ; expected: > 4; ok, because 8 > 4` extra time.

![image](https://user-images.githubusercontent.com/812984/72634896-6f6e9700-3910-11ea-812c-36edcf7e6b23.png)

