### PR TITLE
issue #7645: Update doc for IllegalToken

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenCheck.java
@@ -51,15 +51,29 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <pre>
  * &lt;module name=&quot;IllegalToken&quot;/&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public void myTest() {
+ *     outer: // violation
+ *     for (int i = 0; i &lt; 5; i++) {
+ *         if (i == 1) {
+ *             break outer;
+ *         }
+ *     }
+ * }
+ * </pre>
  * <p>
- * To configure the check to find token LITERAL_NATIVE:
+ * To configure the check to report violation on token LITERAL_NATIVE:
  * </p>
  * <pre>
  * &lt;module name=&quot;IllegalToken&quot;&gt;
  *   &lt;property name=&quot;tokens&quot; value=&quot;LITERAL_NATIVE&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
- *
+ * <p>Example:</p>
+ * <pre>
+ * public native void myTest(); // violation
+ * </pre>
  * @since 3.2
  */
 @StatelessCheck

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -2135,14 +2135,33 @@ class SomeClass
         <source>
 &lt;module name=&quot;IllegalToken&quot;/&gt;
         </source>
+          <p>Example:</p>
+          <div class="wrapper">
+          <pre>
+public void myTest() {
+    outer: // violation
+    for (int i = 0; i &lt; 5; i++) {
+        if (i == 1) {
+            break outer;
+        }
+    }
+}
+          </pre>
+          </div>
         <p>
-          To configure the check to find token LITERAL_NATIVE:
+          To configure the check to report violation on token LITERAL_NATIVE:
         </p>
         <source>
 &lt;module name=&quot;IllegalToken&quot;&gt;
   &lt;property name=&quot;tokens&quot; value=&quot;LITERAL_NATIVE&quot;/&gt;
 &lt;/module&gt;
         </source>
+          <p>Example:</p>
+          <div class="wrapper">
+              <pre>
+public native void myTest(); // violation
+              </pre>
+          </div>
       </subsection>
 
       <subsection name="Example of Usage" id="IllegalToken_Example_of_Usage">


### PR DESCRIPTION
issue: #7645: Update doc for IllegalToken
<img width="599" alt="WechatIMG24" src="https://user-images.githubusercontent.com/50866227/75976299-218c0d80-5f15-11ea-8309-ff9714d89adf.png">


Ouput of default example:
$ cat config.xml
```xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="TreeWalker">
        <module name="IllegalToken"/>
    </module>
```
    
$ cat Test.java
```java
public class Test {

    public void myTest() {
        outer: // violation
        for (int i = 0; i < 5; i++) {
            if (i == 1) {
                break outer;
            }
        }
    }
}
```

$ RUN_LOCALE="-Duser.language=en -Duser.country=US"
$ java $RUN_LOCALE -jar /var/tmp/checkstyle-8.31-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /Users/hgh/Downloads/my_file/IDEA_workspace/Leetcode_maven/engineering_ability/src/main/java/Test.java:4:14: Using 'outer:' is not allowed. [IllegalToken]
Audit done.
Checkstyle ends with 1 errors.

Ouput of configure the check to find token LITERAL_NATIVE example:
$ cat config.xml 
```xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="TreeWalker">
        <module name="IllegalToken">
            <property name="tokens" value="LITERAL_NATIVE"/>
        </module>
    </module>
</module>
```
$ cat Test.java
```java
public class Test {

    public native void myTest();      // violation

}
```
$ RUN_LOCALE="-Duser.language=en -Duser.country=US"
$ java $RUN_LOCALE -jar /var/tmp/checkstyle-8.31-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /Users/hgh/Downloads/my_file/IDEA_workspace/Leetcode_maven/engineering_ability/src/main/java/Test2.java:3:12: Using 'native' is not allowed. [IllegalToken]
Audit done.
Checkstyle ends with 1 errors.

