### PR TITLE
Issue #7625: Updated doc for NoWhiteSpaceBefore

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheck.java
@@ -61,14 +61,77 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <pre>
  * &lt;module name=&quot;NoWhitespaceBefore&quot;/&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * int foo;
+ * foo ++; // violation, whitespace before '++' is not allowed
+ * foo++; // OK
+ * for (int i = 0 ; i &lt; 5; i++) {}  // violation
+ *            // ^ whitespace before ';' is not allowed
+ * for (int i = 0; i &lt; 5; i++) {} // OK
+ * int[][] array = { { 1, 2 }
+ *                 , { 3, 4 } }; // violation, whitespace before ',' is not allowed
+ * int[][] array2 = { { 1, 2 },
+ *                    { 3, 4 } }; // OK
+ * Lists.charactersOf("foo").listIterator()
+ *        .forEachRemaining(System.out::print)
+ *        ; // violation, whitespace before ';' is not allowed
+ * </pre>
+ * <p>To configure the check to allow linebreaks before default tokens:</p>
+ * <pre>
+ * &lt;module name=&quot;NoWhitespaceBefore&quot;&gt;
+ *   &lt;property name=&quot;allowLineBreaks&quot; value=&quot;true&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * int[][] array = { { 1, 2 }
+ *                 , { 3, 4 } }; // OK, linebreak is allowed before ','
+ * int[][] array2 = { { 1, 2 },
+ *                    { 3, 4 } }; // OK, ideal code
+ * void ellipsisExample(String ...params) {}; // violation, whitespace before '...' is not allowed
+ * void ellipsisExample2(String
+ *                         ...params) {}; //OK, linebreak is allowed before '...'
+ * Lists.charactersOf("foo")
+ *        .listIterator()
+ *        .forEachRemaining(System.out::print); // OK
+ * </pre>
  * <p>
- * To configure the check to allow linebreaks before a DOT token:
+ *     To Configure the check to restrict the use of whitespace before METHOD_REF and DOT tokens:
  * </p>
  * <pre>
  * &lt;module name=&quot;NoWhitespaceBefore&quot;&gt;
+ *   &lt;property name=&quot;tokens&quot; value=&quot;METHOD_REF&quot;/&gt;
+ *   &lt;property name=&quot;tokens&quot; value=&quot;DOT&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * Lists.charactersOf("foo").listIterator()
+ *        .forEachRemaining(System.out::print); // violation, whitespace before '.' is not allowed
+ * Lists.charactersOf("foo").listIterator().forEachRemaining(System.out ::print); // violation,
+ *                           // whitespace before '::' is not allowed  ^
+ * Lists.charactersOf("foo").listIterator().forEachRemaining(System.out::print); // OK
+ * </pre>
+ * <p>
+ *     To configure the check to allow linebreak before METHOD_REF and DOT tokens:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;NoWhitespaceBefore&quot;&gt;
+ *   &lt;property name=&quot;tokens&quot; value=&quot;METHOD_REF&quot;/&gt;
  *   &lt;property name=&quot;tokens&quot; value=&quot;DOT&quot;/&gt;
  *   &lt;property name=&quot;allowLineBreaks&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * Lists .charactersOf("foo") //violation, whitespace before '.' is not allowed
+ *         .listIterator()
+ *         .forEachRemaining(System.out ::print); // violation,
+ *                                  // ^ whitespace before '::' is not allowed
+ * Lists.charactersOf("foo")
+ *        .listIterator()
+ *        .forEachRemaining(System.out::print); // OK
  * </pre>
  *
  * @since 3.0

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -1308,16 +1308,80 @@ public void foo(final char @NotNull [] param) {} // No violation
         <source>
 &lt;module name=&quot;NoWhitespaceBefore&quot;/&gt;
         </source>
-
+        <p>Example:</p>
+        <source>
+int foo;
+foo ++; // violation, whitespace before '++' is not allowed
+foo++; // OK
+for (int i = 0 ; i &lt; 5; i++) {}  // violation
+           // ^ whitespace before ';' is not allowed
+for (int i = 0; i &lt; 5; i++) {} // OK
+int[][] array = { { 1, 2 }
+                , { 3, 4 } }; // violation, whitespace before ',' is not allowed
+int[][] array2 = { { 1, 2 },
+                   { 3, 4 } }; // OK
+Lists.charactersOf("foo").listIterator()
+       .forEachRemaining(System.out::print)
+       ; // violation, whitespace before ';' is not allowed
+        </source>
         <p>
