### PR TITLE
Issue #2810: Feature to have JavadocMethod validate parameter order 

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
@@ -244,8 +244,8 @@ public class JavadocDetailNodeParser {
 
     /**
      * Creates child nodes for each node from 'nodes' array.
-     * @param parseTreeParent original ParseTree parent node
      * @param nodes array of JavadocNodeImpl nodes
+     * @param parseTreeParent original ParseTree parent node
      */
     private void insertChildrenNodes(final JavadocNodeImpl[] nodes, ParseTree parseTreeParent) {
         for (int i = 0; i < nodes.length; i++) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -428,8 +428,8 @@ public class RequireThisCheck extends AbstractCheck {
 
     /**
      * Helper method to log a LocalizedMessage.
-     * @param ast a node to get line id column numbers associated with the message.
      * @param msgKey key to locale message format.
+     * @param ast a node to get line id column numbers associated with the message.
      * @param frame the class frame where the violation is found.
      */
     private void logViolation(String msgKey, DetailAST ast, AbstractFrame frame) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -530,8 +530,8 @@ public abstract class AbstractExpressionHandler {
 
     /**
      * Check the indentation of the right parenthesis.
-     * @param rparen parenthesis to check
      * @param lparen left parenthesis associated with aRparen
+     * @param rparen parenthesis to check
      */
     protected final void checkRightParen(DetailAST lparen, DetailAST rparen) {
         if (rparen != null) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
@@ -491,8 +491,8 @@ public class CommentsIndentationCheck extends AbstractCheck {
 
     /**
      * Checks whether case block is empty.
-     * @param nextStmt previous statement.
      * @param prevStmt next statement.
+     * @param nextStmt previous statement.
      * @return true if case block is empty.
      */
     private static boolean isInEmptyCaseBlock(DetailAST prevStmt, DetailAST nextStmt) {
@@ -925,9 +925,9 @@ public class CommentsIndentationCheck extends AbstractCheck {
 
     /**
      * Logs comment which can have the same indentation level as next or previous statement.
+     * @param prevStmt previous statement.
      * @param comment comment.
      * @param nextStmt next statement.
-     * @param prevStmt previous statement.
      */
     private void logMultilineIndentation(DetailAST prevStmt, DetailAST comment,
                                          DetailAST nextStmt) {

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
@@ -9,6 +9,7 @@ javadoc.empty=Javadoc has empty description section.
 javadoc.expectedTag=Expected {0} tag for ''{1}''.
 javadoc.extraHtml=Extra HTML tag found: {0}
 javadoc.incompleteTag=Incomplete HTML tag found: {0}
+javadoc.incorrectTagOrder=Incorrect order of {0} tag for ''{1}''.
 javadoc.invalidInheritDoc=Invalid use of the '{'@inheritDoc'}' tag.
 javadoc.legacyPackageHtml=Legacy package.html file should be removed.
 javadoc.missed.html.close=Javadoc comment at column {0} has parse error. Missed HTML close tag ''{1}''. Sometimes it means that close tag missed for one of previous tags.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
@@ -9,6 +9,7 @@ javadoc.empty=Javadoc enthält einen leeren Beschreibungsabschnitt.
 javadoc.expectedTag=Erwartetes Tag {0} für ''{1}''.
 javadoc.extraHtml=Zusätzliches HTML-Tag gefunden: {0}
 javadoc.incompleteTag=Unvollständiges HTML-Tag gefunden: {0}
+javadoc.incorrectTagOrder=Falsche Reihenfolge von {0} Tag für ''{1}''.
 javadoc.invalidInheritDoc=Unerlaubte Verwendung des Tags '{'@inheritDoc'}'.
 javadoc.legacyPackageHtml=Die veraltete Datei package.html sollte entfernt werden.
 javadoc.missed.html.close=Der Javadoc-Kommentar an Position {0} führt zu einem Parserfehler. Fehlendes schließendes HTML-Tag ''{1}''. Manchmal bedeutet dies, dass das schließende Tag eines vorgehenden Tags fehlt.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
@@ -9,6 +9,7 @@ javadoc.empty=Hay una sección de descripción vacía en el Javadoc.
 javadoc.expectedTag=Se esperaba la etiqueta {0} para ''{1}''.
 javadoc.extraHtml=Se encontró una etiqueta HTML extra: {0}
 javadoc.incompleteTag=Se encontró una etiqueta HTML incompleta: {0}
+javadoc.incorrectTagOrder=Orden incorrecto de {0} Etiqueta ''{1}''.
 javadoc.invalidInheritDoc=Uso no válido del '{'inheritDoc '}' etiqueta.
 javadoc.legacyPackageHtml=Archivo package.html legado debe ser eliminado.
 javadoc.missed.html.close=Javadoc comentario en la columna {0} tiene parse error. Perdidas HTML cerca etiqueta ''{1}''. A veces esto significa que cerca de la etiqueta se perdió por una de las etiquetas anteriores.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
@@ -9,6 +9,7 @@ javadoc.empty=Javadoc on tyhjä §.
 javadoc.expectedTag=Javadoc-tagi puuttuu: {0} tagi ''{1}''.
 javadoc.extraHtml=Extra HTML-koodi löytyy: {0}
 javadoc.incompleteTag=Puutteelliset HTML-koodi löytyy: {0}
+javadoc.incorrectTagOrder=Väärä järjestys {0} tunniste ''{1}''.
 javadoc.invalidInheritDoc=Virheellinen käyttö '{'inheritDoc '}' tag.
 javadoc.legacyPackageHtml=Legacy package.html tiedosto tulisi poistaa.
 javadoc.missed.html.close=Javadoc kommentti sarakkeessa {0} on Jäsennysvirhe. Missed HTML lähellä tag ''{1}''. Joskus se tarkoittaa, että lähellä tag jäi yhden edellisen tunnisteita.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
@@ -9,6 +9,7 @@ javadoc.empty=Le commentaire Javadoc est vide.
 javadoc.expectedTag=Balise Javadoc {0} manquante pour ''{1}''.
 javadoc.extraHtml=Balise HTML en trop : {0}
 javadoc.incompleteTag=Balise HTML incomplète : {0}
+javadoc.incorrectTagOrder=Ordre incorrect de {0} tag pour ''{1}''.
 javadoc.invalidInheritDoc=Utilisation invalide de la balise '{'@inheritDoc '}'.
 javadoc.legacyPackageHtml=L''ancien fichier package.html doit être supprimé.
 javadoc.missed.html.close=Le commentaire Javadoc à la colonne {0} ne peut être analysé. La balise HTML fermante ''{1}'' n''a pas été trouvée. Parfois, cela signifie qu''une des balises fermantes précédentes est manquante.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
@@ -9,6 +9,7 @@ javadoc.empty=Javadocの説明文が空です。
 javadoc.expectedTag=''{1}'' には {0} タグが必要です。
 javadoc.extraHtml=不要な終了タグが見つかりました: {0}
 javadoc.incompleteTag=不完全なHTMLタグが見つかりました: {0}
+javadoc.incorrectTagOrder=間違った順序 {0} のタグ ''{1}''.
 javadoc.invalidInheritDoc='{' @inheritDoc '}'タグの使用が無効です。
 javadoc.legacyPackageHtml=古い形式のpackage.htmlファイルは削除してください。
 javadoc.missed.html.close={0} 桁目の Javadoc コメントでパースエラーが発生しました。HTML タグ ''{1}'' が閉じていません。どこかもっと前のタグが閉じていない可能性もあります。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
@@ -9,6 +9,7 @@ javadoc.empty=O javadoc tem uma seção de descrição vazia.
 javadoc.expectedTag=Esperada a tag {0} para ''{1}''.
 javadoc.extraHtml=Etiqueta HTML extra encontrada: {0}
 javadoc.incompleteTag=Etiqueta HTML incompleta encontrada: {0}
+javadoc.incorrectTagOrder=Ordem incorreta de {0} tag para ''{1}''.
 javadoc.invalidInheritDoc=Uso inválido da tag '{'inheritDoc '}'.
 javadoc.legacyPackageHtml=O arquivo package.html legado deve ser removido.
 javadoc.missed.html.close=O comentário de Javadoc na coluna {0} tem erro sintático. Faltou uma etiqueta de fechamento HTML ''{1}''. Às vezes, isso significa que uma etiqueta de fechamento foi esquecida em uma das etiquetas HTML anteriores.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
@@ -9,6 +9,7 @@ javadoc.empty=Javadoc tanım alanı boş bırakılmış.
 javadoc.expectedTag=''{1}'' için {0} etiketi gerekli.
 javadoc.extraHtml=Fazladan HTML etiketi bulundu: {0}
 javadoc.incompleteTag=Tamamlanmamış HTML etiketi bulundu: {0}
+javadoc.incorrectTagOrder=Yanlış sıralaması {0} için etiket ''{1}''.
 javadoc.invalidInheritDoc='{'@inheritDoc'}' etiketi kullanımı geçersiz.
 javadoc.legacyPackageHtml=Eskide kalan package.html dosyaları kaldırılmalı.
 javadoc.missed.html.close=Sütununda Javadoc comment {0} hatası ayrıştırmak vardır. Cevapsız HTML yakın etiketi ''{1}'' Bazen yakın etiketi önceki etiketler biri için kaçırmış demektir.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
@@ -9,6 +9,7 @@ javadoc.empty=Javadoc 描述块不应为空。
 javadoc.expectedTag=''{1}''需要Javadoc注释 {0} 。
 javadoc.extraHtml=额外的 HTML 标签： {0} 。
 javadoc.incompleteTag=未关闭的 HTML 标签： {0} 。
+javadoc.incorrectTagOrder=错误的顺序 {0} 标记 ''{1}''.
 javadoc.invalidInheritDoc='{'@inheritDoc'}' 标签使用方式错误。
 javadoc.legacyPackageHtml=文件 package.html 应被删除。
 javadoc.missed.html.close=Javadoc 第 {0} 个字符解析错误。缺少 HTML 闭合标签： ''{1}''。 有时这代表前一标签未闭合。

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_DUPLICATE_TAG;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_EXPECTED_TAG;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_INCORRECT_TAG_ORDER;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_INVALID_INHERIT_DOC;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_RETURN_EXPECTED;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_UNUSED_TAG;
@@ -579,6 +580,20 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration config = createModuleConfig(JavadocMethodCheck.class);
         verify(config, getPath("InputJavadocMethodLoadErrors.java"),
                 CommonUtil.EMPTY_STRING_ARRAY);
+    }
+
+    @Test
+    public void testWithIncorrectParamOrder() throws Exception {
+        final DefaultConfiguration config = createModuleConfig(JavadocMethodCheck.class);
+        config.addAttribute("validateParameterOrder", "true");
+
+        final String[] expected = {
+            "13:8: " + getCheckMessage(MSG_INCORRECT_TAG_ORDER, "@param", "b"),
+            "14:8: " + getCheckMessage(MSG_INCORRECT_TAG_ORDER, "@param", "a"),
+            "30:8: " + getCheckMessage(MSG_INCORRECT_TAG_ORDER, "@param", "b"),
+            "32:8: " + getCheckMessage(MSG_INCORRECT_TAG_ORDER, "@param", "<E>"),
+        };
+        verify(config, getPath("InputJavadocMethodIncorrectParamOrder.java"), expected);
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodIncorrectParamOrder.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodIncorrectParamOrder.java
@@ -1,0 +1,35 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
+
+/**
+ * Some explanation.
+ * @param <A> A type param
+ * @param <B1> Another type param
+ * @author Nobody
+ * @version 1.0
+ */
+public class InputJavadocMethodIncorrectParamOrder<A,B1 extends Comparable> {
+    /**
+     * Some description here.
+     * @param b
+     * @param a
+     * @param c
+     */
+    public void testIncorrectTypeOrder(int a, int b, int c) {}
+
+    /**
+     * Some description here
+     * @param <T>
+     * @param <E>
+     * @param a
+     * @param b
+     */
+    public <T, E> void testCorrectTypeOrder(T a, E b) {}
+
+    /**
+     * Some description here
+     * @param b
+     * @param a
+     * @param <E>
+     */
+    public <E> void testIncorrectTypeOrder(E a, int b) {}
+}

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -650,6 +650,16 @@ public int checkReturnTag(final int aTagIndex,
               <td>6.0</td>
             </tr>
             <tr>
+              <td>validateParameterOrder</td>
+              <td>
+                  Control whether to check if the <code>param</code> tags are in the order the
+                  appear in code.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>8.32</td>
+            </tr>
+            <tr>
               <td>scope</td>
               <td>Specify the visibility scope where Javadoc comments are checked.</td>
               <td><a href="property_types.html#scope">Scope</a></td>
@@ -778,6 +788,34 @@ public void doSomething9(File file) throws IOException {
 }
         </source>
 
+        <p>
+          To configure the check to validate that the <code>param</code> tags, appear in the order
+          they appear in code.
+        </p>
+        <source>
+&lt;module name="JavadocMethod"&gt;
+  &lt;property name="validateParameterOrder" value="true"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example: </p>
+        <source>
+/**
+ * Some description here.
+ * @param &lt;T&gt; // OK
+ * @param &lt;E&gt; // OK
+ * @param a // OK
+ * @param b // OK
+ */
+public &lt;T, E&gt; void testCorrectTypeOrder(T a, E b) {}
+
+/**
+ * Some description here.
+ * @param b // violation, b should be the third parameter as show in the code below .
+ * @param a // OK
+ * @param &lt;E&gt; // violation, &lt;E&gt; should be the third parameter as show in the code below.
+ */
+public &lt;E&gt; void testIncorrectTypeOrder(E a, int b) {}
+        </source>
       </subsection>
 
       <subsection name="Example of Usage" id="JavadocMethod_Example_of_Usage">
@@ -810,6 +848,10 @@ public void doSomething9(File file) throws IOException {
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.expectedTag%22">
             javadoc.expectedTag</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.incorrectTagOrder%22">
+            javadoc.incorrectTagOrder</a>
           </li>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.invalidInheritDoc%22">


### PR DESCRIPTION
Fixes #2810 

To add order check-in `JavadocMethod`. As we needed the original order of the param, hence I had to maintain a copy of the original param list through which we search the `position` of parameter with `@param` tag. 