### PR TITLE
Issue #8036: Update test inputs to avoid long lines that violate 100 …

### DIFF
--- a/config/checkstyle_non_main_files_suppressions.xml
+++ b/config/checkstyle_non_main_files_suppressions.xml
@@ -90,20 +90,6 @@
     <suppress id="lineLength"
               files="src[\\/]test[\\/]resources-noncompilable[\\/].*[\\/]customimportorder"/>
 
-    <!-- untill https://github.com/checkstyle/checkstyle/issues/8036 -->
-    <suppress id="lineLength"
-              files="[\\/]InputFinalClassClassWithPrivateCtorWithNestedExtendingClass.java"/>
-    <suppress id="lineLength"
-              files="[\\/]InputJavadocMethod_1379666.java"/>
-    <suppress id="lineLength"
-              files="[\\/]grammar[\\/]InputJava7MultiCatch.java"/>
-    <suppress id="lineLength"
-              files="src[\\/]test[\\/]resources[\\/].*[\\/]checks[\\/]coding[\\/]illegaltype[\\/]InputIllegalType.*\.java"/>
-    <suppress id="lineLength"
-              files="src[\\/]test[\\/]resources[\\/].*[\\/]checks[\\/]coding[\\/]illegaltype[\\/]InputIllegalTypeMemberModifiers.*\.java"/>
-    <suppress id="lineLength"
-              files="src[\\/]test[\\/]resources[\\/].*[\\/]checks[\\/]metrics[\\/]classfanoutcomplexity[\\/]InputClassFanOutComplexityPackageName.*\.java"/>
-
     <!-- apply check numberOfTestCasesInXpath only for files in suppressionxpathfilter directory -->
     <suppress  id="numberOfTestCasesInXpath"
                files="src[\\/]it[\\/]java[\\/]com[\\/].*" />

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
@@ -67,10 +67,10 @@ public class IllegalTypeCheckTest extends AbstractModuleTestSupport {
     public void testDefaults() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IllegalTypeCheck.class);
         final String[] expected = {
-            "16:13: " + getCheckMessage(MSG_KEY, "java.util.TreeSet"),
-            "17:13: " + getCheckMessage(MSG_KEY, "TreeSet"),
-            "42:14: " + getCheckMessage(MSG_KEY, "HashMap"),
-            "44:5: " + getCheckMessage(MSG_KEY, "HashMap"),
+            "17:13: " + getCheckMessage(MSG_KEY, "java.util.TreeSet"),
+            "18:13: " + getCheckMessage(MSG_KEY, "TreeSet"),
+            "43:14: " + getCheckMessage(MSG_KEY, "HashMap"),
+            "45:5: " + getCheckMessage(MSG_KEY, "HashMap"),
         };
 
         verify(checkConfig, getPath("InputIllegalType.java"), expected);
@@ -86,10 +86,10 @@ public class IllegalTypeCheckTest extends AbstractModuleTestSupport {
             "9:13: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.coding.illegaltype."
                     + "InputIllegalType.AbstractClass"),
-            "16:13: " + getCheckMessage(MSG_KEY, "java.util.TreeSet"),
-            "25:36: " + getCheckMessage(MSG_KEY, "java.util.TreeSet"),
-            "42:14: " + getCheckMessage(MSG_KEY, "HashMap"),
-            "44:5: " + getCheckMessage(MSG_KEY, "HashMap"),
+            "17:13: " + getCheckMessage(MSG_KEY, "java.util.TreeSet"),
+            "26:36: " + getCheckMessage(MSG_KEY, "java.util.TreeSet"),
+            "43:14: " + getCheckMessage(MSG_KEY, "HashMap"),
+            "45:5: " + getCheckMessage(MSG_KEY, "HashMap"),
         };
 
         verify(checkConfig, getPath("InputIllegalType.java"), expected);
@@ -101,10 +101,10 @@ public class IllegalTypeCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("illegalAbstractClassNameFormat", "^$");
 
         final String[] expected = {
-            "16:13: " + getCheckMessage(MSG_KEY, "java.util.TreeSet"),
-            "17:13: " + getCheckMessage(MSG_KEY, "TreeSet"),
-            "42:14: " + getCheckMessage(MSG_KEY, "HashMap"),
-            "44:5: " + getCheckMessage(MSG_KEY, "HashMap"),
+            "17:13: " + getCheckMessage(MSG_KEY, "java.util.TreeSet"),
+            "18:13: " + getCheckMessage(MSG_KEY, "TreeSet"),
+            "43:14: " + getCheckMessage(MSG_KEY, "HashMap"),
+            "45:5: " + getCheckMessage(MSG_KEY, "HashMap"),
         };
 
         verify(checkConfig, getPath("InputIllegalType.java"), expected);
