### PR TITLE
Issue #7565: update doc for AbstractClassName

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
@@ -52,10 +52,22 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * {@code false}.</li>
  * </ul>
  * <p>
- * The following example shows how to configure the {@code AbstractClassName} to
- * checks names, but ignore missing {@code abstract} modifiers:
+ * To configure the check:
  * </p>
- * <p>Configuration:</p>
+ * <pre>
+ * &lt;module name="AbstractClassName"/&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * abstract class AbstractFirstClass {} // OK
+ * abstract class SecondClass {} // violation, it should match pattern "^Abstract.+$"
+ * class AbstractThirdClass {} // violation, must be declared 'abstract'
+ * class FourthClass {} // OK
+ * </pre>
+ * <p>
+ * To configure the check so that it check name
+ * but ignore {@code abstract} modifier:
+ * </p>
  * <pre>
  * &lt;module name="AbstractClassName"&gt;
  *   &lt;property name="ignoreModifier" value="true"/&gt;
@@ -64,8 +76,41 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <p>Example:</p>
  * <pre>
  * abstract class AbstractFirstClass {} // OK
- * abstract class SecondClass {} // violation, it should match the pattern "^Abstract.+$"
+ * abstract class SecondClass {} // violation, it should match pattern "^Abstract.+$"
  * class AbstractThirdClass {} // OK, no "abstract" modifier
