### PR TITLE
Issue #6707: fix false violation report that does not allow spaces in front of ellipsis tokens for Google Style

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/NoWhitespaceBeforeTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/NoWhitespaceBeforeTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.checks.whitespace.NoWhitespaceBeforeCheck;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class NoWhitespaceBeforeTest extends AbstractGoogleModuleTestSupport {
 
@@ -58,6 +59,16 @@ public class NoWhitespaceBeforeTest extends AbstractGoogleModuleTestSupport {
         };
         final Configuration checkConfig = getModuleConfig("NoWhitespaceBefore");
         final String filePath = getPath("InputNoWhitespaceBeforeColonOfLabel.java");
+
+        final Integer[] warnList = getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
+    }
+
+    @Test
+    public void testAnnotations() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        final Configuration checkConfig = getModuleConfig("NoWhitespaceBefore");
+        final String filePath = getPath("InputNoWhitespaceBeforeAnnotations.java");
 
         final Integer[] warnList = getLinesWithWarn(filePath);
         verify(checkConfig, filePath, expected, warnList);

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeAnnotations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputNoWhitespaceBeforeAnnotations.java
@@ -1,0 +1,44 @@
+package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE_USE)
+@interface NonNull {
+
+}
+
+public class InputNoWhitespaceBeforeAnnotations {
+
+    public void foo(final char @NonNull [] param) {} // ok
+
+    @NonNull int @NonNull[] @NonNull[] fiel1; // ok until #8205
+    @NonNull int @NonNull [] @NonNull [] field2; // ok
+    //@NonNull int @NonNull ... field3; // non-compilable
+    //@NonNull int @NonNull... field4; // non-compilable
+
+
+    public void foo1(final char[] param) { // ok
+    }
+
+    public void foo2(final char [] param) { // ok
+    }
+
+    public void foo3(final char @NonNull[] param) { // ok until #8205
+    }
+
+    public void foo4(final char @NonNull [] param) { // ok
+    }
+
+    void test1(String... param) { // ok until #8205
+    }
+
+    void test2(String ... param) { // ok until #8205
+    }
+
+    void test3(String @NonNull... param) { // ok until #8205
+    }
+
+    void test4(String @NonNull ... param) { // ok
+    }
+}

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -256,7 +256,7 @@
         </module>
         <module name="NoWhitespaceBefore">
             <property name="tokens"
-             value="COMMA, SEMI, POST_INC, POST_DEC, DOT, ELLIPSIS,
+             value="COMMA, SEMI, POST_INC, POST_DEC, DOT,
                     LABELED_STAT, METHOD_REF"/>
             <property name="allowLineBreaks" value="true"/>
         </module>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -239,7 +239,10 @@ public class AllChecksTest extends AbstractModuleTestSupport {
                 "COLON", "TYPE_EXTENSION_AND").collect(Collectors.toSet()));
         GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("NoWhitespaceBefore", Stream.of(
                 // google uses GenericWhitespace for this behavior
-                "GENERIC_START", "GENERIC_END").collect(Collectors.toSet()));
+                "GENERIC_START", "GENERIC_END",
+                // whitespace is necessary between a type annotation and ellipsis
+                // according '4.6.2 Horizontal whitespace point 9'
+                "ELLIPSIS").collect(Collectors.toSet()));
     }
 
     @Override


### PR DESCRIPTION
Issue #6707: fix false violation report that does not allow spaces in front of ellipsis tokens for Google Style, specific information are in issue.

diff report:
https://huganghui.github.io/6707-ellipsis/diff/