### PR TITLE
Issue #7802: Resolve Pitest Issues - CustomImportOrderCheck (1)

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -73,11 +73,9 @@ pitest-imports)
   declare -a ignoredItems=(
   "AvoidStarImportCheck.java.html:<td class='covered'><pre><span  class='survived'>            &#38;&#38; ast.getType() == TokenTypes.STATIC_IMPORT) {</span></pre></td></tr>"
   "AvoidStarImportCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (exclude.endsWith(STAR_IMPORT_SUFFIX)) {</span></pre></td></tr>"
-  "CustomImportOrderCheck.java.html:<td class='covered'><pre><span  class='survived'>                        &#38;&#38; matcher.start() &#60; betterMatchCandidate.matchPosition) {</span></pre></td></tr>"
   "CustomImportOrderCheck.java.html:<td class='covered'><pre><span  class='survived'>        else if (customImportOrderRules.contains(SAME_PACKAGE_RULE_GROUP)) {</span></pre></td></tr>"
   "CustomImportOrderCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (bestMatch.group.equals(NON_GROUP_RULE_GROUP)) {</span></pre></td></tr>"
   "CustomImportOrderCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (customImportOrderRules.contains(SAME_PACKAGE_RULE_GROUP)) {</span></pre></td></tr>"
-  "CustomImportOrderCheck.java.html:<td class='covered'><pre><span  class='survived'>                    || length == betterMatchCandidate.matchLength</span></pre></td></tr>"
   "IllegalImportCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (regexp) {</span></pre></td></tr>"
   "IllegalImportCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (!result &#38;&#38; illegalClasses != null) {</span></pre></td></tr>"
   "IllegalImportCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (!result) {</span></pre></td></tr>"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -722,6 +722,24 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testMultiplePatternMultipleImportFirstPatternHasLaterPosition() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(CustomImportOrderCheck.class);
+        checkConfig.addAttribute("customImportOrderRules",
+                "SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE");
+        checkConfig.addAttribute("specialImportsRegExp", "Test");
+        checkConfig.addAttribute("standardPackageRegExp", "unit");
+
+        createChecker(checkConfig);
+        final String[] expected = {
+            "4: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STD, "org.junit.Test"),
+        };
+        verify(checkConfig,
+            getPath("InputCustomImportOrder_MultiplePatternMultipleImport.java"),
+            expected);
+    }
+
+    @Test
     public void testNoPackage() throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(CustomImportOrderCheck.class);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrder_MultiplePatternMultipleImport.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrder_MultiplePatternMultipleImport.java
@@ -1,0 +1,7 @@
+package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
+
+import java.util.Scanner;
+import org.junit.Test;
+
+public class InputCustomImportOrder_MultiplePatternMultipleImport {
+}


### PR DESCRIPTION
In https://github.com/checkstyle/checkstyle/issues/7802#issuecomment-597470793 it was found that the current unit tests are not well-designed to kill the mutations produced by pitest. Copied here for reference:
> We already have unit tests in `CustomImportOrderCheckTest.java` that covers the different cases of regex matching, but the problem is that the input file is currently designed such that even if the test were to "fail" with the mutation, the output (violations) does not change, and so the tests incorrectly pass.

This PR aims to address that problem by enhancing the existing unit tests.

Pitest report for this branch: https://wltan.github.io/checkstyle-reports/2020-03-12/202003121402/

Both lines 815 and 816 no longer cause issues under pitest. It appears that this PR can solve both #7802 and #7806 at the same time.