### PR TITLE
Issue #6988: Sort XPath Results in Document Order

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/AbstractNode.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/AbstractNode.java
@@ -49,6 +49,9 @@ public abstract class AbstractNode implements NodeInfo {
     /** The {@code TreeInfo} object. */
     private final TreeInfo treeInfo;
 
+    /** Depth of the node. */
+    private int depth;
+
     /**
      * Constructor of the abstract class {@code AbstractNode}.
      *
@@ -71,6 +74,22 @@ public abstract class AbstractNode implements NodeInfo {
      * @return underlying node
      */
     public abstract DetailAST getUnderlyingNode();
+
+    /**
+     * Getter method for node depth.
+     * @return depth
+     */
+    public int getDepth() {
+        return depth;
+    }
+
+    /**
+     * Setter method for node depth.
+     * @param depth depth of node
+     */
+    public final void setDepth(int depth) {
+        this.depth = depth;
+    }
 
     /**
      * Getter method for children.
@@ -145,17 +164,6 @@ public abstract class AbstractNode implements NodeInfo {
             axisIterator = new Navigator.AxisFilter(axisIterator, nodeTest);
         }
         return axisIterator;
-    }
-
-    /**
-     * Compares current object with specified for order.
-     *
-     * @param nodeInfo another {@code NodeInfo} object
-     * @return number representing order of current object to specified one
-     */
-    @Override
-    public int compareOrder(NodeInfo nodeInfo) {
-        return getLocalPart().compareTo(nodeInfo.getLocalPart());
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/AttributeNode.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/AttributeNode.java
@@ -49,6 +49,17 @@ public class AttributeNode extends AbstractNode {
     }
 
     /**
+     * Compares current object with specified for order.
+     * Throws {@code UnsupportedOperationException} because functionality not required here.
+     * @param nodeInfo another {@code NodeInfo} object
+     * @return number representing order of current object to specified one
+     */
+    @Override
+    public int compareOrder(NodeInfo nodeInfo) {
+        throw throwUnsupportedOperationException();
+    }
+
+    /**
      * Returns attribute value. Throws {@code UnsupportedOperationException} because attribute node
      * has no attributes.
      *

--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/ElementNode.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/ElementNode.java
@@ -77,8 +77,43 @@ public class ElementNode extends AbstractNode {
         this.detailAst = detailAst;
         text = TokenUtil.getTokenName(detailAst.getType());
         indexAmongSiblings = parent.getChildren().size();
+        setDepth(parent.getDepth() + 1);
         createTextAttribute();
         createChildren();
+    }
+
+    /**
+     * Compares current object with specified for order.
+     * @param other another {@code NodeInfo} object
+     * @return number representing order of current object to specified one
+     */
+    @Override
+    public int compareOrder(NodeInfo other) {
+        int result = 0;
+        if (other instanceof AbstractNode) {
+            result = getDepth() - ((AbstractNode) other).getDepth();
+            if (result == 0) {
+                final ElementNode[] children = getCommonAncestorChildren(other);
+                result = children[0].indexAmongSiblings - children[1].indexAmongSiblings;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Finds the ancestors of the children whose parent is their common ancestor.
+     * @param other another {@code NodeInfo} object
+     * @return {@code ElementNode} immediate children(also ancestors of the given children) of the
+     *         common ancestor
+     */
+    private ElementNode[] getCommonAncestorChildren(NodeInfo other) {
+        NodeInfo child1 = this;
+        NodeInfo child2 = other;
+        while (!child1.getParent().equals(child2.getParent())) {
+            child1 = child1.getParent();
+            child2 = child2.getParent();
+        }
+        return new ElementNode[] {(ElementNode) child1, (ElementNode) child2};
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/RootNode.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/RootNode.java
@@ -60,6 +60,17 @@ public class RootNode extends AbstractNode {
     }
 
     /**
+     * Compares current object with specified for order.
+     * Throws {@code UnsupportedOperationException} because functionality not required here.
+     * @param nodeInfo another {@code NodeInfo} object
+     * @return number representing order of current object to specified one
+     */
+    @Override
+    public int compareOrder(NodeInfo nodeInfo) {
+        throw throwUnsupportedOperationException();
+    }
+
+    /**
      * Iterates siblings of the current node and
      * recursively creates new Xpath-nodes.
      */

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/AttributeNodeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/AttributeNodeTest.java
@@ -38,6 +38,18 @@ public class AttributeNodeTest {
     }
 
     @Test
+    public void testCompareOrder() {
+        try {
+            attributeNode.compareOrder(null);
+            fail("Exception is excepted");
+        }
+        catch (UnsupportedOperationException ex) {
+            assertEquals("Operation is not supported",
+                ex.getMessage(), "Invalid exception message");
+        }
+    }
+
+    @Test
     public void testGetAttributeValue() {
         try {
             attributeNode.getAttributeValue("", "");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/ElementNodeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/ElementNodeTest.java
@@ -59,6 +59,49 @@ public class ElementNodeTest extends AbstractPathTestSupport {
     }
 
     @Test
+    public void testParentChildOrdering() {
+        final DetailAstImpl detailAST = new DetailAstImpl();
+        detailAST.setType(TokenTypes.VARIABLE_DEF);
+
+        final DetailAstImpl parentAST = new DetailAstImpl();
+        parentAST.setFirstChild(detailAST);
+        parentAST.setType(TokenTypes.METHOD_DEF);
+
+        final AbstractNode parentNode = new ElementNode(rootNode, rootNode, parentAST);
+        final AbstractNode childNode = new ElementNode(rootNode, parentNode, detailAST);
+        assertEquals(-1, parentNode.compareOrder(childNode), "Incorrect ordering value");
+        assertEquals(1, childNode.compareOrder(parentNode), "Incorrect ordering value");
+    }
+
+    @Test
+    public void testSiblingsOrdering() {
+        final DetailAstImpl detailAst1 = new DetailAstImpl();
+        detailAst1.setType(TokenTypes.VARIABLE_DEF);
+
+        final DetailAstImpl detailAst2 = new DetailAstImpl();
+        detailAst2.setType(TokenTypes.NUM_INT);
+
+        final DetailAstImpl parentAST = new DetailAstImpl();
+        parentAST.setType(TokenTypes.METHOD_DEF);
+        parentAST.addChild(detailAst1);
+        parentAST.addChild(detailAst2);
+
+        final AbstractNode parentNode = new ElementNode(rootNode, rootNode, parentAST);
+        final List<AbstractNode> children = parentNode.getChildren();
+
+        assertEquals(-1, children.get(0).compareOrder(children.get(1)), "Incorrect ordering value");
+        assertEquals(1, children.get(1).compareOrder(children.get(0)), "Incorrect ordering value");
+    }
+
+    @Test
+    public void testCompareOrderWrongInstance() throws Exception {
+        final String xpath = "//OBJBLOCK";
+        final List<NodeInfo> nodes = getXpathItems(xpath, rootNode);
+        final int result = nodes.get(0).compareOrder(null);
+        assertEquals(0, result, "Expected result wrong");
+    }
+
+    @Test
     public void testGetParent() throws Exception {
         final String xpath = "//OBJBLOCK";
         final List<NodeInfo> nodes = getXpathItems(xpath, rootNode);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/RootNodeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/RootNodeTest.java
@@ -58,6 +58,18 @@ public class RootNodeTest extends AbstractPathTestSupport {
     }
 
     @Test
+    public void testCompareOrder() {
+        try {
+            rootNode.compareOrder(null);
+            fail("Exception is excepted");
+        }
+        catch (UnsupportedOperationException ex) {
+            assertEquals("Operation is not supported",
+                ex.getMessage(), "Invalid exception message");
+        }
+    }
+
+    @Test
     public void testXpath() throws Exception {
         final String xpath = "/";
         final List<NodeInfo> nodes = getXpathItems(xpath, rootNode);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.xpath;
 
+import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.internal.utils.XpathUtil.getXpathItems;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -43,6 +44,28 @@ public class XpathMapperTest extends AbstractPathTestSupport {
     @Override
     protected String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/xpath/xpathmapper";
+    }
+
+    @Test
+    public void testNodeOrdering() throws Exception {
+        final String xpath = "//METHOD_DEF/SLIST/*";
+        final RootNode rootNode = getRootNode("InputXpathMapperAst.java");
+        final List<NodeInfo> nodes = getXpathItems(xpath, rootNode);
+        for (int i = 1; i < nodes.size(); i++) {
+            final NodeInfo curr = nodes.get(i);
+            final NodeInfo prev = nodes.get(i - 1);
+
+            if (curr.getLineNumber() == prev.getLineNumber()) {
+                assertWithMessage("Column number is not in document order")
+                    .that(curr.getColumnNumber())
+                    .isGreaterThan(prev.getColumnNumber());
+            }
+            else {
+                assertWithMessage("Line number is not in document order")
+                    .that(curr.getLineNumber())
+                    .isGreaterThan(prev.getLineNumber());
+            }
+        }
     }
 
     @Test
@@ -129,7 +152,7 @@ public class XpathMapperTest extends AbstractPathTestSupport {
                 TokenTypes.PACKAGE_DEF);
         final DetailAST expectedAnnotationsNode = expectedPackageDefNode
                 .findFirstToken(TokenTypes.ANNOTATIONS);
-        final DetailAST[] expected = {expectedAnnotationsNode, expectedPackageDefNode};
+        final DetailAST[] expected = {expectedPackageDefNode, expectedAnnotationsNode};
         assertThat("Result nodes differ from expected", actual, equalTo(expected));
     }
 
@@ -147,8 +170,8 @@ public class XpathMapperTest extends AbstractPathTestSupport {
         final DetailAST expectedMethodDefNode2 = expectedObjblockNode
                 .findFirstToken(TokenTypes.METHOD_DEF)
                 .getNextSibling();
-        final DetailAST[] expected = {expectedClassDefNode, expectedMethodDefNode,
-            expectedMethodDefNode2, expectedObjblockNode};
+        final DetailAST[] expected = {expectedClassDefNode, expectedObjblockNode,
+            expectedMethodDefNode, expectedMethodDefNode2};
         assertThat("Result nodes differ from expected", actual, equalTo(expected));
     }
 
@@ -863,8 +886,8 @@ public class XpathMapperTest extends AbstractPathTestSupport {
                 TokenTypes.CLASS_DEF)
                 .findFirstToken(TokenTypes.OBJBLOCK)
                 .findFirstToken(TokenTypes.METHOD_DEF);
-        final DetailAST[] expected = {expectedMethodDefNode.getNextSibling(),
-            expectedMethodDefNode};
+        final DetailAST[] expected = {expectedMethodDefNode,
+            expectedMethodDefNode.getNextSibling()};
         assertThat("Result nodes differ from expected", actual, equalTo(expected));
         assertThat("Invalid token type", actual[0].getType(), equalTo(TokenTypes.METHOD_DEF));
         assertThat("Invalid token type", actual[1].getType(), equalTo(TokenTypes.METHOD_DEF));
@@ -892,8 +915,8 @@ public class XpathMapperTest extends AbstractPathTestSupport {
         final DetailAST expectedSemiNode1 = expectedVariableDefNode1.getNextSibling();
         final DetailAST expectedVariableDefNode2 = expectedSemiNode1.getNextSibling();
         final DetailAST expectedSemiNode2 = expectedVariableDefNode2.getNextSibling();
-        final DetailAST[] expected = {expectedSemiNode2, expectedSemiNode1,
-            expectedVariableDefNode2, expectedVariableDefNode1};
+        final DetailAST[] expected = {expectedVariableDefNode1, expectedSemiNode1,
+            expectedVariableDefNode2, expectedSemiNode2};
         assertThat("Result nodes differ from expected", actual, equalTo(expected));
     }
 
@@ -911,7 +934,7 @@ public class XpathMapperTest extends AbstractPathTestSupport {
                 .findFirstToken(TokenTypes.VARIABLE_DEF);
         final DetailAST expectedVariableDefNode2 = expectedVariableDefNode1.getNextSibling()
                 .getNextSibling();
-        final DetailAST[] expected = {expectedVariableDefNode2, expectedVariableDefNode1};
+        final DetailAST[] expected = {expectedVariableDefNode1, expectedVariableDefNode2};
         assertThat("Result nodes differ from expected", actual, equalTo(expected));
     }
 
@@ -946,7 +969,7 @@ public class XpathMapperTest extends AbstractPathTestSupport {
         final DetailAST expectedPackageDefNode = getSiblingByType(rootNode.getUnderlyingNode(),
                 TokenTypes.PACKAGE_DEF);
         final DetailAST expectedAnnotationsNode = expectedPackageDefNode.getFirstChild();
-        final DetailAST[] expected = {expectedAnnotationsNode, expectedPackageDefNode};
+        final DetailAST[] expected = {expectedPackageDefNode, expectedAnnotationsNode};
         assertThat("Result nodes differ from expected", actual, equalTo(expected));
     }
 


### PR DESCRIPTION
Resolves #6988 

Extending the work and implementing @rnveach's sort criteria discussed in PR #7485.
Example from: https://github.com/checkstyle/checkstyle/pull/7485#discussion_r373855071

```
$ cat test.java

public class test {
    void method() {
    }
}
```
Before:
```
$  java -jar checkstyle-8.29-all.jar -b "//CLASS_DEF/*" test.java 
CLASS_DEF -> CLASS_DEF [1:0]
|--IDENT -> test [1:13]
---------
CLASS_DEF -> CLASS_DEF [1:0]
|--LITERAL_CLASS -> class [1:7]
---------
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
---------
CLASS_DEF -> CLASS_DEF [1:0]
`--OBJBLOCK -> OBJBLOCK [1:18]
```
After:
```
$ java -jar checkstyle-8.31-SNAPSHOT-all.jar -b "//CLASS_DEF/*" test.java
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
---------
CLASS_DEF -> CLASS_DEF [1:0]
|--LITERAL_CLASS -> class [1:7]
---------
CLASS_DEF -> CLASS_DEF [1:0]
|--IDENT -> test [1:13]
---------
CLASS_DEF -> CLASS_DEF [1:0]
`--OBJBLOCK -> OBJBLOCK [1:18]
```
Diff Report: https://gaurabdg.github.io/checkstyle-tester-reports/regression/XPathSort/diff/