### PR TITLE
Issue #7569: Update doc for AnnotationLocation to have config first and code sample after

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
@@ -95,13 +95,28 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </li>
  * </ul>
  * <p>
- * Example to allow multiple annotations on the same line
+ * Default configuration, to allow one single parameterless annotation on the same line:
  * </p>
  * <pre>
- * &#64;SuppressWarnings("deprecation") &#64;Mock DataLoader loader; // no violations
+ * &lt;module name=&quot;AnnotationLocation&quot;/&gt;
  * </pre>
  * <p>
- * Use the following configuration:
+ * Example for above configuration:
+ * </p>
+ * <pre>
+ * &#64;NotNull private boolean field1; //ok
+ * &#64;Override public int hashCode() { return 1; } //ok
+ * &#64;NotNull //ok
+ * private boolean field2;
+ * &#64;Override //ok
+ * public boolean equals(Object obj) { return true; }
+ * &#64;Mock DataLoader loader; //ok
+ * &#64;SuppressWarnings("deprecation") DataLoader loader; //violation
+ * &#64;SuppressWarnings("deprecation") public int foo() { return 1; } //violation
+ * &#64;NotNull &#64;Mock DataLoader loader; //violation
+ * </pre>
+ * <p>
+ * Use the following configuration to allow multiple annotations on the same line:
  * </p>
  * <pre>
  * &lt;module name=&quot;AnnotationLocation&quot;&gt;
@@ -112,32 +127,23 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * &lt;/module&gt;
  * </pre>
  * <p>
- * Example to allow one single parameterless annotation on the same line
+ * Example to allow any location multiple annotations:
  * </p>
  * <pre>
- * &#64;Override public int hashCode() { ... } // no violations
- * &#64;SuppressWarnings("deprecation") public int foo() { ... } // violation
+ * &#64;NotNull private boolean field1; //ok
+ * &#64;Override public int hashCode() { return 1; } //ok
+ * &#64;NotNull //ok
+ * private boolean field2;
+ * &#64;Override //ok
+ * public boolean equals(Object obj) { return true; }
+ * &#64;Mock DataLoader loader; //ok
+ * &#64;SuppressWarnings("deprecation") DataLoader loader; //ok
+ * &#64;SuppressWarnings("deprecation") public int foo() { return 1; } //ok
+ * &#64;NotNull &#64;Mock DataLoader loader; //ok
  * </pre>
  * <p>
- * Use the following configuration:
- * </p>
- * <pre>
- * &lt;module name=&quot;AnnotationLocation&quot;&gt;
- *   &lt;property name=&quot;allowSamelineMultipleAnnotations&quot; value=&quot;false&quot;/&gt;
- *   &lt;property name=&quot;allowSamelineSingleParameterlessAnnotation&quot;
- *     value=&quot;true&quot;/&gt;
- *   &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;false&quot;/&gt;
- * &lt;/module&gt;
- * </pre>
- * <p>
- * Example to allow only one and only parameterized annotation on the same line
- * </p>
- * <pre>
- * &#64;SuppressWarnings("deprecation") DataLoader loader; // no violations
- * &#64;Mock DataLoader loader; // violation
- * </pre>
- * <p>
- * Use the following configuration:
+ * Use the following configuration to allow only one and only parameterized annotation
+ * on the same line:
  * </p>
  * <pre>
  * &lt;module name=&quot;AnnotationLocation&quot;&gt;
@@ -146,6 +152,49 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *     value=&quot;false&quot;/&gt;
  *   &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example to allow only one and only parameterized annotation on the same line:
+ * </p>
+ * <pre>
+ * &#64;NotNull private boolean field1; //violation
+ * &#64;Override public int hashCode() { return 1; } //violation
+ * &#64;NotNull //ok
+ * private boolean field2;
+ * &#64;Override //ok
+ * public boolean equals(Object obj) { return true; }
+ * &#64;Mock DataLoader loader; //violation
+ * &#64;SuppressWarnings("deprecation") DataLoader loader; //ok
+ * &#64;SuppressWarnings("deprecation") public int foo() { return 1; } //ok
+ * &#64;NotNull &#64;Mock DataLoader loader; //violation
+ * </pre>
+ * <p>
+ * Use the following configuration to only validate annotations on methods to allow one
+ * single parameterless annotation on the same line:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;AnnotationLocation&quot;&gt;
+ *   &lt;property name=&quot;tokens&quot; value=&quot;METHOD_DEF&quot;/&gt;
+ *   &lt;property name=&quot;allowSamelineMultipleAnnotations&quot; value=&quot;false&quot;/&gt;
+ *   &lt;property name=&quot;allowSamelineSingleParameterlessAnnotation&quot;
+ *     value=&quot;true&quot;/&gt;
+ *   &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;false&quot;/&gt;
+ *  &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example for above configuration to check only methods:
+ * </p>
+ * <pre>
+ * &#64;NotNull private boolean field1; //ok
+ * &#64;Override public int hashCode() { return 1; } //ok
+ * &#64;NotNull //ok
+ * private boolean field2;
+ * &#64;Override //ok
+ * public boolean equals(Object obj) { return true; }
+ * &#64;Mock DataLoader loader; //ok
+ * &#64;SuppressWarnings("deprecation") DataLoader loader; //ok
+ * &#64;SuppressWarnings("deprecation") public int foo() { return 1; } //violation
+ * &#64;NotNull &#64;Mock DataLoader loader; //ok
  * </pre>
  *
  * @since 6.0

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -142,13 +142,28 @@ public String getNameIfPresent() { ... }
 
       <subsection name="Examples" id="AnnotationLocation_Examples">
         <p>
