### PR TITLE
Issue #7982: Resolve Pitest Issues - RegexpCheck (1)

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -48,7 +48,6 @@ pitest-annotation|pitest-design \
 pitest-regexp)
   mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;
   declare -a ignoredItems=(
-  "RegexpCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (message == null) {</span></pre></td></tr>"
   "RegexpCheck.java.html:<td class='covered'><pre><span  class='survived'>        return errorCount &#60;= errorLimit - 1</span></pre></td></tr>"
   );
   checkPitestReport "${ignoredItems[@]}"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
@@ -521,12 +521,7 @@ public class RegexpCheck extends AbstractCheck {
      * @param message custom message which should be used in report.
      */
     public void setMessage(String message) {
-        if (message == null) {
-            this.message = "";
-        }
-        else {
-            this.message = message;
-        }
+        this.message = message;
     }
 
     /**


### PR DESCRIPTION
Fixes #7982 

### Solution
This mutation `replaced equality check with true` was surviving  on condition 
`if(message == null)` in method `RegexpCheck@setMessage()`.
Killed the mutation by removing the condition `message == null`

### Explanation
The member `message` is only used in one method `logMessage` and in that method, we are already null checking member `message` as shown below
```
if (message == null || message.isEmpty()) {
     msg = format.pattern();
}
```
This makes our null check in `setMessage()` useless, hence removing this condition won't affect any functionality or test case and would kill the mutation.

