### PR TITLE
Issue #7473: JavadocMethod: false positive with validateThrows

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -55,12 +55,35 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * a different <a href="https://checkstyle.org/property_types.html#scope">scope</a>.
  * </p>
  * <p>
- * Violates parameters and type parameters for which no param tags are present
- * can be suppressed by defining property {@code allowMissingParamTags}.
- * Violates methods which return non-void but for which no return tag is present
- * can be suppressed by defining property {@code allowMissingReturnTag}.
- * Violates exceptions which are declared to be thrown, but for which no throws
- * tag is present by activation of property {@code validateThrows}.
+ * Violates parameters and type parameters for which no param tags are present can
+ * be suppressed by defining property {@code allowMissingParamTags}.
+ * </p>
+ * <p>
+ * Violates methods which return non-void but for which no return tag is present can
+ * be suppressed by defining property {@code allowMissingReturnTag}.
+ * </p>
+ * <p>
+ * Violates exceptions which are declared to be thrown (by {@code throws} in the method
+ * signature or by {@code throw new} in the method body), but for which no throws tag is
+ * present by activation of property {@code validateThrows}.
+ * Note that {@code throw new} is not checked in the following places:
+ * </p>
+ * <ul>
+ * <li>
+ * Inside a try block (with catch). It is not possible to determine if the thrown
+ * exception can be caught by the catch block as there is no knowledge of the
+ * inheritance hierarchy, so the try block is ignored entirely. However, catch
+ * and finally blocks, as well as try blocks without catch, are still checked.
+ * </li>
+ * <li>
+ * Local classes, anonymous classes and lambda expressions. It is not known when the
+ * throw statements inside such classes are going to be evaluated, so they are ignored.
+ * </li>
+ * </ul>
+ * <p>
+ * ATTENTION: Checkstyle does not have information about hierarchy of exception types
+ * so usage of base class is considered as separate exception type.
+ * As workaround you need to specify both types in javadoc (parent and exact type).
  * </p>
  * <p>
  * Javadoc is not required on a method that is tagged with the {@code @Override}
@@ -150,9 +173,6 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * </pre>
  * <p>
  * To configure the check to validate {@code throws} tags, you can use following config.
- * ATTENTION: Checkstyle does not have information about hierarchy of exception types so usage
- * of base class is considered as separate exception type. As workaround you need to
- * specify both types in javadoc (parent and exact type).
  * </p>
  * <pre>
  * &lt;module name="JavadocMethod"&gt;
@@ -186,6 +206,55 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  *     if (file == null) {
  *         throw new FileNotFoundException();
  *     }
+ * }
+ *
+ * &#47;**
+ *  * Ignore try block, but keep catch and finally blocks.
+ *  *
+ *  * &#64;param s String to parse
+ *  * &#64;return A positive integer
+ *  *&#47;
+ * public int parsePositiveInt(String s) {
+ *     try {
+ *         int value = Integer.parseInt(s);
+ *         if (value &lt;= 0) {
+ *             throw new NumberFormatException(value + " is negative/zero"); // ok, try
+ *         }
+ *         return value;
+ *     } catch (NumberFormatException ex) {
+ *         throw new IllegalArgumentException("Invalid number", ex); // violation, catch
+ *     } finally {
+ *         throw new IllegalStateException("Should never reach here"); // violation, finally
+ *     }
+ * }
+ *
+ * &#47;**
+ *  * Try block without catch is not ignored.
+ *  *
+ *  * &#64;return a String from standard input, if there is one
+ *  *&#47;
+ * public String readLine() {
+ *     try (Scanner sc = new Scanner(System.in)) {
+ *         if (!sc.hasNext()) {
+ *             throw new IllegalStateException("Empty input"); // violation, not caught
+ *         }
+ *         return sc.next();
+ *     }
+ * }
+ *
+ * &#47;**
+ *  * Lambda expressions are ignored as we do not know when the exception will be thrown.
+ *  *
+ *  * &#64;param s a String to be printed at some point in the future
+ *  * &#64;return a Runnable to be executed when the string is to be printed
+ *  *&#47;
+ * public Runnable printLater(String s) {
+ *     return () -&gt; {
+ *         if (s == null) {
+ *             throw new NullPointerException(); // ok
+ *         }
+ *         System.out.println(s);
+ *     };
  * }
  * </pre>
  *
