### PR TITLE
Issue #7721: Update AbstractChecks to log DetailAST - AnnotationOnSam…

### DIFF
--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAnnotationOnSameLineTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAnnotationOnSameLineTest.java
@@ -1,0 +1,146 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationOnSameLineCheck;
+
+public class XpathRegressionAnnotationOnSameLineTest extends AbstractXpathTestSupport {
+
+    private final String checkName = AnnotationOnSameLineCheck.class.getSimpleName();
+
+    @Override
+    protected String getCheckName() {
+        return checkName;
+    }
+
+    @Test
+    public void testOne() throws Exception {
+        final File fileToProcess =
+                new File(getPath(
+                        "SuppressionXpathRegressionAnnotationOnSameLineOne.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(AnnotationOnSameLineCheck.class);
+
+        moduleConfig.addAttribute("tokens",
+                "CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, "
+                + "CTOR_DEF, VARIABLE_DEF, PARAMETER_DEF, ANNOTATION_DEF, TYPECAST, "
+                + "LITERAL_THROWS, IMPLEMENTS_CLAUSE, TYPE_ARGUMENT, LITERAL_NEW, DOT, "
+                + "ANNOTATION_FIELD_DEF");
+
+        final String[] expectedViolation = {
+            "6:5: " + getCheckMessage(AnnotationOnSameLineCheck.class,
+                     AnnotationOnSameLineCheck.MSG_KEY_ANNOTATION_ON_SAME_LINE,
+                     "Deprecated"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationOnSameLineOne']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='getX']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationOnSameLineOne']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='getX']]/MODIFIERS",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationOnSameLineOne']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='getX']]/MODIFIERS"
+                        + "/ANNOTATION[./IDENT[@text='Deprecated']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationOnSameLineOne']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='getX']]"
+                        + "/MODIFIERS/ANNOTATION[./IDENT[@text='Deprecated']]/AT"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testTwo() throws Exception {
+        final File fileToProcess =
+                new File(getPath(
+                        "SuppressionXpathRegressionAnnotationOnSameLineTwo.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(AnnotationOnSameLineCheck.class);
+
+        final String[] expectedViolation = {
+            "7:5: " + getCheckMessage(AnnotationOnSameLineCheck.class,
+                    AnnotationOnSameLineCheck.MSG_KEY_ANNOTATION_ON_SAME_LINE,
+                    "Deprecated"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationOnSameLineTwo']]"
+                        + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='names']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationOnSameLineTwo']]"
+                        + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='names']]/MODIFIERS",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationOnSameLineTwo']]"
+                        + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='names']]/MODIFIERS"
+                        + "/ANNOTATION[./IDENT[@text='Deprecated']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationOnSameLineTwo']]"
+                        + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='names']]/MODIFIERS"
+                        + "/ANNOTATION[./IDENT[@text='Deprecated']]/AT"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testThree() throws Exception {
+        final File fileToProcess =
+                new File(getPath(
+                        "SuppressionXpathRegressionAnnotationOnSameLineThree.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(AnnotationOnSameLineCheck.class);
+        moduleConfig.addAttribute("tokens", "CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, "
+                + "CTOR_DEF, VARIABLE_DEF, PARAMETER_DEF, ANNOTATION_DEF, TYPECAST, "
+                + "LITERAL_THROWS, IMPLEMENTS_CLAUSE, TYPE_ARGUMENT, LITERAL_NEW, DOT, "
+                + "ANNOTATION_FIELD_DEF");
+
+        final String[] expectedViolation = {
+            "3:1: " + getCheckMessage(AnnotationOnSameLineCheck.class,
+                    AnnotationOnSameLineCheck.MSG_KEY_ANNOTATION_ON_SAME_LINE,
+                    "Deprecated"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/INTERFACE_DEF["
+                        + "./IDENT[@text='SuppressionXpathRegressionAnnotationOnSameLineThree']]",
+                "/INTERFACE_DEF["
+                        + "./IDENT[@text='SuppressionXpathRegressionAnnotationOnSameLineThree']]"
+                        + "/MODIFIERS",
+                "/INTERFACE_DEF["
+                        + "./IDENT[@text='SuppressionXpathRegressionAnnotationOnSameLineThree']]"
+                        + "/MODIFIERS/ANNOTATION[./IDENT[@text='Deprecated']]",
+                "/INTERFACE_DEF["
+                        + "./IDENT[@text='SuppressionXpathRegressionAnnotationOnSameLineThree']]"
+                        + "/MODIFIERS/ANNOTATION[./IDENT[@text='Deprecated']]/AT"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/annotationonsameline/SuppressionXpathRegressionAnnotationOnSameLineOne.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/annotationonsameline/SuppressionXpathRegressionAnnotationOnSameLineOne.java
@@ -1,0 +1,11 @@
+package org.checkstyle.suppressionxpathfilter.annotationonsameline;
+
+public class SuppressionXpathRegressionAnnotationOnSameLineOne {
+    @Deprecated int x;
+
+    @Deprecated //warn
+    public int getX() {
+        return (int) x;
+    }
+}
+

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/annotationonsameline/SuppressionXpathRegressionAnnotationOnSameLineThree.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/annotationonsameline/SuppressionXpathRegressionAnnotationOnSameLineThree.java
@@ -1,0 +1,6 @@
+package org.checkstyle.suppressionxpathfilter.annotationonsameline;
+
+@Deprecated //warn
+interface SuppressionXpathRegressionAnnotationOnSameLineThree {
+
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/annotationonsameline/SuppressionXpathRegressionAnnotationOnSameLineTwo.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/annotationonsameline/SuppressionXpathRegressionAnnotationOnSameLineTwo.java
@@ -1,0 +1,9 @@
+package org.checkstyle.suppressionxpathfilter.annotationonsameline;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SuppressionXpathRegressionAnnotationOnSameLineTwo {
+    @Deprecated //warn
+    private List<String> names = new ArrayList<>();
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationOnSameLineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationOnSameLineCheck.java
@@ -133,7 +133,7 @@ public class AnnotationOnSameLineCheck extends AbstractCheck {
                     annotationNode = annotationNode.getNextSibling()) {
                 if (annotationNode.getType() == TokenTypes.ANNOTATION
                         && !TokenUtil.areOnSameLine(annotationNode, getNextNode(annotationNode))) {
-                    log(annotationNode.getLineNo(), MSG_KEY_ANNOTATION_ON_SAME_LINE,
+                    log(annotationNode, MSG_KEY_ANNOTATION_ON_SAME_LINE,
                           getAnnotationName(annotationNode));
                 }
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -44,9 +44,6 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * </p>
  * <ul id="SuppressionXpathFilter_IncompatibleChecks">
  * <li>
- * AnnotationOnSameLine
- * </li>
- * <li>
  * AnnotationUseStyle
  * </li>
  * <li>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationOnSameLineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationOnSameLineCheckTest.java
@@ -71,10 +71,10 @@ public class AnnotationOnSameLineCheckTest extends AbstractModuleTestSupport {
     public void testCheck() throws Exception {
         final DefaultConfiguration config = createModuleConfig(AnnotationOnSameLineCheck.class);
         final String[] expected = {
-            "9: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
-            "10: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
-            "11: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Deprecated"),
-            "16: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
+            "9:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
+            "10:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
+            "11:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Deprecated"),
+            "16:18: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
         };
         verify(config, getPath("InputAnnotationOnSameLineCheck.java"), expected);
     }
@@ -87,10 +87,10 @@ public class AnnotationOnSameLineCheckTest extends AbstractModuleTestSupport {
                 + "LITERAL_THROWS, IMPLEMENTS_CLAUSE, TYPE_ARGUMENT, LITERAL_NEW, DOT, "
                 + "ANNOTATION_FIELD_DEF");
         final String[] expected = {
-            "9: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
-            "10: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
-            "11: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Deprecated"),
-            "16: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
+            "9:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
+            "10:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
+            "11:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Deprecated"),
+            "16:18: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Annotation"),
         };
         verify(config, getPath("InputAnnotationOnSameLineCheck.java"), expected);
     }
@@ -99,10 +99,10 @@ public class AnnotationOnSameLineCheckTest extends AbstractModuleTestSupport {
     public void testCheck2() throws Exception {
         final DefaultConfiguration config = createModuleConfig(AnnotationOnSameLineCheck.class);
         final String[] expected = {
-            "11: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "16: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
-            "19: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
-            "20: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "11:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "16:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
+            "19:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "SuppressWarnings"),
+            "20:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
         };
         verify(config, getPath("InputAnnotationOnSameLineCheck2.java"), expected);
     }
@@ -115,22 +115,22 @@ public class AnnotationOnSameLineCheckTest extends AbstractModuleTestSupport {
                 + "LITERAL_THROWS, IMPLEMENTS_CLAUSE, TYPE_ARGUMENT, LITERAL_NEW, DOT, "
                 + "ANNOTATION_FIELD_DEF");
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "8: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "13: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "14: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "17: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "18: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "21: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "24: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "29: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "33: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "34: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "35: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "37: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "43: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "53: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
-            "56: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "5:1: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "8:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "13:8: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "14:72: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "17:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "18:35: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "21:18: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "24:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "29:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "33:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "34:28: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "35:33: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "37:15: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "43:17: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "53:1: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
+            "56:5: " + getCheckMessage(MSG_KEY_ANNOTATION_ON_SAME_LINE, "Ann"),
         };
         verify(config, getPath("InputAnnotationOnSameLineCheckOnDifferentTokens.java"), expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -53,7 +53,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
     // till https://github.com/checkstyle/checkstyle/issues/5777
     public static final Set<String> INCOMPATIBLE_CHECK_NAMES =
         Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-            "AnnotationOnSameLine",
             "AnnotationUseStyle",
             "AvoidEscapedUnicodeCharacters",
             "CommentsIndentation",

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -902,7 +902,6 @@ public class UserService {
           Currently, filter does not support the following checks:
         </p>
         <ul id="SuppressionXpathFilter_IncompatibleChecks">
-          <li>AnnotationOnSameLine</li>
           <li>AnnotationUseStyle</li>
           <li>AvoidEscapedUnicodeCharacters</li>
           <li>CommentsIndentation</li>


### PR DESCRIPTION
Resolve #7721: Update AbstractChecks to log DetailAST - AnnotationOnSameLine

Diff report : https://wilcoln.github.io/checkstyle-reports/7721/diff/index.html

I ran regression on all projects and the diff report was so huge (1.2Gb+)  that  `git add` was taking forever to run. Beside, i'm not sure that github will allow me to upload such a load. So I've decided to host detailed reports for only the 8 first projects.

The number of violations reported remains the same.
I assure you that it is the case for all 34 projects, I checked out details for each of them in local.


