### PR TITLE
Issue #5604: resolve Sonar violation 'Remove this useless assignment'

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -290,36 +290,36 @@ public class XMLLogger
     public static boolean isReference(String ent) {
         boolean reference = false;
 
-        if (ent.charAt(0) != '&' || !CommonUtil.endsWithChar(ent, ';')) {
-            reference = false;
-        }
-        else if (ent.charAt(1) == '#') {
-            // prefix is "&#"
-            int prefixLength = 2;
+        if (ent.charAt(0) == '&' && CommonUtil.endsWithChar(ent, ';')) {
+            if (ent.charAt(1) == '#') {
+                // prefix is "&#"
+                int prefixLength = 2;
 
-            int radix = BASE_10;
-            if (ent.charAt(2) == 'x') {
-                prefixLength++;
-                radix = BASE_16;
-            }
-            try {
-                Integer.parseInt(
-                    ent.substring(prefixLength, ent.length() - 1), radix);
-                reference = true;
-            }
-            catch (final NumberFormatException ignored) {
-                reference = false;
-            }
-        }
-        else {
-            final String name = ent.substring(1, ent.length() - 1);
-            for (String element : ENTITIES) {
-                if (name.equals(element)) {
+                int radix = BASE_10;
+                if (ent.charAt(2) == 'x') {
+                    prefixLength++;
+                    radix = BASE_16;
+                }
+                try {
+                    Integer.parseInt(
+                        ent.substring(prefixLength, ent.length() - 1), radix);
                     reference = true;
-                    break;
+                }
+                catch (final NumberFormatException ignored) {
+                    reference = false;
+                }
+            }
+            else {
+                final String name = ent.substring(1, ent.length() - 1);
+                for (String element : ENTITIES) {
+                    if (name.equals(element)) {
+                        reference = true;
+                        break;
+                    }
                 }
             }
         }
+
         return reference;
     }
 


### PR DESCRIPTION
Issue #5604

'reference' already holds the assigned value along all execution'

https://sonarcloud.io/project/issues?id=org.checkstyle%3Acheckstyle&issues=AW9t2w3qYD2QG1pPXIUe&open=AW9t2w3qYD2QG1pPXIUe

history of how such code appear - https://github.com/checkstyle/checkstyle/commit/69a3d541b4888e5e0e6ab09aa675667155c65381 

diff looks big, but all I did is inverted condition and put adjacent ELSE_IF as nested.