### PR TITLE
Issue #7640: Update doc for FallThrough

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
@@ -110,6 +110,26 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *   &lt;property name=&quot;reliefPattern&quot; value=&quot;continue in next case&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>Violation</p>
+ * <pre>
+ *     switch (i) {
+ *      case 0:
+ *      case 1:
+ *          i++;
+ *      case 2: //Violation
+ *    }
+ * </pre>
+ * <p>acceptable code</p>
+ * <pre>
+ *     switch (i) {
+ *      case 0:
+ *          i++;
+ *          break;
+ *      case 1:
+ *          i++;
+ *          //fall through
+ *    }
+ * </pre>
  *
  * @since 3.4
  */

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -1390,6 +1390,26 @@ case 6:
   &lt;property name=&quot;reliefPattern&quot; value=&quot;continue in next case&quot;/&gt;
 &lt;/module&gt;
         </source>
+          <p>Violation</p>
+          <source>
+switch (i) {
+    case 0:
+    case 1:
+        i++;
+    case 2: //Violation
+}
+          </source>
+          <p>acceptable code</p>
+          <source>
+switch (i) {
+    case 0:
+        i++;
+        break;
+    case 1:
+        i++;
+        //fall through
+}
+          </source>
       </subsection>
 
       <subsection name="Example of Usage" id="FallThrough_Example_of_Usage">


### PR DESCRIPTION
Fixes Issue #7640 
![Capture_fallthrough](https://user-images.githubusercontent.com/60020042/79020001-8518e480-7b2c-11ea-8c54-2f19e5203424.PNG)

$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="FallThrough">
            <property name="reliefPattern" value="continue in next case"/>
        </module>
    </module>
</module>

$ cat Test.java
public class Test {
int i;
    public void myTest() {
                switch (i) {
                        case 0:
                        case 1:
                                i++;
                        case 2:
                }

                switch (i) {
                        case 0:
                        case 1:
                                i++;
                                break;
                        case 2:
                                i++;
                                // fall through
                }
    }

}

$ java -jar checkstyle-8.30-all.jar -c config.xml Test.java
Starting audit...
[ERROR] C:\Users\1\Documents\WSU\Software Maintenance\Project\Testing_FallThrough\Test.java:8:25: Fall through from previous branch of the switch statement. [FallThrough]
Audit done.
Checkstyle ends with 1 errors.