### PR TITLE
Issue #7737: Update AbstractChecks to log DetailAST - InvalidJavadocP…

### DIFF
--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionInvalidJavadocPositionTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionInvalidJavadocPositionTest.java
@@ -1,0 +1,172 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.InvalidJavadocPositionCheck;
+
+public class XpathRegressionInvalidJavadocPositionTest extends AbstractXpathTestSupport {
+
+    private final String checkName = InvalidJavadocPositionCheck.class.getSimpleName();
+
+    @Override
+    protected String getCheckName() {
+        return checkName;
+    }
+
+    @Test
+    public void testOne() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionInvalidJavadocPositionOne.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(InvalidJavadocPositionCheck.class);
+
+        final String[] expectedViolation = {
+            "4:1: " + getCheckMessage(InvalidJavadocPositionCheck.class,
+                InvalidJavadocPositionCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionInvalidJavadocPositionOne']]"
+                + "/MODIFIERS/BLOCK_COMMENT_BEGIN"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testTwo() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionInvalidJavadocPositionTwo.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(InvalidJavadocPositionCheck.class);
+
+        final String[] expectedViolation = {
+            "5:1: " + getCheckMessage(InvalidJavadocPositionCheck.class,
+                InvalidJavadocPositionCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionInvalidJavadocPositionTwo']]"
+                + "/OBJBLOCK/BLOCK_COMMENT_BEGIN"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testThree() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionInvalidJavadocPositionThree.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(InvalidJavadocPositionCheck.class);
+
+        final String[] expectedViolation = {
+            "6:5: " + getCheckMessage(InvalidJavadocPositionCheck.class,
+                InvalidJavadocPositionCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionInvalidJavadocPositionThree']]"
+                + "/OBJBLOCK/BLOCK_COMMENT_BEGIN"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testFour() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionInvalidJavadocPositionFour.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(InvalidJavadocPositionCheck.class);
+
+        final String[] expectedViolation = {
+            "4:5: " + getCheckMessage(InvalidJavadocPositionCheck.class,
+                InvalidJavadocPositionCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionInvalidJavadocPositionFour']]"
+                + "/OBJBLOCK/BLOCK_COMMENT_BEGIN"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testFive() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionInvalidJavadocPositionFive.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(InvalidJavadocPositionCheck.class);
+
+        final String[] expectedViolation = {
+            "5:9: " + getCheckMessage(InvalidJavadocPositionCheck.class,
+                InvalidJavadocPositionCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionInvalidJavadocPositionFive']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]"
+                + "/SLIST/BLOCK_COMMENT_BEGIN"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testSix() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionInvalidJavadocPositionSix.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(InvalidJavadocPositionCheck.class);
+
+        final String[] expectedViolation = {
+            "5:5: " + getCheckMessage(InvalidJavadocPositionCheck.class,
+                InvalidJavadocPositionCheck.MSG_KEY),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionInvalidJavadocPositionSix']]"
+                + "/OBJBLOCK/BLOCK_COMMENT_BEGIN"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/invalidjavadocposition/SuppressionXpathRegressionInvalidJavadocPositionFive.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/invalidjavadocposition/SuppressionXpathRegressionInvalidJavadocPositionFive.java
@@ -1,0 +1,9 @@
+package org.checkstyle.suppressionxpathfilter.invalidjavadocposition;
+
+public class SuppressionXpathRegressionInvalidJavadocPositionFive {
+    public void foo() {
+        /** // warn
+         * Javadoc comment
+         */
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/invalidjavadocposition/SuppressionXpathRegressionInvalidJavadocPositionFour.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/invalidjavadocposition/SuppressionXpathRegressionInvalidJavadocPositionFour.java
@@ -1,0 +1,7 @@
+package org.checkstyle.suppressionxpathfilter.invalidjavadocposition;
+
+public class SuppressionXpathRegressionInvalidJavadocPositionFour {
+    /** // warn
+     * Javadoc Comment
+     */
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/invalidjavadocposition/SuppressionXpathRegressionInvalidJavadocPositionOne.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/invalidjavadocposition/SuppressionXpathRegressionInvalidJavadocPositionOne.java
@@ -1,0 +1,8 @@
+package org.checkstyle.suppressionxpathfilter.invalidjavadocposition;
+
+@SuppressWarnings("serial")
+/** // warn
+ * Javadoc Comment
+ */
+public class SuppressionXpathRegressionInvalidJavadocPositionOne {
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/invalidjavadocposition/SuppressionXpathRegressionInvalidJavadocPositionSix.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/invalidjavadocposition/SuppressionXpathRegressionInvalidJavadocPositionSix.java
@@ -1,0 +1,8 @@
+package org.checkstyle.suppressionxpathfilter.invalidjavadocposition;
+
+public class SuppressionXpathRegressionInvalidJavadocPositionSix {
+	int a;
+    /** // warn
+     * Javadoc Comment
+     */
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/invalidjavadocposition/SuppressionXpathRegressionInvalidJavadocPositionThree.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/invalidjavadocposition/SuppressionXpathRegressionInvalidJavadocPositionThree.java
@@ -1,0 +1,9 @@
+package org.checkstyle.suppressionxpathfilter.invalidjavadocposition;
+
+public class SuppressionXpathRegressionInvalidJavadocPositionThree {
+    public void foo(){
+    }
+    /** // warn
+     * Javadoc comment
+     */
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/invalidjavadocposition/SuppressionXpathRegressionInvalidJavadocPositionTwo.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/invalidjavadocposition/SuppressionXpathRegressionInvalidJavadocPositionTwo.java
@@ -1,0 +1,7 @@
+package org.checkstyle.suppressionxpathfilter.invalidjavadocposition;
+
+public class SuppressionXpathRegressionInvalidJavadocPositionTwo {
+}
+/** // warn
+ * Javadoc comment
+ */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -74,9 +74,6 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * InterfaceMemberImpliedModifier
  * </li>
  * <li>
- * InvalidJavadocPosition
- * </li>
- * <li>
  * JavadocContentLocation
  * </li>
  * <li>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -63,7 +63,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
             "Indentation",
             "InterfaceIsType",
             "InterfaceMemberImpliedModifier",
-            "InvalidJavadocPosition",
             "JavadocContentLocation",
             "JavadocMethod",
             "JavadocType",

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -912,7 +912,6 @@ public class UserService {
           <li>Indentation</li>
           <li>InterfaceIsType</li>
           <li>InterfaceMemberImpliedModifier</li>
-          <li>InvalidJavadocPosition</li>
           <li>JavadocContentLocation</li>
           <li>JavadocMethod</li>
           <li>JavadocType</li>


### PR DESCRIPTION
Fixes #7737 

The check already reports violation to DetailAST node:
https://github.com/checkstyle/checkstyle/blob/34615b4a3c8f8826fb6961ed9a35449e73c16a2f/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/InvalidJavadocPositionCheck.java#L96

Diff file:
https://sulkykookie.github.io/invalidjavadocposition