### PR TITLE
Issue #7617: Update doc for EmptyForInitializerPad

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheck.java
@@ -57,7 +57,19 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *   &lt;property name=&quot;option&quot; value=&quot;space&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
- *
+ * <p>Violation</p>
+ * <pre>
+ * for(; i &lt; 10; i++){
+ *     //Violation
+ * }
+ * </pre>
+ * <p>accepted</p>
+ * <pre>
+ * for( ; i &lt; 10; i++){
+ *    //OK
+ * }
+ * </pre>
+ * 
  * @since 3.4
  */
 @StatelessCheck

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -76,6 +76,18 @@ for (
   &lt;property name=&quot;option&quot; value=&quot;space&quot;/&gt;
 &lt;/module&gt;
         </source>
+          <p>Violation</p>
+          <source>
+for(; i &lt; 10; i++){
+    //Violation
+}
+          </source>
+          <p>accepted</p>
+          <source>
+for( ; i &lt; 10; i++){
+    //OK
+}
+          </source>
       </subsection>
 
       <subsection name="Example of Usage" id="EmptyForInitializerPad_Example_of_Usage">


### PR DESCRIPTION
Fixes Issue #7617 
<img width="1134" alt="image" src="https://user-images.githubusercontent.com/42932479/79076878-136aa300-7cb2-11ea-844b-5e2296cfea43.png">

$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="EmptyForInitializerPad">
            <property name="option" value="space"/>
        </module>
    </module>
</module>

$ cat Test.java
public class Test {
	int i;

    public void myTest() {
    	for(; i < 10; i++){
    	}

    	for( ; i < 10; i++){
		}
    }

$ java -jar checkstyle-8.30-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /Users/coraljain/Downloads/Testing_Emptyforinitializer/Test.java:5:13: ';' is not preceded with whitespace. [EmptyForInitializerPad]
Audit done.
Checkstyle ends with 1 errors.
