### PR TITLE
Issue: #7584 add RightCurly example

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -71,6 +71,51 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * &lt;module name="RightCurly"/&gt;
  * </pre>
  * <p>
+ * Example:
+ * </p>
+ * <pre>
+ *public class Test {
+ *
+ *  public void test() {
+ *
+ *    if (foo) {
+ *      bar();
+ *    }           // violation, right curly must be in the same line as the 'else' keyword
+ *    else {
+ *      bar();
+ *    }
+ *
+ *    if (foo) {
+ *      bar();
+ *    } else {     // OK
+ *      bar();
+ *    }
+ *
+ *    if (foo) { bar(); } int i = 0; // violation
+ *                  // ^^^ statement is not allowed on same line after curly right brace
+ *
+ *    if (foo) { bar(); }            // OK
+ *    int i = 0;
+ *
+ *    try {
+ *      bar();
+ *    }           // violation, rightCurly must be in the same line as 'catch' keyword
+ *    catch (Exception e) {
+ *      bar();
+ *    }
+ *
+ *    try {
+ *      bar();
+ *    } catch (Exception e) { // OK
+ *      bar();
+ *    }
+ *
+ *  }                         // OK
+ *
+ *  public void testSingleLine() { bar(); } // OK, because singleline is allowed
+ *}
+ * </pre>
+ * <p>
  * To configure the check with policy {@code alone} for {@code else} and
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
  * METHOD_DEF</a> tokens:
@@ -81,9 +126,85 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *   &lt;property name=&quot;tokens&quot; value=&quot;LITERAL_ELSE, METHOD_DEF&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ *public class Test {
+ *
+ *  public void test() {
+ *
+ *    if (foo) {
+ *      bar();
+ *    } else { bar(); }   // violation, right curly must be alone on line
+ *
+ *    if (foo) {
+ *      bar();
+ *    } else {
+ *      bar();
+ *    }                   // OK
+ *
+ *    try {
+ *      bar();
+ *    } catch (Exception e) { // OK because config is set to token METHOD_DEF and LITERAL_ELSE
+ *      bar();
+ *    }
+ *
+ *  }                         // OK
+ *
+ *  public void violate() { bar; } // violation, singleline is not allowed here
+ *
+ *  public void ok() {
+ *    bar();
+ *  }                              // OK
+ *}
+ * </pre>
+ * <p>
+ * To configure the check with policy {@code alone_or_singleline} for {@code if}
+ * and <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+ * METHOD_DEF</a>
+ * tokens:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;RightCurly&quot;&gt;
+ *  &lt;property name=&quot;option&quot; value=&quot;alone_or_singleline&quot;/&gt;
+ *  &lt;property name=&quot;tokens&quot; value=&quot;LITERAL_IF, METHOD_DEF&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ *public class Test {
+ *
+ *  public void test() {
+ *
+ *    if (foo) {
+ *      bar();
+ *    } else {        // violation, right curly must be alone on line
+ *      bar();
+ *    }
+ *
+ *    if (foo) {
+ *      bar();
+ *    }               // OK
+ *    else {
+ *      bar();
+ *    }
+ *
+ *    try {
+ *      bar();
+ *    } catch (Exception e) {        // OK because config did not set token LITERAL_TRY
+ *      bar();
+ *    }
+ *
+ *  }                                // OK
+ *
+ *  public void violate() { bar(); } // OK , because singleline
+ *}
+ * </pre>
  *
  * @since 3.0
