### PR TITLE
Issue #7574 : Update doc for PackageAnnotation

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationCheck.java
@@ -48,6 +48,20 @@ import com.puppycrawl.tools.checkstyle.utils.AnnotationUtil;
  * <pre>
  * &lt;module name=&quot;PackageAnnotation&quot;/&gt;
  * </pre>
+ * <p>Example of validating MyClass.java:</p>
+ * <pre>
+ * &#64;Deprecated
+ * package com.example.annotations.packageannotation; //violation
+ * </pre>
+ * <p>Example of fixing violation in MyClass.java:</p>
+ * <pre>
+ * package com.example.annotations.packageannotation; //ok
+ * </pre>
+ * <p>Example of validating package-info.java:</p>
+ * <pre>
+ * &#64;Deprecated
+ * package com.example.annotations.packageannotation; //ok
+ * </pre>
  *
  * @since 5.0
  */

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -810,7 +810,20 @@ public static final int COUNTER = 10; // violation
 
       <subsection name="Examples" id="PackageAnnotation_Examples">
         <p> To configure the check:</p>
-        <source> &lt;module name=&quot;PackageAnnotation&quot;/&gt;
+        <source> &lt;module name=&quot;PackageAnnotation&quot;/&gt; </source>
+        <p>Example of validating MyClass.java:</p>
+        <source>
+@Deprecated
+package com.example.annotations.packageannotation; //violation
+        </source>
+        <p>Example of fixing violation in MyClass.java:</p>
+        <source>
+package com.example.annotations.packageannotation; //ok
+        </source>
+        <p>Example of validating package-info.java:</p>
+        <source>
+@Deprecated
+package com.example.annotations.packageannotation; //ok
         </source>
       </subsection>
 


### PR DESCRIPTION
Issue : https://github.com/checkstyle/checkstyle/issues/7574
![Screenshot from 2020-03-10 09-20-03](https://user-images.githubusercontent.com/50927824/76278017-7da5b780-62b0-11ea-9fc6-b15e0142c809.png)

Configuration
```
$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <property name="charset" value="UTF-8"/>
    <module name="TreeWalker">
	<module name="PackageAnnotation" />
   </module>
</module>
```

Output with violation in MyClass.java
```
$ cat MyClass.java
@Deprecated
package com.example.annotations.packageannotation;

$ java -jar checkstyle-8.29-all.jar -c config.xml MyClass.java
Starting audit...
[ERROR] /home/dunu008/GSOC/CHECKSTYLE-PROJECT/tests/MyClass.java:2: Package annotations must be in the package-info.java info. [PackageAnnotation]
Audit done.
Checkstyle ends with 1 errors.
```
Fixing violation in MyClass.java
```
$ cat MyClass.java
package com.example.annotations.packageannotation;

$ java -jar checkstyle-8.29-all.jar -c config.xml MyClass.java
Starting audit...
Audit done.
```
Ouput in package-info.java
```
$ cat package-info.java
@Deprecated
package com.example.annotations.packageannotation;

$ java -jar checkstyle-8.29-all.jar -c config.xml package-info.java
Starting audit...
Audit done.
```