-          To configure the check to allow linebreaks before a DOT token:
+            To configure the check to allow linebreaks before default tokens:
         </p>
         <source>
 &lt;module name=&quot;NoWhitespaceBefore&quot;&gt;
-  &lt;property name=&quot;tokens&quot; value=&quot;DOT&quot;/&gt;
   &lt;property name=&quot;allowLineBreaks&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
         </source>
+        <p>Example:</p>
+        <source>
+int[][] array = { { 1, 2 }
+                , { 3, 4 } }; // OK, linebreak is allowed before ','
+int[][] array2 = { { 1, 2 },
+                   { 3, 4 } }; // OK, ideal code
+void ellipsisExample(String ...params) {}; // violation, whitespace before '...' is not allowed
+void ellipsisExample2(String
+                        ...params) {}; //OK, linebreak is allowed before '...'
+Lists.charactersOf("foo")
+       .listIterator()
+       .forEachRemaining(System.out::print); // OK
+        </source>
+        <p>
+        To Configure the check to restrict the use of whitespace before METHOD_REF and DOT tokens:
+        </p>
+       <source>
+&lt;module name=&quot;NoWhitespaceBefore&quot;&gt;
+  &lt;property name=&quot;tokens&quot; value=&quot;METHOD_REF&quot;/&gt;
+  &lt;property name=&quot;tokens&quot; value=&quot;DOT&quot;/&gt;
+&lt;/module&gt;
+       </source>
+       <p>Example:</p>
+       <source>
+Lists.charactersOf("foo").listIterator()
+       .forEachRemaining(System.out::print); // violation, whitespace before '.' is not allowed
+Lists.charactersOf("foo").listIterator().forEachRemaining(System.out ::print); // violation,
+                          // whitespace before '::' is not allowed  ^
+Lists.charactersOf("foo").listIterator().forEachRemaining(System.out::print); // OK
+       </source>
+       <p>
+           To configure the check to allow linebreak before METHOD_REF and DOT tokens:
+       </p>
+       <source>
+&lt;module name=&quot;NoWhitespaceBefore&quot;&gt;
+  &lt;property name=&quot;tokens&quot; value=&quot;METHOD_REF&quot;/&gt;
+  &lt;property name=&quot;tokens&quot; value=&quot;DOT&quot;/&gt;
+  &lt;property name=&quot;allowLineBreaks&quot; value=&quot;true&quot;/&gt;
+&lt;/module&gt;
+       </source>
+       <p>Example:</p>
+       <source>
+Lists .charactersOf("foo") //violation, whitespace before '.' is not allowed
+        .listIterator()
+        .forEachRemaining(System.out ::print); // violation,
+                                 // ^ whitespace before '::' is not allowed
+Lists.charactersOf("foo")
+       .listIterator()
+       .forEachRemaining(System.out::print); // OK
+       </source>
       </subsection>
 
       <subsection name="Example of Usage" id="NoWhitespaceBefore_Example_of_Usage">


