### PR TITLE
Issue #7606: updates docs for WriteTag

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java
@@ -71,25 +71,96 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </li>
  * </ul>
  * <p>
- * To configure the check for printing author name:
+ * Example of default Check configuration that do nothing.
+ * </p>
+ * <pre>
+ * &lt;module name="WriteTag"/&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * &#47;**
+ * * Some class
+ * *&#47;
+ * public class Test {
+ *   &#47;** some doc *&#47;
+ *   void foo() {}
+ * }
+ * </pre>
+ * <p>
+ * To configure Check to demand some special tag (for example {@code &#64;since})
+ * to be present on classes javadoc.
  * </p>
  * <pre>
  * &lt;module name="WriteTag"&gt;
- *   &lt;property name="tag" value="@author"/&gt;
- *   &lt;property name="tagFormat" value="\S"/&gt;
+ *   &lt;property name="tag" value="@since"/&gt;
  * &lt;/module&gt;
  * </pre>
  * <p>
- * To configure the check to print warnings if an "@incomplete" tag is found,
- * and not print anything if it is not found:
+ * Example:
+ * </p>
+ * <pre>
+ * &#47;**
+ * * Some class
+ * *&#47;
+ * public class Test { // violation as required tag is missed
+ *   &#47;** some doc *&#47;
+ *   void foo() {} // OK, as methods are not checked by default
+ * }
+ * </pre>
+ * <p>
+ * To configure Check to demand some special tag (for example {@code &#64;since})
+ * to be present on method javadocs also in addition to default tokens.
  * </p>
  * <pre>
  * &lt;module name="WriteTag"&gt;
- *   &lt;property name="tag" value="@incomplete"/&gt;
- *   &lt;property name="tagFormat" value="\S"/&gt;
- *   &lt;property name="severity" value="ignore"/&gt;
- *   &lt;property name="tagSeverity" value="warning"/&gt;
+ *   &lt;property name="tag" value="@since"/&gt;
+ *   &lt;property name="tokens"
+ *          value="INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF, METHOD_DEF" /&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * &#47;**
+ * * Some class
+ * *&#47;
+ * public class Test { // violation as required tag is missed
+ *   &#47;** some doc *&#47;
+ *   void foo() {} // violation as required tag is missed
+ * }
+ * </pre>
+ * <p>
+ * To configure Check to demand {@code &#64;since} tag
+ * to be present with digital value on method javadocs also in addition to default tokens.
+ * Attention: usage of non "ignore" in tagSeverity will print violation with such severity
+ * on each presence of such tag.
+ * </p>
+ * <pre>
+ * &lt;module name="WriteTag"&gt;
+ *   &lt;property name="tag" value="@since"/&gt;
+ *   &lt;property name="tokens"
+ *          value="INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF, METHOD_DEF" /&gt;
+ *   &lt;property name="tagFormat" value="[1-9\.]"/&gt;
+ *   &lt;property name="tagSeverity" value="ignore"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * &#47;**
+ * * Some class
+ * * &#64;since 1.2
+ * *&#47;
+ * public class Test {
+ *   &#47;** some doc
+ *   * &#64;since violation
+ *   *&#47;
+ *   void foo() {}
+ * }
  * </pre>
  * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -3455,28 +3455,96 @@ public class TestClass {
 
       <subsection name="Examples" id="WriteTag_Examples">
         <p>
-        To configure the check for printing author name:
+          Example of default Check configuration that do nothing.
         </p>
-
+        <source>
+&lt;module name="WriteTag"/&gt;
+        </source>
+        <p>
+        Example:
+        </p>
+        <source>
+/**
+* Some class
+*/
+public class Test {
+  /** some doc */
+  void foo() {}
+}
+        </source>
+        <p>
+          To configure Check to demand some special tag (for example <code>@since</code>)
+          to be present on classes javadoc.
+        </p>
         <source>
 &lt;module name="WriteTag"&gt;
-  &lt;property name="tag" value="@author"/&gt;
-  &lt;property name="tagFormat" value="\S"/&gt;
+  &lt;property name="tag" value="@since"/&gt;
 &lt;/module&gt;
         </source>
-
         <p>
-         To configure the check to print warnings if an
-         "@incomplete" tag is found, and not print anything if it is not found:
+        Example:
         </p>
-
+        <source>
+/**
+* Some class
+*/
+public class Test { // violation as required tag is missed
+  /** some doc */
+  void foo() {} // OK, as methods are not checked by default
+}
+        </source>
+        <p>
+          To configure Check to demand some special tag (for example <code>@since</code>)
+          to be present on method javadocs also in addition to default tokens.
+        </p>
         <source>
 &lt;module name="WriteTag"&gt;
-  &lt;property name="tag" value="@incomplete"/&gt;
-  &lt;property name="tagFormat" value="\S"/&gt;
-  &lt;property name="severity" value="ignore"/&gt;
-  &lt;property name="tagSeverity" value="warning"/&gt;
+  &lt;property name="tag" value="@since"/&gt;
+  &lt;property name="tokens"
+            value="INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF, METHOD_DEF" /&gt;
 &lt;/module&gt;
+        </source>
+        <p>
+        Example:
+        </p>
+        <source>
+/**
+* Some class
+*/
+public class Test { // violation as required tag is missed
+  /** some doc */
+  void foo() {} // violation as required tag is missed
+}
+        </source>
+        <p>
+          To configure Check to demand <code>@since</code> tag
+          to be present with digital value on method javadocs also in addition to default tokens.
+          Attention: usage of non "ignore" in tagSeverity will print violation with such severity
+          on each presence of such tag.
+        </p>
+        <source>
+&lt;module name="WriteTag"&gt;
+  &lt;property name="tag" value="@since"/&gt;
+  &lt;property name="tokens"
+            value="INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF, METHOD_DEF" /&gt;
+  &lt;property name="tagFormat" value="[1-9\.]"/&gt;
+  &lt;property name="tagSeverity" value="ignore"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+        Example:
+        </p>
+        <source>
+/**
+* Some class
+* @since 1.2
+*/
+public class Test {
+  /** some doc
+  * @since violation
+  */
+  void foo() {}
+}
         </source>
       </subsection>
 


### PR DESCRIPTION
Issue #7606: update doc for WriteTag

<img width="527" alt="Screen Shot 2020-04-10 at 04 41 54" src="https://user-images.githubusercontent.com/29354535/78946861-9e4a7280-7ae5-11ea-9724-d7995db3ff01.png">

Output of first example:
`$ cat config.xml`
```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="WriteTag">
          <property name="tag" value="@author"/>
          <property name="tagFormat" value="\S"/>
        </module>
    </module>
</module>
```

`java -Djava.util.logging.config.file=log.properties -jar checkstyle-8.30-all.jar -c config.xml java_sandbox/src/com/codestyle/sandbox/Test.java`
```
Starting audit...
[INFO] /Users/demezhanmarikov/IdeaProjects/java_sandbox/src/com/codestyle/sandbox/Test.java:4: Javadoc tag @author=Author [WriteTag]
[ERROR] /Users/demezhanmarikov/IdeaProjects/java_sandbox/src/com/codestyle/sandbox/Test.java:6: Type Javadoc tag @author must match pattern '\S'. [WriteTag]
Audit done.
Checkstyle ends with 1 errors.
```

Output of second example:
`$ cat config.xml`
```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="WriteTag">
          <property name="tag" value="@author"/>
          <property name="tagFormat" value="\S"/>
        </module>
    </module>
</module>
```

`java -Djava.util.logging.config.file=log.properties -jar checkstyle-8.30-all.jar -c config.xml java_sandbox/src/com/codestyle/sandbox/Test.java`
```
Starting audit...
[WARN] /Users/demezhanmarikov/IdeaProjects/java_sandbox/src/com/codestyle/sandbox/Test.java:4: Javadoc tag @incomplete=Incomplete [WriteTag]
[ERROR] /Users/demezhanmarikov/IdeaProjects/java_sandbox/src/com/codestyle/sandbox/Test.java:6: Type Javadoc tag @incomplete must match pattern '\S'. [WriteTag]
Audit done.
Checkstyle ends with 1 errors.
```