-          Example to allow multiple annotations on the same line
+          Default configuration, to allow one single parameterless annotation on the same line:
         </p>
         <source>
-@SuppressWarnings("deprecation") @Mock DataLoader loader; // no violations
+&lt;module name=&quot;AnnotationLocation&quot;/&gt;
         </source>
         <p>
-          Use the following configuration:
+          Example for above configuration:
+        </p>
+        <source>
+@NotNull private boolean field1; //ok
+@Override public int hashCode() { return 1; } //ok
+@NotNull //ok
+private boolean field2;
+@Override //ok
+public boolean equals(Object obj) { return true; }
+@Mock DataLoader loader; //ok
+@SuppressWarnings("deprecation") DataLoader loader; //violation
+@SuppressWarnings("deprecation") public int foo() { return 1; } //violation
+@NotNull @Mock DataLoader loader; //violation
+        </source>
+        <p>
+          Use the following configuration to allow multiple annotations on the same line:
         </p>
         <source>
 &lt;module name=&quot;AnnotationLocation&quot;&gt;
@@ -159,32 +174,23 @@ public String getNameIfPresent() { ... }
 &lt;/module&gt;
         </source>
         <p>
-          Example to allow one single parameterless annotation on the same line
+          Example to allow any location multiple annotations:
         </p>
         <source>
-@Override public int hashCode() { ... } // no violations
-@SuppressWarnings("deprecation") public int foo() { ... } // violation
+@NotNull private boolean field1; //ok
+@Override public int hashCode() { return 1; } //ok
+@NotNull //ok
+private boolean field2;
+@Override //ok
+public boolean equals(Object obj) { return true; }
+@Mock DataLoader loader; //ok
+@SuppressWarnings("deprecation") DataLoader loader; //ok
+@SuppressWarnings("deprecation") public int foo() { return 1; } //ok
+@NotNull @Mock DataLoader loader; //ok
         </source>
         <p>
-          Use the following configuration:
-        </p>
-        <source>
-&lt;module name=&quot;AnnotationLocation&quot;&gt;
-  &lt;property name=&quot;allowSamelineMultipleAnnotations&quot; value=&quot;false&quot;/&gt;
-  &lt;property name=&quot;allowSamelineSingleParameterlessAnnotation&quot;
-    value=&quot;true&quot;/&gt;
-  &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;false&quot;/&gt;
-&lt;/module&gt;
-        </source>
-        <p>
-          Example to allow only one and only parameterized annotation on the same line
-        </p>
-        <source>
-@SuppressWarnings("deprecation") DataLoader loader; // no violations
-@Mock DataLoader loader; // violation
-        </source>
-        <p>
-          Use the following configuration:
+          Use the following configuration to allow only one and only parameterized annotation
+          on the same line:
         </p>
         <source>
 &lt;module name=&quot;AnnotationLocation&quot;&gt;
@@ -193,6 +199,49 @@ public String getNameIfPresent() { ... }
     value=&quot;false&quot;/&gt;
   &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
