### PR TITLE
Issue #7874: Resolve Pitest Issues - ImportOrderCheck (3)

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -76,7 +76,6 @@ pitest-imports)
   "ImportControlLoader.java.html:<td class='covered'><pre><span  class='survived'>        else if (ALLOW_ELEMENT_NAME.equals(qName) || &#34;disallow&#34;.equals(qName)) {</span></pre></td></tr>"
   "ImportOrderCheck.java.html:<td class='covered'><pre><span  class='survived'>                else if (matcher.start() == bestPos &#38;&#38; matcher.end() &#62; bestEnd) {</span></pre></td></tr>"
   "ImportOrderCheck.java.html:<td class='covered'><pre><span  class='survived'>        final boolean separatorBetween = isStatic != lastImportStatic</span></pre></td></tr>"
-  "ImportOrderCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (caseSensitive) {</span></pre></td></tr>"
   "ImportOrderCheck.java.html:<td class='covered'><pre><span  class='survived'>                if (!CommonUtil.endsWithChar(pkg, &#39;.&#39;)) {</span></pre></td></tr>"
   "ImportOrderCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (isStatic) {</span></pre></td></tr>"
   "ImportOrderCheck.java.html:<td class='covered'><pre><span  class='survived'>        return !beforeFirstImport &#38;&#38; line - lastImportLine &#62; 1;</span></pre></td></tr>"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -795,6 +795,22 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testUseContainerOrderingForStatic() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(ImportOrderCheck.class);
+        checkConfig.addAttribute("ordered", "true");
+        checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
+        checkConfig.addAttribute("useContainerOrderingForStatic", "true");
+        final String[] expected = {
+            "6:1: " + getCheckMessage(MSG_ORDERING,
+                    "io.netty.handler.Codec.HTTP.HttpHeaders.tmp.same"),
+            "7:1: " + getCheckMessage(MSG_ORDERING,
+                    "io.netty.handler.Codec.HTTP.HttpHeaders.TKN.same"),
+        };
+        verify(checkConfig, getNonCompilablePath("InputImportOrderContainerOrdering.java"),
+                expected);
+    }
+
+    @Test
     public void testImportGroupsRedundantSeparatedInternally() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(ImportOrderCheck.class);
         checkConfig.addAttribute("groups", "/^javax\\./,com");

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderContainerOrdering.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderContainerOrdering.java
@@ -1,0 +1,11 @@
+//non-compiled with javac: contains specially crafted set of imports for testing
+package com.puppycrawl.tools.checkstyle.checks.imports.importorder;
+import static io.netty.handler.codec.http.HttpConstants.COLON;
+import static io.netty.handler.codec.http.HttpHeaders.addHeader;
+import static io.netty.handler.codec.http.HttpHeaders.setHeader;
+import static io.netty.handler.Codec.HTTP.HttpHeaders.tmp.same;
+import static io.netty.handler.Codec.HTTP.HttpHeaders.TKN.same;
+
+public class InputImportOrderContainerOrdering {
+
+}


### PR DESCRIPTION
Resolves Issue #7874: Resolve Pitest Issues - ImportOrderCheck (3)

PiTest Report, ran before changes, showing surviving mutation:
https://nmancus1.github.io/Issue-7874/com.puppycrawl.tools.checkstyle.checks.imports/ImportOrderCheck.java.html#org.pitest.mutationtest.report.html.SourceFile@7ea147e3_820

Surviving mutation: `removed conditional - replaced equality check with false → SURVIVED`

PiTest Report, ran after changes, to show mutation was killed (updated):
https://nmancus1.github.io/Issue-7874/pitest_3/202003292351/com.puppycrawl.tools.checkstyle.checks.imports/ImportOrderCheck.java.html#org.pitest.mutationtest.report.html.SourceFile@2a2271dc_820