### PR TITLE
Issue #7629: Update doc for SingleSpaceSeparator

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheck.java
@@ -67,6 +67,16 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <pre>
  * &lt;module name=&quot;SingleSpaceSeparator&quot;/&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * int foo()   { // violation, 3 whitespaces
+ *   return  1; // violation, 2 whitespaces
+ * }
+ * int fun1() { // OK, 1 whitespace
+ *   return 3; // OK, 1 whitespace
+ * }
+ * void  fun2() {} // violation, 2 whitespaces
+ * </pre>
  *
  * <p>
  * To configure the check so that it validates comments:
@@ -76,6 +86,25 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * &lt;module name=&quot;SingleSpaceSeparator&quot;&gt;
  *   &lt;property name=&quot;validateComments&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * void fun1() {}  // violation, 2 whitespaces before the comment starts
+ * void fun2() { return; }  /* violation here, 2 whitespaces before the comment starts *&#47;
+ *
+ * /* violation, 2 whitespaces after the comment ends *&#47;  int a;
+ *
+ * String s; /* OK, 1 whitespace *&#47;
+ *
+ * /**
+ * * This is a Javadoc comment
+ * *&#47;  int b; // violation, 2 whitespaces after the javadoc comment ends
+ *
+ * float f1; // OK, 1 whitespace
+ *
+ * /**
+ * * OK, 1 white space after the doc comment ends
+ * *&#47; float f2;
  * </pre>
  *
  * @since 6.19

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -2046,7 +2046,16 @@ public long toMicros(long d) { return d / (C1 / C0); }
         <source>
 &lt;module name=&quot;SingleSpaceSeparator&quot;/&gt;
         </source>
-
+        <p>Example:</p>
+        <source>
+int foo()   { // violation, 3 whitespaces
+  return  1; // violation, 2 whitespaces
+}
+int fun1() { // OK, 1 whitespace
+  return 3; // OK, 1 whitespace
+}
+void  fun2() {} // violation, 2 whitespaces
+        </source>
         <p>
           To configure the check so that it validates comments:
         </p>
@@ -2055,6 +2064,25 @@ public long toMicros(long d) { return d / (C1 / C0); }
 &lt;module name=&quot;SingleSpaceSeparator&quot;&gt;
   &lt;property name=&quot;validateComments&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+void fun1() {}  // violation, 2 whitespaces before the comment starts
+void fun2() { return; }  /* violation here, 2 whitespaces before the comment starts */
+
+/* violation, 2 whitespaces after the comment ends */  int a;
+
+String s; /* OK, 1 whitespace */
+
+/**
+ * This is a Javadoc comment
+ */  int b; // violation, 2 whitespaces after the javadoc comment ends
+
+float f1; // OK, 1 whitespace
+
+/**
+ * OK, 1 white space after the doc comment ends
+ */ float f2;
         </source>
       </subsection>
 


### PR DESCRIPTION
### Fixes #7629 
![Example](https://user-images.githubusercontent.com/43749360/76639980-21bf8500-6575-11ea-9222-c50d0f421eeb.PNG)


### Output of Default example:
```
$ cat config.xml
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <module name="SingleSpaceSeparator">
    </module>
  </module>
</module>

$ cat test.java
public class test {
    int foo()   { // violation, 3 whitespaces
        return  1; // violation, 2 whitespaces
    }
    int fun1() { // OK, 1 whitespace
        return 3; // OK, 1 whitespace
    }
    void  fun2() {} // violation, 2 whitespaces
}

$ java -jar checkstyle-8.30-all.jar -c config.xml test.java
Starting audit...
[ERROR] C:\Users\Shrey\Desktop\PR1\test.java:2:17: Use a single space to separate non-whitespace characters. [SingleSpaceSeparator]
[ERROR] C:\Users\Shrey\Desktop\PR1\test.java:3:17: Use a single space to separate non-whitespace characters. [SingleSpaceSeparator]
[ERROR] C:\Users\Shrey\Desktop\PR1\test.java:8:11: Use a single space to separate non-whitespace characters. [SingleSpaceSeparator]
Audit done.
Checkstyle ends with 3 errors.
```

### Output of non-default example:
```
$ cat config2.xml
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <module name="SingleSpaceSeparator">
        <property name="validateComments" value="true"/>
    </module>
  </module>
</module>

$ cat test2.java
public class test2 {
    void fun1() {}  // violation, 2 whitespaces before the comment starts
    void fun2() { return; }  /* violation here, 2 whitespaces before the comment starts */

    /* violation, 2 whitespaces after the comment ends */  int a;

    String s; /* OK, 1 whitespace */

    /**
     * This is a Javadoc comment
     */  int b; // violation, 2 whitespaces after the javadoc comment ends

    float f1; // OK, 1 whitespace

    /**
     * OK, 1 white space after the doc comment ends
     */ float f2;

$ java -jar checkstyle-8.30-all.jar -c config2.xml test2.java
Starting audit...
[ERROR] C:\Users\Shrey\Desktop\PR1\test2.java:2:21: Use a single space to separate non-whitespace characters. [SingleSpaceSeparator]
[ERROR] C:\Users\Shrey\Desktop\PR1\test2.java:3:30: Use a single space to separate non-whitespace characters. [SingleSpaceSeparator]
[ERROR] C:\Users\Shrey\Desktop\PR1\test2.java:5:60: Use a single space to separate non-whitespace characters. [SingleSpaceSeparator]
[ERROR] C:\Users\Shrey\Desktop\PR1\test2.java:11:10: Use a single space to separate non-whitespace characters. [SingleSpaceSeparator]
Audit done.
Checkstyle ends with 4 errors.
```