### PR TITLE
Issue #7565: Added config examples for AbstractClassName

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
@@ -53,6 +53,21 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </ul>
  * <p>
  * The following example shows how to configure the {@code AbstractClassName} to
+ * default values
+ * </p>
+ * <p>Configuration:</p>
+ * <pre>
+ * &lt;module name="AbstractClassName"/&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * abstract class AbstractFirstClass {} // OK
+ * abstract class SecondClass {} // violation, it should match pattern "^Abstract.+$"
+ * class AbstractThirdClass {} // violation, abstract access modifier should be present
+ * class FourthClass {} // OK
+ * </pre>
+ * <p>
+ * The following example shows how to configure the {@code AbstractClassName} to
  * checks names, but ignore missing {@code abstract} modifiers:
  * </p>
  * <p>Configuration:</p>
@@ -64,8 +79,26 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <p>Example:</p>
  * <pre>
  * abstract class AbstractFirstClass {} // OK
- * abstract class SecondClass {} // violation, it should match the pattern "^Abstract.+$"
+ * abstract class SecondClass {} // violation, it should match pattern "^Abstract.+$"
  * class AbstractThirdClass {} // OK, no "abstract" modifier
+ * class FourthClass {} // OK
+ * </pre>
+ * <p>
+ * The following example shows how to configure the {@code AbstractClassName} to
+ * checks names, but ignore {@code Name} modifiers:
+ * </p>
+ * <p>Configuration:</p>
+ * <pre>
+ * &lt;module name="AbstractClassName"&gt;
+ *   &lt;property name="ignoreName" value="true"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * abstract class AbstractFirstClass {} // OK
+ * abstract class SecondClass {} // OK
+ * class AbstractThirdClass {} // violation
+ * class FourthClass {} // OK
  * </pre>
  * @since 3.2
  */

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -319,6 +319,23 @@ public class MyClass { // OK, ignore checking the class name
       <subsection name="Examples" id="AbstractClassName_Examples">
         <p>
           The following example shows how to configure the
+          <code>AbstractClassName</code> to default values
+        </p>
+        <p>Configuration:</p>
+        <source>
+&lt;module name=&quot;AbstractClassName&quot;/&gt;
+        </source>
+        <p>Example:</p>
+        <div class="wrapper">
+          <pre>
+abstract class AbstractFirstClass {} // OK
+abstract class SecondClass {} // violation, it should match pattern "^Abstract.+$"
+class AbstractThirdClass {} // violation, abstract access modifier should be present
+class FourthClass {} // OK
+          </pre>
+        </div>
+        <p>
+          The following example shows how to configure the
           <code>AbstractClassName</code> to checks names, but ignore
           missing <code>abstract</code> modifiers:
         </p>
@@ -332,8 +349,29 @@ public class MyClass { // OK, ignore checking the class name
         <div class="wrapper">
           <pre>
 abstract class AbstractFirstClass {} // OK
-abstract class SecondClass {} // violation, it should match the pattern "^Abstract.+$"
+abstract class SecondClass {} // violation, it should match pattern "^Abstract.+$"
 class AbstractThirdClass {} // OK, no "abstract" modifier
+class FourthClass {} // OK
+          </pre>
+        </div>
+         <p>
+          The following example shows how to configure the
+          <code>AbstractClassName</code> to checks names, but ignore
+          <code>Name</code> modifiers:
+        </p>
+        <p>Configuration:</p>
+        <source>
+&lt;module name=&quot;AbstractClassName&quot;&gt;
+  &lt;property name=&quot;ignoreName&quot; value=&quot;true&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <div class="wrapper">
+          <pre>
+abstract class AbstractFirstClass {} // OK
+abstract class SecondClass {} // OK
+class AbstractThirdClass {} // violation
+class FourthClass {} // OK
           </pre>
         </div>
       </subsection>


### PR DESCRIPTION
#7565 

Website Look:
![Screenshot from 2020-03-20 22-55-18](https://user-images.githubusercontent.com/42895397/77189850-3e703580-6afe-11ea-95b2-363eddd4dbfc.png)
![Screenshot from 2020-03-20 22-55-23](https://user-images.githubusercontent.com/42895397/77189888-4cbe5180-6afe-11ea-9c69-9cade6e23b65.png)


**Default Config Example**
pk@pk:~/Desktop/check$ cat config.xml

```
<?xml` version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name = "AbstractClassName" />
    </module>
</module>


```
pk@pk:~/Desktop/check$ cat Test.java
```

abstract class AbstractFirstClass{}
abstract class SecondClass{}
class AbstractThirdClass{}
class FourthClass{}

```
pk@pk:~/Desktop/check$ java -jar checkstyle-8.30-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /home/pk/Desktop/check/Test.java:2:1: Name 'SecondClass' must match pattern '^Abstract.+$'. [AbstractClassName]
[ERROR] /home/pk/Desktop/check/Test.java:3:1: Class 'AbstractThirdClass' must be declared as 'abstract'. [AbstractClassName]
Audit done.
Checkstyle ends with 2 errors.

**Non-Default Config Examples**

pk@pk:~/Desktop/check$ cat config.xml

```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="TreeWalker">
        <module name = "AbstractClassName">
            <property name = "format" value = "^Abst.+$"/>
        </module>
    </module>
</module>
```

pk@pk:~/Desktop/check$ cat Test.java
```

abstract class AbsFirstClass{}
abstract class SecondClass{}
class AbstThirdClass{}
class FourthClass{}

```
pk@pk:~/Desktop/check$ java -jar checkstyle-8.30-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /home/pk/Desktop/check/Test.java:1:1: Name 'AbsFirstClass' must match pattern '^Abst.+$'. [AbstractClassName]
[ERROR] /home/pk/Desktop/check/Test.java:2:1: Name 'SecondClass' must match pattern '^Abst.+$'. [AbstractClassName]
[ERROR] /home/pk/Desktop/check/Test.java:3:1: Class 'AbstThirdClass' must be declared as 'abstract'. [AbstractClassName]

pk@pk:~/Desktop/check$ cat config.xml

```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="TreeWalker">
        <module name = "AbstractClassName">
            <property name = "ignoreModifier" value = "true"/>
        </module>
    </module>
</module>

```
pk@pk:~/Desktop/check$ cat Test.java
```
abstract class AbstractFirstClass{}
abstract class SecondClass{}
class AbstractThirdClass{}
class FourthClass{}

```
pk@pk:~/Desktop/check$ java -jar checkstyle-8.30-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /home/pk/Desktop/check/Test.java:2:1: Name 'SecondClass' must match pattern '^Abstract.+$'. [AbstractClassName]
Audit done.
Checkstyle ends with 1 errors.

Audit done.
Checkstyle ends with 3 errors.

pk@pk:~/Desktop/check$ cat config.xml
```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="TreeWalker">
        <module name = "AbstractClassName">
            <property name = "ignoreName" value = "true"/>
        </module>
    </module>
</module>

```
pk@pk:~/Desktop/check$ cat Test.java
```
abstract class AbstractFirstClass{}
abstract class SecondClass{}
class AbstractThirdClass{}
class FourthClass{}

```
pk@pk:~/Desktop/check$ java -jar checkstyle-8.30-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /home/pk/Desktop/check/Test.java:3:1: Class 'AbstractThirdClass' must be declared as 'abstract'. [AbstractClassName]
Audit done.
Checkstyle ends with 1 errors.
