### PR TITLE
Issue #7573: update doc for MissingOverride

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
@@ -72,6 +72,32 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <pre>
  * &lt;module name=&quot;MissingOverride&quot;/&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * class Test extends SuperClass {
+ *
+ *     &#47;** {&#64;inheritDoc} *&#47;
+ *     &#64;Override
+ *     public void test1() { // OK
+ *
+ *     }
+ *
+ *     &#47;** {&#64;inheritDoc} *&#47;
+ *     public void test2() { // violation, should be annotated with &#64;Override
+ *
+ *     }
+ *
+ *     &#47;** {&#64;inheritDoc} *&#47;
+ *     private void test3() { // violation, using the &#64;inheritDoc tag on private method
+ *
+ *     }
+ *
+ *     &#47;** {&#64;inheritDoc} *&#47;
+ *     public static void test4() { // violation, using the &#64;inheritDoc tag on static method
+ *
+ *     }
+ * }
+ * </pre>
  * <p>
  * To configure the check for the {@code javaFiveCompatibility} mode:
  * </p>
@@ -80,6 +106,47 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *   &lt;property name="javaFiveCompatibility"
  *       value="true"/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * class Test1 {
+ *
+ *     &#47;** {&#64;inheritDoc} *&#47;
+ *     public void equals() { // violation, should be annotated with &#64;Override
+ *
+ *     }
+ * }
+ *
+ * interface Test2 {
+ *
+ *     &#47;** {&#64;inheritDoc} *&#47;
+ *     void test(); // violation, should be annotated with &#64;Override
+ * }
+ *
+ * class Test3 extends SuperClass {
+ *
+ *     &#47;** {&#64;inheritDoc} *&#47;
+ *     public void test() { // OK, is ignored because class extends other class
+ *
+ *     }
+ * }
+ *
+ * class Test4 implements SuperInterface {
+ *
+ *     &#47;** {&#64;inheritDoc} *&#47;
+ *     public void test() { // OK, is ignored because class implements interface
+ *
+ *     }
+ * }
+ *
+ * class Test5 {
+ *     Runnable r = new Runnable() {
+ *          &#47;** {&#64;inheritDoc} *&#47;
+ *          public void run() { // OK, is ignored because class is anonymous class
+ *
+ *          }
+ *     };
+ * }
  * </pre>
  *
  * @since 5.0

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -738,7 +738,32 @@ public static final int COUNTER = 10; // violation
         <source>
 &lt;module name=&quot;MissingOverride&quot;/&gt;
         </source>
+        <p>Example:</p>
+        <source>
+class Test extends SuperClass {
 
+    /** {@inheritDoc} */
+    @Override
+    public void test1() { // OK
+
+    }
+
+    /** {@inheritDoc} */
+    public void test2() { // violation, should be annotated with @Override
+
+    }
+
+    /** {@inheritDoc} */
+    private void test3() { // violation, using the @inheritDoc tag on private method
+
+    }
+
+    /** {@inheritDoc} */
+    public static void test4() { // violation, using the @inheritDoc tag on static method
+
+    }
+}
+        </source>
         <p>
           To configure the check for the <code>javaFiveCompatibility</code>
           mode:
@@ -748,6 +773,48 @@ public static final int COUNTER = 10; // violation
   &lt;property name=&quot;javaFiveCompatibility&quot;
       value=&quot;true&quot;/&gt;
 &lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+class Test1 {
+
+    /** {@inheritDoc} */
+    public void equals() { // violation, should be annotated with @Override
+
+    }
+}
+
+interface Test2 {
+
+    /** {@inheritDoc} */
+    void test(); // violation, should be annotated with @Override
+}
+
+class Test3 extends SuperClass {
+
+    /** {@inheritDoc} */
+    public void test() { // OK, is ignored because class extends other class
+
+    }
+}
+
+class Test4 implements SuperInterface {
+
+    /** {@inheritDoc} */
+    public void test() { // OK, is ignored because class implements interface
+
+    }
+}
+
+class Test5 {
+    Runnable r = new Runnable() {
+
+        /** {@inheritDoc} */
+        public void run() { // OK, is ignored because class is anonymous class
+
+        }
+    };
+}
         </source>
       </subsection>
 


### PR DESCRIPTION
Issue #7573: update doc for MissingOverride

<img width="748" alt="image" src="https://user-images.githubusercontent.com/50866227/76333962-5fca6800-632d-11ea-928f-7987298a4ffa.png">
<img width="732" alt="image" src="https://user-images.githubusercontent.com/50866227/76333989-6bb62a00-632d-11ea-9501-a2b5979865b7.png">

Ouput of default example:
$ cat config.xml
```xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="MissingOverride"/>
    </module>
</module>

```

$ cat Test.java
```java
class Test extends SuperClass {

    /** {@inheritDoc} */
    @Override
    public void test1() { // OK

    }

    /** {@inheritDoc} */
    public void test2() { // violation, should be annotated with &#64;Override

    }

    /** {@inheritDoc} */
    private void test3() { // violation, using the @inheritDoc tag on private method that is not valid

    }

    /** {@inheritDoc} */
    public static void test4() { // violation, using the @inheritDoc tag on static method that is not valid

    }

}
```
$ RUN_LOCALE="-Duser.language=en -Duser.country=US"
$ java $RUN_LOCALE -jar /var/tmp/checkstyle-8.31-SNAPSHOT-all.jar -c config.xml Test2.java
Starting audit...
[ERROR] /var/tmp/Test.java:10: Must include @java.lang.Override annotation when {@inheritDoc} Javadoc tag exists. [MissingOverride]
[ERROR]  /var/tmp/Test.java:15: The Javadoc {@inheritDoc} tag is not valid at this location. [MissingOverride]
[ERROR]  /var/tmp/Test.java:20: The Javadoc {@inheritDoc} tag is not valid at this location. [MissingOverride]
Audit done.
Checkstyle ends with 3 errors.


Ouput of configure the check for the javaFiveCompatibility mode:
$ cat config.xml 

```xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="MissingOverride">
            <property name="javaFiveCompatibility"
                      value="true"/>
        </module>
    </module>
</module>

```
$ cat Test.java
```java
class Test1 {

    /** {@inheritDoc} */
    public void equals() { // violation, should be annotated with &#64;Override

    }
}

interface Test2 {

    /** {@inheritDoc} */
    public abstract void test(); // violation, should be annotated with &#64;Override

}

class Test3 extends SuperClass {

    /** {@inheritDoc} */
    public void test() { // OK, is ignored because class extends other class

    }
}

class Test4 implements SuperInterface {

    /** {@inheritDoc} */
    public void test() { // OK, is ignored because class implements interface

    }
}

class Test5 {
    Runnable r = new Runnable() {

        /** {@inheritDoc} */
        public void run() { // OK, is ignored because class is anonymous class

        }
    };
}
```
$ RUN_LOCALE="-Duser.language=en -Duser.country=US"
$ java $RUN_LOCALE -jar /var/tmp/checkstyle-8.31-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /var/tmp/Test.java:4: Must include @java.lang.Override annotation when {@inheritDoc} Javadoc tag exists. [MissingOverride]
[ERROR]  /var/tmp/Test.java:12: Must include @java.lang.Override annotation when {@inheritDoc} Javadoc tag exists. [MissingOverride]
Audit done.
Checkstyle ends with 2 errors.

