### PR TITLE
Issue #7599: update doc for JavadocStyle

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -147,6 +147,20 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * <pre>
  * &lt;module name="JavadocStyle"/&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public class Test {
+ *     &#47;**
+ *      * Some description here. // OK
+ *      *&#47;
+ *     private void methodWithValidCommentStyle() {}
+ *
+ *     &#47;**
+ *      * Some description here // violation, the sentence must end with a proper punctuation
+ *      *&#47;
+ *     private void methodWithInvalidCommentStyle() {}
+ * }
+ * </pre>
  * <p>
  * To configure the check for {@code public} scope:
  * </p>
@@ -154,6 +168,20 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * &lt;module name="JavadocStyle"&gt;
  *   &lt;property name="scope" value="public"/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public class Test {
+ *     &#47;**
+ *      * Some description here // violation, the sentence must end with a proper punctuation
+ *      *&#47;
+ *     public void test1() {}
+ *
+ *     &#47;**
+ *      * Some description here // OK
+ *      *&#47;
+ *     private void test2() {}
+ * }
  * </pre>
  * <p>
  * To configure the check for javadoc which is in {@code private}, but not in {@code package} scope:
@@ -164,6 +192,20 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  *   &lt;property name="excludeScope" value="package"/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public class Test {
+ *     &#47;**
+ *      * Some description here // violation, the sentence must end with a proper punctuation
+ *      *&#47;
+ *     private void test1() {}
+ *
+ *     &#47;**
+ *      * Some description here // OK
+ *      *&#47;
+ *     void test2() {}
+ * }
+ * </pre>
  * <p>
  * To configure the check to turn off first sentence checking:
  * </p>
@@ -171,6 +213,54 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * &lt;module name="JavadocStyle"&gt;
  *   &lt;property name="checkFirstSentence" value="false"/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public class Test {
+ *     &#47;**
+ *      * Some description here // OK
+ *      * Second line of description // violation, the sentence must end with a proper punctuation
+ *      *&#47;
+ *     private void test1() {}
+ * }
+ * </pre>
+ * <p>
+ * To configure the check to turn off validation of incomplete html tags:
+ * </p>
+ * <pre>
+ * &lt;module name="JavadocStyle"&gt;
+ * &lt;property name="checkHtml" value="false"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public class Test {
+ *     &#47;**
+ *      * Some description here // violation, the sentence must end with a proper punctuation
+ *      * &lt;p // OK
+ *      *&#47;
+ *     private void test1() {}
+ * }
+ * </pre>
+ * <p>
+ * To configure the check for only class definitions:
+ * </p>
+ * <pre>
+ * &lt;module name="JavadocStyle"&gt;
+ * &lt;property name="tokens" value="CLASS_DEF"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * &#47;**
+ *  * Some description here // violation, the sentence must end with a proper punctuation
+ *  *&#47;
+ * public class Test {
+ *     &#47;**
+ *      * Some description here // OK
+ *      *&#47;
+ *     private void test1() {}
+ * }
  * </pre>
  *
  * @since 3.2

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -1418,15 +1418,42 @@ public class TestClass {
 &lt;module name="JavadocStyle"/&gt;
         </source>
 
-        <p>
-          To configure the check for <code>public</code>
-          scope:
-        </p>
+        <p>Example:</p>
+        <source>
+public class Test {
+    &#47;**
+     * Some description here. // OK
+     *&#47;
+    private void methodWithValidCommentStyle() {}
 
+    &#47;**
+     * Some description here // violation, the sentence must end with a proper punctuation
+     *&#47;
+    private void methodWithInvalidCommentStyle() {}
+}
+        </source>
+
+        <p>
+          To configure the check for <code>public</code> scope:
+        </p>
         <source>
 &lt;module name="JavadocStyle"&gt;
-  &lt;property name="scope" value="public"/&gt;
+&lt;property name="scope" value="public"/&gt;
 &lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+    &#47;**
+     * Some description here // violation, the sentence must end with a proper punctuation
+     *&#47;
+    public void test1() {}
+
+    &#47;**
+     * Some description here // OK
+     *&#47;
+    private void test2() {}
+}
         </source>
 
         <p>
@@ -1436,9 +1463,23 @@ public class TestClass {
 
         <source>
 &lt;module name="JavadocStyle"&gt;
-  &lt;property name="scope" value="private"/&gt;
-  &lt;property name="excludeScope" value="package"/&gt;
+&lt;property name="scope" value="private"/&gt;
+&lt;property name="excludeScope" value="package"/&gt;
 &lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+    &#47;**
+     * Some description here // violation, the sentence must end with a proper punctuation
+     *&#47;
+    private void test1() {}
+
+    &#47;**
+     * Some description here // OK
+     *&#47;
+    void test2() {}
+}
         </source>
 
         <p>
