### PR TITLE
Issue #7179: Update docs of filters to indicate level in the tree

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilter.java
@@ -29,6 +29,9 @@ import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
  * Filter {@code SeverityMatchFilter} decides audit events according to the
  * <a href="https://checkstyle.org/config.html#Severity">severity level</a> of the event.
  * </p>
+ * <p>
+ * SeverityMatchFilter can suppress Checks that have Treewalker or Checker as parent module.
+ * </p>
  * <ul>
  * <li>
  * Property {@code severity} - Specify the severity level of this filter.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilter.java
@@ -46,6 +46,10 @@ import com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder;
  * any dotted prefix or "Check" suffix removed.
  * </p>
  * <p>
+ * SuppressWarningsFilter can suppress Checks that have Treewalker or
+ * Checker as parent module.
+ * </p>
+ * <p>
  * To configure the check that makes tha annotations available to the filter.
  * </p>
  * <pre>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -52,6 +52,10 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * a <a href="https://checkstyle.org/config_filters.html#SuppressWithPlainTextCommentFilter">
  * SuppressWithPlainTextCommentFilter</a> or similar filter must be used.
  * </p>
+ * <p>
+ * SuppressWithNearbyCommentFilter can suppress Checks that have
+ * Treewalker as parent module.
+ * </p>
  * <ul>
  * <li>
  * Property {@code commentFormat} - Specify comment pattern to trigger filter to begin suppression.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
@@ -68,6 +68,10 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Matcher.html#groupCount()">
  * paren counts</a>.
  * </p>
+ * <p>
+ * SuppressionWithPlainTextCommentFilter can suppress Checks that have Treewalker or
+ * Checker as parent module.
+ * </p>
  * <ul>
  * <li>
  * Property {@code offCommentFormat} - Specify comment pattern to trigger filter

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -65,6 +65,9 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Matcher.html#groupCount()">
  * paren counts</a>.
  * </p>
+ * <p>
+ * SuppressionCommentFilter can suppress Checks that have Treewalker as parent module.
+ * </p>
  * <ul>
  * <li>
  * Property {@code offCommentFormat} - Specify comment pattern to

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
@@ -104,6 +104,9 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * if no file found, then passed to the {@code ClassLoader.getResource()} method.
  * </li>
  * </ol>
+ * <p>
+ * SuppressionFilter can suppress Checks that have Treewalker or Checker as parent module.
+ * </p>
  * <ul>
  * <li>
  * Property {@code file} - Specify the location of the <em>suppressions XML document</em> file.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilter.java
@@ -43,6 +43,10 @@ import com.puppycrawl.tools.checkstyle.api.Filter;
  * Attention: This filter only supports single suppression, and will need multiple instances if
  * users wants to suppress multiple violations.
  * </p>
+ * <p>
+ * SuppressionSingleFilter can suppress Checks that have Treewalker or
+ * Checker as parent module.
+ * </p>
  * <ul>
  * <li>
  * Property {@code files} - Define the RegExp for matching against the file name associated with

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -201,6 +201,9 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * if no file found, then passed to the {@code ClassLoader.getResource()} method.
  * </li>
  * </ol>
+ * <p>
+ * SuppressionXpathFilter can suppress Checks that have Treewalker as parent module.
+ * </p>
  * <ul>
  * <li>
  * Property {@code file} - Specify the location of the <em>suppressions XML document</em> file.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilter.java
@@ -44,6 +44,9 @@ import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
  * Attention: This filter only supports single suppression, and will need multiple
  * instances if users wants to suppress multiple violations.
  * </p>
+ * <p>
+ * SuppressionXpathSingleFilter can suppress Checks that have Treewalker as parent module.
+ * </p>
  * <ul>
  * <li>
  * Property {@code files} - Define a Regular Expression matched against the file

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -31,6 +31,11 @@
           level</a> of the event.
         </p>
       </subsection>
+      <subsection name="Notes" id="SeverityMatchFilter_Notes">
+        <p>
+          SeverityMatchFilter can suppress Checks that have Treewalker or Checker as parent module.
+        </p>
+      </subsection>
       <subsection name="Properties" id="SeverityMatchFilter_Properties">
         <div class="wrapper">
           <table>
