### PR TITLE
Issue #7805: Resolve Pitest Issues - CustomImportOrderCheck (4)

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -71,9 +71,7 @@ pitest-header)
 pitest-imports)
   mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;
   declare -a ignoredItems=(
-  "CustomImportOrderCheck.java.html:<td class='covered'><pre><span  class='survived'>        else if (customImportOrderRules.contains(SAME_PACKAGE_RULE_GROUP)) {</span></pre></td></tr>"
   "CustomImportOrderCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (bestMatch.group.equals(NON_GROUP_RULE_GROUP)) {</span></pre></td></tr>"
-  "CustomImportOrderCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (customImportOrderRules.contains(SAME_PACKAGE_RULE_GROUP)) {</span></pre></td></tr>"
   "IllegalImportCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (regexp) {</span></pre></td></tr>"
   "IllegalImportCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (!result &#38;&#38; illegalClasses != null) {</span></pre></td></tr>"
   "IllegalImportCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (!result) {</span></pre></td></tr>"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -525,10 +525,8 @@ public class CustomImportOrderCheck extends AbstractCheck {
     @Override
     public void visitToken(DetailAST ast) {
         if (ast.getType() == TokenTypes.PACKAGE_DEF) {
-            if (customImportOrderRules.contains(SAME_PACKAGE_RULE_GROUP)) {
-                samePackageDomainsRegExp = createSamePackageRegexp(
-                        samePackageMatchingDepth, ast);
-            }
+            samePackageDomainsRegExp = createSamePackageRegexp(
+                    samePackageMatchingDepth, ast);
         }
         else {
             final String importFullPath = getFullImportIdent(ast);


### PR DESCRIPTION
Resolves #7805 and #7803 

As mentioned in https://github.com/checkstyle/checkstyle/issues/7805#issuecomment-601250261 , there were no differences and no UTs were suggested in the diff report (https://github.com/checkstyle/checkstyle/issues/7805#issuecomment-600638693) and observed no other way to fix the issue.
 Removing the condition was the only approach. The surviving mutation referred to by #7803 is also killed by this approach. 