### PR TITLE
Issue 7487 add method hasChildren() to DetailAST

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java
@@ -374,6 +374,11 @@ public final class DetailAstImpl extends CommonASTWithHiddenTokens implements De
         return (DetailAstImpl) super.getFirstChild();
     }
 
+    @Override
+    public boolean hasChildren() {
+        return getFirstChild() != null;
+    }
+
     /**
      * Clears the child count for the ast instance.
      * @param ast The ast to clear.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -118,4 +118,10 @@ public interface DetailAST {
      */
     int getNumberOfChildren();
 
+    /**
+     * Returns whether this AST has any children.
+     *
+     * @return {@code true} if this AST has any children.
+     */
+    boolean hasChildren();
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
@@ -136,7 +136,7 @@ public abstract class AbstractSuperCheck
      */
     private static boolean hasArguments(DetailAST methodCallDotAst) {
         final DetailAST argumentsList = methodCallDotAst.getNextSibling();
-        return argumentsList.getChildCount() > 0;
+        return argumentsList.hasChildren();
     }
 
     /**
@@ -170,7 +170,7 @@ public abstract class AbstractSuperCheck
 
     /**
      * Determines whether an AST is a method definition for this check,
-     * with 0 parameters.
+     * without any parameters.
      * @param ast the method definition AST.
      * @return true if the method of ast is a method for this check.
      */
@@ -186,7 +186,7 @@ public abstract class AbstractSuperCheck
             if (getMethodName().equals(name)
                     && modifiersAST.findFirstToken(TokenTypes.LITERAL_NATIVE) == null) {
                 final DetailAST params = ast.findFirstToken(TokenTypes.PARAMETERS);
-                overridingMethod = params.getChildCount() == 0;
+                overridingMethod = !params.hasChildren();
             }
         }
         return overridingMethod;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
