### PR TITLE
Issue #7800: Resolve Pitest Issues - AvoidStarImportCheck(2)

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -72,7 +72,6 @@ pitest-imports)
   mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;
   declare -a ignoredItems=(
   "AvoidStarImportCheck.java.html:<td class='covered'><pre><span  class='survived'>            &#38;&#38; ast.getType() == TokenTypes.STATIC_IMPORT) {</span></pre></td></tr>"
-  "AvoidStarImportCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (exclude.endsWith(STAR_IMPORT_SUFFIX)) {</span></pre></td></tr>"
   "CustomImportOrderCheck.java.html:<td class='covered'><pre><span  class='survived'>        else if (customImportOrderRules.contains(SAME_PACKAGE_RULE_GROUP)) {</span></pre></td></tr>"
   "CustomImportOrderCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (bestMatch.group.equals(NON_GROUP_RULE_GROUP)) {</span></pre></td></tr>"
   "CustomImportOrderCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (customImportOrderRules.contains(SAME_PACKAGE_RULE_GROUP)) {</span></pre></td></tr>"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheckTest.java
@@ -60,7 +60,7 @@ public class AvoidStarImportCheckTest
         final DefaultConfiguration checkConfig =
             createModuleConfig(AvoidStarImportCheck.class);
         checkConfig.addAttribute("excludes",
-            "java.io,java.lang,javax.swing.WindowConstants.*, javax.swing.WindowConstants");
+            "java.io,java.lang,javax.swing.WindowConstants.*");
         // allow the java.io/java.lang,javax.swing.WindowConstants star imports
         final String[] expected2 = {
             "7: " + getCheckMessage(MSG_KEY, "com.puppycrawl.tools.checkstyle.checks.imports.*"),


### PR DESCRIPTION
Issue #7800: Resolve Pitest Issues - AvoidStaticImportCheck(2)

As described as in #7800:

**Pitest report**

Link: https://huganghui.github.io/7800-AvoidStarImportCheck(2)/before-pit-reports/202003131405/
Surviving mutations:
on line 188: removed conditional - replaced equality check with false → SURVIVED I am focusing on it.
on line 224: removed conditional - replaced equality check with true → SURVIVED referenced by #7799, wilcoln is focusing on it.

**Hardcoded mutation**

mutation cs branch: https://github.com/HuGanghui/checkstyle/commit/1578ac0229711f39a4a7c77457f430491918cd57
comment:
Looking at the pitest report, we can see that the surviving mutation is the one for which removed conditional - replaced equality check with false → SURVIVED, this is equivalent as simply removing the entire condition and keeping only the else body. Which I did.

**Regression diff report**

Used only guava and elastic-search, but there is no diff found.
Link: https://huganghui.github.io/7800-AvoidStarImportCheck(2)/hardcoded-reports/diff/

**Code Logic Analysis**

Although there is no diff found in Regression diff report, I find that the reason why the surviving mutation exists is maybe a small oversight in an existing UT , details as follows: https://github.com/checkstyle/checkstyle/blob/91f13c1d2ac273f89f12dac7fb83505f42a7bbe1/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheckTest.java#L63

javax.swing.WindowConstants is redundant in this UT, so I remove this import and do Pitest, report shows it can kill the mutation.

**Pitest report after removing redundant code in the UT mentioned above**

Link: https://huganghui.github.io/7800-AvoidStarImportCheck(2)/after-pit-reports/202003131742/
now on line 188, is KILLED
on line 188: removed conditional - replaced equality check with false → KILLED