### PR TITLE
Issue #7638: Update doc for EqualsHashCode

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
@@ -49,7 +49,60 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
  * <pre>
  * &lt;module name=&quot;EqualsHashCode&quot;/&gt;
  * </pre>
- *
+ * <p>Example:</p>
+ * <pre>
+ * public static class Example1 {
+ *     public int hashCode() {
+ *         // code
+ *     }
+ *     public boolean equals(String o) { // violation, overloaded implementation of 'equals'
+ *         // code
+ *     }
+ * }
+ * public static class Example2 {
+ *     public boolean equals(Object o) { // violation, no 'hashCode'
+ *         // code
+ *     }
+ *     public boolean equals(String o) {
+ *         // code
+ *     }
+ * }
+ * public static class Example3 {
+ *     public int hashCode() {
+ *         // code
+ *     }
+ *     public boolean equals(Object o) { // OK
+ *         // code
+ *     }
+ *     public boolean equals(String o) {
+ *         // code
+ *     }
+ * }
+ * public static class Example4 {
+ *     public int hashCode() {
+ *         // code
+ *     }
+ *     public boolean equals(java.lang.Object o) { // OK
+ *         // code
+ *    }
+ * }
+ * public static class Example5 {
+ *     public static int hashCode(int i) {
+ *         // code
+ *     }
+ *     public boolean equals(Object o) { // violation, overloaded implementation of 'hashCode'
+ *         // code
+ *     }
+ * }
+ * public static class Example6 {
+ *     public int hashCode() { // violation, overloaded implementation of 'equals'
+ *         // code
+ *     }
+ *     public static boolean equals(Object o, Object o2) {
+ *         // code
+ *     }
+ * }
+ * </pre>
  * @since 3.0
  */
 @FileStatefulCheck

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -1015,6 +1015,60 @@ String nullString = null;
         <source>
 &lt;module name=&quot;EqualsHashCode&quot;/&gt;
         </source>
+        <p>Example:</p>
+        <source>
+public static class Example1 {
+    public int hashCode() {
+        // code
+    }
+    public boolean equals(String o) { // violation, overloaded implementation of 'equals'
+        // code
+    }
+}
+public static class Example2 {
+    public boolean equals(Object o) { // violation, no 'hashCode'
+        // code
+    }
+    public boolean equals(String o) {
+        // code
+    }
+}
+public static class Example3 {
+    public int hashCode() {
+        // code
+    }
+    public boolean equals(Object o) { // OK
+        // code
+    }
+    public boolean equals(String o) {
+        // code
+    }
+}
+public static class Example4 {
+    public int hashCode() {
+        // code
+    }
+    public boolean equals(java.lang.Object o) { // OK
+        // code
+   }
+}
+public static class Example5 {
+    public static int hashCode(int i) {
+        // code
+    }
+    public boolean equals(Object o) { // violation, overloaded implementation of 'hashCode'
+        // code
+    }
+}
+public static class Example6 {
+    public int hashCode() { // violation, overloaded implementation of 'equals'
+        // code
+    }
+    public static boolean equals(Object o, Object o2) {
+        // code
+    }
+}
+        </source>
       </subsection>
 
       <subsection name="Example of Usage" id="EqualsHashCode_Example_of_Usage">


### PR DESCRIPTION
 **Issue #7638**
EqualsHashCode Check Doc Updation.
![up](https://user-images.githubusercontent.com/38028330/76461293-a4c1cd80-6405-11ea-86f4-0ffd270ef944.png)

**Output of Example:**

```
kaustubh@dxtk:~$ cat Test.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">

<module name="Checker">
    <property name="charset" value="UTF-8"/>

    <module name="TreeWalker">
<module name="EqualsHashCode"/>
    </module>
</module>


kaustubh@dxtk:~$ cat Test.java
public static class Example1 {
    public int hashCode() {
        // code
    }
    public boolean equals(String o) { // violation, overloaded implementation of 'equals'
        // code
    }
}
public static class Example2 {
    public boolean equals(Object o) { // violation, no 'hashCode'
        // code
    }
    public boolean equals(String o) {
        // code
    }
}
public static class Example3 {
    public int hashCode() {
        // code
    }
    public boolean equals(Object o) { // OK
        // code
    }
    public boolean equals(String o) {
        // code
    }
}
public static class Example4 {
    public int hashCode() {
        // code
    }
    public boolean equals(java.lang.Object o) { // OK
        // code
   }
}
public static class Example5 {
    public static int hashCode(int i) {
        // code
    }
    public boolean equals(Object o) { // violation, overloaded implementation of 'hashCode'
        // code
    }
}
public static class Example6 {
    public int hashCode() { // violation, overloaded implementation of 'equals'
        // code
    }
    public static boolean equals(Object o, Object o2) {
        // code
    }
}


kaustubh@dxtk:~$ java -jar checkstyle-8.30-all.jar -c Test.xml Test.java
Starting audit...
[ERROR] /home/kaustubh/Test.java:2:5: Definition of 'hashCode()' without corresponding definition of 'equals()'. [EqualsHashCode]
[ERROR] /home/kaustubh/Test.java:11:5: Definition of 'equals()' without corresponding definition of 'hashCode()'. [EqualsHashCode]
[ERROR] /home/kaustubh/Test.java:44:5: Definition of 'equals()' without corresponding definition of 'hashCode()'. [EqualsHashCode]
[ERROR] /home/kaustubh/Test.java:50:5: Definition of 'hashCode()' without corresponding definition of 'equals()'. [EqualsHashCode]
Audit done.
Checkstyle ends with 4 errors.
```
@strkkk Please review my pull request and suggest necessary changes. I have taken these examples from [https://github.com/checkstyle/checkstyle/blob/master/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/equalshashcode/InputEqualsHashCodeEqualsParameter.java](url)