### PR TITLE
infra: update wercker maven to 3.6.2 to pass build of hibernate-search

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: maven:3.5.2-jdk-8
+box: maven:3.6.2-jdk-8
 
 build:
   steps:


### PR DESCRIPTION
problem at https://app.wercker.com/checkstyle/checkstyle/runs/build/5e5129ae7b63df001ae10266?step=5e5129f61ccc98000832416b

`[INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (enforce-common-rules) @ hibernate-search-parent --- [WARNING] Rule 1: org.apache.maven.plugins.enforcer.RequireMavenVersion failed with message: Detected Maven Version: 3.5.2 is not in the allowed range 3.6.2.`

detected at https://github.com/checkstyle/checkstyle/pull/7577#issuecomment-589996135