### PR TITLE
Issue #7920: Resolve Pitest Issues - RedundantImportCheck

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -86,7 +86,6 @@ pitest-imports)
   "PkgImportControl.java.html:<td class='covered'><pre><span  class='survived'>        if (regex || parent.regex) {</span></pre></td></tr>"
   "PkgImportControl.java.html:<td class='covered'><pre><span  class='survived'>        if (regex) {</span></pre></td></tr>"
   "PkgImportRule.java.html:<td class='covered'><pre><span  class='survived'>        if (isRegExp()) {</span></pre></td></tr>"
-  "RedundantImportCheck.java.html:<td class='covered'><pre><span  class='survived'>            else if (pkgName != null &#38;&#38; isFromPackage(imp.getText(), pkgName)) {</span></pre></td></tr>"
   "UnusedImportsCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (collect) {</span></pre></td></tr>"
   );
   checkPitestReport "${ignoredItems[@]}"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
@@ -150,7 +150,7 @@ public class RedundantImportCheck
         // So '.' must be present in member name and we are not checking for it
         final int index = importName.lastIndexOf('.');
         final String front = importName.substring(0, index);
-        return front.equals(pkg);
+        return pkg.equals(front);
     }
 
 }


### PR DESCRIPTION
Fixes issue #7920 

### Description
This mutation was surviving `removed conditional - replaced equality check with true → KILLED` at line no 120.

### Solution
If `pkgName` is null it means this is an unnamed package and as an unnamed package cannot be imported we don't need to check if the `pkgName` is null as the second condition will return false.