### PR TITLE
Issue #4356: JavadocStyle - Check one line empty before tags in javadoc

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -760,6 +760,7 @@ libexec
 lifecycle
 linebreak
 linecolumn
+linegap
 linejava
 linelength
 linkcheck

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
@@ -11,6 +11,7 @@ javadoc.extraHtml=Extra HTML tag found: {0}
 javadoc.incompleteTag=Incomplete HTML tag found: {0}
 javadoc.invalidInheritDoc=Invalid use of the '{'@inheritDoc'}' tag.
 javadoc.legacyPackageHtml=Legacy package.html file should be removed.
+javadoc.linegapTag=Line gap missing before javadoc tag.
 javadoc.missed.html.close=Javadoc comment at column {0} has parse error. Missed HTML close tag ''{1}''. Sometimes it means that close tag missed for one of previous tags.
 javadoc.missing=Missing a Javadoc comment.
 javadoc.missing.whitespace=Missing a whitespace after the leading asterisk.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
@@ -11,6 +11,7 @@ javadoc.extraHtml=Zusätzliches HTML-Tag gefunden: {0}
 javadoc.incompleteTag=Unvollständiges HTML-Tag gefunden: {0}
 javadoc.invalidInheritDoc=Unerlaubte Verwendung des Tags '{'@inheritDoc'}'.
 javadoc.legacyPackageHtml=Die veraltete Datei package.html sollte entfernt werden.
+javadoc.linegapTag=Linienlücke fehlt vor Javadoc-Tag.
 javadoc.missed.html.close=Der Javadoc-Kommentar an Position {0} führt zu einem Parserfehler. Fehlendes schließendes HTML-Tag ''{1}''. Manchmal bedeutet dies, dass das schließende Tag eines vorgehenden Tags fehlt.
 javadoc.missing=Es fehlt ein Javadoc-Kommentar.
 javadoc.missing.whitespace=Nach dem Sternchen fehlt ein Leerzeichen.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
@@ -11,6 +11,7 @@ javadoc.extraHtml=Se encontró una etiqueta HTML extra: {0}
 javadoc.incompleteTag=Se encontró una etiqueta HTML incompleta: {0}
 javadoc.invalidInheritDoc=Uso no válido del '{'inheritDoc '}' etiqueta.
 javadoc.legacyPackageHtml=Archivo package.html legado debe ser eliminado.
+javadoc.linegapTag=Falta el espacio de línea antes de la etiqueta javadoc.
 javadoc.missed.html.close=Javadoc comentario en la columna {0} tiene parse error. Perdidas HTML cerca etiqueta ''{1}''. A veces esto significa que cerca de la etiqueta se perdió por una de las etiquetas anteriores.
 javadoc.missing=Falta el comentario Javadoc.
 javadoc.missing.whitespace=Falta un espacio en blanco después del asterisco principal.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
@@ -11,6 +11,7 @@ javadoc.extraHtml=Extra HTML-koodi löytyy: {0}
 javadoc.incompleteTag=Puutteelliset HTML-koodi löytyy: {0}
 javadoc.invalidInheritDoc=Virheellinen käyttö '{'inheritDoc '}' tag.
 javadoc.legacyPackageHtml=Legacy package.html tiedosto tulisi poistaa.
+javadoc.linegapTag=Riviväli puuttuu ennen javadoc-tunnistetta.
 javadoc.missed.html.close=Javadoc kommentti sarakkeessa {0} on Jäsennysvirhe. Missed HTML lähellä tag ''{1}''. Joskus se tarkoittaa, että lähellä tag jäi yhden edellisen tunnisteita.
 javadoc.missing=Javadoc-kommentti puuttuu.
 javadoc.missing.whitespace=Valkoinen tila puuttuu edessä olevan tähden jälkeen.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
@@ -11,6 +11,7 @@ javadoc.extraHtml=Balise HTML en trop : {0}
 javadoc.incompleteTag=Balise HTML incomplète : {0}
 javadoc.invalidInheritDoc=Utilisation invalide de la balise '{'@inheritDoc '}'.
 javadoc.legacyPackageHtml=L''ancien fichier package.html doit être supprimé.
