### PR TITLE
Issue #7636: Update doc for DefaultComesLast

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DefaultComesLastCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DefaultComesLastCheck.java
@@ -47,31 +47,64 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <pre>
  * &lt;module name=&quot;DefaultComesLast&quot;/&gt;
  * </pre>
- * <p>
- * To configure the check for skipIfLastAndSharedWithCase:
+ * <p>Example:</p>
+ * <pre>
+ * switch (i) {
+ *   case 1:
+ *     break;
+ *   case 2:
+ *     break;
+ *   default: // OK
+ *     break;
+ * }
+ *
+ * switch (i) {
+ *   case 1:
+ *     break;
+ *   case 2:
+ *     break; // OK, no default
+ * }
+ *
+ * switch (i) {
+ *   case 1:
+ *     break;
+ *   default: // violation, 'default' before 'case'
+ *     break;
+ *   case 2:
+ *     break;
+ * }
+ *
+ * switch (i) {
+ *   case 1:
+ *   default: // violation, 'default' before 'case'
+ *     break;
+ *   case 2:
+ *     break;
+ * }
+ * </pre>
+ * <p>To configure the check to allow default label to be not last if it is shared with case:
  * </p>
  * <pre>
  * &lt;module name=&quot;DefaultComesLast&quot;&gt;
  *   &lt;property name=&quot;skipIfLastAndSharedWithCase&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
- * <p>
- * Example when skipIfLastAndSharedWithCase is set to true.
- * </p>
+ * <p>Example:</p>
  * <pre>
  * switch (i) {
  *   case 1:
  *     break;
  *   case 2:
- *   default: // No violation with the new option is expected
+ *   default: // OK
  *     break;
  *   case 3:
  *     break;
  * }
+ *
  * switch (i) {
  *   case 1:
  *     break;
- *   default: // violation with the new option is expected
+ *   default: // violation
  *   case 2:
  *     break;
  * }

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -751,7 +751,44 @@ class K {
 &lt;module name=&quot;DefaultComesLast&quot;/&gt;
         </source>
         <p>
-            To configure the check for skipIfLastAndSharedWithCase:
+          Example:
+        </p>
+        <source>
+switch (i) {
+  case 1:
+    break;
+  case 2:
+    break;
+  default: // OK
+    break;
+}
+
+switch (i) {
+  case 1:
+    break;
+  case 2:
+    break; // OK, no default
+}
+
+switch (i) {
+  case 1:
+    break;
+  default: // violation, 'default' before 'case'
+    break;
+  case 2:
+    break;
+}
+
+switch (i) {
+  case 1:
+  default: // violation, 'default' before 'case'
+    break;
+  case 2:
+    break;
+}
+        </source>
+        <p>
+          To configure the check to allow default label to be not last if it is shared with case:
         </p>
         <source>
 &lt;module name=&quot;DefaultComesLast&quot;&gt;
@@ -759,22 +796,23 @@ class K {
 &lt;/module&gt;
         </source>
         <p>
-            Example when skipIfLastAndSharedWithCase is set to true.
+          Example:
         </p>
         <source>
 switch (i) {
   case 1:
     break;
   case 2:
-  default: // No violation with the new option is expected
+  default: // OK
     break;
   case 3:
     break;
 }
+
 switch (i) {
   case 1:
     break;
-  default: // violation with the new option is expected
+  default: // violation
   case 2:
     break;
 }


### PR DESCRIPTION
fixes #7636 
![Screenshot from 2020-03-19 00-35-46](https://user-images.githubusercontent.com/38028330/76997730-c973f300-6979-11ea-8086-97ebbbf0932a.png)
![Screenshot from 2020-03-19 00-36-21](https://user-images.githubusercontent.com/38028330/76997789-e27ca400-6979-11ea-8313-50c0f51dd7a9.png)


**Output for default example**

````
kaustubh@dxtk:~$ cat Test.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">

<module name="Checker">
<property name="charset" value="UTF-8"/>
<module name="TreeWalker">
<module name="DefaultComesLast">

</module>
</module>
</module>
kaustubh@dxtk:~$ cat Test.java
public class Test {
  void method(int i) {
    switch (i) {
      case 1:
        break;
      case 2:
        break;
      default: // OK
        break; 
    }

     switch (i) {
      case 1:
        break;
      case 2:
        break; // OK, no default
    }

     switch (i) {
      case 1:
        break;
      default: // violation, 'default' before 'case'
        break;
      case 2:
        break;
    }

     switch (i) {
      case 1:
      default: // violation, 'default' before 'case'
        break;
      case 2:
        break;
    }
  }
}
kaustubh@dxtk:~$ java -jar checkstyle-8.30-all.jar -c Test.xml Test.java
Starting audit...
[ERROR] /home/kaustubh/Test.java:22:7: Default should be last label in the switch. [DefaultComesLast]
[ERROR] /home/kaustubh/Test.java:30:7: Default should be last label in the switch. [DefaultComesLast]
Audit done.
Checkstyle ends with 2 errors.
````

**Output for configuration**
````
kaustubh@dxtk:~$ cat Test.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">

<module name="Checker">
    <property name="charset" value="UTF-8"/>
<module name="TreeWalker">
<module name="DefaultComesLast">
  <property name="skipIfLastAndSharedWithCase" value="true"/>
</module>
</module>
</module>
kaustubh@dxtk:~$ cat Test.java
public class Test {
  void method(int i) {
   switch (i) {
     case 1:
       break;
     case 2:
     default: // OK
       break;
     case 3:
       break;
   }
   switch (i) {
     case 1:
       break;
     default: // violation
     case 2:
       break;
   }  
 }
}
kaustubh@dxtk:~$ java -jar checkstyle-8.30-all.jar -c Test.xml Test.java
Starting audit...
[ERROR] /home/kaustubh/Test.java:15:6: Default should be last label in the case group. [DefaultComesLast]
Audit done.
Checkstyle ends with 1 errors.
````
@strkkk please review. 