+        </source>
+        <p>
+          Example to allow only one and only parameterized annotation on the same line:
+        </p>
+        <source>
+@NotNull private boolean field1; //violation
+@Override public int hashCode() { return 1; } //violation
+@NotNull //ok
+private boolean field2;
+@Override //ok
+public boolean equals(Object obj) { return true; }
+@Mock DataLoader loader; //violation
+@SuppressWarnings("deprecation") DataLoader loader; //ok
+@SuppressWarnings("deprecation") public int foo() { return 1; } //ok
+@NotNull @Mock DataLoader loader; //violation
+        </source>
+        <p>
+          Use the following configuration to only validate annotations on methods to allow one
+          single parameterless annotation on the same line:
+        </p>
+        <source>
+&lt;module name=&quot;AnnotationLocation&quot;&gt;
+  &lt;property name=&quot;tokens&quot; value=&quot;METHOD_DEF&quot;/&gt;
+  &lt;property name=&quot;allowSamelineMultipleAnnotations&quot; value=&quot;false&quot;/&gt;
+  &lt;property name=&quot;allowSamelineSingleParameterlessAnnotation&quot;
+    value=&quot;true&quot;/&gt;
+  &lt;property name=&quot;allowSamelineParameterizedAnnotation&quot; value=&quot;false&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Example for above configuration to check only methods:
+        </p>
+        <source>
+@NotNull private boolean field1; //ok
+@Override public int hashCode() { return 1; } //ok
+@NotNull //ok
+private boolean field2;
+@Override //ok
+public boolean equals(Object obj) { return true; }
+@Mock DataLoader loader; //ok
+@SuppressWarnings("deprecation") DataLoader loader; //ok
+@SuppressWarnings("deprecation") public int foo() { return 1; } //violation
+@NotNull @Mock DataLoader loader; //ok
         </source>
       </subsection>
 


