### PR TITLE
config: disable in linkcheck validation of links to maven.apache.org …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1665,6 +1665,8 @@
             </excludedLink>
             <!-- ConnectTimeoutException -->
             <excludedLink>https://www.w3.org/TR/*</excludedLink>
+            <!-- very frequent SocketTimeoutException : Read timed out -->
+            <excludedLink>https://maven.apache.org/*</excludedLink>
           </excludedLinks>
         </configuration>
       </plugin>


### PR DESCRIPTION
…due to very frequent failures

example https://app.codeship.com/projects/124310/builds/da7ec1ec-2a72-492d-bbdf-a63c95bd8732?line=d7533835-36e5-4951-a803-14c403c32bd5&step=parallel_.ci%2Frun-link-check-plugin.sh

```
2020-03-11 13:48:26
 system ------------ grep of linkcheck.html--BEGIN
2020-03-11 13:48:26
 system <td><i><a class="externalLink" href="https://maven.apache.org/plugins/maven-dependency-plugin/">https://maven.apache.org/plugins/maven-dependency-plugin/</a>: java.net.SocketTimeoutException : Read timed out</i></td></tr>
2020-03-11 13:48:26
 system <td><i><a class="externalLink" href="https://maven.apache.org/plugins/maven-javadoc-plugin/">https://maven.apache.org/plugins/maven-javadoc-plugin/</a>: java.net.SocketTimeoutException : Read timed out</i></td></tr></table></td></tr>
2020-03-11 13:48:26
 system <td><i><a class="externalLink" href="https://img.shields.io/bountysource/team/checkstyle/activity.svg?label=salt.bountysource">https://img.shields.io/bountysource/team/checkstyle/activity.svg?label=salt.bountysource</a>: java.net.SocketTimeoutException : Read timed out</i></td></tr></table></td></tr>
2020-03-11 13:48:26
 system <td><i><a class="externalLink" href="https://maven.apache.org/enforcer/maven-enforcer-plugin/">https://maven.apache.org/enforcer/maven-enforcer-plugin/</a>: org.apache.commons.httpclient.ConnectTimeoutException : The host did not accept the connection within timeout of 6000 ms</i></td></tr>
2020-03-11 13:48:26
 system <td><i><a class="externalLink" href="https://maven.apache.org/plugins/maven-javadoc-plugin/">https://maven.apache.org/plugins/maven-javadoc-plugin/</a>: java.net.SocketTimeoutException : Read timed out</i></td></tr></table></td></tr>
2020-03-11 13:48:26
 system ------------ grep of linkcheck.html--END
2020-03-11 13:48:26
 system Exit code:1
```