### PR TITLE
Issue #7623: Update doc for NoLineWrap

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoLineWrapCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoLineWrapCheck.java
@@ -46,13 +46,13 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <p>Examples of line-wrapped statements (bad case):
  * </p>
  * <pre>
- * package com.puppycrawl. //violation
+ * package com.puppycrawl. // violation
  *     tools.checkstyle.checks;
  *
- * import com.puppycrawl.tools. //violation
+ * import com.puppycrawl.tools. // violation
  *     checkstyle.api.AbstractCheck;
  *
- * import static java.math. //violation
+ * import static java.math. // violation
  *     BigInteger.ZERO;
  * </pre>
  *
@@ -63,6 +63,28 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <pre>
  * &lt;module name=&quot;NoLineWrap&quot;/&gt;
  * </pre>
+ * <p>
+ * Examples:
+ * </p>
+ * <pre>
+ * package com.puppycrawl.tools.checkstyle. // violation
+ *   checks.whitespace;
+ *
+ * import java.lang.Object; // OK
+ * import java.lang. // violation
+ *   Integer;
+ *
+ * import static java.math. // violation
+ *   BigInteger.TEN;
+ * </pre>
+ * <pre>
+ * package com.puppycrawl.tools.checkstyle.checks.coding; // OK
+ *
+ * import java.lang. // violation
+ *   Boolean;
+ *
+ * import static java.math.BigInteger.ONE; // OK
+ * </pre>
  *
  * <p>
  * To configure the check to force no line-wrapping only
@@ -72,6 +94,54 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * &lt;module name=&quot;NoLineWrap&quot;&gt;
  *   &lt;property name="tokens" value="IMPORT"/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * package com.puppycrawl. // OK
+ *   tools.checkstyle.checks;
+ *
+ * import java.io.*; // OK
+ * import java.lang. // violation
+ *  Boolean;
+ *
+ * import static java.math. // OK
+ * BigInteger.ZERO;
+ * </pre>
+ * <p>
+ * To configure the check to force no line-wrapping only
+ * in class, method and constructor definitions:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;NoLineWrap&quot;&gt;
+ *   &lt;property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * public class // violation, class definition not wrapped in a single line
+ *   Foo {
+ *
+ *   public Foo() { // OK
+ *   }
+ *
+ *   public static void // violation, method definition not wrapped in a single line
+ *     doSomething() {
+ *   }
+ * }
+ *
+ * public class Bar { // OK
+ *
+ *   public // violation, constructor definition not wrapped in a single line
+ *     Bar() {
+ *   }
+ *
+ *   public int fun() { // OK
+ *   }
+ * }
  * </pre>
  *
  * <p>Examples of not line-wrapped statements (good case):

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -973,13 +973,13 @@ Pair&lt;Integer, Integer &gt; p; // violation, "&gt;" preceded with whitespace
         Examples of line-wrapped statements (bad case):
       </p>
       <source>
-package com.puppycrawl. //violation
+package com.puppycrawl. // violation
     tools.checkstyle.checks;
 
-import com.puppycrawl.tools. //violation
+import com.puppycrawl.tools. // violation
     checkstyle.api.AbstractCheck;
 
-import static java.math. //violation
+import static java.math. // violation
     BigInteger.ZERO;
       </source>
       <p>
@@ -990,6 +990,28 @@ import static java.math. //violation
 &lt;module name=&quot;NoLineWrap&quot;/&gt;
       </source>
       <p>
+        Examples:
+      </p>
+      <source>
+package com.puppycrawl.tools.checkstyle. // violation
+  checks.whitespace;
+
+import java.lang.Object; // OK
+import java.lang. // violation
+  Integer;
+
+import static java.math. // violation
+  BigInteger.TEN;
+      </source>
+      <source>
+package com.puppycrawl.tools.checkstyle.checks.coding; // OK
+
+import java.lang. // violation
+  Boolean;
+
+import static java.math.BigInteger.ONE; // OK
+      </source>
+      <p>
         To configure the check to force no line-wrapping only
         in import statements:
       </p>
@@ -997,6 +1019,54 @@ import static java.math. //violation
 &lt;module name=&quot;NoLineWrap&quot;&gt;
   &lt;property name="tokens" value="IMPORT"/&gt;
 &lt;/module&gt;
