### PR TITLE
Issue #7755: Update AbstractChecks to log DetailAST - OuterTypeFilename

### DIFF
--- a/config/checkstyle_resources_suppressions.xml
+++ b/config/checkstyle_resources_suppressions.xml
@@ -63,5 +63,7 @@
     files="outertypefilename[\\/]InputOuterTypeFilenameNoPublic\.java"/>
   <suppress checks="OuterTypeFilename"
     files="[\\/]package-info\.java"/>
+  <suppress checks="OuterTypeFilename"
+    files="src[\\/]it[\\/]resources[\\/].*[\\/]SuppressionXpathRegressionOuterTypeFilename.*\.java"/>
 
 </suppressions>

--- a/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule21filename/OuterTypeFilenameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter2filebasic/rule21filename/OuterTypeFilenameTest.java
@@ -60,7 +60,7 @@ public class OuterTypeFilenameTest extends AbstractGoogleModuleTestSupport {
     @Test
     public void testOuterTypeFilename3() throws Exception {
         final String[] expected = {
-            "3: " + getCheckMessage(OuterTypeFilenameCheck.class, MSG_KEY),
+            "3:1: " + getCheckMessage(OuterTypeFilenameCheck.class, MSG_KEY),
         };
 
         final Configuration checkConfig = getModuleConfig("OuterTypeFilename");

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOuterTypeFilenameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOuterTypeFilenameTest.java
@@ -1,0 +1,86 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck;
+
+public class XpathRegressionOuterTypeFilenameTest extends AbstractXpathTestSupport {
+
+    private final String checkName = OuterTypeFilenameCheck.class.getSimpleName();
+
+    @Override
+    protected String getCheckName() {
+        return checkName;
+    }
+
+    @Test
+    public void testNoPublic() throws Exception {
+        final File fileToProcess = new File(getPath(
+                "SuppressionXpathRegressionOuterTypeFilename1.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(OuterTypeFilenameCheck.class);
+
+        final String[] expectedViolation = {
+            "3:1: " + getCheckMessage(OuterTypeFilenameCheck.class,
+                    OuterTypeFilenameCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='Class1']]",
+                "/CLASS_DEF[./IDENT[@text='Class1']]/MODIFIERS",
+                "/CLASS_DEF[./IDENT[@text='Class1']]/LITERAL_CLASS"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testNested() throws Exception {
+        final File fileToProcess = new File(getPath(
+                "SuppressionXpathRegressionOuterTypeFilename2.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(OuterTypeFilenameCheck.class);
+
+        final String[] expectedViolation = {
+            "3:1: " + getCheckMessage(OuterTypeFilenameCheck.class,
+                    OuterTypeFilenameCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='Test']]",
+                "/CLASS_DEF[./IDENT[@text='Test']]/MODIFIERS",
+                "/CLASS_DEF[./IDENT[@text='Test']]/LITERAL_CLASS"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/outertypefilename/SuppressionXpathRegressionOuterTypeFilename1.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/outertypefilename/SuppressionXpathRegressionOuterTypeFilename1.java
@@ -1,0 +1,5 @@
+package org.checkstyle.suppressionxpathfilter.outertypefilename;
+
+class Class1 { // warn
+
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/outertypefilename/SuppressionXpathRegressionOuterTypeFilename2.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/outertypefilename/SuppressionXpathRegressionOuterTypeFilename2.java
@@ -1,0 +1,7 @@
+package org.checkstyle.suppressionxpathfilter.outertypefilename;
+
+class Test { // warn
+    public interface NestedInterface {}
+    public enum NestedEnum {}
+    class NestedClass {}
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheck.java
@@ -115,7 +115,7 @@ public class OuterTypeFilenameCheck extends AbstractCheck {
     @Override
     public void finishTree(DetailAST rootAST) {
         if (!hasPublic && wrongType != null) {
-            log(wrongType.getLineNo(), MSG_KEY);
+            log(wrongType, MSG_KEY);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -131,9 +131,6 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * NoLineWrap
  * </li>
  * <li>
- * OuterTypeFilename
- * </li>
- * <li>
  * OverloadMethodsDeclarationOrder
  * </li>
  * <li>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheckTest.java
@@ -89,7 +89,7 @@ public class OuterTypeFilenameCheckTest extends AbstractModuleTestSupport {
     public void testNestedClass2() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(OuterTypeFilenameCheck.class);
         final String[] expected = {
-            "3: " + getCheckMessage(MSG_KEY),
+            "3:1: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputOuterTypeFilename1a.java"), expected);
     }
@@ -112,7 +112,7 @@ public class OuterTypeFilenameCheckTest extends AbstractModuleTestSupport {
     public void testNoPublicClasses() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(OuterTypeFilenameCheck.class);
         final String[] expected = {
-            "3: " + getCheckMessage(MSG_KEY),
+            "3:1: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputOuterTypeFilenameNoPublic.java"), expected);
     }
@@ -128,7 +128,7 @@ public class OuterTypeFilenameCheckTest extends AbstractModuleTestSupport {
     public void testWrongDefault() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(OuterTypeFilenameCheck.class);
         final String[] expected = {
-            "4: " + getCheckMessage(MSG_KEY),
+            "4:2: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputOuterTypeFilename5.java"), expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -81,7 +81,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
             "MissingSwitchDefault",
             "NeedBraces",
             "NoLineWrap",
-            "OuterTypeFilename",
             "OverloadMethodsDeclarationOrder",
             "PackageAnnotation",
             "PackageDeclaration",

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -931,7 +931,6 @@ public class UserService {
           <li>MissingSwitchDefault</li>
           <li>NeedBraces</li>
           <li>NoLineWrap</li>
-          <li>OuterTypeFilename</li>
           <li>OverloadMethodsDeclarationOrder</li>
           <li>PackageAnnotation</li>
           <li>PackageDeclaration</li>


### PR DESCRIPTION
Issue #7755: Update AbstractChecks to log DetailAST - OuterTypeFilename

https://github.com/checkstyle/checkstyle/blob/0823da3cf1820603a155b5c8f14d5dfa63fe92b5/src/main/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheck.java#L118

Diff report:
https://huganghui.github.io/7755-DetailAST-outerTypeFilename/reports/diff/