### PR TITLE
Issue #7458: 'ThreadLocal' variables should be cleaned up when no longer used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1866,6 +1866,15 @@
                 <!-- needed for SuppressWarningsFilter -->
                 <param>com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilterTest</param>
               </targetTests>
+              <excludedMethods>
+                <!-- destroy method was added in case module had to free up resources
+                before ending, but currently it does ThreadLocal cleanup,
+                to satisfy sonar violation. But right now checkstyle is not multi threading tool.
+                Ones we start multi-threading implementation we should remove this exclude.
+                If we remove this destroy we would have to remove all of them as they are chained
+                together, so we just exclude it from pitest check. -->
+                <param>destroy</param>
+              </excludedMethods>
               <coverageThreshold>100</coverageThreshold>
               <mutationThreshold>100</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
@@ -2233,6 +2242,15 @@
               <excludedTestClasses>
                 <param>*.Input*</param>
               </excludedTestClasses>
+              <excludedMethods>
+                <!-- destroy method was added in case module had to free up resources
+                before ending, but currently it does ThreadLocal cleanup,
+                to satisfy sonar violation. But right now checkstyle is not multi threading tool.
+                Ones we start multi-threading implementation we should remove this exclude.
+                If we remove this destroy we would have to remove all of them as they are chained
+                together, so we just exclude it from pitest check. -->
+                <param>destroy</param>
+              </excludedMethods>
               <coverageThreshold>100</coverageThreshold>
               <mutationThreshold>97</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
@@ -2845,8 +2863,10 @@
                 <param>*.Input*</param>
               </excludedTestClasses>
               <excludedMethods>
-                <!-- destroy in TreeWalker was added in case module had to free up resources
-                before ending, but currently it does nothing, so we cannot check it.
+                <!-- destroy method was added in case module had to free up resources
+                before ending, but currently it does ThreadLocal cleanup,
+                to satisfy sonar violation. But right now checkstyle is not multi threading tool.
+                Ones we start multi-threading implementation we should remove this exclude.
                 If we remove this destroy we would have to remove all of them as they are chained
                 together, so we just exclude it from pitest check. -->
                 <param>destroy</param>
@@ -2904,6 +2924,15 @@
               <excludedTestClasses>
                 <param>*.Input*</param>
               </excludedTestClasses>
+              <excludedMethods>
+                <!-- destroy method was added in case module had to free up resources
+                before ending, but currently it does ThreadLocal cleanup,
+                to satisfy sonar violation. But right now checkstyle is not multi threading tool.
+                Ones we start multi-threading implementation we should remove this exclude.
+                If we remove this destroy we would have to remove all of them as they are chained
+                together, so we just exclude it from pitest check. -->
+                <param>destroy</param>
+              </excludedMethods>
               <coverageThreshold>100</coverageThreshold>
               <mutationThreshold>100</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java
@@ -125,7 +125,7 @@ public abstract class AbstractCheck extends AbstractViolationReporter {
      * Destroy the check. It is being retired from service.
      */
     public void destroy() {
-        // No code by default, should be overridden only by demand at subclasses
+        context.remove();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java
@@ -66,7 +66,7 @@ public abstract class AbstractFileSetCheck
 
     @Override
     public void destroy() {
-        // No code by default, should be overridden only by demand at subclasses
+        context.remove();
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -550,6 +550,12 @@ public class SuppressWarningsHolder
         return valueList;
     }
 
+    @Override
+    public void destroy() {
+        super.destroy();
+        ENTRIES.remove();
+    }
+
     /** Records a particular suppression for a region of a file. */
     private static class Entry {
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -378,6 +378,13 @@ public abstract class AbstractJavadocCheck extends AbstractCheck {
         return javadocTokens.contains(curNode.getType());
     }
 
+    @Override
+    public void destroy() {
+        super.destroy();
+        context.remove();
+        TREE_CACHE.remove();
+    }
+
     /**
      * The file context holder.
      */


### PR DESCRIPTION
Issue #7458

we need to recheck PR validation on sonar to make sure violations gone.