### PR TITLE
minor: Optimize method distance in checkstyle.api.FileText

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
@@ -97,6 +97,46 @@ public final class FileText {
     private int[] lineBreaks;
 
     /**
+     * Copy constructor.
+     * @param fileText to make copy of
+     */
+    public FileText(FileText fileText) {
+        file = fileText.file;
+        charset = fileText.charset;
+        fullText = fileText.fullText;
+        lines = fileText.lines.clone();
+        if (fileText.lineBreaks == null) {
+            lineBreaks = null;
+        }
+        else {
+            lineBreaks = fileText.lineBreaks.clone();
+        }
+    }
+
+    /**
+     * Compatibility constructor.
+     *
+     * <p>This constructor reconstructs the text of the file by joining
+     * lines with linefeed characters. This process does not restore
+     * the original line terminators and should therefore be avoided.
+     *
+     * @param file the name of the file
+     * @param lines the lines of the text, without terminators
+     * @throws NullPointerException if the lines array is null
+     */
+    public FileText(File file, List<String> lines) {
+        final StringBuilder buf = new StringBuilder(1024);
+        for (final String line : lines) {
+            buf.append(line).append('\n');
+        }
+
+        this.file = file;
+        charset = null;
+        fullText = buf.toString();
+        this.lines = lines.toArray(CommonUtil.EMPTY_STRING_ARRAY);
+    }
+
+    /**
      * Creates a new file text representation.
      *
      * <p>The file will be read using the specified encoding, replacing
@@ -144,47 +184,6 @@ public final class FileText {
     }
 
     /**
-     * Copy constructor.
-     *
-     * @param fileText to make copy of
-     */
-    public FileText(FileText fileText) {
-        file = fileText.file;
-        charset = fileText.charset;
-        fullText = fileText.fullText;
-        lines = fileText.lines.clone();
-        if (fileText.lineBreaks == null) {
-            lineBreaks = null;
-        }
-        else {
-            lineBreaks = fileText.lineBreaks.clone();
-        }
-    }
-
-    /**
-     * Compatibility constructor.
-     *
-     * <p>This constructor reconstructs the text of the file by joining
-     * lines with linefeed characters. This process does not restore
-     * the original line terminators and should therefore be avoided.
-     *
-     * @param file the name of the file
-     * @param lines the lines of the text, without terminators
-     * @throws NullPointerException if the lines array is null
-     */
-    public FileText(File file, List<String> lines) {
-        final StringBuilder buf = new StringBuilder(1024);
-        for (final String line : lines) {
-            buf.append(line).append('\n');
-        }
-
-        this.file = file;
-        charset = null;
-        fullText = buf.toString();
-        this.lines = lines.toArray(CommonUtil.EMPTY_STRING_ARRAY);
-    }
-
-    /**
      * Reads file using specific decoder and returns all its content as a String.
      *
      * @param inputFile File to read
@@ -211,6 +210,16 @@ public final class FileText {
             }
         }
         return buf.toString();
+    }
+
+    /**
+     * Retrieves a line of the text by its number.
+     * The returned line will not contain a trailing terminator.
+     * @param lineNo the number of the line to get, starting at zero
+     * @return the line with the given number
+     */
+    public String get(final int lineNo) {
+        return lines[lineNo];
     }
 
     /**
@@ -253,29 +262,6 @@ public final class FileText {
     }
 
     /**
-     * Find positions of line breaks in the full text.
-     *
-     * @return an array giving the first positions of each line.
-     */
-    private int[] findLineBreaks() {
-        if (lineBreaks == null) {
-            final int[] lineBreakPositions = new int[size() + 1];
-            lineBreakPositions[0] = 0;
-            int lineNo = 1;
-            final Matcher matcher = LINE_TERMINATOR.matcher(fullText);
-            while (matcher.find()) {
-                lineBreakPositions[lineNo] = matcher.end();
-                lineNo++;
-            }
-            if (lineNo < lineBreakPositions.length) {
-                lineBreakPositions[lineNo] = fullText.length();
-            }
-            lineBreaks = lineBreakPositions;
-        }
-        return lineBreaks;
-    }
-
-    /**
      * Determine line and column numbers in full text.
      *
      * @param pos the character position in the full text
@@ -296,14 +282,25 @@ public final class FileText {
     }
 
     /**
-     * Retrieves a line of the text by its number.
-     * The returned line will not contain a trailing terminator.
-     *
-     * @param lineNo the number of the line to get, starting at zero
-     * @return the line with the given number
+     * Find positions of line breaks in the full text.
+     * @return an array giving the first positions of each line.
      */
-    public String get(final int lineNo) {
-        return lines[lineNo];
+    private int[] findLineBreaks() {
+        if (lineBreaks == null) {
+            final int[] lineBreakPositions = new int[size() + 1];
+            lineBreakPositions[0] = 0;
+            int lineNo = 1;
+            final Matcher matcher = LINE_TERMINATOR.matcher(fullText);
+            while (matcher.find()) {
+                lineBreakPositions[lineNo] = matcher.end();
+                lineNo++;
+            }
+            if (lineNo < lineBreakPositions.length) {
+                lineBreakPositions[lineNo] = fullText.length();
+            }
+            lineBreaks = lineBreakPositions;
+        }
+        return lineBreaks;
     }
 
     /**


### PR DESCRIPTION
Before Optimization:
https://wilcoln.github.io/com.pupppycrawl.tools.checkstyle.api/before.FileText.java.html

After Optimization:
https://wilcoln.github.io/com.pupppycrawl.tools.checkstyle.api/optimal.FileText.java.html

Submited Optimization:
https://wilcoln.github.io/com.pupppycrawl.tools.checkstyle.api/after.FileText.java.html

Optimization was made manually and with respect to the currently hardcoded criteria defined in the method-distance repository.

@romani 
I'll take this opportunity to suggest that some users might want constructors to be the first methods defined in class .Thus, it might be relevant to count penalty for every constructor defined below a non-constructor method.

Currently, there is no such criterion defined in the method-distance repo, this is why, in this case, first method of optimal reordering isn't a constructor.

I figured out that this might not be what we want for checkstyle, so I submitted a reordering for which constructors are at the top.

What do you think?



