### PR TITLE
Issue #7987: use RegexpSingleline Check to validate amount of tests in Xpath tests

### DIFF
--- a/config/checkstyle_non_main_files_checks.xml
+++ b/config/checkstyle_non_main_files_checks.xml
@@ -17,6 +17,7 @@
     <!-- Miscellaneous -->
     <module name="NewlineAtEndOfFile" />
     <module name="RegexpSingleline">
+      <property name="id" value="lineLength"/>
       <!-- catch lines above 100 symbols -->
       <property name="format"
                value="^(?!(.*href=|.*http(s)?:|import |(.* )?package |.* files=|.*\.dtd)).{101,}$"/>

--- a/config/checkstyle_non_main_files_checks.xml
+++ b/config/checkstyle_non_main_files_checks.xml
@@ -23,4 +23,14 @@
                value="^(?!(.*href=|.*http(s)?:|import |(.* )?package |.* files=|.*\.dtd)).{101,}$"/>
       <property name="message" value="Line should not be longer than 100 symbols"/>
     </module>
+    <!-- check the number of testCases -->
+    <module name="RegexpSingleline">
+      <property name="id" value="numberOfTestCasesInXpath"/>
+      <property name="format" value="@Test"/>
+      <property name="minimum" value="2"/>
+      <property name="maximum" value="9999"/>
+      <property name="fileExtensions" value="java"/>
+      <property name="message"
+               value="Two or more test cases are required for unit testing in Xpath "/>
+    </module>
 </module>

--- a/config/checkstyle_non_main_files_suppressions.xml
+++ b/config/checkstyle_non_main_files_suppressions.xml
@@ -44,64 +44,64 @@
               files="[\\/]test[\\/].*[\\/]checks[\\/]uniqueproperties[\\/]InputUniquePropertiesWithDuplicates\.properties"/>
 
     <!-- till https://issues.apache.org/jira/browse/MRELEASE-1008 -->
-    <suppress checks="RegexpSingleline" files="pom.xml"/>
+    <suppress id="lineLength" files="pom.xml"/>
     <!-- this file is created by Appveyor CI after checkout -->
-    <suppress checks="RegexpSingleline" files="appveyor.cmd"/>
+    <suppress id="lineLength" files="appveyor.cmd"/>
     <!-- test resources are weird by design, no validations in them -->
-    <suppress checks="RegexpSingleline"
+    <suppress id="lineLength"
               files="src[\\/]it[\\/]resources[\\/].*[\\/]InputLineLength.*\.java"/>
-    <suppress checks="RegexpSingleline"
+    <suppress id="lineLength"
               files="src[\\/]test[\\/]resources[\\/].*[\\/]InputLineLength.*\.java"/>
-    <suppress checks="RegexpSingleline"
+    <suppress id="lineLength"
               files="src[\\/]test[\\/]resources[\\/].*[\\/]grammar[\\/]comments[\\/].*"/>
-    <suppress checks="RegexpSingleline"
+    <suppress id="lineLength"
               files="src[\\/]test[\\/]resources[\\/].*[\\/]asttreestringprinter[\\/]InputAstTreeStringPrinterFullOfBlockComments\.java"/>
-    <suppress checks="RegexpSingleline"
+    <suppress id="lineLength"
               files="src[\\/]test[\\/]resources[\\/].*[\\/]abstractjavadoc[\\/]InputAbstractJavadocPosition.*\.java"/>
 
     <!-- we can not change expected as it will require change of main class logic -->
-    <suppress checks="RegexpSingleline"
+    <suppress id="lineLength"
               files="src[\\/]test[\\/]resources[\\/].*[\\/].*ExpectedXMLLogger.*\.xml"/>
-    <suppress checks="RegexpSingleline"
+    <suppress id="lineLength"
               files="src[\\/]test[\\/]resources[\\/].*[\\/]ant[\\/]checkstyleanttask[\\/]ExpectedCheckstyleAntTaskXmlOutput\.xml"/>
-    <suppress checks="RegexpSingleline"
+    <suppress id="lineLength"
               files="src[\\/]test[\\/]resources[\\/].*[\\/]checks[\\/]translation[\\/]Expected.*\.xml"/>
 
     <!-- content is generated -->
-    <suppress checks="RegexpSingleline"
+    <suppress id="lineLength"
               files="src[\\/]xdocs[\\/]releasenotes_old.xml"/>
-    <suppress checks="RegexpSingleline"
+    <suppress id="lineLength"
               files="src[\\/]xdocs[\\/]releasenotes.xml"/>
     <!-- it contains list of html text, no way to wrap -->
-    <suppress checks="RegexpSingleline"
+    <suppress id="lineLength"
               files=".ci[\\/]pitest.sh"/>
     <!-- property names a too long, nothing we can do -->
-    <suppress checks="RegexpSingleline"
+    <suppress id="lineLength"
               files="config[\\/]org.eclipse.jdt.core.prefs"/>
     <!-- there is no way to make line wrap in property value -->
-    <suppress checks="RegexpSingleline"
+    <suppress id="lineLength"
               files="config[\\/]intellij-idea-inspection-scope.xml"/>
 
     <!-- there is no way to make line wrap in property value -->
-    <suppress checks="RegexpSingleline"
+    <suppress id="lineLength"
               files="src[\\/]test[\\/]resources[\\/].*[\\/]customimportorder"/>
 
     <!-- there is no way to make line wrap in property value -->
-    <suppress checks="RegexpSingleline"
+    <suppress id="lineLength"
               files="src[\\/]test[\\/]resources-noncompilable[\\/].*[\\/]customimportorder"/>
 
     <!-- untill https://github.com/checkstyle/checkstyle/issues/8036 -->
