### PR TITLE
doc: fix indentation of config example

### DIFF
--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -4061,7 +4061,7 @@ enum Foo10 { FOO, BAR } // OK
               An example of how to configure this Check:
           </p>
           <source>
-              &lt;module name=&quot;OneStatementPerLine&quot;/&gt;
+&lt;module name=&quot;OneStatementPerLine&quot;/&gt;
           </source>
           <p>
               The following examples will be flagged as a violation:


### PR DESCRIPTION
Fix ugly indent
![image](https://user-images.githubusercontent.com/8901354/75257740-7386b200-57f6-11ea-91cc-fa988cda7849.png)
