### PR TITLE
Issue #7605: Update examples for SingleLineJavadoc check

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -1109,6 +1109,7 @@ RHSOf
 rickgiles
 rightcurly
 rl
+rmdir
 rnveach
 romani
 romanivanov

--- a/.ci/travis/travis.sh
+++ b/.ci/travis/travis.sh
@@ -2,6 +2,13 @@
 # Attention, there is no "-x" to avoid problems on Travis
 set -e
 
+removeFolderWithProtectedFiles() {
+  cd "$1"
+  find . -delete
+  cd ..
+  rmdir "$1"
+}
+
 case $1 in
 
 checkstyle-and-sevntu)
@@ -441,6 +448,20 @@ no-exception-test-alot-of-project1)
   export MAVEN_OPTS="-Xmx2048m"
   groovy ./launch.groovy --listOfProjects projects-to-test-on.properties \
       --config checks-nonjavadoc-error.xml --checkstyleVersion $CS_POM_VERSION
+  ;;
+
+
+no-error-pmd)
+  CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
+                     --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
+  echo CS_version: ${CS_POM_VERSION}
+  mkdir -p .ci-temp/
+  cd .ci-temp/
+  git clone https://github.com/pmd/pmd.git
+  cd pmd
+  mvn -e install checkstyle:check -Dcheckstyle.version=${CS_POM_VERSION}
+  cd ..
+  removeFolderWithProtectedFiles pmd
   ;;
 
 check-missing-pitests)

--- a/.travis.yml
+++ b/.travis.yml
@@ -308,6 +308,13 @@ matrix:
         - DESC="validate since javadoc tag if new module is created"
         - CMD="./.ci/travis/travis.sh check-since-version"
 
