### PR TITLE
Issue #7630: Update doc for TypecastParenPad

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadCheck.java
@@ -41,12 +41,52 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * &lt;module name=&quot;TypecastParenPad&quot;/&gt;
  * </pre>
  * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * class Foo {
+ *
+ *   float f1 = 3.14f;
+ *
+ *   int n = ( int ) f1; // violation, space after left parenthesis and before right parenthesis
+ *
+ *   double d = 1.234567;
+ *
+ *   float f2 = (float ) d; // violation, space before right parenthesis
+ *
+ *   float f3 = (float) d; // OK
+ *
+ *   float f4 = ( float) d; // violation, space after left parenthesis
+ *
+ * }
+ * </pre>
+ * <p>
  * To configure the check to require spaces:
  * </p>
  * <pre>
  * &lt;module name=&quot;TypecastParenPad&quot;&gt;
  *   &lt;property name=&quot;option&quot; value=&quot;space&quot;/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * class Bar {
+ *
+ *   double d1 = 3.14;
+ *
+ *   int n = ( int ) d1; // OK
+ *
+ *   int m = (int ) d1; // violation, no space after left parenthesis
+ *
+ *   double d2 = 9.8;
+ *
+ *   int x = (int) d2; // violation, no space after left parenthesis and before right parenthesis
+ *
+ *   int y = ( int) d2; // violation, no space before right parenthesis
+ *
+ * }
  * </pre>
  *
  * @since 3.2

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -2363,6 +2363,26 @@ float f1; // OK, 1 whitespace
         <source>
 &lt;module name=&quot;TypecastParenPad&quot;/&gt;
         </source>
+        <p>
+          Example:
+        </p>
+        <source>
+class Foo {
+
+  float f1 = 3.14f;
+
+  int n = ( int ) f1; // violation, space after left parenthesis and before right parenthesis
+
+  double d = 1.234567;
+
+  float f2 = (float ) d; // violation, space before right parenthesis
+
+  float f3 = (float) d; // OK
+
+  float f4 = ( float) d; // violation, space after left parenthesis
+
+}
+        </source>
 
         <p>
           To configure the check to require spaces:
@@ -2371,6 +2391,26 @@ float f1; // OK, 1 whitespace
 &lt;module name=&quot;TypecastParenPad&quot;&gt;
   &lt;property name=&quot;option&quot; value=&quot;space&quot;/&gt;
 &lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+class Bar {
+
+  double d1 = 3.14;
+
+  int n = ( int ) d1; // OK
+
+  int m = (int ) d1; // violation, no space after left parenthesis
+
+  double d2 = 9.8;
+
+  int x = (int) d2; // violation, no space after left parenthesis and before right parenthesis
+
+  int y = ( int) d2; // violation, no space before right parenthesis
+
+}
         </source>
       </subsection>
 


### PR DESCRIPTION
Fixes #7630
![PR7](https://user-images.githubusercontent.com/43749360/78644949-586a9000-78d4-11ea-9db7-bc38652cc7e4.PNG)

Default example:
```
$ cat config.xml
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <module name="TypecastParenPad">
    </module>
  </module>
</module>

$ cat Test.java
class Foo {

  float f1 = 3.14f;

  int n = ( int ) f1; // violation, space after left parenthesis and before right parenthesis

  double d = 1.234567;

  float f2 = (float ) d; // violation, space before right parenthesis

  float f3 = (float) d; // OK

  float f4 = ( float) d; // violation, space after left parenthesis

}

$ java -jar checkstyle-8.30-all.jar -c config.xml Test.java
Starting audit...
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\Test.java:5:11: '(' is followed by whitespace. [TypecastParenPad]
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\Test.java:5:17: ')' is preceded with whitespace. [TypecastParenPad]
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\Test.java:9:21: ')' is preceded with whitespace. [TypecastParenPad]
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\Test.java:13:14: '(' is followed by whitespace. [TypecastParenPad]
Audit done.
Checkstyle ends with 4 errors.
```

Non-default example:
```
$ cat config2.xml
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <module name="TypecastParenPad">
        <property name="option" value="space"/>
    </module>
  </module>
</module>

$ cat Test2.java
class Bar {

  double d1 = 3.14;

  int n = ( int ) d1; // OK

  int m = (int ) d1; // violation, no space after left parenthesis

  double d2 = 9.8;

  int x = (int) d2; // violation, no space after left parenthesis and before right parenthesis

  int y = ( int) d2; // violation, no space before right parenthesis

}

$ java -jar checkstyle-8.30-all.jar -c config2.xml Test2.java
Starting audit...
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\Test2.java:7:11: '(' is not followed by whitespace. [TypecastParenPad]
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\Test2.java:11:11: '(' is not followed by whitespace. [TypecastParenPad]
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\Test2.java:11:15: ')' is not preceded with whitespace. [TypecastParenPad]
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\Test2.java:13:16: ')' is not preceded with whitespace. [TypecastParenPad]
Audit done.
Checkstyle ends with 4 errors.
```