### PR TITLE
Issue #7969: drop jdk13 build, add jdk14 build

### DIFF
--- a/.ci/appveyor.bat
+++ b/.ci/appveyor.bat
@@ -27,7 +27,7 @@ if "%OPTION%" ==  "verify_without_checkstyle_JDK11" (
   goto :END_CASE
 )
 
-if "%OPTION%" ==  "verify_without_checkstyle_JDK13" (
+if "%OPTION%" ==  "verify_without_checkstyle_JDK14" (
   call mvn -e verify -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true^
     || goto :ERROR
   goto :END_CASE

--- a/.ci/travis/travis.sh
+++ b/.ci/travis/travis.sh
@@ -115,26 +115,26 @@ javac9)
   fi
   ;;
 
-javac13)
-  files=($(grep -Rl --include='*.java' ': Compilable with Java13' \
+javac14)
+  files=($(grep -Rl --include='*.java' ': Compilable with Java14' \
         src/test/resources-noncompilable || true))
   if [[  ${#files[@]} -eq 0 ]]; then
-    echo "No Java13 files to process"
+    echo "No Java14 files to process"
   else
       mkdir -p target
       for file in "${files[@]}"
       do
-        javac --release 13 --enable-preview -d target "${file}"
+        javac --release 14 --enable-preview -d target "${file}"
       done
   fi
   ;;
 
-jdk13-assembly-site)
+jdk14-assembly-site)
   mvn -e package -Passembly
   mvn -e site -Pno-validations
   ;;
 
-jdk13-verify-limited)
+jdk14-verify-limited)
   # we skip pmd and spotbugs as they executed in special Travis build
   mvn -e verify -Dpmd.skip=true -Dspotbugs.skip=true
   ;;

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,8 +79,8 @@ jobs:
         - CMD="export MAVEN_OPTS='-Xmx2000m' && mvn -e clean compile pmd:check spotbugs:check"
         - USE_MAVEN_REPO="true"
 
-    # spotbugs and pmd (openjdk13)
-    - jdk: openjdk13
+    # spotbugs and pmd (openjdk14)
+    - jdk: openjdk14
       env:
         - DESC="spotbugs,pmd"
         - CMD="export MAVEN_OPTS='-Xmx2000m' && mvn -e clean compile pmd:check spotbugs:check"
@@ -260,19 +260,19 @@ jobs:
         - USE_MAVEN_REPO="true"
         - CMD="mvn -e package -Passembly && mvn -e site -Dlinkcheck.skip=true"
 
-    # OpenJDK13 build
-    - jdk: openjdk13
+    # OpenJDK14 build
+    - jdk: openjdk14
       env:
-        - DESC="build with OpenJDK13"
+        - DESC="build with OpenJDK14"
         - USE_MAVEN_REPO="true"
-        - CMD="./.ci/travis/travis.sh jdk13-assembly-site"
+        - CMD="./.ci/travis/travis.sh jdk14-assembly-site"
 
-    # OpenJDK13 verify limited
-    - jdk: openjdk13
+    # OpenJDK14 verify limited
+    - jdk: openjdk14
       env:
-        - DESC="verify limited with OpenJDK13"
+        - DESC="verify limited with OpenJDK14"
         - USE_MAVEN_REPO="true"
-        - CMD="./.ci/travis/travis.sh jdk13-verify-limited"
+        - CMD="./.ci/travis/travis.sh jdk14-verify-limited"
 
     # OpenJDK11 compile input files with jdk9 specific syntax
     - jdk: openjdk11
@@ -286,11 +286,11 @@ jobs:
         - DESC="compile input files that are not compiled by eclipse"
         - CMD="./.ci/travis/travis.sh javac8"
 
-    # OpenJDK13 compile input files with jdk13 specific syntax
-    - jdk: openjdk13
+    # OpenJDK14 compile input files with jdk14 specific syntax
+    - jdk: openjdk14
       env:
-        - DESC="compile input files with jdk13 specific syntax"
-        - CMD="./.ci/travis/travis.sh javac13"
+        - DESC="compile input files with jdk14 specific syntax"
+        - CMD="./.ci/travis/travis.sh javac14"
 
     # find missing pitests
     - env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,10 +49,10 @@ environment:
     - JAVA_HOME: C:\Program Files\Java\jdk11
       DESC: "verify without checkstyle (JDK11)"
       CMD: "./.ci/appveyor.bat verify_without_checkstyle_JDK11"
-    # verify without checkstyle (JDK13)
-    - JAVA_HOME: C:\Program Files\Java\jdk13
-      DESC: "verify without checkstyle (JDK13)"
-      CMD: "./.ci/appveyor.bat verify_without_checkstyle_JDK13"
+    # verify without checkstyle (JDK14)
+    - JAVA_HOME: C:\Program Files\Java\jdk14
+      DESC: "verify without checkstyle (JDK14)"
+      CMD: "./.ci/appveyor.bat verify_without_checkstyle_JDK14"
     # site, without verify (JDK8)
     - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
       DESC: "site, without verify (JDK8)"
@@ -61,9 +61,9 @@ environment:
     - JAVA_HOME: C:\Program Files\Java\jdk11
       DESC: "site, without verify (JDK11)"
       CMD: "./.ci/appveyor.bat site_without_verify"
-    # site, without verify (JDK13)
-    - JAVA_HOME: C:\Program Files\Java\jdk13
-      DESC: "site, without verify (JDK13)"
+    # site, without verify (JDK14)
+    - JAVA_HOME: C:\Program Files\Java\jdk14
+      DESC: "site, without verify (JDK14)"
       CMD: "./.ci/appveyor.bat site_without_verify"
 
 build_script:


### PR DESCRIPTION
Issue #7969

JDK13 is no more supported, we are moving to jdk14.
Except the OSX build, since an xcode image with jdk14 for OSX is not released yet.
We have no files with jdk13 specific syntax, so travis stage javac13 can be safely replaced with javac14.
