### PR TITLE
Issue #5089: LineLength measures Java characters, not Unicode characters

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
@@ -130,7 +130,7 @@ public class LineLengthCheck extends AbstractFileSetCheck {
         for (int i = 0; i < fileText.size(); i++) {
             final String line = fileText.get(i);
             final int realLength = CommonUtil.lengthExpandedTabs(
-                line, line.length(), getTabWidth());
+                line, line.codePointCount(0, line.length()), getTabWidth());
 
             if (realLength > max && !IGNORE_PATTERN.matcher(line).find()
                 && !ignorePattern.matcher(line).find()) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
@@ -315,7 +315,7 @@ public final class CommonUtil {
             int tabWidth) {
         int len = 0;
         for (int idx = 0; idx < toIdx; idx++) {
-            if (inputString.charAt(idx) == '\t') {
+            if (inputString.codePointAt(idx) == '\t') {
                 len = (len / tabWidth + 1) * tabWidth;
             }
             else {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckTest.java
@@ -21,6 +21,8 @@ package com.puppycrawl.tools.checkstyle.checks.sizes;
 
 import static com.puppycrawl.tools.checkstyle.checks.sizes.LineLengthCheck.MSG_KEY;
 
+import java.nio.charset.StandardCharsets;
+
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
@@ -96,6 +98,24 @@ public class LineLengthCheckTest extends AbstractModuleTestSupport {
             "4: " + getCheckMessage(MSG_KEY, 80, 98),
         };
         verify(checkConfig, getPath("InputLineLengthLongLink.java"), expected);
+    }
+
+    @Test
+    public void countUnicodePointsOnce() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(LineLengthCheck.class);
+        checkConfig.addAttribute("max", "100");
+        // we need to set charset to let test pass when default charset is not UTF-8
+        final DefaultConfiguration checkerConfig = createRootConfig(checkConfig);
+        checkerConfig.addAttribute("charset", StandardCharsets.UTF_8.name());
+
+        final String[] expected = {
+            "6: " + getCheckMessage(MSG_KEY, 100, 136),
+            "7: " + getCheckMessage(MSG_KEY, 100, 136),
+        };
+
+        verify(checkerConfig, getPath("InputLineLengthUnicodeChars.java"), expected);
+
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthUnicodeChars.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthUnicodeChars.java
@@ -1,0 +1,8 @@
+package com.puppycrawl.tools.checkstyle.checks.sizes.linelength;
+
+public class InputLineLengthUnicodeChars {
+    String aaaaaaa = "1234567890123456789012345678901234567890" + "1234567890123456789012345" + "_";
+    String aaaaaab = "1234567890123456789012345678901234567890" + "1234567890123456789012345" + "💩";
+    String aaaaaac = "This line is too long, and will be reported by checkstyle.  This line is 137 characters long, excluding unicode.";
+    String aaaaaad = "This line is too long, and will be reported by checkstyle.💩💩This line is 137 characters long, including unicode.";
+}


### PR DESCRIPTION
This PR fixes Issue #5089, namely, `LineLength() `will now count codepoints (unicode characters) instead of 2 byte characters, thus correcting existing issue where unicode characters are counted as two, 2 byte characters.  I have added some test cases, and the diff report can be found [here](https://nmancus1.github.io/diff_3_13_2020/index.html).