### PR TITLE
Issue #525: Support for Default IntelliJ IDEA Formatting in CustomImportOrder.

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -80,6 +80,10 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * SPECIAL_IMPORTS group. This group may contains some imports that have particular meaning for the
  * user.
  * </li>
+ * <li>
+ * BLANK_LINE. This optional attribute can be used between groups to give more flexibility
+ * and control over placing blankLines between them.
+ * </li>
  * </ol>
  * <p>
  * Use the separator '###' between rules.
@@ -233,7 +237,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </pre>
  * <p>
  * To configure the check so that it matches default IntelliJ IDEA formatter configuration
- * (tested on v14):
+ * (tested on v2019.3.4):
  * </p>
  * <ul>
  * <li>
@@ -250,17 +254,18 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </li>
  * </ul>
  * <p>
- * Note: "separated" option is disabled because IDEA default has blank line between "java" and
- * static imports, and no blank line between "javax" and "java"
+ * Note: "BLANK_LINE" attribute is used here to gain extra control over
+ * blank lines because IDEA default has blank line between "java"
+ * and static imports, and no blank line between "javax" and "java"
  * </p>
  * <pre>
  * &lt;module name="CustomImportOrder"&gt;
  *   &lt;property name="customImportOrderRules"
- *     value="THIRD_PARTY_PACKAGE###SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE###STATIC"/&gt;
+ *     value=&quot;THIRD_PARTY_PACKAGE###BLANK_LINE###SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE
+ *             ###BLANK_LINE###STATIC&quot;/&gt;
  *   &lt;property name="specialImportsRegExp" value="^javax\."/&gt;
  *   &lt;property name="standardPackageRegExp" value="^java\."/&gt;
  *   &lt;property name="sortImportsInGroupAlphabetically" value="true"/&gt;
- *   &lt;property name="separateLineBetweenGroups" value="false"/&gt;
  * &lt;/module&gt;
  * </pre>
  * <p>
@@ -297,6 +302,16 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <pre>
  * &lt;module name=&quot;CustomImportOrder&quot;&gt;
  *   &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;true&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ *    To configure the check to only allow empty line between static and thirdPartyGroups.
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;CustomImportOrder&quot;&gt;
+ *   &lt;property name=&quot;customImportOrderRules&quot;
+ *     value=&quot;STATIC###BLANK_LINE###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE&quot;/&gt;
+ *   &lt;property name=&quot;thirdPartyPackageRegExp&quot; value=&quot;^(com|org)\.&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
  * <p>