+      </source>
+      <p>
+        Example:
+      </p>
+      <source>
+package com.puppycrawl. // OK
+  tools.checkstyle.checks;
+
+import java.io.*; // OK
+import java.lang. // violation
+  Boolean;
+
+import static java.math. // OK
+  BigInteger.ZERO;
+      </source>
+      <p>
+        To configure the check to force no line-wrapping only
+        in class, method and constructor definitions:
+      </p>
+      <source>
+&lt;module name=&quot;NoLineWrap&quot;&gt;
+  &lt;property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF"/&gt;
+&lt;/module&gt;
+      </source>
+      <p>
+        Example:
+      </p>
+      <source>
+public class // violation, class definition not wrapped in a single line
+  Foo {
+
+  public Foo() { // OK
+  }
+
+  public static void // violation, method definition not wrapped in a single line
+    doSomething() {
+  }
+}
+
+public class Bar { // OK
+
+  public // violation, constructor definition not wrapped in a single line
+    Bar() {
+  }
+
+  public int fun() { // OK
+  }
+}
       </source>
       <p>
         Examples of not line-wrapped statements (good case):


### PR DESCRIPTION
#### Fixes #7623
![1](https://user-images.githubusercontent.com/43749360/77826774-6a5f6c80-7137-11ea-8e49-0545edddb5c1.PNG)
![2](https://user-images.githubusercontent.com/43749360/77826775-6b909980-7137-11ea-9bc4-a8300d06fe25.PNG)


Default examples:

```
$ cat config.xml 
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <module name="NoLineWrap"/>
  </module>
</module>

$ cat test.java 
package com.puppycrawl.tools.checkstyle. //violation
	checks.whitespace;

import java.lang.Object; // OK
import java.lang. // violation
	Integer;

import static java.math. // violation
	BigInteger.TEN;

$ java -jar checkstyle-8.30-all.jar -c config.xml test.java 
Starting audit...
[ERROR] /home/shrey/Desktop/CheckstyleJar/test.java:1: package statement should not be line-wrapped. [NoLineWrap]
[ERROR] /home/shrey/Desktop/CheckstyleJar/test.java:5: import statement should not be line-wrapped. [NoLineWrap]
[ERROR] /home/shrey/Desktop/CheckstyleJar/test.java:8: import statement should not be line-wrapped. [NoLineWrap]
Audit done.
Checkstyle ends with 3 errors.
```

```
$ cat test2.java 
package com.puppycrawl.tools.checkstyle.checks.coding; // OK

import java.lang. // violation
	Boolean;

import static java.math.BigInteger.ONE; // OK


$ java -jar checkstyle-8.30-all.jar -c config.xml test2.java  
Starting audit...
[ERROR] /home/shrey/Desktop/CheckstyleJar/test2.java:3: import statement should not be line-wrapped. [NoLineWrap]
Audit done.
Checkstyle ends with 1 errors.
```

Non-default example for just import statements:
```
$ cat config2.xml 
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <module name="NoLineWrap">
    	<property name="tokens" value="IMPORT"/>
    </module>
  </module>
</module>s

$ cat test3.java 
package com.puppycrawl. // OK
	tools.checkstyle.checks;

import java.io.*; // OK
import java.lang. // violation
	Boolean;

import static java.math. // OK
	BigInteger.ZERO;

$ java -jar checkstyle-8.30-all.jar -c config2.xml test3.java 
Starting audit...
[ERROR] /home/shrey/Desktop/CheckstyleJar/test3.java:5: import statement should not be line-wrapped. [NoLineWrap]
Audit done.
Checkstyle ends with 1 errors.

```

Non-default example for class, method and constructor definitions:
```
$ cat config3.xml 
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <module name="NoLineWrap">
      <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF"/>
    </module>
  </module>
</module>

$ cat test4.java 
public class // violation, class definiton not wrapped in a single line
  Foo {

  public Foo() { // OK
  }

  public static void // violation, method definition not wrapped in a single line
    doSomething() {
  }
}

public class Bar { // OK

  public // violation, constructor definition not wrapped in a single line
    Bar() {
  }

  public int fun() { // OK
  }
}

$ java -jar checkstyle-8.30-all.jar-c config3.xml test4.java 
Starting audit...
[ERROR] /home/shrey/Desktop/CheckstyleJar/test4.java:1: CLASS_DEF statement should not be line-wrapped. [NoLineWrap]
[ERROR] /home/shrey/Desktop/CheckstyleJar/test4.java:7: METHOD_DEF statement should not be line-wrapped. [NoLineWrap]
[ERROR] /home/shrey/Desktop/CheckstyleJar/test4.java:14: CTOR_DEF statement should not be line-wrapped. [NoLineWrap]
Audit done.
Checkstyle ends with 3 errors.
```