### PR TITLE
Issue #7722: Update AbstractChecks to log DetailAST - AnnotationUseStyle

### DIFF
--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAnnotationUseStyleTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAnnotationUseStyleTest.java
@@ -1,0 +1,272 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck;
+
+public class XpathRegressionAnnotationUseStyleTest extends AbstractXpathTestSupport {
+
+    private final String checkName = AnnotationUseStyleCheck.class.getSimpleName();
+
+    @Override
+    protected String getCheckName() {
+        return checkName;
+    }
+
+    @Test
+    public void testOne() throws Exception {
+        final File fileToProcess = new File(getPath(
+                "SuppressionXpathRegressionAnnotationUseStyleOne.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(AnnotationUseStyleCheck.class);
+
+        final String[] expectedViolation = {
+            "4:1: " + getCheckMessage(AnnotationUseStyleCheck.class,
+                    AnnotationUseStyleCheck.MSG_KEY_ANNOTATION_INCORRECT_STYLE,
+                    "COMPACT_NO_ARRAY"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationUseStyleOne']]"
+                        + "/MODIFIERS/ANNOTATION[./IDENT[@text='SuppressWarnings']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationUseStyleOne']]"
+                        + "/MODIFIERS/ANNOTATION[./IDENT[@text='SuppressWarnings']]/AT"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testTwo() throws Exception {
+        final File fileToProcess = new File(getPath(
+                "SuppressionXpathRegressionAnnotationUseStyleTwo.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(AnnotationUseStyleCheck.class);
+
+        moduleConfig.addAttribute("closingParens", "ALWAYS");
+        moduleConfig.addAttribute("elementStyle", "ignore");
+        moduleConfig.addAttribute("trailingArrayComma", "ignore");
+
+        final String[] expectedViolation = {
+            "3:1: " + getCheckMessage(AnnotationUseStyleCheck.class,
+                    AnnotationUseStyleCheck.MSG_KEY_ANNOTATION_PARENS_MISSING),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationUseStyleTwo']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationUseStyleTwo']]"
+                        + "/MODIFIERS",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationUseStyleTwo']]"
+                        + "/MODIFIERS/ANNOTATION[./IDENT[@text='Deprecated']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationUseStyleTwo']]"
+                        + "/MODIFIERS/ANNOTATION[./IDENT[@text='Deprecated']]/AT"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testThree() throws Exception {
+        final File fileToProcess = new File(getPath(
+                "SuppressionXpathRegressionAnnotationUseStyleThree.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(AnnotationUseStyleCheck.class);
+
+        moduleConfig.addAttribute("trailingArrayComma", "ignore");
+
+        final String[] expectedViolation = {
+            "4:5: " + getCheckMessage(AnnotationUseStyleCheck.class,
+                    AnnotationUseStyleCheck.MSG_KEY_ANNOTATION_INCORRECT_STYLE,
+                    "COMPACT_NO_ARRAY"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationUseStyleThree']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationUseStyleThree']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]/MODIFIERS",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationUseStyleThree']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]/MODIFIERS"
+                        + "/ANNOTATION[./IDENT[@text='SuppressWarnings']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationUseStyleThree']]"
+                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]/MODIFIERS"
+                        + "/ANNOTATION[./IDENT[@text='SuppressWarnings']]/AT"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testFour() throws Exception {
+        final File fileToProcess = new File(getPath(
+                "SuppressionXpathRegressionAnnotationUseStyleFour.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(AnnotationUseStyleCheck.class);
+
+        moduleConfig.addAttribute("closingParens", "ignore");
+        moduleConfig.addAttribute("elementStyle", "ignore");
+        moduleConfig.addAttribute("trailingArrayComma", "ALWAYS");
+
+        final String[] expectedViolation = {
+            "3:20: " + getCheckMessage(AnnotationUseStyleCheck.class,
+                    AnnotationUseStyleCheck.MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationUseStyleFour']]"
+                        + "/MODIFIERS/ANNOTATION[./IDENT[@text='SuppressWarnings']]"
+                        + "/ANNOTATION_ARRAY_INIT/RCURLY"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testFive() throws Exception {
+        final File fileToProcess = new File(getPath(
+                "SuppressionXpathRegressionAnnotationUseStyleFive.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(AnnotationUseStyleCheck.class);
+
+        moduleConfig.addAttribute("closingParens", "ignore");
+        moduleConfig.addAttribute("elementStyle", "COMPACT");
+        moduleConfig.addAttribute("trailingArrayComma", "ignore");
+
+        final String[] expectedViolation = {
+            "3:1: " + getCheckMessage(AnnotationUseStyleCheck.class,
+                    AnnotationUseStyleCheck.MSG_KEY_ANNOTATION_INCORRECT_STYLE,
+                    "COMPACT"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationUseStyleFive']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationUseStyleFive']]"
+                         + "/MODIFIERS",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationUseStyleFive']]"
+                        + "/MODIFIERS/ANNOTATION[./IDENT[@text='SuppressWarnings']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationUseStyleFive']]"
+                        + "/MODIFIERS/ANNOTATION[./IDENT[@text='SuppressWarnings']]/AT"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testSix() throws Exception {
+        final File fileToProcess = new File(getPath(
+                "SuppressionXpathRegressionAnnotationUseStyleSix.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(AnnotationUseStyleCheck.class);
+
+        moduleConfig.addAttribute("closingParens", "ignore");
+        moduleConfig.addAttribute("elementStyle", "EXPANDED");
+        moduleConfig.addAttribute("trailingArrayComma", "ignore");
+
+        final String[] expectedViolation = {
+            "3:1: " + getCheckMessage(AnnotationUseStyleCheck.class,
+                    AnnotationUseStyleCheck.MSG_KEY_ANNOTATION_INCORRECT_STYLE,
+                    "EXPANDED"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationUseStyleSix']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationUseStyleSix']]"
+                        + "/MODIFIERS",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationUseStyleSix']]"
+                        + "/MODIFIERS/ANNOTATION[./IDENT[@text='SuppressWarnings']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationUseStyleSix']]"
+                        + "/MODIFIERS/ANNOTATION[./IDENT[@text='SuppressWarnings']]/AT"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testSeven() throws Exception {
+        final File fileToProcess = new File(getPath(
+                "SuppressionXpathRegressionAnnotationUseStyleSeven.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(AnnotationUseStyleCheck.class);
+
+        final String[] expectedViolation = {
+            "4:1: " + getCheckMessage(AnnotationUseStyleCheck.class,
+                    AnnotationUseStyleCheck.MSG_KEY_ANNOTATION_INCORRECT_STYLE,
+                    "COMPACT_NO_ARRAY"),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationUseStyleSeven']]"
+                        + "/MODIFIERS/ANNOTATION[./IDENT[@text='SuppressWarnings']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationUseStyleSeven']]"
+                        + "/MODIFIERS/ANNOTATION[./IDENT[@text='SuppressWarnings']]/AT"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testEight() throws Exception {
+        final File fileToProcess = new File(getPath(
+                "SuppressionXpathRegressionAnnotationUseStyleEight.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(AnnotationUseStyleCheck.class);
+
+        moduleConfig.addAttribute("closingParens", "ignore");
+        moduleConfig.addAttribute("elementStyle", "ignore");
+        moduleConfig.addAttribute("trailingArrayComma", "NEVER");
+
+        final String[] expectedViolation = {
+            "3:31: " + getCheckMessage(AnnotationUseStyleCheck.class,
+                    AnnotationUseStyleCheck.MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnnotationUseStyleEight']]"
+                        + "/MODIFIERS/ANNOTATION[./IDENT[@text='SuppressWarnings']]"
+                        + "/ANNOTATION_ARRAY_INIT/COMMA"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/annotationusestyle/SuppressionXpathRegressionAnnotationUseStyleEight.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/annotationusestyle/SuppressionXpathRegressionAnnotationUseStyleEight.java
@@ -1,0 +1,6 @@
+package org.checkstyle.suppressionxpathfilter.annotationusestyle;
+
+@SuppressWarnings({"something",}) //warn
+public class SuppressionXpathRegressionAnnotationUseStyleEight {
+
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/annotationusestyle/SuppressionXpathRegressionAnnotationUseStyleFive.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/annotationusestyle/SuppressionXpathRegressionAnnotationUseStyleFive.java
@@ -1,0 +1,6 @@
+package org.checkstyle.suppressionxpathfilter.annotationusestyle;
+
+@SuppressWarnings(value={"foo", "bar"}) //warn
+public class SuppressionXpathRegressionAnnotationUseStyleFive {
+
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/annotationusestyle/SuppressionXpathRegressionAnnotationUseStyleFour.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/annotationusestyle/SuppressionXpathRegressionAnnotationUseStyleFour.java
@@ -1,0 +1,6 @@
+package org.checkstyle.suppressionxpathfilter.annotationusestyle;
+
+@SuppressWarnings({}) //warn
+public class SuppressionXpathRegressionAnnotationUseStyleFour {
+
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/annotationusestyle/SuppressionXpathRegressionAnnotationUseStyleOne.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/annotationusestyle/SuppressionXpathRegressionAnnotationUseStyleOne.java
@@ -1,0 +1,7 @@
+package org.checkstyle.suppressionxpathfilter.annotationusestyle;
+
+@Deprecated
+@SuppressWarnings({""}) //warn
+public class SuppressionXpathRegressionAnnotationUseStyleOne {
+
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/annotationusestyle/SuppressionXpathRegressionAnnotationUseStyleSeven.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/annotationusestyle/SuppressionXpathRegressionAnnotationUseStyleSeven.java
@@ -1,0 +1,7 @@
+package org.checkstyle.suppressionxpathfilter.annotationusestyle;
+
+@Deprecated
+@SuppressWarnings(value={"foo"}) //warn
+public class SuppressionXpathRegressionAnnotationUseStyleSeven {
+
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/annotationusestyle/SuppressionXpathRegressionAnnotationUseStyleSix.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/annotationusestyle/SuppressionXpathRegressionAnnotationUseStyleSix.java
@@ -1,0 +1,6 @@
+package org.checkstyle.suppressionxpathfilter.annotationusestyle;
+
+@SuppressWarnings({"foo", "bar"}) //warn
+public class SuppressionXpathRegressionAnnotationUseStyleSix {
+
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/annotationusestyle/SuppressionXpathRegressionAnnotationUseStyleThree.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/annotationusestyle/SuppressionXpathRegressionAnnotationUseStyleThree.java
@@ -1,0 +1,8 @@
+package org.checkstyle.suppressionxpathfilter.annotationusestyle;
+
+public class SuppressionXpathRegressionAnnotationUseStyleThree {
+    @SuppressWarnings({"common",}) //warn
+    public void foo() {
+
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/annotationusestyle/SuppressionXpathRegressionAnnotationUseStyleTwo.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/annotationusestyle/SuppressionXpathRegressionAnnotationUseStyleTwo.java
@@ -1,0 +1,6 @@
+package org.checkstyle.suppressionxpathfilter.annotationusestyle;
+
+@Deprecated //warn
+public class SuppressionXpathRegressionAnnotationUseStyleTwo {
+
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -385,7 +385,7 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
             annotation.getChildCount(TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR);
 
         if (valuePairCount == 0 && hasArguments(annotation)) {
-            log(annotation.getLineNo(), MSG_KEY_ANNOTATION_INCORRECT_STYLE, ElementStyle.EXPANDED);
+            log(annotation, MSG_KEY_ANNOTATION_INCORRECT_STYLE, ElementStyle.EXPANDED);
         }
     }
 
@@ -417,7 +417,7 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
         if (valuePairCount == 1
             && ANNOTATION_ELEMENT_SINGLE_NAME.equals(
                 valuePair.getFirstChild().getText())) {
-            log(annotation.getLineNo(), MSG_KEY_ANNOTATION_INCORRECT_STYLE,
+            log(annotation, MSG_KEY_ANNOTATION_INCORRECT_STYLE,
                 ElementStyle.COMPACT);
         }
     }
@@ -434,7 +434,7 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
         // in compact style with one value
         if (arrayInit != null
             && arrayInit.getChildCount(TokenTypes.EXPR) == 1) {
-            log(annotation.getLineNo(), MSG_KEY_ANNOTATION_INCORRECT_STYLE,
+            log(annotation, MSG_KEY_ANNOTATION_INCORRECT_STYLE,
                 ElementStyle.COMPACT_NO_ARRAY);
         }
         // in expanded style with pairs
@@ -445,7 +445,7 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
                     ast.findFirstToken(TokenTypes.ANNOTATION_ARRAY_INIT);
                 if (nestedArrayInit != null
                     && nestedArrayInit.getChildCount(TokenTypes.EXPR) == 1) {
-                    log(annotation.getLineNo(), MSG_KEY_ANNOTATION_INCORRECT_STYLE,
+                    log(annotation, MSG_KEY_ANNOTATION_INCORRECT_STYLE,
                         ElementStyle.COMPACT_NO_ARRAY);
                 }
                 ast = ast.getNextSibling();
@@ -515,11 +515,11 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
 
             if (closingParens == ClosingParens.ALWAYS) {
                 if (paren.getType() != TokenTypes.RPAREN) {
-                    log(ast.getLineNo(), MSG_KEY_ANNOTATION_PARENS_MISSING);
+                    log(ast, MSG_KEY_ANNOTATION_PARENS_MISSING);
                 }
             }
             else if (paren.getPreviousSibling().getType() == TokenTypes.LPAREN) {
-                log(ast.getLineNo(), MSG_KEY_ANNOTATION_PARENS_PRESENT);
+                log(ast, MSG_KEY_ANNOTATION_PARENS_PRESENT);
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -44,9 +44,6 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * </p>
  * <ul id="SuppressionXpathFilter_IncompatibleChecks">
  * <li>
- * AnnotationUseStyle
- * </li>
- * <li>
  * AvoidEscapedUnicodeCharacters
  * </li>
  * <li>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckTest.java
@@ -83,20 +83,20 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
     public void testDefault() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(AnnotationUseStyleCheck.class);
         final String[] expected = {
-            "4: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "11: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "13: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
-            "19: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "20: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "24: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "30: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
-            "33: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
-            "41: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "43: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "47: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "75: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
-            "77: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "4:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "5:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "11:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "13:1: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "19:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "20:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "24:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "30:1: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "33:5: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "41:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "43:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "47:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "75:32: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "77:40: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
         };
 
         verify(checkConfig, getPath("InputAnnotationUseStyleDifferentStyles.java"), expected);
@@ -112,11 +112,13 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("elementStyle", "ignore");
         checkConfig.addAttribute("trailingArrayComma", "ignore");
         final String[] expected = {
-            "3: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_MISSING),
-            "18: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_MISSING),
-            "23: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_MISSING),
-            "71: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_MISSING),
-            "73: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_MISSING),
+            "3:1: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_MISSING),
+            "18:1: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_MISSING),
+            "23:5: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_MISSING),
+            "71:32: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_MISSING),
+            "73:40: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_MISSING),
+            "81:8: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_MISSING),
+            "81:30: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_MISSING),
         };
 
         verify(checkConfig, getPath("InputAnnotationUseStyleDifferentStyles.java"), expected);
@@ -132,11 +134,11 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("elementStyle", "ignore");
         checkConfig.addAttribute("trailingArrayComma", "ignore");
         final String[] expected = {
-            "13: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
-            "30: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
-            "33: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
-            "75: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
-            "77: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "13:1: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "30:1: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "33:5: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "75:32: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "77:40: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
         };
 
         verify(checkConfig, getPath("InputAnnotationUseStyleDifferentStyles.java"), expected);
@@ -149,16 +151,16 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("elementStyle", "EXPANDED");
         checkConfig.addAttribute("trailingArrayComma", "ignore");
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
-            "12: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
-            "20: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
-            "26: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
-            "39: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
-            "41: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
-            "58: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
-            "63: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
-            "71: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
-            "75: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
+            "5:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
+            "12:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
+            "20:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
+            "26:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
+            "39:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
+            "41:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
+            "58:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
+            "63:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
+            "71:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
+            "75:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "EXPANDED"),
         };
 
         verify(checkConfig, getPath("InputAnnotationUseStyleDifferentStyles.java"), expected);
@@ -171,11 +173,11 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("elementStyle", "COMPACT");
         checkConfig.addAttribute("trailingArrayComma", "ignore");
         final String[] expected = {
-            "43: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT"),
-            "47: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT"),
-            "67: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT"),
-            "73: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT"),
-            "77: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT"),
+            "43:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT"),
+            "47:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT"),
+            "67:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT"),
+            "73:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT"),
+            "77:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT"),
         };
 
         verify(checkConfig, getPath("InputAnnotationUseStyleDifferentStyles.java"), expected);
@@ -188,15 +190,15 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("elementStyle", "COMPACT_NO_ARRAY");
         checkConfig.addAttribute("trailingArrayComma", "ignore");
         final String[] expected = {
-            "4: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "11: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "19: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "20: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "24: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "41: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "43: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "47: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "4:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "5:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "11:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "19:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "20:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "24:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "41:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "43:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "47:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
         };
 
         verify(checkConfig, getPath("InputAnnotationUseStyleDifferentStyles.java"), expected);
@@ -273,10 +275,10 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(AnnotationUseStyleCheck.class);
         checkConfig.addAttribute("trailingArrayComma", "ignore");
         final String[] expected = {
-            "9: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "16: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "27: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "33: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "9:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "16:13: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "27:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "33:9: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
         };
 
         verify(checkConfig, getPath("InputAnnotationUseStyleWithTrailingComma.java"), expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -53,7 +53,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
     // till https://github.com/checkstyle/checkstyle/issues/5777
     public static final Set<String> INCOMPATIBLE_CHECK_NAMES =
         Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-            "AnnotationUseStyle",
             "AvoidEscapedUnicodeCharacters",
             "CommentsIndentation",
             "CustomImportOrder",

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleDifferentStyles.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleDifferentStyles.java
@@ -77,6 +77,10 @@ class Example3 {}
 @AnnotationWithAnnotationValue(value = @Another())
 class Example4 {}
 
+class Foo {
+   Foo(@Another String par1, @Another int par2) {}
+}
+
 @interface AnnotationWithAnnotationValue {
     Another value();
 }

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -902,7 +902,6 @@ public class UserService {
           Currently, filter does not support the following checks:
         </p>
         <ul id="SuppressionXpathFilter_IncompatibleChecks">
-          <li>AnnotationUseStyle</li>
           <li>AvoidEscapedUnicodeCharacters</li>
           <li>CommentsIndentation</li>
           <li>CustomImportOrder</li>


### PR DESCRIPTION
Resolve #7722: Update AbstractChecks to log DetailAST - AnnotationUseStyle

Diff report : https://wilcoln.github.io/checkstyle-reports/7722/diff/index.html

I ran regression on all projects and the diff report was so huge (1.2Gb+)  that  `git add` was taking forever to run. Beside, i'm not sure that github will allow me to upload such a load. So I've decided to host detailed reports for only the 8 first projects.

The number of violations **has increased** as there are often multiple violations on same line.
For example in the **apache-struts** project, [this file](https://github.com/apache/struts/blob/master/core/src/main/java/com/opensymphony/xwork2/conversion/impl/DefaultObjectTypeDeterminer.java) contains two violations on line [71](https://github.com/apache/struts/blob/9053c84d505dfbcca0f1452b8ee2f2adbb5e54a5/core/src/main/java/com/opensymphony/xwork2/conversion/impl/DefaultObjectTypeDeterminer.java#L71), at col 40 and 74 respectively.

Input files for UT's have been updated accordingly :
https://github.com/checkstyle/checkstyle/blob/3db6cfd4d735e63aa83f2f65855773797d0d802f/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleDifferentStyles.java#L81 