### PR TITLE
doc: update IndentationCheck note for SuppressionXpathFilter

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -155,6 +155,8 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * Note, that support for these Checks will be available after resolving issues
  * <a href="https://github.com/checkstyle/checkstyle/issues/5770">#5770</a> and
  * <a href="https://github.com/checkstyle/checkstyle/issues/5777">#5777</a>.
+ * Support for Indentation check will be available after resolving issue
+ * <a href="https://github.com/checkstyle/checkstyle/issues/7734">#7734</a>.
  * </p>
  * <p>
  * Currently, filter supports the following xpath axes:

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -946,6 +946,8 @@ public class UserService {
           Note, that support for these Checks will be available after resolving issues
           <a href="https://github.com/checkstyle/checkstyle/issues/5770">#5770</a> and
           <a href="https://github.com/checkstyle/checkstyle/issues/5777">#5777</a>.
+          Support for Indentation check will be available after resolving issue
+          <a href="https://github.com/checkstyle/checkstyle/issues/7734">#7734</a>.
         </p>
         <p>
           Currently, filter supports the following


### PR DESCRIPTION
As for now Indentationcheck support for XpathSuppression is not supported till the [Issue #7734 ](https://github.com/checkstyle/checkstyle/issues/7734) is resolved.
PR is made in support of following comment https://github.com/checkstyle/checkstyle/issues/7734#issuecomment-602221021
Updated site screenshot :
![Screenshot_2020-03-24 checkstyle – Filters](https://user-images.githubusercontent.com/48255244/77433596-90b69c80-6e05-11ea-82d2-9c154f81e4cf.png)
