### PR TITLE
Issue #7647: Update doc for IllegalType

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -550,6 +550,7 @@ hh
 hiddenfield
 hideutilityclassconstructor
 hipparchus
+hmap
 hne
 Homepage
 horizontalwhitespace
@@ -576,6 +577,7 @@ igorminar
 IInterfacable
 Ilja
 illegalcatch
+illegalex
 illegalimport
 illegalinstantiation
 illegalthrows
@@ -611,6 +613,7 @@ intercell
 interfaceistype
 interfacememberimpliedmodifier
 interfacetypeparametername
+intqueue
 invalidformat
 invalidinherit
 invalidjavadocposition
@@ -753,6 +756,7 @@ len
 lexer
 lgpl
 lharris
+lhmap
 LHSOf
 libcore
 liberapay
@@ -1295,6 +1299,8 @@ Toolbar
 Touchscreen
 trailingcomment
 treelayout
+treemap
+treeset
 treewalker
 TRequest
 tschneeberger

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -130,12 +130,87 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </li>
  * </ul>
  * <p>
- * To configure the check so that it ignores getInstance() methods:
+ * Default Configuration:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;IllegalType&quot;/&gt;
+ * </pre>
+ * <pre>
+ * public class Test extends TreeSet { // violation
+ *   public &lt;T extends java.util.HashSet&gt; void method() { // violation
+ *
+ *     LinkedHashMap&lt;Integer, String&gt; lhmap =
+ *     new LinkedHashMap&lt;Integer, String&gt;(); // violation
+ *     TreeMap&lt;Integer, String&gt; treemap =
+ *     new TreeMap&lt;Integer, String&gt;(); // violation
+ *     Test t; // OK
+ *     HashMap&lt;String, String&gt; hmap; // violation
+ *     Queue&lt;Integer&gt; intqueue; // OK
+ *
+ *     java.lang.IllegalArgumentException illegalex; // OK
+ *     java.util.TreeSet treeset; // violation
+ *   }
+ *
+ * }
+ * </pre>
+ * <p>
+ * To configure the Check so that particular tokens are checked:
+ * </p>
+ * <pre>
+ * &lt;module name="IllegalType"&gt;
+ *   &lt;property name="tokens" value="METHOD_DEF"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <pre>
+ * public class Test extends TreeSet { // OK
+ *   public &lt;T extends java.util.HashSet&gt; void method() { // violation
+ *     LinkedHashMap&lt;Integer, String&gt; lhmap =
+ *     new LinkedHashMap&lt;Integer, String&gt;(); // OK
+ *
+ *     java.lang.IllegalArgumentException illegalex; // OK
+ *     java.util.TreeSet treeset; // Ok
+ *   }
+ *
+ *   public &lt;T extends java.util.HashSet&gt; void typeParam(T t) {} // violation
+ *
+ *   public void fullName(TreeSet a) {} // OK
+ *
+ * }
+ * </pre>
+ * <p>
+ * To configure the Check so that it ignores function() methods:
  * </p>
  * <pre>
  * &lt;module name=&quot;IllegalType&quot;&gt;
- *   &lt;property name=&quot;ignoredMethodNames&quot; value=&quot;getInstance&quot;/&gt;
+ *   &lt;property name=&quot;ignoredMethodNames&quot; value=&quot;function&quot;/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <pre>
+ * public class Test {
+ *   public HashMap&lt;String, String&gt; function() { // OK
+ *     // code
+ *   }
+ *
+ *   public HashMap&lt;String, String&gt; function1() { // violation
+ *     // code
+ *   }
+ * }
+ * </pre>
+ * <p>
+ * To configure the Check so that it validates abstract class names:
+ * </p>
+ * <pre>
+ *  &lt;module name=&quot;IllegalType&quot;&gt;
+ *    &lt;property name=&quot;validateAbstractClassNames&quot; value=&quot;true&quot;/&gt;
+ *    &lt;property name=&quot;illegalAbstractClassNameFormat&quot; value=&quot;Gitt&quot;/&gt;
+ *  &lt;/module&gt;
+ * </pre>
+ * <pre>
+ * class Test extends Gitter { // violation
+ * }
+ *
+ * class Test1 extends Github { // OK
+ * }
  * </pre>
  * <p>
  * To configure the Check so that it verifies only public, protected or static methods and fields:
@@ -145,6 +220,26 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *   &lt;property name=&quot;memberModifiers&quot; value=&quot;LITERAL_PUBLIC,
  *    LITERAL_PROTECTED, LITERAL_STATIC&quot;/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <pre>
+ * public class Test {
+ *   public HashMap&lt;String, String&gt; function1() { // violation
+ *     // code
+ *   }
+ *
+ *   private HashMap&lt;String, String&gt; function2() { // OK
+ *     // code
+ *   }
+ *
+ *   protected HashMap&lt;Integer, String&gt; function3() { // violation
+ *     // code
+ *   }
+ *
+ *   public static TreeMap&lt;Integer, String&gt; function4() { // violation
+ *     // code
+ *   }
+ *
+ * }
  * </pre>
  * <p>
  * To configure the check so that it verifies usage of types Boolean and Foo:

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -2696,12 +2696,86 @@ List list; //No violation here
 
       <subsection name="Examples" id="IllegalType_Examples">
         <p>
-          To configure the check so that it ignores getInstance() methods:
+          Default Configuration:
+        </p>
+        <source>
+&lt;module name=&quot;IllegalType&quot;/&gt;
+        </source>
+        <source>
+public class Test extends TreeSet { // violation
+  public &lt;T extends java.util.HashSet&gt; void method() { // violation
+
+    LinkedHashMap&lt;Integer, String&gt; lhmap =
+        new LinkedHashMap&lt;Integer, String&gt;(); // violation
+    TreeMap&lt;Integer, String&gt; treemap = new TreeMap&lt;Integer, String&gt;(); // violation
+    Test t; // OK
+    HashMap&lt;String, String&gt; hmap; // violation
+    Queue&lt;Integer&gt; intqueue; // OK
+
+    java.lang.IllegalArgumentException illegalex; // OK
+    java.util.TreeSet treeset; // violation
+  }
+
+}
+        </source>
+        <p>
+          To configure the Check so that particular tokens are checked:
+        </p>
+        <source>
+&lt;module name="IllegalType"&gt;
+  &lt;property name="tokens" value="METHOD_DEF"/&gt;
+&lt;/module&gt;
+        </source>
+        <source>
+public class Test extends TreeSet { // OK
+  public &lt;T extends java.util.HashSet&gt; void method() { // violation
+
+    LinkedHashMap&lt;Integer, String&gt; lhmap = new LinkedHashMap&lt;Integer, String&gt;(); // OK
+
+    java.lang.IllegalArgumentException illegalex; // OK
+    java.util.TreeSet treeset; // Ok
+  }
+
+  public &lt;T extends java.util.HashSet&gt; void typeParam(T t) {} // violation
+
+  public void fullName(TreeSet a) {} // OK
+
+}
+        </source>
+        <p>
+          To configure the Check so that it ignores function() methods:
         </p>
         <source>
 &lt;module name=&quot;IllegalType&quot;&gt;
-  &lt;property name=&quot;ignoredMethodNames&quot; value=&quot;getInstance&quot;/&gt;
+  &lt;property name=&quot;ignoredMethodNames&quot; value=&quot;function&quot;/&gt;
 &lt;/module&gt;
+        </source>
+        <source>
+public class Test {
+  public HashMap&lt;String, String&gt; function() { // OK
+    // code
+  }
+
+  public HashMap&lt;String, String&gt; function1() { // violation
+    // code
+  }
+}
+        </source>
+        <p>
+          To configure the Check so that it validates abstract class names:
+        </p>
+        <source>
+&lt;module name=&quot;IllegalType&quot;&gt;
+  &lt;property name=&quot;validateAbstractClassNames&quot; value=&quot;true&quot;/&gt;
+  &lt;property name=&quot;illegalAbstractClassNameFormat&quot; value=&quot;Gitt&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <source>
+class Test extends Gitter { // violation
+}
+
+class Test1 extends Github { // OK
+}
         </source>
         <p>
           To configure the Check so that it verifies only public, protected or static