+    # No error testing - pmd
+    - jdk: openjdk11
+      env:
+          - DESC="no error test on pmd"
+          - USE_MAVEN_REPO="true"
+          - CMD="./.ci/travis/travis.sh no-error-pmd"
+
 script:
   - SKIP_FILES1=".github|codeship-*|buddy.yml|appveyor.yml|circleci"
   - SKIP_FILES2="|fast-forward-merge.sh|LICENSE|LICENSE.apache20|README.md|release.sh|RIGHTS.antlr"

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule331nowildcard/AvoidStarImportTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule331nowildcard/AvoidStarImportTest.java
@@ -34,10 +34,12 @@ public class AvoidStarImportTest extends AbstractGoogleModuleTestSupport {
     @Test
     public void testStarImport() throws Exception {
         final String[] expected = {
-            "3: Using the '.*' form of import should be avoided - java.io.*.",
-            "4: Using the '.*' form of import should be avoided - java.lang.*.",
-            "18: Using the '.*' form of import should be avoided - javax.swing.WindowConstants.*.",
-            "19: Using the '.*' form of import should be avoided - javax.swing.WindowConstants.*.",
+            "3:15: Using the '.*' form of import should be avoided - java.io.*.",
+            "4:17: Using the '.*' form of import should be avoided - java.lang.*.",
+            "18:42: Using the '.*' form of import should be avoided - "
+                + "javax.swing.WindowConstants.*.",
+            "19:42: Using the '.*' form of import should be avoided - "
+                + "javax.swing.WindowConstants.*.",
         };
 
         final Configuration checkConfig = getModuleConfig("AvoidStarImport");

--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/NoLineWrapTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule332nolinewrap/NoLineWrapTest.java
@@ -37,9 +37,9 @@ public class NoLineWrapTest extends AbstractGoogleModuleTestSupport {
     @Test
     public void testBadLineWrap() throws Exception {
         final String[] expected = {
-            "1: " + getCheckMessage(NoLineWrapCheck.class, "no.line.wrap", "package"),
-            "6: " + getCheckMessage(NoLineWrapCheck.class, "no.line.wrap", "import"),
-            "10: " + getCheckMessage(NoLineWrapCheck.class, "no.line.wrap", "import"),
+            "1:1: " + getCheckMessage(NoLineWrapCheck.class, "no.line.wrap", "package"),
+            "6:1: " + getCheckMessage(NoLineWrapCheck.class, "no.line.wrap", "import"),
+            "10:1: " + getCheckMessage(NoLineWrapCheck.class, "no.line.wrap", "import"),
         };
 
         final Configuration checkConfig = getModuleConfig("NoLineWrap");

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4843defaultcasepresent/MissingSwitchDefaultTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule4843defaultcasepresent/MissingSwitchDefaultTest.java
@@ -38,12 +38,12 @@ public class MissingSwitchDefaultTest extends AbstractGoogleModuleTestSupport {
             "missing.switch.default");
 
         final String[] expected = {
-            "11: " + msg,
-            "19: " + msg,
-            "23: " + msg,
-            "31: " + msg,
-            "38: " + msg,
-            "42: " + msg,
+            "11:9: " + msg,
+            "19:9: " + msg,
+            "23:9: " + msg,
+            "31:13: " + msg,
+            "38:21: " + msg,
+            "42:21: " + msg,
         };
 
         final Configuration checkConfig = getModuleConfig("MissingSwitchDefault");

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidStarImportTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidStarImportTest.java
@@ -1,0 +1,82 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
+
+public class XpathRegressionAvoidStarImportTest
+        extends AbstractXpathTestSupport {
+
+    private static final Class<AvoidStarImportCheck> CLASS =
+        AvoidStarImportCheck.class;
+
+    @Override
+    protected String getCheckName() {
+        return CLASS.getSimpleName();
+    }
+
+    @Test
+    public void testOne() throws Exception {
+        final File fileToProcess = new File(getPath(
+            "SuppressionXpathRegressionAvoidStarImport1.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(CLASS);
+
+        final String[] expectedViolation = {
+            "3:42: " + getCheckMessage(CLASS,
+                AvoidStarImportCheck.MSG_KEY, "javax.swing.WindowConstants.*"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/STATIC_IMPORT/DOT"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+
+    @Test
+    public void testTwo() throws Exception {
+        final File fileToProcess = new File(getPath(
+            "SuppressionXpathRegressionAvoidStarImport2.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(CLASS);
+
+        final String[] expectedViolation = {
+            "4:15: " + getCheckMessage(CLASS,
+                AvoidStarImportCheck.MSG_KEY, "java.io.*"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/IMPORT/DOT"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+
+}

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidStaticImportTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidStaticImportTest.java
@@ -1,0 +1,82 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStaticImportCheck;
+
+public class XpathRegressionAvoidStaticImportTest
+        extends AbstractXpathTestSupport {
+
+    private static final Class<AvoidStaticImportCheck> CLASS =
+        AvoidStaticImportCheck.class;
+
+    @Override
+    protected String getCheckName() {
+        return CLASS.getSimpleName();
+    }
+
+    @Test
+    public void testOne() throws Exception {
+        final File fileToProcess = new File(getPath(
+            "SuppressionXpathRegressionAvoidStaticImport1.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(CLASS);
+
+        final String[] expectedViolation = {
+            "3:42: " + getCheckMessage(CLASS,
+                AvoidStaticImportCheck.MSG_KEY, "javax.swing.WindowConstants.*"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/STATIC_IMPORT/DOT"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+
+    @Test
+    public void testTwo() throws Exception {
+        final File fileToProcess = new File(getPath(
+            "SuppressionXpathRegressionAvoidStaticImport2.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(CLASS);
+
+        final String[] expectedViolation = {
+            "3:27: " + getCheckMessage(CLASS,
+                AvoidStaticImportCheck.MSG_KEY, "java.io.File.createTempFile"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/STATIC_IMPORT/DOT[./IDENT[@text='createTempFile']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+
+}

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionFinalClassTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionFinalClassTest.java
@@ -1,0 +1,94 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.design.FinalClassCheck;
+
+public class XpathRegressionFinalClassTest extends AbstractXpathTestSupport {
+    private final String checkName = FinalClassCheck.class.getSimpleName();
+
+    @Override
+    protected String getCheckName() {
+        return checkName;
+    }
+
+    @Test
+    public void testOne() throws Exception {
+        final File fileToProcess = new File(getPath(
+                "SuppressionXpathRegressionFinalClass1.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(FinalClassCheck.class);
+
+        final String[] expectedViolation = {
+            "3:1: " + getCheckMessage(FinalClassCheck.class,
+                    FinalClassCheck.MSG_KEY, "SuppressionXpathRegressionFinalClass1"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT["
+                        + "@text='SuppressionXpathRegressionFinalClass1']]",
+                "/CLASS_DEF[./IDENT["
+                        + "@text='SuppressionXpathRegressionFinalClass1']]/MODIFIERS",
+                "/CLASS_DEF[./IDENT["
+                        + "@text='SuppressionXpathRegressionFinalClass1']]/MODIFIERS/LITERAL_PUBLIC"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testTwo() throws Exception {
+        final File fileToProcess = new File(getPath(
+                "SuppressionXpathRegressionFinalClass2.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(FinalClassCheck.class);
+
+        final String[] expectedViolation = {
+            "4:5: " + getCheckMessage(FinalClassCheck.class,
+                    FinalClassCheck.MSG_KEY, "Test"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT["
+                        + "@text='SuppressionXpathRegressionFinalClass2']]"
+                        + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='Test']]",
+                "/CLASS_DEF[./IDENT["
+                        + "@text='SuppressionXpathRegressionFinalClass2']]"
+                        + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='Test']]/MODIFIERS",
+                "/CLASS_DEF[./IDENT["
+                        + "@text='SuppressionXpathRegressionFinalClass2']]"
+                        + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='Test']]/LITERAL_CLASS"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+}
+

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionImportOrderTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionImportOrderTest.java
@@ -1,0 +1,149 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck;
+
+public class XpathRegressionImportOrderTest extends AbstractXpathTestSupport {
+
+    private final String checkName = ImportOrderCheck.class.getSimpleName();
+
+    @Override
+    protected String getCheckName() {
+        return checkName;
+    }
+
+    @Test
+    public void testOne() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionImportOrderOne.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(ImportOrderCheck.class);
+
+        final String[] expectedViolation = {
+            "4:1: " + getCheckMessage(ImportOrderCheck.class,
+                        ImportOrderCheck.MSG_ORDERING, "java.util.Set"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/IMPORT"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testTwo() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionImportOrderTwo.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(ImportOrderCheck.class);
+
+        final String[] expectedViolation = {
+            "5:1: " + getCheckMessage(ImportOrderCheck.class,
+                        ImportOrderCheck.MSG_SEPARATED_IN_GROUP, "java.util.Set"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/IMPORT[./DOT/IDENT[@text='Set']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testThree() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionImportOrderThree.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(ImportOrderCheck.class);
+        moduleConfig.addAttribute("groups", "/^java\\./,javax,org");
+        moduleConfig.addAttribute("separated", "true");
+
+        final String[] expectedViolation = {
+            "4:1: " + getCheckMessage(ImportOrderCheck.class,
+                        ImportOrderCheck.MSG_SEPARATION, "org.junit.*"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/IMPORT[./DOT/DOT/IDENT[@text='org']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testFour() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionImportOrderFour.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(ImportOrderCheck.class);
+        moduleConfig.addAttribute("option", "inflow");
+
+        final String[] expectedViolation = {
+            "5:1: " + getCheckMessage(ImportOrderCheck.class,
+                        ImportOrderCheck.MSG_ORDERING, "java.lang.Math.PI"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/STATIC_IMPORT"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testFive() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionImportOrderFive.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(ImportOrderCheck.class);
+        moduleConfig.addAttribute("groups", "/^java\\./,javax,org");
+
+        final String[] expectedViolation = {
+            "5:1: " + getCheckMessage(ImportOrderCheck.class,
+                        ImportOrderCheck.MSG_ORDERING, "java.util.Date"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/IMPORT[./DOT/IDENT[@text='Date']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+}

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionJavadocStyleTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionJavadocStyleTest.java
@@ -1,0 +1,58 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck;
+
+public class XpathRegressionJavadocStyleTest extends AbstractXpathTestSupport {
+
+    private final String checkName = JavadocStyleCheck.class.getSimpleName();
+
+    @Override
+    protected String getCheckName() {
+        return checkName;
+    }
+
+    @Test
+    public void testOne() throws Exception {
+        final File fileToProcess = new File(getPath("SuppressionXpathRegression"
+                + File.separator + "package-info.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(JavadocStyleCheck.class);
+
+        final String[] expectedViolation = {
+            "1:1: " + getCheckMessage(JavadocStyleCheck.class,
+                JavadocStyleCheck.MSG_JAVADOC_MISSING),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList("/PACKAGE_DEF");
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+}

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMissingCtorTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMissingCtorTest.java
@@ -1,0 +1,93 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.coding.MissingCtorCheck;
+
+public class XpathRegressionMissingCtorTest extends AbstractXpathTestSupport {
+
+    private final String checkName = MissingCtorCheck.class.getSimpleName();
+
+    @Override
+    protected String getCheckName() {
+        return checkName;
+    }
+
+    @Test
+    public void testOne() throws Exception {
+        final File fileToProcess = new File(getPath(
+                "SuppressionXpathRegressionMissingCtor1.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(MissingCtorCheck.class);
+
+        final String[] expectedViolation = {
+            "3:1: " + getCheckMessage(MissingCtorCheck.class,
+                    MissingCtorCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMissingCtor1']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMissingCtor1']]/MODIFIERS",
+                "/CLASS_DEF[./IDENT["
+                    + "@text='SuppressionXpathRegressionMissingCtor1']]/MODIFIERS/LITERAL_PUBLIC"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testTwo() throws Exception {
+        final File fileToProcess = new File(getPath(
+                "SuppressionXpathRegressionMissingCtor2.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(MissingCtorCheck.class);
+
+        final String[] expectedViolation = {
+            "9:5: " + getCheckMessage(MissingCtorCheck.class,
+                    MissingCtorCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT["
+                    + "@text='SuppressionXpathRegressionMissingCtor2']]"
+                    + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='InnerClass']]",
+                "/CLASS_DEF[./IDENT["
+                    + "@text='SuppressionXpathRegressionMissingCtor2']]"
+                    + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='InnerClass']]/MODIFIERS",
+                "/CLASS_DEF[./IDENT["
+                    + "@text='SuppressionXpathRegressionMissingCtor2']]"
+                    + "/OBJBLOCK/CLASS_DEF[./IDENT[@text='InnerClass']]/LITERAL_CLASS"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+}

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMissingSwitchDefaultTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMissingSwitchDefaultTest.java
@@ -1,0 +1,83 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.coding.MissingSwitchDefaultCheck;
+
+public class XpathRegressionMissingSwitchDefaultTest extends AbstractXpathTestSupport {
+
+    private final Class<MissingSwitchDefaultCheck> clss = MissingSwitchDefaultCheck.class;
+
+    @Override
+    protected String getCheckName() {
+        return clss.getSimpleName();
+    }
+
+    @Test
+    public void testOne() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionMissingSwitchDefaultOne.java"));
+
+        final DefaultConfiguration moduleConfig = createModuleConfig(clss);
+        final String[] expectedViolation = {
+            "6:9: " + getCheckMessage(clss, MissingSwitchDefaultCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMissingSwitchDefaultOne']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test1']]"
+                        + "/SLIST/LITERAL_SWITCH"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+
+    @Test
+    public void testTwo() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionMissingSwitchDefaultTwo.java"));
+
+        final DefaultConfiguration moduleConfig = createModuleConfig(clss);
+
+        final String[] expectedViolation = {
+            "12:17: " + getCheckMessage(clss, MissingSwitchDefaultCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMissingSwitchDefaultTwo']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test2']]"
+                        + "/SLIST/LITERAL_SWITCH/CASE_GROUP/SLIST",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMissingSwitchDefaultTwo']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test2']]"
+                        + "/SLIST/LITERAL_SWITCH/CASE_GROUP/SLIST/"
+                        + "LITERAL_SWITCH"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+}

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNoLineWrapTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNoLineWrapTest.java
@@ -1,0 +1,122 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.whitespace.NoLineWrapCheck;
+
+public class XpathRegressionNoLineWrapTest extends AbstractXpathTestSupport {
+
+    @Override
+    protected String getCheckName() {
+        return NoLineWrapCheck.class.getSimpleName();
+    }
+
+    @Test
+    public void testOne() throws Exception {
+        final File fileToProcess = new File(
+                getPath("SuppressionXpathRegressionNoLineWrap1.java")
+        );
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(NoLineWrapCheck.class);
+
+        final String[] expectedViolation = {
+            "1:1: " + getCheckMessage(NoLineWrapCheck.class,
+                    NoLineWrapCheck.MSG_KEY, "package"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/PACKAGE_DEF"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+
+    @Test
+    public void testTwo() throws Exception {
+        final File fileToProcess = new File(
+                getPath("SuppressionXpathRegressionNoLineWrap2.java")
+        );
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(NoLineWrapCheck.class);
+        moduleConfig.addAttribute("tokens", "METHOD_DEF");
+
+        final String[] expectedViolation = {
+            "4:5: " + getCheckMessage(NoLineWrapCheck.class,
+                    NoLineWrapCheck.MSG_KEY, "METHOD_DEF"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionNoLineWrap2']]"
+                    + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test2']]",
+
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionNoLineWrap2']]"
+                    + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test2']]"
+                    + "/MODIFIERS",
+
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionNoLineWrap2']]"
+                    + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test2']]"
+                    + "/MODIFIERS/LITERAL_PUBLIC"
+
+                );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+
+    @Test
+    public void testThree() throws Exception {
+        final File fileToProcess = new File(
+                getPath("SuppressionXpathRegressionNoLineWrap3.java")
+        );
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(NoLineWrapCheck.class);
+        moduleConfig.addAttribute("tokens", "CTOR_DEF");
+
+        final String[] expectedViolation = {
+            "4:5: " + getCheckMessage(NoLineWrapCheck.class,
+                    NoLineWrapCheck.MSG_KEY, "CTOR_DEF"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionNoLineWrap3']]"
+                    + "/OBJBLOCK/CTOR_DEF[./IDENT[@text='SuppressionXpathRegressionNoLineWrap3']]",
+
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionNoLineWrap3']]"
+                    + "/OBJBLOCK/CTOR_DEF[./IDENT[@text='SuppressionXpathRegressionNoLineWrap3']]"
+                    + "/MODIFIERS",
+
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionNoLineWrap3']]"
+                    + "/OBJBLOCK/CTOR_DEF/IDENT[@text='SuppressionXpathRegressionNoLineWrap3']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+
+}

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionPackageAnnotationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionPackageAnnotationTest.java
@@ -1,0 +1,79 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.annotation.PackageAnnotationCheck;
+
+public class XpathRegressionPackageAnnotationTest extends AbstractXpathTestSupport {
+
+    private final String checkName = PackageAnnotationCheck.class.getSimpleName();
+
+    @Override
+    protected String getCheckName() {
+        return checkName;
+    }
+
+    @Test
+    public void testOne() throws Exception {
+        final File fileToProcess =
+                new File(getNonCompilablePath(
+                        "SuppressionXpathRegressionPackageAnnotationOne.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(PackageAnnotationCheck.class);
+
+        final String[] expectedViolation = {
+            "4:1: " + getCheckMessage(PackageAnnotationCheck.class,
+                PackageAnnotationCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList("/PACKAGE_DEF");
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testTwo() throws Exception {
+        final File fileToProcess =
+                new File(getNonCompilablePath(
+                        "SuppressionXpathRegressionPackageAnnotationTwo.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(PackageAnnotationCheck.class);
+
+        final String[] expectedViolation = {
+            "4:1: " + getCheckMessage(PackageAnnotationCheck.class,
+                PackageAnnotationCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList("/PACKAGE_DEF");
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+}

--- a/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/packageannotation/SuppressionXpathRegressionPackageAnnotationOne.java
+++ b/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/packageannotation/SuppressionXpathRegressionPackageAnnotationOne.java
@@ -1,8 +1,8 @@
 //non-compiled with javac: non-compilable, compiling on jdk before 8
 //more details at https://github.com/checkstyle/checkstyle/issues/7846
 @Deprecated
-package com.puppycrawl.tools.checkstyle.checks.annotation.packageannotation;
+package com.puppycrawl.tools.checkstyle.checks.annotation.packageannotation; // warn
 
-public class InputPackageAnnotation2 {
+public class SuppressionXpathRegressionPackageAnnotationOne {
 
 }

--- a/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/packageannotation/SuppressionXpathRegressionPackageAnnotationTwo.java
+++ b/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/packageannotation/SuppressionXpathRegressionPackageAnnotationTwo.java
@@ -1,0 +1,10 @@
+//non-compiled with javac: non-compilable, compiling on jdk before 8
+//more details at https://github.com/checkstyle/checkstyle/issues/7846
+@Deprecated @Generated("foo")
+package com.puppycrawl.tools.checkstyle.checks.annotation.packageannotation.two; // warn
+
+import javax.annotation.Generated;
+
+public class SuppressionXpathRegressionPackageAnnotationOne {
+
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/avoidstarimport/SuppressionXpathRegressionAvoidStarImport1.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/avoidstarimport/SuppressionXpathRegressionAvoidStarImport1.java
@@ -1,0 +1,6 @@
+package org.checkstyle.suppressionxpathfilter.avoidstarimport;
+
+import static javax.swing.WindowConstants.*; // warn
+
+public class SuppressionXpathRegressionAvoidStarImport1 {
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/avoidstarimport/SuppressionXpathRegressionAvoidStarImport2.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/avoidstarimport/SuppressionXpathRegressionAvoidStarImport2.java
@@ -1,0 +1,7 @@
+package org.checkstyle.suppressionxpathfilter.avoidstarimport;
+
+import java.util.Scanner;
+import java.io.*;  // warn
+
+public class SuppressionXpathRegressionAvoidStarImport2 {
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/avoidstaticimport/SuppressionXpathRegressionAvoidStaticImport1.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/avoidstaticimport/SuppressionXpathRegressionAvoidStaticImport1.java
@@ -1,0 +1,6 @@
+package org.checkstyle.suppressionxpathfilter.avoidstaticimport;
+
+import static javax.swing.WindowConstants.*; // warn
+
+public class SuppressionXpathRegressionAvoidStaticImport1 {
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/avoidstaticimport/SuppressionXpathRegressionAvoidStaticImport2.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/avoidstaticimport/SuppressionXpathRegressionAvoidStaticImport2.java
@@ -1,0 +1,6 @@
+package org.checkstyle.suppressionxpathfilter.avoidstaticimport;
+
+import static java.io.File.createTempFile; // warn
+
+public class SuppressionXpathRegressionAvoidStaticImport2 {
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/finalclass/SuppressionXpathRegressionFinalClass1.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/finalclass/SuppressionXpathRegressionFinalClass1.java
@@ -1,0 +1,7 @@
+package org.checkstyle.suppressionxpathfilter.finalclass;
+
+public class SuppressionXpathRegressionFinalClass1 { // warn
+    private SuppressionXpathRegressionFinalClass1() {
+
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/finalclass/SuppressionXpathRegressionFinalClass2.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/finalclass/SuppressionXpathRegressionFinalClass2.java
@@ -1,0 +1,9 @@
+package org.checkstyle.suppressionxpathfilter.finalclass;
+
+public class SuppressionXpathRegressionFinalClass2 {
+    class Test { // warn
+        private Test(){
+
+        }
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/importorder/SuppressionXpathRegressionImportOrderFive.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/importorder/SuppressionXpathRegressionImportOrderFive.java
@@ -1,0 +1,9 @@
+package org.checkstyle.suppressionxpathfilter.importorder;
+
+import java.util.List;
+import static org.junit.After.*;
+import java.util.Date; // warn
+
+public class SuppressionXpathRegressionImportOrderFive {
+	// code
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/importorder/SuppressionXpathRegressionImportOrderFour.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/importorder/SuppressionXpathRegressionImportOrderFour.java
@@ -1,0 +1,9 @@
+package org.checkstyle.suppressionxpathfilter.importorder;
+
+import java.io.*;
+import java.util.Set;
+import static java.lang.Math.PI; // warn
+
+public class SuppressionXpathRegressionImportOrderFour {
+	// code
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/importorder/SuppressionXpathRegressionImportOrderOne.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/importorder/SuppressionXpathRegressionImportOrderOne.java
@@ -1,0 +1,8 @@
+package org.checkstyle.suppressionxpathfilter.importorder;
+
+import static java.lang.Math.PI;
+import java.util.Set; // warn
+
+public class SuppressionXpathRegressionImportOrderOne {
+	// code
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/importorder/SuppressionXpathRegressionImportOrderThree.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/importorder/SuppressionXpathRegressionImportOrderThree.java
@@ -1,0 +1,8 @@
+package org.checkstyle.suppressionxpathfilter.importorder;
+
+import java.io.*;
+import org.junit.*; // warn
+
+public class SuppressionXpathRegressionImportOrderThree {
+    // code
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/importorder/SuppressionXpathRegressionImportOrderTwo.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/importorder/SuppressionXpathRegressionImportOrderTwo.java
@@ -1,0 +1,9 @@
+package org.checkstyle.suppressionxpathfilter.importorder;
+
+import java.util.List;
+
+import java.util.Set; // warn
+
+public class SuppressionXpathRegressionImportOrderTwo {
+	// code
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/javadocstyle/SuppressionXpathRegression/package-info.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/javadocstyle/SuppressionXpathRegression/package-info.java
@@ -1,0 +1,1 @@
+package org.checkstyle.suppressionxpathfilter.javadocstyle.SuppressionXpathRegression; //warn

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/missingctor/SuppressionXpathRegressionMissingCtor1.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/missingctor/SuppressionXpathRegressionMissingCtor1.java
@@ -1,0 +1,5 @@
+package org.checkstyle.suppressionxpathfilter.missingctor;
+
+public class SuppressionXpathRegressionMissingCtor1 { // warn
+
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/missingctor/SuppressionXpathRegressionMissingCtor2.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/missingctor/SuppressionXpathRegressionMissingCtor2.java
@@ -1,0 +1,13 @@
+package org.checkstyle.suppressionxpathfilter.missingctor;
+
+public class SuppressionXpathRegressionMissingCtor2 {
+
+    private SuppressionXpathRegressionMissingCtor2() {
+
+    }
+
+    class InnerClass { // warn
+
+    }
+
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/missingswitchdefault/SuppressionXpathRegressionMissingSwitchDefaultOne.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/missingswitchdefault/SuppressionXpathRegressionMissingSwitchDefaultOne.java
@@ -1,0 +1,13 @@
+package org.checkstyle.suppressionxpathfilter.missingswitchdefault;
+
+public class SuppressionXpathRegressionMissingSwitchDefaultOne {
+    public static void test1() {
+        int key = 2;
+        switch (key) { // warn
+            case 1:
+                break;
+            case 2:
+                break;
+        }
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/missingswitchdefault/SuppressionXpathRegressionMissingSwitchDefaultTwo.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/missingswitchdefault/SuppressionXpathRegressionMissingSwitchDefaultTwo.java
@@ -1,0 +1,18 @@
+package org.checkstyle.suppressionxpathfilter.missingswitchdefault;
+
+public class SuppressionXpathRegressionMissingSwitchDefaultTwo {
+    public static void test2() {
+        int key = 2;
+        switch (key) {
+            case 1:
+                break;
+            case 2:
+                break;
+            default:
+                switch (key) { // warn
+                    case 2:
+                        break;
+                }
+        }
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/nolinewrap/SuppressionXpathRegressionNoLineWrap1.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/nolinewrap/SuppressionXpathRegressionNoLineWrap1.java
@@ -1,0 +1,5 @@
+package org.checkstyle.suppressionxpathfilter // warn
+        .nolinewrap;
+
+public class SuppressionXpathRegressionNoLineWrap1 {
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/nolinewrap/SuppressionXpathRegressionNoLineWrap2.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/nolinewrap/SuppressionXpathRegressionNoLineWrap2.java
@@ -1,0 +1,8 @@
+package org.checkstyle.suppressionxpathfilter.nolinewrap;
+
+public class SuppressionXpathRegressionNoLineWrap2 {
+    public static // warn
+        void test2() {
+                       
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/nolinewrap/SuppressionXpathRegressionNoLineWrap3.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/nolinewrap/SuppressionXpathRegressionNoLineWrap3.java
@@ -1,0 +1,8 @@
+package org.checkstyle.suppressionxpathfilter.nolinewrap;
+
+public class SuppressionXpathRegressionNoLineWrap3 {
+    SuppressionXpathRegressionNoLineWrap3 //warn
+            (String input1, String input2) {
+
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.java
@@ -460,7 +460,7 @@ public final class JavadocTokenTypes {
      *
      * <p><b>Example:</b></p>
      * <pre><code>{&#64;docRoot
-     *}</code></pre>
+     * }</code></pre>
      * <b>Tree:</b>
      * <pre>
      * <code>  |--JAVADOC_INLINE_TAG[1x0] : [{&#64;docRoot \n}]

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
@@ -29,7 +29,7 @@ import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 
 /**
- *<p>
+ * <p>
  * Checks whether files end with a line separator.
  * </p>
  * <p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationCheck.java
@@ -99,7 +99,7 @@ public class PackageAnnotationCheck extends AbstractCheck {
             getFileContents().inPackageInfo();
 
         if (containsAnnotation && !inPackageInfo) {
-            log(ast.getLineNo(), MSG_KEY);
+            log(ast, MSG_KEY);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -74,46 +74,46 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * Example:
  * </p>
  * <pre>
- *public class Test {
+ * public class Test {
  *
- *  public void test() {
+ *   public void test() {
  *
- *    if (foo) {
- *      bar();
- *    }           // violation, right curly must be in the same line as the 'else' keyword
- *    else {
- *      bar();
- *    }
+ *     if (foo) {
+ *       bar();
+ *     }           // violation, right curly must be in the same line as the 'else' keyword
+ *     else {
+ *       bar();
+ *     }
  *
- *    if (foo) {
- *      bar();
- *    } else {     // OK
- *      bar();
- *    }
+ *     if (foo) {
+ *       bar();
+ *     } else {     // OK
+ *       bar();
+ *     }
  *
- *    if (foo) { bar(); } int i = 0; // violation
- *                  // ^^^ statement is not allowed on same line after curly right brace
+ *     if (foo) { bar(); } int i = 0; // violation
+ *                   // ^^^ statement is not allowed on same line after curly right brace
  *
- *    if (foo) { bar(); }            // OK
- *    int i = 0;
+ *     if (foo) { bar(); }            // OK
+ *     int i = 0;
  *
- *    try {
- *      bar();
- *    }           // violation, rightCurly must be in the same line as 'catch' keyword
- *    catch (Exception e) {
- *      bar();
- *    }
+ *     try {
+ *       bar();
+ *     }           // violation, rightCurly must be in the same line as 'catch' keyword
+ *     catch (Exception e) {
+ *       bar();
+ *     }
  *
- *    try {
- *      bar();
- *    } catch (Exception e) { // OK
- *      bar();
- *    }
+ *     try {
+ *       bar();
+ *     } catch (Exception e) { // OK
+ *       bar();
+ *     }
  *
- *  }                         // OK
+ *   }                         // OK
  *
- *  public void testSingleLine() { bar(); } // OK, because singleline is allowed
- *}
+ *   public void testSingleLine() { bar(); } // OK, because singleline is allowed
+ * }
  * </pre>
  * <p>
  * To configure the check with policy {@code alone} for {@code else} and
@@ -130,34 +130,34 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * Example:
  * </p>
  * <pre>
- *public class Test {
+ * public class Test {
  *
- *  public void test() {
+ *   public void test() {
  *
- *    if (foo) {
- *      bar();
- *    } else { bar(); }   // violation, right curly must be alone on line
+ *     if (foo) {
+ *       bar();
+ *     } else { bar(); }   // violation, right curly must be alone on line
  *
- *    if (foo) {
- *      bar();
- *    } else {
- *      bar();
- *    }                   // OK
+ *     if (foo) {
+ *       bar();
+ *     } else {
+ *       bar();
+ *     }                   // OK
  *
- *    try {
- *      bar();
- *    } catch (Exception e) { // OK because config is set to token METHOD_DEF and LITERAL_ELSE
- *      bar();
- *    }
+ *     try {
+ *       bar();
+ *     } catch (Exception e) { // OK because config is set to token METHOD_DEF and LITERAL_ELSE
+ *       bar();
+ *     }
  *
- *  }                         // OK
+ *   }                         // OK
  *
- *  public void violate() { bar; } // violation, singleline is not allowed here
+ *   public void violate() { bar; } // violation, singleline is not allowed here
  *
- *  public void ok() {
- *    bar();
- *  }                              // OK
- *}
+ *   public void ok() {
+ *     bar();
+ *   }                              // OK
+ * }
  * </pre>
  * <p>
  * To configure the check with policy {@code alone_or_singleline} for {@code if}
@@ -175,33 +175,33 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * Example:
  * </p>
  * <pre>
- *public class Test {
+ * public class Test {
  *
- *  public void test() {
+ *   public void test() {
  *
- *    if (foo) {
- *      bar();
- *    } else {        // violation, right curly must be alone on line
- *      bar();
- *    }
+ *     if (foo) {
+ *       bar();
+ *     } else {        // violation, right curly must be alone on line
+ *       bar();
+ *     }
  *
- *    if (foo) {
- *      bar();
- *    }               // OK
- *    else {
- *      bar();
- *    }
+ *     if (foo) {
+ *       bar();
+ *     }               // OK
+ *     else {
+ *       bar();
+ *     }
  *
- *    try {
- *      bar();
- *    } catch (Exception e) {        // OK because config did not set token LITERAL_TRY
- *      bar();
- *    }
+ *     try {
+ *       bar();
+ *     } catch (Exception e) {        // OK because config did not set token LITERAL_TRY
+ *       bar();
+ *     }
  *
- *  }                                // OK
+ *   }                                // OK
  *
- *  public void violate() { bar(); } // OK , because singleline
- *}
+ *   public void violate() { bar(); } // OK , because singleline
+ * }
  * </pre>
  *
  * @since 3.0

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DefaultComesLastCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DefaultComesLastCheck.java
@@ -47,31 +47,64 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <pre>
  * &lt;module name=&quot;DefaultComesLast&quot;/&gt;
  * </pre>
- * <p>
- * To configure the check for skipIfLastAndSharedWithCase:
+ * <p>Example:</p>
+ * <pre>
+ * switch (i) {
+ *   case 1:
+ *     break;
+ *   case 2:
+ *     break;
+ *   default: // OK
+ *     break;
+ * }
+ *
+ * switch (i) {
+ *   case 1:
+ *     break;
+ *   case 2:
+ *     break; // OK, no default
+ * }
+ *
+ * switch (i) {
+ *   case 1:
+ *     break;
+ *   default: // violation, 'default' before 'case'
+ *     break;
+ *   case 2:
+ *     break;
+ * }
+ *
+ * switch (i) {
+ *   case 1:
+ *   default: // violation, 'default' before 'case'
+ *     break;
+ *   case 2:
+ *     break;
+ * }
+ * </pre>
+ * <p>To configure the check to allow default label to be not last if it is shared with case:
  * </p>
  * <pre>
  * &lt;module name=&quot;DefaultComesLast&quot;&gt;
  *   &lt;property name=&quot;skipIfLastAndSharedWithCase&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
- * <p>
- * Example when skipIfLastAndSharedWithCase is set to true.
- * </p>
+ * <p>Example:</p>
  * <pre>
  * switch (i) {
  *   case 1:
  *     break;
  *   case 2:
- *   default: // No violation with the new option is expected
+ *   default: // OK
  *     break;
  *   case 3:
  *     break;
  * }
+ *
  * switch (i) {
  *   case 1:
  *     break;
- *   default: // violation with the new option is expected
+ *   default: // violation
  *   case 2:
  *     break;
  * }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -794,7 +794,7 @@ public class FinalLocalVariableCheck extends AbstractCheck {
 
     }
 
-    /**Represents information about final local variable candidate. */
+    /** Represents information about final local variable candidate. */
     private static class FinalVariableCandidate {
 
         /** Identifier token. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingCtorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingCtorCheck.java
@@ -68,7 +68,7 @@ public class MissingCtorCheck extends AbstractCheck {
         if (modifiers.findFirstToken(TokenTypes.ABSTRACT) == null
                 && ast.findFirstToken(TokenTypes.OBJBLOCK)
                     .findFirstToken(TokenTypes.CTOR_DEF) == null) {
-            log(ast.getLineNo(), MSG_KEY);
+            log(ast, MSG_KEY);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheck.java
@@ -94,7 +94,7 @@ public class MissingSwitchDefaultCheck extends AbstractCheck {
         final DetailAST firstCaseGroupAst = ast.findFirstToken(TokenTypes.CASE_GROUP);
 
         if (!containsDefaultSwitch(firstCaseGroupAst)) {
-            log(ast.getLineNo(), MSG_KEY);
+            log(ast, MSG_KEY);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
@@ -205,7 +205,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *
  *   public int foo4() {return 4;} // violation
  * }
- *</pre>
+ * </pre>
  *
  * @since 3.1
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
@@ -134,7 +134,7 @@ public class FinalClassCheck
                 && !ScopeUtil.isInInterfaceOrAnnotationBlock(ast)) {
                 final String qualifiedName = desc.getQualifiedName();
                 final String className = getClassNameFromQualifiedName(qualifiedName);
-                log(ast.getLineNo(), MSG_KEY, className);
+                log(ast, MSG_KEY, className);
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
@@ -238,7 +238,7 @@ public class AvoidStarImportCheck
         final FullIdent name = FullIdent.createFullIdent(startingDot);
         final String importText = name.getText();
         if (importText.endsWith(STAR_IMPORT_SUFFIX) && !excludes.contains(importText)) {
-            log(startingDot.getLineNo(), MSG_KEY, importText);
+            log(startingDot, MSG_KEY, importText);
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
@@ -125,7 +125,7 @@ public class AvoidStaticImportCheck
         final FullIdent name = FullIdent.createFullIdent(startingDot);
 
         if (!isExempt(name.getText())) {
-            log(startingDot.getLineNo(), MSG_KEY, name.getText());
+            log(startingDot, MSG_KEY, name.getText());
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
@@ -33,14 +33,14 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Checks for redundant import statements. An import statement is
  * considered redundant if:
  * </p>
- *<ul>
- *  <li>It is a duplicate of another import. This is, when a class is imported
- *  more than once.</li>
- *  <li>The class non-statically imported is from the {@code java.lang}
- *  package, e.g. importing {@code java.lang.String}.</li>
- *  <li>The class non-statically imported is from the same package as the
- *  current package.</li>
- *</ul>
+ * <ul>
+ *   <li>It is a duplicate of another import. This is, when a class is imported
+ *   more than once.</li>
+ *   <li>The class non-statically imported is from the {@code java.lang}
+ *   package, e.g. importing {@code java.lang.String}.</li>
+ *   <li>The class non-statically imported is from the same package as the
+ *   current package.</li>
+ * </ul>
  * <p>
  * To configure the check:
  * </p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheck.java
@@ -110,7 +110,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *   * This comment is OK because it starts from the second line.
  *   *&#47;
  * &#47;** This comment is OK because it is on the single line. *&#47;
- *</pre>
+ * </pre>
  * <p>
  * To ensure that Javadoc content starts from the first line:
  * </p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -331,7 +331,7 @@ public class JavadocStyleCheck
             // made sense to make another check just to ensure that the
             // package-info.java file actually contains package Javadocs.
             if (getFileContents().inPackageInfo()) {
-                log(ast.getLineNo(), MSG_JAVADOC_MISSING);
+                log(ast, MSG_JAVADOC_MISSING);
             }
         }
         else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
@@ -61,21 +61,19 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <p>Example:</p>
  * <pre>
  * public class Test {
- *   /** &#64;return integer value *&#47;
+ *   /** &#64;return integer value *&#47;//Violation. Javadoc contains one at-clause, it should be written in multiple lines.
  *   public int sum(int a, int b) {
  *     return a + b;
  *   }
- * } //Violation. If Javadoc contains at least one at-clause, it should be formatted in multiple lines. 
- * 
- * 
+ * }
  * public class Test {
  *   /** 
  *    * &#64;return integer value 
- *    *&#47;
+ *    *&#47;//OK. Correct Javadoc. 
  *   public int sum(int a, int b) {
  *     return a + b;
  *   }
- * } //OK. Correct Javadoc. 
+ * }
  * </pre>
  * <p>
  * To configure this check to print violations if Tight-HTML rules are being violated.
@@ -91,11 +89,11 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *   /**
  *    *&#64;return integer value
  *    *&lt;p&gt; First
- *    *&#47;
+ *    *&#47;//Prints violation for unclosed HTML tag.
  *   public int sum(int a, int b) {
  *     return a + b;
  *     }
- * } //Prints violation for unclosed HTML tag.
+ * } 
  * </pre>
  * <p>
  * To configure the check with a list of ignored at-clauses
@@ -110,18 +108,17 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <p>Examples:</p>
  * <pre>
  * public class Test {
- *   /** @see #sum(int a, int b) *&#47;
+ *   /** &#64;see #sum(int a, int b) *&#47;//OK. No violation because @see is in list of ignored tags
  *   public int sum(int a, int b) {
  *     return a + b;
  *   }
- * }//OK. No violation because @see is in list of ignored tags
- * 
+ * }
  * public class Test {
- *   /** Testing class for {@link Example} *&#47;
+ *   /** Testing class for {&#64;link Example} *&#47;//Prints violation for making Javadoc with inline tag in single line.
  *   public int sum(int a, int b) {
  *     return a + b;
  *   }
- * }//Prints violation for making Javadoc with inline tag in single line.
+ * }
  * </pre>
  * @since 6.0
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
@@ -58,6 +58,45 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <pre>
  * &lt;module name=&quot;SingleLineJavadoc&quot;/&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public class Test {
+ *   /** &#64;return integer value *&#47;
+ *   public int sum(int a, int b) {
+ *     return a + b;
+ *   }
+ * } //Violation. If Javadoc contains at least one at-clause, it should be formatted in multiple lines. 
+ * 
+ * 
+ * public class Test {
+ *   /** 
+ *    * &#64;return integer value 
+ *    *&#47;
+ *   public int sum(int a, int b) {
+ *     return a + b;
+ *   }
+ * } //OK. Correct Javadoc. 
+ * </pre>
+ * <p>
+ * To configure this check to print violations if Tight-HTML rules are being violated.
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;SingleLineJavadoc&quot;&gt;
+ *   &lt;property name=&quot;violateExecutionOnNonTightHtml&quot; value=&quot;true&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public class Test {
+ *   /**
+ *    *&#64;return integer value
+ *    *&lt;p&gt; First
+ *    *&#47;
+ *   public int sum(int a, int b) {
+ *     return a + b;
+ *     }
+ * } //Prints violation for unclosed HTML tag.
+ * </pre>
  * <p>
  * To configure the check with a list of ignored at-clauses
  * and make inline at-clauses not ignored:
@@ -68,7 +107,22 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *   &lt;property name=&quot;ignoreInlineTags&quot; value=&quot;false&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
- *
+ * <p>Examples:</p>
+ * <pre>
+ * public class Test {
+ *   /** @see #sum(int a, int b) *&#47;
+ *   public int sum(int a, int b) {
+ *     return a + b;
+ *   }
+ * }//OK. No violation because @see is in list of ignored tags
+ * 
+ * public class Test {
+ *   /** Testing class for {@link Example} *&#47;
+ *   public int sum(int a, int b) {
+ *     return a + b;
+ *   }
+ * }//Prints violation for making Javadoc with inline tag in single line.
+ * </pre>
  * @since 6.0
  */
 @StatelessCheck

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
@@ -32,7 +32,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 
 /**
- *<p>
+ * <p>
  * Checks that
  * <a href="https://www.oracle.com/technetwork/java/javase/documentation/index-137868.html#firstsentence">
  * Javadoc summary sentence</a> does not contain phrases that are not recommended to use.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoLineWrapCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoLineWrapCheck.java
@@ -119,7 +119,7 @@ public class NoLineWrapCheck extends AbstractCheck {
     @Override
     public void visitToken(DetailAST ast) {
         if (!TokenUtil.areOnSameLine(ast, ast.getLastChild())) {
-            log(ast.getLineNo(), MSG_KEY, ast.getText());
+            log(ast, MSG_KEY, ast.getText());
         }
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheck.java
@@ -61,14 +61,77 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <pre>
  * &lt;module name=&quot;NoWhitespaceBefore&quot;/&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * int foo;
+ * foo ++; // violation, whitespace before '++' is not allowed
+ * foo++; // OK
+ * for (int i = 0 ; i &lt; 5; i++) {}  // violation
+ *            // ^ whitespace before ';' is not allowed
+ * for (int i = 0; i &lt; 5; i++) {} // OK
+ * int[][] array = { { 1, 2 }
+ *                 , { 3, 4 } }; // violation, whitespace before ',' is not allowed
+ * int[][] array2 = { { 1, 2 },
+ *                    { 3, 4 } }; // OK
+ * Lists.charactersOf("foo").listIterator()
+ *        .forEachRemaining(System.out::print)
+ *        ; // violation, whitespace before ';' is not allowed
+ * </pre>
+ * <p>To configure the check to allow linebreaks before default tokens:</p>
+ * <pre>
+ * &lt;module name=&quot;NoWhitespaceBefore&quot;&gt;
+ *   &lt;property name=&quot;allowLineBreaks&quot; value=&quot;true&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * int[][] array = { { 1, 2 }
+ *                 , { 3, 4 } }; // OK, linebreak is allowed before ','
+ * int[][] array2 = { { 1, 2 },
+ *                    { 3, 4 } }; // OK, ideal code
+ * void ellipsisExample(String ...params) {}; // violation, whitespace before '...' is not allowed
+ * void ellipsisExample2(String
+ *                         ...params) {}; //OK, linebreak is allowed before '...'
+ * Lists.charactersOf("foo")
+ *        .listIterator()
+ *        .forEachRemaining(System.out::print); // OK
+ * </pre>
  * <p>
- * To configure the check to allow linebreaks before a DOT token:
+ *     To Configure the check to restrict the use of whitespace before METHOD_REF and DOT tokens:
  * </p>
  * <pre>
  * &lt;module name=&quot;NoWhitespaceBefore&quot;&gt;
+ *   &lt;property name=&quot;tokens&quot; value=&quot;METHOD_REF&quot;/&gt;
+ *   &lt;property name=&quot;tokens&quot; value=&quot;DOT&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * Lists.charactersOf("foo").listIterator()
+ *        .forEachRemaining(System.out::print); // violation, whitespace before '.' is not allowed
+ * Lists.charactersOf("foo").listIterator().forEachRemaining(System.out ::print); // violation,
+ *                           // whitespace before '::' is not allowed  ^
+ * Lists.charactersOf("foo").listIterator().forEachRemaining(System.out::print); // OK
+ * </pre>
+ * <p>
+ *     To configure the check to allow linebreak before METHOD_REF and DOT tokens:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;NoWhitespaceBefore&quot;&gt;
+ *   &lt;property name=&quot;tokens&quot; value=&quot;METHOD_REF&quot;/&gt;
  *   &lt;property name=&quot;tokens&quot; value=&quot;DOT&quot;/&gt;
  *   &lt;property name=&quot;allowLineBreaks&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * Lists .charactersOf("foo") //violation, whitespace before '.' is not allowed
+ *         .listIterator()
+ *         .forEachRemaining(System.out ::print); // violation,
+ *                                  // ^ whitespace before '::' is not allowed
+ * Lists.charactersOf("foo")
+ *        .listIterator()
+ *        .forEachRemaining(System.out::print); // OK
  * </pre>
  *
  * @since 3.0

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -65,9 +65,6 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * EmptyLineSeparator
  * </li>
  * <li>
- * FinalClass
- * </li>
- * <li>
  * IllegalCatch
  * </li>
  * <li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -65,9 +65,6 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * IllegalCatch
  * </li>
  * <li>
- * ImportOrder
- * </li>
- * <li>
  * Indentation
  * </li>
  * <li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -131,9 +131,6 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * OverloadMethodsDeclarationOrder
  * </li>
  * <li>
- * PackageAnnotation
- * </li>
- * <li>
  * PackageDeclaration
  * </li>
  * <li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -113,9 +113,6 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * MissingJavadocType
  * </li>
  * <li>
- * MissingSwitchDefault
- * </li>
- * <li>
  * NeedBraces
  * </li>
  * <li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -53,9 +53,6 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * AvoidEscapedUnicodeCharacters
  * </li>
  * <li>
- * AvoidStarImport
- * </li>
- * <li>
  * CommentsIndentation
  * </li>
  * <li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -86,9 +86,6 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * JavadocMethod
  * </li>
  * <li>
- * JavadocStyle
- * </li>
- * <li>
  * JavadocType
  * </li>
  * <li>
@@ -141,7 +138,7 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * </li>
  * </ul>
  * <p>
- * Also, the filter does not support Javadoc checks:
+ * Also, the filter does not support suppressions inside javadoc reported by Javadoc checks:
  * </p>
  * <ul id="SuppressionXpathFilter_JavadocChecks">
  * <li>
@@ -152,6 +149,9 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * </li>
  * <li>
  * JavadocParagraph
+ * </li>
+ * <li>
+ * JavadocStyle
  * </li>
  * <li>
  * JavadocTagContinuationIndentation

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -56,9 +56,6 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * AvoidStarImport
  * </li>
  * <li>
- * AvoidStaticImport
- * </li>
- * <li>
  * CommentsIndentation
  * </li>
  * <li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -125,9 +125,6 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * NeedBraces
  * </li>
  * <li>
- * NoLineWrap
- * </li>
- * <li>
  * OverloadMethodsDeclarationOrder
  * </li>
  * <li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -104,9 +104,6 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * MethodCount
  * </li>
  * <li>
- * MissingCtor
- * </li>
- * <li>
  * MissingJavadocMethod
  * </li>
  * <li>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -222,6 +222,14 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testIsSuppressedAfterEventStart2() throws Exception {
+        populateHolder("check", 100, 100, 350, 350);
+        final AuditEvent event = createAuditEvent("check", 100, 0);
+
+        assertTrue(SuppressWarningsHolder.isSuppressed(event), "Event is not suppressed");
+    }
+
+    @Test
     public void testIsSuppressedWithAllArgument() throws Exception {
         populateHolder("all", 100, 100, 350, 350);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationCheckTest.java
@@ -45,19 +45,19 @@ public class PackageAnnotationCheckTest extends AbstractModuleTestSupport {
 
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getNonCompilablePath("package-info.java"), expected);
+        verify(checkConfig, getPath("package-info.java"), expected);
     }
 
     @Test
     public void testGetAcceptableTokens() {
         final PackageAnnotationCheck constantNameCheckObj = new PackageAnnotationCheck();
         final int[] actual = constantNameCheckObj.getAcceptableTokens();
-        final int[] expected = {TokenTypes.PACKAGE_DEF };
+        final int[] expected = {TokenTypes.PACKAGE_DEF};
         assertArrayEquals(expected, actual, "Invalid acceptable tokens");
     }
 
     @Test
-    public void testAnnotationNotInPackageInfo() throws Exception {
+    public void testNoPackageAnnotation() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(PackageAnnotationCheck.class);
 
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
@@ -66,11 +66,11 @@ public class PackageAnnotationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testWithoutAnnotation() throws Exception {
+    public void testBadPackageAnnotation() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(PackageAnnotationCheck.class);
 
         final String[] expected = {
-            "3: " + getCheckMessage(MSG_KEY),
+            "4:1: " + getCheckMessage(MSG_KEY),
         };
 
         verify(checkConfig, getNonCompilablePath("InputPackageAnnotation2.java"), expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingCtorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingCtorCheckTest.java
@@ -40,7 +40,7 @@ public class MissingCtorCheckTest extends AbstractModuleTestSupport {
             createModuleConfig(MissingCtorCheck.class);
 
         final String[] expected = {
-            "3: " + getCheckMessage(MSG_KEY),
+            "3:1: " + getCheckMessage(MSG_KEY),
         };
 
         verify(checkConfig,
@@ -54,6 +54,22 @@ public class MissingCtorCheckTest extends AbstractModuleTestSupport {
         assertNotNull(check.getAcceptableTokens(), "Acceptable tokens should not be null");
         assertNotNull(check.getDefaultTokens(), "Default tokens should not be null");
         assertNotNull(check.getRequiredTokens(), "Required tokens should not be null");
+    }
+
+    @Test
+    public void testMissingCtorClassOnOneLine() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(MissingCtorCheck.class);
+
+        final String[] expected = {
+            "3:1: " + getCheckMessage(MSG_KEY),
+            "3:34: " + getCheckMessage(MSG_KEY),
+            "3:49: " + getCheckMessage(MSG_KEY),
+        };
+
+        verify(checkConfig,
+                getPath("InputMissingCtor2.java"),
+                expected);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheckTest.java
@@ -40,7 +40,9 @@ public class MissingSwitchDefaultCheckTest
         final DefaultConfiguration checkConfig =
                 createModuleConfig(MissingSwitchDefaultCheck.class);
         final String[] expected = {
-            "17: " + getCheckMessage(MSG_KEY, "default"),
+            "17:9: " + getCheckMessage(MSG_KEY, "default"),
+            "29:17: " + getCheckMessage(MSG_KEY, "default"),
+            "40:17: " + getCheckMessage(MSG_KEY, "default"),
         };
         verify(
             checkConfig,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
@@ -55,9 +55,9 @@ public class FinalClassCheckTest
         final DefaultConfiguration checkConfig =
             createModuleConfig(FinalClassCheck.class);
         final String[] expected = {
-            "7: " + getCheckMessage(MSG_KEY, "InputFinalClass"),
-            "15: " + getCheckMessage(MSG_KEY, "test4"),
-            "113: " + getCheckMessage(MSG_KEY, "someinnerClass"),
+            "7:1: " + getCheckMessage(MSG_KEY, "InputFinalClass"),
+            "15:4: " + getCheckMessage(MSG_KEY, "test4"),
+            "113:5: " + getCheckMessage(MSG_KEY, "someinnerClass"),
         };
         verify(checkConfig, getPath("InputFinalClass.java"), expected);
     }
@@ -67,7 +67,7 @@ public class FinalClassCheckTest
         final DefaultConfiguration checkConfig =
                 createModuleConfig(FinalClassCheck.class);
         final String[] expected = {
-            "16: " + getCheckMessage(MSG_KEY, "C"),
+            "16:5: " + getCheckMessage(MSG_KEY, "C"),
         };
         verify(checkConfig,
                 getNonCompilablePath(
@@ -81,7 +81,7 @@ public class FinalClassCheckTest
         final DefaultConfiguration checkConfig =
                 createModuleConfig(FinalClassCheck.class);
         final String[] expected = {
-            "8: " + getCheckMessage(MSG_KEY, "C"),
+            "8:5: " + getCheckMessage(MSG_KEY, "C"),
         };
         verify(checkConfig,
                 getNonCompilablePath(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheckTest.java
@@ -42,12 +42,12 @@ public class AvoidStarImportCheckTest
         final DefaultConfiguration checkConfig =
             createModuleConfig(AvoidStarImportCheck.class);
         final String[] expected = {
-            "7: " + getCheckMessage(MSG_KEY, "com.puppycrawl.tools.checkstyle.checks.imports.*"),
-            "9: " + getCheckMessage(MSG_KEY, "java.io.*"),
-            "10: " + getCheckMessage(MSG_KEY, "java.lang.*"),
-            "25: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "26: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "28: " + getCheckMessage(MSG_KEY, "java.io.File.*"),
+            "7:54: " + getCheckMessage(MSG_KEY, "com.puppycrawl.tools.checkstyle.checks.imports.*"),
+            "9:15: " + getCheckMessage(MSG_KEY, "java.io.*"),
+            "10:17: " + getCheckMessage(MSG_KEY, "java.lang.*"),
+            "25:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
+            "26:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
+            "28:27: " + getCheckMessage(MSG_KEY, "java.io.File.*"),
         };
 
         verify(checkConfig, getPath("InputAvoidStarImportDefault.java"),
@@ -63,8 +63,8 @@ public class AvoidStarImportCheckTest
             "java.io,java.lang,javax.swing.WindowConstants.*");
         // allow the java.io/java.lang,javax.swing.WindowConstants star imports
         final String[] expected2 = {
-            "7: " + getCheckMessage(MSG_KEY, "com.puppycrawl.tools.checkstyle.checks.imports.*"),
-            "28: " + getCheckMessage(MSG_KEY, "java.io.File.*"),
+            "7:54: " + getCheckMessage(MSG_KEY, "com.puppycrawl.tools.checkstyle.checks.imports.*"),
+            "28:27: " + getCheckMessage(MSG_KEY, "java.io.File.*"),
         };
         verify(checkConfig, getPath("InputAvoidStarImportDefault.java"),
                 expected2);
@@ -76,9 +76,9 @@ public class AvoidStarImportCheckTest
         checkConfig.addAttribute("allowClassImports", "true");
         // allow all class star imports
         final String[] expected2 = {
-            "25: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "26: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "28: " + getCheckMessage(MSG_KEY, "java.io.File.*"), };
+            "25:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
+            "26:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
+            "28:27: " + getCheckMessage(MSG_KEY, "java.io.File.*"), };
         verify(checkConfig, getPath("InputAvoidStarImportDefault.java"), expected2);
     }
 
@@ -88,9 +88,9 @@ public class AvoidStarImportCheckTest
         checkConfig.addAttribute("allowStaticMemberImports", "true");
         // allow all static star imports
         final String[] expected2 = {
-            "7: " + getCheckMessage(MSG_KEY, "com.puppycrawl.tools.checkstyle.checks.imports.*"),
-            "9: " + getCheckMessage(MSG_KEY, "java.io.*"),
-            "10: " + getCheckMessage(MSG_KEY, "java.lang.*"),
+            "7:54: " + getCheckMessage(MSG_KEY, "com.puppycrawl.tools.checkstyle.checks.imports.*"),
+            "9:15: " + getCheckMessage(MSG_KEY, "java.io.*"),
+            "10:17: " + getCheckMessage(MSG_KEY, "java.lang.*"),
         };
         verify(checkConfig, getPath("InputAvoidStarImportDefault.java"), expected2);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheckTest.java
@@ -50,17 +50,17 @@ public class AvoidStaticImportCheckTest
         final DefaultConfiguration checkConfig =
             createModuleConfig(AvoidStaticImportCheck.class);
         final String[] expected = {
-            "23: " + getCheckMessage(MSG_KEY, "java.io.File.listRoots"),
-            "25: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "26: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "27: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
-            "28: " + getCheckMessage(MSG_KEY, "java.io.File.pathSeparator"),
-            "29: " + getCheckMessage(MSG_KEY, "java.lang.Math.E"),
-            "30: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
-            "31: " + getCheckMessage(MSG_KEY,
+            "23:27: " + getCheckMessage(MSG_KEY, "java.io.File.listRoots"),
+            "25:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
+            "26:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
+            "27:27: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
+            "28:27: " + getCheckMessage(MSG_KEY, "java.io.File.pathSeparator"),
+            "29:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.E"),
+            "30:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
+            "31:113: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass"),
-            "32: " + getCheckMessage(MSG_KEY,
+            "32:124: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass.one"),
         };
@@ -76,14 +76,14 @@ public class AvoidStaticImportCheckTest
         checkConfig.addAttribute("excludes", "java.io.File.*,sun.net.ftpclient.FtpClient.*");
         // allow the "java.io.File.*" AND "sun.net.ftpclient.FtpClient.*" star imports
         final String[] expected = {
-            "25: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "26: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "29: " + getCheckMessage(MSG_KEY, "java.lang.Math.E"),
-            "30: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
-            "31: " + getCheckMessage(MSG_KEY,
+            "25:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
+            "26:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
+            "29:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.E"),
+            "30:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
+            "31:113: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass"),
-            "32: " + getCheckMessage(MSG_KEY,
+            "32:124: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass.one"),
         };
@@ -98,15 +98,15 @@ public class AvoidStaticImportCheckTest
         checkConfig.addAttribute("excludes", "java.io.File.listRoots,java.lang.Math.E");
         // allow the java.io.File.listRoots and java.lang.Math.E member imports
         final String[] expected = {
-            "25: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "26: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "27: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
-            "28: " + getCheckMessage(MSG_KEY, "java.io.File.pathSeparator"),
-            "30: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
-            "31: " + getCheckMessage(MSG_KEY,
+            "25:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
+            "26:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
+            "27:27: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
+            "28:27: " + getCheckMessage(MSG_KEY, "java.io.File.pathSeparator"),
+            "30:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
+            "31:113: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass"),
-            "32: " + getCheckMessage(MSG_KEY,
+            "32:124: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass.one"),
         };
@@ -126,17 +126,17 @@ public class AvoidStaticImportCheckTest
             + "sun.net.ftpclient.FtpClient.*FtpClient, sun.net.ftpclient.FtpClientjunk,"
             + " java.io.File.listRootsmorejunk");
         final String[] expected = {
-            "23: " + getCheckMessage(MSG_KEY, "java.io.File.listRoots"),
-            "25: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "26: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "27: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
-            "28: " + getCheckMessage(MSG_KEY, "java.io.File.pathSeparator"),
-            "29: " + getCheckMessage(MSG_KEY, "java.lang.Math.E"),
-            "30: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
-            "31: " + getCheckMessage(MSG_KEY,
+            "23:27: " + getCheckMessage(MSG_KEY, "java.io.File.listRoots"),
+            "25:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
+            "26:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
+            "27:27: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
+            "28:27: " + getCheckMessage(MSG_KEY, "java.io.File.pathSeparator"),
+            "29:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.E"),
+            "30:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
+            "31:113: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass"),
-            "32: " + getCheckMessage(MSG_KEY,
+            "32:124: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass.one"),
         };
@@ -156,14 +156,14 @@ public class AvoidStaticImportCheckTest
             "com.puppycrawl.tools.checkstyle.checks.imports."
                 + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass.*");
         final String[] expected = {
-            "23: " + getCheckMessage(MSG_KEY, "java.io.File.listRoots"),
-            "25: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "26: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "27: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
-            "28: " + getCheckMessage(MSG_KEY, "java.io.File.pathSeparator"),
-            "29: " + getCheckMessage(MSG_KEY, "java.lang.Math.E"),
-            "30: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
-            "31: " + getCheckMessage(MSG_KEY,
+            "23:27: " + getCheckMessage(MSG_KEY, "java.io.File.listRoots"),
+            "25:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
+            "26:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
+            "27:27: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
+            "28:27: " + getCheckMessage(MSG_KEY, "java.io.File.pathSeparator"),
+            "29:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.E"),
+            "30:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
+            "31:113: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass"),
         };

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheckTest.java
@@ -52,15 +52,14 @@ public class AvoidStaticImportCheckTest
         final String[] expected = {
             "23:27: " + getCheckMessage(MSG_KEY, "java.io.File.listRoots"),
             "25:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "26:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "27:27: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
-            "28:27: " + getCheckMessage(MSG_KEY, "java.io.File.pathSeparator"),
-            "29:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.E"),
-            "30:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
-            "31:113: " + getCheckMessage(MSG_KEY,
+            "26:27: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
+            "27:27: " + getCheckMessage(MSG_KEY, "java.io.File.pathSeparator"),
+            "28:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.E"),
+            "29:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
+            "30:113: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass"),
-            "32:124: " + getCheckMessage(MSG_KEY,
+            "31:124: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass.one"),
         };
@@ -77,13 +76,12 @@ public class AvoidStaticImportCheckTest
         // allow the "java.io.File.*" AND "sun.net.ftpclient.FtpClient.*" star imports
         final String[] expected = {
             "25:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "26:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "29:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.E"),
-            "30:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
-            "31:113: " + getCheckMessage(MSG_KEY,
+            "28:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.E"),
+            "29:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
+            "30:113: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass"),
-            "32:124: " + getCheckMessage(MSG_KEY,
+            "31:124: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass.one"),
         };
@@ -99,14 +97,13 @@ public class AvoidStaticImportCheckTest
         // allow the java.io.File.listRoots and java.lang.Math.E member imports
         final String[] expected = {
             "25:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "26:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "27:27: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
-            "28:27: " + getCheckMessage(MSG_KEY, "java.io.File.pathSeparator"),
-            "30:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
-            "31:113: " + getCheckMessage(MSG_KEY,
+            "26:27: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
+            "27:27: " + getCheckMessage(MSG_KEY, "java.io.File.pathSeparator"),
+            "29:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
+            "30:113: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass"),
-            "32:124: " + getCheckMessage(MSG_KEY,
+            "31:124: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass.one"),
         };
@@ -128,15 +125,14 @@ public class AvoidStaticImportCheckTest
         final String[] expected = {
             "23:27: " + getCheckMessage(MSG_KEY, "java.io.File.listRoots"),
             "25:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "26:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "27:27: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
-            "28:27: " + getCheckMessage(MSG_KEY, "java.io.File.pathSeparator"),
-            "29:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.E"),
-            "30:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
-            "31:113: " + getCheckMessage(MSG_KEY,
+            "26:27: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
+            "27:27: " + getCheckMessage(MSG_KEY, "java.io.File.pathSeparator"),
+            "28:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.E"),
+            "29:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
+            "30:113: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass"),
-            "32:124: " + getCheckMessage(MSG_KEY,
+            "31:124: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass.one"),
         };
@@ -158,12 +154,11 @@ public class AvoidStaticImportCheckTest
         final String[] expected = {
             "23:27: " + getCheckMessage(MSG_KEY, "java.io.File.listRoots"),
             "25:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "26:42: " + getCheckMessage(MSG_KEY, "javax.swing.WindowConstants.*"),
-            "27:27: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
-            "28:27: " + getCheckMessage(MSG_KEY, "java.io.File.pathSeparator"),
-            "29:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.E"),
-            "30:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
-            "31:113: " + getCheckMessage(MSG_KEY,
+            "26:27: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
+            "27:27: " + getCheckMessage(MSG_KEY, "java.io.File.pathSeparator"),
+            "28:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.E"),
+            "29:29: " + getCheckMessage(MSG_KEY, "java.lang.Math.sqrt"),
+            "30:113: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass"),
         };
@@ -181,3 +176,4 @@ public class AvoidStaticImportCheckTest
     }
 
 }
+

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -60,11 +60,11 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig =
             createModuleConfig(ImportOrderCheck.class);
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_ORDERING, "java.awt.Dialog"),
-            "9: " + getCheckMessage(MSG_ORDERING, "javax.swing.JComponent"),
-            "11: " + getCheckMessage(MSG_ORDERING, "java.io.File"),
-            "13: " + getCheckMessage(MSG_ORDERING, "java.io.IOException"),
-            "18: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
+            "5:1: " + getCheckMessage(MSG_ORDERING, "java.awt.Dialog"),
+            "9:1: " + getCheckMessage(MSG_ORDERING, "javax.swing.JComponent"),
+            "11:1: " + getCheckMessage(MSG_ORDERING, "java.io.File"),
+            "13:1: " + getCheckMessage(MSG_ORDERING, "java.io.IOException"),
+            "18:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
                     "sun.tools.util.ModifierFilter.ALL_ACCESS"),
         };
 
@@ -86,10 +86,10 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("groups", "javax.swing");
         checkConfig.addAttribute("groups", "java.io");
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_ORDERING, "java.awt.Dialog"),
-            "13: " + getCheckMessage(MSG_ORDERING, "java.io.IOException"),
-            "16: " + getCheckMessage(MSG_ORDERING, "javax.swing.WindowConstants.*"),
-            "18: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
+            "5:1: " + getCheckMessage(MSG_ORDERING, "java.awt.Dialog"),
+            "13:1: " + getCheckMessage(MSG_ORDERING, "java.io.IOException"),
+            "16:1: " + getCheckMessage(MSG_ORDERING, "javax.swing.WindowConstants.*"),
+            "18:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
                     "sun.tools.util.ModifierFilter.ALL_ACCESS"),
         };
 
@@ -102,8 +102,8 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("groups", "java, /^javax?\\.(awt|swing)\\./");
         checkConfig.addAttribute("ordered", "false");
         final String[] expected = {
-            "11: " + getCheckMessage(MSG_ORDERING, "java.io.File"),
-            "18: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
+            "11:1: " + getCheckMessage(MSG_ORDERING, "java.io.File"),
+            "18:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
                     "sun.tools.util.ModifierFilter.ALL_ACCESS"),
         };
 
@@ -117,9 +117,9 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("separated", "true");
         checkConfig.addAttribute("ordered", "false");
         final String[] expected = {
-            "9: " + getCheckMessage(MSG_SEPARATION, "javax.swing.JComponent"),
-            "11: " + getCheckMessage(MSG_SEPARATION, "java.io.File"),
-            "16: " + getCheckMessage(MSG_ORDERING, "javax.swing.WindowConstants.*"),
+            "9:1: " + getCheckMessage(MSG_SEPARATION, "javax.swing.JComponent"),
+            "11:1: " + getCheckMessage(MSG_SEPARATION, "java.io.File"),
+            "16:1: " + getCheckMessage(MSG_ORDERING, "javax.swing.WindowConstants.*"),
         };
 
         verify(checkConfig, getNonCompilablePath("InputImportOrder.java"), expected);
@@ -133,8 +133,8 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("ordered", "true");
         checkConfig.addAttribute("option", "top");
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.lang.Math.cos"),
-            "7: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.junit.Assert.assertEquals"),
+            "5:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.lang.Math.cos"),
+            "7:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.junit.Assert.assertEquals"),
         };
 
         verify(checkConfig, getPath("InputImportOrderStaticGroupSeparated.java"), expected);
@@ -175,10 +175,10 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("option", "top");
         checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
         final String[] expected = {
-            "4: " + getCheckMessage(MSG_ORDERING,
+            "4:1: " + getCheckMessage(MSG_ORDERING,
                 "javax.xml.transform.TransformerFactory.newInstance"),
-            "5: " + getCheckMessage(MSG_ORDERING, "java.lang.Math.cos"),
-            "6: " + getCheckMessage(MSG_ORDERING, "java.lang.Math.abs"),
+            "5:1: " + getCheckMessage(MSG_ORDERING, "java.lang.Math.cos"),
+            "6:1: " + getCheckMessage(MSG_ORDERING, "java.lang.Math.abs"),
         };
 
         verify(checkConfig, getPath("InputImportOrderSortStaticImportsAlphabetically.java"),
@@ -234,11 +234,11 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
             createModuleConfig(ImportOrderCheck.class);
         checkConfig.addAttribute("option", "top");
         final String[] expected = {
-            "7: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.awt.Button"),
-            "12: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.io.IOException"),
-            "15: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "javax.swing.JComponent"),
-            "18: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.io.File.*"),
-            "18: " + getCheckMessage(MSG_ORDERING, "java.io.File.*"),
+            "7:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.awt.Button"),
+            "12:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.io.IOException"),
+            "15:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "javax.swing.JComponent"),
+            "18:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.io.File.*"),
+            "18:1: " + getCheckMessage(MSG_ORDERING, "java.io.File.*"),
         };
 
         verify(checkConfig, getPath("InputImportOrder_Top.java"), expected);
@@ -250,11 +250,11 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
             createModuleConfig(ImportOrderCheck.class);
         checkConfig.addAttribute("option", "above");
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_ORDERING, "java.awt.Button.ABORT"),
-            "8: " + getCheckMessage(MSG_ORDERING, "java.awt.Dialog"),
-            "13: " + getCheckMessage(MSG_ORDERING, "java.io.File"),
-            "13: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.io.File"),
-            "14: " + getCheckMessage(MSG_ORDERING, "java.io.File.createTempFile"),
+            "5:1: " + getCheckMessage(MSG_ORDERING, "java.awt.Button.ABORT"),
+            "8:1: " + getCheckMessage(MSG_ORDERING, "java.awt.Dialog"),
+            "13:1: " + getCheckMessage(MSG_ORDERING, "java.io.File"),
+            "13:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.io.File"),
+            "14:1: " + getCheckMessage(MSG_ORDERING, "java.io.File.createTempFile"),
         };
 
         verify(checkConfig, getPath("InputImportOrder_Above.java"), expected);
@@ -266,15 +266,15 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
             createModuleConfig(ImportOrderCheck.class);
         checkConfig.addAttribute("option", "inflow");
         final String[] expected = {
-            "6: " + getCheckMessage(MSG_ORDERING, "java.awt.Dialog"),
-            "9: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "javax.swing.JComponent"),
-            "11: " + getCheckMessage(MSG_ORDERING,
+            "6:1: " + getCheckMessage(MSG_ORDERING, "java.awt.Dialog"),
+            "9:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "javax.swing.JComponent"),
+            "11:1: " + getCheckMessage(MSG_ORDERING,
                      "javax.swing.WindowConstants.DO_NOTHING_ON_CLOSE"),
-            "12: " + getCheckMessage(MSG_ORDERING, "javax.swing.WindowConstants.*"),
-            "13: " + getCheckMessage(MSG_ORDERING, "javax.swing.JTable"),
-            "15: " + getCheckMessage(MSG_ORDERING, "java.io.File.createTempFile"),
-            "15: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.io.File.createTempFile"),
-            "16: " + getCheckMessage(MSG_ORDERING, "java.io.File"),
+            "12:1: " + getCheckMessage(MSG_ORDERING, "javax.swing.WindowConstants.*"),
+            "13:1: " + getCheckMessage(MSG_ORDERING, "javax.swing.JTable"),
+            "15:1: " + getCheckMessage(MSG_ORDERING, "java.io.File.createTempFile"),
+            "15:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.io.File.createTempFile"),
+            "16:1: " + getCheckMessage(MSG_ORDERING, "java.io.File"),
         };
 
         verify(checkConfig, getPath("InputImportOrder_InFlow.java"), expected);
@@ -287,10 +287,10 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
             createModuleConfig(ImportOrderCheck.class);
         checkConfig.addAttribute("option", "under");
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_ORDERING, "java.awt.Dialog"),
-            "11: " + getCheckMessage(MSG_ORDERING, "java.awt.Button.ABORT"),
-            "13: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.io.File.createTempFile"),
-            "14: " + getCheckMessage(MSG_ORDERING, "java.io.File"),
+            "5:1: " + getCheckMessage(MSG_ORDERING, "java.awt.Dialog"),
+            "11:1: " + getCheckMessage(MSG_ORDERING, "java.awt.Button.ABORT"),
+            "13:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.io.File.createTempFile"),
+            "14:1: " + getCheckMessage(MSG_ORDERING, "java.io.File"),
         };
 
         verify(checkConfig, getPath("InputImportOrder_Under.java"), expected);
@@ -302,13 +302,13 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
             createModuleConfig(ImportOrderCheck.class);
         checkConfig.addAttribute("option", "bottom");
         final String[] expected = {
-            "8: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.io.IOException"),
-            "11: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "javax.swing.JComponent"),
-            "14: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.io.File.*"),
-            "15: " + getCheckMessage(MSG_ORDERING, "java.io.File"),
-            "17: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.io.File.createTempFile"),
-            "21: " + getCheckMessage(MSG_ORDERING, "java.io.Reader"),
-            "21: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.io.Reader"),
+            "8:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.io.IOException"),
+            "11:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "javax.swing.JComponent"),
+            "14:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.io.File.*"),
+            "15:1: " + getCheckMessage(MSG_ORDERING, "java.io.File"),
+            "17:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.io.File.createTempFile"),
+            "21:1: " + getCheckMessage(MSG_ORDERING, "java.io.Reader"),
+            "21:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.io.Reader"),
         };
 
         verify(checkConfig, getPath("InputImportOrder_Bottom.java"), expected);
@@ -331,7 +331,7 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
             createModuleConfig(ImportOrderCheck.class);
         checkConfig.addAttribute("tokens", "IMPORT");
         final String[] expected = {
-            "6: " + getCheckMessage(MSG_ORDERING, "java.awt.Button"),
+            "6:1: " + getCheckMessage(MSG_ORDERING, "java.awt.Button"),
         };
 
         verify(checkConfig, getPath("InputImportOrder_HonorsTokensProperty.java"), expected);
@@ -342,7 +342,7 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(ImportOrderCheck.class);
         checkConfig.addAttribute("groups", "com,*,java");
         final String[] expected = {
-            "9: " + getCheckMessage(MSG_ORDERING, "javax.crypto.Cipher"),
+            "9:1: " + getCheckMessage(MSG_ORDERING, "javax.crypto.Cipher"),
         };
 
         verify(checkConfig, getPath("InputImportOrder_Wildcard.java"), expected);
@@ -354,7 +354,7 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
 
         checkConfig.addAttribute("groups", "java,javax,org");
         final String[] expected = {
-            "11: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
+            "11:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
                 "com.puppycrawl.tools.checkstyle.checks.imports.importorder.InputImportOrderBug"),
         };
 
@@ -378,8 +378,8 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("groups", "org, java");
         checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
         final String[] expected = {
-            "6: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.*"),
-            "8: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
+            "6:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.*"),
+            "8:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
         };
 
         verify(checkConfig, getPath("InputImportOrderStaticGroupOrder.java"), expected);
@@ -392,8 +392,8 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("option", "top");
         checkConfig.addAttribute("groups", "org, java");
         final String[] expected = {
-            "6: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.*"),
-            "8: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
+            "6:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.*"),
+            "8:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
         };
         verify(checkConfig, getPath("InputImportOrderStaticGroupOrder.java"), expected);
     }
@@ -406,8 +406,8 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("groups", "org, java");
         checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
-            "7: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.lang.Math.PI"),
+            "5:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
+            "7:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.lang.Math.PI"),
         };
         verify(checkConfig, getPath("InputImportOrderStaticGroupOrderBottom.java"), expected);
     }
@@ -421,7 +421,7 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("separated", "true");
         checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
         final String[] expected = {
-            "8: " + getCheckMessage(MSG_ORDERING, "java.util.Set"),
+            "8:1: " + getCheckMessage(MSG_ORDERING, "java.util.Set"),
         };
         verify(checkConfig, getPath("InputImportOrderStaticGroupOrderBottom_Negative.java"),
             expected);
@@ -440,7 +440,7 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("separated", "true");
         checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_ORDERING, "java.lang.Math.PI"),
+            "5:1: " + getCheckMessage(MSG_ORDERING, "java.lang.Math.PI"),
         };
         verify(checkConfig, getPath("InputImportOrderStaticGroupOrderBottom_Negative.java"),
             expected);
@@ -459,7 +459,7 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("separated", "true");
         checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
         final String[] expected = {
-            "8: " + getCheckMessage(MSG_ORDERING, "java.util.Set"),
+            "8:1: " + getCheckMessage(MSG_ORDERING, "java.util.Set"),
         };
         verify(checkConfig, getPath("InputImportOrderStaticGroupOrderBottom_Negative2.java"),
             expected);
@@ -472,8 +472,8 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("option", "bottom");
         checkConfig.addAttribute("groups", "org, java");
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
-            "7: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.lang.Math.PI"),
+            "5:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
+            "7:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.lang.Math.PI"),
         };
         verify(checkConfig, getPath("InputImportOrderStaticGroupOrderBottom.java"), expected);
     }
@@ -507,8 +507,8 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("separated", "true");
         checkConfig.addAttribute("groups", "java, org");
         final String[] expected = {
-            "4: " + getCheckMessage(MSG_SEPARATION, "org.antlr.v4.runtime.CommonToken.*"),
-            "7: " + getCheckMessage(MSG_ORDERING, "java.util.Set"),
+            "4:1: " + getCheckMessage(MSG_SEPARATION, "org.antlr.v4.runtime.CommonToken.*"),
+            "7:1: " + getCheckMessage(MSG_ORDERING, "java.util.Set"),
         };
         verify(checkConfig, getPath("InputImportOrderStaticRepetition.java"), expected);
     }
@@ -521,10 +521,10 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("groups", "org, java, sun");
         checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
-            "7: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.lang.Math.PI"),
-            "7: " + getCheckMessage(MSG_ORDERING, "java.lang.Math.PI"),
-            "8: " + getCheckMessage(MSG_ORDERING, "org.antlr.v4.runtime.Recognizer.EOF"),
+            "5:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
+            "7:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.lang.Math.PI"),
+            "7:1: " + getCheckMessage(MSG_ORDERING, "java.lang.Math.PI"),
+            "8:1: " + getCheckMessage(MSG_ORDERING, "org.antlr.v4.runtime.Recognizer.EOF"),
         };
         verify(checkConfig, getPath("InputImportOrderStaticGroupOrderBottom.java"), expected);
     }
@@ -536,9 +536,9 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("option", "top");
         checkConfig.addAttribute("groups", "org, java");
         final String[] expected = {
-            "6: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.*"),
-            "8: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
-            "9: " + getCheckMessage(MSG_ORDERING, "org.junit.Test"),
+            "6:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.*"),
+            "8:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
+            "9:1: " + getCheckMessage(MSG_ORDERING, "org.junit.Test"),
         };
         verify(checkConfig, getPath("InputImportOrderStaticOnDemandGroupOrder.java"), expected);
     }
@@ -551,9 +551,9 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("groups", "org, java");
         checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
         final String[] expected = {
-            "6: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.*"),
-            "8: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
-            "9: " + getCheckMessage(MSG_ORDERING, "org.junit.Test"),
+            "6:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.*"),
+            "8:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
+            "9:1: " + getCheckMessage(MSG_ORDERING, "org.junit.Test"),
         };
         verify(checkConfig, getPath("InputImportOrderStaticOnDemandGroupOrder.java"), expected);
     }
@@ -565,8 +565,8 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("option", "bottom");
         checkConfig.addAttribute("groups", "org, java");
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
-            "7: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.lang.Math.*"),
+            "5:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
+            "7:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.lang.Math.*"),
         };
         verify(checkConfig, getPath("InputImportOrderStaticOnDemandGroupOrderBottom.java"),
             expected);
@@ -580,8 +580,8 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("groups", "org, java");
         checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
-            "7: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.lang.Math.*"),
+            "5:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
+            "7:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.lang.Math.*"),
         };
         verify(checkConfig, getPath("InputImportOrderStaticOnDemandGroupOrderBottom.java"),
             expected);
@@ -595,10 +595,10 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("groups", "org, java");
         checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
-            "7: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.lang.Math.*"),
-            "7: " + getCheckMessage(MSG_ORDERING, "java.lang.Math.*"),
-            "8: " + getCheckMessage(MSG_ORDERING, "org.antlr.v4.runtime.CommonToken.*"),
+            "5:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
+            "7:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.lang.Math.*"),
+            "7:1: " + getCheckMessage(MSG_ORDERING, "java.lang.Math.*"),
+            "8:1: " + getCheckMessage(MSG_ORDERING, "org.antlr.v4.runtime.CommonToken.*"),
         };
         verify(checkConfig, getPath("InputImportOrderStaticOnDemandGroupOrderBottom.java"),
             expected);
@@ -642,7 +642,7 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(ImportOrderCheck.class);
         checkConfig.addAttribute("groups", "/java/,/rga/,/myO/,/org/,/organ./");
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.*"),
+            "5:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.*"),
         };
 
         verify(checkConfig, getNonCompilablePath("InputImportOrder_MultiplePatternMatches.java"),
@@ -739,8 +739,8 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("option", "top");
         checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
         final String[] expected = {
-            "12: " + getCheckMessage(MSG_SEPARATION, "javax.swing.JComponent"),
-            "17: " + getCheckMessage(MSG_ORDERING, "org.junit.Test"),
+            "12:1: " + getCheckMessage(MSG_SEPARATION, "javax.swing.JComponent"),
+            "17:1: " + getCheckMessage(MSG_ORDERING, "org.junit.Test"),
             };
 
         verify(checkConfig,
@@ -772,7 +772,7 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
         checkConfig.addAttribute("useContainerOrderingForStatic", "false");
         final String[] expected = {
-            "6: " + getCheckMessage(MSG_ORDERING,
+            "6:1: " + getCheckMessage(MSG_ORDERING,
                 "io.netty.handler.codec.http.HttpHeaders.Names.addDate"),
         };
         verify(checkConfig, getNonCompilablePath("InputImportOrderEclipseStatic.java"), expected);
@@ -788,7 +788,7 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
         checkConfig.addAttribute("useContainerOrderingForStatic", "true");
         final String[] expected = {
-            "7: " + getCheckMessage(MSG_ORDERING,
+            "7:1: " + getCheckMessage(MSG_ORDERING,
                 "io.netty.handler.codec.http.HttpHeaders.Names.DATE"),
             };
         verify(checkConfig, getNonCompilablePath("InputImportOrderEclipseStatic.java"), expected);
@@ -802,7 +802,7 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("separated", "true");
         checkConfig.addAttribute("option", "bottom");
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.*"),
+            "5:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.*"),
         };
         verify(checkConfig, getNonCompilablePath("InputImportOrder_MultiplePatternMatches.java"),
                 expected);
@@ -875,8 +875,8 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
         checkConfig.addAttribute("useContainerOrderingForStatic", "false");
         final String[] expected = {
-            "16: " + getCheckMessage(MSG_ORDERING, "org.junit.Assert.fail"),
-            "18: " + getCheckMessage(MSG_ORDERING, "org.infinispan.test.TestingUtil.extract"),
+            "16:1: " + getCheckMessage(MSG_ORDERING, "org.junit.Assert.fail"),
+            "18:1: " + getCheckMessage(MSG_ORDERING, "org.infinispan.test.TestingUtil.extract"),
         };
 
         verify(checkConfig, getNonCompilablePath("InputImportOrderStaticGroupsNegative.java"),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
@@ -382,7 +382,7 @@ public class JavadocStyleCheckTest
         final DefaultConfiguration checkConfig =
             createModuleConfig(JavadocStyleCheck.class);
         final String[] expected = {
-            "1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "1:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
         };
 
         verify(checkConfig,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoLineWrapCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoLineWrapCheckTest.java
@@ -46,9 +46,9 @@ public class NoLineWrapCheckTest
     public void testDefaultTokensLineWrapping() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(NoLineWrapCheck.class);
         final String[] expected = {
-            "1: " + getCheckMessage(MSG_KEY, "package"),
-            "6: " + getCheckMessage(MSG_KEY, "import"),
-            "10: " + getCheckMessage(MSG_KEY, "import"),
+            "1:1: " + getCheckMessage(MSG_KEY, "package"),
+            "6:1: " + getCheckMessage(MSG_KEY, "import"),
+            "10:1: " + getCheckMessage(MSG_KEY, "import"),
         };
         verify(checkConfig, getPath("InputNoLineWrapBad.java"), expected);
     }
@@ -60,11 +60,11 @@ public class NoLineWrapCheckTest
         checkConfig.addAttribute(
                 "tokens", "IMPORT, STATIC_IMPORT, CLASS_DEF, METHOD_DEF, ENUM_DEF");
         final String[] expected = {
-            "6: " + getCheckMessage(MSG_KEY, "import"),
-            "10: " + getCheckMessage(MSG_KEY, "import"),
-            "13: " + getCheckMessage(MSG_KEY, "CLASS_DEF"),
-            "16: " + getCheckMessage(MSG_KEY, "METHOD_DEF"),
-            "23: " + getCheckMessage(MSG_KEY, "ENUM_DEF"),
+            "6:1: " + getCheckMessage(MSG_KEY, "import"),
+            "10:1: " + getCheckMessage(MSG_KEY, "import"),
+            "13:1: " + getCheckMessage(MSG_KEY, "CLASS_DEF"),
+            "16:9: " + getCheckMessage(MSG_KEY, "METHOD_DEF"),
+            "23:1: " + getCheckMessage(MSG_KEY, "ENUM_DEF"),
         };
         verify(checkConfig, getPath("InputNoLineWrapBad.java"), expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -60,7 +60,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
             "CustomImportOrder",
             "EmptyLineSeparator",
             "IllegalCatch",
-            "ImportOrder",
             "Indentation",
             "InterfaceIsType",
             "InterfaceMemberImpliedModifier",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -59,7 +59,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
             "CommentsIndentation",
             "CustomImportOrder",
             "EmptyLineSeparator",
-            "FinalClass",
             "IllegalCatch",
             "ImportOrder",
             "Indentation",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck;
 import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
 
 public class XpathRegressionTest extends AbstractModuleTestSupport {
@@ -66,7 +67,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
             "InvalidJavadocPosition",
             "JavadocContentLocation",
             "JavadocMethod",
-            "JavadocStyle",
             "JavadocType",
             "LambdaParameterName",
             "MethodCount",
@@ -95,12 +95,18 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
                     "AtclauseOrder",
                     "JavadocBlockTagLocation",
                     "JavadocParagraph",
+                    "JavadocStyle",
                     "JavadocTagContinuationIndentation",
                     "MissingDeprecated",
                     "NonEmptyAtclauseDescription",
                     "SingleLineJavadoc",
                     "SummaryJavadoc"
     )));
+
+    // Older regex-based checks that are under INCOMPATIBLE_JAVADOC_CHECK_NAMES
+    // but not subclasses of AbstractJavadocCheck.
+    private static final Set<Class<?>> REGEXP_JAVADOC_CHECKS =
+            Collections.singleton(JavadocStyleCheck.class);
 
     // Checks that allowed to have no XPath IT Regression Testing
     // till https://github.com/checkstyle/checkstyle/issues/6207
@@ -196,10 +202,13 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
 
     @Test
     public void validateIncompatibleJavadocCheckNames() throws IOException {
+        // subclasses of AbstractJavadocCheck
         final Set<Class<?>> abstractJavadocCheckNames = CheckUtil.getCheckstyleChecks()
                 .stream()
                 .filter(AbstractJavadocCheck.class::isAssignableFrom)
                 .collect(Collectors.toSet());
+        // add the extra checks
+        abstractJavadocCheckNames.addAll(REGEXP_JAVADOC_CHECKS);
         assertWithMessage("INCOMPATIBLE_JAVADOC_CHECK_NAMES should contains all descendants "
                     + "of AbstractJavadocCheck")
             .that(CheckUtil.getSimpleNames(abstractJavadocCheckNames))

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -56,7 +56,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
             "AnnotationUseStyle",
             "AvoidEscapedUnicodeCharacters",
             "AvoidStarImport",
-            "AvoidStaticImport",
             "CommentsIndentation",
             "CustomImportOrder",
             "EmptyLineSeparator",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -79,7 +79,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
             "MissingJavadocType",
             "MissingSwitchDefault",
             "NeedBraces",
-            "NoLineWrap",
             "OverloadMethodsDeclarationOrder",
             "PackageDeclaration",
             "Regexp",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -55,7 +55,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
             "AnnotationOnSameLine",
             "AnnotationUseStyle",
             "AvoidEscapedUnicodeCharacters",
-            "AvoidStarImport",
             "CommentsIndentation",
             "CustomImportOrder",
             "EmptyLineSeparator",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -81,7 +81,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
             "NeedBraces",
             "NoLineWrap",
             "OverloadMethodsDeclarationOrder",
-            "PackageAnnotation",
             "PackageDeclaration",
             "Regexp",
             "RegexpSinglelineJava",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -75,7 +75,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
             "MissingJavadocMethod",
             "MissingJavadocPackage",
             "MissingJavadocType",
-            "MissingSwitchDefault",
             "NeedBraces",
             "OverloadMethodsDeclarationOrder",
             "PackageDeclaration",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -72,7 +72,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
             "JavadocType",
             "LambdaParameterName",
             "MethodCount",
-            "MissingCtor",
             "MissingJavadocMethod",
             "MissingJavadocPackage",
             "MissingJavadocType",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/packageannotation/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/packageannotation/package-info.java
@@ -1,4 +1,3 @@
-//non-compiled with javac: non-compilable annotation, for testing
 @Deprecated
 package com.puppycrawl.tools.checkstyle.checks.annotation.packageannotation;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/missingctor/InputMissingCtor2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/missingctor/InputMissingCtor2.java
@@ -1,0 +1,7 @@
+package com.puppycrawl.tools.checkstyle.checks.coding.missingctor;
+
+public class InputMissingCtor2 { class Inner1 { class Inner2 {
+
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefault.java
@@ -19,4 +19,29 @@ class bad_test {
         case 2: i--; break;
         }
     }
+
+    public void nestedSwitch1() {
+        int i = 1;
+        switch (i) {
+            case 1: i++; break;
+            case 2: i--; break;
+            default:
+                switch (i++) { // violation
+                    case 2: i++; break;
+                    case 3: i--; break;
+            }
+        }
+    }
+
+    public void nestedSwitch2() {
+        int i = 1, j = 2;
+        switch(i) {
+            case 1:
+                switch (j) { // violation
+                    case 2: break;
+                    case 3: break;
+            }
+            default: break;
+        }
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefault.java
@@ -4,9 +4,9 @@ public class InputMissingSwitchDefault {
     public void foo() {
         int i = 1;
         switch (i) {
-        case 1: i++; break;
-        case 2: i--; break;
-        default: return;
+            case 1: i++; break;
+            case 2: i--; break;
+            default: return;
         }
     }
 }
@@ -14,9 +14,9 @@ public class InputMissingSwitchDefault {
 class bad_test {
     public void foo() {
         int i = 1;
-        switch (i) {
-        case 1: i++; break;
-        case 2: i--; break;
+        switch (i) { // violation
+            case 1: i++; break;
+            case 2: i--; break;
         }
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstaticimport/InputAvoidStaticImportDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/avoidstaticimport/InputAvoidStaticImportDefault.java
@@ -23,7 +23,6 @@ import javax.swing.BorderFactory;
 import static java.io.File.listRoots;
 
 import static javax.swing.WindowConstants.*;
-import static javax.swing.WindowConstants.*;
 import static java.io.File.createTempFile;
 import static java.io.File.pathSeparator;
 import static java.lang.Math.E;

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -751,7 +751,44 @@ class K {
 &lt;module name=&quot;DefaultComesLast&quot;/&gt;
         </source>
         <p>
-            To configure the check for skipIfLastAndSharedWithCase:
+          Example:
+        </p>
+        <source>
+switch (i) {
+  case 1:
+    break;
+  case 2:
+    break;
+  default: // OK
+    break;
+}
+
+switch (i) {
+  case 1:
+    break;
+  case 2:
+    break; // OK, no default
+}
+
+switch (i) {
+  case 1:
+    break;
+  default: // violation, 'default' before 'case'
+    break;
+  case 2:
+    break;
+}
+
+switch (i) {
+  case 1:
+  default: // violation, 'default' before 'case'
+    break;
+  case 2:
+    break;
+}
+        </source>
+        <p>
+          To configure the check to allow default label to be not last if it is shared with case:
         </p>
         <source>
 &lt;module name=&quot;DefaultComesLast&quot;&gt;
@@ -759,22 +796,23 @@ class K {
 &lt;/module&gt;
         </source>
         <p>
-            Example when skipIfLastAndSharedWithCase is set to true.
+          Example:
         </p>
         <source>
 switch (i) {
   case 1:
     break;
   case 2:
-  default: // No violation with the new option is expected
+  default: // OK
     break;
   case 3:
     break;
 }
+
 switch (i) {
   case 1:
     break;
-  default: // violation with the new option is expected
+  default: // violation
   case 2:
     break;
 }

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -929,7 +929,6 @@ public class UserService {
           <li>MissingJavadocType</li>
           <li>MissingSwitchDefault</li>
           <li>NeedBraces</li>
-          <li>NoLineWrap</li>
           <li>OverloadMethodsDeclarationOrder</li>
           <li>PackageDeclaration</li>
           <li>Regexp</li>

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -925,7 +925,6 @@ public class UserService {
           <li>MissingJavadocMethod</li>
           <li>MissingJavadocPackage</li>
           <li>MissingJavadocType</li>
-          <li>MissingSwitchDefault</li>
           <li>NeedBraces</li>
           <li>OverloadMethodsDeclarationOrder</li>
           <li>PackageDeclaration</li>

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -909,7 +909,6 @@ public class UserService {
           <li>CustomImportOrder</li>
           <li>EmptyLineSeparator</li>
           <li>IllegalCatch</li>
-          <li>ImportOrder</li>
           <li>Indentation</li>
           <li>InterfaceIsType</li>
           <li>InterfaceMemberImpliedModifier</li>

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -922,7 +922,6 @@ public class UserService {
           <li>JavadocType</li>
           <li>LambdaParameterName</li>
           <li>MethodCount</li>
-          <li>MissingCtor</li>
           <li>MissingJavadocMethod</li>
           <li>MissingJavadocPackage</li>
           <li>MissingJavadocType</li>

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -906,7 +906,6 @@ public class UserService {
           <li>AnnotationUseStyle</li>
           <li>AvoidEscapedUnicodeCharacters</li>
           <li>AvoidStarImport</li>
-          <li>AvoidStaticImport</li>
           <li>CommentsIndentation</li>
           <li>CustomImportOrder</li>
           <li>EmptyLineSeparator</li>

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -905,7 +905,6 @@ public class UserService {
           <li>AnnotationOnSameLine</li>
           <li>AnnotationUseStyle</li>
           <li>AvoidEscapedUnicodeCharacters</li>
-          <li>AvoidStarImport</li>
           <li>CommentsIndentation</li>
           <li>CustomImportOrder</li>
           <li>EmptyLineSeparator</li>

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -931,7 +931,6 @@ public class UserService {
           <li>NeedBraces</li>
           <li>NoLineWrap</li>
           <li>OverloadMethodsDeclarationOrder</li>
-          <li>PackageAnnotation</li>
           <li>PackageDeclaration</li>
           <li>Regexp</li>
           <li>RegexpSinglelineJava</li>

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -909,7 +909,6 @@ public class UserService {
           <li>CommentsIndentation</li>
           <li>CustomImportOrder</li>
           <li>EmptyLineSeparator</li>
-          <li>FinalClass</li>
           <li>IllegalCatch</li>
           <li>ImportOrder</li>
           <li>Indentation</li>

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -916,7 +916,6 @@ public class UserService {
           <li>InvalidJavadocPosition</li>
           <li>JavadocContentLocation</li>
           <li>JavadocMethod</li>
-          <li>JavadocStyle</li>
           <li>JavadocType</li>
           <li>LambdaParameterName</li>
           <li>MethodCount</li>
@@ -936,12 +935,13 @@ public class UserService {
           <li>WriteTag</li>
         </ul>
         <p>
-          Also, the filter does not support Javadoc checks:
+          Also, the filter does not support suppressions inside javadoc reported by Javadoc checks:
         </p>
         <ul id="SuppressionXpathFilter_JavadocChecks">
           <li>AtclauseOrder</li>
           <li>JavadocBlockTagLocation</li>
           <li>JavadocParagraph</li>
+          <li>JavadocStyle</li>
           <li>JavadocTagContinuationIndentation</li>
           <li>MissingDeprecated</li>
           <li>NonEmptyAtclauseDescription</li>

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -2531,6 +2531,49 @@ class DatabaseConfiguration {}
         <source>
 &lt;module name=&quot;SingleLineJavadoc&quot;/&gt;
         </source>
+        <p>Example:</p>
+        <div class = "wrapper">
+          <pre>
+public class Test {
+  /** @return integer value */ 
+  public int sum(int a, int b) {
+    return a + b;
+  }
+} //Violation. If Javadoc contains at least one at-clause, it should be formatted in multiple lines.
+
+
+public class Test {
+  /** 
+   * @return integer value 
+   */
+  public int sum(int a, int b) {
+    return a + b;
+  }
+} //OK. Correct Javadoc.
+          </pre>
+        </div>
+        <p>
+          To configure this check to print violations if Tight-HTML rules are being violated.
+        </p>
+        <source>
+&lt;module name=&quot;SingleLineJavadoc&quot;&gt;
+  &lt;property name=&quot;violateExecutionOnNonTightHtml&quot; value=&quot;true&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <div class = "wrapper">
+         <pre>
+public class Test {
+  /**
+   *@return integer value
+   *&lt;p&gt; First
+   */
+  public int sum(int a, int b) {
+    return a + b;
+  }
+} //Prints violation for unclosed HTML tag.
+         </pre>
+        </div>
         <p>
           To configure the check with a list of ignored at-clauses and make
           inline at-clauses not ignored:
@@ -2541,6 +2584,24 @@ class DatabaseConfiguration {}
   &lt;property name=&quot;ignoreInlineTags&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
         </source>
+        <p>Examples:</p>
+        <div class = "wrapper">
+         <pre>
+public class Test {
+  /** @see #sum(int a, int b) */
+  public int sum(int a, int b) {
+    return a + b;
+  }
+}//OK. No violation because @see is in list of ignored tags
+
+public class Test {
+  /** Testing class for {@link Example} */
+  public int sum(int a, int b) {
+    return a + b;
+  }
+}//Prints violation for making Javadoc with inline tag in single line.
+         </pre>
+        </div>
       </subsection>
 
       <subsection name="Example of Usage" id="SingleLineJavadoc_Example_of_Usage">

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -2535,21 +2535,19 @@ class DatabaseConfiguration {}
         <div class = "wrapper">
           <pre>
 public class Test {
-  /** @return integer value */ 
+  /** @return integer value */ //Violation. Javadoc contains one at-clause, it should be written in multiple lines.
   public int sum(int a, int b) {
     return a + b;
   }
-} //Violation. If Javadoc contains at least one at-clause, it should be formatted in multiple lines.
-
-
+} 
 public class Test {
   /** 
    * @return integer value 
-   */
+   */ //OK. Correct Javadoc.
   public int sum(int a, int b) {
     return a + b;
   }
-} //OK. Correct Javadoc.
+}
           </pre>
         </div>
         <p>
@@ -2567,11 +2565,11 @@ public class Test {
   /**
    *@return integer value
    *&lt;p&gt; First
-   */
+   */ //Prints violation for unclosed HTML tag.
   public int sum(int a, int b) {
     return a + b;
   }
-} //Prints violation for unclosed HTML tag.
+}
          </pre>
         </div>
         <p>
@@ -2588,18 +2586,17 @@ public class Test {
         <div class = "wrapper">
          <pre>
 public class Test {
-  /** @see #sum(int a, int b) */
+  /** @see #sum(int a, int b) */ //OK. No violation because @see is in list of ignored tags
   public int sum(int a, int b) {
     return a + b;
   }
-}//OK. No violation because @see is in list of ignored tags
-
+}
 public class Test {
-  /** Testing class for {@link Example} */
+  /** Testing class for {@link Example} */ //Prints violation for making Javadoc with inline tag in single line.
   public int sum(int a, int b) {
     return a + b;
   }
-}//Prints violation for making Javadoc with inline tag in single line.
+}
          </pre>
         </div>
       </subsection>

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -1308,16 +1308,80 @@ public void foo(final char @NotNull [] param) {} // No violation
         <source>
 &lt;module name=&quot;NoWhitespaceBefore&quot;/&gt;
         </source>
-
+        <p>Example:</p>
+        <source>
+int foo;
+foo ++; // violation, whitespace before '++' is not allowed
+foo++; // OK
+for (int i = 0 ; i &lt; 5; i++) {}  // violation
+           // ^ whitespace before ';' is not allowed
+for (int i = 0; i &lt; 5; i++) {} // OK
+int[][] array = { { 1, 2 }
+                , { 3, 4 } }; // violation, whitespace before ',' is not allowed
+int[][] array2 = { { 1, 2 },
+                   { 3, 4 } }; // OK
+Lists.charactersOf("foo").listIterator()
+       .forEachRemaining(System.out::print)
+       ; // violation, whitespace before ';' is not allowed
+        </source>
         <p>
-          To configure the check to allow linebreaks before a DOT token:
+            To configure the check to allow linebreaks before default tokens:
         </p>
         <source>
 &lt;module name=&quot;NoWhitespaceBefore&quot;&gt;
-  &lt;property name=&quot;tokens&quot; value=&quot;DOT&quot;/&gt;
   &lt;property name=&quot;allowLineBreaks&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
         </source>
+        <p>Example:</p>
+        <source>
+int[][] array = { { 1, 2 }
+                , { 3, 4 } }; // OK, linebreak is allowed before ','
+int[][] array2 = { { 1, 2 },
+                   { 3, 4 } }; // OK, ideal code
+void ellipsisExample(String ...params) {}; // violation, whitespace before '...' is not allowed
+void ellipsisExample2(String
+                        ...params) {}; //OK, linebreak is allowed before '...'
+Lists.charactersOf("foo")
+       .listIterator()
+       .forEachRemaining(System.out::print); // OK
+        </source>
+        <p>
+        To Configure the check to restrict the use of whitespace before METHOD_REF and DOT tokens:
+        </p>
+       <source>
+&lt;module name=&quot;NoWhitespaceBefore&quot;&gt;
+  &lt;property name=&quot;tokens&quot; value=&quot;METHOD_REF&quot;/&gt;
+  &lt;property name=&quot;tokens&quot; value=&quot;DOT&quot;/&gt;
+&lt;/module&gt;
+       </source>
+       <p>Example:</p>
+       <source>
+Lists.charactersOf("foo").listIterator()
+       .forEachRemaining(System.out::print); // violation, whitespace before '.' is not allowed
+Lists.charactersOf("foo").listIterator().forEachRemaining(System.out ::print); // violation,
+                          // whitespace before '::' is not allowed  ^
+Lists.charactersOf("foo").listIterator().forEachRemaining(System.out::print); // OK
+       </source>
+       <p>
+           To configure the check to allow linebreak before METHOD_REF and DOT tokens:
+       </p>
+       <source>
+&lt;module name=&quot;NoWhitespaceBefore&quot;&gt;
+  &lt;property name=&quot;tokens&quot; value=&quot;METHOD_REF&quot;/&gt;
+  &lt;property name=&quot;tokens&quot; value=&quot;DOT&quot;/&gt;
+  &lt;property name=&quot;allowLineBreaks&quot; value=&quot;true&quot;/&gt;
+&lt;/module&gt;
+       </source>
+       <p>Example:</p>
+       <source>
+Lists .charactersOf("foo") //violation, whitespace before '.' is not allowed
+        .listIterator()
+        .forEachRemaining(System.out ::print); // violation,
+                                 // ^ whitespace before '::' is not allowed
+Lists.charactersOf("foo")
+       .listIterator()
+       .forEachRemaining(System.out::print); // OK
+       </source>
       </subsection>
 
       <subsection name="Example of Usage" id="NoWhitespaceBefore_Example_of_Usage">

--- a/wercker.yml
+++ b/wercker.yml
@@ -332,7 +332,7 @@ build:
         git status
         echo "------"
         echo "Content of .ci-temp folder:"
-        ls -la .ci-temp
+        ls -la .ci-temp | cat
         echo "------"
         find ${WERCKER_CACHE_DIR} -type d -name "*SNAPSHOT" -ls -exec rm -rf {} +
         echo "------"

--- a/wercker.yml
+++ b/wercker.yml
@@ -329,6 +329,12 @@ build:
   - script:
       name: Cleanup maven local repo
       code: |
+        echo "git status"
+        git status
+        echo "------"
+        echo "Content of .ci-temp folder:"
+        ls -la .ci-temp
+        echo "------"
         find ${WERCKER_CACHE_DIR} -type d -name "*SNAPSHOT" -ls -exec rm -rf {} +
         echo "------"
         du -hs ${WERCKER_CACHE_DIR}

--- a/wercker.yml
+++ b/wercker.yml
@@ -184,6 +184,7 @@ build:
          echo "build is skipped ..."
        fi
 
+  - script:
      name: NoErrorTest - methods distance
      code: |
        if [[ $RUN_JOB == 1 ]]; then
@@ -213,17 +214,15 @@ build:
           echo "build is skipped ..."
         fi
 
-  # disabled until https://github.com/checkstyle/checkstyle/issues/7534
-  #
-  # - script:
-  #     name: NoExceptiontest - Checkstyle ,sevntu-checkstyle javadoc
-  #     code: |
-  #       if [[ $RUN_JOB == 1 ]]; then
-  #         echo "Command: ./.ci/wercker.sh no-exception-checkstyle-sevntu-javadoc"
-  #         ./.ci/wercker.sh no-exception-checkstyle-sevntu-javadoc
-  #       else
-  #         echo "build is skipped ..."
-  #       fi
+  - script:
+       name: NoExceptiontest - Checkstyle ,sevntu-checkstyle javadoc
+       code: |
+         if [[ $RUN_JOB == 1 ]]; then
+           echo "Command: ./.ci/wercker.sh no-exception-checkstyle-sevntu-javadoc"
+           ./.ci/wercker.sh no-exception-checkstyle-sevntu-javadoc
+         else
+           echo "build is skipped ..."
+         fi
 
   - script:
       name: NoExceptiontest - Guava
@@ -342,3 +341,4 @@ build:
         du -hs ${WERCKER_CACHE_DIR}/* | sort -h
         echo "------"
         du -hs * | sort -h
+


### PR DESCRIPTION
Website generated:

![Screenshot (11)](https://user-images.githubusercontent.com/51456744/76866146-b681f580-6889-11ea-8c4d-6454bdc02cfb.png)
![Screenshot (12)](https://user-images.githubusercontent.com/51456744/76866157-baae1300-6889-11ea-9562-28bfd0f60305.png)
![Screenshot (13)](https://user-images.githubusercontent.com/51456744/76866166-be419a00-6889-11ea-9c54-ea542dadaff5.png)


1.) The output of default example:
config.xml
```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
   <module name="SingleLineJavadoc"/>
  </module>
</module>
```

Test.java
```
public class Test {
  /**@return integer value*/
  public int sum(int a, int b) {
    return a + b;
  }
}
```
```
C:\Users\hp\Desktop>java -jar ../Downloads/checkstyle-8.29-all.jar -c config.xml Test.java
Starting audit...
[ERROR] C:\Users\hp\Desktop\Test.java:2: Single-line Javadoc comment should be multi-line. [SingleLineJavadoc]
Audit done.
Checkstyle ends with 1 errors.
```

2.) Output of non-default example for violateExecutionOnNonTightHtml
config.xml
```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
   <module name="SingleLineJavadoc">
     <property name="violateExecutionOnNonTightHtml" value="true"/>
   </module>
  </module>
</module>
```

Test.java
```
public class Test {
  /**
   *@return integer value
   *<p> First
   */
  public int sum(int a, int b) {
    return a + b;
  }
} //Prints violation for unclosed HTML tag.
```
```
C:\Users\hp\Desktop>java -jar ../Downloads/checkstyle-8.29-all.jar -c config.xml Test.java
Starting audit...
[ERROR] C:\Users\hp\Desktop\Test.java:4: Unclosed HTML tag found: p [SingleLineJavadoc]
Audit done.
Checkstyle ends with 1 errors.
```

3.) Output for non-default example for ignoredTags and ignoredInlineTags
config.xml
```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
   <module name="SingleLineJavadoc">
     <property name="ignoredTags" value="@inheritDoc, @see"/>
     <property name="ignoreInlineTags" value="false"/>
   </module>
  </module>
</module>
```
Test.java
```
public class Test {
  /** @see #sum(int a, int b) */
  public int sum(int a, int b) {
    return a + b;
  }
}
```
```
C:\Users\hp\Desktop>java -jar ../Downloads/checkstyle-8.29-all.jar -c config.xml Test.java
Starting audit...
Audit done.
```
Test.java
```
public class Test {
  /** Testing class for {@link Example} */
  public int sum(int a, int b) {
    return a + b;
  }
}
```
```
C:\Users\hp\Desktop>java -jar ../Downloads/checkstyle-8.29-all.jar -c config.xml Test.java
Starting audit...
[ERROR] C:\Users\hp\Desktop\Test.java:2: Single-line Javadoc comment should be multi-line. [SingleLineJavadoc]
Audit done.
Checkstyle ends with 1 errors.
```
```