### PR TITLE
Issue #6582: static final option for AbbreviationAsWordInName

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
@@ -50,6 +50,14 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * is what should be used to enforce strict camel casing. The identifier 'MyTest' would
  * be allowed, but 'MyTEst' would not be.
  * </p>
+ * <p>
+ * {@code ignoreFinal}, {@code ignoreStatic}, and {@code ignoreStaticFinal}
+ * control whether variables with the respective modifiers are to be ignored.
+ * Note that a variable that is both static and final will always be considered under
+ * {@code ignoreStaticFinal} only, regardless of the values of {@code ignoreFinal}
+ * and {@code ignoreStatic}. So for example if {@code ignoreStatic} is true but
+ * {@code ignoreStaticFinal} is false, then static final variables will not be ignored.
+ * </p>
  * <ul>
  * <li>
  * Property {@code allowedAbbreviationLength} - Indicate the number of consecutive capital
@@ -67,6 +75,10 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <li>
  * Property {@code ignoreStatic} - Allow to skip variables with {@code static} modifier. Default
  * value is {@code true}.
+ * </li>
+ * <li>
+ * Property {@code ignoreStaticFinal} - Allow to skip variables with both {@code static} and
+ * {@code final} modifiers. Default value is {@code true}.
  * </li>
  * <li>
  * Property {@code ignoreOverriddenMethods} - Allow to ignore methods tagged with {@code @Override}
@@ -123,6 +135,8 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *                         // and only 1 consecutive capital letter is allowed
  *   String firstXML; // OK, XML abbreviation is allowed
  *   String firstURL; // OK, URL abbreviation is allowed
+ *   final int TOTAL = 5; // OK, final is ignored
+ *   static final int LIMIT = 10; // OK, static final is ignored
  * }
  * </pre>
  * <p>
@@ -152,6 +166,54 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *                         // would be ignored
  *   String firstCSV; // OK, CSV abbreviation is allowed
  *   String firstXML; // violation, XML abbreviation is not allowed
+ *   final int TOTAL = 5; // OK, final is ignored
+ *   static final int LIMIT = 10; // OK, static final is ignored
+ * }
+ * </pre>
+ * <p>
+ * To configure to check variables, enforcing no abbreviations
+ * except for variables that are both static and final.
+ * </p>
+ * <p>Configuration:</p>
+ * <pre>
+ * &lt;module name="AbbreviationAsWordInName"&gt;
+ *     &lt;property name="tokens" value="VARIABLE_DEF"/&gt;
+ *     &lt;property name="ignoreFinal" value="false"/&gt;
+ *     &lt;property name="ignoreStatic" value="false"/&gt;
+ *     &lt;property name="ignoreStaticFinal" value="true"/&gt;
+ *     &lt;property name="allowedAbbreviationLength" value="0"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public class MyClass {
+ *     public int counterXYZ = 1;                // violation
+ *     public final int customerID = 2;          // violation
+ *     public static int nextID = 3;             // violation
+ *     public static final int MAX_ALLOWED = 4;  // OK, ignored
+ * }
+ * </pre>
+ * <p>
+ * To configure to check variables, enforcing no abbreviations
+ * and ignoring static (but non-final) variables only.
+ * </p>
+ * <p>Configuration:</p>
+ * <pre>
+ * &lt;module name="AbbreviationAsWordInName"&gt;
+ *     &lt;property name="tokens" value="VARIABLE_DEF"/&gt;
+ *     &lt;property name="ignoreFinal" value="false"/&gt;
+ *     &lt;property name="ignoreStatic" value="true"/&gt;
+ *     &lt;property name="ignoreStaticFinal" value="false"/&gt;
+ *     &lt;property name="allowedAbbreviationLength" value="0"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public class MyClass {
+ *     public int counterXYZ = 1;                // violation
+ *     public final int customerID = 2;          // violation
+ *     public static int nextID = 3;             // OK, ignored
+ *     public static final int MAX_ALLOWED = 4;  // violation
  * }
  * </pre>
  *
@@ -190,6 +252,9 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
     /** Allow to skip variables with {@code static} modifier. */
     private boolean ignoreStatic = true;
 
+    /** Allow to skip variables with both {@code static} and {@code final} modifiers. */
+    private boolean ignoreStaticFinal = true;
+
     /**
      * Allow to ignore methods tagged with {@code @Override} annotation (that
      * usually mean inherited name).
@@ -214,6 +279,15 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
      */
     public void setIgnoreStatic(boolean ignoreStatic) {
         this.ignoreStatic = ignoreStatic;
+    }
+
+    /**
+     * Setter to allow to skip variables with both {@code static} and {@code final} modifiers.
+     * @param ignoreStaticFinal
+     *        Defines if ignore variables with both 'static' and 'final' modifiers or not.
+     */
+    public void setIgnoreStaticFinal(boolean ignoreStaticFinal) {
+        this.ignoreStaticFinal = ignoreStaticFinal;
     }
 
     /**
@@ -306,23 +380,18 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
      * @param ast input DetailAST node.
      * @return true if it is an ignore situation found for given input DetailAST
      *         node.
-     * @noinspection SimplifiableIfStatement
      */
     private boolean isIgnoreSituation(DetailAST ast) {
         final DetailAST modifiers = ast.getFirstChild();
 
         final boolean result;
         if (ast.getType() == TokenTypes.VARIABLE_DEF) {
-            if ((ignoreFinal || ignoreStatic)
-                    && isInterfaceDeclaration(ast)) {
+            if (isInterfaceDeclaration(ast)) {
                 // field declarations in interface are static/final
-                result = true;
+                result = ignoreStaticFinal;
             }
             else {
-                result = ignoreFinal
-                          && modifiers.findFirstToken(TokenTypes.FINAL) != null
-                    || ignoreStatic
-                        && modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) != null;
+                result = hasIgnoredModifiers(modifiers);
             }
         }
         else if (ast.getType() == TokenTypes.METHOD_DEF) {
@@ -330,6 +399,24 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
         }
         else {
             result = CheckUtil.isReceiverParameter(ast);
+        }
+        return result;
+    }
+
+    /**
+     * Checks if a variable is to be ignored based on its modifiers.
+     * @param modifiers modifiers of the variable to be checked
+     * @return true if there is a modifier to be ignored
+     */
+    private boolean hasIgnoredModifiers(DetailAST modifiers) {
+        final boolean isStatic = modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) != null;
+        final boolean isFinal = modifiers.findFirstToken(TokenTypes.FINAL) != null;
+        final boolean result;
+        if (isStatic && isFinal) {
+            result = ignoreStaticFinal;
+        }
+        else {
+            result = ignoreStatic && isStatic || ignoreFinal && isFinal;
         }
         return result;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
@@ -140,6 +140,7 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         checkConfig.addAttribute("allowedAbbreviations", "NUMBER,MARAZMATIC,VARIABLE");
         checkConfig.addAttribute("ignoreStatic", "false");
         checkConfig.addAttribute("ignoreFinal", "false");
