### PR TITLE
Issue #7754: Update AbstractChecks to log DetailAST - OneTopLevelClass

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/OneTopLevelClassTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/OneTopLevelClassTest.java
@@ -39,12 +39,12 @@ public class OneTopLevelClassTest extends AbstractGoogleModuleTestSupport {
         final String messageKey = "one.top.level.class";
 
         final String[] expected = {
-            "25: " + getCheckMessage(clazz, messageKey, "NoSuperClone"),
-            "33: " + getCheckMessage(clazz, messageKey, "InnerClone"),
-            "50: " + getCheckMessage(clazz, messageKey, "CloneWithTypeArguments"),
-            "55: " + getCheckMessage(clazz, messageKey, "CloneWithTypeArgumentsAndNoSuper"),
-            "60: " + getCheckMessage(clazz, messageKey, "MyClassWithGenericSuperMethod"),
-            "77: " + getCheckMessage(clazz, messageKey, "AnotherClass"),
+            "25:1: " + getCheckMessage(clazz, messageKey, "NoSuperClone"),
+            "33:1: " + getCheckMessage(clazz, messageKey, "InnerClone"),
+            "50:1: " + getCheckMessage(clazz, messageKey, "CloneWithTypeArguments"),
+            "55:1: " + getCheckMessage(clazz, messageKey, "CloneWithTypeArgumentsAndNoSuper"),
+            "60:1: " + getCheckMessage(clazz, messageKey, "MyClassWithGenericSuperMethod"),
+            "77:1: " + getCheckMessage(clazz, messageKey, "AnotherClass"),
         };
 
         final Configuration checkConfig = getModuleConfig("OneTopLevelClass");
@@ -71,7 +71,7 @@ public class OneTopLevelClassTest extends AbstractGoogleModuleTestSupport {
         final String messageKey = "one.top.level.class";
 
         final String[] expected = {
-            "4: " + getCheckMessage(clazz, messageKey, "FooEnum"),
+            "4:1: " + getCheckMessage(clazz, messageKey, "FooEnum"),
         };
 
         final Configuration checkConfig = getModuleConfig("OneTopLevelClass");
@@ -87,8 +87,8 @@ public class OneTopLevelClassTest extends AbstractGoogleModuleTestSupport {
         final String messageKey = "one.top.level.class";
 
         final String[] expected = {
-            "5: " + getCheckMessage(clazz, messageKey, "FooIn"),
-            "7: " + getCheckMessage(clazz, messageKey, "FooClass"),
+            "5:1: " + getCheckMessage(clazz, messageKey, "FooIn"),
+            "7:1: " + getCheckMessage(clazz, messageKey, "FooClass"),
         };
 
         final Configuration checkConfig = getModuleConfig("OneTopLevelClass");

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOneTopLevelClassTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOneTopLevelClassTest.java
@@ -1,0 +1,62 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.design.OneTopLevelClassCheck;
+
+public class XpathRegressionOneTopLevelClassTest extends AbstractXpathTestSupport {
+
+    private final String checkName = OneTopLevelClassCheck.class.getSimpleName();
+
+    @Override
+    protected String getCheckName() {
+        return checkName;
+    }
+
+    @Test
+    public void testOne() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionOneTopLevelClass.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(OneTopLevelClassCheck.class);
+
+        final String[] expectedViolation = {
+            "7:1: " + getCheckMessage(OneTopLevelClassCheck.class,
+                OneTopLevelClassCheck.MSG_KEY, "ViolatingSecondClass"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='ViolatingSecondClass']]",
+                "/CLASS_DEF[./IDENT[@text='ViolatingSecondClass']]/MODIFIERS",
+                "/CLASS_DEF[./IDENT[@text='ViolatingSecondClass']]/LITERAL_CLASS"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/onetoplevelclass/SuppressionXpathRegressionOneTopLevelClass.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/onetoplevelclass/SuppressionXpathRegressionOneTopLevelClass.java
@@ -1,0 +1,9 @@
+package org.checkstyle.suppressionxpathfilter.onetoplevelclass;
+
+public class SuppressionXpathRegressionOneTopLevelClass {
+    // methods
+}
+
+class ViolatingSecondClass { //warn
+    // methods
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -143,9 +143,6 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * NoLineWrap
  * </li>
  * <li>
- * OneTopLevelClass
- * </li>
- * <li>
  * OuterTypeFilename
  * </li>
  * <li>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheckTest.java
@@ -62,10 +62,10 @@ public class OneTopLevelClassCheckTest extends AbstractModuleTestSupport {
         };
 
         final List<String> expectedFirstInput = Collections.singletonList(
-            "10: " + getCheckMessage(MSG_KEY, "InputDeclarationOrderEnum"));
+            "10:1: " + getCheckMessage(MSG_KEY, "InputDeclarationOrderEnum"));
         final List<String> expectedSecondInput = Arrays.asList(
-            "3: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassInterface2inner1"),
-            "11: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassInterface2inner2"));
+            "3:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassInterface2inner1"),
+            "11:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassInterface2inner2"));
 
         verify(createChecker(checkConfig), inputs,
             ImmutableMap.of(firstInputFilePath, expectedFirstInput,
@@ -111,7 +111,7 @@ public class OneTopLevelClassCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig =
                 createModuleConfig(OneTopLevelClassCheck.class);
         final String[] expected = {
-            "8: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassNoPublic2"),
+            "8:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassNoPublic2"),
         };
         verify(checkConfig, getPath("InputOneTopLevelClassNoPublic.java"), expected);
     }
