### PR TITLE
doc: add example of non-instance member for MemberNameCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MemberNameCheck.java
@@ -60,15 +60,18 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * class MyClass {
  *   public int num1; // OK
  *   protected int num2; // OK
- *   int num3; // OK
+ *   final int num3 = 3; // OK
  *   private int num4; // OK
+ *
+ *   static int num5; // ignored: not an instance variable
+ *   public static final int CONSTANT = 1; // ignored: not an instance variable
  *
  *   public int NUM1; // violation, name 'NUM1'
  *                    // must match pattern '^[a-z][a-zA-Z0-9]*$'
  *   protected int NUM2; // violation, name 'NUM2'
  *                       // must match pattern '^[a-z][a-zA-Z0-9]*$'
- *   int NUM3; // violation, name 'NUM3'
- *             // must match pattern '^[a-z][a-zA-Z0-9]*$'
+ *   final int NUM3; // violation, name 'NUM3'
+ *                   // must match pattern '^[a-z][a-zA-Z0-9]*$'
  *   private int NUM4; // violation, name 'NUM4'
  *                     // must match pattern '^[a-z][a-zA-Z0-9]*$'
  * }

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -1392,15 +1392,18 @@ class MyClass {
 class MyClass {
   public int num1; // OK
   protected int num2; // OK
-  int num3; // OK
+  final int num3 = 3; // OK
   private int num4; // OK
+
+  static int num5; // ignored: not an instance variable
+  public static final int CONSTANT = 1; // ignored: not an instance variable
 
   public int NUM1; // violation, name 'NUM1'
                    // must match pattern '^[a-z][a-zA-Z0-9]*$'
   protected int NUM2; // violation, name 'NUM2'
                       // must match pattern '^[a-z][a-zA-Z0-9]*$'
-  int NUM3; // violation, name 'NUM3'
-            // must match pattern '^[a-z][a-zA-Z0-9]*$'
+  final int NUM3; // violation, name 'NUM3'
+                  // must match pattern '^[a-z][a-zA-Z0-9]*$'
   private int NUM4; // violation, name 'NUM4'
                     // must match pattern '^[a-z][a-zA-Z0-9]*$'
 }


### PR DESCRIPTION
It is a bit unclear that [MemberName](https://checkstyle.org/config_naming.html#MemberName) is for **instance** members only.

This PR adds an example on non-instance member to make obvious.