+javadoc.linegapTag=Intervalle de ligne manquant avant la balise javadoc.
 javadoc.missed.html.close=Le commentaire Javadoc à la colonne {0} ne peut être analysé. La balise HTML fermante ''{1}'' n''a pas été trouvée. Parfois, cela signifie qu''une des balises fermantes précédentes est manquante.
 javadoc.missing=Commentaire Javadoc manquant.
 javadoc.missing.whitespace=Manque un espace après l'astérisque de tête.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
@@ -11,6 +11,7 @@ javadoc.extraHtml=不要な終了タグが見つかりました: {0}
 javadoc.incompleteTag=不完全なHTMLタグが見つかりました: {0}
 javadoc.invalidInheritDoc='{' @inheritDoc '}'タグの使用が無効です。
 javadoc.legacyPackageHtml=古い形式のpackage.htmlファイルは削除してください。
+javadoc.linegapTag=javadocタグの前に行ギャップがありません。
 javadoc.missed.html.close={0} 桁目の Javadoc コメントでパースエラーが発生しました。HTML タグ ''{1}'' が閉じていません。どこかもっと前のタグが閉じていない可能性もあります。
 javadoc.missing=Javadoc コメントがありません。
 javadoc.missing.whitespace=先頭のアスタリスクの後に空白がありません。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
@@ -11,6 +11,7 @@ javadoc.extraHtml=Etiqueta HTML extra encontrada: {0}
 javadoc.incompleteTag=Etiqueta HTML incompleta encontrada: {0}
 javadoc.invalidInheritDoc=Uso inválido da tag '{'inheritDoc '}'.
 javadoc.legacyPackageHtml=O arquivo package.html legado deve ser removido.
+javadoc.linegapTag=Falta de espaço na linha antes da tag javadoc.
 javadoc.missed.html.close=O comentário de Javadoc na coluna {0} tem erro sintático. Faltou uma etiqueta de fechamento HTML ''{1}''. Às vezes, isso significa que uma etiqueta de fechamento foi esquecida em uma das etiquetas HTML anteriores.
 javadoc.missing=Falta o comentário Javadoc.
 javadoc.missing.whitespace=Falta um espaço em branco após o asterisco inicial.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
@@ -11,6 +11,7 @@ javadoc.extraHtml=Fazladan HTML etiketi bulundu: {0}
 javadoc.incompleteTag=Tamamlanmamış HTML etiketi bulundu: {0}
 javadoc.invalidInheritDoc='{'@inheritDoc'}' etiketi kullanımı geçersiz.
 javadoc.legacyPackageHtml=Eskide kalan package.html dosyaları kaldırılmalı.
+javadoc.linegapTag=Javadoc etiketinden önce satır boşluğu eksik.
 javadoc.missed.html.close=Sütununda Javadoc comment {0} hatası ayrıştırmak vardır. Cevapsız HTML yakın etiketi ''{1}'' Bazen yakın etiketi önceki etiketler biri için kaçırmış demektir.
 javadoc.missing=Javadoc açıklaması eksik.
 javadoc.missing.whitespace=Önde gelen yıldız işaretinden sonra boşluk bırakma.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
@@ -11,6 +11,7 @@ javadoc.extraHtml=额外的 HTML 标签： {0} 。
 javadoc.incompleteTag=未关闭的 HTML 标签： {0} 。
 javadoc.invalidInheritDoc='{'@inheritDoc'}' 标签使用方式错误。
 javadoc.legacyPackageHtml=文件 package.html 应被删除。
+javadoc.linegapTag=javadoc标记之前缺少行间距。
 javadoc.missed.html.close=Javadoc 第 {0} 个字符解析错误。缺少 HTML 闭合标签： ''{1}''。 有时这代表前一标签未闭合。
 javadoc.missing=缺少 Javadoc 。
 javadoc.missing.whitespace=前导星号后缺少空格。

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
@@ -23,6 +23,7 @@ import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck.M
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck.MSG_EXTRA_HTML;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck.MSG_INCOMPLETE_TAG;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck.MSG_JAVADOC_MISSING;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck.MSG_LINEGAP_FIRST_TAG;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck.MSG_NO_PERIOD;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheck.MSG_UNCLOSED_HTML;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -432,6 +433,19 @@ public class JavadocStyleCheckTest
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
         verify(checkConfig, getPath("InputJavadocStyleNeverEndingXmlComment.java"), expected);
