### PR TITLE
Issue #7522: fix @SuppressWarnings as an annotation property exception

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -399,6 +399,8 @@ public class SuppressWarningsHolder
         switch (parentAST.getType()) {
             case TokenTypes.MODIFIERS:
             case TokenTypes.ANNOTATIONS:
+            case TokenTypes.ANNOTATION:
+            case TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR:
                 targetAST = getAcceptableParent(parentAST);
                 break;
             default:
@@ -437,6 +439,8 @@ public class SuppressWarningsHolder
             case TokenTypes.TYPE_ARGUMENT:
             case TokenTypes.IMPLEMENTS_CLAUSE:
             case TokenTypes.DOT:
+            case TokenTypes.ANNOTATION:
+            case TokenTypes.MODIFIERS:
                 result = parent;
                 break;
             default:

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -380,6 +380,15 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testSuppressWarningsAsAnnotationProperty() throws Exception {
+        final Configuration checkConfig = createModuleConfig(SuppressWarningsHolder.class);
+
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verify(checkConfig, getPath("InputSuppressWarningsHolder7.java"), expected);
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     public void testClearState() throws Exception {
         final SuppressWarningsHolder check = new SuppressWarningsHolder();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder7.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder7.java
@@ -1,0 +1,31 @@
+package com.puppycrawl.tools.checkstyle.checks.suppresswarningsholder;
+
+import java.lang.annotation.*;
+import java.util.List;
+
+public class InputSuppressWarningsHolder7 {
+
+    @TestSwAnnotation(@SuppressWarnings("unchecked"))
+    private List<String> testSwAnnotation;
+
+    @TestSwAnnotationVal(onMethod = @SuppressWarnings("unchecked"))
+    private List<String> testSwAnnotationVal;
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+@interface TestSwAnnotation {
+    SuppressWarnings value();
+}
+
+@Target({ElementType.FIELD, ElementType.TYPE})
+@Retention(RetentionPolicy.SOURCE)
+@interface TestSwAnnotationVal{
+
+    SuppressWarnings[] onMethod() default {};
+
+    @Deprecated
+    @Retention(RetentionPolicy.SOURCE)
+    @Target({})
+    @interface AnyAnnotation {}
+}


### PR DESCRIPTION
Issue #7522 

Add support for using SuppressWarningsHolder with @SuppressWarnings as an annotation property

Examples of a valid code now

@CustomAnnotation(@SuppressWarnings("unchecked")) 

@Getter(onMethod_ = @SuppressWarnings("unchecked"))

Report
https://amrdeveloper.github.io/checkstyle-reports/7522/