### PR TITLE
minor: add missing test case to SuperCloneCheckTest

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperCloneCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperCloneCheckTest.java
@@ -62,6 +62,7 @@ public class SuperCloneCheckTest
         final DefaultConfiguration checkConfig =
             createModuleConfig(SuperCloneCheck.class);
         final String[] expected = {
+            "43:17: " + getCheckMessage(MSG_KEY, "clone", "super.clone"),
             "9:17: " + getCheckMessage(MSG_KEY, "clone", "super.clone"),
         };
         verify(checkConfig, getPath("InputSuperClonePlainAndSubclasses.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/superclone/InputSuperClonePlainAndSubclasses.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/superclone/InputSuperClonePlainAndSubclasses.java
@@ -6,7 +6,7 @@ interface InputSuperClonePlainAndSubclasses {
 }
 
 class A {
-  public Object clone() {
+  public Object clone() { // violation
       return null;
   }
 }
@@ -36,4 +36,13 @@ class C extends B {
       }
     };
   }
+}
+
+class D extends B {
+
+  public Object clone() throws CloneNotSupportedException { // violation
+    super.clone(null, null);
+    return null;
+  }
+
 }


### PR DESCRIPTION
Discovered [here](https://github.com/checkstyle/checkstyle/pull/7489#discussion_r368164607)

JFYI: the Pitest can not appy `BooleanFalseReturnValsMutator` to code like `return a > b`.
After extracting a local variable,
```java
final boolean result = a > b;
return result;
``` 
the mutator `BooleanFalseReturnValsMutator` is able to add the mutation and the missing coverage is detected.

This PR adds the missing case.