### PR TITLE
Issue #2622: Update documentation for windows users

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -15,6 +15,13 @@ Check documentation: https://checkstyle.org/config_xxxxxx.html#NameOfAffectedChe
 #[[PLACE YOUR OUTPUT HERE]]
 ```
 
+For Windows users, please use `type` instead of `cat` and run 
+```
+set RUN_LOCALE="-Duser.language=en -Duser.country=US"
+java %RUN_LOCALE% -jar checkstyle-X.XX-all.jar -c config.xml YOUR_FILE.java
+```
+in place of the last 2 commands above.
+
 ---------------
 
 Describe what you expect in detail.

--- a/src/xdocs/report_issue.xml
+++ b/src/xdocs/report_issue.xml
@@ -64,7 +64,8 @@
         that cause problem.<br/>
         We do not need real source code. Any obfuscation of your super secret code is OK.<br/>
         Link to your source code would be awesome.
-        Code has to be compilable, in other case behaviour could be strange.
+        Code has to be compilable, in other case behaviour could be strange.<br/>
+        Always specify what is expected.
       </p>
 
       <p>
@@ -94,21 +95,55 @@ private static final int SOMETHING = 1;
   </module>
 </module>
 
-/var/tmp $ java -Duser.language=en -Duser.country=US -jar checkstyle-6.XX-all.jar \
-  -c config.xml Test.java
+/var/tmp $ RUN_LOCALE="-Duser.language=en -Duser.country=US"
+/var/tmp $ java $RUN_LOCALE -jar checkstyle-6.XX-all.jar -c config.xml Test.java
 Starting audit...
 Audit done.
 
+Expected: violation on first line.
+/var/tmp/Test.java:1:28: error: '{' is not preceded with whitespace.
         ]]></source>
       </p>
 
       <p>
-        Always specify what is expected.<br/>
+        For Windows users, please use "type" command instead of "cat".
+        Example of report that we expect:
 
-        <code>
-          Expected: violation on first line.
-          /var/tmp/Test.java:1:28: error: '{' is not preceded with whitespace.
-        </code>
+        <source><![CDATA[
+Check documentation: https://checkstyle.org/config_misc.html#Indentation
+
+D:\>type config.xml
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="Indentation"/>
+    </module>
+</module>
+
+D:\>type Test.java
+class Test {
+    void method() {
+        try { return; // violation, but it is not expected
+        }
+        catch (Exception e) { return; // no violation, but expected
+        }
+    }
+}
+
+D:\>set RUN_LOCALE="-Duser.language=en -Duser.country=US"
+D:\>java %RUN_LOCALE% -jar checkstyle-8.XX-all.jar -c config.xml Test.java
+Starting audit...
+[ERROR] D:\Test.java:3: 'try' child has incorrect indentation level 8,
+expected level should be 12. [Indentation]
+Audit done.
+
+Expected: A violation on line 5 and nowhere else.
+D:\Test.java:5: 'catch' child has incorrect indentation level 8,
+expected level should be 12. [Indentation]
+        ]]></source>
       </p>
 
     </section>


### PR DESCRIPTION
Resolve #2622: Update documentation for windows users

Notes:
- The example for linux was already patched so I couldn't replicate it. I used a different case, adapted from #5685.
- To accommodate both linux and windows report examples, I moved around some of the text a bit so it looks better (in my opinion).
- I also added the variation for Windows to the issue template, in #7926 the user had problems running the issue template commands due to Windows command line.
- I'm open to further improvements/suggestions for wording and formatting, so far this is just my take on what needs to be done.

New site looks like this:
![image](https://user-images.githubusercontent.com/53135010/79066383-184b4900-7cea-11ea-9f02-9e01aec4d43e.png)