+    }
+
+    @Test
+    public void testLineGapBeforeParam() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(JavadocStyleCheck.class);
+        checkConfig.addAttribute("checkEmptyLineBeforeFirstTag", "true");
+        final String[] expected = {
+            "34: " + getCheckMessage(MSG_LINEGAP_FIRST_TAG),
+            "74: " + getCheckMessage(MSG_LINEGAP_FIRST_TAG),
+            "86: " + getCheckMessage(MSG_LINEGAP_FIRST_TAG),
+            "98: " + getCheckMessage(MSG_LINEGAP_FIRST_TAG),
+        };
+        verify(checkConfig, getPath("InputJavadocStyleTags.java"), expected);
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleTags.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2009 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocstyle;
+
+public class InputJavadocStyleTags {
+
+    /** @author xyz */
+    private String singleLineJavadoc(final String name) {
+        return null;
+    }
+
+    /**
+     * @author xyz
+     * @param name name
+     */
+    private String onlyTags(final String name) {
+        return null;
+    }
+
+    /**
+     * desc.
+     * @author xyz
+     * @param name name
+     */
+    private String simpleViolation(final String name) {
+        return null;
+    }
+
+    /**
+     * Looking if a given name is alias.
+     *
+     * @param name given name
+     * @return string
+     * @noinspection WeakerAccess
+     */
+    private String default1(final String name) {
+        return null;
+    }
+
+    /**
+     * Looking if a given name is alias.
+     *
+     */
+    private String noTags(final String name) {
+        return null;
+    }
+
+    /**
+     * Looking if a given name is alias.
+     *
+     * @return string sample
+     * @noinspection WeakerAccess
+     */
+    private String default2(final String name) {
+        return null;
+    }
+
+    /**
+     * Looking if a given name is alias.
+     *     desc1
+     *desc2
+     * @param name given name
+     * @return string
+     * @noinspection WeakerAccess
+     */
+    private String diffTypeofNonEmptyLines(final String name) {
+        return null;
+    }
+
+    /**
+     * Looking if a given name is alias.
+     *     desc1
+     *             desc2
+     * @param name given name
+     * @return string
+     * @noinspection WeakerAccess
+     */
+    private String diffTypeofNonEmptyLines2(final String name) {
+        return null;
+    }
+
+    /**
+     * Looking if a given name is alias.
+     *     desc1
+     *desc2 {@code} xyz
+     * @param name given name
+     * @return string
+     * @noinspection WeakerAccess
+     */
+    private String tagRegexPresent(final String name) {
+        return null;
+    }
+
+    /**
+     * Looking if a given name is alias.
+     *
+     *@param name given name
+     * @return string
+     * @noinspection WeakerAccess
+     */
+    private String noSpaceParam(final String name) {
+        return null;
+    }
+
+    /**
+     * Looking if a given name is alias.
+     *
+     *  @param name given name
+     *
+     * @return string
+     *
+     * @noinspection WeakerAccess
+     */
+    private String multipleSpaceTags(final String name) {
+        return null;
+    }
+
+    /**
+     * Looking if a given name is alias.
+     *
+     *  @param name given name
+     *
+     * @return string
+     *
+     * @noinspection WeakerAccess
+     */
+    private String multipleSpaceTags2(final String name) {
+        return null;
+    }
+}

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -1289,6 +1289,9 @@ public class TestClass {
             "sup", "table", "tbody", "td", "tfoot", "th", "thead", "tr", "tt",
             "u", "ul", "var".
           </li>
+          <li>
+            Checks if the first javadoc tag is missing an empty line before it.
+          </li>
         </ul>
 
         <p>
@@ -1355,6 +1358,16 @@ public class TestClass {
               <td><a href="property_types.html#boolean">Boolean</a></td>
               <td><code>true</code></td>
               <td>3.2</td>
+            </tr>
+            <tr>
+              <td>checkEmptyLineBeforeFirstTag</td>
+              <td>
+                Control whether to check if the first javadoc tag is missing an empty line before
+                  it.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>8.32</td>
             </tr>
             <tr>
               <td>tokens</td>
@@ -1571,6 +1584,10 @@ public class Test {
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.incompleteTag%22">
             javadoc.incompleteTag</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.linegapTag%22">
+            javadoc.linegapTag</a>
           </li>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missing%22">


### PR DESCRIPTION
Resolves #4356 

Diff report - https://gaurabdg.github.io/checkstyle-tester-reports/regression/JavadocStyle-lineBeforeTag/diff/