### PR TITLE
Issue #7591: Update doc for TodoComment

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheck.java
@@ -50,12 +50,28 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * &lt;module name="TodoComment"/&gt;
  * </pre>
  * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * i++; // TODO: do differently in future   // violation
+ * i++; // todo: do differently in future   // OK
+ * </pre>
+ * <p>
  * To configure the check for comments that contain {@code TODO} and {@code FIXME}:
  * </p>
  * <pre>
  * &lt;module name="TodoComment"&gt;
  *   &lt;property name="format" value="(TODO)|(FIXME)"/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * i++;   // TODO: do differently in future   // violation
+ * i++;   // todo: do differently in future   // OK
+ * i=i/x; // FIXME: handle x = 0 case         // violation
+ * i=i/x; // FIX :  handle x = 0 case         // OK
  * </pre>
  *
  * @since 3.0

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -1731,7 +1731,13 @@ key.png =value - violation
         <source>
 &lt;module name=&quot;TodoComment&quot;/&gt;
         </source>
-
+        <p>
+          Example:
+        </p>
+        <source>
+i++; // TODO: do differently in future   // violation
+i++; // todo: do differently in future   // OK
+        </source>
         <p>
           To configure the check for comments that contain <code>TODO</code> and <code>FIXME</code>:
         </p>
@@ -1739,6 +1745,15 @@ key.png =value - violation
 &lt;module name=&quot;TodoComment&quot;&gt;
   &lt;property name=&quot;format&quot; value=&quot;(TODO)|(FIXME)&quot;/&gt;
 &lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+i++;   // TODO: do differently in future   // violation
+i++;   // todo: do differently in future   // OK
+i=i/x; // FIXME: handle x = 0 case         // violation
+i=i/x; // FIX :  handle x = 0 case         // OK
         </source>
       </subsection>
 


### PR DESCRIPTION
Fixes Issue: #7591

![todocheck](https://user-images.githubusercontent.com/23631699/75577517-cff20780-5a6a-11ea-8961-604801a7ca0b.PNG)

Output of default example:
   

    $ cat config.xml
    <?xml version="1.0"?>
    <!DOCTYPE module PUBLIC
            "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
            "https://checkstyle.org/dtds/configuration_1_3.dtd">
    <module name="Checker">
      <module name="TreeWalker">
        <module name="TodoComment"/>
      </module>
     </module>

     $ cat Test.java
     public class Test {
 
     public void myTest() {
        i++;   // TODO: do differently in future   // violation
        i++;   // todo: do differently in future   // OK
       }

     }

     $ java -jar checkstyle-8.29-all.jar -c config.xml Test.java
     Starting audit...
     [ERROR] D:\OpenSource\TestCommit\Test.java:4: Comment matches to-do format 'TODO:'. [TodoComment] 
     Audit done.
     Checkstyle ends with 1 errors.


Output of non-default example:

    $ cat config2.xml

    <?xml version="1.0"?>
    <!DOCTYPE module PUBLIC
              "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
              "https://checkstyle.org/dtds/configuration_1_3.dtd">
    <module name="Checker">
      <module name="TreeWalker">
       <module name="TodoComment">
        <property name="format" value="(TODO)|(FIXME)"/>
      </module>
      </module>
    </module>

    $ cat Test2.java

    public class Test {

      public void myTest() {
          i++;   // TODO: do differently in future   // violation
          i++;   // todo: do differently in future   // OK
          i=i/x; // FIXME: handle x = 0 case         // violation
          i=i/x; // FIX :  handle x = 0 case         // OK
      }

    }
    $ java -jar checkstyle-8.29-all.jar -c config2.xml Test2.java
    Starting audit...
    [ERROR] D:\OpenSource\TestCommit\Test2.java:4: Comment matches to-do format '(TODO)|(FIXME)'. [TodoComment]
    [ERROR] D:\OpenSource\TestCommit\Test2.java:6: Comment matches to-do format '(TODO)|(FIXME)'. [TodoComment]
    Audit done.
    Checkstyle ends with 2 errors.