+        checkConfig.addAttribute("ignoreStaticFinal", "false");
         checkConfig.addAttribute("tokens", "CLASS_DEF"
             + ",VARIABLE_DEF"
             + ",METHOD_DEF,ENUM_DEF,ENUM_CONSTANT_DEF"
@@ -148,16 +149,19 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 6;
 
         final String[] expected = {
-            "32:11: " + getWarningMessage("AbstractINNERRClass", expectedCapitalCount),
-            "37:11: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
-            "38:21: " + getWarningMessage("marazmaticMETHODName", expectedCapitalCount),
-            "66:16: " + getWarningMessage("VALUEEEE", expectedCapitalCount),
-            "72:23: " + getWarningMessage("VALUEEEE", expectedCapitalCount),
-            "78:22: " + getWarningMessage("VALUEEEE", expectedCapitalCount),
-            "84:29: " + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "44:15: " + getWarningMessage("AbstractINNERRClass", expectedCapitalCount),
+            "49:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "50:25: " + getWarningMessage("marazmaticMETHODName", expectedCapitalCount),
+            "78:16: " + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "84:23: " + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "90:22: " + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "96:29: " + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "134:17: " + getWarningMessage("InnerClassOneVIOLATION", expectedCapitalCount),
+            "138:18: " + getWarningMessage("InnerClassTwoVIOLATION", expectedCapitalCount),
+            "142:24: " + getWarningMessage("InnerClassThreeVIOLATION", expectedCapitalCount),
         };
 
-        verify(checkConfig, getPath("InputAbbreviationAsWordInNameType.java"), expected);
+        verify(checkConfig, getPath("InputAbbreviationAsWordInNameNoIgnore.java"), expected);
     }
 
     @Test
@@ -168,6 +172,7 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         checkConfig.addAttribute("allowedAbbreviations", "NUMBER,MARAZMATIC,VARIABLE");
         checkConfig.addAttribute("ignoreStatic", "true");
         checkConfig.addAttribute("ignoreFinal", "true");
+        checkConfig.addAttribute("ignoreStaticFinal", "true");
         checkConfig.addAttribute("tokens", "CLASS_DEF"
             + ",VARIABLE_DEF"
             + ",METHOD_DEF,ENUM_DEF,ENUM_CONSTANT_DEF"
@@ -176,12 +181,15 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 6;
 
         final String[] expected = {
-            "32:11: " + getWarningMessage("AbstractINNERRClass", expectedCapitalCount),
-            "37:11: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
-            "38:21: " + getWarningMessage("marazmaticMETHODName", expectedCapitalCount),
+            "44:15: " + getWarningMessage("AbstractINNERRClass", expectedCapitalCount),
+            "49:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "50:25: " + getWarningMessage("marazmaticMETHODName", expectedCapitalCount),
+            "134:17: " + getWarningMessage("InnerClassOneVIOLATION", expectedCapitalCount),
+            "138:18: " + getWarningMessage("InnerClassTwoVIOLATION", expectedCapitalCount),
+            "142:24: " + getWarningMessage("InnerClassThreeVIOLATION", expectedCapitalCount),
         };
 
-        verify(checkConfig, getPath("InputAbbreviationAsWordInNameType.java"), expected);
+        verify(checkConfig, getPath("InputAbbreviationAsWordInNameIgnore.java"), expected);
     }
 
     @Test
@@ -192,6 +200,7 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         checkConfig.addAttribute("allowedAbbreviations", "MARAZMATIC,VARIABLE");
         checkConfig.addAttribute("ignoreStatic", "false");
         checkConfig.addAttribute("ignoreFinal", "true");
+        checkConfig.addAttribute("ignoreStaticFinal", "true");
         checkConfig.addAttribute("tokens", "CLASS_DEF"
             + ",VARIABLE_DEF"
             + ",METHOD_DEF,ENUM_DEF,ENUM_CONSTANT_DEF"
@@ -200,41 +209,218 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         final int expectedCapitalCount = 5;
 
         final String[] expected = {
-            "12:16: " + getWarningMessage("AbstractCLASSName", expectedCapitalCount),
-            "32:11: " + getWarningMessage("AbstractINNERRClass", expectedCapitalCount),
-            "37:11: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
-            "38:21: " + getWarningMessage("marazmaticMETHODName", expectedCapitalCount),
-            "58:20: "
+            "24:20: " + getWarningMessage("AbstractCLASSName", expectedCapitalCount),
+            "44:15: " + getWarningMessage("AbstractINNERRClass", expectedCapitalCount),
+            "49:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "50:25: " + getWarningMessage("marazmaticMETHODName", expectedCapitalCount),
+            "70:20: "
                 + getWarningMessage("serialNUMBER", expectedCapitalCount), // not in ignore list
-            "60:28: "
+            "72:28: "
                 + getWarningMessage("s2erialNUMBER", expectedCapitalCount), // no ignore for static
         };
 
-        verify(checkConfig, getPath("InputAbbreviationAsWordInNameType.java"), expected);
+        verify(checkConfig, getPath(
+                "InputAbbreviationAsWordInNameIgnoreFinal.java"), expected);
     }
 
     @Test
     public void testTypeAndVariablesAndMethodNamesWithIgnoresStatic() throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(AbbreviationAsWordInNameCheck.class);
-        checkConfig.addAttribute("allowedAbbreviationLength", "5");
+        checkConfig.addAttribute("allowedAbbreviationLength", "4");
         checkConfig.addAttribute("allowedAbbreviations", "MARAZMATIC,VARIABLE");
         checkConfig.addAttribute("ignoreStatic", "true");
         checkConfig.addAttribute("ignoreFinal", "false");
+        checkConfig.addAttribute("ignoreStaticFinal", "true");
         checkConfig.addAttribute("tokens", "CLASS_DEF"
             + ",VARIABLE_DEF"
             + ",METHOD_DEF,ENUM_DEF,ENUM_CONSTANT_DEF"
             + ",PARAMETER_DEF,INTERFACE_DEF,ANNOTATION_DEF");
         checkConfig.addAttribute("ignoreOverriddenMethods", "true");
-        final int expectedCapitalCount = 6;
+        final int expectedCapitalCount = 5;
 
         final String[] expected = {
-            "32:11: " + getWarningMessage("AbstractINNERRClass", expectedCapitalCount),
-            "37:11: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
-            "38:21: " + getWarningMessage("marazmaticMETHODName", expectedCapitalCount),
+            "24:20: " + getWarningMessage("AbstractCLASSName", expectedCapitalCount),
+            "44:15: " + getWarningMessage("AbstractINNERRClass", expectedCapitalCount),
+            "49:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "50:25: " + getWarningMessage("marazmaticMETHODName", expectedCapitalCount),
+            "70:20: "
+                + getWarningMessage("serialNUMBER", expectedCapitalCount), // not in ignore list
+            "71:26: "
+                + getWarningMessage("s1erialNUMBER", expectedCapitalCount), // no ignore for final
         };
 