@@ -410,6 +425,9 @@ public class CustomImportOrderCheck extends AbstractCheck {
     /** Pattern used to separate groups of imports. */
     private static final Pattern GROUP_SEPARATOR_PATTERN = Pattern.compile("\\s*###\\s*");
 
+    /** Blank line group name that is used as customImportOrderRules attribute. */
+    private static final String BLANK_LINE = "BLANK_LINE";
+
     /** Processed list of import order rules. */
     private final List<String> customOrderRules = new ArrayList<>();
 
@@ -510,6 +528,39 @@ public class CustomImportOrderCheck extends AbstractCheck {
         customImportOrderRules = inputCustomImportOrder;
     }
 
+    /**
+     * Check if BLANK_LINE property is being used in the customImportOrderRules.
+     *
+     * @return If BLANK_LINE attribute is present in the customImportOrderRules.
+     * */
+    private boolean isBlankLinePresent() {
+        return customOrderRules.contains(BLANK_LINE);
+    }
+
+    /**
+     * Check if BLANK_LINE attribute is present between the two groups.
+     *
+     * @param currentGroupNo Index of CurrentGroup in CustomImportOrderRules.
+     * @param importObject Instance of importObject in importToGroupList.
+     * @param previousImportObject Previous Import Object from Current Group.
+     * @param fullImportIdent Full name of Import.
+     */
+    private void checkBlankLineAtGroupChange(int currentGroupNo, ImportDetails importObject,
+                    ImportDetails previousImportObject, String fullImportIdent) {
+        if (isBlankLinePresent()) {
+            if (customOrderRules.get(currentGroupNo + 1).equals(BLANK_LINE)) {
+                separateLineBetweenGroups = true;
+                validateMissedEmptyLine(previousImportObject,
+                    importObject, fullImportIdent);
+                separateLineBetweenGroups = false;
+            }
+            else {
+                validateExtraEmptyLine(previousImportObject,
+                    importObject, fullImportIdent);
+            }
+        }
+    }
+
     @Override
     public int[] getDefaultTokens() {
         return getRequiredTokens();
@@ -582,8 +633,10 @@ public class CustomImportOrderCheck extends AbstractCheck {
                 previousImportObjectFromCurrentGroup = importObject;
             }
             else {
-                // not the last group, last one is always NON_GROUP
                 if (customOrderRules.size() > currentGroupNumber + 1) {
+                    checkBlankLineAtGroupChange(currentGroupNumber, importObject,
+                        previousImportObjectFromCurrentGroup, fullImportIdent);
+                    // not the last group, last one is always NON_GROUP
                     final String nextGroup = getNextImportGroup(currentGroupNumber + 1);
                     if (importGroup.equals(nextGroup)) {
                         validateMissedEmptyLine(previousImportObjectFromCurrentGroup,
@@ -916,7 +969,8 @@ public class CustomImportOrderCheck extends AbstractCheck {
         if (STATIC_RULE_GROUP.equals(ruleStr)
                 || THIRD_PARTY_PACKAGE_RULE_GROUP.equals(ruleStr)
                 || STANDARD_JAVA_PACKAGE_RULE_GROUP.equals(ruleStr)
-                || SPECIAL_IMPORTS_RULE_GROUP.equals(ruleStr)) {
+                || SPECIAL_IMPORTS_RULE_GROUP.equals(ruleStr)
+                || BLANK_LINE.equals(ruleStr)) {
             customOrderRules.add(ruleStr);
         }
         else if (ruleStr.startsWith(SAME_PACKAGE_RULE_GROUP)) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -128,6 +128,42 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
         verify(checkConfig, getPath("InputCustomImportOrderDefault.java"), expected);
     }
 
+    /** Checks IntelliJ default formatting abilities. */
+    @Test
+    public void intellijConfig1() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(CustomImportOrderCheck.class);
+        checkConfig.addAttribute("customImportOrderRules",
+            "THIRD_PARTY_PACKAGE###BLANK_LINE###SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE"
+                + "###BLANK_LINE###STATIC");
+        checkConfig.addAttribute("specialImportsRegExp", "^javax\\.");
+        checkConfig.addAttribute("standardPackageRegExp", "^java\\.");
+        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
+
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verify(checkConfig, getPath("InputCustomImportOrderIntellijGoodCase.java"), expected);
+    }
+
+    @Test
+    public void intellijConfig2() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(CustomImportOrderCheck.class);
+        checkConfig.addAttribute("customImportOrderRules",
+            "THIRD_PARTY_PACKAGE###BLANK_LINE###SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE"
+                + "###BLANK_LINE###STATIC");
+        checkConfig.addAttribute("specialImportsRegExp", "^javax\\.");
+        checkConfig.addAttribute("standardPackageRegExp", "^java\\.");
+        checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
+
+        final String[] expected = {
+            "8: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.applet.AudioClip"),
+            "10: " + getCheckMessage(MSG_LINE_SEPARATOR, "java.awt.Button.ABORT"),
+        };
+
+        verify(checkConfig, getPath("InputCustomImportOrderIntellijBadCase.java"), expected);
+    }
+
     /**
      * Checks different combinations for same_package group.
      */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderIntellijBadCase.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderIntellijBadCase.java
@@ -1,0 +1,14 @@
+package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
+
+import org.apache.tools.ant.helper.AntXMLContext;
+
+import javax.crypto.Cipher;
+import javax.lang.model.util.AbstractAnnotationValueVisitor6;
+
+import java.applet.AudioClip; // warn
+import java.util.*;
+import static java.awt.Button.ABORT; //warn
+import static java.io.File.createTempFile;
+
+public class InputCustomImportOrderIntellijBadCase {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderIntellijGoodCase.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderIntellijGoodCase.java
@@ -1,0 +1,14 @@
+package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
+
+import org.apache.tools.ant.helper.AntXMLContext;
+
+import javax.crypto.Cipher;
+import javax.lang.model.util.AbstractAnnotationValueVisitor6;
+import java.applet.AudioClip; // warn
+import java.util.*;
+
+import static java.awt.Button.ABORT;
+import static java.io.File.createTempFile;
+
+public class InputCustomImportOrderIntellijGoodCase {
+}

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -362,6 +362,10 @@ import java.util.regex.Matcher; //#8
             SPECIAL_IMPORTS group. This group may contains some imports that have particular
             meaning for the user.
           </li>
+          <li>
+          BLANK_LINE. This optional attribute can be used between groups to give more flexibility
+          and control over placing blankLines between them.
+          </li>
         </ol>
       </subsection>
 
@@ -519,7 +523,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
         </source>
 
         <p>To configure the check so that it matches default IntelliJ IDEA formatter configuration
-           (tested on v14):</p>
+           (tested on v2019.3.4):</p>
         <ul>
           <li>group of static imports is on the bottom</li>
           <li>groups of non-static imports: all imports except of &quot;javax&quot; and
@@ -529,19 +533,19 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
         </ul>
 
         <p>
-        Note: &quot;separated&quot; option is disabled because IDEA default has blank line
-        between &quot;java&quot; and static imports, and no blank line between
-        &quot;javax&quot; and &quot;java&quot;
+        Note: "BLANK_LINE" attribute is used here to gain extra control over
+        blank lines because IDEA default has blank line between &quot;java&quot;
+        and static imports, and no blank line between &quot;javax&quot; and &quot;java&quot;
         </p>
 
         <source>
 &lt;module name=&quot;CustomImportOrder&quot;&gt;
   &lt;property name=&quot;customImportOrderRules&quot;
-    value=&quot;THIRD_PARTY_PACKAGE###SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE###STATIC&quot;/&gt;
+    value=&quot;THIRD_PARTY_PACKAGE###BLANK_LINE###SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE
+            ###BLANK_LINE###STATIC&quot;/&gt;
   &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;^javax\.&quot;/&gt;
   &lt;property name=&quot;standardPackageRegExp&quot; value=&quot;^java\.&quot;/&gt;
   &lt;property name=&quot;sortImportsInGroupAlphabetically&quot; value=&quot;true&quot;/&gt;
-  &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
         </source>
 
@@ -576,6 +580,16 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
         <source>
 &lt;module name=&quot;CustomImportOrder&quot;&gt;
   &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;true&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+            To configure the check to only allow empty line between static and thirdPartyGroups.
+        </p>
+        <source>
+&lt;module name=&quot;CustomImportOrder&quot;&gt;
+  &lt;property name=&quot;customImportOrderRules&quot;
+    value=&quot;STATIC###BLANK_LINE###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE&quot;/&gt;
+  &lt;property name=&quot;thirdPartyPackageRegExp&quot; value=&quot;^(com|org)\.&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>


### PR DESCRIPTION
Fix for Issue #525 , 
UT coverage report: 
https://abhishek-kumar09.github.io/525/jacoco/index.html
Xdoc screenshot(with marked changes) :
[IMG_20200404_020645](https://user-images.githubusercontent.com/48255244/78404143-6641bc00-761b-11ea-9401-0d519f1850bd.jpg)
full xdoc:
https://abhishek-kumar09.github.io/525/site/config_imports.html#CustomImportOrder
No change in Diff report is observed hence not uploaded.
