### PR TITLE
Issue #7472: disable instatiation of modules with private ctor

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle;
 
 import java.io.IOException;
-import java.lang.reflect.Constructor;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -354,9 +353,7 @@ public class PackageObjectFactory implements ModuleFactory {
 
         if (clazz != null) {
             try {
-                final Constructor<?> declaredConstructor = clazz.getDeclaredConstructor();
-                declaredConstructor.setAccessible(true);
-                instance = declaredConstructor.newInstance();
+                instance = clazz.getDeclaredConstructor().newInstance();
             }
             catch (final ReflectiveOperationException ex) {
                 throw new CheckstyleException("Unable to instantiate " + className, ex);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -1435,7 +1435,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.destroy();
     }
 
-    private static class DummyFilter implements Filter {
+    public static class DummyFilter implements Filter {
 
         @Override
         public boolean accept(AuditEvent event) {
@@ -1444,7 +1444,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
     }
 
-    private static class DummyFileSetViolationCheck extends AbstractFileSetCheck
+    public static class DummyFileSetViolationCheck extends AbstractFileSetCheck
         implements ExternalResourceHolder {
 
         @Override
@@ -1461,7 +1461,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
     }
 
-    private static class DummyFilterSet extends FilterSet implements ExternalResourceHolder {
+    public static class DummyFilterSet extends FilterSet implements ExternalResourceHolder {
 
         @Override
         public Set<String> getExternalResourceLocations() {
@@ -1472,7 +1472,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
     }
 
-    private static class DynamicalResourceHolderCheck extends AbstractFileSetCheck
+    public static final class DynamicalResourceHolderCheck extends AbstractFileSetCheck
         implements ExternalResourceHolder {
 
         private String firstExternalResourceLocation;
@@ -1504,7 +1504,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
     }
 
-    private static class CheckWhichDoesNotRequireCommentNodes extends AbstractCheck {
+    public static class CheckWhichDoesNotRequireCommentNodes extends AbstractCheck {
 
         /** Number of children of method definition token. */
         private static final int METHOD_DEF_CHILD_COUNT = 7;
@@ -1558,7 +1558,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
     }
 
-    private static class CheckWhichRequiresCommentNodes extends AbstractCheck {
+    public static class CheckWhichRequiresCommentNodes extends AbstractCheck {
 
         /** Number of children of method definition token. */
         private static final int METHOD_DEF_CHILD_COUNT = 7;
@@ -1615,7 +1615,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
     }
 
-    private static class CheckWhichThrowsError extends AbstractCheck {
+    public static class CheckWhichThrowsError extends AbstractCheck {
 
         @Override
         public int[] getDefaultTokens() {
@@ -1639,7 +1639,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
     }
 
-    private static class DummyFileSet extends AbstractFileSetCheck {
+    public static final class DummyFileSet extends AbstractFileSetCheck {
 
         private final List<String> methodCalls = new ArrayList<>();
 
@@ -1688,7 +1688,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
     }
 
-    private static class VerifyPositionAfterTabFileSet extends AbstractFileSetCheck {
+    public static class VerifyPositionAfterTabFileSet extends AbstractFileSetCheck {
 
         @Override
         protected void processFiltered(File file, FileText fileText) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
@@ -366,7 +366,7 @@ public class PackageObjectFactoryTest {
             assertEquals("Unable to instantiate com.puppycrawl.tools.checkstyle."
                     + "PackageObjectFactoryTest$FailConstructorFileSet", ex.getMessage(),
                     "Invalid exception message");
-            assertEquals("IllegalArgumentException", ex.getCause().getCause().getClass()
+            assertEquals("IllegalAccessException", ex.getCause().getClass()
                     .getSimpleName(), "Invalid exception cause class");
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -509,7 +509,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         verify(checkerConfig, filePath, expected);
     }
 
-    private static class BadJavaDocCheck extends AbstractCheck {
+    public static class BadJavaDocCheck extends AbstractCheck {
 
         @Override
         public int[] getDefaultTokens() {
@@ -528,7 +528,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
 
     }
 
-    private static class VerifyInitCheck extends AbstractCheck {
+    public static class VerifyInitCheck extends AbstractCheck {
 
         private static boolean initWasCalled;
 
@@ -559,7 +559,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
 
     }
 
-    private static class VerifyDestroyCheck extends AbstractCheck {
+    public static class VerifyDestroyCheck extends AbstractCheck {
 
         private static boolean destroyWasCalled;
 
@@ -594,7 +594,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
 
     }
 
-    private static class VerifyDestroyCommentCheck extends VerifyDestroyCheck {
+    public static class VerifyDestroyCommentCheck extends VerifyDestroyCheck {
 
         @Override
         public boolean isCommentNodesRequired() {
@@ -603,7 +603,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
 
     }
 
-    private static class RequiredTokenIsEmptyIntArray extends AbstractCheck {
+    public static class RequiredTokenIsEmptyIntArray extends AbstractCheck {
 
         @Override
         public int[] getRequiredTokens() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
@@ -321,7 +321,7 @@ public class AbstractCheckTest extends AbstractModuleTestSupport {
         verify(checkConfig, getPath("InputAbstractCheckTestFileContents.java"), expected);
     }
 
-    private static final class DummyAbstractCheck extends AbstractCheck {
+    public static final class DummyAbstractCheck extends AbstractCheck {
 
         private static final int[] DUMMY_ARRAY = {6};
 
@@ -349,7 +349,7 @@ public class AbstractCheckTest extends AbstractModuleTestSupport {
 
     }
 
-    private static final class VisitCounterCheck extends AbstractCheck {
+    public static final class VisitCounterCheck extends AbstractCheck {
 
         private int count;
 
@@ -375,7 +375,7 @@ public class AbstractCheckTest extends AbstractModuleTestSupport {
         }
     }
 
-    private static class ViolationCheck extends AbstractCheck {
+    public static class ViolationCheck extends AbstractCheck {
 
         private static final String MSG_KEY = "Violation.";
 
@@ -402,7 +402,7 @@ public class AbstractCheckTest extends AbstractModuleTestSupport {
 
     }
 
-    private static class ViolationAstCheck extends AbstractCheck {
+    public static class ViolationAstCheck extends AbstractCheck {
 
         private static final String MSG_KEY = "Violation.";
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
@@ -221,7 +221,7 @@ public class AbstractFileSetCheckTest extends AbstractModuleTestSupport {
                 "finishProcessing was called twice");
     }
 
-    private static class DummyFileSetCheck extends AbstractFileSetCheck {
+    public static class DummyFileSetCheck extends AbstractFileSetCheck {
 
         private static final String MSG_KEY = "File should not be empty.";
 
@@ -234,7 +234,7 @@ public class AbstractFileSetCheckTest extends AbstractModuleTestSupport {
 
     }
 
-    private static class ViolationFileSetCheck extends AbstractFileSetCheck {
+    public static class ViolationFileSetCheck extends AbstractFileSetCheck {
 
         private static final String MSG_KEY = "Violation.";
 
@@ -245,7 +245,7 @@ public class AbstractFileSetCheckTest extends AbstractModuleTestSupport {
 
     }
 
-    private static class MultiFileViolationFileSetCheck extends AbstractFileSetCheck {
+    public static class MultiFileViolationFileSetCheck extends AbstractFileSetCheck {
 
         private static final String MSG_KEY = "Violation.";
         private static int finishProcessingCount;
@@ -267,7 +267,7 @@ public class AbstractFileSetCheckTest extends AbstractModuleTestSupport {
 
     }
 
-    private static class ExceptionFileSetCheck extends AbstractFileSetCheck {
+    public static class ExceptionFileSetCheck extends AbstractFileSetCheck {
 
         private static final String MSG_KEY = "Test.";
         private int count = 1;
@@ -281,7 +281,7 @@ public class AbstractFileSetCheckTest extends AbstractModuleTestSupport {
 
     }
 
-    private static class ViolationDispatcher implements MessageDispatcher {
+    public static class ViolationDispatcher implements MessageDispatcher {
         private String name;
         private SortedSet<LocalizedMessage> errorList;
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporterTest.java
@@ -126,7 +126,7 @@ public class AbstractViolationReporterTest {
         }
     }
 
-    private static class EmptyCheck extends AbstractCheck {
+    public static class EmptyCheck extends AbstractCheck {
 
         @Override
         public int[] getDefaultTokens() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
@@ -247,7 +247,7 @@ public class AutomaticBeanTest {
 
     }
 
-    private static class TestBean extends AutomaticBean {
+    public static final class TestBean extends AutomaticBean {
 
         private String privateField;
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileSetCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileSetCheckTest.java
@@ -58,7 +58,7 @@ public class FileSetCheckTest
                 "FileContent should be available during finishProcessing() call");
     }
 
-    private static class TestFileSetCheck extends AbstractFileSetCheck {
+    public static class TestFileSetCheck extends AbstractFileSetCheck {
 
         private static boolean destroyed;
         private static boolean fileContentAvailable;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
@@ -466,7 +466,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
         verify(checkConfig, getPath("InputAbstractJavadocNonTightHtmlTags2.java"), expected);
     }
 
-    private static class TempCheck extends AbstractJavadocCheck {
+    public static class TempCheck extends AbstractJavadocCheck {
 
         @Override
         public int[] getDefaultJavadocTokens() {
@@ -480,7 +480,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
 
     }
 
-    private static class JavadocCatchCheck extends AbstractJavadocCheck {
+    public static class JavadocCatchCheck extends AbstractJavadocCheck {
 
         private static int javadocsNumber;
 
@@ -504,7 +504,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
 
     }
 
-    private static class RequiredTokenIsNotInDefaultsJavadocCheck extends AbstractJavadocCheck {
+    public static class RequiredTokenIsNotInDefaultsJavadocCheck extends AbstractJavadocCheck {
 
         @Override
         public int[] getRequiredJavadocTokens() {
@@ -528,7 +528,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
 
     }
 
-    private static class TokenIsNotInAcceptablesJavadocCheck extends AbstractJavadocCheck {
+    public static class TokenIsNotInAcceptablesJavadocCheck extends AbstractJavadocCheck {
 
         @Override
         public int[] getRequiredJavadocTokens() {
@@ -552,7 +552,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
 
     }
 
-    private static class JavadocVisitLeaveCheck extends AbstractJavadocCheck {
+    public static class JavadocVisitLeaveCheck extends AbstractJavadocCheck {
 
         private static int visitCount;
         private static int leaveCount;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammar/comments/AllBlockCommentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammar/comments/AllBlockCommentsTest.java
@@ -59,7 +59,7 @@ public class AllBlockCommentsTest extends AbstractModuleTestSupport {
         assertTrue(ALL_COMMENTS.isEmpty(), "All comments should be empty");
     }
 
-    private static class BlockCommentListenerCheck extends AbstractCheck {
+    public static class BlockCommentListenerCheck extends AbstractCheck {
 
         @Override
         public boolean isCommentNodesRequired() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammar/comments/AllSinglelineCommentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammar/comments/AllSinglelineCommentsTest.java
@@ -58,7 +58,7 @@ public class AllSinglelineCommentsTest extends AbstractModuleTestSupport {
         assertTrue(ALL_COMMENTS.isEmpty(), "All comments should be empty");
     }
 
-    private static class SinglelineCommentListenerCheck extends AbstractCheck {
+    public static class SinglelineCommentListenerCheck extends AbstractCheck {
 
         @Override
         public boolean isCommentNodesRequired() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -396,7 +396,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
         return result.toString();
     }
 
-    private static class JavaDocCapture extends AbstractCheck {
+    public static class JavaDocCapture extends AbstractCheck {
         private static final Pattern SETTER_PATTERN = Pattern.compile("^set[A-Z].*");
 
         @Override


### PR DESCRIPTION
Issue #7472


final modifier was added to satisfy Check
```
     [echo] Checkstyle started (checkstyle_checks.xml): 17/01/2020 11:59:45 AM
[checkstyle] Running Checkstyle  on 1105 files
[checkstyle] [ERROR] src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java:1481:9: Class 'DynamicalResourceHolderCheck' looks like designed for extension (can be subclassed), but the method 'setFirstExternalResourceLocation' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'DynamicalResourceHolderCheck' final or making the method 'setFirstExternalResourceLocation' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[checkstyle] [ERROR] src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java:1485:9: Class 'DynamicalResourceHolderCheck' looks like designed for extension (can be subclassed), but the method 'setSecondExternalResourceLocation' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'DynamicalResourceHolderCheck' final or making the method 'setSecondExternalResourceLocation' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[checkstyle] [ERROR] src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java:1677:9: Class 'DummyFileSet' looks like designed for extension (can be subclassed), but the method 'getMethodCalls' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'DummyFileSet' final or making the method 'getMethodCalls' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[checkstyle] [ERROR] src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java:1681:9: Class 'DummyFileSet' looks like designed for extension (can be subclassed), but the method 'isInitCalled' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'DummyFileSet' final or making the method 'isInitCalled' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[checkstyle] [ERROR] src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java:1685:9: Class 'DummyFileSet' looks like designed for extension (can be subclassed), but the method 'getInternalMessageDispatcher' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'DummyFileSet' final or making the method 'getInternalMessageDispatcher' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[checkstyle] [ERROR] src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java:258:9: Class 'TestBean' looks like designed for extension (can be subclassed), but the method 'setWrong' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'TestBean' final or making the method 'setWrong' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[checkstyle] [ERROR] src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java:262:9: Class 'TestBean' looks like designed for extension (can be subclassed), but the method 'setVal' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'TestBean' final or making the method 'setVal' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[checkstyle] [ERROR] src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java:266:9: Class 'TestBean' looks like designed for extension (can be subclassed), but the method 'assignPrivateFieldSecretly' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'TestBean' final or making the method 'assignPrivateFieldSecretly' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[checkstyle] [ERROR] src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java:270:9: Class 'TestBean' looks like designed for extension (can be subclassed), but the method 'setExceptionalMethod' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'TestBean' final or making the method 'setExceptionalMethod' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]

```