### PR TITLE
Issue #7610: Update doc for HideUtilityClassConstructor

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
@@ -57,6 +57,40 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <pre>
  * &lt;module name=&quot;HideUtilityClassConstructor&quot;/&gt;
  * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * class Test { // violation, class only has a static method and a constructor
+ *
+ *   public Test() {
+ *   }
+ *
+ *   public static void fun() {
+ *   }
+ * }
+ *
+ * class Foo { // OK
+ *
+ *   private Foo() {
+ *   }
+ *
+ *   static int n;
+ * }
+ *
+ * class Bar { // OK
+ *
+ *   protected Bar() {
+ *     // prevents calls from subclass
+ *     throw new UnsupportedOperationException();
+ *   }
+ * }
+ *
+ * class UtilityClass { // violation, class only has a static field
+ *
+ *   static float f;
+ * }
+ * </pre>
  *
  * @since 3.1
  */

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -361,6 +361,40 @@ public class StringUtils // not final to allow subclassing
         <source>
 &lt;module name=&quot;HideUtilityClassConstructor&quot;/&gt;
         </source>
+        <p>
+          Example:
+        </p>
+        <source>
+class Test { // violation, class only has a static method and a constructor
+
+  public Test() {
+  }
+
+  public static void fun() {
+  }
+}
+
+class Foo { // OK
+
+  private Foo() {
+  }
+
+  static int n;
+}
+
+class Bar { // OK
+
+  protected Bar() {
+    // prevents calls from subclass
+    throw new UnsupportedOperationException();
+  }
+}
+
+class UtilityClass { // violation, class only has a static field
+
+  static float f;
+}
+        </source>
       </subsection>
 
       <subsection name="Example of Usage" id="HideUtilityClassConstructor_Example_of_Usage">


### PR DESCRIPTION
Fixes #7610
![PR6](https://user-images.githubusercontent.com/43749360/78544897-7b376e80-7818-11ea-8059-f0124fa9f9a3.PNG)


Default Example:
```
$ cat config3.xml
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <module name="HideUtilityClassConstructor">
    </module>
  </module>
</module>

$ cat Test3.java
class Test { // violation, class only has a static method and a constructor

  public Test() {
  }

  public static void fun() {
  }
}

class Foo { // OK

  private Foo() {
  }

  static int n;
}

class Bar { // OK

  protected Bar() {
    // prevents calls from subclass
    throw new UnsupportedOperationException();
  }
}

class UtilityClass { // violation, class only has a static field

  static float f;
}

$ java -jar checkstyle-8.30-all.jar -c config3.xml Test3.java
Starting audit...
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\Test3.java:1:1: Utility classes should not have a public or default constructor. [HideUtilityClassConstructor]
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\Test3.java:26:1: Utility classes should not have a public or default constructor. [HideUtilityClassConstructor]
Audit done.
Checkstyle ends with 2 errors.
```

The check provides no properties.