@@ -2710,15 +2784,35 @@ List list; //No violation here
         <source>
 &lt;module name=&quot;IllegalType&quot;&gt;
   &lt;property name=&quot;memberModifiers&quot; value=&quot;LITERAL_PUBLIC,
-   LITERAL_PROTECTED, LITERAL_STATIC&quot;/&gt;
+    LITERAL_PROTECTED, LITERAL_STATIC&quot;/&gt;
 &lt;/module&gt;
+        </source>
+        <source>
+public class Test {
+  public HashMap&lt;String, String&gt; function1() { // violation
+    // code
+  }
+
+  private HashMap&lt;String, String&gt; function2() { // OK
+    // code
+  }
+
+  protected HashMap&lt;Integer, String&gt; function3() { // violation
+    // code
+  }
+
+  public static TreeMap&lt;Integer, String&gt; function4() { // violation
+    // code
+  }
+
+}
         </source>
           <p>
             To configure the check so that it verifies usage of types Boolean and Foo:
           </p>
         <source>
 &lt;module name="IllegalType"&gt;
-          &lt;property name=&quot;illegalClassNames&quot; value=&quot;Boolean, Foo&quot;/&gt;
+  &lt;property name=&quot;illegalClassNames&quot; value=&quot;Boolean, Foo&quot;/&gt;
 &lt;/module&gt;
         </source>
 
