### PR TITLE
Issue #7644: Update doc for IllegalThrows

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheck.java
@@ -60,6 +60,15 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
  * <pre>
  * &lt;module name="IllegalThrows"/&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public class Test {
+ *   public void func1() throws RuntimeException {} // violation
+ *   public void func2() throws Exception {}  // ok
+ *   public void func3() throws Error {}  // violation
+ *   public void func4() throws Throwable {} // violation
+ * }
+ * </pre>
  * <p>
  * To configure the check rejecting throws NullPointerException from methods:
  * </p>
@@ -68,13 +77,27 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
  *   &lt;property name="illegalClassNames" value="NullPointerException"/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public class Test {
+ *   public void func1() throws RuntimeException {} // ok
+ *   public void func2() throws NullPointerException {} // violation
+ * }
+ * </pre>
  * <p>
- * To configure the check ignoring method named "foo()":
+ * To configure the check ignoring method named "func1()":
  * </p>
  * <pre>
  * &lt;module name="IllegalThrows"&gt;
- *   &lt;property name="ignoredMethodNames" value="foo"/&gt;
+ *   &lt;property name="ignoredMethodNames" value="func1"/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public class Test {
+ *   public void func1() throws RuntimeException {}  // ok
+ *   public void func2() throws Error {}  // violation
+ * }
  * </pre>
  * <p>
  * To configure the check to warn on overridden methods:
@@ -83,6 +106,15 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
  * &lt;module name=&quot;IllegalThrows&quot;&gt;
  *   &lt;property name=&quot;ignoreOverriddenMethods&quot; value=&quot;false&quot;/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public class Test {
+ *   public void func1() throws Throwable {} // violation
+ * }
+ * class OverrideTest extends Test {
+ *   public void func1() throws RuntimeException {}  // violation
+ * }
  * </pre>
  *
  * @since 4.0

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -2156,6 +2156,15 @@ try {
         <source>
 &lt;module name=&quot;IllegalThrows&quot;/&gt;
         </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+  public void func1() throws RuntimeException {} // violation
+  public void func2() throws Exception {}  // ok
+  public void func3() throws Error {}  // violation
+  public void func4() throws Throwable {} // violation
+}
+        </source>
         <p>
           To configure the check rejecting throws NullPointerException from methods:
         </p>
@@ -2164,13 +2173,27 @@ try {
   &lt;property name=&quot;illegalClassNames&quot; value=&quot;NullPointerException&quot;/&gt;
 &lt;/module&gt;
         </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+  public void func1() throws RuntimeException {} // ok
+  public void func2() throws NullPointerException {} // violation
+}
+        </source>
         <p>
-          To configure the check ignoring method named &quot;foo()&quot;:
+          To configure the check ignoring method named &quot;func1()&quot;:
         </p>
         <source>
 &lt;module name=&quot;IllegalThrows&quot;&gt;
-  &lt;property name=&quot;ignoredMethodNames&quot; value=&quot;foo&quot;/&gt;
+  &lt;property name=&quot;ignoredMethodNames&quot; value=&quot;func1&quot;/&gt;
 &lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+  public void func1() throws RuntimeException {}  // ok
+  public void func2() throws Error {}  // violation
+}
         </source>
         <p>
           To configure the check to warn on overridden methods:
@@ -2179,6 +2202,15 @@ try {
 &lt;module name=&quot;IllegalThrows&quot;&gt;
   &lt;property name=&quot;ignoreOverriddenMethods&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+  public void func1() throws Throwable {} // violation
+}
+class OverrideTest extends Test {
+  public void func1() throws RuntimeException {}  // violation
+}
         </source>
       </subsection>
 


### PR DESCRIPTION
Fixes Issue: #7644
![2020-03-19_022944](https://user-images.githubusercontent.com/56132196/76994690-bff28700-6989-11ea-87b6-1e5e9a95046d.jpg)
Output of default example:
```
$ cat test/config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
"http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
       <module name="IllegalThrows"/>
    </module>
</module>

$ cat test/Test.java
public class Test{
	public void func1() throws RuntimeException{}  // violation
	
	public void func2() throws Exception{}   // ok
	
	public void func3() throws Error{}    // violation
	
	public void func4() throws Throwable{}    // violation
}

$ java -Duser.language=en -Duser.country=US -jar checkstyle-8.30-all.jar -c test/config.xml test/Test.java
Starting audit...
[ERROR] D:\checkstyle\test\Test.java:2:36: Throwing 'RuntimeException' is not allowed. [IllegalThrows]
[ERROR] D:\checkstyle\test\Test.java:6:36: Throwing 'Error' is not allowed. [IllegalThrows]
[ERROR] D:\checkstyle\test\Test.java:8:36: Throwing 'Throwable' is not allowed. [IllegalThrows]
Audit done.
Checkstyle ends with 3 errors.
```
Output of illegalClassNames example:
```
$ cat test/config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
"http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
       <module name="IllegalThrows">
                  <property name="illegalClassNames" value="NullPointerException"/>
           </module>
    </module>
</module>

$ cat test/Test.java
public class Test{
        public void func1() throws RuntimeException{} // ok

        public void func2() throws NullPointerException{} // violation
}

$ java -Duser.language=en -Duser.country=US -jar checkstyle-8.30-all.jar -c test/config.xml test/Test.java
Starting audit...
[ERROR] D:\checkstyle\test\Test.java:4:36: Throwing 'NullPointerException' is not allowed. [IllegalThrows]
Audit done.
Checkstyle ends with 1 errors.
```
Output of ignoredMethodNames example:
```
$ cat test/config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
"http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
       <module name="IllegalThrows">
                  <property name="ignoredMethodNames" value="func1"/>
           </module>
    </module>
</module>

$ cat test/Test.java
public class Test{
        public void func1() throws RuntimeException{}  // ok (method func1 is ignored)

        public void func2() throws Error{}  // violation
}

$ java -Duser.language=en -Duser.country=US -jar checkstyle-8.30-all.jar -c test/config.xml test/Test.java
Starting audit...
[ERROR] D:\checkstyle\test\Test.java:4:36: Throwing 'Error' is not allowed. [IllegalThrows]
Audit done.
Checkstyle ends with 1 errors.
```
Output of ignoreOverriddenMethods example:
```
$ cat test/config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
"http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
       <module name="IllegalThrows">
                  <property name="ignoreOverriddenMethods" value="false"/>
           </module>
    </module>
</module>

$ cat test/Test.java
public class Test{
        public void func1() throws Throwable{} // violation
}

class Son extends Test{
        public void func1() throws RuntimeException{}  // violation
}

$ java -Duser.language=en -Duser.country=US -jar checkstyle-8.30-all.jar -c test/config.xml test/Test.java
Starting audit...
[ERROR] D:\checkstyle\test\Test.java:2:36: Throwing 'Throwable' is not allowed. [IllegalThrows]
[ERROR] D:\checkstyle\test\Test.java:7:36: Throwing 'RuntimeException' is not allowed. [IllegalThrows]
Audit done.
Checkstyle ends with 2 errors.
```