### PR TITLE
Issue #7723: Update AbstractChecks to log DetailAST - ArrayTrailingComma

### DIFF
--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionArrayTrailingCommaTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionArrayTrailingCommaTest.java
@@ -1,0 +1,90 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.coding.ArrayTrailingCommaCheck;
+
+public class XpathRegressionArrayTrailingCommaTest extends AbstractXpathTestSupport {
+
+    private final String checkName = ArrayTrailingCommaCheck.class.getSimpleName();
+
+    @Override
+    protected String getCheckName() {
+        return checkName;
+    }
+
+    @Test
+    public void testOne() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionArrayTrailingCommaOne.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(ArrayTrailingCommaCheck.class);
+
+        final String[] expectedViolation = {
+            "16:9: " + getCheckMessage(ArrayTrailingCommaCheck.class,
+                ArrayTrailingCommaCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionArrayTrailingCommaOne']]"
+                + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='a2']]/ASSIGN/EXPR/LITERAL_NEW"
+                + "/ARRAY_INIT/EXPR[./NUM_INT[@text='3']]",
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionArrayTrailingCommaOne']]"
+                + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='a2']]/ASSIGN/EXPR/LITERAL_NEW"
+                + "/ARRAY_INIT/EXPR/NUM_INT[@text='3']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testTwo() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionArrayTrailingCommaTwo.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(ArrayTrailingCommaCheck.class);
+
+        final String[] expectedViolation = {
+            "17:9: " + getCheckMessage(ArrayTrailingCommaCheck.class,
+                ArrayTrailingCommaCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionArrayTrailingCommaTwo']]"
+                + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='d2']]/ASSIGN/EXPR/LITERAL_NEW"
+                + "/ARRAY_INIT/ARRAY_INIT[./EXPR/NUM_INT[@text='5']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/arraytrailingcomma/SuppressionXpathRegressionArrayTrailingCommaOne.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/arraytrailingcomma/SuppressionXpathRegressionArrayTrailingCommaOne.java
@@ -1,0 +1,18 @@
+package org.checkstyle.suppressionxpathfilter.arraytrailingcomma;
+
+public class SuppressionXpathRegressionArrayTrailingCommaOne
+{
+    int[] a1 = new int[]
+    {
+        1,
+        2,
+        3,
+    };
+
+    int[] a2 = new int[]
+    {
+        1,
+        2,
+        3 // warn
+    };
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/arraytrailingcomma/SuppressionXpathRegressionArrayTrailingCommaTwo.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/arraytrailingcomma/SuppressionXpathRegressionArrayTrailingCommaTwo.java
@@ -1,0 +1,20 @@
+package org.checkstyle.suppressionxpathfilter.arraytrailingcomma;
+
+public class SuppressionXpathRegressionArrayTrailingCommaTwo
+{
+     int[][] d1 = new int[][]
+    {
+        {1, 2,},
+        {3, 3,},
+        {5, 6,},
+    };
+
+    int[][] d2 = new int[][]
+    {
+        {1,
+         2},
+        {3, 3,},
+        {5, 6,} // warn
+    };
+
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheck.java
@@ -167,7 +167,7 @@ public class ArrayTrailingCommaCheck extends AbstractCheck {
                 && !TokenUtil.areOnSameLine(rcurly, previousSibling)
                 && !TokenUtil.areOnSameLine(arrayInit, previousSibling)
                 && previousSibling.getType() != TokenTypes.COMMA) {
-            log(rcurly.getLineNo(), MSG_KEY);
+            log(previousSibling, MSG_KEY);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -53,9 +53,6 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * AnnotationUseStyle
  * </li>
  * <li>
- * ArrayTrailingComma
- * </li>
- * <li>
  * AvoidEscapedUnicodeCharacters
  * </li>
  * <li>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheckTest.java
@@ -41,8 +41,10 @@ public class ArrayTrailingCommaCheckTest
         final DefaultConfiguration checkConfig =
             createModuleConfig(ArrayTrailingCommaCheck.class);
         final String[] expected = {
-            "17: " + getCheckMessage(MSG_KEY),
-            "37: " + getCheckMessage(MSG_KEY),
+            "16:9: " + getCheckMessage(MSG_KEY),
+            "36:9: " + getCheckMessage(MSG_KEY),
+            "75:12: " + getCheckMessage(MSG_KEY),
+            "73:9: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputArrayTrailingComma.java"), expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -55,7 +55,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
             "AnnotationLocation",
             "AnnotationOnSameLine",
             "AnnotationUseStyle",
-            "ArrayTrailingComma",
             "AvoidEscapedUnicodeCharacters",
             "AvoidStarImport",
             "AvoidStaticImport",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/arraytrailingcomma/InputArrayTrailingComma.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/arraytrailingcomma/InputArrayTrailingComma.java
@@ -13,7 +13,7 @@ public class InputArrayTrailingComma
     {
         1,
         2,
-        3
+        3 // violation
     };
 
     int[] b1 = new int[] {1, 2, 3,};
@@ -33,7 +33,7 @@ public class InputArrayTrailingComma
         {1,
          2},
         {3, 3,},
-        {5, 6,}
+        {5, 6,} // violation
     };
 
     int[] e1 = new int[] {
@@ -58,4 +58,20 @@ public class InputArrayTrailingComma
             1,
             2
             ,};
+
+    Object[][] g1 = new Object[][]
+    {
+        { 1, 1 },
+        {
+           null,
+           new int[] { 2,
+                   3 }, }, };
+
+    Object[][] g2 = new Object[][]
+    {
+        { 1, 1 },
+        {
+           null,
+           new int[] { 2,
+                   3 } } }; // violation
 }

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -905,7 +905,6 @@ public class UserService {
           <li>AnnotationLocation</li>
           <li>AnnotationOnSameLine</li>
           <li>AnnotationUseStyle</li>
-          <li>ArrayTrailingComma</li>
           <li>AvoidEscapedUnicodeCharacters</li>
           <li>AvoidStarImport</li>
           <li>AvoidStaticImport</li>


### PR DESCRIPTION
Resolve #7723 : Update AbstractChecks to log DetailAST - ArrayTrailingComma

Diff report links :
- violation reported on rcurly (old) : https://wilcoln.github.io/checkstyle-reports/7723/diff/index.html
- violation reported on last item : https://wilcoln.github.io/checkstyle-reports/7723v2/diff/index.html

As expected/wanted, the number of violations reported remains the same for all projects. The only difference between the two diff reports are the lines and cols on which the violations are being found. Which is also completely normal.