### PR TITLE
Issue #7668: Add examples for Missing Switch default

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheck.java
@@ -43,7 +43,26 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <pre>
  * &lt;module name=&quot;MissingSwitchDefault&quot;/&gt;
  * </pre>
- *
+ * <p>Example of violation:</p>
+ * <pre>
+ * switch (i) {    // violation
+ *  case 1:
+ *    break;
+ *  case 2:
+ *    break;
+ * }
+ * </pre>
+ * <p>Example of correct code:</p>
+ * <pre>
+ * switch (i) {
+ *  case 1:
+ *    break;
+ *  case 2:
+ *    break;
+ *  default: // OK
+ *    break;
+ * }
+ * </pre>
  * @since 3.1
  */
 @StatelessCheck

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -2988,6 +2988,30 @@ class TestMethodCall {
         <source>
 &lt;module name=&quot;MissingSwitchDefault&quot;/&gt;
         </source>
+        <p>
+          Example of violation:
+        </p>
+        <source>
+switch (i) {    // violation
+  case 1:
+    break;
+  case 2:
+    break;
+}
+        </source>
+        <p>
+          Example of correct code:
+        </p>
+        <source>
+switch (i) {
+  case 1:
+    break;
+  case 2:
+    break;
+  default: // OK
+    break;
+}
+        </source>
       </subsection>
 
       <subsection name="Example of Usage" id="MissingSwitchDefault_Example_of_Usage">


### PR DESCRIPTION
Fixes Issue: #7668 

![switchscreen](https://user-images.githubusercontent.com/23631699/75578787-2e1fea00-5a6d-11ea-86ef-1f9f5318e303.PNG)

Ouput of default example:

     $ cat config.xml

     <?xml version="1.0"?>
     <!DOCTYPE module PUBLIC
            "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
            "https://checkstyle.org/dtds/configuration_1_3.dtd">
     <module name="Checker">
       <module name="TreeWalker">
         <module name="MissingSwitchDefault"/>
       </module>
     </module>

     $ cat Test.java

     public class Test {

        public void myTest() {
             switch (i) {
                 case 1:
                     break;
                 case 2:
                     break;
                 // violation
             }

             switch (i) {
                 case 1:
                     break;
                 default: // OK
                     break;
             }
        }

       }

     $ java -jar checkstyle-8.29-all.jar -c config.xml Test.java

     Starting audit...
     [ERROR] D:\OpenSource\TestCommit\Test.java:4: switch without "default" clause. [MissingSwitchDefault]
     Audit done.
     Checkstyle ends with 1 errors.