### PR TITLE
config: bump sonar-maven-plugin to 3.7.0.1746

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -400,7 +400,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>sonar-maven-plugin</artifactId>
-          <version>3.6.1.1688</version>
+          <version>3.7.0.1746</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
detected by https://travis-ci.org/checkstyle/checkstyle/jobs/637603836#L1140
 and dependabot do not see such version bump ability, even I manually asked it to "Bump now" at https://app.dependabot.com/accounts/checkstyle

so our shell hack is still useful :) 