### PR TITLE
Issue #7626: Update doc for OperatorWrap

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheck.java
@@ -94,6 +94,34 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * &lt;module name="OperatorWrap"/&gt;
  * </pre>
  * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * class Test {
+ *     public static void main(String[] args) {
+ *         String s = "Hello" +
+ *         "World"; // violation, '+' should be on new line
+ *
+ *         if (10 ==
+ *                 20) { // violation, '==' should be on new line.
+ *         // body
+ *         }
+ *         if (10
+ *                 ==
+ *                 20) { // ok
+ *         // body
+ *         }
+ *
+ *         int c = 10 /
+ *                 5; // violation, '/' should be on new line.
+ *
+ *         int d = c
+ *                 + 10; // ok
+ *     }
+ *
+ * }
+ * </pre>
+ * <p>
  * To configure the check for assignment operators at the end of a line:
  * </p>
  * <pre>
@@ -103,6 +131,49 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *            SR_ASSIGN,BSR_ASSIGN,SL_ASSIGN,BXOR_ASSIGN,BOR_ASSIGN,BAND_ASSIGN"/&gt;
  *   &lt;property name="option" value="eol"/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * class Test {
+ *     public static void main(String[] args) {
+ *             int b
+ *                     = 10; // violation, '=' should be on previous line
+ *             int c =
+ *                     10; // ok
+ *             b
+ *                     += 10; // violation, '+=' should be on previous line
+ *             b +=
+ *                     10; // ok
+ *             c
+ *                     *= 10; // violation, '*=' should be on previous line
+ *             c *=
+ *                     10; // ok
+ *             c
+ *                     -= 5; // violation, '-=' should be on previous line
+ *             c -=
+ *                     5; // ok
+ *             c
+ *                     /= 2; // violation, '/=' should be on previous line
+ *             c
+ *                     %= 1; // violation, '%=' should be on previous line
+ *             c
+ *                     &gt;&gt;= 1; // violation, '&gt;&gt;=' should be on previous line
+ *             c
+ *                 &gt;&gt;&gt;= 1; // violation, '&gt;&gt;&gt;=' should be on previous line
+ *         }
+ *         public void myFunction() {
+ *             c
+ *                     ^= 1; // violation, '^=' should be on previous line
+ *             c
+ *                     |= 1; // violation, '|=' should be on previous line
+ *             c
+ *                     &amp;=1 ; // violation, '&amp;=' should be on previous line
+ *             c
+ *                     &lt;&lt;= 1; // violation, '&lt;&lt;=' should be on previous line
+ *     }
+ * }
  * </pre>
  *
  * @since 3.0

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -1665,7 +1665,34 @@ Lists.charactersOf("foo")
         <source>
 &lt;module name=&quot;OperatorWrap&quot;/&gt;
         </source>
+        <p>
+         Example:
+        </p>
+        <source>
+class Test {
+    public static void main(String[] args) {
+        String s = "Hello" +
+        "World"; // violation, '+' should be on new line
 
+        if (10 ==
+                20) { // violation, '==' should be on new line.
+        // body
+        }
+        if (10
+                ==
+                20) { // ok
+        // body
+        }
+
+        int c = 10 /
+                5; // violation, '/' should be on new line.
+
+        int d = c
+                + 10; // ok
+    }
+
+}
+        </source>
         <p>
           To configure the check for assignment operators at the end of a line:
         </p>
@@ -1676,6 +1703,49 @@ Lists.charactersOf("foo")
            SR_ASSIGN,BSR_ASSIGN,SL_ASSIGN,BXOR_ASSIGN,BOR_ASSIGN,BAND_ASSIGN"/&gt;
   &lt;property name="option" value="eol"/&gt;
 &lt;/module&gt;
+        </source>
+        <p>
+         Example:
+        </p>
+        <source>
+class Test {
+    public static void main(String[] args) {
+            int b
+                    = 10; // violation, '=' should be on previous line
+            int c =
+                    10; // ok
+            b
+                    += 10; // violation, '+=' should be on previous line
+            b +=
+                    10; // ok
+            c
+                    *= 10; // violation, '*=' should be on previous line
+            c *=
+                    10; // ok
+            c
+                    -= 5; // violation, '-=' should be on previous line
+            c -=
+                    5; // ok
+            c
+                    /= 2; // violation, '/=' should be on previous line
+            c
+                    %= 1; // violation, '%=' should be on previous line
+            c
+                    &gt;&gt;= 1; // violation, '&gt;&gt;=' should be on previous line
+            c
+                &gt;&gt;&gt;= 1; // violation, '&gt;&gt;&gt;=' should be on previous line
+        }
+        public void myFunction() {
+            c
+                    ^= 1; // violation, '^=' should be on previous line
+            c
+                    |= 1; // violation, '|=' should be on previous line
+            c
+                    &amp;=1 ; // violation, '&amp;=' should be on previous line
+            c
+                    &lt;&lt;= 1; // violation, '&lt;&lt;=' should be on previous line
+    }
+}
         </source>
       </subsection>
 


