### PR TITLE
Issue #7922: Resolve Pitest Issues - JavadocMethodCheck (1)

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -172,7 +172,6 @@ pitest-javadoc)
   "AbstractJavadocCheck.java.html:<td class='covered'><pre><span  class='survived'>        beginJavadocTree(root);</span></pre></td></tr>"
   "AbstractJavadocCheck.java.html:<td class='covered'><pre><span  class='survived'>        finishJavadocTree(root);</span></pre></td></tr>"
   "AbstractJavadocCheck.java.html:<td class='covered'><pre><span  class='survived'>        javadocTokens.clear();</span></pre></td></tr>"
-  "JavadocMethodCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (!currentClassName.isEmpty()) {</span></pre></td></tr>"
   "JavadocMethodCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (classInfo == null) {</span></pre></td></tr>"
   "JavadocMethodCheck.java.html:<td class='covered'><pre><span  class='survived'>                 child != null;</span></pre></td></tr>"
   "JavadocMethodCheck.java.html:<td class='covered'><pre><span  class='survived'>                if (child.getType() == TokenTypes.TYPE_PARAMETER) {</span></pre></td></tr>"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -405,13 +405,7 @@ public class JavadocMethodCheck extends AbstractCheck {
             || ast.getType() == TokenTypes.ENUM_DEF) {
             // perhaps it was inner class
             final int dotIdx = currentClassName.lastIndexOf('$');
-            if (dotIdx == -1) {
-                // looks like a topmost class
-                currentClassName = "";
-            }
-            else {
-                currentClassName = currentClassName.substring(0, dotIdx);
-            }
+            currentClassName = currentClassName.substring(0, dotIdx);
             currentTypeParams.pop();
         }
         else if (ast.getType() == TokenTypes.METHOD_DEF) {
@@ -1035,9 +1029,7 @@ public class JavadocMethodCheck extends AbstractCheck {
         final DetailAST ident = ast.findFirstToken(TokenTypes.IDENT);
         String innerClass = ident.getText();
 
-        if (!currentClassName.isEmpty()) {
-            innerClass = "$" + innerClass;
-        }
+        innerClass = "$" + innerClass;
         currentClassName += innerClass;
         processTypeParams(ast);
     }


### PR DESCRIPTION
**Fixes** #7922

**Reports:** https://github.com/checkstyle/checkstyle/issues/7922#issuecomment-604274485

The only property requiring the ```currentClassName``` variable is ```validateThrows```. As can be seen in the code:
https://github.com/checkstyle/checkstyle/blob/834b505b9938e93f6950dd20a13e39e295e5ac86/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java#L485

which further calls ```getThrows``` and ```getThrowed``` method both requiring the ```currentClassName``` variable.
However, once we get the ```classInfo``` by this ```currentClassName``` variable, it calls ```checkThrowsTags``` method:
https://github.com/checkstyle/checkstyle/blob/834b505b9938e93f6950dd20a13e39e295e5ac86/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java#L486

which further needs ```currentClassName``` in:
https://github.com/checkstyle/checkstyle/blob/834b505b9938e93f6950dd20a13e39e295e5ac86/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java#L925

which just checks whether the class names are same or not:
https://github.com/checkstyle/checkstyle/blob/834b505b9938e93f6950dd20a13e39e295e5ac86/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java#L953

**Bottom Line:** It shouldn't matter what the class name is, at the moment, that is, even the outer class' name can have a $ before its name in the ```currentClassName``` variable and it should not matter as it's just going to check the equality of the class names as shown above. That is why that ```if``` can be removed from the check's java files, keeping its body only.