### PR TITLE
Issue #7128: customImportOrderRules does not support the default value

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -158,6 +158,18 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testOrderRuleEmpty() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(CustomImportOrderCheck.class);
+        checkConfig.addAttribute("customImportOrderRules", "");
+        final String[] expected = {
+            "5: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.List"),
+        };
+
+        verify(checkConfig, getPath("InputCustomImportOrderEmptyRule.java"), expected);
+    }
+
+    @Test
     public void testOrderRuleWithOneGroup() throws Exception {
         final DefaultConfiguration checkConfig =
                 createModuleConfig(CustomImportOrderCheck.class);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -937,11 +937,6 @@ public class XdocsPagesTest {
             // dynamic custom expression
             result = "Regular Expression";
         }
-        else if ("CustomImportOrder".equals(sectionName)
-                && "customImportOrderRules".equals(propertyName)) {
-            // specially separated list
-            result = "String";
-        }
         else if (fieldClass == boolean.class) {
             result = "Boolean";
         }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderEmptyRule.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderEmptyRule.java
@@ -1,0 +1,15 @@
+package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
+
+import java.util.Map;
+
+import java.util.List; // violation, extra separation in import group
+
+public class InputCustomImportOrderEmptyRule {
+}
+/*
+ * test: testOrderRuleEmpty()
+ *
+ * Config = default
+ * customImportOrderRules = ""
+ *
+ */

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -425,9 +425,9 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
             </tr>
             <tr>
               <td>customImportOrderRules</td>
-              <td>Specify list of order declaration customizing by user.</td>
+              <td>Specify format of order declaration customizing by user.</td>
               <td><a href="property_types.html#string">String</a></td>
-              <td><code>{}</code></td>
+              <td><code>""</code></td>
               <td>5.8</td>
             </tr>
             <tr>


### PR DESCRIPTION
Fix #7128 

The documentation mistakenly shows the default value to be an empty set `{}` when it should be the empty string `""`. This led to some confusion in #7128 when the user thought that they could use `{}` as the default value.

This PR aims to fix the two points brought up in https://github.com/checkstyle/checkstyle/issues/7128#issuecomment-544254686:
1. Documentation is now updated to show `""` instead of `{}`
2. `setCustomImportOrderRules` now checks if `inputCustomImportOrder` is empty, and will not modify `customImportOrderRules` at all if it is the case.

Diff report: https://wltan.github.io/checkstyle-reports/2020-03-18/customimport-defaultrule-regression/diff/