### PR TITLE
Issue #7745: Integration tests added for MissingJavadocMethod

### DIFF
--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMissingJavadocMethodTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMissingJavadocMethodTest.java
@@ -1,0 +1,102 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck;
+
+public class XpathRegressionMissingJavadocMethodTest extends AbstractXpathTestSupport {
+
+    @Override
+    protected String getCheckName() {
+        return MissingJavadocMethodCheck.class.getSimpleName();
+    }
+
+    @Test
+    public void testOne() throws Exception {
+        final File fileToProcess = new File(
+            getPath("SuppressionXpathRegressionMissingJavadocMethod1.java")
+        );
+
+        final DefaultConfiguration moduleConfig =
+            createModuleConfig(MissingJavadocMethodCheck.class);
+        moduleConfig.addAttribute("tokens", "CTOR_DEF");
+
+        final String[] expectedViolation = {
+            "4:5: " + getCheckMessage(MissingJavadocMethodCheck.class,
+                MissingJavadocMethodCheck.MSG_JAVADOC_MISSING),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMissingJavadocMethod1']]"
+                    + "/OBJBLOCK/CTOR_DEF[."
+                    + "/IDENT[@text='SuppressionXpathRegressionMissingJavadocMethod1']]",
+
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMissingJavadocMethod1']]"
+                    + "/OBJBLOCK/CTOR_DEF[."
+                    + "/IDENT[@text='SuppressionXpathRegressionMissingJavadocMethod1']]"
+                    + "/MODIFIERS",
+
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMissingJavadocMethod1']]"
+                    + "/OBJBLOCK/CTOR_DEF[."
+                    + "/IDENT[@text='SuppressionXpathRegressionMissingJavadocMethod1']]"
+                    + "/MODIFIERS/LITERAL_PUBLIC"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+
+    @Test
+    public void testTwo() throws Exception {
+        final File fileToProcess = new File(
+            getPath("SuppressionXpathRegressionMissingJavadocMethod2.java")
+        );
+
+        final DefaultConfiguration moduleConfig =
+            createModuleConfig(MissingJavadocMethodCheck.class);
+        moduleConfig.addAttribute("tokens", "METHOD_DEF");
+
+        final String[] expectedViolation = {
+            "4:5: " + getCheckMessage(MissingJavadocMethodCheck.class,
+                MissingJavadocMethodCheck.MSG_JAVADOC_MISSING),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMissingJavadocMethod2']]"
+                    + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]",
+
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMissingJavadocMethod2']]"
+                    + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]"
+                    + "/MODIFIERS",
+
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMissingJavadocMethod2']]"
+                    + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]"
+                    + "/MODIFIERS/LITERAL_PUBLIC"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/missingjavadocmethod/SuppressionXpathRegressionMissingJavadocMethod1.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/missingjavadocmethod/SuppressionXpathRegressionMissingJavadocMethod1.java
@@ -1,0 +1,7 @@
+package org.checkstyle.suppressionxpathfilter.missingjavadocmethod;
+
+public class SuppressionXpathRegressionMissingJavadocMethod1 {
+    public SuppressionXpathRegressionMissingJavadocMethod1() { // warn
+        // code
+    }
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/missingjavadocmethod/SuppressionXpathRegressionMissingJavadocMethod2.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/missingjavadocmethod/SuppressionXpathRegressionMissingJavadocMethod2.java
@@ -1,0 +1,7 @@
+package org.checkstyle.suppressionxpathfilter.missingjavadocmethod;
+
+public class SuppressionXpathRegressionMissingJavadocMethod2 {
+    public void foo() { // warn
+        // code
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -68,9 +68,6 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * JavadocType
  * </li>
  * <li>
- * MissingJavadocMethod
- * </li>
- * <li>
  * MissingJavadocType
  * </li>
  * <li>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -61,7 +61,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
             "InterfaceMemberImpliedModifier",
             "JavadocMethod",
             "JavadocType",
-            "MissingJavadocMethod",
             "MissingJavadocType",
             "OverloadMethodsDeclarationOrder",
             "PackageDeclaration",

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -910,7 +910,6 @@ public class UserService {
           <li>InterfaceMemberImpliedModifier</li>
           <li>JavadocMethod</li>
           <li>JavadocType</li>
-          <li>MissingJavadocMethod</li>
           <li>MissingJavadocType</li>
           <li>OverloadMethodsDeclarationOrder</li>
           <li>PackageDeclaration</li>


### PR DESCRIPTION
Resolves #7745 
Diff report: https://shashwat70.github.io/diff3/index.html
Diff is empty as the check was already logging DetailAST node.