@@ -120,10 +120,10 @@ public class IllegalTypeCheckTest extends AbstractModuleTestSupport {
             "9:13: " + getCheckMessage(MSG_KEY,
                 "com.puppycrawl.tools.checkstyle.checks.coding.illegaltype."
                     + "InputIllegalType.AbstractClass"),
-            "16:13: " + getCheckMessage(MSG_KEY, "java.util.TreeSet"),
-            "17:13: " + getCheckMessage(MSG_KEY, "TreeSet"),
-            "42:14: " + getCheckMessage(MSG_KEY, "HashMap"),
-            "44:5: " + getCheckMessage(MSG_KEY, "HashMap"),
+            "17:13: " + getCheckMessage(MSG_KEY, "java.util.TreeSet"),
+            "18:13: " + getCheckMessage(MSG_KEY, "TreeSet"),
+            "43:14: " + getCheckMessage(MSG_KEY, "HashMap"),
+            "45:5: " + getCheckMessage(MSG_KEY, "HashMap"),
         };
 
         verify(checkConfig, getPath("InputIllegalType.java"), expected);
@@ -271,17 +271,13 @@ public class IllegalTypeCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("memberModifiers", "LITERAL_PRIVATE, LITERAL_PROTECTED,"
                 + " LITERAL_STATIC");
         final String[] expected = {
-            "6:13: " + getCheckMessage(MSG_KEY, "AbstractClass"),
-            "9:13: " + getCheckMessage(MSG_KEY,
-                "com.puppycrawl.tools.checkstyle.checks.coding.illegaltype."
-                    + "InputIllegalTypeMemberModifiers.AbstractClass"),
-            "16:13: " + getCheckMessage(MSG_KEY, "java.util.TreeSet"),
-            "17:13: " + getCheckMessage(MSG_KEY, "TreeSet"),
-            "23:15: " + getCheckMessage(MSG_KEY,
-                "com.puppycrawl.tools.checkstyle.checks.coding.illegaltype."
-                    + "InputIllegalTypeMemberModifiers.AbstractClass"),
-            "25:25: " + getCheckMessage(MSG_KEY, "java.util.TreeSet"),
-            "33:15: " + getCheckMessage(MSG_KEY, "AbstractClass"),
+            "5:13: " + getCheckMessage(MSG_KEY, "AbstractClass"),
+            "8:13: " + getCheckMessage(MSG_KEY, "java.util.AbstractList"),
+            "15:13: " + getCheckMessage(MSG_KEY, "java.util.TreeSet"),
+            "16:13: " + getCheckMessage(MSG_KEY, "TreeSet"),
+            "22:15: " + getCheckMessage(MSG_KEY, "java.util.AbstractList"),
+            "24:25: " + getCheckMessage(MSG_KEY, "java.util.TreeSet"),
+            "32:15: " + getCheckMessage(MSG_KEY, "AbstractClass"),
         };
 
         verify(checkConfig, getPath("InputIllegalTypeMemberModifiers.java"), expected);