@@ -431,7 +431,7 @@ public class MagicNumberCheck extends AbstractCheck {
                     final DetailAST paramAST = methodDefAST.findFirstToken(TokenTypes.PARAMETERS);
                     // we are in a 'public int hashCode()' method! The compiler will ensure
                     // the method returns an 'int' and is public.
-                    inHashCodeMethod = paramAST.getChildCount() == 0;
+                    inHashCodeMethod = !paramAST.hasChildren();
                 }
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
@@ -388,10 +388,15 @@ public class UnnecessaryParenthesesCheck extends AbstractCheck {
      */
     private static boolean isLambdaSingleParameterSurrounded(DetailAST ast) {
         final DetailAST firstChild = ast.getFirstChild();
-        return firstChild.getType() == TokenTypes.LPAREN
-                && firstChild.getNextSibling().getChildCount(TokenTypes.PARAMETER_DEF) == 1
-                && firstChild.getNextSibling().getFirstChild().findFirstToken(TokenTypes.TYPE)
-                        .getChildCount() == 0;
+        boolean result = false;
+        if (firstChild.getType() == TokenTypes.LPAREN) {
+            final DetailAST parameters = firstChild.getNextSibling();
+            if (parameters.getChildCount(TokenTypes.PARAMETER_DEF) == 1
+                    && !parameters.getFirstChild().findFirstToken(TokenTypes.TYPE).hasChildren()) {
+                result = true;
+            }
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ClassDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ClassDefHandler.java
@@ -68,7 +68,10 @@ public class ClassDefHandler extends BlockParentHandler {
     @Override
     public void checkIndentation() {
         final DetailAST modifiers = getMainAst().findFirstToken(TokenTypes.MODIFIERS);
-        if (modifiers.getChildCount() == 0) {
+        if (modifiers.hasChildren()) {
+            checkModifiers();
+        }
+        else {
             if (getMainAst().getType() != TokenTypes.ANNOTATION_DEF) {
                 final DetailAST ident = getMainAst().findFirstToken(TokenTypes.IDENT);
                 final int lineStart = getLineStart(ident);
@@ -76,9 +79,6 @@ public class ClassDefHandler extends BlockParentHandler {
                     logError(ident, "ident", lineStart);
                 }
             }
-        }
-        else {
-            checkModifiers();
         }
         if (getMainAst().getType() == TokenTypes.ANNOTATION_DEF) {
             final DetailAST atAst = getMainAst().findFirstToken(TokenTypes.AT);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MemberDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MemberDefHandler.java
@@ -44,11 +44,11 @@ public class MemberDefHandler extends AbstractExpressionHandler {
     @Override
     public void checkIndentation() {
         final DetailAST modifiersNode = getMainAst().findFirstToken(TokenTypes.MODIFIERS);
-        if (modifiersNode.getChildCount() == 0) {
-            checkType();
+        if (modifiersNode.hasChildren()) {
+            checkModifiers();
         }
         else {
-            checkModifiers();
+            checkType();
         }
         final DetailAST firstNode = getMainAst();
         final DetailAST lastNode = getVarDefStatementSemicolon(firstNode);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheck.java
@@ -108,7 +108,7 @@ public class EmptyForInitializerPadCheck
 
     @Override
     public void visitToken(DetailAST ast) {
-        if (ast.getChildCount() == 0) {
+        if (!ast.hasChildren()) {
             //empty for initializer. test pad before semi.
             final DetailAST semi = ast.getNextSibling();
             final int semiLineIdx = semi.getLineNo() - 1;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheck.java
@@ -108,7 +108,7 @@ public class EmptyForIteratorPadCheck
 
     @Override
     public void visitToken(DetailAST ast) {
-        if (ast.getChildCount() == 0) {
+        if (!ast.hasChildren()) {
             //empty for iterator. test pad after semi.
             final DetailAST semi = ast.getPreviousSibling();
             final String line = getLines()[semi.getLineNo() - 1];

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -499,7 +499,7 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
     private void processPackage(DetailAST ast, DetailAST nextToken) {
         if (ast.getLineNo() > 1 && !hasEmptyLineBefore(ast)) {
             if (getFileContents().getFileName().endsWith("package-info.java")) {
-                if (ast.getFirstChild().getChildCount() == 0 && !isPrecededByJavadoc(ast)) {
+                if (!ast.getFirstChild().hasChildren() && !isPrecededByJavadoc(ast)) {
                     log(ast.getLineNo(), MSG_SHOULD_BE_SEPARATED, ast.getText());
                 }
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheck.java
@@ -149,7 +149,7 @@ public class NoWhitespaceBeforeCheck
         if (sibling != null
                 && (sibling.getType() == TokenTypes.FOR_INIT
                         || sibling.getType() == TokenTypes.FOR_CONDITION)
-                && sibling.getChildCount() == 0) {
+                && !sibling.hasChildren()) {
             result = true;
         }
         return result;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheck.java
@@ -328,7 +328,7 @@ public class ParenPadCheck extends AbstractParenPadCheck {
         if (parent.findFirstToken(TokenTypes.FOR_EACH_CLAUSE) == null) {
             final DetailAST forIterator =
                 parent.findFirstToken(TokenTypes.FOR_ITERATOR);
-            result = forIterator.getChildCount() == 0;
+            result = !forIterator.hasChildren();
         }
         return result;
     }
@@ -345,7 +345,7 @@ public class ParenPadCheck extends AbstractParenPadCheck {
         if (parent.findFirstToken(TokenTypes.FOR_EACH_CLAUSE) == null) {
             final DetailAST forIterator =
                     parent.findFirstToken(TokenTypes.FOR_INIT);
-            result = forIterator.getChildCount() == 0;
+            result = !forIterator.hasChildren();
         }
         return result;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelectorPresentation.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelectorPresentation.java
@@ -96,12 +96,11 @@ public class CodeSelectorPresentation {
     private void findSelectionPositions(DetailAST ast) {
         selectionStart = lines2position.get(ast.getLineNo()) + ast.getColumnNo();
 
-        if (ast.getChildCount() == 0
-                && TokenUtil.getTokenName(ast.getType()).equals(ast.getText())) {
-            selectionEnd = selectionStart;
+        if (ast.hasChildren() || !TokenUtil.getTokenName(ast.getType()).equals(ast.getText())) {
+            selectionEnd = findLastPosition(ast);
         }
         else {
-            selectionEnd = findLastPosition(ast);
+            selectionEnd = selectionStart;
         }
     }
 
@@ -123,12 +122,12 @@ public class CodeSelectorPresentation {
      */
     private int findLastPosition(final DetailAST astNode) {
         final int lastPosition;
-        if (astNode.getChildCount() == 0) {
-            lastPosition = lines2position.get(astNode.getLineNo()) + astNode.getColumnNo()
-                    + astNode.getText().length();
+        if (astNode.hasChildren()) {
+            lastPosition = findLastPosition(astNode.getLastChild());
         }
         else {
-            lastPosition = findLastPosition(astNode.getLastChild());
+            lastPosition = lines2position.get(astNode.getLineNo()) + astNode.getColumnNo()
+                    + astNode.getText().length();
         }
         return lastPosition;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPosition.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPosition.java
@@ -169,15 +169,21 @@ public final class BlockCommentPosition {
      * @return true if node is before enum constant
      */
     public static boolean isOnEnumConstant(DetailAST blockComment) {
-        final boolean isOnPlainConst = blockComment.getParent() != null
-                && blockComment.getParent().getType() == TokenTypes.ENUM_CONSTANT_DEF
-                && getPrevSiblingSkipComments(blockComment).getType() == TokenTypes.ANNOTATIONS
-                && getPrevSiblingSkipComments(blockComment).getChildCount() == 0;
-        final boolean isOnConstWithAnnotation = !isOnPlainConst && blockComment.getParent() != null
-                && blockComment.getParent().getType() == TokenTypes.ANNOTATION
-                && blockComment.getParent().getParent().getParent().getType()
-                    == TokenTypes.ENUM_CONSTANT_DEF;
-        return isOnPlainConst || isOnConstWithAnnotation;
+        final DetailAST parent = blockComment.getParent();
+        boolean result = false;
+        if (parent != null) {
+            if (parent.getType() == TokenTypes.ENUM_CONSTANT_DEF) {
+                final DetailAST prevSibling = getPrevSiblingSkipComments(blockComment);
+                if (prevSibling.getType() == TokenTypes.ANNOTATIONS && !prevSibling.hasChildren()) {
+                    result = true;
+                }
+            }
+            else if (parent.getType() == TokenTypes.ANNOTATION
+                    && parent.getParent().getParent().getType() == TokenTypes.ENUM_CONSTANT_DEF) {
+                result = true;
+            }
+        }
+        return result;
     }
 
     /**
@@ -202,7 +208,7 @@ public final class BlockCommentPosition {
             int parentTokenType, int nextTokenType) {
         return blockComment.getParent() != null
                 && blockComment.getParent().getType() == parentTokenType
-                && getPrevSiblingSkipComments(blockComment).getChildCount() == 0
+                && !getPrevSiblingSkipComments(blockComment).hasChildren()
                 && getNextSiblingSkipComments(blockComment).getType() == nextTokenType;
     }
 
@@ -251,7 +257,7 @@ public final class BlockCommentPosition {
                     || parent.getType() == TokenTypes.TYPE_PARAMETERS)
                 && parent.getParent().getType() == memberType
                 // previous parent sibling is always TokenTypes.MODIFIERS
-                && parent.getPreviousSibling().getChildCount() == 0
+                && !parent.getPreviousSibling().hasChildren()
                 && parent.getParent().getParent().getType() == TokenTypes.OBJBLOCK;
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
@@ -136,12 +136,10 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testHasChildren() throws Exception {
+    public void testHasChildren() {
         final DetailAstImpl root = new DetailAstImpl();
         final DetailAstImpl child = new DetailAstImpl();
-
         root.setFirstChild(child);
-        getSetParentMethod().invoke(child, root);
 
         assertWithMessage("Root node should have children")
                 .that(root.hasChildren())

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle;
 
+import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -132,6 +133,22 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
         assertNull(firstLevelA.getPreviousSibling(), "Previous sibling should be null");
         assertNull(secondLevelA.getPreviousSibling(), "Previous sibling should be null");
         assertEquals(firstLevelA, firstLevelB.getPreviousSibling(), "Invalid previous sibling");
+    }
+
+    @Test
+    public void testHasChildren() throws Exception {
+        final DetailAstImpl root = new DetailAstImpl();
+        final DetailAstImpl child = new DetailAstImpl();
+
+        root.setFirstChild(child);
+        getSetParentMethod().invoke(child, root);
+
+        assertWithMessage("Root node should have children")
+                .that(root.hasChildren())
+                .isTrue();
+        assertWithMessage("Child node should have no children")
+                .that(child.hasChildren())
+                .isFalse();
     }
 
     @Test


### PR DESCRIPTION
Issue #7487 

First commit to add the method.
Second commit to switch `ast.getChildCount() > 0` to `ast.hasChildren()` and `ast.getChildCount() == 0` to `!ast.hasChildren()`

Some `if`'s are inverted for readablity. The method `isOnEnumConstant` is rewritten to eliminate multiple calls to `getPrevSiblingSkipComments`


### Regression

[InvalidJavadocPosition, DesignForExtension, JavadocContentLocation, MissingJavadocPackage](https://pbludov.github.io/issue-7487-has-children-6/)

[AtclauseOrder, JavadocBlockTagLocation, JavadocParagraph, JavadocTagContinuationIndentation, MissingDeprecated, NonEmptyAtclauseDescription, SingleLineJavadoc, SummaryJavadoc](https://pbludov.github.io/issue-7487-has-children-5/)

[SummaryJavadoc only](https://pbludov.github.io/issue-7487-has-children-4/)