### PR TITLE
Issue #7509: resolve some pmd warnings

### DIFF
--- a/config/pmd-main.xml
+++ b/config/pmd-main.xml
@@ -11,7 +11,6 @@
     <exclude-pattern>.*/src/test/.*</exclude-pattern>
     <rule ref="config/pmd.xml"/>
 
-    <rule ref="category/java/design.xml/CollapsibleIfStatements"/>
     <rule ref="category/java/design.xml/ImmutableField">
         <properties>
             <!-- Fields with these annotations will have their value injected by picocli.

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -88,21 +88,17 @@
      <property name="enumPattern" value="[A-Z][a-zA-Z0-9]*" />
      <property name="annotationPattern" value="[A-Z][a-zA-Z0-9]*" />
      <property name="utilityClassPattern" value="[A-Z][a-zA-Z0-9]*Util" />
-     <!-- We can not brake compatibility with previous versions. -->
-     <property name="violationSuppressXPath"
-               value="//ClassOrInterfaceDeclaration
-                          [@Image='AbstractClassNameCheck' or @Image='AutomaticBean']"/>
-    </properties>
-  </rule>
-  <rule ref="category/java/codestyle.xml/ClassNamingConventions">
-    <properties>
      <!-- Definitions and XmlLoader.LoadExternalDtdFeatureProvider aren't utility classes.
-          JavadocTokenTypes and TokenTypes aren't utility classes.
-            They are token definition classes. Also, they are part of the API. -->
+          AutomaticBean is part of API, we can not change a name.
+          JavadocTokenTypes and TokenTypes aren't utility classes. They are
+            token definition classes. Also, they are part of the API. -->
      <property name="violationSuppressXPath"
                value="//ClassOrInterfaceDeclaration[@Image='Definitions'
-                   or @Image='JavadocTokenTypes' or @Image='TokenTypes'
-                   or @Image='LoadExternalDtdFeatureProvider']"/>
+                           or @Image='LoadExternalDtdFeatureProvider'
+                           or @Image='JavadocTokenTypes'
+                           or @Image='TokenTypes'
+                           or @Image='AutomaticBean']
+                   "/>
     </properties>
   </rule>
   <rule ref="category/java/codestyle.xml/ConfusingTernary">


### PR DESCRIPTION
partially address #7509

still not resolved:
```
[WARNING] The rule CollapsibleIfStatements is referenced multiple times 
in "PMD ruleset for Checkstyle". Only the last rule configuration is used.
[WARNING] The rule CollapsibleIfStatements is referenced multiple times 
in "PMD ruleset for Checkstyle". Only the last rule configuration is used.
[WARNING] Use of deprecated attribute 'ClassOrInterfaceDeclaration/@Image'
 in XPath query
```

but `CollapsibleIfStatements` is used only ones:
```
✔ ~/java/github/romani/checkstyle [7509-pmd L|✔] 
$ ag "CollapsibleIfStatements"
config/pmd-main.xml
14:    <rule ref="category/java/design.xml/CollapsibleIfStatements"/>
```