### PR TITLE
Issue #7921: Resolve Pitest Issues - UnusedImportsCheck

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -82,7 +82,6 @@ pitest-imports)
   "PkgImportControl.java.html:<td class='covered'><pre><span  class='survived'>        if (regex || parent.regex) {</span></pre></td></tr>"
   "PkgImportControl.java.html:<td class='covered'><pre><span  class='survived'>        if (regex) {</span></pre></td></tr>"
   "PkgImportRule.java.html:<td class='covered'><pre><span  class='survived'>        if (isRegExp()) {</span></pre></td></tr>"
-  "UnusedImportsCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (collect) {</span></pre></td></tr>"
   );
   checkPitestReport "${ignoredItems[@]}"
   ;;
@@ -216,6 +215,5 @@ pitest-utils)
   ;;
 
 esac
-
 
 

--- a/config/checkstyle_resources_suppressions.xml
+++ b/config/checkstyle_resources_suppressions.xml
@@ -50,6 +50,10 @@
 
   <!-- intentional problem for testing -->
   <suppress checks="PackageDeclarationCheck"
+            files="unusedimports[\\/]InputUnusedImportsSingleWordPackage\.java"/>
+
+  <!-- intentional problem for testing -->
+  <suppress checks="PackageDeclarationCheck"
     files="linelength[\\/]InputLineLengthLongPackageStatement\.java"/>
 
   <!-- intentional problem for testing -->

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
@@ -249,4 +249,14 @@ public class UnusedImportsCheckTest extends AbstractModuleTestSupport {
         verify(checkConfig, getPath("InputUnusedImportsJavadocQualifiedName.java"), expected);
     }
 
+    @Test
+    public void testSingleWordPackage() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(UnusedImportsCheck.class);
+        final String[] expected = {
+            "3:8: " + getCheckMessage(MSG_KEY, "module"),
+        };
+        verify(checkConfig, getNonCompilablePath("InputUnusedImportsSingleWordPackage.java"),
+                expected);
+    }
+
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsSingleWordPackage.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsSingleWordPackage.java
@@ -1,0 +1,3 @@
+//non-compiled with javac: no package by design of test
+
+import module;


### PR DESCRIPTION
Issue #7921 

Description: 
We don't need the variable collect to check if we should start collecting or not because it will always true because every java fill will contain package keyword or class that will make collect = true

Reports:
Diff Report : https://amrdeveloper.github.io/checkstyle-reports/7921/diff/
pitest-after : https://amrdeveloper.github.io/checkstyle-reports/7921/pitest-after
pitest-before : https://amrdeveloper.github.io/checkstyle-reports/7921/pitest-before/