### PR DESCRIPTION
Fix for issue #7626 
Website changes
![image](https://user-images.githubusercontent.com/40023562/78351351-44691a80-75c4-11ea-85e5-b6c7e3695987.png)
![image](https://user-images.githubusercontent.com/40023562/78351380-4cc15580-75c4-11ea-8c3a-a48b182036a2.png)

CLI Output:

```
Karunas-MacBook-Pro:checkstyle Harsh$ cat config.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="OperatorWrap"/>
    </module>
</module>Karunas-MacBook-Pro:checkstyle Harsh$ cat Test.java
class Test {
    public static void main(String[] args) {
        String s = "Hello" +
                "World"; // violation, '+' should be on new line

        if (10 ==
                20) { // violation, '==' should be on new line.
            // body
        }
        if (10
                ==
                20) { // ok
            // body
        }

        int c = 10 /
                5; // violation, '/' should be on new line.

        int d = c
                + 10; // ok
    }

}Karunas-MacBook-Pro:checkstyle Harsh$ java -jar target/checkstyle-8.32-SNAPSHOT-all.jar -c config.xml Test.java 
Starting audit...
[ERROR] /Users/Harsh/Desktop/checkstyle/Test.java:3:28: '+' should be on a new line. [OperatorWrap]
[ERROR] /Users/Harsh/Desktop/checkstyle/Test.java:6:16: '==' should be on a new line. [OperatorWrap]
[ERROR] /Users/Harsh/Desktop/checkstyle/Test.java:16:20: '/' should be on a new line. [OperatorWrap]
Audit done.
Checkstyle ends with 3 errors.
```


```
Karunas-MacBook-Pro:checkstyle Harsh$ cat config.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="OperatorWrap">
            <property name="tokens"
                      value="ASSIGN,DIV_ASSIGN,PLUS_ASSIGN,MINUS_ASSIGN,STAR_ASSIGN,MOD_ASSIGN,
           SR_ASSIGN,BSR_ASSIGN,SL_ASSIGN,BXOR_ASSIGN,BOR_ASSIGN,BAND_ASSIGN"/>
            <property name="option" value="eol"/>
        </module>
    </module>
</module>Karunas-MacBook-Pro:checkstylcat Test.java 
class Test {
    public static void main(String[] args) {
        int b
                = 10; // violation, '=' should be on previous line
        int c =
                10; // ok
        b
                += 10; // violation, '+=' should be on previous line
        b +=
                10; // ok
        c
                *= 10; // violation, '*=' should be on previous line
        c *=
                10; // ok
        c
                -= 5; // violation, '-=' should be on previous line
        c -=
                5; // ok
        c
                /= 2; // violation, '/=' should be on previous line
        c
                %= 1; // violation, '%=' should be on previous line
        c
                >>= 1; // violation, '>>=' should be on previous line
        c
                >>>= 1; // violation, '>>>=' should be on previous line
    }
    public void myFunction() {
        c
                ^= 1; // violation, '^=' should be on previous line
        c
                |= 1; // violation, '|=' should be on previous line
        c
                &=1 ; // violation, '&=' should be on previous line
        c
                <<= 1; // violation, '<<=' should be on previous line
    }
}Karunas-MacBook-Pro:checkstyle Harsh$ java -jar target/checkstyle-8.32-SNAPSHOT-all.jar -c config.xml Test.java 
Starting audit...
[ERROR] /Users/Harsh/Desktop/checkstyle/Test.java:4:17: '=' should be on the previous line. [OperatorWrap]
[ERROR] /Users/Harsh/Desktop/checkstyle/Test.java:8:17: '+=' should be on the previous line. [OperatorWrap]
[ERROR] /Users/Harsh/Desktop/checkstyle/Test.java:12:17: '*=' should be on the previous line. [OperatorWrap]
[ERROR] /Users/Harsh/Desktop/checkstyle/Test.java:16:17: '-=' should be on the previous line. [OperatorWrap]
[ERROR] /Users/Harsh/Desktop/checkstyle/Test.java:20:17: '/=' should be on the previous line. [OperatorWrap]
[ERROR] /Users/Harsh/Desktop/checkstyle/Test.java:22:17: '%=' should be on the previous line. [OperatorWrap]
[ERROR] /Users/Harsh/Desktop/checkstyle/Test.java:24:17: '>>=' should be on the previous line. [OperatorWrap]
[ERROR] /Users/Harsh/Desktop/checkstyle/Test.java:26:17: '>>>=' should be on the previous line. [OperatorWrap]
[ERROR] /Users/Harsh/Desktop/checkstyle/Test.java:30:17: '^=' should be on the previous line. [OperatorWrap]
[ERROR] /Users/Harsh/Desktop/checkstyle/Test.java:32:17: '|=' should be on the previous line. [OperatorWrap]
[ERROR] /Users/Harsh/Desktop/checkstyle/Test.java:34:17: '&=' should be on the previous line. [OperatorWrap]
[ERROR] /Users/Harsh/Desktop/checkstyle/Test.java:36:17: '<<=' should be on the previous line. [OperatorWrap]
Audit done.
Checkstyle ends with 12 errors.

```
