### PR TITLE
 Issue #7969: upgrade AppVeyor build image to VS2019 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-os: Windows Server 2012
+image: Visual Studio 2019
 version: '{build}'
 skip_tags: true
 


### PR DESCRIPTION
Issue #7969 

JDK13 is no more supported, we are moving to jdk14.
AppVeyor image upgraded from Windows Server 2012 to Windows Server 2019.
We have no files with jdk13 specific syntax, so travis stage `javac13` can be replaced with `javac14` too.