-        verify(checkConfig, getPath("InputAbbreviationAsWordInNameType.java"), expected);
+        verify(checkConfig, getPath(
+                "InputAbbreviationAsWordInNameIgnoreStatic.java"), expected);
+    }
+
+    @Test
+    public void testTypeAndVariablesAndMethodNamesWithIgnoresStaticFinal() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(AbbreviationAsWordInNameCheck.class);
+        checkConfig.addAttribute("allowedAbbreviationLength", "4");
+        checkConfig.addAttribute("allowedAbbreviations", "MARAZMATIC,VARIABLE");
+        checkConfig.addAttribute("ignoreStatic", "false");
+        checkConfig.addAttribute("ignoreFinal", "false");
+        checkConfig.addAttribute("ignoreStaticFinal", "true");
+        checkConfig.addAttribute("tokens", "CLASS_DEF"
+            + ",VARIABLE_DEF"
+            + ",METHOD_DEF,ENUM_DEF,ENUM_CONSTANT_DEF"
+            + ",PARAMETER_DEF,INTERFACE_DEF,ANNOTATION_DEF");
+        checkConfig.addAttribute("ignoreOverriddenMethods", "true");
+        final int expectedCapitalCount = 5;
+
+        final String[] expected = {
+            "24:20: " + getWarningMessage("AbstractCLASSName", expectedCapitalCount),
+            "44:15: " + getWarningMessage("AbstractINNERRClass", expectedCapitalCount),
+            "49:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "50:25: " + getWarningMessage("marazmaticMETHODName", expectedCapitalCount),
+            "70:20: "
+                + getWarningMessage("serialNUMBER", expectedCapitalCount), // not in ignore list
+            "71:26: "
+                + getWarningMessage("s1erialNUMBER", expectedCapitalCount), // no ignore for final
+            "72:28: "
+                + getWarningMessage("s2erialNUMBER", expectedCapitalCount), // no ignore for static
+        };
+
+        verify(checkConfig, getPath(
+                "InputAbbreviationAsWordInNameIgnoreStaticFinal.java"), expected);
+    }
+
+    @Test
+    public void testTypeAndVariablesAndMethodNamesWithIgnoresNonStaticFinal() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(AbbreviationAsWordInNameCheck.class);
+        checkConfig.addAttribute("allowedAbbreviationLength", "4");
+        checkConfig.addAttribute("allowedAbbreviations", "MARAZMATIC,VARIABLE");
+        checkConfig.addAttribute("ignoreStatic", "true");
+        checkConfig.addAttribute("ignoreFinal", "true");
+        checkConfig.addAttribute("ignoreStaticFinal", "false");
+        checkConfig.addAttribute("tokens", "CLASS_DEF"
+            + ",VARIABLE_DEF"
+            + ",METHOD_DEF,ENUM_DEF,ENUM_CONSTANT_DEF"
+            + ",PARAMETER_DEF,INTERFACE_DEF,ANNOTATION_DEF");
+        checkConfig.addAttribute("ignoreOverriddenMethods", "true");
+        final int expectedCapitalCount = 5;
+
+        final String[] expected = {
+            "24:20: " + getWarningMessage("AbstractCLASSName", expectedCapitalCount),
+            "44:15: " + getWarningMessage("AbstractINNERRClass", expectedCapitalCount),
+            "49:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "50:25: " + getWarningMessage("marazmaticMETHODName", expectedCapitalCount),
+            "70:20: "
+                + getWarningMessage("serialNUMBER", expectedCapitalCount), // not in ignore list
+            "73:34: " // no ignore for static final
+                + getWarningMessage("s3erialNUMBER", expectedCapitalCount),
+            "78:16: "
+                + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "84:23: "
+                + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "90:22: "
+                + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "96:29: "
+                + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "119:16: "
+                + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "123:23: "
+                + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "127:22: "
+                + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "131:29: "
+                + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "134:17: " + getWarningMessage("InnerClassOneVIOLATION", expectedCapitalCount),
+            "138:18: " + getWarningMessage("InnerClassTwoVIOLATION", expectedCapitalCount),
+            "142:24: " + getWarningMessage("InnerClassThreeVIOLATION", expectedCapitalCount),
+        };
+
+        verify(checkConfig, getPath(
+                "InputAbbreviationAsWordInNameIgnoreNonStaticFinal.java"), expected);
+    }
+
+    @Test
+    public void testTypeAndVariablesAndMethodNamesWithIgnoresFinalKeepStaticFinal()
+            throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(AbbreviationAsWordInNameCheck.class);
+        checkConfig.addAttribute("allowedAbbreviationLength", "4");
+        checkConfig.addAttribute("allowedAbbreviations", "MARAZMATIC,VARIABLE");
+        checkConfig.addAttribute("ignoreStatic", "false");
+        checkConfig.addAttribute("ignoreFinal", "true");
+        checkConfig.addAttribute("ignoreStaticFinal", "false");
+        checkConfig.addAttribute("tokens", "CLASS_DEF"
+            + ",VARIABLE_DEF"
+            + ",METHOD_DEF,ENUM_DEF,ENUM_CONSTANT_DEF"
+            + ",PARAMETER_DEF,INTERFACE_DEF,ANNOTATION_DEF");
+        checkConfig.addAttribute("ignoreOverriddenMethods", "true");
+        final int expectedCapitalCount = 5;
+
+        final String[] expected = {
+            "24:20: " + getWarningMessage("AbstractCLASSName", expectedCapitalCount),
+            "44:15: " + getWarningMessage("AbstractINNERRClass", expectedCapitalCount),
+            "49:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "50:25: " + getWarningMessage("marazmaticMETHODName", expectedCapitalCount),
+            "70:20: "
+                + getWarningMessage("serialNUMBER", expectedCapitalCount), // not in ignore list
+            "72:28: "
+                + getWarningMessage("s2erialNUMBER", expectedCapitalCount), // no ignore for static
+            "73:34: " // no ignore for static final
+                + getWarningMessage("s3erialNUMBER", expectedCapitalCount),
+            "78:16: "
+                + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "84:23: "
+                + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "90:22: "
+                + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "96:29: "
+                + getWarningMessage("VALUEEEE", expectedCapitalCount),
+        };
+
+        verify(checkConfig,
+                getPath("InputAbbreviationAsWordInNameIgnoreFinalKeepStaticFinal.java"),
+                expected);
+    }
+
+    @Test
+    public void testTypeAndVariablesAndMethodNamesWithIgnoresStaticKeepStaticFinal()
+            throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(AbbreviationAsWordInNameCheck.class);
+        checkConfig.addAttribute("allowedAbbreviationLength", "4");
+        checkConfig.addAttribute("allowedAbbreviations", "MARAZMATIC,VARIABLE");
+        checkConfig.addAttribute("ignoreStatic", "true");
+        checkConfig.addAttribute("ignoreFinal", "false");
+        checkConfig.addAttribute("ignoreStaticFinal", "false");
+        checkConfig.addAttribute("tokens", "CLASS_DEF"
+            + ",VARIABLE_DEF"
+            + ",METHOD_DEF,ENUM_DEF,ENUM_CONSTANT_DEF"
+            + ",PARAMETER_DEF,INTERFACE_DEF,ANNOTATION_DEF");
+        checkConfig.addAttribute("ignoreOverriddenMethods", "true");
+        final int expectedCapitalCount = 5;
+
+        final String[] expected = {
+            "24:20: " + getWarningMessage("AbstractCLASSName", expectedCapitalCount),
+            "44:15: " + getWarningMessage("AbstractINNERRClass", expectedCapitalCount),
+            "49:15: " + getWarningMessage("WellNamedFACTORY", expectedCapitalCount),
+            "50:25: " + getWarningMessage("marazmaticMETHODName", expectedCapitalCount),
+            "70:20: "
+                + getWarningMessage("serialNUMBER", expectedCapitalCount), // not in ignore list
+            "71:26: "
+                + getWarningMessage("s1erialNUMBER", expectedCapitalCount), // no ignore for final
+            "73:34: " // no ignore for static final
+                + getWarningMessage("s3erialNUMBER", expectedCapitalCount),
+            "78:16: "
+                + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "84:23: "
+                + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "90:22: "
+                + getWarningMessage("VALUEEEE", expectedCapitalCount),
+            "96:29: "
+                + getWarningMessage("VALUEEEE", expectedCapitalCount),
+        };
+
+        verify(checkConfig,
+                getPath("InputAbbreviationAsWordInNameIgnoreStaticKeepStaticFinal.java"),
+                expected);
     }
 
     @Test