@@ -1447,10 +1488,62 @@ public class TestClass {
 
         <source>
 &lt;module name="JavadocStyle"&gt;
-  &lt;property name="checkFirstSentence" value="false"/&gt;
+&lt;property name="checkFirstSentence" value="false"/&gt;
 &lt;/module&gt;
         </source>
-      </subsection>
+        <p>Example:</p>
+        <source>
+public class Test {
+    &#47;**
+     * Some description here // OK
+     * Second line of description // violation, the sentence must end with a proper punctuation
+     *&#47;
+    private void test1() {}
+}
+        </source>
+
+        <p>
+          To configure the check to turn off validation of incomplete html tags:
+        </p>
+        <source>
+&lt;module name="JavadocStyle"&gt;
+&lt;property name="checkHtml" value="false"/&gt;
+&lt;/module&gt;
+        </source>
+
+        <p>Example:</p>
+        <source>
+public class Test {
+    &#47;**
+     * Some description here // violation, the sentence must end with a proper punctuation
+     * &lt;p // OK
+     *&#47;
+    private void test1() {}
+}
+        </source>
+
+        <p>
+          To configure the check for only class definitions:
+        </p>
+        <source>
+&lt;module name="JavadocStyle"&gt;
+&lt;property name="tokens" value="CLASS_DEF"/&gt;
+&lt;/module&gt;
+        </source>
+
+        <p>Example:</p>
+        <source>
+&#47;**
+ * Some description here // violation, the sentence must end with a proper punctuation
+ *&#47;
+public class Test {
+    &#47;**
+     * Some description here // OK
+     *&#47;
+    private void test1() {}
+}
+        </source>
+    </subsection>
 
       <subsection name="Example of Usage" id="JavadocStyle_Example_of_Usage">
         <ul>


### PR DESCRIPTION
Fixes issue #7599 

Screenshot:
<img width="1440" alt="Screen Shot 2020-03-24 at 9 23 48 PM" src="https://user-images.githubusercontent.com/36587580/77448138-7507c200-6e16-11ea-9c44-9a9102c9349e.png">
<img width="1440" alt="Screen Shot 2020-03-24 at 9 24 03 PM" src="https://user-images.githubusercontent.com/36587580/77448173-789b4900-6e16-11ea-91f1-daa1b6f54f33.png">
<img width="1440" alt="Screen Shot 2020-03-24 at 9 24 22 PM" src="https://user-images.githubusercontent.com/36587580/77448176-79cc7600-6e16-11ea-99a4-a5b50a2a76e2.png">
<img width="1440" alt="Screen Shot 2020-03-24 at 9 24 44 PM" src="https://user-images.githubusercontent.com/36587580/77448180-7a650c80-6e16-11ea-9a72-33e1cf14fc47.png">

#### CLI Test Results
1. Default check
```
gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="JavadocStyle">
        </module>
    </module>
</module>gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ java -jar target/checkstyle-8.31-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /Users/gauravpunjabi/Coding/Open Source/checkstyle/Test.java:7: First sentence should end with a period. [JavadocStyle]
Audit done.
Checkstyle ends with 1 errors.
```

2. Check for public scope
```
punjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="JavadocStyle">
            <property name="scope" value="public"/>
        </module>
    </module>
</module>gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ java -jar target/checkstyle-8.31-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /Users/gauravpunjabi/Coding/Open Source/checkstyle/Test.java:2: First sentence should end with a period. [JavadocStyle]
Audit done.
Checkstyle ends with 1 errors.
```

3. Check for private scope excluding package scope
```
auravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="JavadocStyle">
            <property name="scope" value="private"/>
            <property name="excludeScope" value="package"/>
        </module>
    </module>
</module>gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ java -jar target/checkstyle-8.31-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /Users/gauravpunjabi/Coding/Open Source/checkstyle/Test.java:2: First sentence should end with a period. [JavadocStyle]
Audit done.
Checkstyle ends with 1 errors.
```

4. Check to turn off first sentence checking
```
gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="JavadocStyle">
            <property name="checkFirstSentence" value="false"/>
        </module>
    </module>
</module>gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ java -jar target/checkstyle-8.31-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /Users/gauravpunjabi/Coding/Open Source/checkstyle/Test.java:4: Incomplete HTML tag found:      * <p [JavadocStyle]
Audit done.
Checkstyle ends with 1 errors.
```

5. Check to turn off validation of incomplete html tags
```
MacBook-Pro:~/Coding/Open Source/checkstyle$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="JavadocStyle">
            <property name="checkHtml" value="false"/>
        </module>
    </module>
</module>gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ java -jar target/checkstyle-8.31-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /Users/gauravpunjabi/Coding/Open Source/checkstyle/Test.java:2: First sentence should end with a period. [JavadocStyle]
Audit done.
Checkstyle ends with 1 errors.
```

6. Check for only class definitions
```
MacBook-Pro:~/Coding/Open Source/checkstyle$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="JavadocStyle">
            <property name="tokens" value="CLASS_DEF"/>
        </module>
    </module>
</module>gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ java -jar target/checkstyle-8.31-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /Users/gauravpunjabi/Coding/Open Source/checkstyle/Test.java:1: First sentence should end with a period. [JavadocStyle]
Audit done.
Checkstyle ends with 1 errors.
```