@@ -694,16 +763,48 @@ public class JavadocMethodCheck extends AbstractCheck {
             final List<DetailAST> throwLiterals = findTokensInAstByType(blockAst,
                     TokenTypes.LITERAL_THROW);
             for (DetailAST throwAst : throwLiterals) {
-                final DetailAST newAst = throwAst.getFirstChild().getFirstChild();
-                if (newAst.getType() == TokenTypes.LITERAL_NEW) {
-                    final FullIdent ident = FullIdent.createFullIdent(newAst.getFirstChild());
-                    final ExceptionInfo exceptionInfo = new ExceptionInfo(
-                            createClassInfo(new Token(ident), currentClassName));
-                    returnValue.add(exceptionInfo);
+                if (!isInIgnoreBlock(blockAst, throwAst)) {
+                    final DetailAST newAst = throwAst.getFirstChild().getFirstChild();
+                    if (newAst.getType() == TokenTypes.LITERAL_NEW) {
+                        final FullIdent ident = FullIdent.createFullIdent(newAst.getFirstChild());
+                        final ExceptionInfo exceptionInfo = new ExceptionInfo(
+                                createClassInfo(new Token(ident), currentClassName));
+                        returnValue.add(exceptionInfo);
+                    }
                 }
             }
         }
         return returnValue;
+    }
+
+    /**
+     * Checks if a 'throw' usage is contained within a block that should be ignored.
+     * Such blocks consist of try (with catch) blocks, local classes, anonymous classes,
+     * and lambda expressions. Note that a try block without catch is not considered.
+     * @param methodBodyAst DetailAST node representing the method body
+     * @param throwAst DetailAST node representing the 'throw' literal
+     * @return true if throwAst is inside a block that should be ignored
+     */
+    private static boolean isInIgnoreBlock(DetailAST methodBodyAst, DetailAST throwAst) {
+        DetailAST ancestor = throwAst.getParent();
+        while (ancestor != methodBodyAst) {
+            if (ancestor.getType() == TokenTypes.LITERAL_TRY
+                    && ancestor.findFirstToken(TokenTypes.LITERAL_CATCH) != null
+                    || ancestor.getType() == TokenTypes.LAMBDA
+                    || ancestor.getType() == TokenTypes.OBJBLOCK) {
+                // throw is inside a try block, and there is a catch block,
+                // or throw is inside a lambda expression/anonymous class/local class
+                break;
+            }
+            if (ancestor.getType() == TokenTypes.LITERAL_CATCH
+                    || ancestor.getType() == TokenTypes.LITERAL_FINALLY) {
+                // if the throw is inside a catch or finally block,
+                // skip the immediate ancestor (try token)
+                ancestor = ancestor.getParent();
+            }
+            ancestor = ancestor.getParent();
+        }
+        return ancestor != methodBodyAst;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -98,6 +98,20 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testIgnoreThrows() throws Exception {
+        final DefaultConfiguration config = createModuleConfig(JavadocMethodCheck.class);
+        config.addAttribute("validateThrows", "true");
+        final String[] expected = {
+            "31:23: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "IllegalArgumentException"),
+            "33:23: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "IllegalStateException"),
+            "49:23: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "IllegalArgumentException"),
+            "129:27: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "IllegalArgumentException"),
+            "185:27: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "IllegalArgumentException"),
+        };
+        verify(config, getPath("InputJavadocMethodIgnoreThrows.java"), expected);
+    }
+
+    @Test
     public void testTags() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(JavadocMethodCheck.class);
         checkConfig.addAttribute("validateThrows", "true");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodIgnoreThrows.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodIgnoreThrows.java
@@ -1,0 +1,193 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Scanner;
+import java.util.function.Function;
+
+/**
+ * Config:
+ * validateThrows = true
+ */
+public class InputJavadocMethodIgnoreThrows {
+
+    /**
+     * Ignore try block, but keep catch and finally blocks.
+     *
+     * @param s String to parse
+     * @return A positive integer
+     */
+    private static int parsePositiveInt(String s) {
+        try {
+            int value = Integer.parseInt(s);
+            if (value <= 0) {
+                throw new NumberFormatException(value + " is negative/zero"); // ok, try
+            }
+            return value;
+        } catch (NumberFormatException ex) {
+            throw new IllegalArgumentException("Invalid number", ex); // violation, catch
+        } finally {
+            throw new IllegalStateException("Should never reach here"); // violation, finally
+        }
+    }
+
+    /**
+     * For exceptions that are thrown, caught, and rethrown, violation is in the catch block.
+     * Prior to issue 7473, violation was logged in the try block instead.
+     *
+     * @param o An input
+     */
+    private static void catchAndRethrow(Object o) {
+        try {
+            if (o == null) {
+                throw new IllegalArgumentException("null"); // ok, try
+            }
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException(ex.toString()); // violation, catch
+        }
+    }
+
+    /**
+     * However, rethrowing the same exception (without creating a new one)
+     * will not be treated as a violation.
+     *
+     * @param o An input
+     */
+    private static void catchAndRethrowSame(Object o) {
+        try {
+            if (o == null) {
+                throw new IllegalArgumentException("null"); // ok, try
+            }
+        } catch (IllegalArgumentException ex) {
+            throw ex; // no violation
+        }
+    }
+
+    /**
+     * It is not possible to tell the exact type of the exception
+     * unless 'throw new' is used.
+     *
+     * @param o An input
+     * @param i Another input
+     */
+    private static void catchAndRethrowDifferent(Object o, int i) {
+        try {
+            float x = 1 / i; // ArithmeticException when i = 0
+        } catch (RuntimeException ex) {
+            if (o == null) {
+                ex = new NullPointerException("");
+            }
+            throw ex; // no violation
+        }
+    }
+
+    /**
+     * Ignore everything inside lambda.
+     *
+     * @param maxLength Max length
+     * @return A function to truncate string
+     */
+    private static Function<String, String> getTruncateFunction(int maxLength) {
+        return s -> {
+            if (s == null) {
+                throw new IllegalArgumentException("Cannot truncate null"); // ok, inside lambda
+            }
+            return s.length() > maxLength ? s.substring(0, maxLength) : s;
+        };
+    }
+
+    /**
+     * Try-with-resources should also be ignored if there is a catch block.
+     *
+     * @param input file to read
+     */
+    private static void ignoreTryWithResources(String input) {
+        try (BufferedReader in = new BufferedReader(new FileReader(input))) {
+            String s = in.readLine();
+            System.out.println(s);
+            if (s.length() == 0) {
+                // false negative, unable to tell what was caught
+                throw new IllegalArgumentException("empty input"); // no violation
+            }
+            else {
+                throw new IOException(); // ok, exception was caught
+            }
+        } catch (IOException e) {
+            System.out.println("Error reading file");
+        }
+    }
+
+    /**
+     * However, do not ignore try block without catch.
+     */
+    private static void keepTryWithoutCatch() {
+        try (Scanner sc = new Scanner(System.in)) {
+            if (sc.nextInt() <= 0) {
+                throw new IllegalArgumentException(""); // violation, not caught and no @param
+            }
+        }
+    }
+
+    /**
+     * Local inner classes should be ignored.
+     *
+     * @param ast input
+     */
+    void dfs(DetailAST ast) {
+        class DFS {
+            void neverCalled() {
+                throw new IllegalStateException(""); // ok, inside local class
+            }
+
+            void dfs(DetailAST ast) {
+                if (ast != null) {
+                    dfs(ast.getFirstChild());
+                    System.out.println(ast);
+                    dfs(ast.getNextSibling());
+                }
+            }
+        }
+        new DFS().dfs(ast);
+    }
+
+    /**
+     * Anonymous classes should be ignored as well.
+     *
+     * @return some Runnable
+     */
+    Runnable ignoreAnonClasses() {
+        return new Runnable() {
+            @Override
+            public void run() {
+                throw new UnsupportedOperationException(""); // ok, inside anon class
+            }
+        };
+    }
+
+    /**
+     * Catch block is not ignored, but lambda is still ignored.
+     *
+     * @param s a string
+     * @return a function
+     */
+    Function<String, Integer> lambdaInCatchBlock(String s) {
+        try {
+            int value = Integer.parseInt(s);
+            if (value <= 0) {
+                throw new NumberFormatException(value + " is negative/zero"); // ok, try
+            }
+            return x -> value;
+        } catch (NumberFormatException ex) {
+            if (s.length() == 1) {
+                throw new IllegalArgumentException("Invalid number", ex); // violation, catch
+            }
+            return x -> {
+                throw new UnsupportedOperationException(""); // ok, inside lambda
+            };
+        }
+    }
+
+}

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -585,12 +585,37 @@ public void method();
           for which no param tags are
           present can be suppressed by defining property
           <code>allowMissingParamTags</code>.
+        </p>
+
+        <p>
           Violates methods which return non-void but for which no return tag is
           present can be suppressed by defining property
           <code>allowMissingReturnTag</code>.
-          Violates exceptions which are declared to be thrown, but for which no
-          throws tag is present by activation of property
-          <code>validateThrows</code>.
+        </p>
+
+        <p>
+          Violates exceptions which are declared to be thrown (by <code>throws</code> in the method
+          signature or by <code>throw new</code> in the method body), but for which no throws tag is
+          present by activation of property <code>validateThrows</code>.
+          Note that <code>throw new</code> is not checked in the following places:
+        </p>
+          <ul>
+            <li>
+              Inside a try block (with catch). It is not possible to determine if the thrown
+              exception can be caught by the catch block as there is no knowledge of the
+              inheritance hierarchy, so the try block is ignored entirely. However, catch
+              and finally blocks, as well as try blocks without catch, are still checked.
+            </li>
+            <li>
+              Local classes, anonymous classes and lambda expressions. It is not known when the
+              throw statements inside such classes are going to be evaluated, so they are ignored.
+            </li>
+          </ul>
+
+        <p>
+          ATTENTION: Checkstyle does not have information about hierarchy of exception types
+          so usage of base class is considered as separate exception type.
+          As workaround you need to specify both types in javadoc (parent and exact type).
         </p>
 
         <p>
@@ -739,9 +764,6 @@ public int checkReturnTag(final int aTagIndex,
 
         <p>
           To configure the check to validate <code>throws</code> tags, you can use following config.
-          ATTENTION: Checkstyle does not have information about hierarchy of exception types
-          so usage of base class is considered as separate exception type.
-          As workaround you need to specify both types in javadoc (parent and exact type).
         </p>
         <source>
 &lt;module name="JavadocMethod"&gt;
@@ -775,6 +797,55 @@ public void doSomething9(File file) throws IOException {
     if (file == null) {
         throw new FileNotFoundException();
     }
+}
+
+/**
+ * Ignore try block, but keep catch and finally blocks.
+ *
+ * @param s String to parse
+ * @return A positive integer
+ */
+public int parsePositiveInt(String s) {
+    try {
+        int value = Integer.parseInt(s);
+        if (value &lt;= 0) {
+            throw new NumberFormatException(value + " is negative/zero"); // ok, try
+        }
+        return value;
+    } catch (NumberFormatException ex) {
+        throw new IllegalArgumentException("Invalid number", ex); // violation, catch
+    } finally {
+        throw new IllegalStateException("Should never reach here"); // violation, finally
+    }
+}
+
+/**
+ * Try block without catch is not ignored.
+ *
+ * @return a String from standard input, if there is one
+ */
+public String readLine() {
+    try (Scanner sc = new Scanner(System.in)) {
+        if (!sc.hasNext()) {
+            throw new IllegalStateException("Empty input"); // violation, not caught
+        }
+        return sc.next();
+    }
+}
+
+/**
+ * Lambda expressions are ignored as we do not know when the exception will be thrown.
+ *
+ * @param s a String to be printed at some point in the future
+ * @return a Runnable to be executed when the string is to be printed
+ */
+public Runnable printLater(String s) {
+    return () -&gt; {
+        if (s == null) {
+            throw new NullPointerException(); // ok
+        }
+        System.out.println(s);
+    };
 }
         </source>
 


### PR DESCRIPTION
Issue #7473: JavadocMethod: false positive with validateThrows if catched inside the method

Logic has been tweaked as follows:
1. For every use of the `throws` literal, check the AST node's ancestors to see where it comes from
2. If we find that it is from a lambda or `try` block, we disregard that node. **Update**: Local and anonymous classes defined in the method will also be ignored.
3. `catch` and `finally` literals are considered children of the `try` literal. However they should not be ignored because exceptions can be thrown there that go uncaught. Hence if we encounter `catch` and `finally` on the way up then we need to 'skip' the next ancestor (the `try` literal).

Regression: https://wltan.github.io/checkstyle-reports/2020-04-20/javadocmethod-throws/index (updated)