### PR TITLE
Issue #7590: Update doc for OuterTypeFilename

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheck.java
@@ -38,7 +38,30 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <pre>
  * &lt;module name=&quot;OuterTypeFilename&quot;/&gt;
  * </pre>
+ * <p>Example of class Test in a file named Test.java</p>
+ * <pre>
+ * public class Test { // OK
  *
+ * }
+ * </pre>
+ * <p>Example of class Foo in a file named Test.java</p>
+ * <pre>
+ * class Foo { // violation
+ *
+ * }
+ * </pre>
+ * <p>Example of interface Foo in a file named Test.java</p>
+ * <pre>
+ * interface Foo { // violation
+ *
+ * }
+ * </pre>
+ * <p>Example of enum Foo in a file named Test.java</p>
+ * <pre>
+ * enum Foo { // violation
+ *
+ * }
+ * </pre>
  * @since 5.3
  */
 @FileStatefulCheck

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -1640,6 +1640,30 @@ key.png =value - violation
         <source>
 &lt;module name=&quot;OuterTypeFilename&quot;/&gt;
         </source>
+        <p>Example of class Test in a file named Test.java</p>
+        <source>
+public class Test { // OK
+
+}
+        </source>
+        <p>Example of class Foo in a file named Test.java</p>
+        <source>
+class Foo { // violation
+
+}
+        </source>
+        <p>Example of interface Foo in a file named Test.java</p>
+        <source>
+interface Foo { // violation
+
+}
+        </source>
+        <p>Example of enum Foo in a file named Test.java</p>
+        <source>
+enum Foo { // violation
+
+}
+        </source>
       </subsection>
 
       <subsection name="Example of Usage" id="OuterTypeFilename_Example_of_Usage">


### PR DESCRIPTION
Issue #7590: Update doc for OuterTypeFilename

<img width="848" alt="image" src="https://user-images.githubusercontent.com/50866227/76685457-b944d680-664e-11ea-8695-ce19226c70b9.png">


Output of configure the check: 
$ cat config.xml
```xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="OuterTypeFilename"/>
    </module>
</module>
```
$ cat Test.java
```java
public class Test { // OK

}
```
$ RUN_LOCALE="-Duser.language=en -Duser.country=US"
$ java $RUN_LOCALE -jar /var/tmp/checkstyle-8.31-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
Audit done.
$ cat Test.java
```java
class Foo { // violation

}
```
$ RUN_LOCALE="-Duser.language=en -Duser.country=US"
$ java $RUN_LOCALE -jar /var/tmp/checkstyle-8.31-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /var/tmp/Test.java:1: The name of the outer type and the file do not match. [OuterTypeFilename]
Audit done.
Checkstyle ends with 1 errors.

$ cat Test.java
```java
interface Foo { // violation

}
```
$ RUN_LOCALE="-Duser.language=en -Duser.country=US"
$ java $RUN_LOCALE -jar /var/tmp/checkstyle-8.31-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /var/tmp/Test.java:1: The name of the outer type and the file do not match. [OuterTypeFilename]
Audit done.
Checkstyle ends with 1 errors.

$ cat Test.java
```java
enum Foo { // violation

}
```
$ RUN_LOCALE="-Duser.language=en -Duser.country=US"
$ java $RUN_LOCALE -jar /var/tmp/checkstyle-8.31-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /var/tmp/Test.java:1: The name of the outer type and the file do not match. [OuterTypeFilename]
Audit done.
Checkstyle ends with 1 errors.