### PR TITLE
Issue #7512: mark DetailAST::getNumberOfChildren deprecated

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -115,7 +115,10 @@ public interface DetailAST {
     /**
      * Get number of children of this AST.
      * @return the number of children.
+     * @deprecated This method will be removed in a future release.
+     *             Use {@link #getChildCount()} instead.
      */
+    @Deprecated
     int getNumberOfChildren();
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheck.java
@@ -135,10 +135,19 @@ public class AvoidNestedBlocksCheck extends AbstractCheck {
     public void visitToken(DetailAST ast) {
         final DetailAST parent = ast.getParent();
         if (parent.getType() == TokenTypes.SLIST
-                && (!allowInSwitchCase
-                    || parent.getNumberOfChildren() != 1)) {
+                && (!allowInSwitchCase || hasSiblings(ast))) {
             log(ast, MSG_KEY_BLOCK_NESTED);
         }
+    }
+
+    /**
+     * Checks whether the AST node has any siblings or not.
+     *
+     * @param ast node to examine
+     * @return {@code true} if the node has one or more siblings
+     */
+    private static boolean hasSiblings(DetailAST ast) {
+        return ast.getPreviousSibling() != null || ast.getNextSibling() != null;
     }
 
     /**


### PR DESCRIPTION
Issue #7512 

The method was used only in one check.

Regression (no difference):
https://pbludov.github.io/issue-7512-get-number-of-children/