### PR TITLE
Issue #7801: Resolve Pitest Issues - AvoidStaticImportCheck

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -73,7 +73,6 @@ pitest-imports)
   declare -a ignoredItems=(
   "AvoidStarImportCheck.java.html:<td class='covered'><pre><span  class='survived'>            &#38;&#38; ast.getType() == TokenTypes.STATIC_IMPORT) {</span></pre></td></tr>"
   "AvoidStarImportCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (exclude.endsWith(STAR_IMPORT_SUFFIX)) {</span></pre></td></tr>"
-  "AvoidStaticImportCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (exclude.endsWith(&#34;.*&#34;)) {</span></pre></td></tr>"
   "CustomImportOrderCheck.java.html:<td class='covered'><pre><span  class='survived'>                        &#38;&#38; matcher.start() &#60; betterMatchCandidate.matchPosition) {</span></pre></td></tr>"
   "CustomImportOrderCheck.java.html:<td class='covered'><pre><span  class='survived'>        else if (customImportOrderRules.contains(SAME_PACKAGE_RULE_GROUP)) {</span></pre></td></tr>"
   "CustomImportOrderCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (bestMatch.group.equals(NON_GROUP_RULE_GROUP)) {</span></pre></td></tr>"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheckTest.java
@@ -55,10 +55,12 @@ public class AvoidStaticImportCheckTest
             "26: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
             "27: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
             "28: " + getCheckMessage(MSG_KEY, "java.io.File.pathSeparator"),
-            "29: " + getCheckMessage(MSG_KEY,
+            "29: " + getCheckMessage(MSG_KEY, "java.lang.Math.E"),
+            "30: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
+            "31: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass"),
-            "30: " + getCheckMessage(MSG_KEY,
+            "32: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass.one"),
         };
@@ -76,10 +78,12 @@ public class AvoidStaticImportCheckTest
         final String[] expected = {
             "25: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
             "26: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "29: " + getCheckMessage(MSG_KEY,
+            "29: " + getCheckMessage(MSG_KEY, "java.lang.Math.E"),
+            "30: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
+            "31: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass"),
-            "30: " + getCheckMessage(MSG_KEY,
+            "32: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass.one"),
         };
@@ -91,17 +95,18 @@ public class AvoidStaticImportCheckTest
             throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(AvoidStaticImportCheck.class);
-        checkConfig.addAttribute("excludes", "java.io.File.listRoots");
-        // allow the java.io.File.listRoots member imports
+        checkConfig.addAttribute("excludes", "java.io.File.listRoots,java.lang.Math.E");
+        // allow the java.io.File.listRoots and java.lang.Math.E member imports
         final String[] expected = {
             "25: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
             "26: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
             "27: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
             "28: " + getCheckMessage(MSG_KEY, "java.io.File.pathSeparator"),
-            "29: " + getCheckMessage(MSG_KEY,
+            "30: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
+            "31: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass"),
-            "30: " + getCheckMessage(MSG_KEY,
+            "32: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass.one"),
         };
@@ -126,10 +131,12 @@ public class AvoidStaticImportCheckTest
             "26: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
             "27: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
             "28: " + getCheckMessage(MSG_KEY, "java.io.File.pathSeparator"),
-            "29: " + getCheckMessage(MSG_KEY,
+            "29: " + getCheckMessage(MSG_KEY, "java.lang.Math.E"),
+            "30: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
+            "31: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass"),
-            "30: " + getCheckMessage(MSG_KEY,
+            "32: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass.one"),
         };
@@ -154,7 +161,9 @@ public class AvoidStaticImportCheckTest
             "26: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
             "27: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
             "28: " + getCheckMessage(MSG_KEY, "java.io.File.pathSeparator"),
-            "29: " + getCheckMessage(MSG_KEY,
+            "29: " + getCheckMessage(MSG_KEY, "java.lang.Math.E"),
+            "30: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
+            "31: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass"),
         };

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstaticimport/InputAvoidStaticImportDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstaticimport/InputAvoidStaticImportDefault.java
@@ -26,6 +26,8 @@ import static javax.swing.WindowConstants.*;
 import static javax.swing.WindowConstants.*;
 import static java.io.File.createTempFile;
 import static java.io.File.pathSeparator;
+import static java.lang.Math.E;
+import static java.lang.Math.sqrt;
 import static com.puppycrawl.tools.checkstyle.checks.imports.avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass;
 import static com.puppycrawl.tools.checkstyle.checks.imports.avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass.one;
 


### PR DESCRIPTION
Fixes Issue #7801 

Adds an UT for fixing the issue mentioned in https://github.com/checkstyle/checkstyle/issues/7801#issuecomment-597193539:
> ## 4. Regression and Code Logic Analysis
> Although the results of the regression report wasn't useful, I have discovered an UT by analysing the code which tests a particular edge case of `if(exclude.endsWith(".*")) `. The reason the absence of the if statement didn't break the test codes:
> `if(exclude.endsWith(".*"))` is redundant, since even if this check wasn't there and let's assume the exclude was a random member, it would yield true for the second condition but not for the first condition in `if (classOrStaticMember.startsWith(excludeMinusDotStar)&& !classOrStaticMember.equals(excludeMinusDotStar))`. and hence not move forward.
> 
> But if a specific exclude had a pattern like `package.path.class.<member>` where was a single letter ( for e.g. `java.lang.Math.E`) the absence of the if statement would yield that as if `.E` is `.*` and give a false positive. Hence, including this test case has forced the if statement to do an important check and the mutation was `killed`.