@@ -284,6 +470,7 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
         checkConfig.addAttribute("allowedAbbreviations", "");
         checkConfig.addAttribute("ignoreStatic", "false");
         checkConfig.addAttribute("ignoreFinal", "false");
+        checkConfig.addAttribute("ignoreStaticFinal", "false");
         checkConfig.addAttribute("ignoreOverriddenMethods", "false");
         checkConfig.addAttribute("tokens", "CLASS_DEF,INTERFACE_DEF,ENUM_DEF,"
             + "ANNOTATION_DEF,ANNOTATION_FIELD_DEF,ENUM_CONSTANT_DEF,"

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnore.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnore.java
@@ -1,0 +1,146 @@
+package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
+
+/*
+ * Config:
+ * allowedAbbreviationLength = 5
+ * allowedAbbreviations = NUMBER,MARAZMATIC,VARIABLE
+ * tokens = CLASS_DEF,VARIABLE_DEF,METHOD_DEF,ENUM_DEF,ENUM_CONSTANT_DEF,
+ *      PARAMETER_DEF,INTERFACE_DEF,ANNOTATION_DEF
+ * ignoreStatic = true
+ * ignoreFinal = true
+ * ignoreStaticFinal = true
+ */
+public class InputAbbreviationAsWordInNameIgnore {
+
+    abstract class InputAbbreviationAsWordInNameType {
+    }
+
+    abstract class NonAAAAbstractClassName {
+    }
+
+    abstract class FactoryWithBADNAme {
+    }
+
+    abstract class AbstractCLASSName {
+        abstract class NonAbstractInnerClass {
+        }
+    }
+
+    abstract class ClassFactory1 {
+        abstract class WellNamedFactory {
+        }
+    }
+
+    class NonAbstractClass1 {
+    }
+
+    class AbstractClass1 {
+    }
+
+    class Class1Factory1 {
+    }
+
+    abstract class AbstractClassName3 {
+        class AbstractINNERRClass { // violation
+        }
+    }
+
+    abstract class Class3Factory {
+        class WellNamedFACTORY { // violation
+            public void marazmaticMETHODName() { // violation
+                int marazmaticVARIABLEName = 2;
+                int MARAZMATICVariableName = 1;
+            }
+        }
+    }
+
+    interface Directions {
+      int RIGHT=1;
+      int LEFT=2;
+      int UP=3;
+      int DOWN=4;
+    }
+
+    interface BadNameForInterface
+    {
+       void interfaceMethod();
+    }
+
+    abstract static class NonAAAAbstractClassName2 {
+        public int serialNUMBER = 6;
+        public final int s1erialNUMBER = 6;
+        private static int s2erialNUMBER = 6;
+        private static final int s3erialNUMBER = 6;
+    }
+
+    interface Interface1 {
+
+        String VALUEEEE = "value"; // in interface this is final/static
+
+    }
+
+    interface Interface2 {
+
+        static String VALUEEEE = "value"; // in interface this is final/static
+
+    }
+
+    interface Interface3 {
+
+        final String VALUEEEE = "value"; // in interface this is final/static
+
+    }
+
+    interface Interface4 {
+
+        final static String VALUEEEE = "value"; // in interface this is final/static
+
+    }
+
+    class FIleNameFormatException extends Exception {
+
+        private static final long serialVersionUID = 1L;
+
+        public FIleNameFormatException(Exception e) {
+            super(e);
+        }
+    }
+
+    class StateX {
+        int userID;
+        int scaleX, scaleY, scaleZ;
+
+        int getScaleX() {
+            return this.scaleX;
+        }
+    }
+
+    @interface Annotation1 {
+        String VALUE = "value"; // in @interface this is final/static
+    }
+
+    @interface Annotation2 {
+        static String VALUE = "value"; // in @interface this is final/static
+    }
+
+    @interface Annotation3 {
+        final String VALUE = "value"; // in @interface this is final/static
+    }
+
+    @interface Annotation4 {
+        final static String VALUE = "value"; // in @interface this is final/static
+    }
+
+    final class InnerClassOneVIOLATION { // violation
+        // only variable definitions are affected by ignore static/final properties
+    }
+
+    static class InnerClassTwoVIOLATION { // violation
+        // only variable definitions are affected by ignore static/final properties
+    }
+
+    static final class InnerClassThreeVIOLATION { // violation
+        // only variable definitions are affected by ignore static/final properties
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreFinal.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreFinal.java
@@ -1,0 +1,134 @@
+package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
+
+/*
+ * Config:
+ * allowedAbbreviationLength = 4
+ * allowedAbbreviations = MARAZMATIC,VARIABLE
+ * tokens = CLASS_DEF,VARIABLE_DEF,METHOD_DEF,ENUM_DEF,ENUM_CONSTANT_DEF,
+ *      PARAMETER_DEF,INTERFACE_DEF,ANNOTATION_DEF
+ * ignoreStatic = false
+ * ignoreFinal = true
+ * ignoreStaticFinal = false
+ */
+public class InputAbbreviationAsWordInNameIgnoreFinal {
+
+    abstract class InputAbbreviationAsWordInNameType {
+    }
+
+    abstract class NonAAAAbstractClassName {
+    }
+
+    abstract class FactoryWithBADNAme {
+    }
+
+    abstract class AbstractCLASSName { // violation
+        abstract class NonAbstractInnerClass {
+        }
+    }
+
+    abstract class ClassFactory1 {
+        abstract class WellNamedFactory {
+        }
+    }
+
+    class NonAbstractClass1 {
+    }
+
+    class AbstractClass1 {
+    }
+
+    class Class1Factory1 {
+    }
+
+    abstract class AbstractClassName3 {
+        class AbstractINNERRClass { // violation
+        }
+    }
+
+    abstract class Class3Factory {
+        class WellNamedFACTORY { // violation
+            public void marazmaticMETHODName() { // violation
+                int marazmaticVARIABLEName = 2;
+                int MARAZMATICVariableName = 1;
+            }
+        }
+    }
+
+    interface Directions {
+      int RIGHT=1;
+      int LEFT=2;
+      int UP=3;
+      int DOWN=4;
+    }
+
+    interface BadNameForInterface
+    {
+       void interfaceMethod();
+    }
+
+    abstract static class NonAAAAbstractClassName2 {
+        public int serialNUMBER = 6; // violation
+        public final int s1erialNUMBER = 6;
+        private static int s2erialNUMBER = 6; // violation
+        private static final int s3erialNUMBER = 6;
+    }
+
+    interface Interface1 {
+
+        String VALUEEEE = "value"; // in interface this is final/static
+
+    }
+
+    interface Interface2 {
+
+        static String VALUEEEE = "value"; // in interface this is final/static
+
+    }
+
+    interface Interface3 {
+
+        final String VALUEEEE = "value"; // in interface this is final/static
+
+    }
+
+    interface Interface4 {
+
+        final static String VALUEEEE = "value"; // in interface this is final/static
+
+    }
+
+    class FIleNameFormatException extends Exception {
+
+        private static final long serialVersionUID = 1L;
+
+        public FIleNameFormatException(Exception e) {
+            super(e);
+        }
+    }
+
+    class StateX {
+        int userID;
+        int scaleX, scaleY, scaleZ;
+
+        int getScaleX() {
+            return this.scaleX;
+        }
+    }
+
+    @interface Annotation1 {
+        String VALUE = "value"; // in @interface this is final/static
+    }
+
+    @interface Annotation2 {
+        static String VALUE = "value"; // in @interface this is final/static
+    }
+
+    @interface Annotation3 {
+        final String VALUE = "value"; // in @interface this is final/static
+    }
+
+    @interface Annotation4 {
+        final static String VALUE = "value"; // in @interface this is final/static
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreFinalKeepStaticFinal.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreFinalKeepStaticFinal.java
@@ -1,0 +1,134 @@
+package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
+
+/*
+ * Config:
+ * allowedAbbreviationLength = 4
+ * allowedAbbreviations = MARAZMATIC,VARIABLE
+ * tokens = CLASS_DEF,VARIABLE_DEF,METHOD_DEF,ENUM_DEF,ENUM_CONSTANT_DEF,
+ *      PARAMETER_DEF,INTERFACE_DEF,ANNOTATION_DEF
+ * ignoreStatic = false
+ * ignoreFinal = true
+ * ignoreStaticFinal = false
+ */
+public class InputAbbreviationAsWordInNameIgnoreFinalKeepStaticFinal {
+
+    abstract class InputAbbreviationAsWordInNameType {
+    }
+
+    abstract class NonAAAAbstractClassName {
+    }
+
+    abstract class FactoryWithBADNAme {
+    }
+
+    abstract class AbstractCLASSName { // violation
+        abstract class NonAbstractInnerClass {
+        }
+    }
+
+    abstract class ClassFactory1 {
+        abstract class WellNamedFactory {
+        }
+    }
+
+    class NonAbstractClass1 {
+    }
+
+    class AbstractClass1 {
+    }
+
+    class Class1Factory1 {
+    }
+
+    abstract class AbstractClassName3 {
+        class AbstractINNERRClass { // violation
+        }
+    }
+
+    abstract class Class3Factory {
+        class WellNamedFACTORY { // violation
+            public void marazmaticMETHODName() { // violation
+                int marazmaticVARIABLEName = 2;
+                int MARAZMATICVariableName = 1;
+            }
+        }
+    }
+
+    interface Directions {
+      int RIGHT=1;
+      int LEFT=2;
+      int UP=3;
+      int DOWN=4;
+    }
+
+    interface BadNameForInterface
+    {
+       void interfaceMethod();
+    }
+
+    abstract static class NonAAAAbstractClassName2 {
+        public int serialNUMBER = 6; // violation
+        public final int s1erialNUMBER = 6;
+        private static int s2erialNUMBER = 6; // violation
+        private static final int s3erialNUMBER = 6; // violation
+    }
+
+    interface Interface1 {
+
+        String VALUEEEE = "value"; // violation
+
+    }
+
+    interface Interface2 {
+
+        static String VALUEEEE = "value"; // violation
+
+    }
+
+    interface Interface3 {
+
+        final String VALUEEEE = "value"; // violation
+
+    }
+
+    interface Interface4 {
+
+        final static String VALUEEEE = "value"; // violation
+
+    }
+
+    class FIleNameFormatException extends Exception {
+
+        private static final long serialVersionUID = 1L;
+
+        public FIleNameFormatException(Exception e) {
+            super(e);
+        }
+    }
+
+    class StateX {
+        int userID;
+        int scaleX, scaleY, scaleZ;
+
+        int getScaleX() {
+            return this.scaleX;
+        }
+    }
+
+    @interface Annotation1 {
+        String VALUE = "value"; // in @interface this is final/static
+    }
+
+    @interface Annotation2 {
+        static String VALUE = "value"; // in @interface this is final/static
+    }
+
+    @interface Annotation3 {
+        final String VALUE = "value"; // in @interface this is final/static
+    }
+
+    @interface Annotation4 {
+        final static String VALUE = "value"; // in @interface this is final/static
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreNonStaticFinal.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreNonStaticFinal.java
@@ -1,0 +1,146 @@
+package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
+
+/*
+ * Config:
+ * allowedAbbreviationLength = 4
+ * allowedAbbreviations = MARAZMATIC,VARIABLE
+ * tokens = CLASS_DEF,VARIABLE_DEF,METHOD_DEF,ENUM_DEF,ENUM_CONSTANT_DEF,
+ *      PARAMETER_DEF,INTERFACE_DEF,ANNOTATION_DEF
+ * ignoreStatic = true
+ * ignoreFinal = true
+ * ignoreStaticFinal = false
+ */
+public class InputAbbreviationAsWordInNameIgnoreNonStaticFinal {
+
+    abstract class InputAbbreviationAsWordInNameType {
+    }
+
+    abstract class NonAAAAbstractClassName {
+    }
+
+    abstract class FactoryWithBADNAme {
+    }
+
+    abstract class AbstractCLASSName { // violation
+        abstract class NonAbstractInnerClass {
+        }
+    }
+
+    abstract class ClassFactory1 {
+        abstract class WellNamedFactory {
+        }
+    }
+
+    class NonAbstractClass1 {
+    }
+
+    class AbstractClass1 {
+    }
+
+    class Class1Factory1 {
+    }
+
+    abstract class AbstractClassName3 {
+        class AbstractINNERRClass { // violation
+        }
+    }
+
+    abstract class Class3Factory {
+        class WellNamedFACTORY { // violation
+            public void marazmaticMETHODName() { // violation
+                int marazmaticVARIABLEName = 2;
+                int MARAZMATICVariableName = 1;
+            }
+        }
+    }
+
+    interface Directions {
+      int RIGHT=1;
+      int LEFT=2;
+      int UP=3;
+      int DOWN=4;
+    }
+
+    interface BadNameForInterface
+    {
+       void interfaceMethod();
+    }
+
+    abstract static class NonAAAAbstractClassName2 {
+        public int serialNUMBER = 6; // violation
+        public final int s1erialNUMBER = 6;
+        private static int s2erialNUMBER = 6;
+        private static final int s3erialNUMBER = 6; // violation
+    }
+
+    interface Interface1 {
+
+        String VALUEEEE = "value"; // violation
+
+    }
+
+    interface Interface2 {
+
+        static String VALUEEEE = "value"; // violation
+
+    }
+
+    interface Interface3 {
+
+        final String VALUEEEE = "value"; // violation
+
+    }
+
+    interface Interface4 {
+
+        final static String VALUEEEE = "value"; // violation
+
+    }
+
+    class FIleNameFormatException extends Exception {
+
+        private static final long serialVersionUID = 1L;
+
+        public FIleNameFormatException(Exception e) {
+            super(e);
+        }
+    }
+
+    class StateX {
+        int userID;
+        int scaleX, scaleY, scaleZ;
+
+        int getScaleX() {
+            return this.scaleX;
+        }
+    }
+
+    @interface Annotation1 {
+        String VALUEEEE = "value"; // violation
+    }
+
+    @interface Annotation2 {
+        static String VALUEEEE = "value"; // violation
+    }
+
+    @interface Annotation3 {
+        final String VALUEEEE = "value"; // violation
+    }
+
+    @interface Annotation4 {
+        final static String VALUEEEE = "value"; // violation
+    }
+
+    final class InnerClassOneVIOLATION { // violation
+        // only variable definitions are affected by ignore static/final properties
+    }
+
+    static class InnerClassTwoVIOLATION { // violation
+        // only variable definitions are affected by ignore static/final properties
+    }
+
+    static final class InnerClassThreeVIOLATION { // violation
+        // only variable definitions are affected by ignore static/final properties
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreStatic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreStatic.java
@@ -1,0 +1,134 @@
+package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
+
+/*
+ * Config:
+ * allowedAbbreviationLength = 4
+ * allowedAbbreviations = MARAZMATIC,VARIABLE
+ * tokens = CLASS_DEF,VARIABLE_DEF,METHOD_DEF,ENUM_DEF,ENUM_CONSTANT_DEF,
+ *      PARAMETER_DEF,INTERFACE_DEF,ANNOTATION_DEF
+ * ignoreStatic = true
+ * ignoreFinal = false
+ * ignoreStaticFinal = true
+ */
+public class InputAbbreviationAsWordInNameIgnoreStatic {
+
+    abstract class InputAbbreviationAsWordInNameType {
+    }
+
+    abstract class NonAAAAbstractClassName {
+    }
+
+    abstract class FactoryWithBADNAme {
+    }
+
+    abstract class AbstractCLASSName { // violation
+        abstract class NonAbstractInnerClass {
+        }
+    }
+
+    abstract class ClassFactory1 {
+        abstract class WellNamedFactory {
+        }
+    }
+
+    class NonAbstractClass1 {
+    }
+
+    class AbstractClass1 {
+    }
+
+    class Class1Factory1 {
+    }
+
+    abstract class AbstractClassName3 {
+        class AbstractINNERRClass { // violation
+        }
+    }
+
+    abstract class Class3Factory {
+        class WellNamedFACTORY { // violation
+            public void marazmaticMETHODName() { // violation
+                int marazmaticVARIABLEName = 2;
+                int MARAZMATICVariableName = 1;
+            }
+        }
+    }
+
+    interface Directions {
+      int RIGHT=1;
+      int LEFT=2;
+      int UP=3;
+      int DOWN=4;
+    }
+
+    interface BadNameForInterface
+    {
+       void interfaceMethod();
+    }
+
+    abstract static class NonAAAAbstractClassName2 {
+        public int serialNUMBER = 6; // violation
+        public final int s1erialNUMBER = 6; // violation
+        private static int s2erialNUMBER = 6;
+        private static final int s3erialNUMBER = 6;
+    }
+
+    interface Interface1 {
+
+        String VALUEEEE = "value"; // in interface this is final/static
+
+    }
+
+    interface Interface2 {
+
+        static String VALUEEEE = "value"; // in interface this is final/static
+
+    }
+
+    interface Interface3 {
+
+        final String VALUEEEE = "value"; // in interface this is final/static
+
+    }
+
+    interface Interface4 {
+
+        final static String VALUEEEE = "value"; // in interface this is final/static
+
+    }
+
+    class FIleNameFormatException extends Exception {
+
+        private static final long serialVersionUID = 1L;
+
+        public FIleNameFormatException(Exception e) {
+            super(e);
+        }
+    }
+
+    class StateX {
+        int userID;
+        int scaleX, scaleY, scaleZ;
+
+        int getScaleX() {
+            return this.scaleX;
+        }
+    }
+
+    @interface Annotation1 {
+        String VALUE = "value"; // in @interface this is final/static
+    }
+
+    @interface Annotation2 {
+        static String VALUE = "value"; // in @interface this is final/static
+    }
+
+    @interface Annotation3 {
+        final String VALUE = "value"; // in @interface this is final/static
+    }
+
+    @interface Annotation4 {
+        final static String VALUE = "value"; // in @interface this is final/static
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreStaticFinal.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreStaticFinal.java
@@ -1,0 +1,134 @@
+package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
+
+/*
+ * Config:
+ * allowedAbbreviationLength = 4
+ * allowedAbbreviations = MARAZMATIC,VARIABLE
+ * tokens = CLASS_DEF,VARIABLE_DEF,METHOD_DEF,ENUM_DEF,ENUM_CONSTANT_DEF,
+ *      PARAMETER_DEF,INTERFACE_DEF,ANNOTATION_DEF
+ * ignoreStatic = false
+ * ignoreFinal = false
+ * ignoreStaticFinal = true
+ */
+public class InputAbbreviationAsWordInNameIgnoreStaticFinal {
+
+    abstract class InputAbbreviationAsWordInNameType {
+    }
+
+    abstract class NonAAAAbstractClassName {
+    }
+
+    abstract class FactoryWithBADNAme {
+    }
+
+    abstract class AbstractCLASSName { // violation
+        abstract class NonAbstractInnerClass {
+        }
+    }
+
+    abstract class ClassFactory1 {
+        abstract class WellNamedFactory {
+        }
+    }
+
+    class NonAbstractClass1 {
+    }
+
+    class AbstractClass1 {
+    }
+
+    class Class1Factory1 {
+    }
+
+    abstract class AbstractClassName3 {
+        class AbstractINNERRClass { // violation
+        }
+    }
+
+    abstract class Class3Factory {
+        class WellNamedFACTORY { // violation
+            public void marazmaticMETHODName() { // violation
+                int marazmaticVARIABLEName = 2;
+                int MARAZMATICVariableName = 1;
+            }
+        }
+    }
+
+    interface Directions {
+      int RIGHT=1;
+      int LEFT=2;
+      int UP=3;
+      int DOWN=4;
+    }
+
+    interface BadNameForInterface
+    {
+       void interfaceMethod();
+    }
+
+    abstract static class NonAAAAbstractClassName2 {
+        public int serialNUMBER = 6; // violation
+        public final int s1erialNUMBER = 6; // violation
+        private static int s2erialNUMBER = 6; // violation
+        private static final int s3erialNUMBER = 6;
+    }
+
+    interface Interface1 {
+
+        String VALUEEEE = "value"; // in interface this is final/static
+
+    }
+
+    interface Interface2 {
+
+        static String VALUEEEE = "value"; // in interface this is final/static
+
+    }
+
+    interface Interface3 {
+
+        final String VALUEEEE = "value"; // in interface this is final/static
+
+    }
+
+    interface Interface4 {
+
+        final static String VALUEEEE = "value"; // in interface this is final/static
+
+    }
+
+    class FIleNameFormatException extends Exception {
+
+        private static final long serialVersionUID = 1L;
+
+        public FIleNameFormatException(Exception e) {
+            super(e);
+        }
+    }
+
+    class StateX {
+        int userID;
+        int scaleX, scaleY, scaleZ;
+
+        int getScaleX() {
+            return this.scaleX;
+        }
+    }
+
+    @interface Annotation1 {
+        String VALUE = "value"; // in @interface this is final/static
+    }
+
+    @interface Annotation2 {
+        static String VALUE = "value"; // in @interface this is final/static
+    }
+
+    @interface Annotation3 {
+        final String VALUE = "value"; // in @interface this is final/static
+    }
+
+    @interface Annotation4 {
+        final static String VALUE = "value"; // in @interface this is final/static
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreStaticKeepStaticFinal.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameIgnoreStaticKeepStaticFinal.java
@@ -1,0 +1,134 @@
+package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
+
+/*
+ * Config:
+ * allowedAbbreviationLength = 4
+ * allowedAbbreviations = MARAZMATIC,VARIABLE
+ * tokens = CLASS_DEF,VARIABLE_DEF,METHOD_DEF,ENUM_DEF,ENUM_CONSTANT_DEF,
+ *      PARAMETER_DEF,INTERFACE_DEF,ANNOTATION_DEF
+ * ignoreStatic = true
+ * ignoreFinal = false
+ * ignoreStaticFinal = false
+ */
+public class InputAbbreviationAsWordInNameIgnoreStaticKeepStaticFinal {
+
+    abstract class InputAbbreviationAsWordInNameType {
+    }
+
+    abstract class NonAAAAbstractClassName {
+    }
+
+    abstract class FactoryWithBADNAme {
+    }
+
+    abstract class AbstractCLASSName { // violation
+        abstract class NonAbstractInnerClass {
+        }
+    }
+
+    abstract class ClassFactory1 {
+        abstract class WellNamedFactory {
+        }
+    }
+
+    class NonAbstractClass1 {
+    }
+
+    class AbstractClass1 {
+    }
+
+    class Class1Factory1 {
+    }
+
+    abstract class AbstractClassName3 {
+        class AbstractINNERRClass { // violation
+        }
+    }
+
+    abstract class Class3Factory {
+        class WellNamedFACTORY { // violation
+            public void marazmaticMETHODName() { // violation
+                int marazmaticVARIABLEName = 2;
+                int MARAZMATICVariableName = 1;
+            }
+        }
+    }
+
+    interface Directions {
+      int RIGHT=1;
+      int LEFT=2;
+      int UP=3;
+      int DOWN=4;
+    }
+
+    interface BadNameForInterface
+    {
+       void interfaceMethod();
+    }
+
+    abstract static class NonAAAAbstractClassName2 {
+        public int serialNUMBER = 6; // violation
+        public final int s1erialNUMBER = 6; // violation
+        private static int s2erialNUMBER = 6;
+        private static final int s3erialNUMBER = 6; // violation
+    }
+
+    interface Interface1 {
+
+        String VALUEEEE = "value"; // violation
+
+    }
+
+    interface Interface2 {
+
+        static String VALUEEEE = "value"; // violation
+
+    }
+
+    interface Interface3 {
+
+        final String VALUEEEE = "value"; // violation
+
+    }
+
+    interface Interface4 {
+
+        final static String VALUEEEE = "value"; // violation
+
+    }
+
+    class FIleNameFormatException extends Exception {
+
+        private static final long serialVersionUID = 1L;
+
+        public FIleNameFormatException(Exception e) {
+            super(e);
+        }
+    }
+
+    class StateX {
+        int userID;
+        int scaleX, scaleY, scaleZ;
+
+        int getScaleX() {
+            return this.scaleX;
+        }
+    }
+
+    @interface Annotation1 {
+        String VALUE = "value"; // in @interface this is final/static
+    }
+
+    @interface Annotation2 {
+        static String VALUE = "value"; // in @interface this is final/static
+    }
+
+    @interface Annotation3 {
+        final String VALUE = "value"; // in @interface this is final/static
+    }
+
+    @interface Annotation4 {
+        final static String VALUE = "value"; // in @interface this is final/static
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameNoIgnore.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameNoIgnore.java
@@ -1,0 +1,146 @@
+package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
+
+/*
+ * Config:
+ * allowedAbbreviationLength = 5
+ * allowedAbbreviations = NUMBER,MARAZMATIC,VARIABLE
+ * tokens = CLASS_DEF,VARIABLE_DEF,METHOD_DEF,ENUM_DEF,ENUM_CONSTANT_DEF,
+ *      PARAMETER_DEF,INTERFACE_DEF,ANNOTATION_DEF
+ * ignoreStatic = false
+ * ignoreFinal = false
+ * ignoreStaticFinal = false
+ */
+public class InputAbbreviationAsWordInNameNoIgnore {
+
+    abstract class InputAbbreviationAsWordInNameType {
+    }
+
+    abstract class NonAAAAbstractClassName {
+    }
+
+    abstract class FactoryWithBADNAme {
+    }
+
+    abstract class AbstractCLASSName {
+        abstract class NonAbstractInnerClass {
+        }
+    }
+
+    abstract class ClassFactory1 {
+        abstract class WellNamedFactory {
+        }
+    }
+
+    class NonAbstractClass1 {
+    }
+
+    class AbstractClass1 {
+    }
+
+    class Class1Factory1 {
+    }
+
+    abstract class AbstractClassName3 {
+        class AbstractINNERRClass { // violation
+        }
+    }
+
+    abstract class Class3Factory {
+        class WellNamedFACTORY { // violation
+            public void marazmaticMETHODName() { // violation
+                int marazmaticVARIABLEName = 2;
+                int MARAZMATICVariableName = 1;
+            }
+        }
+    }
+
+    interface Directions {
+      int RIGHT=1;
+      int LEFT=2;
+      int UP=3;
+      int DOWN=4;
+    }
+
+    interface BadNameForInterface
+    {
+       void interfaceMethod();
+    }
+
+    abstract static class NonAAAAbstractClassName2 {
+        public int serialNUMBER = 6;
+        public final int s1erialNUMBER = 6;
+        private static int s2erialNUMBER = 6;
+        private static final int s3erialNUMBER = 6;
+    }
+
+    interface Interface1 {
+
+        String VALUEEEE = "value"; // in interface this is final/static
+
+    }
+
+    interface Interface2 {
+
+        static String VALUEEEE = "value"; // in interface this is final/static
+
+    }
+
+    interface Interface3 {
+
+        final String VALUEEEE = "value"; // in interface this is final/static
+
+    }
+
+    interface Interface4 {
+
+        final static String VALUEEEE = "value"; // in interface this is final/static
+
+    }
+
+    class FIleNameFormatException extends Exception {
+
+        private static final long serialVersionUID = 1L;
+
+        public FIleNameFormatException(Exception e) {
+            super(e);
+        }
+    }
+
+    class StateX {
+        int userID;
+        int scaleX, scaleY, scaleZ;
+
+        int getScaleX() {
+            return this.scaleX;
+        }
+    }
+
+    @interface Annotation1 {
+        String VALUE = "value"; // in @interface this is final/static
+    }
+
+    @interface Annotation2 {
+        static String VALUE = "value"; // in @interface this is final/static
+    }
+
+    @interface Annotation3 {
+        final String VALUE = "value"; // in @interface this is final/static
+    }
+
+    @interface Annotation4 {
+        final static String VALUE = "value"; // in @interface this is final/static
+    }
+
+    final class InnerClassOneVIOLATION { // violation
+        // only variable definitions are affected by ignore static/final properties
+    }
+
+    static class InnerClassTwoVIOLATION { // violation
+        // only variable definitions are affected by ignore static/final properties
+    }
+
+    static final class InnerClassThreeVIOLATION { // violation
+        // only variable definitions are affected by ignore static/final properties
+    }
+
+}

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -53,6 +53,15 @@
          is what should be used to enforce strict camel casing. The identifier 'MyTest' would
          be allowed, but 'MyTEst' would not be.
         </p>
+
+        <p>
+          <code>ignoreFinal</code>, <code>ignoreStatic</code>, and <code>ignoreStaticFinal</code>
+          control whether variables with the respective modifiers are to be ignored.
+          Note that a variable that is both static and final will always be considered under
+          <code>ignoreStaticFinal</code> only, regardless of the values of <code>ignoreFinal</code>
+          and <code>ignoreStatic</code>. So for example if <code>ignoreStatic</code> is true but
+          <code>ignoreStaticFinal</code> is false, then static final variables will not be ignored.
+        </p>
       </subsection>
 
        <subsection name="Properties" id="AbbreviationAsWordInName_Properties">
@@ -95,6 +104,14 @@
                <td><a href="property_types.html#boolean">Boolean</a></td>
                <td><code>true</code></td>
                <td>5.8</td>
+             </tr>
+             <tr>
+               <td>ignoreStaticFinal</td>
+               <td>Allow to skip variables with both <code>static</code>
+                 and <code>final</code> modifiers.</td>
+               <td><a href="property_types.html#boolean">Boolean</a></td>
+               <td><code>true</code></td>
+               <td>8.32</td>
              </tr>
              <tr>
                <td>ignoreOverriddenMethods</td>
@@ -184,6 +201,8 @@ public class MyClass { // OK
                         // and only 1 consecutive capital letter is allowed
   String firstXML; // OK, XML abbreviation is allowed
   String firstURL; // OK, URL abbreviation is allowed
+  final int TOTAL = 5; // OK, final is ignored
+  static final int LIMIT = 10; // OK, static final is ignored
 }
         </source>
         <p>
@@ -213,6 +232,54 @@ public class MyClass { // OK, ignore checking the class name
                         // would be ignored
   String firstCSV; // OK, CSV abbreviation is allowed
   String firstXML; // violation, XML abbreviation is not allowed
+  final int TOTAL = 5; // OK, final is ignored
+  static final int LIMIT = 10; // OK, static final is ignored
+}
+        </source>
+        <p>
+          To configure to check variables, enforcing no abbreviations
+          except for variables that are both static and final.
+        </p>
+        <p>Configuration:</p>
+        <source>
+&lt;module name="AbbreviationAsWordInName"&gt;
+    &lt;property name="tokens" value="VARIABLE_DEF"/&gt;
+    &lt;property name="ignoreFinal" value="false"/&gt;
+    &lt;property name="ignoreStatic" value="false"/&gt;
+    &lt;property name="ignoreStaticFinal" value="true"/&gt;
+    &lt;property name="allowedAbbreviationLength" value="0"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class MyClass {
+    public int counterXYZ = 1;                // violation
+    public final int customerID = 2;          // violation
+    public static int nextID = 3;             // violation
+    public static final int MAX_ALLOWED = 4;  // OK, ignored
+}
+        </source>
+        <p>
+          To configure to check variables, enforcing no abbreviations
+          and ignoring static (but non-final) variables only.
+        </p>
+        <p>Configuration:</p>
+        <source>
+&lt;module name="AbbreviationAsWordInName"&gt;
+    &lt;property name="tokens" value="VARIABLE_DEF"/&gt;
+    &lt;property name="ignoreFinal" value="false"/&gt;
+    &lt;property name="ignoreStatic" value="true"/&gt;
+    &lt;property name="ignoreStaticFinal" value="false"/&gt;
+    &lt;property name="allowedAbbreviationLength" value="0"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class MyClass {
+    public int counterXYZ = 1;                // violation
+    public final int customerID = 2;          // violation
+    public static int nextID = 3;             // OK, ignored
+    public static final int MAX_ALLOWED = 4;  // violation
 }
         </source>
       </subsection>


### PR DESCRIPTION
Issue #6582: static final option for AbbreviationAsWordInName

Currently, we are able to ignore `static` fields and `final` fields separately, but have no way to ignore only variables that are both `static` and `final`, which are usually (but not necessarily) constants.

I have added a new property `ignoreStaticFinal` to the check. The default value is `true` so that anyone running the default configuration (i.e. `ignoreStatic` and `ignoreFinal` both true) will not notice any difference in violations as a result of this change.

Note however that a `static final` variable will only respect `ignoreStaticFinal` and not `ignoreStatic` or `ignoreFinal`. For example, if `ignoreStatic` is false but `ignoreStaticFinal` remains true, only `static` and non-`final` variables will be ignored.

An alternative implementation is to have `ignoreStaticFinal` be overshadowed by `ignoreStatic` and `ignoreFinal` if either is true. This is what I came up with originally, but it felt less intuitive as we would want `ignoreStaticFinal` to be respected when it is explicitly set to false.

Regression (for default configuration): https://wltan.github.io/checkstyle-reports/2020-04-05/abbrword-staticfinal/
Regression for all other cases - https://github.com/checkstyle/checkstyle/pull/8017#issuecomment-609686830

A potential problem is that if existing projects do not want ignores at all, they will have configured `ignoreStatic` and `ignoreFinal` to false but `ignoreStaticFinal` comes with a default value of true, so there will be a lot of missing violations until the config is updated to make `ignoreStaticFinal` false as well.

Sample run:
```D:\checkstyletest>type config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <property name="charset" value="UTF-8"/>

    <module name="TreeWalker">
        <module name="AbbreviationAsWordInName">
            <property name="ignoreFinal" value="false"/>
            <property name="ignoreStatic" value="false"/>
            <property name="ignoreStaticFinal" value="true"/>
            <property name="allowedAbbreviationLength" value="0"/>
        </module>
    </module>
</module>

D:\checkstyletest>type test\*.java

test\Test.java


public class MyClass {
    public int AAAA = 1;              // violation, not ignored
    public final int BBBB = 2;        // violation, not ignored
    public static int CCCC = 3;       // violation, not ignored
    public static final int DDDD = 4; // OK, ignored
}

D:\checkstyletest>java -jar -Duser.language=en -Duser.country=US checkstyle-8.32-SNAPSHOT-all.jar -c config.xml test\*.java
Starting audit...
[ERROR] D:\checkstyletest\test\Test.java:2:16: Abbreviation in name 'AAAA' must contain no more than '1' consecutive capital letters. [AbbreviationAsWordInName]
[ERROR] D:\checkstyletest\test\Test.java:3:22: Abbreviation in name 'BBBB' must contain no more than '1' consecutive capital letters. [AbbreviationAsWordInName]
[ERROR] D:\checkstyletest\test\Test.java:4:23: Abbreviation in name 'CCCC' must contain no more than '1' consecutive capital letters. [AbbreviationAsWordInName]
Audit done.
Checkstyle ends with 3 errors.
```
Documentation has been updated as follows:

![image](https://user-images.githubusercontent.com/53135010/79121170-43f03100-7dc7-11ea-92a8-bfefb47b5ec6.png)

![image](https://user-images.githubusercontent.com/53135010/79121201-510d2000-7dc7-11ea-9c58-14f9e4b525af.png)