@@ -6667,3 +6761,4 @@ for (int i = 0; i &lt; 20; i++) {
 
   </body>
 </document>
+


### PR DESCRIPTION
Fixes: #7647 

![it1](https://user-images.githubusercontent.com/38028330/78893807-93fa8b00-7a89-11ea-8908-4dd22590bab6.png)
![it2](https://user-images.githubusercontent.com/38028330/78893840-a248a700-7a89-11ea-9a7f-8148d731c060.png)


**default:**

```
kaustubh@dxtk:~$ cat Test.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">

<module name="Checker">
    <property name="charset" value="UTF-8"/>
<module name="TreeWalker">
<module name="IllegalType">
</module>
</module>
</module>
kaustubh@dxtk:~$ cat Test.java
public class Test extends TreeSet { // violation
  public <T extends java.util.HashSet> void method() { // violation

    LinkedHashMap<Integer, String> lhmap = new LinkedHashMap<Integer, String>(); // violation
    TreeMap<Integer, String> treemap = new TreeMap<Integer, String>(); // violation
    Test t; // OK
    HashMap<String, String> hmap; // violation
    Queue<Integer> intqueue; // OK

    java.lang.IllegalArgumentException illegalex; // OK
    java.util.TreeSet treeset; // violation
  }

}
kaustubh@dxtk:~$ java -jar checkstyle-8.30-all.jar -c Test.xml Test.java
Starting audit...
[ERROR] /home/kaustubh/Test.java:1:27: Usage of type 'TreeSet' is not allowed. [IllegalType]
[ERROR] /home/kaustubh/Test.java:2:21: Usage of type 'java.util.HashSet' is not allowed. [IllegalType]
[ERROR] /home/kaustubh/Test.java:4:5: Usage of type 'LinkedHashMap' is not allowed. [IllegalType]
[ERROR] /home/kaustubh/Test.java:6:5: Usage of type 'TreeMap' is not allowed. [IllegalType]
[ERROR] /home/kaustubh/Test.java:8:5: Usage of type 'HashMap' is not allowed. [IllegalType]
[ERROR] /home/kaustubh/Test.java:12:5: Usage of type 'java.util.TreeSet' is not allowed. [IllegalType]
Audit done.
Checkstyle ends with 6 errors.
kaustubh@dxtk:~$ 
```
**Config 1:**

```
kaustubh@dxtk:~$ cat Test.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">

<module name="Checker">
    <property name="charset" value="UTF-8"/>
<module name="TreeWalker">
<module name="IllegalType">

  <property name="tokens" value="METHOD_DEF"/> 
</module>
</module>
</module>
kaustubh@dxtk:~$ cat Test.java
public class Test extends TreeSet { // OK
  public <T extends java.util.HashSet> void method() { // violation
 
    LinkedHashMap<Integer, String> lhmap = 
      new LinkedHashMap<Integer, String>(); // OK
    
    java.lang.IllegalArgumentException illegalex; // OK
    java.util.TreeSet treeset; // Ok
  }

  public <T extends java.util.HashSet> void typeParam(T t) {} // violation

  public void fullName(TreeSet a) {} // OK

}

kaustubh@dxtk:~$ java -jar checkstyle-8.30-all.jar -c Test.xml Test.java
Starting audit...
[ERROR] /home/kaustubh/Test.java:2:21: Usage of type 'java.util.HashSet' is not allowed. [IllegalType]
[ERROR] /home/kaustubh/Test.java:11:21: Usage of type 'java.util.HashSet' is not allowed. [IllegalType]
Audit done.
Checkstyle ends with 2 errors.

```



**Config2:**
```
kaustubh@dxtk:~$ cat Test.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">

<module name="Checker">
    <property name="charset" value="UTF-8"/>
<module name="TreeWalker">
<module name="IllegalType">
  <property name="ignoredMethodNames" value="function"/>
</module>
</module>
</module>

kaustubh@dxtk:~$ cat Test3.java
public class Test3 {
  public HashMap<String, String> function(){ // OK
    // code
  }

  public HashMap<String, String> function1(){ // violation
    // code
  }

}

kaustubh@dxtk:~$ java -jar checkstyle-8.30-all.jar -c Test.xml Test3.java
Starting audit...
[ERROR] /home/kaustubh/Test3.java:6:10: Usage of type 'HashMap' is not allowed. [IllegalType]
Audit done.
Checkstyle ends with 1 errors.
```







**Config 3:**

```
kaustubh@dxtk:~$ cat Test.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">

<module name="Checker">
    <property name="charset" value="UTF-8"/>
<module name="TreeWalker">
<module name="IllegalType">
  <property name="validateAbstractClassNames" value="true"/>
  <property name="illegalAbstractClassNameFormat" value="Gitt"/>

</module>
</module>
</module>

kaustubh@dxtk:~$ cat Test.java
class Test extends Gitter{ // violation
}

class Test1 extends Github{ // OK
}

kaustubh@dxtk:~$ java -jar checkstyle-8.30-all.jar -c Test.xml Test.java
Starting audit...
[ERROR] /home/kaustubh/Test.java:1:20: Usage of type 'Gitter' is not allowed. [IllegalType]
Audit done.
Checkstyle ends with 1 errors.

```




**Config 4:**
```
kaustubh@dxtk:~$ cat Test.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">

<module name="Checker">
    <property name="charset" value="UTF-8"/>
<module name="TreeWalker">
<module name="IllegalType">
  <property name="memberModifiers" value="LITERAL_PUBLIC,
   LITERAL_PROTECTED, LITERAL_STATIC"/>
</module>
</module>
</module>

kaustubh@dxtk:~$ cat Test2.java
public class Test2 {
  public HashMap<String, String> method1(){ // violation
    // code
  }

  private HashMap<String, String> method2(){ // OK
    // code
  }

  protected HashMap<Integer, String> method3(){ // violation
    // code
  }

  public static TreeMap<Integer, String> method4(){ // violation
    // code
  }

}

kaustubh@dxtk:~$ java -jar checkstyle-8.30-all.jar -c Test.xml Test2.java
Starting audit...
[ERROR] /home/kaustubh/Test2.java:2:10: Usage of type 'HashMap' is not allowed. [IllegalType]
[ERROR] /home/kaustubh/Test2.java:10:13: Usage of type 'HashMap' is not allowed. [IllegalType]
[ERROR] /home/kaustubh/Test2.java:14:17: Usage of type 'TreeMap' is not allowed. [IllegalType]
Audit done.
Checkstyle ends with 3 errors.

```


@strkkk, please review