### PR TITLE
minor: add Check with id noDefaultCommentWithOtherVisibility

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -137,6 +137,13 @@
     <property name="message"
               value="Old site links should not be used, please use https://checkstyle.org"/>
   </module>
+  <module name="RegexpSingleline">
+    <property name="id" value="noPackageCommentWithOtherVisibility"/>
+    <property name="format" value="/\*\s+package\s+\*/\s+(private|protected|public)"/>
+    <property name="fileExtensions" value="java"/>
+    <property name="message"
+              value="Package comment marker should not be used if other visibility is defined"/>
+  </module>
   <module name="RegexpOnFilename" />
   <module name="RegexpOnFilename">
       <property name="folderPattern" value="[\\/]src[\\/]\w+[\\/]java[\\/]"/>

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -147,6 +147,14 @@
                 value="//ClassOrInterfaceDeclaration[@Image='Main' or @Image='Tag']"/>
     </properties>
   </rule>
+  <rule ref="category/java/codestyle.xml/CommentDefaultAccessModifier">
+      <properties>
+          <property name="ignoredAnnotations" value="" />
+          <property name="regex" value="\/\*\s+(package)\s+\*\/" />
+          <property name="checkTopLevelTypes" value="false" />
+      </properties>
+  </rule>
+
   <rule ref="category/java/errorprone.xml">
     <!-- That rule is not practical, no options to allow some magic numbers,
          we will use our implementation. -->

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -1189,7 +1189,7 @@ public class JavadocMethodCheck extends AbstractCheck {
          * @param lineNo token's line number
          * @param columnNo token's column number
          */
-        /* default */ Token(String text, int lineNo, int columnNo) {
+        /* package */ Token(String text, int lineNo, int columnNo) {
             this.text = text;
             this.lineNo = lineNo;
             this.columnNo = columnNo;
@@ -1199,7 +1199,7 @@ public class JavadocMethodCheck extends AbstractCheck {
          * Converts FullIdent to Token.
          * @param fullIdent full ident to convert.
          */
-        /* default */ Token(FullIdent fullIdent) {
+        /* package */ Token(FullIdent fullIdent) {
             text = fullIdent.getText();
             lineNo = fullIdent.getLineNo();
             columnNo = fullIdent.getColumnNo();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/ElementNode.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/ElementNode.java
@@ -365,7 +365,7 @@ public class ElementNode extends AbstractNode {
          * Create an iterator over the "following" axis.
          * @param start the initial context node.
          */
-        /* default */ FollowingEnumeration(NodeInfo start) {
+        /* package */ FollowingEnumeration(NodeInfo start) {
             siblingEnum = start.iterateAxis(AxisInfo.FOLLOWING_SIBLING);
         }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
@@ -238,7 +238,7 @@ public class NewlineAtEndOfFileCheckTest
 
     private static class ReadZeroRandomAccessFile extends RandomAccessFile {
 
-        /* default */ ReadZeroRandomAccessFile(String name, String mode)
+        /* package */ ReadZeroRandomAccessFile(String name, String mode)
                 throws FileNotFoundException {
             super(name, mode);
         }


### PR DESCRIPTION
from https://github.com/checkstyle/checkstyle/pull/7485#discussion_r373470333

tested:
```
✔ ~/java/github/romani/checkstyle [minor-extra-regexp-check L|✚ 1] 
$ git diff
diff --git a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/ElementNode.java 
b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/ElementNode.java
index 6eefd8e..15a5622 100644
--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/ElementNode.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/ElementNode.java
@@ -374,7 +374,7 @@ public class ElementNode extends AbstractNode {
          * Create an iterator over the "following" axis.
          * @param start the initial context node.
          */
-        /* default */ FollowingEnumeration(NodeInfo start) {
+        /* default */ public FollowingEnumeration(NodeInfo start) {
             siblingEnum = start.iterateAxis(AxisInfo.FOLLOWING_SIBLING);
         }

$ mvn compile antrun:run@ant-phase-verify
....
execute:
 [echo] Checkstyle started (checkstyle_checks.xml): 01/02/2020 07:36:47 PM
[checkstyle] Running Checkstyle  on 1105 files
[checkstyle] [ERROR] /home/rivanov/java/github/romani/checkstyle/
src/main/java/com/puppycrawl/tools/checkstyle/xpath/ElementNode.java:377: 
Default comment marker should not be used if other visibility is defined
 [noDefaultCommentWithOtherVisibility]
[checkstyle] [ERROR] /home/rivanov/java/github/romani/checkstyle/
src/main/java/com/puppycrawl/tools/checkstyle/xpath/ElementNode.java:377:23: 
Redundant 'public' modifier. 
[RedundantModifier]
```