-    <suppress checks="RegexpSingleline"
+    <suppress id="lineLength"
               files="[\\/]InputFinalClassClassWithPrivateCtorWithNestedExtendingClass.java"/>
-    <suppress checks="RegexpSingleline"
+    <suppress id="lineLength"
               files="[\\/]InputJavadocMethod_1379666.java"/>
-        <suppress checks="RegexpSingleline"
+    <suppress id="lineLength"
               files="[\\/]grammar[\\/]InputJava7MultiCatch.java"/>
-    <suppress checks="RegexpSingleline"
+    <suppress id="lineLength"
               files="src[\\/]test[\\/]resources[\\/].*[\\/]checks[\\/]coding[\\/]illegaltype[\\/]InputIllegalType.*\.java"/>
-    <suppress checks="RegexpSingleline"
+    <suppress id="lineLength"
               files="src[\\/]test[\\/]resources[\\/].*[\\/]checks[\\/]coding[\\/]illegaltype[\\/]InputIllegalTypeMemberModifiers.*\.java"/>
-    <suppress checks="RegexpSingleline"
+    <suppress id="lineLength"
               files="src[\\/]test[\\/]resources[\\/].*[\\/]checks[\\/]metrics[\\/]classfanoutcomplexity[\\/]InputClassFanOutComplexityPackageName.*\.java"/>
 
 </suppressions>

--- a/config/checkstyle_non_main_files_suppressions.xml
+++ b/config/checkstyle_non_main_files_suppressions.xml
@@ -104,4 +104,64 @@
     <suppress id="lineLength"
               files="src[\\/]test[\\/]resources[\\/].*[\\/]checks[\\/]metrics[\\/]classfanoutcomplexity[\\/]InputClassFanOutComplexityPackageName.*\.java"/>
 
+    <!-- apply check numberOfTestCasesInXpath only for files in suppressionxpathfilter directory -->
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]java[\\/]com[\\/].*" />
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]base[\\/].*" />
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]checks[\\/].*" />
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]resources[\\/].*" />
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]resources-noncompilable[\\/].*" />
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]java[\\/]com[\\/].*" />
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]test[\\/].*" />
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]site[\\/].*" />
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]xdocs[\\/].*" />
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]AbstractXpathTestSupport.java"/>
+
+    <!-- Until https://github.com/checkstyle/checkstyle/issues/8151 -->
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionAnonInnerLengthTest.java"/>
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionAvoidDoubleBraceInitializationTest.java"/>
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionAvoidNoArgumentSuperConstructorCallTest.java"/>
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionJavadocStyleTest.java"/>
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionJavadocStyleTest.java"/>
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionNestedForDepthTest.java"/>
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionNestedIfDepthTest.java"/>
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionNestedTryDepthTest.java"/>
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionNoWhitespaceAfterTest.java"/>
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionNoWhitespaceBeforeTest.java"/>
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionOneTopLevelClassTest.java"/>
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionOuterTypeNumberTest.java"/>
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionSingleSpaceSeparatorTest.java"/>
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionSuppressWarningsHolderTest.java"/>
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest.java"/>
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionUnnecessarySemicolonInEnumerationTest.java"/>
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionUnnecessarySemicolonInTryWithResourcesTest.java"/>
+    <suppress  id="numberOfTestCasesInXpath"
+               files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionUpperEllTest.java"/>
+
 </suppressions>


### PR DESCRIPTION
This resolves #7987 

### Description
use ```@Test``` occurrences in the test files in suppressionxpathfilter directory to validate the number of test cases written.

### sample
```
public class XpathRegressionAnonInnerLengthTest extends AbstractXpathTestSupport {

    private final String checkName = AnonInnerLengthCheck.class.getSimpleName();

    @Override
    protected String getCheckName() {
        return checkName;
    }

    @Test
    public void testMaxLength() throws Exception {
        final int maxLen = 5;
        final File fileToProcess =
                new File(getPath("SuppressionXpathRegressionAnonInnerLength.java"));

        final DefaultConfiguration moduleConfig =
                createModuleConfig(AnonInnerLengthCheck.class);
        moduleConfig.addAttribute("max", String.valueOf(maxLen));

        final String[] expectedViolation = {
            "7:41: " + getCheckMessage(AnonInnerLengthCheck.class,
                    AnonInnerLengthCheck.MSG_KEY, 6, maxLen),
        };

        final List<String> expectedXpathQueries = Arrays.asList(
                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnonInnerLength']]"
                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='compare']]/SLIST"
                        + "/VARIABLE_DEF[./IDENT[@text='comparator']]/ASSIGN/EXPR",
                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnonInnerLength']]"
                        + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='compare']]/SLIST"
                        + "/VARIABLE_DEF[./IDENT[@text='comparator']]/ASSIGN/EXPR"
                        + "/LITERAL_NEW[./IDENT[@text='Comparator']]"
        );

        runVerifications(moduleConfig, fileToProcess, expectedViolation,
                expectedXpathQueries);
    }

}
```
#### output
```
[checkstyle] [ERROR] /home/malintha/Documents/projects/checkstyle/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAnonInnerLengthTest.java:1: Two or more test cases are required [numberOfTestCases]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:17 min
[INFO] Finished at: 2020-04-01T20:38:09+05:30
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:1.8:run (ant-phase-verify) on project checkstyle: An Ant BuildException has occured: The following error occurred while executing this line:
[ERROR] /home/malintha/Documents/projects/checkstyle/config/ant-phase-verify.xml:64: Got 1 errors and 0 warnings.
[ERROR] around Ant part ...<ant antfile="config/ant-phase-verify.xml"/>... @ 8:47 in /home/malintha/Documents/projects/checkstyle/target/antrun/build-main.xml
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException

```