### PR TITLE
Issue #7618: Update doc for EmptyForIteratorPad

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheck.java
@@ -57,6 +57,18 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *   &lt;property name=&quot;option&quot; value=&quot;space&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>violation</p>
+ * <pre>
+ * for(int i; i&lt;10;){
+ *     //violation
+ * }
+ * </pre>
+ * <p>acceptable code</p>
+ * <pre>
+ * for(int i; i&lt;10; i++){
+ *     //OK
+ * }
+ * </pre>
  *
  * @since 3.0
  */

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -173,6 +173,18 @@ for (Iterator foo = very.long.line.iterator();
   &lt;property name=&quot;option&quot; value=&quot;space&quot;/&gt;
 &lt;/module&gt;
         </source>
+          <p>violation</p>
+          <source>
+for(int i; i&lt;10;){
+    //violation
+}
+          </source>
+          <p>acceptable code</p>
+          <source>
+for(int i; i&lt;10; i++){
+    //OK
+}
+          </source>
       </subsection>
 
       <subsection name="Example of Usage" id="EmptyForIteratorPad_Example_of_Usage">


### PR DESCRIPTION
Fixes Issue #7618 
<img width="1141" alt="Screen Shot 2020-04-09 at 5 14 58 PM" src="https://user-images.githubusercontent.com/42932479/78951499-3a915c80-7a87-11ea-8f3f-8e89d7d5554a.png">

$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="EmptyForIteratorPad">
            <property name="option" value="space"/>
        </module>
    </module>

$ cat Test.java
public class Test {
int i;

    public void myTest() {
		for(i=0; i<10;){
		}

		for(i=0; i<10; i++){
		}
    }

$ java -jar checkstyle-8.30-all.jar -c config.xml Test.java 
Starting audit...
[ERROR] /Users/coraljain/Downloads/Testing_EmptyForIterator/Test.java:5:31: ';' is not followed by whitespace. [EmptyForIteratorPad]
Audit done.
Checkstyle ends with 1 errors.