### PR TITLE
Issue #7646: Update doc for IllegalTokenText

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
@@ -60,6 +60,31 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *   &lt;property name=&quot;format&quot; value=&quot;a href&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public void myTest() {
+ *     String test = "a href"; // violation
+ *     String test2 = "A href"; // OK, case is sensitive
+ * }
+ * </pre>
+ * <p>
+ * To configure the check to forbid String literals containing {@code "a href"}
+ * for the ignoreCase mode:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;IllegalTokenText&quot;&gt;
+ *   &lt;property name=&quot;tokens&quot; value=&quot;STRING_LITERAL&quot;/&gt;
+ *   &lt;property name=&quot;format&quot; value=&quot;a href&quot;/&gt;
+ *   &lt;property name=&quot;ignoreCase&quot; value=&quot;true&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public void myTest() {
+ *     String test = "a href"; // violation
+ *     String test2 = "A href"; // violation, case is ignored
+ * }
+ * </pre>
  * <p>
  * To configure the check to forbid leading zeros in an integer literal,
  * other than zero and a hex literal:
@@ -70,6 +95,17 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *   &lt;property name=&quot;format&quot; value=&quot;^0[^lx]&quot;/&gt;
  *   &lt;property name=&quot;ignoreCase&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public void myTest() {
+ *     int test1 = 0; // OK
+ *     int test2 = 0x111; // OK
+ *     int test3 = 0X111; // OK, case is ignored
+ *     int test4 = 010; // violation
+ *     long test5 = 0L; // OK
+ *     long test6 = 010L; // violation
+ * }
  * </pre>
  *
  * @since 3.2

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -2279,7 +2279,31 @@ public native void myTest(); // violation
   &lt;property name=&quot;format&quot; value=&quot;a href&quot;/&gt;
 &lt;/module&gt;
         </source>
-
+          <p>Example:</p>
+          <source>
+public void myTest() {
+    String test = "a href"; // violation
+    String test2 = "A href"; // OK, case is sensitive
+}
+          </source>
+        <p>
+            To configure the check to forbid String literals containing
+            <code>&quot;a href&quot;</code> for the ignoreCase mode:
+        </p>
+        <source>
+&lt;module name=&quot;IllegalTokenText&quot;&gt;
+  &lt;property name=&quot;tokens&quot; value=&quot;STRING_LITERAL&quot;/&gt;
+  &lt;property name=&quot;format&quot; value=&quot;a href&quot;/&gt;
+  &lt;property name=&quot;ignoreCase&quot; value=&quot;true&quot;/&gt;
+&lt;/module&gt;
+        </source>
+          <p>Example:</p>
+          <source>
+public void myTest() {
+    String test = "a href"; // violation
+    String test2 = "A href"; // violation, case is ignored
+}
+          </source>
         <p>
           To configure the check to forbid leading zeros in an integer
           literal, other than zero and a hex literal:
@@ -2291,6 +2315,17 @@ public native void myTest(); // violation
   &lt;property name=&quot;ignoreCase&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
         </source>
+          <p>Example:</p>
+          <source>
+public void myTest() {
+    int test1 = 0; // OK
+    int test2 = 0x111; // OK
+    int test3 = 0X111; // OK, case is ignored
+    int test4 = 010; // violation
+    long test5 = 0L; // OK
+    long test6 = 010L; // violation
+}
+          </source>
       </subsection>
 
       <subsection name="Example of Usage" id="IllegalTokenText_Example_of_Usage">


### PR DESCRIPTION
Issue #7646: Update doc for IllegalTokenText

<img width="780" alt="image" src="https://user-images.githubusercontent.com/50866227/76160956-7d4ed480-6169-11ea-8197-ff73207e9ca6.png">


Output of configure to configure the check to forbid String literals containing "a href": 
$ cat config.xml
```xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="TreeWalker">
        <module name="IllegalTokenText">
            <property name="tokens" value="STRING_LITERAL"/>
            <property name="format" value="a href"/>
        </module>
    </module>
</module>
```
$ cat Test.java
```java
public class Test {

    public void myTest() {
        String test = "a href"; // violation
    }
}
```
$ RUN_LOCALE="-Duser.language=en -Duser.country=US"
$ java $RUN_LOCALE -jar /var/tmp/checkstyle-8.31-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /var/tmp/Test.java:4:23: Token text matches the illegal pattern 'a href'. [IllegalTokenText]
Audit done.
Checkstyle ends with 1 errors.

Output of  to configure the check to forbid leading zeros in an integer literal, other than zero and a hex literal:
$ cat config.xml
```xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="TreeWalker">
        <module name="IllegalTokenText">
            <property name="tokens" value="NUM_INT,NUM_LONG"/>
            <property name="format" value="^0[^lx]"/>
            <property name="ignoreCase" value="true"/>
        </module>
    </module>
</module>
```
$ cat Test.java
```java
public class Test {

    public void myTest() {
        int test1 = 0; // OK
        int test2 = 0x111; // OK
        int test3 = 0X111; // OK, case is ignored
        int test4 = 010; // violation
        long test5 = 0L; // OK
        long test6 = 010L; // violation
    }
}
```
$ RUN_LOCALE="-Duser.language=en -Duser.country=US"
$ java $RUN_LOCALE -jar /var/tmp/checkstyle-8.31-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /Users/hgh/Downloads/my_file/IDEA_workspace/Leetcode_maven/engineering_ability/src/main/java/checkstyle_demo/illegalTokenText/Test.java:9:21: Token text matches the illegal pattern '^0[^lx]'. [IllegalTokenText]
[ERROR] /Users/hgh/Downloads/my_file/IDEA_workspace/Leetcode_maven/engineering_ability/src/main/java/checkstyle_demo/illegalTokenText/Test.java:11:22: Token text matches the illegal pattern '^0[^lx]'. [IllegalTokenText]
Audit done.
Checkstyle ends with 2 errors.
