### PR TITLE
Issue: #7738 Update AbstractChecks to log DetailAST - JavadocContentLocation 

### DIFF
--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionJavadocContentLocationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionJavadocContentLocationTest.java
@@ -1,0 +1,89 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationCheck;
+
+public class XpathRegressionJavadocContentLocationTest extends AbstractXpathTestSupport {
+
+    private final String checkName = JavadocContentLocationCheck.class.getSimpleName();
+
+    @Override
+    protected String getCheckName() {
+        return checkName;
+    }
+
+    @Test
+    public void testOne() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionJavadocContentLocationOne.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(JavadocContentLocationCheck.class);
+
+        final String[] expectedViolation = {
+            "5:5: " + getCheckMessage(JavadocContentLocationCheck.class,
+                    JavadocContentLocationCheck.MSG_JAVADOC_CONTENT_SECOND_LINE),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/INTERFACE_DEF[./IDENT[@text='SuppressionXpathRegressionJavadocContentLocationOne']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/TYPE/BLOCK_COMMENT_BEGIN"
+
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testTwo() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionJavadocContentLocationTwo.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(JavadocContentLocationCheck.class);
+
+        moduleConfig.addAttribute("location", "first_line");
+
+        final String[] expectedViolation = {
+            "5:16: " + getCheckMessage(JavadocContentLocationCheck.class,
+                    JavadocContentLocationCheck.MSG_JAVADOC_CONTENT_FIRST_LINE),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/INTERFACE_DEF[./IDENT"
+                    + "[@text='SuppressionXpathRegressionJavadocContentLocationTwo']]"
+                    + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/TYPE/BLOCK_COMMENT_BEGIN[2]"
+
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/javadoccontentlocation/SuppressionXpathRegressionJavadocContentLocationOne.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/javadoccontentlocation/SuppressionXpathRegressionJavadocContentLocationOne.java
@@ -1,0 +1,8 @@
+package org.checkstyle.suppressionxpathfilter.javadoccontentlocation;
+
+public interface SuppressionXpathRegressionJavadocContentLocationOne {
+
+    /** Text. // warn
+     */
+    void test();
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/javadoccontentlocation/SuppressionXpathRegressionJavadocContentLocationTwo.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/javadoccontentlocation/SuppressionXpathRegressionJavadocContentLocationTwo.java
@@ -1,0 +1,9 @@
+package org.checkstyle.suppressionxpathfilter.javadoccontentlocation;
+
+public interface SuppressionXpathRegressionJavadocContentLocationTwo {
+
+    /* warn */ /**
+     * Text.
+     */
+    void test();
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -71,9 +71,6 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * InterfaceMemberImpliedModifier
  * </li>
  * <li>
- * JavadocContentLocation
- * </li>
- * <li>
  * JavadocMethod
  * </li>
  * <li>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -62,7 +62,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
             "Indentation",
             "InterfaceIsType",
             "InterfaceMemberImpliedModifier",
-            "JavadocContentLocation",
             "JavadocMethod",
             "JavadocType",
             "LambdaParameterName",

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -911,7 +911,6 @@ public class UserService {
           <li>Indentation</li>
           <li>InterfaceIsType</li>
           <li>InterfaceMemberImpliedModifier</li>
-          <li>JavadocContentLocation</li>
           <li>JavadocMethod</li>
           <li>JavadocType</li>
           <li>LambdaParameterName</li>


### PR DESCRIPTION
Issue resolves #7738 .
# 1. Site Changes.
<img width="1440" alt="Screenshot 2020-03-20 at 12 16 57 AM" src="https://user-images.githubusercontent.com/40023562/77103494-7d3fb600-6a40-11ea-8dc7-3a95c4bc06a1.png">

# 2. Diff Report
(Default Config):
https://harsh-kukreja.github.io/diff%20report%20default%20config/diff/

(Config with location of first_line):
https://harsh-kukreja.github.io/diff%20report%20first_line%20config/diff/

# 3. Goal
Update AbstractChecks to log DetailAST - JavadocContentLocation 