### PR TITLE
Issue #7758: Update AbstractChecks to log DetailAST - PackageDeclaration

### DIFF
--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionPackageDeclarationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionPackageDeclarationTest.java
@@ -1,0 +1,85 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.coding.PackageDeclarationCheck;
+
+public class XpathRegressionPackageDeclarationTest extends AbstractXpathTestSupport {
+
+    private final String checkName = PackageDeclarationCheck.class.getSimpleName();
+
+    @Override
+    protected String getCheckName() {
+        return checkName;
+    }
+
+    @Test
+    public void test1() throws Exception {
+        final File fileToProcess =
+                new File(getNonCompilablePath("SuppressionXpathRegression1.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(PackageDeclarationCheck.class);
+
+        final String[] expectedViolation = {
+            "2:1: " + getCheckMessage(PackageDeclarationCheck.class,
+                    PackageDeclarationCheck.MSG_KEY_MISMATCH),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/PACKAGE_DEF"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void test2() throws Exception {
+        final File fileToProcess =
+                new File(getNonCompilablePath("SuppressionXpathRegression2.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(PackageDeclarationCheck.class);
+
+        final String[] expectedViolation = {
+            "3:1: " + getCheckMessage(PackageDeclarationCheck.class,
+                    PackageDeclarationCheck.MSG_KEY_MISSING),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegression2']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegression2']]/MODIFIERS",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegression2']]/MODIFIERS/LITERAL_PUBLIC"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+}

--- a/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/packagedeclaration/SuppressionXpathRegression1.java
+++ b/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/packagedeclaration/SuppressionXpathRegression1.java
@@ -1,0 +1,6 @@
+// non-compiled with javac: wrong package. Used for Testing purpose.
+package my.packagename.mismatch.with.folder; // warn
+
+public class SuppressionXpathRegression1 {
+	// code
+}

--- a/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/packagedeclaration/SuppressionXpathRegression2.java
+++ b/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/packagedeclaration/SuppressionXpathRegression2.java
@@ -1,0 +1,5 @@
+// non-compiled with javac: missing package. Used for Testing purpose.
+// package is missing.
+public class SuppressionXpathRegression2 { // warn
+	// code
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheck.java
@@ -42,6 +42,13 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * These directories are added to the classpath so that your classes
  * are visible to JVM when it runs the code.
  * </p>
+ * <p>
+ * <b>Note:</b>
+ * This Check is partially supported by Xpath Suppression Filters. In case of testing empty
+ * java files, Xpath Suppression Filters are not supported for this Check.
+ * (until
+ * <a href="https://github.com/checkstyle/checkstyle/pull/8110">#8110</a>)
+ * </p>
  * <ul>
  * <li>
  * Property {@code matchDirectoryStructure} - Control whether to check for
@@ -141,11 +148,12 @@ public final class PackageDeclarationCheck extends AbstractCheck {
     @Override
     public void finishTree(DetailAST ast) {
         if (!defined) {
-            int lineNumber = DEFAULT_LINE_NUMBER;
-            if (ast != null) {
-                lineNumber = ast.getLineNo();
+            if (ast == null) {
+                log(DEFAULT_LINE_NUMBER, MSG_KEY_MISSING);
             }
-            log(lineNumber, MSG_KEY_MISSING);
+            else {
+                log(ast, MSG_KEY_MISSING);
+            }
         }
     }
 
@@ -161,7 +169,7 @@ public final class PackageDeclarationCheck extends AbstractCheck {
             final String directoryName = getDirectoryName();
 
             if (!directoryName.endsWith(packageName)) {
-                log(fullIdent.getLineNo(), MSG_KEY_MISMATCH, packageName);
+                log(ast, MSG_KEY_MISMATCH, packageName);
             }
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -68,9 +68,6 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * MissingJavadocType
  * </li>
  * <li>
- * PackageDeclaration
- * </li>
- * <li>
  * Regexp
  * </li>
  * <li>
@@ -87,6 +84,15 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * </li>
  * <li>
  * VariableDeclarationUsageDistance
+ * </li>
+ * </ul>
+ * <p>
+ * Certain Checks are partially supported by the filter:
+ * </p>
+ * <ul>
+ * <li>
+ * PackageDeclaration (until
+ * <a href="https://github.com/checkstyle/checkstyle/pull/8110">#8110</a>)
  * </li>
  * </ul>
  * <p>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheckTest.java
@@ -41,7 +41,7 @@ public class PackageDeclarationCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(PackageDeclarationCheck.class);
 
         final String[] expected = {
-            "1: " + getCheckMessage(MSG_KEY_MISSING),
+            "1:1: " + getCheckMessage(MSG_KEY_MISSING),
         };
 
         verify(checkConfig, getPath("InputPackageDeclarationNoPackage.java"), expected);
@@ -72,7 +72,7 @@ public class PackageDeclarationCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(PackageDeclarationCheck.class);
 
         final String[] expected = {
-            "1: " + getCheckMessage(MSG_KEY_MISMATCH),
+            "1:1: " + getCheckMessage(MSG_KEY_MISMATCH),
         };
 
         verify(checkConfig,
@@ -84,7 +84,7 @@ public class PackageDeclarationCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(PackageDeclarationCheck.class);
 
         final String[] expected = {
-            "1: " + getCheckMessage(MSG_KEY_MISMATCH),
+            "1:1: " + getCheckMessage(MSG_KEY_MISMATCH),
         };
 
         verify(checkConfig,
@@ -97,7 +97,7 @@ public class PackageDeclarationCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(PackageDeclarationCheck.class);
 
         final String[] expected = {
-            "1: " + getCheckMessage(MSG_KEY_MISMATCH),
+            "1:1: " + getCheckMessage(MSG_KEY_MISMATCH),
         };
 
         verify(checkConfig,
@@ -141,7 +141,7 @@ public class PackageDeclarationCheckTest extends AbstractModuleTestSupport {
     public void testNoPackage() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(PackageDeclarationCheck.class);
         final String[] expected = {
-            "2: " + getCheckMessage(MSG_KEY_MISSING),
+            "2:1: " + getCheckMessage(MSG_KEY_MISSING),
         };
 
         verify(checkConfig,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -63,7 +63,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
             "InterfaceMemberImpliedModifier",
             "JavadocMethod",
             "MissingJavadocType",
-            "PackageDeclaration",
             "Regexp",
             "RegexpSinglelineJava",
             "TodoComment",

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -4738,6 +4738,13 @@ public void foo(String s, int i) {}
           These directories are added to the classpath so that your classes
           are visible to JVM when it runs the code.
         </p>
+        <p>
+          <b>Note:</b>
+          This Check is partially supported by Xpath Suppression Filters. In case of testing empty
+          java files, Xpath Suppression Filters are not supported for this Check. (until
+          <a href="https://github.com/checkstyle/checkstyle/pull/8110">#8110
+          </a>)
+        </p>
       </subsection>
 
       <subsection name="Properties" id="PackageDeclaration_Properties">

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -927,13 +927,22 @@ public class UserService {
           <li>InterfaceMemberImpliedModifier</li>
           <li>JavadocMethod</li>
           <li>MissingJavadocType</li>
-          <li>PackageDeclaration</li>
           <li>Regexp</li>
           <li>RegexpSinglelineJava</li>
           <li>TodoComment</li>
           <li>TrailingComment</li>
           <li>UnnecessaryParentheses</li>
           <li>VariableDeclarationUsageDistance</li>
+        </ul>
+        <p>
+          Certain Checks are partially supported by the filter:
+        </p>
+        <ul>
+          <li>
+             PackageDeclaration
+             (until
+             <a href="https://github.com/checkstyle/checkstyle/pull/8110">#8110</a>)
+          </li>
         </ul>
         <p>
           Also, the filter does not support suppressions inside javadoc reported by Javadoc checks:


### PR DESCRIPTION
fixes: #7758 

This check partially supports Xpath.

Two log calls:
https://github.com/checkstyle/checkstyle/blob/676dc23d4f239e1b3f57b5cdce043067d8c996e5/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheck.java#L147
https://github.com/checkstyle/checkstyle/blob/676dc23d4f239e1b3f57b5cdce043067d8c996e5/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheck.java#L163

Due to certain reason(https://github.com/checkstyle/checkstyle/issues/7758#issuecomment-604070675), I had to provide one more log call when AST is null.

Diff report: https://dxtkastb.github.io/checkstyle/reports/packed/diff2/index.html

**Changes in Documentation:**

Under Check documentation:

![pckg1](https://user-images.githubusercontent.com/38028330/79490737-faa81780-803a-11ea-816d-479dd4c0e5bb.png)

---------------------------------------------------------------------------------------------------------------------------------

Under Filter Documentation:

![pckg2](https://user-images.githubusercontent.com/38028330/79490752-009df880-803b-11ea-8977-f9dd8549085b.png)

