### PR TITLE
Issue #7892: add empty .ci-temp validation

### DIFF
--- a/.ci/wercker.sh
+++ b/.ci/wercker.sh
@@ -447,6 +447,19 @@ no-warning-imports-java-design-patterns)
   fi
   ;;
 
+validate-ci-temp-empty)
+  fail=0
+  if [ -z "$(ls -A .ci-temp)" ]; then
+    echo "Empty .ci-temp/ validation did not find any warnings."
+  else
+    echo "Directory .ci-temp/ is not empty. Verification failed."
+    echo "Contents of .ci-temp/:"
+    fail=1
+  fi
+  ls -A .ci-temp --color=auto
+  exit $fail
+  ;;
+
 *)
   echo "Unexpected argument: $1"
   sleep 5s

--- a/wercker.yml
+++ b/wercker.yml
@@ -335,13 +335,20 @@ build:
         fi
 
   - script:
+      name: Empty .ci-temp validation
+      code: |
+        if [[ $RUN_JOB == 1 ]]; then
+          echo "Command: ./.ci/wercker.sh validate-ci-temp-empty"
+          ./.ci/wercker.sh validate-ci-temp-empty
+        else
+          echo "build is skipped ..."
+        fi
+
+  - script:
       name: Cleanup maven local repo
       code: |
         echo "git status"
         git status
-        echo "------"
-        echo "Content of .ci-temp folder:"
-        ls -la .ci-temp | cat
         echo "------"
         find ${WERCKER_CACHE_DIR} -type d -name "*SNAPSHOT" -ls -exec rm -rf {} +
         echo "------"


### PR DESCRIPTION
Update for #7892: Add validation for empty .ci-temp folder after CI runs