+ * class FourthClass {} // OK
+ * </pre>
+ * <p>
+ * To configure the check to ignore name
+ * validation when class declared as 'abstract'
+ * </p>
+ * <pre>
+ * &lt;module name="AbstractClassName"&gt;
+ *   &lt;property name="ignoreName" value="true"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * abstract class AbstractFirstClass {} // OK
+ * abstract class SecondClass {} // OK, name validation is ignored
+ * class AbstractThirdClass {} // violation, must be declared as 'abstract'
+ * class FourthClass {} // OK, no "abstract" modifier
+ * </pre>
+ * <p>
+ * To configure the check
+ * with {@code format}:
+ * </p>
+ * <pre>
+ * &lt;module name="AbstractClassName"&gt;
+ *   &lt;property name="format" value="^Generator.+$"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * abstract class GeneratorFirstClass {} // OK
+ * abstract class SecondClass {} // violation, must match pattern '^Generator.+$'
+ * class GeneratorThirdClass {} // violation, must be declared 'abstract'
+ * class FourthClass {} // OK, no "abstract" modifier
  * </pre>
  * @since 3.2
  */

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -312,11 +312,22 @@ public class MyClass { // OK, ignore checking the class name
 
       <subsection name="Examples" id="AbstractClassName_Examples">
         <p>
-          The following example shows how to configure the
-          <code>AbstractClassName</code> to checks names, but ignore
-          missing <code>abstract</code> modifiers:
+          To configure the check:
         </p>
-        <p>Configuration:</p>
+        <source>
+&lt;module name=&quot;AbstractClassName&quot;/&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+abstract class AbstractFirstClass {} // OK
+abstract class SecondClass {} // violation, it should match pattern "^Abstract.+$"
+class AbstractThirdClass {} // violation, must be declared 'abstract'
+class FourthClass {} // OK
+        </source>
+        <p>
+          To configure the check so that it check name
+          but ignore <code>abstract</code> modifier:
+        </p>
         <source>
 &lt;module name=&quot;AbstractClassName&quot;&gt;
   &lt;property name=&quot;ignoreModifier&quot; value=&quot;true&quot;/&gt;
@@ -325,9 +336,42 @@ public class MyClass { // OK, ignore checking the class name
         <p>Example:</p>
         <source>
 abstract class AbstractFirstClass {} // OK
-abstract class SecondClass {} // violation, it should match the pattern "^Abstract.+$"
+abstract class SecondClass {} // violation, it should match pattern "^Abstract.+$"
 class AbstractThirdClass {} // OK, no "abstract" modifier
+class FourthClass {} // OK
+         </source>
+         <p>
+            To configure the check to ignore name
+            validation when class declared as 'abstract'
+        </p>
+        <source>
+&lt;module name=&quot;AbstractClassName&quot;&gt;
+  &lt;property name=&quot;ignoreName&quot; value=&quot;true&quot;/&gt;
+&lt;/module&gt;
         </source>
+        <p>Example:</p>
+        <source>
+abstract class AbstractFirstClass {} // OK
+abstract class SecondClass {} // OK, name validation is ignored
+class AbstractThirdClass {} // violation, must be declared as 'abstract'
+class FourthClass {} // OK, no "abstract" modifier
+         </source>
+        <p>
+          To configure the check
+          with <code>format</code>:
+        </p>
+        <source>
+&lt;module name=&quot;AbstractClassName&quot;&gt;
+  &lt;property name=&quot;format&quot; value=&quot;^Generator.+$&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+abstract class GeneratorFirstClass {} // OK
+abstract class SecondClass {} // violation, must match pattern '^Generator.+$'
+class GeneratorThirdClass {} // violation, must be declared 'abstract'
+class FourthClass {} // OK, no "abstract" modifier
+      </source>
       </subsection>
 
       <subsection name="Example of Usage" id="AbstractClassName_Example_of_Usage">


### PR DESCRIPTION
 #7565 
**Website Look**
![Screenshot from 2020-04-15 21-09-16](https://user-images.githubusercontent.com/42895397/79357644-f0641b80-7f5d-11ea-9dc6-47847df2d79d.png)
![Screenshot from 2020-04-15 21-09-21](https://user-images.githubusercontent.com/42895397/79357656-f35f0c00-7f5d-11ea-806a-b987910f823c.png)



**Non Default Config**

pk@pk:~/Desktop/check$ cat config.xml 
```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="TreeWalker">
        <module name = "AbstractClassName">
            <property name = "format" value = "^Generator.+$"/>
        </module>
    </module>
</module>
```

pk@pk:~/Desktop/check$ cat Test.java
```

abstract class GeneratorFirstClass{}
abstract class SecondClass{}
class GeneratorThirdClass{}
class FourthClass{}

```
pk@pk:~/Desktop/check$ java -jar checkstyle-8.30-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /home/pk/Desktop/check/Test.java:2:1: Name 'SecondClass' must match pattern '^Generator.+$'. [AbstractClassName]
[ERROR] /home/pk/Desktop/check/Test.java:3:1: Class 'GeneratorThirdClass' must be declared as 'abstract'. [AbstractClassName]
Audit done.
Checkstyle ends with 2 errors.


pk@pk:~/Desktop/check$ cat config.xml 
```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="TreeWalker">
        <module name = "AbstractClassName">
            <property name = "ignoreModifier" value = "true"/>
        </module>
    </module>
</module>
```
pk@pk:~/Desktop/check$ cat Test.java
```
abstract class AbstractFirstClass{}
abstract class SecondClass{}
class AbstractThirdClass{}
class FourthClass{}
```
pk@pk:~/Desktop/check$ java -jar checkstyle-8.30-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /home/pk/Desktop/check/Test.java:2:1: Name 'SecondClass' must match pattern '^Abstract.+$'. [AbstractClassName]
Audit done.
Checkstyle ends with 1 errors.

pk@pk:~/Desktop/check$ cat config.xml
```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="TreeWalker">
        <module name = "AbstractClassName">
            <property name = "ignoreName" value = "true"/>
        </module>
    </module>
</module>
```
pk@pk:~/Desktop/check$ cat Test.java
```
abstract class AbstractFirstClass{}
abstract class SecondClass{}
class AbstractThirdClass{}
class FourthClass{}
```
pk@pk:~/Desktop/check$ java -jar checkstyle-8.30-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /home/pk/Desktop/check/Test.java:3:1: Class 'AbstractThirdClass' must be declared as 'abstract'. [AbstractClassName]
Audit done.
Checkstyle ends with 1 errors.


**Default Config**

pk@pk:~/Desktop/check$ cat config.xml
```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="TreeWalker">
        <module name = "AbstractClassName">
        </module>
    </module>
</module>
```
pk@pk:~/Desktop/check$ cat Test.java
```
abstract class AbstractFirstClass{}
abstract class SecondClass{}
class AbstractThirdClass{}
class FourthClass{}
```
pk@pk:~/Desktop/check$ java -jar checkstyle-8.30-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /home/pk/Desktop/check/Test.java:2:1: Name 'SecondClass' must match pattern '^Abstract.+$'. [AbstractClassName]
[ERROR] /home/pk/Desktop/check/Test.java:3:1: Class 'AbstractThirdClass' must be declared as 'abstract'. [AbstractClassName]
Audit done.
Checkstyle ends with 2 errors.

