### PR TITLE
Issue #2986: Add property to skip package-info.java in HeaderCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.header;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.FileText;
@@ -75,6 +76,10 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
  * <li>
  * Property {@code fileExtensions} - Specify the file type extension of files to process.
  * Default value is {@code all files}.
+ * </li>
+ * <li>
+ * Property {@code skipFiles} - Specify files to skip.
+ * Default value is {@code "^$" (empty)}.
  * </li>
  * </ul>
  * <p>
@@ -135,6 +140,9 @@ public class HeaderCheck extends AbstractHeaderCheck {
     /** Specify the line numbers to ignore. */
     private int[] ignoreLines = EMPTY_INT_ARRAY;
 
+    /** Specify files to skip. */
+    private Pattern skipFiles = Pattern.compile("^$");
+
     /**
      * Returns true if lineNo is header lines or false.
      * @param lineNo a line number
@@ -157,6 +165,15 @@ public class HeaderCheck extends AbstractHeaderCheck {
     }
 
     /**
+     * Checks if the file is set to be skipped.
+     * @param file the file to check whether it should be skipped.
+     * @return true if and only if the file name matches the skipFiles regex string.
+     */
+    private boolean skipFile(File file) {
+        return skipFiles.matcher(file.getName()).find();
+    }
+
+    /**
      * Setter to specify the line numbers to ignore.
      *
      * @param list comma separated list of line numbers to ignore in header.
@@ -172,16 +189,27 @@ public class HeaderCheck extends AbstractHeaderCheck {
         }
     }
 
+    /**
+     * Setter to specify files to skip.
+     *
+     * @param skipFiles regex to specify the files to skip.
+     */
+    public void setSkipFiles(Pattern skipFiles) {
+        this.skipFiles = skipFiles;
+    }
+
     @Override
     protected void processFiltered(File file, FileText fileText) {
-        if (getHeaderLines().size() > fileText.size()) {
-            log(1, MSG_MISSING);
-        }
-        else {
-            for (int i = 0; i < getHeaderLines().size(); i++) {
-                if (!isMatch(i, fileText.get(i))) {
-                    log(i + 1, MSG_MISMATCH, getHeaderLines().get(i));
-                    break;
+        if (!skipFile(file)) {
+            if (getHeaderLines().size() > fileText.size()) {
+                log(1, MSG_MISSING);
+            }
+            else {
+                for (int i = 0; i < getHeaderLines().size(); i++) {
+                    if (!isMatch(i, fileText.get(i))) {
+                        log(i + 1, MSG_MISMATCH, getHeaderLines().get(i));
+                        break;
+                    }
                 }
             }
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
@@ -49,6 +49,36 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testPackageInfoCheck() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(HeaderCheck.class);
+        checkConfig.addAttribute("skipFiles", "package-info.java");
+        checkConfig.addAttribute("header", "example");
+        createChecker(checkConfig);
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("package-info.java"), expected);
+    }
+
+    @Test
+    public void testPackageInfoCheckFalse() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(HeaderCheck.class);
+        createChecker(checkConfig);
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("package-info.java"), expected);
+    }
+
+    @Test
+    public void testPackageInfoCheckOtherFile() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(HeaderCheck.class);
+        checkConfig.addAttribute("headerFile", getPath("InputHeaderjava.header"));
+        checkConfig.addAttribute("ignoreLines", "");
+        checkConfig.addAttribute("skipFiles", "package-info.java");
+        final String[] expected = {
+            "1: " + getCheckMessage(MSG_MISSING),
+        };
+        verify(checkConfig, getPath("InputHeader.java"), expected);
+    }
+
+    @Test
     public void testStaticHeader() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(HeaderCheck.class);
         checkConfig.addAttribute("headerFile", getPath("InputHeaderjava.header"));

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/header/header/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/header/header/package-info.java
@@ -1,0 +1,2 @@
+
+package com.puppycrawl.tools.checkstyle.checks.header.header;

--- a/src/xdocs/config_header.xml
+++ b/src/xdocs/config_header.xml
@@ -113,6 +113,13 @@ line 5: ////////////////////////////////////////////////////////////////////
               <td><code>all files</code></td>
               <td>6.9</td>
             </tr>
+            <tr>
+              <td>skipFiles</td>
+              <td>Specify files to skip.</td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>"^$" (empty)</code></td>
+              <td>8.31</td>
+            </tr>
           </table>
         </div>
       </subsection>


### PR DESCRIPTION
Fixes Issue #2986 
Diff Report for default configs for base & patch: https://gaurabdg.github.io/checkstyle-tester-reports/regression/Header-default/diff/index.html
Diff Report for forced violations in base & fixed violations in patch: https://gaurabdg.github.io/checkstyle-tester-reports/regression/Header-propertycheck/diff/index.html
The `skipFiles` property suppressed all violations.