### PR TITLE
Issue #6807: update xpath for RcurlyAlone to keep violations on initializers

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -6,7 +6,7 @@
 
 <suppressions>
     <!-- can't split long messages between lines -->
-    <suppress checks="RegexpSingleline" files="google_checks\.xml" lines="56,119"/>
+    <suppress checks="RegexpSingleline" files="google_checks\.xml" lines="56,121"/>
     <!-- don't validate generated files -->
     <suppress checks="RegexpSingleline" files="releasenotes\.xml"/>
 

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -98,8 +98,10 @@
         <module name="SuppressionXpathSingleFilter">
           <!-- suppresion is required till https://github.com/checkstyle/checkstyle/issues/7541 -->
           <property name="id" value="RightCurlyAlone"/>
-          <property name="query" value="//RCURLY[parent::SLIST[count(./*)=1]
-                                                 or preceding-sibling::*[last()][self::LCURLY]]"/>
+          <property name="query" value="//RCURLY[
+                                          parent::SLIST[count(./*)=1][not(parent::STATIC_INIT)]
+                                          or parent::SLIST[count(./*)=1][not(parent::INSTANCE_INIT)]
+                                          or preceding-sibling::*[last()][self::LCURLY]]"/>
         </module>
         <module name="WhitespaceAround">
             <property name="allowEmptyConstructors" value="true"/>


### PR DESCRIPTION
Issue #6807

Diff Report on all projects, get me absolutely no diff.
I do not share it, as I amended commit message and removed commit to suppress javadoc parse errors.

performance is not de-gradated:
```

✔ ~/java/github/checkstyle/contribution/checkstyle-tester [master|✚ 2…1] 
$ groovy diff.groovy --localGitRepo ~/java/github/romani/checkstyle      \
--baseBranch master      --patchBranch rcurly-init       \
--patchConfig ~/java/github/romani/checkstyle/src/main/resources/google_checks.xml \
--baseConfig /home/rivanov/java/github/google_checks_7543.xml  \
--listOfProjects projects-to-test-on.properties > 1.log

$ cat 1.log | grep -E "(Total time:)|( files to .*/checkstyle-tester/src)" | \
   grep -v "Total time:  0.1.* s" | grep "Total time: " | grep -v " s"
[INFO] Total time:  01:05 min
[INFO] Total time:  01:50 min
[INFO] Total time:  01:06 min
[INFO] Total time:  01:54 min
```