### PR TITLE
Issue: #7697 update doc for RegexpSingleline

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheck.java
@@ -62,25 +62,53 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
  * </li>
  * </ul>
  * <p>
- * To configure the check to find trailing whitespace at the end of a line:
+ *   To configure the check with default values:
  * </p>
  * <pre>
- * &lt;module name="RegexpSingleline"&gt;
- *   &lt;!-- \s matches whitespace character, $ matches end of line. --&gt;
- *   &lt;property name="format" value="\s+$"/&gt;
- * &lt;/module&gt;
+ * &lt;module name="RegexpSingleline" /&gt;
  * </pre>
  * <p>
- * To configure the check to find trailing whitespace at the end of a line,
- * with some <i>slack</i> of allowing two occurrences per file:
+ *   This configuration does not match to anything,
+ *   so we do not provide any code example for it
+ *   as no violation will ever be reported.
+ * </p>
+ * <p>
+ * To configure the check to find occurrences of 'System.exit('
+ * with some <i>slack</i> of allowing only one occurrence per file:
  * </p>
  * <pre>
  * &lt;module name="RegexpSingleline"&gt;
- *   &lt;property name="format" value="\s+$"/&gt;
+ *   &lt;property name="format" value="System.exit\("/&gt;
  *   &lt;!-- next line not required as 0 is the default --&gt;
  *   &lt;property name="minimum" value="0"/&gt;
- *   &lt;property name="maximum" value="2"/&gt;
+ *   &lt;property name="maximum" value="1"/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * class MyClass {
+ *      void myFunction() {
+ *          try {
+ *             doSomething();
+ *          } catch (Exception e) {
+ *             System.exit(1); // OK, as only there is only one occurrence.
+ *          }
+ *      }
+ *      void doSomething(){};
+ * }
+ * </pre>
+ * <pre>
+ * class MyClass {
+ *     void myFunction() {
+ *         try {
+ *             doSomething();
+ *             System.exit(0);
+ *         } catch (Exception e) {
+ *             System.exit(1); // Violation, as there are more than one occurrence.
+ *         }
+ *     }
+ *     void doSomething(){};
+ * }
  * </pre>
  * <p>
  * An example of how to configure the check to make sure a copyright statement
@@ -94,7 +122,52 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
  *   &lt;property name="maximum" value="10"/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * &#47;**
+ * * This file is copyrighted under CC. // Ok, as the file contains a copyright statement.
+ * *&#47;
+ * class MyClass {
  *
+ * }
+ * </pre>
+ * <pre>
+ * &#47;** // violation, as the file doesn't contain a copyright statement.
+ * * MyClass as a configuration example.
+ * *&#47;
+ * class MyClass {
+ *
+ * }
+ * </pre>
+ * <p>
+ *  An example of how to configure the check to make sure sql files contains the term 'license'.
+ * </p>
+ * <pre>
+ * &lt;module name="RegexpSingleline"&gt;
+ *     &lt;property name="format" value="license"/&gt;
+ *     &lt;property name="minimum" value="1"/&gt;
+ *     &lt;property name="maximum" value="9999"/&gt;
+ *     &lt;property name="ignoreCase" value="true"/&gt;
+ *     &lt;!--  Configure a message to be shown on violation of the Check. --&gt;
+ *     &lt;property name="message"
+ *           value="File must contain at least one occurrence of 'license' term"/&gt;
+*      &lt;!--  Perform the Check only on files with java extension. --&gt;
+ *     &lt;property name="fileExtensions" value="sql"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * &#47;*
+ * AP 2.0 License. // Ok, Check ignores the case of the term.
+ * *&#47;
+ * CREATE DATABASE MyDB;
+ * </pre>
+ * <pre>
+ * &#47;* // violation, file doesn't contain the term.
+ * Example sql file.
+ * *&#47;
+ * CREATE DATABASE MyDB;
+ * </pre>
  * @since 5.0
  */
 @StatelessCheck

