### PR TITLE
Issue #7740: Update AbstractChecks to log DetailAST - JavadocStyle

### DIFF
--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionJavadocStyleTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionJavadocStyleTest.java
@@ -1,0 +1,58 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck;
+
+public class XpathRegressionJavadocStyleTest extends AbstractXpathTestSupport {
+
+    private final String checkName = JavadocStyleCheck.class.getSimpleName();
+
+    @Override
+    protected String getCheckName() {
+        return checkName;
+    }
+
+    @Test
+    public void testOne() throws Exception {
+        final File fileToProcess = new File(getPath("SuppressionXpathRegression"
+                + File.separator + "package-info.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(JavadocStyleCheck.class);
+
+        final String[] expectedViolation = {
+            "1:1: " + getCheckMessage(JavadocStyleCheck.class,
+                JavadocStyleCheck.MSG_JAVADOC_MISSING),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList("/PACKAGE_DEF");
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/javadocstyle/SuppressionXpathRegression/package-info.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/javadocstyle/SuppressionXpathRegression/package-info.java
@@ -1,0 +1,1 @@
+package org.checkstyle.suppressionxpathfilter.javadocstyle.SuppressionXpathRegression; //warn

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -331,7 +331,7 @@ public class JavadocStyleCheck
             // made sense to make another check just to ensure that the
             // package-info.java file actually contains package Javadocs.
             if (getFileContents().inPackageInfo()) {
-                log(ast.getLineNo(), MSG_JAVADOC_MISSING);
+                log(ast, MSG_JAVADOC_MISSING);
             }
         }
         else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -95,9 +95,6 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * JavadocMethod
  * </li>
  * <li>
- * JavadocStyle
- * </li>
- * <li>
  * JavadocType
  * </li>
  * <li>
@@ -162,7 +159,7 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * </li>
  * </ul>
  * <p>
- * Also, the filter does not support Javadoc checks:
+ * Also, the filter does not support suppressions inside javadoc reported by Javadoc checks:
  * </p>
  * <ul id="SuppressionXpathFilter_JavadocChecks">
  * <li>
@@ -173,6 +170,9 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * </li>
  * <li>
  * JavadocParagraph
+ * </li>
+ * <li>
+ * JavadocStyle
  * </li>
  * <li>
  * JavadocTagContinuationIndentation

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
@@ -382,7 +382,7 @@ public class JavadocStyleCheckTest
         final DefaultConfiguration checkConfig =
             createModuleConfig(JavadocStyleCheck.class);
         final String[] expected = {
-            "1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "1:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
 
         verify(checkConfig,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck;
 import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
 
 public class XpathRegressionTest extends AbstractModuleTestSupport {
@@ -69,7 +70,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
             "InvalidJavadocPosition",
             "JavadocContentLocation",
             "JavadocMethod",
-            "JavadocStyle",
             "JavadocType",
             "LambdaParameterName",
             "MethodCount",
@@ -102,12 +102,18 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
                     "AtclauseOrder",
                     "JavadocBlockTagLocation",
                     "JavadocParagraph",
+                    "JavadocStyle",
                     "JavadocTagContinuationIndentation",
                     "MissingDeprecated",
                     "NonEmptyAtclauseDescription",
                     "SingleLineJavadoc",
                     "SummaryJavadoc"
     )));
+
+    // Older regex-based checks that are under INCOMPATIBLE_JAVADOC_CHECK_NAMES
+    // but not subclasses of AbstractJavadocCheck.
+    private static final Set<Class<?>> REGEXP_JAVADOC_CHECKS =
+            Collections.singleton(JavadocStyleCheck.class);
 
     // Checks that allowed to have no XPath IT Regression Testing
     // till https://github.com/checkstyle/checkstyle/issues/6207
@@ -203,10 +209,13 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
 
     @Test
     public void validateIncompatibleJavadocCheckNames() throws IOException {
+        // subclasses of AbstractJavadocCheck
         final Set<Class<?>> abstractJavadocCheckNames = CheckUtil.getCheckstyleChecks()
                 .stream()
                 .filter(AbstractJavadocCheck.class::isAssignableFrom)
                 .collect(Collectors.toSet());
+        // add the extra checks
+        abstractJavadocCheckNames.addAll(REGEXP_JAVADOC_CHECKS);
         assertWithMessage("INCOMPATIBLE_JAVADOC_CHECK_NAMES should contains all descendants "
                     + "of AbstractJavadocCheck")
             .that(CheckUtil.getSimpleNames(abstractJavadocCheckNames))

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -919,7 +919,6 @@ public class UserService {
           <li>InvalidJavadocPosition</li>
           <li>JavadocContentLocation</li>
           <li>JavadocMethod</li>
-          <li>JavadocStyle</li>
           <li>JavadocType</li>
           <li>LambdaParameterName</li>
           <li>MethodCount</li>
@@ -943,12 +942,13 @@ public class UserService {
           <li>WriteTag</li>
         </ul>
         <p>
-          Also, the filter does not support Javadoc checks:
+          Also, the filter does not support suppressions inside javadoc reported by Javadoc checks:
         </p>
         <ul id="SuppressionXpathFilter_JavadocChecks">
           <li>AtclauseOrder</li>
           <li>JavadocBlockTagLocation</li>
           <li>JavadocParagraph</li>
+          <li>JavadocStyle</li>
           <li>JavadocTagContinuationIndentation</li>
           <li>MissingDeprecated</li>
           <li>NonEmptyAtclauseDescription</li>


### PR DESCRIPTION
Issue #7740: Update AbstractChecks to log DetailAST - JavadocStyle

Diff report (finally here!): https://wltan.github.io/checkstyle-reports/2020-03-18/javadocstyle-detailast-regression/diff/

Discrepancies observed are due to logging column number where we previously did not.

Note that although there are seven calls to `log` as highlighted in https://github.com/checkstyle/checkstyle/issues/7740#issuecomment-599047248, this PR only fixes one of them as instructed in https://github.com/checkstyle/checkstyle/issues/7740#issuecomment-599061545. Please see the discussion on that thread for more details.