### PR DESCRIPTION
Fixes Issue #7625 
![Screenshot_2020-03-18 checkstyle – Whitespace(1)](https://user-images.githubusercontent.com/48255244/76904348-cc151080-68c5-11ea-8e6a-76863a3cb878.png)

**Default Example**
```
$ cat config.xml

<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">

<module name = "Checker">
    <module name="TreeWalker">
        <module name="NoWhitespaceBefore">         
    </module>
    </module>
</module>

$ cat Test.java

class Test {
  void defaultTest() {
    int foo;
    foo ++; // violation, whitespace before '++' is not allowed
    foo++; // OK
    for (int i = 0 ; i < 5; i++) {}  // violation
              // ^ whitespace before ';' is not allowed
    for (int i = 0; i < 5; i++) {} // OK
    int[][] array = { { 1, 2 }
                    , { 3, 4 } }; // violation, whitespace before ',' is not allowed
    int[][] array2 = { { 1, 2 },
                      { 3, 4 } }; // OK
    Lists.charactersOf("foo").listIterator()
          .forEachRemaining(System.out::print)
	  ; // violation, whitespace before '.' is not allowed       
   }
}

$ java -jar checkstyle-8.30-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /home/abhishek99/GSoC/NoWhitespaceBefore/Test.java:4:9: '++' is preceded with whitespace. [NoWhitespaceBefore]
[ERROR] /home/abhishek99/GSoC/NoWhitespaceBefore/Test.java:6:20: ';' is preceded with whitespace. [NoWhitespaceBefore]
[ERROR] /home/abhishek99/GSoC/NoWhitespaceBefore/Test.java:10:21: ',' is preceded with whitespace. [NoWhitespaceBefore]
[ERROR] /home/abhishek99/GSoC/NoWhitespaceBefore/Test.java:15:11: ';' is preceded with whitespace. [NoWhitespaceBefore]
Audit done.
Checkstyle ends with 3 errors.
```
**Non- Default Example**
```
cat config.xml

<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">

<module name = "Checker">
    <module name="TreeWalker">
        <module name="NoWhitespaceBefore">    
            <property name="allowLineBreaks" value="true"/>     
        </module>
    </module>
</module>

$ cat Test.java

class Test {
  void config2() {
    int[][] array = { { 1, 2 }
                    , { 3, 4 } }; // OK, linebreak is allowed before ','
    int[][] array2 = { { 1, 2 },
                       { 3, 4 } }; // OK, ideal code
    Lists.charactersOf("foo")
    .listIterator()
    .forEachRemaining(System.out::print); // OK 
   }
   void ellipsisExample(String ...params) {}; // violation, whitespace before '...' is not allowed
   void ellipsisExample2(String
            ...params) {}; //OK, linebreak is allowed before '...'

}

$ java -jar checkstyle-8.30-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /home/abhishek99/GSoC/NoWhitespaceBefore/Test.java:11:32: '...' is preceded with whitespace. [NoWhitespaceBefore]
Audit done.
Checkstyle ends with 1 errors.
```
```
$ cat config.xml

<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">

<module name = "Checker">
    <module name="TreeWalker">
        <module name="NoWhitespaceBefore">    
            <property name="tokens" value="METHOD_REF"/>
            <property name="tokens" value="DOT"/>
        </module>
    </module>
</module>

$ cat Test.java

class Test {
  void config3() {
    Lists.charactersOf("foo").listIterator()
       .forEachRemaining(System.out::print); // violation, whitespace before '.' is not allowed
    Lists.charactersOf("foo").listIterator().forEachRemaining(System.out ::print); // violation,
                              // whitespace before '::' is not allowed  ^
    Lists.charactersOf("foo").listIterator().forEachRemaining(System.out::print); // OK
  }
}

$ java -jar checkstyle-8.30-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /home/abhishek99/GSoC/NoWhitespaceBefore/Test.java:4:8: '.' is preceded with whitespace. [NoWhitespaceBefore]
[ERROR] /home/abhishek99/GSoC/NoWhitespaceBefore/Test.java:5:74: '::' is preceded with whitespace. [NoWhitespaceBefore]
Audit done.
Checkstyle ends with 2 errors.
```
```
$ cat config.xml

<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">

<module name = "Checker">
    <module name="TreeWalker">
        <module name="NoWhitespaceBefore">    
           <property name="tokens" value="METHOD_REF"/>
           <property name="tokens" value="DOT"/>
           <property name="allowLineBreaks" value="true"/>
        </module>
    </module>
</module>

$ cat Test.java

class Test {
  void config4() {
    Lists .charactersOf("foo") //violation, whitespace before '.' is not allowed
            .listIterator()
            .forEachRemaining(System.out ::print); // violation,
                                    // ^ whitespace before '::' is not allowed
    Lists.charactersOf("foo")
          .listIterator()
          .forEachRemaining(System.out::print); // OK
  }
}

$ java -jar checkstyle-8.30-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /home/abhishek99/GSoC/NoWhitespaceBefore/Test.java:3:11: '.' is preceded with whitespace. [NoWhitespaceBefore]
[ERROR] /home/abhishek99/GSoC/NoWhitespaceBefore/Test.java:5:42: '::' is preceded with whitespace. [NoWhitespaceBefore]
Audit done.
Checkstyle ends with 2 errors.
```