### PR TITLE
minor: update test inputs for JDK15

### DIFF
--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsFromJavaLang.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsFromJavaLang.java
@@ -31,7 +31,7 @@ public class InputUnusedImportsFromJavaLang {
         }
     };
     private ProcessBuilder processBuilder = new ProcessBuilder();
-    private Modifier modifier = new Modifier();
+    private int modifier = Modifier.fieldModifiers();
     private Field field;
     private Annotation annotation;
 


### PR DESCRIPTION
This is the only change required to compile Checkstyle with JDK15.

One test input should be updated since `java.lang.reflect.Modifier` ctor was removed in
https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8230723
