### PR TITLE
Issue #7642: Update doc for IllegalCatch

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
@@ -56,7 +56,79 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
  * <pre>
  * &lt;module name=&quot;IllegalCatch&quot;/&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * try {
+ *     // some code here
+ * } catch (Exception e) { // violation
  *
+ * }
+ *
+ * try {
+ *     // some code here
+ * } catch (ArithmeticException e) { // OK
+ *
+ * } catch (Exception e) { // violation, catching Exception is illegal
+ *                           and order of catch blocks doesn't matter
+ * }
+ *
+ * try {
+ *     // some code here
+ * } catch (ArithmeticException | Exception e) { // violation, catching Exception is illegal
+ *
+ * }
+ *
+ * try {
+ *     // some code here
+ * } catch (ArithmeticException e) { // OK
+ *
+ * }
+ *
+ * </pre>
+ * <p>
+ * To configure the check to override the default list
+ * with ArithmeticException and OutOfMemoryError:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;IllegalCatch&quot;&gt;
+ *   &lt;property name=&quot;illegalClassNames&quot; value=&quot;ArithmeticException,
+ *               OutOfMemoryError&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * try {
+ *     // some code here
+ * } catch (OutOfMemoryError e) { // violation
+ *
+ * }
+ *
+ * try {
+ *     // some code here
+ * } catch (ArithmeticException e) { // violation
+ *
+ * }
+ *
+ * try {
+ *     // some code here
+ * } catch (NullPointerException e) { // OK
+ *
+ * } catch (OutOfMemoryError e) { // violation
+ *
+ * }
+ *
+ * try {
+ *     // some code here
+ * } catch (ArithmeticException | Exception e) {  // violation
+ *
+ * }
+ *
+ * try {
+ *     // some code here
+ * } catch (Exception e) { // OK
+ *
+ * }
+ * </pre>
  * @since 3.2
  */
 @StatelessCheck

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -1808,6 +1808,82 @@ class SomeClass
         <source>
 &lt;module name=&quot;IllegalCatch&quot;/&gt;
         </source>
+          <p>
+              Example:
+          </p>
+        <source>
+try {
+    // some code here
+} catch (Exception e) { // violation
+
+}
+
+try {
+    // some code here
+} catch (ArithmeticException e) { // OK
+
+} catch (Exception e) { // violation, catching Exception is illegal
+                          and order of catch blocks doesn't matter
+}
+
+try {
+    // some code here
+} catch (ArithmeticException | Exception e) { // violation, catching Exception is illegal
+
+}
+
+try {
+    // some code here
+} catch (ArithmeticException e) { // OK
+
+}
+          </source>
+          <p>
+              To configure the check to override the default list with
+              ArithmeticException and OutOfMemoryError:
+          </p>
+          <source>
+&lt;module name=&quot;IllegalCatch&quot;&gt;
+  &lt;property name=&quot;illegalClassNames&quot; value=&quot;ArithmeticException,
+              OutOfMemoryError&quot;/&gt;
+&lt;/module&gt;
+          </source>
+          <p>
+              Example:
+          </p>
+          <source>
+try {
+    // some code here
+} catch (OutOfMemoryError e) { // violation
+
+}
+
+try {
+    // some code here
+} catch (ArithmeticException e) { // violation
+
+}
+
+try {
+    // some code here
+} catch (NullPointerException e) { // OK
+
+} catch (OutOfMemoryError e) { // violation
+
+}
+
+try {
+    // some code here
+} catch (ArithmeticException | Exception e) {  // violation
+
+}
+
+try {
+    // some code here
+} catch (Exception e) { // OK
+
+}
+          </source>
       </subsection>
 
       <subsection name="Example of Usage" id="IllegalCatch_Example_of_Usage">


### PR DESCRIPTION
Fixes Issue #7642 
![n1](https://user-images.githubusercontent.com/23253816/76160425-415b4580-6150-11ea-9645-dcd7558facff.png)
![n2](https://user-images.githubusercontent.com/23253816/76160428-43250900-6150-11ea-87df-370d3d2337be.png)

Output for default example:
```
$ cat config.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
      "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
      "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="IllegalCatch"/>
  </module>
</module>

$ cat test.java 
class test{
    public static void main(String[] args)
    {
        try {
            // do stuff
        } catch (Exception e) { // Violation

        }

        try {
            // do stuff
        } catch (ArithmeticException e) {
            
        } catch (Exception e) { //Violation, one of the exception is declared to be illegal and order of multi-catch blocks doesn't matter

        }

        try {
            // do stuff
        } catch (ArithmeticException | Exception e) {  Violation, one of the exception is declared to be illegal
            
        }

        try {
            // do stuff
        } catch (ArithmeticException e) { // OK

        }        
    }
}

$ java -jar checkstyle-8.29-SNAPSHOT-all.jar -c config.xml test.java
Starting audit...
[ERROR] /home/gaurab/Workspace/checkstyle-test/test.java:6:11: Catching 'Exception' is not allowed. [IllegalCatch]
[ERROR] /home/gaurab/Workspace/checkstyle-test/test.java:14:11: Catching 'Exception' is not allowed. [IllegalCatch]
[ERROR] /home/gaurab/Workspace/checkstyle-test/test.java:20:11: Catching 'Exception' is not allowed. [IllegalCatch]
Audit done.
Checkstyle ends with 3 errors.
              
```
Output for non-default example:
```
$ cat config.xml                                                    
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
      "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
      "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="IllegalCatch">
      <property name="illegalClassNames" value="ArithmeticException, OutOfMemoryError"/>
    </module>
  </module>
</module>

$ cat test.java
 class test{
     public static void main(String[] args){
        try {
            // some code here
        } catch (OutOfMemoryError e) { // violation
        
        }
        
        try {
            // some code here
        } catch (ArithmeticException e) { // violation
        
        }
        
        try {
            // some code here
        } catch (NullPointerException e) {
        
        } catch (OutOfMemoryError e) { // violation, catching OutOfMemoryError is illegal
        
        }
        
        try {
            // some code here
        } catch (ArithmeticException | Exception e) {  // violation
        
        }
        
        try {
            // some code here
        } catch (Exception e) { // OK
        
        }
     }
 }


$ java -jar checkstyle-8.29-all.jar -c config.xml test.java
Starting audit...
[ERROR] /home/gaurabdg/Workspace/checkstyle-try/test.java:5:11: Catching 'OutOfMemoryError' is not allowed. [IllegalCatch]
[ERROR] /home/gaurabdg/Workspace/checkstyle-try/test.java:11:11: Catching 'ArithmeticException' is not allowed. [IllegalCatch]
[ERROR] /home/gaurabdg/Workspace/checkstyle-try/test.java:19:11: Catching 'OutOfMemoryError' is not allowed. [IllegalCatch]
[ERROR] /home/gaurabdg/Workspace/checkstyle-try/test.java:25:11: Catching 'ArithmeticException' is not allowed. [IllegalCatch]
Audit done.
Checkstyle ends with 4 errors.
```