@@ -129,6 +134,9 @@
           <code>offCommentFormat</code> and <code>onCommentFormat</code> must have equal
           <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Matcher.html#groupCount()">
             paren counts</a>.
+        </p>
+        <p>
+          SuppressionCommentFilter can suppress Checks that have Treewalker as parent module.
         </p>
       </subsection>
       <subsection name="Properties" id="SuppressionCommentFilter_Properties">
@@ -551,6 +559,9 @@ public class UserService {
             <code>ClassLoader.getResource()</code> method.
           </li>
         </ol>
+        <p>
+          SuppressionFilter can suppress Checks that have Treewalker or Checker as parent module.
+        </p>
       </subsection>
       <subsection name="Examples" id="SuppressionFilter_Examples">
           <p>
@@ -698,6 +709,12 @@ public class UserService {
         <p>
           Attention: This filter only supports single suppression, and will need
           multiple instances if users wants to suppress multiple violations.
+        </p>
+      </subsection>
+      <subsection name="Notes" id="SuppressionSingleFilter_Notes">
+        <p>
+          SuppressionSingleFilter can suppress Checks that have Treewalker or
+          Checker as parent module.
         </p>
       </subsection>
       <subsection name="Properties" id="SuppressionSingleFilter_Properties">
@@ -985,6 +1002,9 @@ public class UserService {
             <code>ClassLoader.getResource()</code> method.
           </li>
         </ol>
+        <p>
+          SuppressionXpathFilter can suppress Checks that have Treewalker as parent module.
+        </p>
       </subsection>
       <subsection name="Properties" id="SuppressionXpathFilter_Properties">
         <div class="wrapper">
@@ -1383,6 +1403,11 @@ CLASS_DEF -> CLASS_DEF [1:0]
         <p>
           Attention: This filter only supports single suppression, and will need
           multiple instances if users wants to suppress multiple violations.
+        </p>
+      </subsection>
+      <subsection name="Notes" id="SuppressionXpathSingleFilter_Notes">
+        <p>
+          SuppressionXpathSingleFilter can suppress Checks that have Treewalker as parent module.
         </p>
       </subsection>
       <subsection name="Properties" id="SuppressionXpathSingleFilter_Properties">
@@ -1845,6 +1870,12 @@ public class TestClass {
               and should be written with any dotted prefix or "Check" suffix removed.
           </p>
       </subsection>
+      <subsection name="Notes" id="SuppressWarningsFilter_Notes">
+        <p>
+          SuppressWarningsFilter can suppress Checks that have Treewalker or
+          Checker as parent module.
+        </p>
+      </subsection>
       <subsection name="Examples" id="SuppressWarningsFilter_Examples">
           <p>
               To configure the check that makes tha annotations available to
@@ -1950,6 +1981,12 @@ public static void foo() {
                 a <a href="config_filters.html#SuppressWithPlainTextCommentFilter">
                 SuppressWithPlainTextCommentFilter</a> or similar filter must be used.
             </p>
+        </subsection>
+        <subsection name="Notes" id="SuppressWithNearbyCommentFilter_Notes">
+          <p>
+            SuppressWithNearbyCommentFilter can suppress Checks that have
+            Treewalker as parent module.
+          </p>
         </subsection>
         <subsection name="Properties" id="SuppressWithNearbyCommentFilter_Properties">
           <div class="wrapper">
@@ -2280,6 +2317,10 @@ public class UserService {
                   must have equal
                   <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Matcher.html#groupCount()">
                   paren counts</a>.
+              </p>
+              <p>
+                SuppressionWithPlainTextCommentFilter can suppress Checks that have Treewalker or
+                Checker as parent module.
               </p>
           </subsection>
           <subsection name="Examples" id="SuppressWithPlainTextCommentFilter_Examples">


### PR DESCRIPTION
Fixes #7179 

Updated docs as per the respective parent module of each filter under the "Notes" section.

Example of filter which did not have a "Notes" section earlier: (contains a typo, which is fixed via commit)
![pr9_1](https://user-images.githubusercontent.com/43749360/79067568-da482800-7cdd-11ea-9c80-233be2e00409.PNG)

Example of filter which had a "Notes" section earlier:
![pr9_2](https://user-images.githubusercontent.com/43749360/79067570-e3d19000-7cdd-11ea-82ce-c81833107855.PNG)
