### PR TITLE
Issue #7589: Update doc for NewlineAtEndOfFile

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
@@ -88,6 +88,19 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
  * <pre>
  * &lt;module name=&quot;NewlineAtEndOfFile&quot;/&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * // File ending with a new line
+ * public class Test {⤶
+ * ⤶
+ * }⤶ // ok
+ * Note: The comment // ok is a virtual, not actually present in the file
+ *
+ * // File ending without a new line
+ * public class Test1 {⤶
+ * ⤶
+ * } // violation, the file does not end with a new line
+ * </pre>
  * <p>
  * To configure the check to always use Unix-style line separators:
  * </p>
@@ -95,6 +108,19 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
  * &lt;module name=&quot;NewlineAtEndOfFile&quot;&gt;
  *   &lt;property name=&quot;lineSeparator&quot; value=&quot;lf&quot;/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * // File ending with a new line
+ * public class Test {⤶
+ * ⤶
+ * }⤶ // ok
+ * Note: The comment // ok is a virtual, not actually present in the file
+ *
+ * // File ending without a new line
+ * public class Test1 {⤶
+ * ⤶
+ * }␍⤶ // violation, expected line ending for file is LF(\n), but CRLF(\r\n) is detected
  * </pre>
  * <p>
  * To configure the check to work only on Java, XML and Python files:
@@ -104,7 +130,18 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
  *   &lt;property name=&quot;fileExtensions&quot; value=&quot;java, xml, py&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * // Any java file
+ * public class Test {⤶
+ * } // violation, file should end with a new line.
  *
+ * // Any py file
+ * print("Hello World") // violation, file should end with a new line.
+ *
+ * // Any txt file
+ * This is a sample text file. // ok, this file is not specified in the config.
+ * </pre>
  * @since 3.1
  */
 @StatelessCheck

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -1436,6 +1436,19 @@ StaticMethodCandidateCheck.name = Static Method Candidate
         <source>
 &lt;module name=&quot;NewlineAtEndOfFile&quot;/&gt;
         </source>
+        <p>Example:</p>
+        <source>
+// File ending with a new line
+public class Test {⤶
+⤶
+}⤶ // ok
+Note: The comment // ok is a virtual, not actually present in the file
+
+// File ending without a new line
+public class Test1 {⤶
+⤶
+} // violation, the file does not end with a new line
+        </source>
 
         <p>
           To configure the check to always use Unix-style line separators:
@@ -1445,6 +1458,19 @@ StaticMethodCandidateCheck.name = Static Method Candidate
   &lt;property name=&quot;lineSeparator&quot; value=&quot;lf&quot;/&gt;
 &lt;/module&gt;
         </source>
+        <p>Example:</p>
+        <source>
+// File ending with a new line
+public class Test {⤶
+⤶
+}⤶ // ok
+Note: The comment // ok is a virtual, not actually present in the file
+
+// File ending without a new line
+public class Test1 {⤶
+⤶
+}␍⤶ // violation, expected line ending for file is LF(\n), but CRLF(\r\n) is detected
+        </source>
 
           <p>
             To configure the check to work only on Java, XML and Python files:
@@ -1453,6 +1479,18 @@ StaticMethodCandidateCheck.name = Static Method Candidate
 &lt;module name=&quot;NewlineAtEndOfFile&quot;&gt;
   &lt;property name=&quot;fileExtensions&quot; value=&quot;java, xml, py&quot;/&gt;
 &lt;/module&gt;
+          </source>
+          <p>Example:</p>
+          <source>
+// Any java file
+public class Test {⤶
+} // violation, file should end with a new line.
+
+// Any py file
+print("Hello World") // violation, file should end with a new line.
+
+// Any txt file
+This is a sample text file. // ok, this file is not specified in the config.
           </source>
       </subsection>
 


### PR DESCRIPTION
Fixes issue #7589 

Screenshot
<img width="1260" alt="Screen Shot 2020-03-26 at 9 43 27 PM" src="https://user-images.githubusercontent.com/36587580/77670531-56d3ca80-6fac-11ea-83f3-3c103fb11ee2.png">
<img width="1260" alt="Screen Shot 2020-03-26 at 9 43 42 PM" src="https://user-images.githubusercontent.com/36587580/77670539-5a675180-6fac-11ea-8bb1-17144ce50d19.png">

### CLI Test Results
1. Check with default config
```
gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ cat conifg.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="NewlineAtEndOfFile"/>
</module>gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ java -jar target/checkstyle-8.31-SNAPSHOT-all.jar -c conifg.xml Test.java
Starting audit...
[ERROR] /Users/gauravpunjabi/Coding/Open Source/checkstyle/Test.java:1: File does not end with a newline. [NewlineAtEndOfFile]
Audit done.
Checkstyle ends with 1 errors.
```

2. Check with lineSeparator config
```
gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ cat conifg.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="NewlineAtEndOfFile">
        <property name="lineSeparator" value="lf"/>
    </module>
</module>gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ java -jar target/checkstyle-8.31-SNAPSHOT-all.jar -c conifg.xml Test.java
Starting audit...
[ERROR] /Users/gauravpunjabi/Coding/Open Source/checkstyle/Test.java:1: File does not end with a newline. [NewlineAtEndOfFile]
Audit done.
Checkstyle ends with 1 errors.
```

3. Check with fileExtension configuration
```
gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ cat conifg.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="NewlineAtEndOfFile">
        <property name="fileExtensions" value="java, xml, py"/>
    </module>
</module>gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ java -jar target/checkstyle-8.31-SNAPSHOT-all.jar -c conifg.xml Test.java
Starting audit...
[ERROR] /Users/gauravpunjabi/Coding/Open Source/checkstyle/Test.java:1: File does not end with a newline. [NewlineAtEndOfFile]
Audit done.
Checkstyle ends with 1 errors.
```
