### PR TITLE
Issue: #7696 update doc for RegexpOnFilename

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheck.java
@@ -101,8 +101,15 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <pre>
  * &lt;module name=&quot;RegexpOnFilename&quot;/&gt;
  * </pre>
+ *
+ * <p>Example:</p>
+ * <pre>
+ * src/xdocs/config_regexp.xml  //OK, contains no whitespace
+ * src/xdocs/&quot;config regexp&quot;.xml  //violation, contains whitespace
+ * </pre>
+ *
  * <p>
- * To configure the check to force picture files to not be 'gif':
+ * To configure the check to forbid 'gif' files in folders:
  * </p>
  *
  * <pre>
@@ -110,15 +117,34 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *   &lt;property name=&quot;fileNamePattern&quot; value=&quot;\.gif$&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
+ *
+ * <p>Example:</p>
+ * <pre>
+ * src/site/resources/images/favicon.png  //OK
+ * src/site/resources/images/logo.jpg  //OK
+ * src/site/resources/images/groups.gif  //violation, .gif images not allowed
+ * </pre>
+ *
  * <p>
- * OR:
+ * To configure the check to forbid 'md' files except 'README.md file' in folders,
+ * with custom message:
  * </p>
  *
  * <pre>
  * &lt;module name=&quot;RegexpOnFilename&quot;&gt;
- *   &lt;property name=&quot;fileNamePattern&quot; value=&quot;.&quot;/&gt;
- *   &lt;property name=&quot;fileExtensions&quot; value=&quot;gif&quot;/&gt;
+ *   &lt;property name=&quot;fileNamePattern&quot; value=&quot;README&quot;/&gt;
+ *   &lt;property name=&quot;fileExtensions&quot; value=&quot;md&quot;/&gt;
+ *   &lt;property name=&quot;match&quot; value=&quot;false&quot;/&gt;
+ *   &lt;message key=&quot;regexp.filename.mismatch&quot;
+ *     value=&quot;No '*.md' files other then 'README.md'&quot;/&gt;
  * &lt;/module&gt;
+ * </pre>
+ *
+ * <p>Example:</p>
+ * <pre>
+ * src/site/resources/README.md  //OK
+ * src/site/resources/Logo.png  //OK
+ * src/site/resources/Text.md  //violation, .md files other than 'README.md' are not allowed
  * </pre>
  *
  * <p>
@@ -135,6 +161,13 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * &lt;/module&gt;
  * </pre>
  *
+ * <p>Example:</p>
+ * <pre>
+ * src/main/resources/sun_checks.xml  //OK
+ * src/main/resources/check_properties.properties  //OK
+ * src/main/resources/JavaClass.java  //violation, xml|property files are allowed in resource folder
+ * </pre>
+ *
  * <p>
  * To configure the check to only allow Java and XML files in your folders use
  * the below.
@@ -145,6 +178,16 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *   &lt;property name=&quot;fileNamePattern&quot; value=&quot;\.(java|xml)$&quot;/&gt;
  *   &lt;property name=&quot;match&quot; value=&quot;false&quot;/&gt;
  * &lt;/module&gt;
+ * </pre>
+ *
+ * <p>Example:</p>
+ * <pre>
+ * src/main/java/JavaClass.java  //OK
+ * src/main/MainClass.java  //OK
+ * src/main/java/java_xml.xml  //OK
+ * src/main/main_xml.xml  //OK
+ * src/main/java/image.png  //violation, folders should only contain java or xml files
+ * src/main/check_properties.properties  //violation, folders should only contain java or xml files
  * </pre>
  *
  * <p>
@@ -158,6 +201,14 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *   &lt;property name=&quot;fileNamePattern&quot; value=&quot;\.(java|xml)$&quot;/&gt;
  *   &lt;property name=&quot;match&quot; value=&quot;false&quot;/&gt;
  * &lt;/module&gt;
+ * </pre>
+ *
+ * <p>Example:</p>
+ * <pre>
+ * src/SourceClass.java  //OK
+ * src/source_xml.xml  //OK
+ * src/image.png  //violation, only java and xml files are allowed in src folder
+ * src/main/main_properties.properties  //OK, this check only applies to src folder
  * </pre>
  *
  * <p>
@@ -176,6 +227,14 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *   &lt;property name=&quot;match&quot; value=&quot;false&quot;/&gt;
  *   &lt;property name=&quot;ignoreFileNameExtensions&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