@@ -303,8 +299,8 @@ public class IllegalTypeCheckTest extends AbstractModuleTestSupport {
         final String violationFile = getPath("InputIllegalType.java");
         checkConfig.addAttribute("illegalClassNames", "java.util.TreeSet");
         final String[] expected = {
-            "16:13: " + getCheckMessage(MSG_KEY, "java.util.TreeSet"),
-            "17:13: " + getCheckMessage(MSG_KEY, "TreeSet"),
+            "17:13: " + getCheckMessage(MSG_KEY, "java.util.TreeSet"),
+            "18:13: " + getCheckMessage(MSG_KEY, "TreeSet"),
         };
 
         verify(createChecker(checkConfig), new File[] {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassClassWithPrivateCtorWithNestedExtendingClass.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassClassWithPrivateCtorWithNestedExtendingClass.java
@@ -9,8 +9,8 @@ public class InputFinalClassClassWithPrivateCtorWithNestedExtendingClass {
 
     class B {
         private B() {}
-        private class ExtendB extends
-                com.puppycrawl.tools.checkstyle.checks.design.finalclass.InputFinalClassClassWithPrivateCtorWithNestedExtendingClass.B {}
+        private class ExtendB extends com.puppycrawl.tools.checkstyle.checks.design.finalclass.
+            InputFinalClassClassWithPrivateCtorWithNestedExtendingClass.B {}
     }
 
     class C {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalType.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalType.java
@@ -6,8 +6,9 @@ public class InputIllegalType implements InputIllegalTypeSuper {
     private AbstractClass a = null; //WARNING
     private NotAnAbstractClass b = null; /*another comment*/
 
-    private com.puppycrawl.tools.checkstyle.checks.coding.illegaltype.InputIllegalType.AbstractClass c = null; //WARNING
-    private com.puppycrawl.tools.checkstyle.checks.coding.illegaltype.InputIllegalType.NotAnAbstractClass d = null;
+    private com.puppycrawl.tools.checkstyle.checks.coding.illegaltype.InputIllegalType.AbstractClass
+        c = null; //WARNING
+    private java.util.List d = null;
 
     private abstract class AbstractClass {/*one more comment*/}
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeMemberModifiers.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeMemberModifiers.java
@@ -1,13 +1,12 @@
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
 import java.util.TreeSet;
-import java.util.Hashtable;
 //configuration: default
 public class InputIllegalTypeMemberModifiers {
     private AbstractClass a = null; //WARNING
     private NotAnAbstractClass b = null; /*another comment*/
 
-    private com.puppycrawl.tools.checkstyle.checks.coding.illegaltype.InputIllegalTypeMemberModifiers.AbstractClass c = null; //WARNING
-    private com.puppycrawl.tools.checkstyle.checks.coding.illegaltype.InputIllegalTypeMemberModifiers.NotAnAbstractClass d = null;
+    private java.util.AbstractList c = null; //WARNING
+    private java.util.List d = null;
 
     private abstract class AbstractClass {/*one more comment*/}
 
@@ -20,7 +19,7 @@ public class InputIllegalTypeMemberModifiers {
     }
 
     //WARNING if memberModifiers is set and contains TokenTypes.LITERAL_PROTECTED
-    protected com.puppycrawl.tools.checkstyle.checks.coding.illegaltype.InputIllegalTypeMemberModifiers.AbstractClass c1 = null;
+    protected java.util.AbstractList c1 = null;
     //NO WARNING if memberModifiers is set and does not contain TokenTypes.LITERAL_PUBLIC
     public final static java.util.TreeSet<Object> table3() { return null; }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod_1379666.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod_1379666.java
@@ -13,10 +13,10 @@ public class InputJavadocMethod_1379666 {
 
     /**
      * Some comment.
-     * @throws com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod.InputJavadocMethod_1379666.BadStringFormat some text
+     * @throws java.lang.Exception some text
      */
     public void error1()
-        throws com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod.InputJavadocMethod_1379666.BadStringFormat {
+        throws java.lang.Exception {
     }
 
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityPackageName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityPackageName.java
@@ -1,7 +1,9 @@
 package com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity;
 
 public interface InputClassFanOutComplexityPackageName {
-    public com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity.InputClassFanOutComplexityPackageName method1();
+    public com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity.
+        InputClassFanOutComplexityPackageName method1();
 
-    public com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity.InputClassFanOutComplexityPackageName method2();
+    public com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity.
+        InputClassFanOutComplexityPackageName method2();
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/InputJava7MultiCatch.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/InputJava7MultiCatch.java
@@ -23,7 +23,8 @@ public class InputJava7MultiCatch
         try {
             FileInputStream in = new FileInputStream("InputJava7MultiCatch.java");
             throw new CustomException();
-        } catch (final FileNotFoundException | CustomException | com.puppycrawl.tools.checkstyle.grammar.InputJava7MultiCatch.AnotherCustomException e) {
+        } catch (final FileNotFoundException | CustomException |
+            com.puppycrawl.tools.checkstyle.grammar.InputJava7MultiCatch.AnotherCustomException e) {
             logException(e);
         }
     }


### PR DESCRIPTION
Fixes #8036 : wrapped all the lines longer than 100 characters in the input files. 

#### Tested
```
gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ mvn compile antrun:run@ant-phase-verify
[INFO] Scanning for projects...
[INFO] Inspecting build with total of 1 modules...
.......
[INFO] Executed tasks
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  10.086 s
[INFO] Finished at: 2020-04-15T06:45:39+05:30
[INFO] ------------------------------------------------------------------------

```