### PR DESCRIPTION
Issue : https://github.com/checkstyle/checkstyle/issues/7569
![Screenshot from 2020-03-22 20-26-16](https://user-images.githubusercontent.com/50927824/77252704-b7e16280-6c7b-11ea-8f6d-b78a7588a554.png)
![Screenshot from 2020-03-22 20-26-27](https://user-images.githubusercontent.com/50927824/77252707-bc0d8000-6c7b-11ea-9317-4e295126a189.png)


1. Default Configuration
```$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <property name="charset" value="UTF-8"/>
    <module name="TreeWalker">
	<module name="AnnotationLocation" />
   </module>
</module>
```
```
$ cat testone.java
public class testone{
	@NotNull private boolean field1; //ok
	@Override public int hashCode() { return 1; } // ok
	@NotNull //ok
	private boolean field2;
	@Override //ok
	public boolean equals(Object obj) { return true; }
	@Mock DataLoader loader; // ok
	@SuppressWarnings("deprecation") DataLoader loader; // violation
	@SuppressWarnings("deprecation") public int foo() { return 1; } // violation
	@NotNull @Mock DataLoader loader; //violation
}

$ java $RUN_LOCALE -jar checkstyle-8.29-all.jar -c config.xml testone.java
Starting audit...
[ERROR] /home/dunu008/GSOC/CHECKSTYLE-PROJECT/tests/testone.java:9: Annotation 'SuppressWarnings' should be alone on line. [AnnotationLocation]
[ERROR] /home/dunu008/GSOC/CHECKSTYLE-PROJECT/tests/testone.java:10: Annotation 'SuppressWarnings' should be alone on line. [AnnotationLocation]
[ERROR] /home/dunu008/GSOC/CHECKSTYLE-PROJECT/tests/testone.java:11: Annotation 'Mock' should be alone on line. [AnnotationLocation]
Audit done.
Checkstyle ends with 3 errors.
```

2. Allow multiple annotations on the same line
```
$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <property name="charset" value="UTF-8"/>
    <module name="TreeWalker">
	<module name="AnnotationLocation" >
	  <property name="allowSamelineMultipleAnnotations" value="true" />
	  <property name="allowSamelineSingleParameterlessAnnotation" value="false" />
	  <property name="allowSamelineParameterizedAnnotation" value="false" />
	</module>
   </module>
</module>
```
```
$ cat testone.java
public class testone{
	@NotNull private boolean field1; //ok
	@Override public int hashCode() { return 1; } // ok
	@NotNull //ok
	private boolean field2;
	@Override //ok
	public boolean equals(Object obj) { return true; }
	@Mock DataLoader loader; // ok
	@SuppressWarnings("deprecation") DataLoader loader; // ok
	@SuppressWarnings("deprecation") public int foo() { return 1; } // ok
	@NotNull @Mock DataLoader loader; //ok
}

$ java $RUN_LOCALE -jar checkstyle-8.29-all.jar -c config.xml testone.java
Starting audit...
Audit done.
```

3. Allow one single parameterless annotation on the same line
```
$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <property name="charset" value="UTF-8"/>
    <module name="TreeWalker">
	<module name="AnnotationLocation" >
	  <property name="allowSamelineMultipleAnnotations" value="false" />
	  <property name="allowSamelineSingleParameterlessAnnotation" value="true" />
	  <property name="allowSamelineParameterizedAnnotation" value="false" />
	</module>
   </module>
</module>
```
```
$ cat testone.java
public class testone{
	@NotNull private boolean field1; //ok
	@Override public int hashCode() { return 1; } // ok
	@NotNull //ok
	private boolean field2;
	@Override //ok
	public boolean equals(Object obj) { return true; }
	@Mock DataLoader loader; // ok
	@SuppressWarnings("deprecation") DataLoader loader; // violation
	@SuppressWarnings("deprecation") public int foo() { return 1; } // violation
	@NotNull @Mock DataLoader loader; //violation
}

$ java $RUN_LOCALE -jar checkstyle-8.29-all.jar -c config.xml testone.java
Starting audit...
[ERROR] /home/dunu008/GSOC/CHECKSTYLE-PROJECT/tests/testone.java:9: Annotation 'SuppressWarnings' should be alone on line. [AnnotationLocation]
[ERROR] /home/dunu008/GSOC/CHECKSTYLE-PROJECT/tests/testone.java:10: Annotation 'SuppressWarnings' should be alone on line. [AnnotationLocation]
[ERROR] /home/dunu008/GSOC/CHECKSTYLE-PROJECT/tests/testone.java:11: Annotation 'Mock' should be alone on line. [AnnotationLocation]
Audit done.
Checkstyle ends with 3 errors.
```

4. Allow only one and only parameterized annotation on the same line:
```
$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <property name="charset" value="UTF-8"/>
    <module name="TreeWalker">
	<module name="AnnotationLocation" >
	  <property name="allowSamelineMultipleAnnotations" value="false" />
	  <property name="allowSamelineSingleParameterlessAnnotation" value="false" />
	  <property name="allowSamelineParameterizedAnnotation" value="true" />
	</module>
   </module>
</module>
```
```
$ cat testone.java
public class testone{
	@NotNull private boolean field1; //violation
	@Override public int hashCode() { return 1; } //violation
	@NotNull //ok
	private boolean field2;
	@Override //ok
	public boolean equals(Object obj) { return true; }
	@Mock DataLoader loader; // violation
	@SuppressWarnings("deprecation") DataLoader loader; // ok
	@SuppressWarnings("deprecation") public int foo() { return 1; } // ok
	@NotNull @Mock DataLoader loader; //violation
}

$ java $RUN_LOCALE -jar checkstyle-8.29-all.jar -c config.xml testone.java
Starting audit...
[ERROR] /home/dunu008/GSOC/CHECKSTYLE-PROJECT/tests/testone.java:2: Annotation 'NotNull' should be alone on line. [AnnotationLocation]
[ERROR] /home/dunu008/GSOC/CHECKSTYLE-PROJECT/tests/testone.java:3: Annotation 'Override' should be alone on line. [AnnotationLocation]
[ERROR] /home/dunu008/GSOC/CHECKSTYLE-PROJECT/tests/testone.java:8: Annotation 'Mock' should be alone on line. [AnnotationLocation]
[ERROR] /home/dunu008/GSOC/CHECKSTYLE-PROJECT/tests/testone.java:11: Annotation 'Mock' should be alone on line. [AnnotationLocation]
[ERROR] /home/dunu008/GSOC/CHECKSTYLE-PROJECT/tests/testone.java:11: Annotation 'NotNull' should be alone on line. [AnnotationLocation]
Audit done.
Checkstyle ends with 5 errors.
```

5. To only validate annotations on methods to allow one single parameterless annotation on the same line

```
$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <property name="charset" value="UTF-8"/>
    <module name="TreeWalker">
	<module name="AnnotationLocation" >
	  <property name="tokens" value="METHOD_DEF" />
	  <property name="allowSamelineMultipleAnnotations" value="false" />
	  <property name="allowSamelineSingleParameterlessAnnotation" value="true" />
	  <property name="allowSamelineParameterizedAnnotation" value="false" />
	</module>
   </module>
</module>
```

```
$ cat testone.java
public class testone{
	@NotNull private boolean field1; //ok
	@Override public int hashCode() { return 1; } // ok
	@NotNull //ok
	private boolean field2;
	@Override //ok
	public boolean equals(Object obj) { return true; }
	@Mock DataLoader loader; // ok
	@SuppressWarnings("deprecation") DataLoader loader; // ok
	@SuppressWarnings("deprecation") public int foo() { return 1; } // violation
	@NotNull @Mock DataLoader loader; //ok
}

$ java $RUN_LOCALE -jar checkstyle-8.29-all.jar -c config.xml testone.java
Starting audit...
[ERROR] /home/dunu008/GSOC/CHECKSTYLE-PROJECT/tests/testone.java:10: Annotation 'SuppressWarnings' should be alone on line. [AnnotationLocation]
Audit done.
Checkstyle ends with 1 errors.

```