### PR TITLE
Issue #6192: New module RequireEmptyLineBeforeBlockTagGroup to ensure there is an empty line before javadoc tag like @param

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -1124,6 +1124,7 @@ regexpsinglelinejava
 relativized
 releasenotes
 remkop
+requireemptylinebeforeblocktaggroup
 requirethis
 Rethrown
 returncount

--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -549,6 +549,7 @@
     <module name="SingleLineJavadoc"/>
     <module name="WriteTag"/>
     <module name="SummaryJavadoc"/>
+    <module name="RequireEmptyLineBeforeBlockTagGroup"/>
 
     <!-- Metrics -->
     <module name="BooleanExpressionComplexity">

--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/RequireEmptyLineBeforeBlockTagGroupTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/RequireEmptyLineBeforeBlockTagGroupTest.java
@@ -1,0 +1,73 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.google.checkstyle.test.chapter7javadoc.rule712paragraphs;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.RequireEmptyLineBeforeBlockTagGroupCheck;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+
+public class RequireEmptyLineBeforeBlockTagGroupTest extends AbstractGoogleModuleTestSupport {
+
+    @Override
+    protected String getPackageLocation() {
+        return "com/google/checkstyle/test/chapter7javadoc/rule712paragraphs";
+    }
+
+    @Test
+    public void testJavadocParagraphCorrect() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        final Configuration checkConfig = getModuleConfig(
+                "RequireEmptyLineBeforeBlockTagGroup");
+        final String filePath = getPath(
+                "InputCorrectRequireEmptyLineBeforeBlockTagGroupCheck.java");
+
+        final Integer[] warnList = getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
+    }
+
+    @Test
+    public void testJavadocParagraphIncorrect() throws Exception {
+        final String[] expected = {
+            "5: " + getTagCheckMessage("@since"),
+            "11: " + getTagCheckMessage("@param"),
+            "19: " + getTagCheckMessage("@param"),
+        };
+
+        final Configuration checkConfig = getModuleConfig(
+                "RequireEmptyLineBeforeBlockTagGroup");
+        final String filePath = getPath(
+                "InputIncorrectRequireEmptyLineBeforeBlockTagGroupCheck.java");
+
+        final Integer[] warnList = getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
+    }
+
+    private static String getTagCheckMessage(String tag) throws IOException {
+        return getCheckMessage(RequireEmptyLineBeforeBlockTagGroupCheck.class,
+                "javadoc.tag.line.before",
+                tag);
+    }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputCorrectRequireEmptyLineBeforeBlockTagGroupCheck.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputCorrectRequireEmptyLineBeforeBlockTagGroupCheck.java
@@ -1,0 +1,39 @@
+package com.google.checkstyle.test.chapter7javadoc.rule712paragraphs;
+
+/**
+ * Some Javadoc.
+ *
+ * @since 8.36
+ */
+class InputCorrectRequireEmptyLineBeforeBlockTagGroupCheck {
+
+    /**
+     * This javadoc does not have a tag. There should be no violations.
+     */
+    public static final byte NO_TAG = 0;
+
+    /**
+     * This javadoc does has one tag, with an empty line. There should be no violations.
+     *
+     * @since 8.36
+     */
+    public static final byte ONE_TAG = 0;
+
+    /**
+     * This javadoc has multiple tag, with an empty line before the. There should be no
+     * violations.
+     *
+     * @param input this is the first tag.
+     * @return this is the second tag.
+     */
+    public static boolean test(boolean input) {
+        return false;
+    }
+
+    /**
+     * @return this only has an tag.
+     */
+    public static boolean test() {
+        return false;
+    }
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputIncorrectRequireEmptyLineBeforeBlockTagGroupCheck.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/InputIncorrectRequireEmptyLineBeforeBlockTagGroupCheck.java
@@ -1,0 +1,25 @@
+package com.google.checkstyle.test.chapter7javadoc.rule712paragraphs;
+
+/**
+ * Some Javadoc.
+ * @since 8.36 //warn
+ */
+class InputIncorrectRequireEmptyLineBeforeBlockTagGroupCheck {
+
+    /**
+     * This documents the private method.
+     * @param thisParamTagNeedsNewline this documents the parameter. //warn
+     */
+    private boolean paramTagNeedsNewline(boolean thisParamTagNeedsNewline) {
+        return false;
+    }
+
+    /**
+     * This documents the private method.
+     * @param thisParamTagNeedsNewline this documents the parameter. //warn
+     * @return this one does not need an empty line, but the tag before this one does.
+     */
+    private boolean paramMultiTagNeedsNewline(boolean thisParamTagNeedsNewline) {
+        return false;
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -673,6 +673,8 @@ public class PackageObjectFactory implements ModuleFactory {
                 BASE_PACKAGE + ".checks.javadoc.MissingJavadocTypeCheck");
         NAME_TO_FULL_MODULE_NAME.put("NonEmptyAtclauseDescriptionCheck",
                 BASE_PACKAGE + ".checks.javadoc.NonEmptyAtclauseDescriptionCheck");
+        NAME_TO_FULL_MODULE_NAME.put("RequireEmptyLineBeforeBlockTagGroupCheck",
+                BASE_PACKAGE + ".checks.javadoc.RequireEmptyLineBeforeBlockTagGroupCheck");
         NAME_TO_FULL_MODULE_NAME.put("SingleLineJavadocCheck",
                 BASE_PACKAGE + ".checks.javadoc.SingleLineJavadocCheck");
         NAME_TO_FULL_MODULE_NAME.put("SummaryJavadocCheck",

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
@@ -33,8 +33,7 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
  * Checks that:
  * </p>
  * <ul>
- * <li>There is one blank line between each of two paragraphs
- * and one blank line before the at-clauses block if it is present.</li>
+ * <li>There is one blank line between each of two paragraphs.</li>
  * <li>Each paragraph but the first has &lt;p&gt; immediately
  * before the first word, with no space after.</li>
  * </ul>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/RequireEmptyLineBeforeBlockTagGroupCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/RequireEmptyLineBeforeBlockTagGroupCheck.java
@@ -1,0 +1,257 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import com.puppycrawl.tools.checkstyle.StatelessCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailNode;
+import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
+
+/**
+ * <p>
+ * Checks that one blank line before the block tag if it is present in Javadoc.
+ * </p>
+ * <ul>
+ * <li>
+ * Property {@code violateExecutionOnNonTightHtml} - Control when to print violations
+ * if the Javadoc being examined by this check violates the tight html rules defined at
+ * <a href="https://checkstyle.org/writingjavadocchecks.html#Tight-HTML_rules">
+ * Tight-HTML Rules</a>.
+ * Type is {@code boolean}. Default value is {@code false}.
+ * </li>
+ * </ul>
+ * <p>
+ * To configure the check:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;RequireEmptyLineBeforeBlockTagGroup&quot;/&gt;
+ * </pre>
+ * <p>
+ * By default, the check will report a violation if there is no blank line before the block tag,
+ * like in the example below.
+ * </p>
+ * <pre>
+ * &#47;**
+ *  * testMethod's javadoc.
+ *  * &#64;return something (violation)
+ *  *&#47;
+ * public boolean testMethod() {
+ *     return false;
+ * }
+ * </pre>
+ * <p>
+ *  Valid javadoc should have a blank line separating the parameters, return, throw, or
+ *  other tags like in the example below.
+ *  </p>
+ *  <pre>
+ *  &#47;**
+ *  * testMethod's javadoc.
+ *  *
+ *  * &#64;param firstParam
+ *  * &#64;return something
+ *  *&#47;
+ *  public boolean testMethod(int firstParam) {
+ *      return false;
+ *  }
+ *  </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code javadoc.missed.html.close}
+ * </li>
+ * <li>
+ * {@code javadoc.parse.rule.error}
+ * </li>
+ * <li>
+ * {@code javadoc.tag.line.before}
+ * </li>
+ * <li>
+ * {@code javadoc.wrong.singleton.html.tag}
+ * </li>
+ * </ul>
+ *
+ * @since 8.36
+ */
+@StatelessCheck
+public class RequireEmptyLineBeforeBlockTagGroupCheck extends AbstractJavadocCheck {
+
+    /**
+     * The key in "messages.properties" for the message that describes a tag in javadoc
+     * requiring an empty line before it.
+     */
+    public static final String MSG_JAVADOC_TAG_LINE_BEFORE = "javadoc.tag.line.before";
+
+    /**
+     * Case when space separates the tag and the asterisk like in the below example.
+     * <pre>
+     *  /**
+     *   * &#64;param noSpace there is no space here
+     * </pre>
+     */
+    private static final List<Integer> ONLY_TAG_VARIATION_1 = Arrays.asList(
+            JavadocTokenTypes.WS,
+            JavadocTokenTypes.LEADING_ASTERISK,
+            JavadocTokenTypes.NEWLINE);
+
+    /**
+     * Case when no space separates the tag and the asterisk like in the below example.
+     * <pre>
+     *  /**
+     *   *&#64;param noSpace there is no space here
+     * </pre>
+     */
+    private static final List<Integer> ONLY_TAG_VARIATION_2 = Arrays.asList(
+            JavadocTokenTypes.LEADING_ASTERISK,
+            JavadocTokenTypes.NEWLINE);
+
+    /**
+     * Returns only javadoc tags so visitJavadocToken only receives javadoc tags.
+     *
+     * @return only javadoc tags.
+     */
+    @Override
+    public int[] getDefaultJavadocTokens() {
+        return new int[] {
+            JavadocTokenTypes.JAVADOC_TAG,
+        };
+    }
+
+    @Override
+    public int[] getRequiredJavadocTokens() {
+        return getAcceptableJavadocTokens();
+    }
+
+    /**
+     * Logs when there is no empty line before the tag.
+     *
+     * @param tagNode the at tag node to check for an empty space before it.
+     */
+    @Override
+    public void visitJavadocToken(DetailNode tagNode) {
+        // No need to filter token because overridden getDefaultJavadocTokens ensures that we only
+        // receive JAVADOC_TAG DetailNode.
+        if (!isAnotherTagBefore(tagNode)
+                && !isOnlyTagInWholeJavadoc(tagNode)
+                && hasInsufficientConsecutiveNewlines(tagNode)) {
+            log(tagNode.getLineNumber(),
+                    MSG_JAVADOC_TAG_LINE_BEFORE,
+                    tagNode.getChildren()[0].getText());
+        }
+    }
+
+    /**
+     * Returns true when there is a javadoc tag before the provided tagNode.
+     *
+     * @param tagNode the javadoc tag node, to look for more tags before it.
+     * @return true when there is a javadoc tag before the provided tagNode.
+     */
+    private static boolean isAnotherTagBefore(DetailNode tagNode) {
+        boolean found = false;
+        DetailNode currentNode = JavadocUtil.getPreviousSibling(tagNode);
+        while (currentNode != null) {
+            if (currentNode.getType() == JavadocTokenTypes.JAVADOC_TAG) {
+                found = true;
+                break;
+            }
+            currentNode = JavadocUtil.getPreviousSibling(currentNode);
+        }
+        return found;
+    }
+
+    /**
+     * Returns true when there are is only whitespace and asterisks before the provided tagNode.
+     * When javadoc has only a javadoc tag like {@literal @} in it, the JAVADOC_TAG in a JAVADOC
+     * detail node will always have 2 or 3 siblings before it. The parse tree looks like:
+     * <pre>
+     * JAVADOC[3x0]
+     * |--NEWLINE[3x0] : [\n]
+     * |--LEADING_ASTERISK[4x0] : [ *]
+     * |--WS[4x2] : [ ]
+     * |--JAVADOC_TAG[4x3] : [@param T The bar.\n ]
+     * </pre>
+     * Or it can also look like:
+     * <pre>
+     * JAVADOC[3x0]
+     * |--NEWLINE[3x0] : [\n]
+     * |--LEADING_ASTERISK[4x0] : [ *]
+     * |--JAVADOC_TAG[4x3] : [@param T The bar.\n ]
+     * </pre>
+     * We do not include the variation
+     * <pre>
+     *  /**&#64;param noSpace there is no space here
+     * </pre>
+     * which results in the tree
+     * <pre>
+     * JAVADOC[3x0]
+     * |--JAVADOC_TAG[4x3] : [@param noSpace there is no space here\n ]
+     * </pre>
+     * because this one is invalid. We must recommend placing a blank line to separate &#64;param
+     * from the first javadoc asterisks.
+     *
+     * @param tagNode the at tag node to check if there is nothing before it.
+     * @return true if there no text before the tagNode.
+     */
+    private static boolean isOnlyTagInWholeJavadoc(DetailNode tagNode) {
+        final List<Integer> previousNodeTypes = new ArrayList<>();
+        DetailNode currentNode = JavadocUtil.getPreviousSibling(tagNode);
+        while (currentNode != null) {
+            previousNodeTypes.add(currentNode.getType());
+            currentNode = JavadocUtil.getPreviousSibling(currentNode);
+        }
+        return ONLY_TAG_VARIATION_1.equals(previousNodeTypes)
+                || ONLY_TAG_VARIATION_2.equals(previousNodeTypes);
+    }
+
+    /**
+     * Returns true when there are not enough empty lines before the provided tagNode.
+     *
+     * <p>Iterates through the previous siblings of the tagNode looking for empty lines until
+     * there are no more siblings or it hits something other than asterisk, whitespace or newline.
+     * If it finds at least one empty line, return true. Return false otherwise.</p>
+     *
+     * @param tagNode the tagNode to check if there are sufficient empty lines before it.
+     * @return true if there are not enough empty lines before the tagNode.
+     */
+    private static boolean hasInsufficientConsecutiveNewlines(DetailNode tagNode) {
+        int count = 0;
+        DetailNode currentNode = JavadocUtil.getPreviousSibling(tagNode);
+        while (count <= 1
+                && currentNode != null
+                && (currentNode.getType() == JavadocTokenTypes.NEWLINE
+                    || currentNode.getType() == JavadocTokenTypes.WS
+                    || currentNode.getType() == JavadocTokenTypes.LEADING_ASTERISK)) {
+            if (currentNode.getType() == JavadocTokenTypes.NEWLINE) {
+                count++;
+            }
+            currentNode = JavadocUtil.getPreviousSibling(currentNode);
+        }
+
+        return count <= 1;
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/PatternVariableNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/PatternVariableNameCheck.java
@@ -105,6 +105,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * {@code name.invalidPattern}
  * </li>
  * </ul>
+ *
  * @since 8.36
  */
 public class PatternVariableNameCheck extends AbstractNameCheck {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -93,6 +93,9 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * NonEmptyAtclauseDescription
  * </li>
  * <li>
+ * RequireEmptyLineBeforeBlockTagGroup
+ * </li>
+ * <li>
  * SingleLineJavadoc
  * </li>
  * <li>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
@@ -22,6 +22,7 @@ javadoc.paragraph.redundant.paragraph=Redundant <p> tag.
 javadoc.paragraph.tag.after=Empty line should be followed by <p> tag on the next line.
 javadoc.parse.rule.error=Javadoc comment at column {0} has parse error. Details: {1} while parsing {2}
 javadoc.return.expected=@return tag should be present and have description.
+javadoc.tag.line.before=Javadoc tag ''{0}'' should be preceded with an empty line.
 javadoc.unclosedHtml=Unclosed HTML tag found: {0}
 javadoc.unknownTag=Unknown tag ''{0}''.
 javadoc.unusedTag=Unused {0} tag for ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
@@ -22,6 +22,7 @@ javadoc.paragraph.redundant.paragraph=Redundantes <p>-Tag.
 javadoc.paragraph.tag.after=Auf eine leere Zeile im Javadoc sollte ein <p>-Tag in der nächsten Zeile folgen.
 javadoc.parse.rule.error=Der Javadoc-Kommentar an Position {0} führt zu einem Parserfehler. Details: {1} beim Parsen von {2}
 javadoc.return.expected=@return-Tag sollte vorhanden sein und eine Beschreibung haben.
+javadoc.tag.line.before=Vor Javadoc tag ''{0}'' sollte eine Leerzeile stehen.
 javadoc.unclosedHtml=Nicht geschlossenes HTML-Tag gefunden: {0}
 javadoc.unknownTag=Unbekanntes Tag ''{0}''.
 javadoc.unusedTag=Nicht verwendetes Tag {0} für ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
@@ -22,6 +22,7 @@ javadoc.paragraph.redundant.paragraph=Redundante etiqueta <p>.
 javadoc.paragraph.tag.after=Línea de vacío debe ser seguido por etiqueta <p> en la línea siguiente.
 javadoc.parse.rule.error=Javadoc comentario en la columna {0} tiene parse error. Detalles: {1} al analizar {2}
 javadoc.return.expected=La etiqueta @return debe estar presente y tener una descripción.
+javadoc.tag.line.before=Javadoc tag ''{0}'' debe ir precedido de una línea vacía.
 javadoc.unclosedHtml=Se encontró una etiqueta HTML sin cerrar: {0}
 javadoc.unknownTag=Desconocido etiqueta ''{0}''.
 javadoc.unusedTag=Etiqueta {0} no usada en ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
@@ -22,6 +22,7 @@ javadoc.paragraph.redundant.paragraph=Turhat <p> tag.
 javadoc.paragraph.tag.after=Tyhjä rivi jälkeen olisi <p> ​​tag seuraavalla rivillä.
 javadoc.parse.rule.error=Javadoc kommentti sarakkeessa {0} on Jäsennysvirhe. Tiedot: {1} jäsennettäessä {2}
 javadoc.return.expected=@return-tunnisteen tulisi olla läsnä ja sillä on oltava kuvaus.
+javadoc.tag.line.before=Javadoc tag ''{0}'' edessä on tyhjä rivi.
 javadoc.unclosedHtml=Unclosed HTML-koodi löytyy: {0}
 javadoc.unknownTag=Tuntematon tag ''{0}''.
 javadoc.unusedTag=Tuntematon tagi ''{1}'':lle: {0}.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
@@ -22,6 +22,7 @@ javadoc.paragraph.redundant.paragraph=Balise <p> redondante.
 javadoc.paragraph.tag.after=Une ligne vide doit être suivie par une balise <p> sur la ligne suivante.
 javadoc.parse.rule.error=Le commentaire Javadoc à la colonne {0} ne peut être analysé. Détails : {1} lors de l''analyse {2}
 javadoc.return.expected=La balise @return doit être présente et avoir une description.
+javadoc.tag.line.before=Javadoc tag ''{0}'' doit être précédé d'une ligne vide.
 javadoc.unclosedHtml=Balise HTML trouvée dans la Javadoc : {0}
 javadoc.unknownTag=Balise inconnue ''{0}''.
 javadoc.unusedTag=Balise Javadoc {0} inutilisée pour ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
@@ -22,6 +22,7 @@ javadoc.paragraph.redundant.paragraph=冗長な <p> タグです。
 javadoc.paragraph.tag.after=<p> タグの次の行には空行を入れてください。
 javadoc.parse.rule.error={0} 桁目の Javadoc コメントでパースエラーが発生しました。詳細: {1}、{2} の解析中に発生。
 javadoc.return.expected=@returnタグが存在し、説明が必要です。
+javadoc.tag.line.before=Javadoc tag ''{0}'' の前には空の行が必要です。
 javadoc.unclosedHtml=閉じていない HTML タグが見つかりました: {0}
 javadoc.unknownTag=不明なタグ ''{0}''。
 javadoc.unusedTag=''{1}'' に対する使用されない {0} タグです。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
@@ -22,6 +22,7 @@ javadoc.paragraph.redundant.paragraph=Tag <p> redundante.
 javadoc.paragraph.tag.after=A linha vazia deveria ser seguida por uma tag <p> na linha seguinte.
 javadoc.parse.rule.error=O comentário Javadoc na coluna {0} tem um erro sintático. Detalhes: {1} ao analisar {2}
 javadoc.return.expected=A tag @return deve estar presente e ter uma descrição.
+javadoc.tag.line.before=Javadoc tag ''{0}'' deve ser precedido com uma linha vazia.
 javadoc.unclosedHtml=Encontrada uma etiqueta HTML não fechada: {0}
 javadoc.unknownTag=Tag desconhecida ''{0}''.
 javadoc.unusedTag=Tag {0} não utilizada pelo ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
@@ -22,6 +22,7 @@ javadoc.paragraph.redundant.paragraph=Yedek <p> etiketi.
 javadoc.paragraph.tag.after=Boş satır bir sonraki satırda <p> etiketi ile takip edilmelidir.
 javadoc.parse.rule.error=Sütununda Javadoc comment {0} hatası ayrıştırmak vardır. Detaylar: {1} ayrıştırılırken {2}
 javadoc.return.expected=@return etiketi mevcut olmalı ve açıklamaya sahip olmalıdır.
+javadoc.tag.line.before=Javadoc tag ''{0}'' öncesinde boş bir satır olmalıdır
 javadoc.unclosedHtml=Kapatılmamış bir HTML etiketi bulundu: {0}
 javadoc.unknownTag=Bilinmeyen etiket: ''{0}''.
 javadoc.unusedTag=''{1}'' için kullanılmayan {0} etiketi mevcut.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
@@ -22,6 +22,7 @@ javadoc.paragraph.redundant.paragraph=多余的 <p> 标签。
 javadoc.paragraph.tag.after=空行后应有 <p> 标签。
 javadoc.parse.rule.error=Javadoc 第 {0} 个字符解析错误。解析 {2} ，详情： {1}
 javadoc.return.expected=@return標籤應存在並具有說明。
+javadoc.tag.line.before=Javadoc tag ''{0}'' 前面应有一个空行。
 javadoc.unclosedHtml=未关闭的 HTML 标签： {0} 。
 javadoc.unknownTag=未知标签 ''{0}'' 。
 javadoc.unusedTag=''{1}'' 的无用标签 {0} 。

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -306,6 +306,7 @@
                value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
     </module>
     <module name="JavadocParagraph"/>
+    <module name="RequireEmptyLineBeforeBlockTagGroup"/>
     <module name="AtclauseOrder">
       <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
       <property name="target"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/RequireEmptyLineBeforeBlockTagGroupCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/RequireEmptyLineBeforeBlockTagGroupCheckTest.java
@@ -1,0 +1,74 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc;
+
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.RequireEmptyLineBeforeBlockTagGroupCheck.MSG_JAVADOC_TAG_LINE_BEFORE;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+
+public class RequireEmptyLineBeforeBlockTagGroupCheckTest extends AbstractModuleTestSupport {
+
+    @Override
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/checks/javadoc/"
+                + "requireemptylinebeforeblocktaggroup";
+    }
+
+    @Test
+    public void testGetRequiredTokens() {
+        final RequireEmptyLineBeforeBlockTagGroupCheck checkObj =
+                new RequireEmptyLineBeforeBlockTagGroupCheck();
+        final int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN};
+        assertArrayEquals(expected, checkObj.getRequiredTokens(),
+                "Default required tokens are invalid");
+    }
+
+    @Test
+    public void testCorrect() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(
+                RequireEmptyLineBeforeBlockTagGroupCheck.class);
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verify(checkConfig,
+                getPath("InputRequireEmptyLineBeforeBlockTagGroupCorrect.java"),
+                expected);
+    }
+
+    @Test
+    public void testIncorrect() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(RequireEmptyLineBeforeBlockTagGroupCheck.class);
+        final String[] expected = {
+            "8: " + getCheckMessage(MSG_JAVADOC_TAG_LINE_BEFORE, "@since"),
+            "14: " + getCheckMessage(MSG_JAVADOC_TAG_LINE_BEFORE, "@param"),
+            "22: " + getCheckMessage(MSG_JAVADOC_TAG_LINE_BEFORE, "@param"),
+            "29: " + getCheckMessage(MSG_JAVADOC_TAG_LINE_BEFORE, "@return"),
+        };
+        verify(checkConfig,
+                getPath("InputRequireEmptyLineBeforeBlockTagGroupIncorrect.java"),
+                expected);
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -78,6 +78,7 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
                     "JavadocType",
                     "MissingDeprecated",
                     "NonEmptyAtclauseDescription",
+                    "RequireEmptyLineBeforeBlockTagGroup",
                     "SingleLineJavadoc",
                     "SummaryJavadoc",
                     "WriteTag"

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/requireemptylinebeforeblocktaggroup/InputRequireEmptyLineBeforeBlockTagGroupCorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/requireemptylinebeforeblocktaggroup/InputRequireEmptyLineBeforeBlockTagGroupCorrect.java
@@ -1,0 +1,67 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.requireemptylinebeforeblocktaggroup;
+
+/**
+ * Config: default
+ * Some Javadoc.
+ *
+ * @since 8.36 // ok
+ */
+class InputRequireEmptyLineBeforeBlockTagGroupCorrect {
+
+    /**
+     * This javadoc does not have a tag. There should be no violations.
+     */
+    public static final byte NO_TAG = 0;
+
+    /**
+     * This javadoc does has one tag, with an empty line. There should be no violations.
+     *
+     * @since 8.36 // ok
+     */
+    public static final byte ONE_TAG = 0;
+
+    /**
+     * This javadoc does has one tag, with two empty lines before it. There should be no violations.
+     * Another independent check will verify if there is too much whitespace.
+     *
+     *
+     * @since 8.36 // ok
+     */
+    public static final byte TWO_BLANK_LINES = 0;
+
+    /**
+     * This javadoc has multiple tags, with an empty line before the. There should be no
+     * violations.
+     *
+     * @param input this is the first tag. // ok
+     * @return this is the second tag.
+     */
+    public static boolean test(boolean input) {
+        return false;
+    }
+
+    /**
+     * This javadoc has an empty line with no asterisks. There should be no violation because
+     * a separate check ensures the asterisks are well-formed.
+
+     * @param input this is the first tag. // ok
+     * @return this is the second tag.
+     */
+    public static boolean noAsterisks(boolean input) {
+        return false;
+    }
+
+    /**
+     * @return this only has an tag. // ok
+     */
+    public static boolean test() {
+        return false;
+    }
+
+    /**
+     *@return this tag has no whitespace before it. // ok
+     */
+    public static boolean noWhiteSpace() {
+        return false;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/requireemptylinebeforeblocktaggroup/InputRequireEmptyLineBeforeBlockTagGroupIncorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/requireemptylinebeforeblocktaggroup/InputRequireEmptyLineBeforeBlockTagGroupIncorrect.java
@@ -1,0 +1,38 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.requireemptylinebeforeblocktaggroup;
+
+import java.io.IOException;
+
+/**
+ * Config: default
+ * Some Javadoc.
+ * @since 8.36 // violation
+ */
+class InputRequireEmptyLineBeforeBlockTagGroupIncorrect {
+
+    /**
+     * This documents the private method.
+     * @param thisParamTagNeedsNewline this documents the parameter. // violation
+     */
+    private boolean paramTagNeedsNewline(boolean thisParamTagNeedsNewline) {
+        return false;
+    }
+
+    /**
+     * This documents the private method.
+     * @param thisParamTagNeedsNewline this documents the parameter. // violation
+     * @return this one does not need an empty line, but the tag before this one does.
+     */
+    private boolean paramMultiTagNeedsNewline(boolean thisParamTagNeedsNewline) {
+        return false;
+    }
+
+    /**@return clientPort return clientPort if there is another ZK backup can run // violation
+     *         when killing the current active; return -1, if there is no backups.
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    public int killCurrentActiveZooKeeperServer() throws IOException,
+            InterruptedException {
+        return 0;
+    }
+}

--- a/src/xdocs/checks.xml
+++ b/src/xdocs/checks.xml
@@ -819,6 +819,13 @@
               at-clauses.</td>
           </tr>
           <tr>
+            <td><a href="config_javadoc.html#RequireEmptyLineBeforeBlockTagGroup">
+              RequireEmptyLineBeforeBlockTagGroup</a></td>
+            <td>
+              Checks that one blank line before the block tag if it is present in Javadoc.
+            </td>
+          </tr>
+          <tr>
             <td><a href="config_whitespace.html#SingleSpaceSeparator">SingleSpaceSeparator</a></td>
             <td>
              Checks that non-whitespace characters are separated by no more than one

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -939,6 +939,7 @@ files=&quot;com[\\/]mycompany[\\/]app[\\/].*IT.java&quot;/&gt;
           <li>JavadocType</li>
           <li>MissingDeprecated</li>
           <li>NonEmptyAtclauseDescription</li>
+          <li>RequireEmptyLineBeforeBlockTagGroup</li>
           <li>SingleLineJavadoc</li>
           <li>SummaryJavadoc</li>
           <li>WriteTag</li>

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -1164,8 +1164,7 @@ class TestClass {
         </p>
         <ul>
           <li>
-            There is one blank line between each of two paragraphs and one blank line before the
-            at-clauses block if it is present.
+            There is one blank line between each of two paragraphs.
           </li>
           <li>
             Each paragraph but the first has &lt;p&gt; immediately before the first word, with
@@ -2940,6 +2939,128 @@ class DatabaseConfiguration {}
       </subsection>
 
       <subsection name="Parent Module" id="NonEmptyAtclauseDescription_Parent_Module">
+        <p>
+          <a href="config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+
+    <section name="RequireEmptyLineBeforeBlockTagGroup">
+      <p>Since Checkstyle 8.36</p>
+      <subsection name="Description" id="RequireEmptyLineBeforeBlockTagGroup_Description">
+        <p>
+          Checks that one blank line before the block tag if it is present in Javadoc.
+        </p>
+      </subsection>
+      <subsection name="Properties" id="RequireEmptyLineBeforeBlockTagGroup_Properties">
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>violateExecutionOnNonTightHtml</td>
+              <td>
+                Control when to print violations if the Javadoc being examined by this check
+                violates the tight html rules defined at
+                <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.
+              </td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
+              <td><code>false</code></td>
+              <td>8.36</td>
+            </tr>
+          </table>
+        </div>
+      </subsection>
+
+      <subsection name="Examples" id="RequireEmptyLineBeforeBlockTagGroup_Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name=&quot;RequireEmptyLineBeforeBlockTagGroup&quot;/&gt;
+        </source>
+        <p>
+          By default, the check will report a violation if there is no blank line before the
+          block tag, like in the example below.
+        </p>
+        <source>
+&#47;**
+ * testMethod's javadoc.
+ * &#64;return something (violation)
+ *&#47;
+public boolean testMethod() {
+    return false;
+}
+        </source>
+        <p>
+          Valid javadoc should have a blank line separating the parameters, return, throw, or
+          other tags like in the example below.
+        </p>
+        <source>
+&#47;**
+* testMethod's javadoc.
+*
+* &#64;param firstParam
+* &#64;return something
+*&#47;
+public boolean testMethod(int firstParam) {
+    return false;
+}
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage"
+                  id="RequireEmptyLineBeforeBlockTagGroup_Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+RequireEmptyLineBeforeBlockTagGroup">
+                Google Style</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig+filename%3Acheckstyle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+RequireEmptyLineBeforeBlockTagGroup">
+                Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages"
+                  id="RequireEmptyLineBeforeBlockTagGroup_Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missed.html.close%22">
+                javadoc.missed.html.close</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.parse.rule.error%22">
+                javadoc.parse.rule.error</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.tag.line.before%22">
+                javadoc.tag.line.before</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.wrong.singleton.html.tag%22">
+                javadoc.wrong.singleton.html.tag</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="config.html#Custom_messages">see the documentation</a> to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="RequireEmptyLineBeforeBlockTagGroup_Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.javadoc
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="RequireEmptyLineBeforeBlockTagGroup_Parent_Module">
         <p>
           <a href="config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -2034,11 +2034,21 @@
                         alt="" />
                   </span>
                   <a href="config_javadoc.html#JavadocParagraph">JavadocParagraph</a>
+                  <span class="wrapper inline">
+                    <img
+                        src="images/ok_green.png"
+                        alt="" />
+                  </span>
+                  <a href="config_javadoc.html#RequireEmptyLineBeforeBlockTagGroup">RequireEmptyLineBeforeBlockTagGroup</a>
                 </td>
                 <td>
                   <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocParagraph">
                     config</a><br/>
                   <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/JavadocParagraphTest.java">
+                    test</a>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+RequireEmptyLineBeforeBlockTagGroup">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule712paragraphs/RequireEmptyLineBeforeBlockTagGroupTest.java">
                     test</a>
                 </td>
               </tr>


### PR DESCRIPTION
Resolves Issue #6192
Contribution PR: https://github.com/checkstyle/contribution/pull/478

Diff Regression projects: https://gist.githubusercontent.com/josephmate/a39a39b4c60aa11929aee4574aa90220/raw/6cff315508233d6056dc37debcb8737e4c031fd5/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/josephmate/a39a39b4c60aa11929aee4574aa90220/raw/6cff315508233d6056dc37debcb8737e4c031fd5/my_check_base.xml

Diff Regression patch config: https://gist.githubusercontent.com/josephmate/a39a39b4c60aa11929aee4574aa90220/raw/6cff315508233d6056dc37debcb8737e4c031fd5/my_check_patch.xml

**How the functional change works:**

1. only inspect nodes of type `JavadocTokenTypes.JAVADOC_TAG`
2. ignore if there is already an at-clause before the current at-clause. an empty line is only needed before the first at-clause
3. ignore if the at-clause is the only thing in the javadoc. for some reason, a developer might only want the at-clause inside the javadoc with nothing else. it would be strange to recommend an empty like before it
4. check that there are enough empty lines before it