- *
  */
 @StatelessCheck
 public class RightCurlyCheck extends AbstractCheck {

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -1045,6 +1045,50 @@ allowedFuture.addCallback(result -> {
 &lt;module name=&quot;RightCurly&quot;/&gt;
         </source>
 
+        <p>Example: </p>
+        <source>
+public class Test {
+
+  public void test() {
+
+    if (foo) {
+      bar();
+    }           // violation, right curly must be in the same line as the 'else' keyword
+    else {
+      bar();
+    }
+
+    if (foo) {
+      bar();
+    } else {     // OK
+      bar();
+    }
+
+    if (foo) { bar(); } int i = 0;  // violation
+                  // ^^^ statement is not allowed on same line after curly right brace
+
+    if (foo) { bar(); }            // OK
+    int i = 0;
+
+    try {
+      bar();
+    }           // violation, rightCurly must be in the same line as 'catch' keyword
+    catch (Exception e) {
+      bar();
+    }
+
+    try {
+      bar();
+    } catch (Exception e) { // OK
+      bar();
+    }
+
+  }                         // OK
+
+  public void testSingleLine() { bar(); } // OK, because singleline is allowed
+}
+        </source>
+
         <p>
           To configure the check with policy <code>alone</code> for <code> else</code> and <a
              href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
@@ -1056,6 +1100,82 @@ allowedFuture.addCallback(result -> {
   &lt;property name=&quot;option&quot; value=&quot;alone&quot;/&gt;
   &lt;property name=&quot;tokens&quot; value=&quot;LITERAL_ELSE, METHOD_DEF&quot;/&gt;
 &lt;/module&gt;
+        </source>
+
+        <p>Example: </p>
+        <source>
+public class Test {
+
+  public void test() {
+
+    if (foo) {
+      bar();
+    } else { bar(); }   // violation, right curly must be alone on line
+
+    if (foo) {
+      bar();
+    } else {
+      bar();
+    }                   // OK
+
+    try {
+      bar();
+    } catch (Exception e) { // OK because config is set to token METHOD_DEF and LITERAL_ELSE
+      bar();
+    }
+
+  }                         // OK
+
+  public void violate() { bar; } // violation, singleline is not allowed here
+
+  public void ok() {
+    bar();
+  }                              // OK
+}
+        </source>
+
+        <p>
+          To configure the check with policy <code>alone_or_singleline</code> for <code> if</code>
+          and <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+          METHOD_DEF</a>
+          tokens:
+        </p>
+        <source>
+&lt;module name=&quot;RightCurly&quot;&gt;
+  &lt;property name=&quot;option&quot; value=&quot;alone_or_singleline&quot;/&gt;
+  &lt;property name=&quot;tokens&quot; value=&quot;LITERAL_IF, METHOD_DEF&quot;/&gt;
+&lt;/module&gt;
+        </source>
+
+        <p>Example: </p>
+        <source>
+public class Test {
+
+  public void test() {
+
+    if (foo) {
+      bar();
+    } else {        // violation, right curly must be alone on line
+      bar();
+    }
+
+    if (foo) {
+      bar();
+    }               // OK
+    else {
+      bar();
+    }
+
+    try {
+      bar();
+    } catch (Exception e) {        // OK because config did not set token LITERAL_TRY
+      bar();
+    }
+
+  }                                // OK
+
+  public void violate() { bar(); } // OK , because singleline
+}
         </source>
       </subsection>
 


### PR DESCRIPTION
Resolves #7584 

![2020-03-14](https://user-images.githubusercontent.com/29332774/76693465-e1770a00-663b-11ea-8713-d098dd143484.png)
![2020-03-14 (1)](https://user-images.githubusercontent.com/29332774/76693466-e3d96400-663b-11ea-862a-9f2179772031.png)

Ouput of default example:
```
$ cat configRightCurlyDefault.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="RightCurly"/>
  </module>
</module>

$ cat RightCurlyDefault.java
public class Test {

  public void test() {

    if (foo) {
      bar();
    }           // violation, right curly must be in the same line as the 'else' keyword
    else {
      bar();
    }

    if (foo) {
      bar();
    } else {     // OK
      bar();
    }

    if (foo) { bar(); } int i = 0;  // violation
                  // ^^^ statement is not allowed on same line after curly right brace

    if (foo) { bar(); }            // OK
    int i = 0;

    try {
      bar();
    }           // violation, rightCurly must be in the same line as 'catch' keyword
    catch (Exception e) {
      bar();
    }

    try {
      bar();
    } catch (Exception e) { // OK
      bar();
    }

  }                         // OK

  public void testSingleLine() { bar(); } // OK, because singleline is allowed
}

$  java -jar checkstyle-8.29-all.jar -c configRightCurlyDefault.xml RightCurlyDefault.java
Starting audit...
[ERROR] /mnt/c/Users/jrl-c/Desktop/GSoC checkstyle/GSoC checkstyle workspace/RightCurlyDefault.java:7:5: '}' at column 5 should be on the same line as the next part of a multi-block statement (one that directly contains multiple blocks: if/else-if/else, do/while or try/catch/finally). [RightCurly]
[ERROR] /mnt/c/Users/jrl-c/Desktop/GSoC checkstyle/GSoC checkstyle workspace/RightCurlyDefault.java:18:23: '}' at column 23 should be alone on a line. [RightCurly]
[ERROR] /mnt/c/Users/jrl-c/Desktop/GSoC checkstyle/GSoC checkstyle workspace/RightCurlyDefault.java:25:5: '}' at column 5 should be on the same line as the next part of a multi-block statement (one that directly contains multiple blocks: if/else-if/else, do/while or try/catch/finally). [RightCurly]
Audit done.
Checkstyle ends with 3 errors.
```

Output of non-default example:
```
$ cat configRightCurly.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="RightCurly">
        <property name="option" value="alone"/>
        <property name="tokens" value="LITERAL_ELSE, METHOD_DEF"/>
        </module>
  </module>
</module>

$ cat RightCurly.java
public class Test {

  public void test() {

    if (foo) {
      bar();
    } else { bar(); }   // violation, right curly must be alone on line

    if (foo) {
      bar();
    } else {
      bar();
    }                   // OK

    try {
      bar();
    } catch (Exception e) { // OK because config is set to token METHOD_DEF and LITERAL_ELSE
      bar();
    }

  }                         // OK

  public void violate() { bar; } // violation, singleline is not allowed here

  public void ok() {
    bar();
  }                              // OK
}

$  java -jar checkstyle-8.2-all.jar -c configRightCurly.xml RightCurly.java
Starting audit...
[ERROR] /mnt/c/Users/jrl-c/Desktop/GSoC checkstyle/GSoC checkstyle workspace/RightCurly.java:7:21: '}' at column 21 should be alone on a line. [RightCurly]
[ERROR] /mnt/c/Users/jrl-c/Desktop/GSoC checkstyle/GSoC checkstyle workspace/RightCurly.java:23:32: '}' at column 32 should be alone on a line. [RightCurly]
Audit done.
Checkstyle ends with 2 errors.
```
Add more examples:
![2020-03-14 (2)](https://user-images.githubusercontent.com/29332774/76693467-ed62cc00-663b-11ea-8f1b-6ce539ceebcc.png)


``` 
$ cat configRightCurlyAloneOrSingleline.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="RightCurly">
        <property name="option" value="alone_or_singleline"/>
        <property name="tokens" value="LITERAL_IF, METHOD_DEF"/>
        </module>
  </module>
</module>

$ cat RightCurlyAloneOrSingleline.java
public class Test {

  public void test() {

    if (foo) {
      bar();
    } else {        // violation, right curly must be alone
      bar();
    }

    if (foo) {
      bar();
    }               // OK
    else {
      bar();
    }

    try {
      bar();
    } catch (Exception e) {        // OK because config did not set token LITERAL_TRY
      bar();
    }

  }                                // OK

  public void violate() { bar(); } // OK , because singleline
}

$ java -jar checkstyle-8.29-
all.jar -c configRightCurlyAloneOrSingleline.xml RightCurlyAloneOrSingleline.java
Starting audit...
[ERROR] /mnt/c/Users/jrl-c/Desktop/GSoC checkstyle/GSoC checkstyle workspace/RightCurlyAloneOrSingleline.java:7:5: '}' at column 5 should be alone on a line. [RightCurly]
Audit done.
Checkstyle ends with 1 errors.

```