### PR TITLE
Issue #7684: update doc for AvoidStarImport

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
@@ -64,6 +64,14 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <pre>
  * &lt;module name="AvoidStarImport"/&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * import java.util.Scanner;         // OK
+ * import java.io.*;                 // violation
+ * import static java.lang.Math.*;   // violation
+ * import java.util.*;               // violation
+ * import java.net.*;                // violation
+ * </pre>
  * <p>
  * To configure the check so that star imports from packages
  * {@code java.io and java.net} as well as static members from class
@@ -73,6 +81,46 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * &lt;module name="AvoidStarImport"&gt;
  *   &lt;property name="excludes" value="java.io,java.net,java.lang.Math"/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * import java.util.Scanner;         // OK
+ * import java.io.*;                 // OK
+ * import static java.lang.Math.*;   // OK
+ * import java.util.*;               // violation
+ * import java.net.*;                // OK
+ * </pre>
+ * <p>
+ * To configure the check so that star imports from all packages are allowed:
+ * </p>
+ * <pre>
+ * &lt;module name="AvoidStarImport"&gt;
+ *   &lt;property name="allowClassImports" value="true"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * import java.util.Scanner;         // OK
+ * import java.io.*;                 // OK
+ * import static java.lang.Math.*;   // violation
+ * import java.util.*;               // OK
+ * import java.net.*;                // OK
+ * </pre>
+ * <p>
+ * To configure the check so that starred static member imports from all packages are allowed:
+ * </p>
+ * <pre>
+ * &lt;module name="AvoidStarImport"&gt;
+ *   &lt;property name="allowStaticMemberImports" value="true"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * import java.util.Scanner;         // OK
+ * import java.io.*;                 // violation
+ * import static java.lang.Math.*;   // OK
+ * import java.util.*;               // violation
+ * import java.net.*;                // violation
  * </pre>
  *
  * @since 3.0

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -95,6 +95,16 @@
 &lt;module name="AvoidStarImport"/&gt;
         </source>
         <p>
+          Example:
+        </p>
+        <source>
+import java.util.Scanner;         // OK
+import java.io.*;                 // violation
+import static java.lang.Math.*;   // violation
+import java.util.*;               // violation
+import java.net.*;                // violation
+        </source>
+        <p>
           To configure the check so that star imports from packages
           <code>java.io and java.net</code> as well as static members from class
           <code>java.lang.Math</code> are allowed:
@@ -103,6 +113,54 @@
 &lt;module name="AvoidStarImport"&gt;
   &lt;property name="excludes" value="java.io,java.net,java.lang.Math"/&gt;
 &lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+import java.util.Scanner;         // OK
+import java.io.*;                 // OK
+import static java.lang.Math.*;   // OK
+import java.util.*;               // violation
+import java.net.*;                // OK
+        </source>
+        <p>
+          To configure the check so that star imports
+          from all packages are allowed:
+        </p>
+        <source>
+&lt;module name="AvoidStarImport"&gt;
+  &lt;property name="allowClassImports" value="true"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+import java.util.Scanner;         // OK
+import java.io.*;                 // OK
+import static java.lang.Math.*;   // violation
+import java.util.*;               // OK
+import java.net.*;                // OK
+        </source>
+        <p>
+          To configure the check so that starred static member imports
+          from all packages are allowed:
+        </p>
+        <source>
+&lt;module name="AvoidStarImport"&gt;
+  &lt;property name="allowStaticMemberImports" value="true"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+import java.util.Scanner;         // OK
+import java.io.*;                 // violation
+import static java.lang.Math.*;   // OK
+import java.util.*;               // violation
+import java.net.*;                // violation
         </source>
       </subsection>
 


### PR DESCRIPTION
Fixes Issue: #7684 

![avoid star impoer](https://user-images.githubusercontent.com/23631699/75631749-293e7000-5bfe-11ea-8da0-6f1d0e244e08.PNG)

Output of default example:

    $ cat config.xml

    <?xml version="1.0"?>
    <!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
    <module name="Checker">
      <module name="TreeWalker">
       <module name="AvoidStarImport">
       </module>
      </module>
    </module>

    $ cat Test.java
    import java.util.Scanner;         // OK
    import java.io.*;                 // violation
    import static java.lang.Math.*;   // violation

    $ java -jar checkstyle-8.29-all.jar -c config.xml Test.java
    Starting audit...
    [ERROR] D:\OpenSource\TestCommit\Test.java:2: Using the '.*' form of import should be avoided - java.io.*. [AvoidStarImport]
    [ERROR] D:\OpenSource\TestCommit\Test.java:3: Using the '.*' form of import should be avoided - java.lang.Math.*. [AvoidStarImport]
    Audit done.
    Checkstyle ends with 2 errors.


Output of non-default example:

    $ cat config.xml

    <?xml version="1.0"?>
    <!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
    <module name="Checker">
      <module name="TreeWalker">
       <module name="AvoidStarImport">
           <property name="excludes" value="java.io,java.net,java.lang.Math"/>
       </module>
      </module>
    </module>

    $ cat Test.java

    import java.util.Scanner;         // OK
    import java.io.*;                 // OK
    import static java.lang.Math.*;   // OK
    import java.util.*;               // violation

    $ java -jar checkstyle-8.29-all.jar -c config.xml Test.java
    Starting audit...
    [ERROR] D:\OpenSource\TestCommit\Test.java:4: Using the '.*' form of import should be avoided - java.util.*. [AvoidStarImport]
    Audit done.
    Checkstyle ends with 1 errors.

Output of allowClassImports example:

    $ cat config.xml

    <?xml version="1.0"?>
    <!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
    <module name="Checker">
      <module name="TreeWalker">
       <module name="AvoidStarImport">
           <property name="allowClassImports" value="true"/>
       </module>
      </module>
    </module>

    $ cat Test.java

    import java.util.Scanner;         // OK
    import java.io.*;                 // OK
    import static java.lang.Math.*;   // violation
    import java.util.*;               // OK

    $ java -jar checkstyle-8.29-all.jar -c config2.xml Test2.java

    Starting audit...
    [ERROR] D:\OpenSource\TestCommit\Test.java:3: Using the '.*' form of import should be avoided - java.lang.Math.*. [AvoidStarImport]
    Audit done.
    Checkstyle ends with 1 errors.

Output of non-allowStaticMemberImports example:

    $ cat config.xml
    <?xml version="1.0"?>
    <!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
    <module name="Checker">
      <module name="TreeWalker">
       <module name="AvoidStarImport">
           <property name="allowStaticMemberImports" value="true"/>
       </module>
      </module>
    </module>

    $ cat Test.java

    import java.util.Scanner;         // OK
    import java.io.*;                 // violation
    import static java.lang.Math.*;   // OK
    import java.util.*;               // violation

    $ java -jar checkstyle-8.29-all.jar -c config2.xml Test2.java
    Starting audit...
    [ERROR] D:\OpenSource\TestCommit\Test.java:2: Using the '.*' form of import should be avoided - java.io.*. [AvoidStarImport]
    [ERROR] D:\OpenSource\TestCommit\Test.java:4: Using the '.*' form of import should be avoided - java.util.*. [AvoidStarImport]
    Audit done.
    Checkstyle ends with 2 errors.