@@ -121,8 +121,8 @@ public class OneTopLevelClassCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig =
                 createModuleConfig(OneTopLevelClassCheck.class);
         final String[] expected = {
-            "3: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassInterface2inner1"),
-            "11: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassInterface2inner2"),
+            "3:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassInterface2inner1"),
+            "11:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassInterface2inner2"),
         };
         verify(checkConfig, getPath("InputOneTopLevelClassInterface2.java"), expected);
     }
@@ -132,8 +132,8 @@ public class OneTopLevelClassCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig =
                 createModuleConfig(OneTopLevelClassCheck.class);
         final String[] expected = {
-            "3: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassEnum2inner1"),
-            "11: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassEnum2inner2"),
+            "3:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassEnum2inner1"),
+            "11:1: " + getCheckMessage(MSG_KEY, "InputOneTopLevelClassEnum2inner2"),
         };
         verify(checkConfig, getPath("InputOneTopLevelClassEnum2.java"), expected);
     }
@@ -143,13 +143,13 @@ public class OneTopLevelClassCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig =
             createModuleConfig(OneTopLevelClassCheck.class);
         final String[] expected = {
-            "25: " + getCheckMessage(MSG_KEY, "NoSuperClone"),
-            "29: " + getCheckMessage(MSG_KEY, "InnerClone"),
-            "33: " + getCheckMessage(MSG_KEY, "CloneWithTypeArguments"),
-            "37: " + getCheckMessage(MSG_KEY, "CloneWithTypeArgumentsAndNoSuper"),
-            "41: " + getCheckMessage(MSG_KEY, "MyClassWithGenericSuperMethod"),
-            "45: " + getCheckMessage(MSG_KEY, "AnotherClass"),
-            "48: " + getCheckMessage(MSG_KEY, "NativeTest"),
+            "25:1: " + getCheckMessage(MSG_KEY, "NoSuperClone"),
+            "29:1: " + getCheckMessage(MSG_KEY, "InnerClone"),
+            "33:1: " + getCheckMessage(MSG_KEY, "CloneWithTypeArguments"),
+            "37:1: " + getCheckMessage(MSG_KEY, "CloneWithTypeArgumentsAndNoSuper"),
+            "41:1: " + getCheckMessage(MSG_KEY, "MyClassWithGenericSuperMethod"),
+            "45:1: " + getCheckMessage(MSG_KEY, "AnotherClass"),
+            "48:1: " + getCheckMessage(MSG_KEY, "NativeTest"),
         };
         verify(checkConfig, getPath("InputOneTopLevelClassClone.java"), expected);
     }
