### PR TITLE
Issue #7672:Updated doc for OverloadMethodsDeclarationOrder

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheck.java
@@ -29,25 +29,36 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 /**
  * <p>
- * Checks that overload methods are grouped together.
+ * Checks that overloaded methods are grouped together. Overloaded methods have the same
+ * name but different signatures where the signature can differ by the number of
+ * input parameters or type of input parameters or both.
  * </p>
  * <p>
- * Example of incorrect grouping overload methods:
+ * To configure the check:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;OverloadMethodsDeclarationOrder&quot;/&gt;
+ * </pre>
+ * <p>
+ * Example of correct grouping of overloaded methods:
  * </p>
  * <pre>
  * public void foo(int i) {}
  * public void foo(String s) {}
- * public void notFoo() {} // Have to be after foo(int i, String s)
+ * public void foo(String s, int i) {}
  * public void foo(int i, String s) {}
+ * public void notFoo() {}
  * </pre>
  * <p>
- * An example of how to configure the check is:
+ * Example of incorrect grouping of overloaded methods:
  * </p>
- *
  * <pre>
- * &lt;module name=&quot;OverloadMethodsDeclarationOrder&quot;/&gt;
+ * public void foo(int i) {} // OK
+ * public void foo(String s) {} // OK
+ * public void notFoo() {} // violation. Have to be after foo(String s, int i)
+ * public void foo(int i, String s) {}
+ * public void foo(String s, int i) {}
  * </pre>
- *
  * @since 5.8
  */
 @StatelessCheck

--- a/src/xdocs/checks.xml
+++ b/src/xdocs/checks.xml
@@ -673,7 +673,7 @@
           <tr>
             <td><a href="config_coding.html#OverloadMethodsDeclarationOrder">
               OverloadMethodsDeclarationOrder</a></td>
-            <td>Checks that overload methods are grouped together.</td>
+            <td>Checks that overloaded methods are grouped together.</td>
           </tr>
           <tr>
             <td><a href="config_annotation.html#PackageAnnotation">PackageAnnotation</a></td>

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -4559,27 +4559,34 @@ try (Reader r = new PipedReader(); s2; Reader s3 = new PipedReader() // violatio
       <p>Since Checkstyle 5.8</p>
       <subsection name="Description" id="OverloadMethodsDeclarationOrder_Description">
         <p>
-          Checks that overload methods are grouped together.
+          Checks that overloaded methods are grouped together. Overloaded methods have the same
+          name but different signatures where the signature can differ by the number of input
+          parameters or type of input parameters or both.
         </p>
       </subsection>
 
       <subsection name="Examples" id="OverloadMethodsDeclarationOrder_Examples">
-        <p>
-          Example of incorrect grouping overload methods:
-        </p>
-        <source>
-public void foo(int i) {}
-public void foo(String s) {}
-public void notFoo() {} // Have to be after foo(int i, String s)
-public void foo(int i, String s) {}
-        </source>
-        <p>
-          An example of how to configure the check is:
-        </p>
+        <p>To configure the check:</p>
         <source>
 &lt;module name="OverloadMethodsDeclarationOrder"/&gt;
         </source>
-        </subsection>
+        <p>Example of correct grouping of overloaded methods:</p>
+        <source>
+public void foo(int i) {}
+public void foo(String s) {}
+public void foo(String s, int i) {}
+public void foo(int i, String s) {}
+public void notFoo() {}
+        </source>
+        <p>Example of incorrect grouping of overloaded methods:</p>
+        <source>
+public void foo(int i) {} // OK
+public void foo(String s) {} // OK
+public void notFoo() {} // violation. Have to be after foo(String s, int i)
+public void foo(int i, String s) {}
+public void foo(String s, int i) {}
+        </source>
+      </subsection>
 
       <subsection name="Example of Usage" id="OverloadMethodsDeclarationOrder_Example_of_Usage">
         <ul>


### PR DESCRIPTION
Fix for #7672 

<img width="1440" alt="Screen Shot" src="https://user-images.githubusercontent.com/49328081/75708108-04391400-5c75-11ea-9981-6d24baf05e1b.png">

Output of default example (invalid):
```
$ cat config.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker" >
    <module name="TreeWalker">
        <module name="OverloadMethodsDeclarationOrder" />
    </module>
</module>

$ cat MyClass.java 
public class MyClass{
    public void foo(int i) {} //OK
    public void foo(String s) {} //OK
    public void notFoo() {} // violation. Have to be after foo(String s, int i)
    public void foo(int i, String s) {}
    public void foo(String s, int i) {}
}

$ java -jar checkstyle-8.30-all.jar -c config.xml MyClass.java
Starting audit...
[ERROR] /Users/guneshi/github/test/MyClass.java:5: Overload methods should not be split. Previous overloaded method located at line '3'. [OverloadMethodsDeclarationOrder]
Audit done.
Checkstyle ends with 1 errors.
```
Output of default example (correct):

```
$ cat config.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker" >
    <module name="TreeWalker">
        <module name="OverloadMethodsDeclarationOrder" />
    </module>
</module>

$ cat MyClass.java 
public class MyClass{
    public void foo(int i) {}
    public void foo(String s) {}
    public void foo(String s, int i) {}
    public void foo(int i, String s) {}
    public void notFoo() {}
}
$ java -jar checkstyle-8.30-all.jar -c config.xml MyClass.java
Starting audit...
Audit done.
```




