### PR TITLE
Issue #2410: JavadocStyleCheck: need to support VAR html tag

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -76,7 +76,7 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * <li>
  * Check for allowed HTML tags. The list of allowed HTML tags is
  * "a", "abbr", "acronym", "address", "area", "b", "bdo", "big", "blockquote",
- * "br", "caption", "cite", "code", "colgroup", "dd", "del", "div", "dfn", "dl",
+ * "br", "caption", "cite", "code", "colgroup", "dd", "del", "dfn", "div", "dl",
  * "dt", "em", "fieldset", "font", "h1", "h2", "h3", "h4", "h5", "h6", "hr",
  * "i", "img", "ins", "kbd", "li", "ol", "p", "pre", "q", "samp", "small",
  * "span", "strong", "sub", "sup", "table", "tbody", "td", "tfoot", "th",
@@ -211,7 +211,7 @@ public class JavadocStyleCheck
         Arrays.stream(new String[] {
             "a", "abbr", "acronym", "address", "area", "b", "bdo", "big",
             "blockquote", "br", "caption", "cite", "code", "colgroup", "dd",
-            "del", "div", "dfn", "dl", "dt", "em", "fieldset", "font", "h1",
+            "del", "dfn", "div", "dl", "dt", "em", "fieldset", "font", "h1",
             "h2", "h3", "h4", "h5", "h6", "hr", "i", "img", "ins", "kbd",
             "li", "ol", "p", "pre", "q", "samp", "small", "span", "strong",
             "style", "sub", "sup", "table", "tbody", "td", "tfoot", "th",

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -74,12 +74,13 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * NOT missing from any package-info.java files.
  * </li>
  * <li>
- * Check for allowed HTML tags. The list of allowed HTML tags is "a", "abbr",
- * "acronym", "address", "area", "b", "bdo", "big", "blockquote", "br",
- * "caption", "cite", "code", "colgroup", "dd", "del", "div", "dfn", "dl", "dt",
- * "em", "fieldset", "font", "h1" to "h6", "hr", "i", "img", "ins", "kbd", "li",
- * "ol", "p", "pre", "q", "samp", "small", "span", "strong", "sub", "sup",
- * "table", "tbody", "td", "tfoot", "th", "thread", "tr", "tt", "u", "ul", "var".
+ * Check for allowed HTML tags. The list of allowed HTML tags is
+ * "a", "abbr", "acronym", "address", "area", "b", "bdo", "big", "blockquote",
+ * "br", "caption", "cite", "code", "colgroup", "dd", "del", "div", "dfn", "dl",
+ * "dt", "em", "fieldset", "font", "h1", "h2", "h3", "h4", "h5", "h6", "hr",
+ * "i", "img", "ins", "kbd", "li", "ol", "p", "pre", "q", "samp", "small",
+ * "span", "strong", "sub", "sup", "table", "tbody", "td", "tfoot", "th",
+ * "thead", "tr", "tt", "u", "ul", "var".
  * </li>
  * </ul>
  * <p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -79,7 +79,7 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * "caption", "cite", "code", "colgroup", "dd", "del", "div", "dfn", "dl", "dt",
  * "em", "fieldset", "font", "h1" to "h6", "hr", "i", "img", "ins", "kbd", "li",
  * "ol", "p", "pre", "q", "samp", "small", "span", "strong", "sub", "sup",
- * "table", "tbody", "td", "tfoot", "th", "thread", "tr", "tt", "u", "ul".
+ * "table", "tbody", "td", "tfoot", "th", "thread", "tr", "tt", "u", "ul", "var".
  * </li>
  * </ul>
  * <p>

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -1167,7 +1167,7 @@ public class TestClass {
             Check for allowed HTML tags. The list of allowed HTML tags
             is "a", "abbr", "acronym", "address", "area", "b", "bdo", "big",
             "blockquote", "br", "caption", "cite", "code", "colgroup", "dd",
-            "del", "div", "dfn", "dl", "dt", "em", "fieldset", "font", "h1",
+            "del", "dfn", "div", "dl", "dt", "em", "fieldset", "font", "h1",
             "h2", "h3", "h4", "h5", "h6", "hr", "i", "img", "ins", "kbd", "li",
             "ol", "p", "pre", "q", "samp", "small", "span", "strong", "sub",
             "sup", "table", "tbody", "td", "tfoot", "th", "thead", "tr", "tt",

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -1171,7 +1171,7 @@ public class TestClass {
             "fieldset", "font", "h1" to "h6", "hr", "i", "img", "ins",
             "kbd", "li", "ol", "p", "pre", "q", "samp", "small", "span",
             "strong", "sub", "sup", "table", "tbody", "td", "tfoot", "th",
-            "thread", "tr", "tt", "u", "ul".
+            "thread", "tr", "tt", "u", "ul", "var".
           </li>
         </ul>
 

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -1165,13 +1165,13 @@ public class TestClass {
           </li>
           <li>
             Check for allowed HTML tags. The list of allowed HTML tags
-            is "a", "abbr", "acronym", "address", "area", "b", "bdo",
-            "big", "blockquote", "br", "caption", "cite", "code",
-            "colgroup", "dd", "del", "div", "dfn", "dl", "dt", "em",
-            "fieldset", "font", "h1" to "h6", "hr", "i", "img", "ins",
-            "kbd", "li", "ol", "p", "pre", "q", "samp", "small", "span",
-            "strong", "sub", "sup", "table", "tbody", "td", "tfoot", "th",
-            "thread", "tr", "tt", "u", "ul", "var".
+            is "a", "abbr", "acronym", "address", "area", "b", "bdo", "big",
+            "blockquote", "br", "caption", "cite", "code", "colgroup", "dd",
+            "del", "div", "dfn", "dl", "dt", "em", "fieldset", "font", "h1",
+            "h2", "h3", "h4", "h5", "h6", "hr", "i", "img", "ins", "kbd", "li",
+            "ol", "p", "pre", "q", "samp", "small", "span", "strong", "sub",
+            "sup", "table", "tbody", "td", "tfoot", "th", "thead", "tr", "tt",
+            "u", "ul", "var".
           </li>
         </ul>
 


### PR DESCRIPTION
"var" has already been added as an allowed tag: https://github.com/checkstyle/checkstyle/blob/12c6e69fe7de3d462f5ca117dc4a6f0ba51a1d7c/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java#L209-L218

I've tested it on the latest release:
```
D:\checkstyletest>type config.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">

<module name = "Checker">
    <module name="TreeWalker">
        <module name="JavadocStyle"/>
    </module>
</module>

D:\checkstyletest>type test\Test.java 
/**
 * First sentence.
 * 
 * <div>this is a valid tag</div>
 * <var>this is also a valid tag</var>
 * <foo>this is not a valid tag</foo>
 * 
 */
public class Test {}

D:\checkstyletest>java -jar -Duser.language=en -Duser.country=US checkstyle-8.30-all.jar -c config.xml test\Test.java 
Starting audit...
[ERROR] D:\checkstyletest\test\Test.java:6:32: Extra HTML tag found: </foo> [JavadocStyle]
Audit done.
```
The docs (javadoc and xdoc) seems to be the only thing left to do. Unless I'm missing something out, this looks like a very simple change to resolve #2410.