@@ -159,7 +159,7 @@ public class OneTopLevelClassCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig =
             createModuleConfig(OneTopLevelClassCheck.class);
         final String[] expected = {
-            "10: " + getCheckMessage(MSG_KEY, "InputDeclarationOrderEnum"),
+            "10:1: " + getCheckMessage(MSG_KEY, "InputDeclarationOrderEnum"),
         };
         verify(checkConfig, getPath("InputOneTopLevelClassDeclarationOrder.java"), expected);
     }
@@ -169,6 +169,28 @@ public class OneTopLevelClassCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(OneTopLevelClassCheck.class);
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig, getNonCompilablePath("package-info.java"), expected);
+    }
+
+    @Test
+    public void testFileWithMultipleSameLine() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(OneTopLevelClassCheck.class);
+        final String[] expected = {
+            "3:47: " + getCheckMessage(MSG_KEY, "ViolatingSecondType"),
+        };
+        verify(checkConfig, getPath("InputOneTopLevelClassSameLine.java"), expected);
+    }
+
+    @Test
+    public void testFileWithIndentation() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(OneTopLevelClassCheck.class);
+        final String[] expected = {
+            "7:2: " + getCheckMessage(MSG_KEY, "ViolatingIndentedClass1"),
+            "11:5: " + getCheckMessage(MSG_KEY, "ViolatingIndentedClass2"),
+            "15:1: " + getCheckMessage(MSG_KEY, "ViolatingNonIndentedInterface"),
+        };
+        verify(checkConfig, getPath("InputOneTopLevelClassIndentation.java"), expected);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -85,7 +85,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
             "NoClone",
             "NoFinalizer",
             "NoLineWrap",
-            "OneTopLevelClass",
             "OuterTypeFilename",
             "OverloadMethodsDeclarationOrder",
             "PackageAnnotation",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassIndentation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassIndentation.java
@@ -1,0 +1,17 @@
+package com.puppycrawl.tools.checkstyle.checks.design.onetoplevelclass;
+
+public class InputOneTopLevelClassIndentation {
+    // methods
+}
+
+ class ViolatingIndentedClass1 {
+    // methods
+ }
+
+    class ViolatingIndentedClass2 {
+        // methods
+    }
+
+interface ViolatingNonIndentedInterface {
+    // methods
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassSameLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassSameLine.java
@@ -1,0 +1,3 @@
+package com.puppycrawl.tools.checkstyle.checks.design.onetoplevelclass;
+
+public class InputOneTopLevelClassSameLine {} enum ViolatingSecondType {}

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -935,7 +935,6 @@ public class UserService {
           <li>NoClone</li>
           <li>NoFinalizer</li>
           <li>NoLineWrap</li>
-          <li>OneTopLevelClass</li>
           <li>OuterTypeFilename</li>
           <li>OverloadMethodsDeclarationOrder</li>
           <li>PackageAnnotation</li>


### PR DESCRIPTION
Resolve #7754: Update AbstractChecks to log DetailAST - OneTopLevelClass

Diff report: https://wltan.github.io/checkstyle-reports/2020-03-08/onetoplevel/diff/

There is only one log call to fix: https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheck.java#L153

Notes:
1. I wasn't able to upload all of the "deeper" files due to the max file path length (on Windows). But I think all of the essential information should be there.
2. All of the discrepancies seem to be about the extra column number, which is expected as we now log the DetailAST node instead of just the line number.
3. Our unit tests only cover violations at column 1, but other projects can have violations at other columns as well (e.g. `apache-ant` has a violation at column 2 instead as there is a whitespace in front of the declaration for whatever reason). I think we should update our tests to reflect this?