### PR TITLE
Issue #7605: Update doc for SingleLineJavadoc

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
@@ -58,6 +58,45 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <pre>
  * &lt;module name=&quot;SingleLineJavadoc&quot;/&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ *   public class Test {
+ *     /** &#64;return integer value *&#47; // violation
+ *     // Javadoc has one at-clause, should be written in multiple lines
+ *     public int sum(int a, int b) {
+ *       return a + b;
+ *     }
+ *   }
+ *   public class Test {
+ *     /**
+ *      * &#64;return integer value
+ *      *&#47; // ok
+ *     public int sum(int a, int b) {
+ *       return a + b;
+ *     }
+ *   }
+ * </pre>
+ * <p>
+ * To configure this check to print violations for unclosed HTML tags.
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;SingleLineJavadoc&quot;&gt;
+ *   &lt;property name=&quot;violateExecutionOnNonTightHtml&quot; value=&quot;true&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ *   public class Test {
+ *     /**
+ *      * &#64;return integer value
+ *      *
+ *      * &lt;p&gt; First // violation, unclosed HTML tag &lt;p&gt;
+ *      *&#47;
+ *     public int sum(int a, int b) {
+ *       return a + b;
+ *     }
+ *   }
+ * </pre>
  * <p>
  * To configure the check with a list of ignored at-clauses
  * and make inline at-clauses not ignored:
@@ -68,7 +107,22 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *   &lt;property name=&quot;ignoreInlineTags&quot; value=&quot;false&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
- *
+ * <p>Example:</p>
+ * <pre>
+ *   public class Test {
+ *     /** &#64;see #sum(int a, int b) *&#47; // ok
+ *     public int sum(int a, int b) {
+ *       return a + b;
+ *     }
+ *   }
+ *   public class Test {
+ *     /** Testing class for {&#64;link Example} *&#47; // violation
+ *     // single-line javadoc comment should be multi-line
+ *     public int sum(int a, int b) {
+ *       return a + b;
+ *     }
+ *   }
+ * </pre>
  * @since 6.0
  */
 @StatelessCheck

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -2531,6 +2531,49 @@ class DatabaseConfiguration {}
         <source>
 &lt;module name=&quot;SingleLineJavadoc&quot;/&gt;
         </source>
+        <p>Example:</p>
+        <div class="wrapper">
+        <pre>
+public class Test {
+  /** @return integer value */ // violation
+  // Javadoc has one at-clause, should be written in multiple lines
+  public int sum(int a, int b) {
+    return a + b;
+  }
+}
+public class Test {
+  /**
+   * @return integer value
+   */ // ok
+  public int sum(int a, int b) {
+    return a + b;
+  }
+}
+        </pre>
+        </div>
+        <p>
+          To configure this check to print violations for unclosed HTML tags.
+        </p>
+        <source>
+&lt;module name=&quot;SingleLineJavadoc&quot;&gt;
+  &lt;property name=&quot;violateExecutionOnNonTightHtml&quot; value=&quot;true&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <div class="wrapper">
+        <pre>
+public class Test {
+  /**
+   * @return integer value
+   *
+   * &lt;p&gt; First // violation, unclosed HTML tag &lt;p&gt;
+   */
+  public int sum(int a, int b) {
+    return a + b;
+  }
+}
+        </pre>
+        </div>
         <p>
           To configure the check with a list of ignored at-clauses and make
           inline at-clauses not ignored:
@@ -2541,6 +2584,24 @@ class DatabaseConfiguration {}
   &lt;property name=&quot;ignoreInlineTags&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
         </source>
+        <p>Example:</p>
+        <div class="wrapper">
+        <pre>
+public class Test {
+  /** @see #sum(int a, int b) */ // ok
+  public int sum(int a, int b) {
+    return a + b;
+  }
+}
+public class Test {
+  /** Testing class for {@link Example} */ // violation
+  // single-line javadoc comment should be multi-line
+  public int sum(int a, int b) {
+    return a + b;
+  }
+}
+        </pre>
+        </div>
       </subsection>
 
       <subsection name="Example of Usage" id="SingleLineJavadoc_Example_of_Usage">


### PR DESCRIPTION
Issue #7605: add examples
![Screenshot (22)](https://user-images.githubusercontent.com/51456744/77694489-18e89d80-6fd0-11ea-88f5-571cf5e94f83.png)
![Screenshot (23)](https://user-images.githubusercontent.com/51456744/77694498-1be38e00-6fd0-11ea-8e21-3603f66d0e01.png)
![Screenshot (24)](https://user-images.githubusercontent.com/51456744/77694505-1e45e800-6fd0-11ea-973a-91bf961a269f.png)



Default Example:
config.xml
```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
   <module name="SingleLineJavadoc"/>
  </module>
</module>
```
Test.java
```
public class Test {
  /** @return integer value */ // violation
  // Javadoc has one at-clause, should be written in multiple lines
  public int sum(int a, int b) {
    return a + b;
  }
}
```
```
$ java -jar ../Downloads/checkstyle-8.29-all.jar -c config.xml Test.java
Starting audit...
[ERROR] C:\Users\hp\Desktop\Test.java:2: Single-line Javadoc comment should be multi-line. [SingleLineJavadoc]
Audit done.
Checkstyle ends with 1 errors.
```
Non-default example 1:
config.xml
```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
   <module name="SingleLineJavadoc">
     <property name="violateExecutionOnNonTightHtml" value="true"/>
   </module>
  </module>
</module>
```
Test.java
```
public class Test {
  /**
   * @return integer value
   *
   * &lt;p&gt; First // violation, unclosed HTML tag &lt;p&gt;
   */
  public int sum(int a, int b) {
    return a + b;
  }
}
```
```
$ java -jar ../Downloads/checkstyle-8.29-all.jar -c config.xml Test.java
Starting audit...
[ERROR] C:\Users\hp\Desktop\Test.java:5: Unclosed HTML tag found: p [SingleLineJavadoc]
Audit done.
Checkstyle ends with 1 errors.
```
Non-default example 2:
config.xml
```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
   <module name="SingleLineJavadoc">
     <property name="ignoredTags" value="@inheritDoc, @see"/>
     <property name="ignoreInlineTags" value="false"/>
   </module>
  </module>
</module>
```
Test.java
```
public class Test {
  /** @see #sum(int a, int b) */ // ok
  public int sum(int a, int b) {
    return a + b;
  }
}
```
$ java -jar ../Downloads/checkstyle-8.29-all.jar -c config.xml Test.java
Starting audit...
Audit done.
```
Non-default example 3:
config.xml
```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
   <module name="SingleLineJavadoc">
     <property name="ignoredTags" value="@inheritDoc, @see"/>
     <property name="ignoreInlineTags" value="false"/>
   </module>
  </module>
</module>
```
Test.java
```
public class Test {
  /** Testing class for {@link Example} */ // violation
  // single-line javadoc comment should be multi-line
  public int sum(int a, int b) {
    return a + b;
  }
}
```
```
$ java -jar ../Downloads/checkstyle-8.29-all.jar -c config.xml Test.java                                                Starting audit...
[ERROR] C:\Users\hp\Desktop\Test.java:2: Single-line Javadoc comment should be multi-line. [SingleLineJavadoc]
Audit done.
Checkstyle ends with 1 errors.
```