### PR TITLE
Issue #7612: Update doc for InterfaceIsType

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/InterfaceIsTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/InterfaceIsTypeCheck.java
@@ -53,7 +53,40 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <pre>
  * &lt;module name="InterfaceIsType"/&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public interface Test1 { // violation
+ *     int a = 3;
  *
+ * }
+ *
+ * public interface Test2 { // OK
+ *
+ * }
+ *
+ * public interface Test3 { // OK
+ *     int a = 3;
+ *     void test();
+ * }
+ * </pre>
+ * <p>
+ * To configure the check to report violation so that it doesn't allow Marker Interfaces:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;InterfaceIsType&quot;&gt;
+ *   &lt;property name=&quot;allowMarkerInterfaces&quot; value=&quot;false&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public interface Test1 { // violation
+ *     int a = 3;
+ * }
+ *
+ * public interface Test2 { // violation
+ *
+ * }
+ * </pre>
  * @since 3.1
  */
 @StatelessCheck

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -510,6 +510,39 @@ public class StringUtils // not final to allow subclassing
         <source>
 &lt;module name=&quot;InterfaceIsType&quot;/&gt;
         </source>
+        <p>Example:</p>
+        <source>
+public interface Test1 { // violation
+    int a = 3;
+}
+
+public interface Test2 { // OK
+
+}
+
+public interface Test3 { // OK
+    int a = 3;
+    void test();
+}
+        </source>
+        <p>
+          To configure the check to report violation so that it doesn't allow Marker Interfaces:
+        </p>
+        <source>
+&lt;module name=&quot;InterfaceIsType&quot;&gt;
+  &lt;property name=&quot;allowMarkerInterfaces&quot; value=&quot;false&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public interface Test1 { // violation
+    int a = 3;
+}
+
+public interface Test2 { // violation
+
+}
+        </source>
       </subsection>
 
       <subsection name="Example of Usage" id="InterfaceIsType_Example_of_Usage">


### PR DESCRIPTION
Issue #7612: Update doc for InterfaceIsType

<img width="658" alt="image" src="https://user-images.githubusercontent.com/50866227/77244694-20681980-6c53-11ea-85f5-83eb003399f9.png">

Ouput of default example:
$ cat config.xml
```xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="InterfaceIsType"/>
    </module>
</module>
```
$ cat Test.java
```java
public interface Test1 { // violation
    int a = 3;
}

interface Test2 { // OK

}

interface Test3 { // OK
    int a = 3;
    void test();
}
```
$ RUN_LOCALE="-Duser.language=en -Duser.country=US"
$ java $RUN_LOCALE -jar /var/tmp/checkstyle-8.31-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /var/tmp/Test.java:1: interfaces should describe a type and hence have methods. [InterfaceIsType]
Audit done.
Checkstyle ends with 1 errors.

Ouput of configure the check to report violation so that it doesn't allow Marker Interfaces: 
$ cat config.xml
```xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="InterfaceIsType">
                 <property name="allowMarkerInterfaces" value="false"/>
        </module>
    </module>
</module>
```
$ cat Test.java
```java
public interface Test1 { // violation
    int a = 3;
}

interface Test2 { // violation

}
```
$ RUN_LOCALE="-Duser.language=en -Duser.country=US"
$ java $RUN_LOCALE -jar /var/tmp/checkstyle-8.31-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /var/tmp/Test.java:1: interfaces should describe a type and hence have methods. [InterfaceIsType]
[ERROR] /var/tmp/Test.java:6: interfaces should describe a type and hence have methods. [InterfaceIsType]
Audit done.
Checkstyle ends with 2 errors.
