### PR TITLE
doc: deprecated -> Deprecated

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
@@ -83,11 +83,11 @@ import com.puppycrawl.tools.checkstyle.utils.AnnotationUtil;
  * Examples of validating source code:
  * </p>
  * <pre>
- * &#64;deprecated
+ * &#64;Deprecated
  * public static final int MY_CONST = 123456; // no violation
  *
  * &#47;** This javadoc is missing deprecated tag. *&#47;
- * &#64;deprecated
+ * &#64;Deprecated
  * public static final int COUNTER = 10; // violation
  * </pre>
  *

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -618,11 +618,11 @@ public int foo() { ... }
         </source>
         <p>Examples of validating source code:</p>
         <source>
-@deprecated
+@Deprecated
 public static final int MY_CONST = 123456; // no violation
 
 /** This javadoc is missing deprecated tag. */
-@deprecated
+@Deprecated
 public static final int COUNTER = 10; // violation
         </source>
       </subsection>


### PR DESCRIPTION
lowercase is used for javadoc tag, but in example there is an annotation, it should be uppercase
