### PR TITLE
Issue #7621: Update doc for GenericWhitespace

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
@@ -50,6 +50,12 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <li> should be followed with whitespace in almost all cases,
  *   except diamond operators and when preceding method name or constructor.</li></ul>
  * <p>
+ * To configure the check:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;GenericWhitespace&quot;/&gt;
+ * </pre>
+ * <p>
  * Examples with correct spacing:
  * </p>
  * <pre>
@@ -71,10 +77,16 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * MyClass obj = new &lt;String&gt;MyClass();
  * </pre>
  * <p>
- * To configure the check:
+ * Examples with incorrect spacing:
  * </p>
  * <pre>
- * &lt;module name=&quot;GenericWhitespace&quot;/&gt;
+ * List&lt; String&gt; l; // violation, "&lt;" followed by whitespace
+ * Box b = Box. &lt;String&gt;of("foo"); // violation, "&lt;" preceded with whitespace
+ * public&lt;T&gt; void foo() {} // violation, "&lt;" not preceded with whitespace
+ *
+ * List a = new ArrayList&lt;&gt; (); // violation, "&gt;" followed by whitespace
+ * Map&lt;Integer, String&gt;m; // violation, "&gt;" not followed by whitespace
+ * Pair&lt;Integer, Integer &gt; p; // violation, "&gt;" preceded with whitespace
  * </pre>
  *
  * @since 5.0

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -655,11 +655,20 @@ class Foo {
           <li> should be followed with whitespace in almost all cases, except diamond operators
                and when preceding method name or constructor.</li>
         </ul>
+      </subsection>
 
+      <subsection name="Examples" id="GenericWhitespace_Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name=&quot;GenericWhitespace&quot;/&gt;
+        </source>
         <p>
           Examples with correct spacing:
         </p>
-        <source>
+        <div class="wrapper">
+          <pre>
 // Generic methods definitions
 public void &lt;K, V extends Number&gt; boolean foo(K, V) {}
 // Generic type definition
@@ -676,16 +685,22 @@ List&lt;T&gt; list = ImmutableList.Builder&lt;T&gt;::new;
 sort(list, Comparable::&lt;String&gt;compareTo);
 // Constructor call
 MyClass obj = new &lt;String&gt;MyClass();
-        </source>
-      </subsection>
-
-      <subsection name="Examples" id="GenericWhitespace_Examples">
+          </pre>
+        </div>
         <p>
-          To configure the check:
+          Examples with incorrect spacing:
         </p>
-        <source>
-&lt;module name=&quot;GenericWhitespace&quot;/&gt;
-        </source>
+        <div class="wrapper">
+          <pre>
+List&lt; String&gt; l; // violation, "&lt;" followed by whitespace
+Box b = Box. &lt;String&gt;of("foo"); // violation, "&lt;" preceded with whitespace
+public&lt;T&gt; void foo() {} // violation, "&lt;" not preceded with whitespace
+
+List a = new ArrayList&lt;&gt; (); // violation, "&gt;" followed by whitespace
+Map&lt;Integer, String&gt;m; // violation, "&gt;" not followed by whitespace
+Pair&lt;Integer, Integer &gt; p; // violation, "&gt;" preceded with whitespace
+          </pre>
+        </div>
       </subsection>
 
       <subsection name="Example of Usage" id="GenericWhitespace_Example_of_Usage">


### PR DESCRIPTION
Issue #7621: Update doc for GenericWhitespace

The relevant section has been modified. It now looks like this: 
![image](https://user-images.githubusercontent.com/53135010/75612984-a10b8c80-5b63-11ea-986c-c5a8141d64ac.png)

There are no additional configurations, so there is only one set of example violations. Output:
```
D:\checkstyletest>type config.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">

<module name = "Checker">
    <module name="TreeWalker">
        <module name="GenericWhitespace"/>
    </module>
</module>

D:\checkstyletest>type test\Test.java 
public class Test {

    public<T> void foo() {} // violation, "<" not preceded with whitespace

    public void test() {
        List< String> l; // violation, "<" followed with whitespace
        List a = new ArrayList <>(); // violation, "<" preceded with whitespace

        Box b = Box.<String> of("foo"); // violation, ">" followed with whitespace
        Map<Integer, String>m; // violation, ">" not followed with whitespace
        Pair<Integer, Integer > p; // violation, ">" preceded with whitespace
    }

}

D:\checkstyletest>java -jar -Duser.language=en -Duser.country=US checkstyle-8.29-all.jar -c config.xml test\Test.java 
Starting audit...
[ERROR] D:\checkstyletest\test\Test.java:3:11: '<' is not preceded with whitespace. [GenericWhitespace]
[ERROR] D:\checkstyletest\test\Test.java:6:13: '<' is followed by whitespace. [GenericWhitespace]
[ERROR] D:\checkstyletest\test\Test.java:7:32: '<' is preceded with whitespace. [GenericWhitespace]
[ERROR] D:\checkstyletest\test\Test.java:9:28: '>' is followed by whitespace. [GenericWhitespace]
[ERROR] D:\checkstyletest\test\Test.java:10:28: '>' is followed by an illegal character. [GenericWhitespace]
[ERROR] D:\checkstyletest\test\Test.java:11:31: '>' is preceded with whitespace. [GenericWhitespace]
Audit done.
```