### PR TITLE
Issue #2813: JavadocTagContinuationIndentation doesn't report some lines

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
@@ -30,7 +30,11 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 
 /**
  * <p>
- * Checks the indentation of the continuation lines in at-clauses.
+ * Checks the indentation of the continuation lines in at-clauses. That is whether the continued
+ * description of at clauses should be indented or not. If the text is not properly indented it
+ * throws a violation. A continuation line is when the description starts/spans past the line with
+ * the tag. Default indentation required is at least 4, but this can be changed with the help of
+ * properties below.
  * </p>
  * <ul>
  * <li>
@@ -148,9 +152,8 @@ public class JavadocTagContinuationIndentationCheck extends AbstractJavadocCheck
         if (!isInlineDescription(ast)) {
             final List<DetailNode> textNodes = getAllNewlineNodes(ast);
             for (DetailNode newlineNode : textNodes) {
-                final DetailNode textNode = JavadocUtil.getNextSibling(JavadocUtil
-                        .getNextSibling(newlineNode));
-                if (textNode != null && textNode.getType() == JavadocTokenTypes.TEXT) {
+                final DetailNode textNode = JavadocUtil.getNextSibling(newlineNode);
+                if (textNode.getType() == JavadocTokenTypes.TEXT) {
                     final String text = textNode.getText();
                     if (!CommonUtil.isBlank(text.trim())
                             && (text.length() <= offset
@@ -172,7 +175,7 @@ public class JavadocTagContinuationIndentationCheck extends AbstractJavadocCheck
         final List<DetailNode> textNodes = new ArrayList<>();
         DetailNode node = JavadocUtil.getFirstChild(descriptionNode);
         while (JavadocUtil.getNextSibling(node) != null) {
-            if (node.getType() == JavadocTokenTypes.NEWLINE) {
+            if (node.getType() == JavadocTokenTypes.LEADING_ASTERISK) {
                 textNodes.add(node);
             }
             node = JavadocUtil.getNextSibling(node);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
@@ -93,4 +93,20 @@ public class JavadocTagContinuationIndentationCheckTest
                 expected);
     }
 
+    @Test
+    public void testCheckWithDescription() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(JavadocTagContinuationIndentationCheck.class);
+        final String[] expected = {
+            "9: " + getCheckMessage(MSG_KEY, 4),
+            "10: " + getCheckMessage(MSG_KEY, 4),
+            "11: " + getCheckMessage(MSG_KEY, 4),
+            "40: " + getCheckMessage(MSG_KEY, 4),
+            "42: " + getCheckMessage(MSG_KEY, 4),
+            "43: " + getCheckMessage(MSG_KEY, 4),
+        };
+        verify(checkConfig, getPath("InputJavadocTagContinuationIndentationDescription.java"),
+                expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentation.java
@@ -16,7 +16,7 @@ import java.io.Serializable;
  */
 class InputJavadocTagContinuationIndentation implements Serializable
 {
-        /**
+    /**
      * The client's first name.
      * @serial Some javadoc.
      *     Some javadoc.

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationDescription.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationDescription.java
@@ -1,0 +1,46 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctagcontinuationindentation;
+
+/** Config: default */
+public class InputJavadocTagContinuationIndentationDescription {
+    /**
+     * General Description here.
+     *
+     * @param s
+     * Description 1. // violation
+     * Description 2. // violation
+     * Description 3. // violation
+     *                         Description 4 with extra indentation.
+     *
+     *
+     */
+    public void testWithInvalidIndentation(String s) {}
+
+    /**
+     * General Description here.
+     *
+     * @param a
+     *     Description 1
+     * @param b
+     *     Description 2
+     */
+    public void testWithValidIndentation(int a, int b) {}
+
+    /** This is an inline description */
+    public void testWithInlineDescription() {}
+
+    /**
+     * General Description.
+     * @param x
+       Description 1.
+     */
+    public void testWithMissingAsterisk(int x) {}
+
+    /**
+     * @param s
+     *Description with missing space.
+     * @param s2
+     *****Description with multiple asterisk and missing space
+     ***** Description with multiple asterisk and missing space
+     */
+    public void testOtherCases(String s, String s2) {}
+}

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -1608,7 +1608,11 @@ public class Test {
       <p>Since Checkstyle 6.0</p>
       <subsection name="Description" id="JavadocTagContinuationIndentation_Description">
         <p>
-          Checks the indentation of the continuation lines in at-clauses.
+          Checks the indentation of the continuation lines in at-clauses. That is whether the
+          continued description of at clauses should be indented or not. If the text is not properly
+          indented it throws a violation. A continuation line is when the description starts/spans
+          past the line with the tag. Default indentation required is at least 4, but this can be
+          changed with the help of properties below.
         </p>
       </subsection>
 


### PR DESCRIPTION
Fixes issue #2813 

### Cause of the issue
Originally in this, we retrieved all the new line nodes (`\n`) in the Javadoc and considered their 2nd next sibling as our description. The problem with this technique was that it was failing to consider the first description in the example below .i.e `Description 1` because according to the AST `Description 1` is not 2nd next sibling of `\n`, hence it was not being violated as specified in the issue. 
```
    /**
     * @param s
     * Description 1.
     * Description 2.
     */
     public void test(String s) {}
```

### Solution
To solve this problem, I changed the traversing technique. Now we are retrieving all the `LEADING_ASTRISK` nodes, as from my observation each description is followed by a `LEADIN_ASTERISK`. The important change in this technique is that a `LEADING_ASTRISK` is always followed by either a `NEWLINE` or `TEXT` node. Hence I had to remove the condition `textNode != null` in method `visitJavadocToken` to achieve 100% branch coverage as I couldn't find any case where `LEADING_ASTRISK` was not followed by `NEWLINE`


#### Note
```
/**
 * @param s
 *                  Some description here // not a violation
 */
public void test() {}
```
I didn't consider the above case as a violation because it has minimum indentation of 4 char and many of the projects have indentations greater than min length. So we cannot provide this check by default. Either we'll need to add a new property for this or we'll need to change the violated Javadoc in the all the projects.

#### Regression Report
https://gaurav-punjabi.github.io/checkstyle/issue-2813/index.html