--- a/src/xdocs/config_regexp.xml
+++ b/src/xdocs/config_regexp.xml
@@ -938,30 +938,55 @@ void method() {
 
       <subsection name="Examples" id="RegexpSingleline_Examples">
         <p>
-          To configure the check to find trailing whitespace at the end
-          of a line:
+        To configure the check with default values:
         </p>
         <source>
-&lt;module name=&quot;RegexpSingleline&quot;&gt;
-  &lt;!-- \s matches whitespace character, $ matches end of line. --&gt;
-  &lt;property name=&quot;format&quot; value=&quot;\s+$&quot;/&gt;
-&lt;/module&gt;
+&lt;module name=&quot;RegexpSingleline&quot; /&gt;
         </source>
-
         <p>
-          To configure the check to find trailing whitespace at the end
-          of a line, with some <i>slack</i> of allowing two occurrences
-          per file:
+        This configuration does not match to anything,
+        so we do not provide any code example for it
+        as no violation will ever be reported.
+        </p>
+        <p>
+        To configure the check to find occurrences of 'System.exit('
+        with some <i>slack</i> of allowing only one occurrence per file:
         </p>
         <source>
 &lt;module name=&quot;RegexpSingleline&quot;&gt;
-  &lt;property name=&quot;format&quot; value=&quot;\s+$&quot;/&gt;
+  &lt;property name=&quot;format&quot; value=&quot;System.exit\(&quot;/&gt;
   &lt;!-- next line not required as 0 is the default --&gt;
   &lt;property name=&quot;minimum&quot; value=&quot;0&quot;/&gt;
-  &lt;property name=&quot;maximum&quot; value=&quot;2&quot;/&gt;
+  &lt;property name=&quot;maximum&quot; value=&quot;1&quot;/&gt;
 &lt;/module&gt;
         </source>
 
+        <p>Example:</p>
+        <source>
+class MyClass {
+    void myFunction() {
+        try {
+            doSomething();
+        } catch (Exception e) {
+            System.exit(1); // OK, as only there is only one occurrence.
+        }
+    }
+    void doSomething(){};
+}
+        </source>
+        <source>
+class MyClass {
+    void myFunction() {
+        try {
+            doSomething();
+            System.exit(0);
+        } catch (Exception e) {
+            System.exit(1); // Violation, as there are more than one occurrence.
+        }
+    }
+    void doSomething(){};
+}
+        </source>
         <p>
           An example of how to configure the check to make sure a copyright
           statement is included in the file:
@@ -974,8 +999,53 @@ void method() {
   &lt;property name=&quot;maximum&quot; value=&quot;10&quot;/&gt;
 &lt;/module&gt;
         </source>
-      </subsection>
+      <p>Example:</p>
+      <source>
+/**
+* This file is copyrighted under CC. // Ok, as the file contains a copyright statement.
+*/
+class MyClass {
 
+}
+      </source>
+      <source>
+/** // violation, as the file doesn't contain a copyright statement.
+* MyClass as a configuration example.
+*/
+class MyClass {
+
+}
+      </source>
+      <p>
+       An example of how to configure the check to make sure sql files contains the term 'license'.
+      </p>
+      <source>
+&lt;module name=&quot;RegexpSingleline&quot;&gt;
+    &lt;property name=&quot;format&quot; value=&quot;license&quot;/&gt;
+    &lt;property name=&quot;minimum&quot; value=&quot;1&quot;/&gt;
+    &lt;property name=&quot;maximum&quot; value=&quot;9999&quot;/&gt;
+    &lt;property name=&quot;ignoreCase&quot; value=&quot;true&quot;/&gt;
+    &lt;!--  Configure a message to be shown on violation of the Check. --&gt;
+    &lt;property name=&quot;message&quot;
+          value=&quot;File must contain at least one occurrence of 'license' term&quot;/&gt;
+    &lt;!--  Perform the Check only on files with java extension. --&gt;
+    &lt;property name=&quot;fileExtensions&quot; value=&quot;sql&quot;/&gt;
+&lt;/module&gt;
+      </source>
+      <p>Example:</p>
+      <source>
+/*
+ AP 2.0 License. // Ok, Check ignores the case of the term.
+*/
+CREATE DATABASE MyDB;
+      </source>
+      <source>
+/* // violation, file doesn't contain the term.
+ Example sql file.
+*/
+CREATE DATABASE MyDB;
+      </source>
+      </subsection>
       <subsection name="Example of Usage" id="RegexpSingleline_Example_of_Usage">
         <ul>
           <li>


### PR DESCRIPTION
#### Description
This fixes #7697 
![Screenshot from 2020-03-29 20-59-39](https://user-images.githubusercontent.com/35211477/77853159-4a47b000-7200-11ea-9fcd-475f12a42520.png)
![2](https://user-images.githubusercontent.com/35211477/77253136-7d2cf980-6c7e-11ea-9210-3888a4b360ba.png)
![3](https://user-images.githubusercontent.com/35211477/77253138-7f8f5380-6c7e-11ea-8cc6-5de00918fd9c.png)



#### Output of default example:
```
$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="RegexpSingleline">
        <property name="format" value="System.exit\("/>
        <!-- next line not required as 0 is the default -->
        <property name="minimum" value="0"/>
        <property name="maximum" value="1"/>
    </module>
</module>

$ cat MyClass.java
class MyClass {
    void myFunction() {
        try{
            doSomething();
        } catch (Exception e) {
            System.exit(1); // OK, as only there is only one occurrence.
        } 
    }
    void doSomething() {};
}

$ java -jar checkstyle-8.29-all.jar -c config.xml MyClass.java
Starting audit...
Audit done.

$ cat MyClass.java
  class MyClass {
    void myFunction() {
        try {
            doSomething();
            System.exit(0);
        } catch (Exception e) {
            System.exit(1); // violation, as there are more than one occurrence.
        }
    }
    void doSomething(){};
}

$ java -jar .\checkstyle-8.31-SNAPSHOT-all.jar -c .\config.xml .\MyClass.java
   Starting audit...
   [ERROR] F:\FY\gosc\checkstyle\MyClass.java:7: Line matches the illegal pattern 'System.exit\('. 
   [RegexpSingleline]
   Audit done.
   Checkstyle ends with 1 errors.


```

#### Output of default example:
```
$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="RegexpSingleline">
        <property name="format" value="This file is copyrighted"/>
        <property name="minimum" value="1"/>
        <!--  Need to specify a maximum, so 10 times is more than enough. -->
        <property name="maximum" value="10"/>
    </module>
</module>


$ cat MyClass.java
/**
* This file is copyrighted under CC. // Ok, as the file contains a copyright statement.
*/
class MyClass {

}

$ java -jar checkstyle-8.29-all.jar -c config.xml MyClass.java
Starting audit...
Audit done.

$ cat MyClass.java
/** // violation, as the file doesn't contain a copyright statement.
* MyClass as a configuration example.
*/
class MyClass {

}

java -jar checkstyle-8.29-all.jar -c config.xml MyClass.java
Starting audit...
[ERROR] MyClass.java:1: File does not contain at least 1 matches for pattern 'This file is copyrighted'. [RegexpSingleline]
Audit done.
Checkstyle ends with 1 errors.


```
#### Output of example:
```
$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="RegexpSingleline">
        <property name="format" value="license"/>
        <property name="ignoreCase" value="true"/>
        <property name="minimum" value="1"/>
        <property name="maximum" value="9999"/>
        <!--  Configure a message to be shown on violation of the Check. -->
        <property name="message" value="File must contain at least one occurrence of 'license' term"/>
        <!--  Perform the Check only on files with java extension. -->
        <property name="fileExtensions" value="sql" />
    </module>
</module>

$ cat mysql.sql
/*
 AP 2.0 License. // Ok, Check ignores the case of the term.
*/
CREATE DATABASE MyDB;
  

$ java -jar checkstyle-8.29-all.jar -c config.xml mysql.sql
Starting audit...
Audit done.

$ cat mysql.sql
/* // violation, file doesn't contain the term.
 Example sql file.
*/
CREATE DATABASE MyDB;

$ java -jar checkstyle-8.29-all.jar -c config.xml  mysql.sql
Starting audit...
[ERROR] F:\FY\gosc\checkstyle\mysql.sql:1: File must contain at least one occurrence of license term [RegexpSingleline]
Audit done.
Checkstyle ends with 1 errors.


```


## Goal
Add code examples for RegexpSingleline doc