+ * </pre>
+ *
+ * <p>Example:</p>
+ * <pre>
+ * src/main/java/JavaClass.java  //OK
+ * src/main/MainClass.java  //OK
+ * src/main/java/java_class.java  //violation, file names should be in Camel Case
+ * src/main/main_class.java  //violation, file names should be in Camel Case
  * </pre>
  *
  * @since 6.15

--- a/src/xdocs/config_regexp.xml
+++ b/src/xdocs/config_regexp.xml
@@ -761,23 +761,50 @@ void method() {
         <source>
 &lt;module name=&quot;RegexpOnFilename&quot;/&gt;
         </source>
+        <p>Example:</p>
+        <div class="wrapper">
+          <pre>
+src/xdocs/config_regexp.xml  //OK, contains no whitespace
+src/xdocs/&quot;config regexp&quot;.xml  //violation, contains whitespace
+          </pre>
+        </div>
         <p>
-          To configure the check to force picture files to not be 'gif':
+          To configure the check to forbid 'gif' files in folders:
         </p>
         <source>
 &lt;module name=&quot;RegexpOnFilename&quot;&gt;
   &lt;property name=&quot;fileNamePattern&quot; value=&quot;\.gif$&quot;/&gt;
 &lt;/module&gt;
         </source>
+        <p>Example:</p>
+        <div class="wrapper">
+          <pre>
+src/site/resources/images/favicon.png  //OK
+src/site/resources/images/logo.jpg  //OK
+src/site/resources/images/groups.gif  //violation, .gif images not allowed
+          </pre>
+        </div>
         <p>
-          OR:
+          To configure the check to forbid 'md' files except 'README.md file' in folders,
+          with custom message:
         </p>
         <source>
 &lt;module name=&quot;RegexpOnFilename&quot;&gt;
-  &lt;property name=&quot;fileNamePattern&quot; value=&quot;.&quot;/&gt;
-  &lt;property name=&quot;fileExtensions&quot; value=&quot;gif&quot;/&gt;
+  &lt;property name=&quot;fileNamePattern&quot; value=&quot;README&quot;/&gt;
+  &lt;property name=&quot;fileExtensions&quot; value=&quot;md&quot;/&gt;
+  &lt;property name=&quot;match&quot; value=&quot;false&quot;/&gt;
+  &lt;message key=&quot;regexp.filename.mismatch&quot;
+    value=&quot;No '*.md' files other then 'README.md'&quot;/&gt;
 &lt;/module&gt;
         </source>
+        <p>Example:</p>
+        <div class="wrapper">
+          <pre>
+src/site/resources/README.md  //OK
+src/site/resources/Logo.png  //OK
+src/site/resources/Text.md  //violation, .md files other than 'README.md' are not allowed
+          </pre>
+        </div>
         <p>
           To configure the check to only allow property and xml files to be located
           in the resource folder:
@@ -790,6 +817,14 @@ void method() {
   &lt;property name=&quot;fileExtensions&quot; value=&quot;properties, xml&quot;/&gt;
 &lt;/module&gt;
         </source>
+        <p>Example:</p>
+        <div class="wrapper">
+          <pre>
+src/main/resources/sun_checks.xml  //OK
+src/main/resources/check_properties.properties  //OK
+src/main/resources/JavaClass.java  //violation, xml|property files are allowed in resource folder
+          </pre>
+        </div>
         <p>
           To configure the check to only allow Java and XML files in your folders use the below.
         </p>
@@ -799,6 +834,17 @@ void method() {
   &lt;property name=&quot;match&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
         </source>
+        <p>Example:</p>
+        <div class="wrapper">
+          <pre>
+src/main/java/JavaClass.java  //OK
+src/main/MainClass.java  //OK
+src/main/java/java_xml.xml  //OK
+src/main/main_xml.xml  //OK
+src/main/java/image.png  //violation, folders should only contain java or xml files
+src/main/check_properties.properties  //violation, folders should only contain java or xml files
+          </pre>
+        </div>
         <p>
           To configure the check to only allow Java and XML files only in your source folder
           and ignore any other folders:
@@ -810,6 +856,15 @@ void method() {
   &lt;property name=&quot;match&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
         </source>
+        <p>Example:</p>
+        <div class="wrapper">
+          <pre>
+src/SourceClass.java  //OK
+src/source_xml.xml  //OK
+src/image.png  //violation, only java and xml files are allowed in src folder
+src/main/main_properties.properties  //OK, this check only applies to src folder
+          </pre>
+        </div>
         <p>
           <b>Note:</b> 'folderPattern' must be specified if checkstyle is analyzing more than
           the normal source folder, like the 'bin' folder where class files can be located.
@@ -824,6 +879,15 @@ void method() {
   &lt;property name=&quot;ignoreFileNameExtensions&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
         </source>
+        <p>Example:</p>
+        <div class="wrapper">
+          <pre>
+src/main/java/JavaClass.java  //OK
+src/main/MainClass.java  //OK
+src/main/java/java_class.java  //violation, file names should be in Camel Case
+src/main/main_class.java  //violation, file names should be in Camel Case
+          </pre>
+        </div>
       </subsection>
 
       <subsection name="Example of Usage" id="RegexpOnFilename_Example_of_Usage">


### PR DESCRIPTION
Issue #7696: update doc for RegexpOnFilename

### Examples Added:
![Changes4](https://user-images.githubusercontent.com/53093601/79877751-43c8e480-840a-11ea-9b19-5921ad941336.PNG)


![Changes2](https://user-images.githubusercontent.com/53093601/77468952-5b757300-6e34-11ea-91b8-ae188136a56e.PNG)

![Changes3](https://user-images.githubusercontent.com/53093601/77469190-b6a76580-6e34-11ea-828a-727ee3b5eb83.PNG)

### CLI Results:

**For default configuration**
config.xml

```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC 
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
	<module name="RegexpOnFilename"/>
</module>
```

Results
```
F:\College\Checkstyle Jar>java -jar checkstyle-8.30-all.jar -c config.xml src/xdocs/"config regexp.xml"
Starting audit...
[ERROR] F:\College\Checkstyle Jar\src\xdocs\config regexp.xml:1: File match folder pattern '' and file pattern '\s'. [RegexpOnFilename]
Audit done.
Checkstyle ends with 1 errors.
```
**For custom configurations**
config.xml
```
<?xml version="1.0"?>                                           
<!DOCTYPE module PUBLIC                                         
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" 
          "https://checkstyle.org/dtds/configuration_1_3.dtd">  
        
<module name="Checker">
<module name="RegexpOnFilename">
<property name="folderPattern" value="[\\/]src"/>
<property name="fileNamePattern" value="\.(java|xml)$"/>
<property name="match" value="false"/>
</module>
</module>
```
Results
```
F:\College\Checkstyle Jar>java -jar checkstyle-8.30-all.jar -c config.xml src\main_properties.properties
Starting audit...
[ERROR] F:\College\Checkstyle Jar\src\main_properties.properties:1: File not match folder pattern '[\\/]src' and file pattern '\.(java|xml)$'. [RegexpOnFilename]
Audit done.
Checkstyle ends with 1 errors.

F:\College\Checkstyle Jar>java -jar checkstyle-8.30-all.jar -c config.xml src\NewClass.java
Starting audit...
Audit done.
```

**New Configuration**
To configure the check to forbid 'md' files except 'README.md file' in folders, with custom message:

config.xml

```
<?xml version="1.0"?>                                           
<!DOCTYPE module PUBLIC                                         
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" 
          "https://checkstyle.org/dtds/configuration_1_3.dtd">  
        
<module name="Checker">
	<module name="RegexpOnFilename">
		<property name="fileNamePattern" value="README"/>
		<property name="fileExtensions" value="md"/>
		<property name="match" value="false"/>
		<message key="regexp.filename.mismatch"
		value="No '*.md' files other then 'README.md'"
		/>
	</module>
</module>
```

Results

```
F:\College\Checkstyle Jar\src>java -jar checkstyle-8.30-all.jar -c config.xml README.md
Starting audit...
Audit done.

F:\College\Checkstyle Jar\src>java -jar checkstyle-8.30-all.jar -c config.xml hello.md
Starting audit...
[ERROR] F:\College\Checkstyle Jar\src\hello.md:1: No *.md files other then README.md [RegexpOnFilename]
Audit done.
Checkstyle ends with 1 errors.

F:\College\Checkstyle Jar\src>java -jar checkstyle-8.30-all.jar -c config.xml NewClass.class
Starting audit...
Audit done.
```


