### PR TITLE
Issue #7628: Update doc for SeparatorWrap

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheck.java
@@ -45,15 +45,6 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * COMMA</a>.
  * </li>
  * </ul>
- * <p>
- * Code example for comma and dot at the new line:
- * </p>
- * <pre>
- * s
- *     .isEmpty();
- * foo(i
- *     ,s);
- * </pre>
  *  <p>
  * To configure the check:
  * </p>
@@ -61,22 +52,28 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * &lt;module name=&quot;SeparatorWrap&quot;/&gt;
  * </pre>
  * <p>
- * Code example for comma and dot at the previous line:
+ * Example:
  * </p>
  * <pre>
- * s.
- *     isEmpty();
- * foo(i,
- *     s);
- * </pre>
- * <p>
- * Example for checking method reference at new line (good case and bad case):
- * </p>
- * <pre>
- * Arrays.sort(stringArray, String:: // violation
- *     compareToIgnoreCase);
- * Arrays.sort(stringArray, String
- *     ::compareToIgnoreCase); // good
+ * import java.io.
+ *          IOException; // OK
+ *
+ * class Test {
+ *
+ *   String s;
+ *
+ *   public void foo(int a,
+ *                     int b) { // OK
+ *   }
+ *
+ *   public void bar(int p
+ *                     , int q) { // violation, separator comma on new line
+ *     if (s
+ *           .isEmpty()) { // violation, separator dot on new line
+ *     }
+ *   }
+ *
+ * }
  * </pre>
  * <p>
  * To configure the check for
@@ -90,6 +87,25 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * &lt;/module&gt;
  * </pre>
  * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * import java.util.Arrays;
+ *
+ * class Test2 {
+ *
+ *   String[] stringArray = {&quot;foo&quot;, &quot;bar&quot;};
+ *
+ *   void fun() {
+ *     Arrays.sort(stringArray, String::
+ *       compareToIgnoreCase);  // violation, separator method reference on same line
+ *     Arrays.sort(stringArray, String
+ *       ::compareTo);  // OK
+ *   }
+ *
+ * }
+ * </pre>
+ * <p>
  * To configure the check for comma at the new line:
  * </p>
  * <pre>
@@ -97,6 +113,29 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *   &lt;property name=&quot;tokens&quot; value=&quot;COMMA&quot;/&gt;
  *   &lt;property name=&quot;option&quot; value=&quot;nl&quot;/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * class Test3 {
+ *
+ *   String s;
+ *
+ *   int a,
+ *     b;  // violation, separator comma on same line
+ *
+ *   public void foo(int a,
+ *                      int b) {  // violation, separator comma on the same line
+ *     int r
+ *       , t; // OK
+ *   }
+ *
+ *   public void bar(int p
+ *                     , int q) {  // OK
+ *   }
+ *
+ * }
  * </pre>
  *
  * @since 5.8

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -2091,37 +2091,34 @@ try (Closeable resource = acquire(); ) // no check before right parenthesis
 
       <subsection name="Examples" id="SeparatorWrap_Examples">
         <p>
-          Code example for comma and dot at the new line:
-        </p>
-        <source>
-s
-    .isEmpty();
-foo(i
-    ,s);
-        </source>
-        <p>
           To configure the check:
         </p>
         <source>
 &lt;module name="SeparatorWrap"/&gt;
         </source>
         <p>
-          Code example for comma and dot at the previous line:
+          Example:
         </p>
         <source>
-s.
-    isEmpty();
-foo(i,
-    s);
-        </source>
-        <p>
-          Example for checking method reference at new line (good case and bad case):
-        </p>
-        <source>
-Arrays.sort(stringArray, String:: // violation
-    compareToIgnoreCase);
-Arrays.sort(stringArray, String
-    ::compareToIgnoreCase); // good
+import java.io.
+         IOException; // OK
+
+class Test {
+
+  String s;
+
+  public void foo(int a,
+                    int b) { // OK
+  }
+
+  public void bar(int p
+                    , int q) { // violation, separator comma on new line
+    if (s
+          .isEmpty()) { // violation, separator dot on new line
+    }
+  }
+
+}
         </source>
         <p>
           To configure the check for
@@ -2135,6 +2132,25 @@ Arrays.sort(stringArray, String
 &lt;/module&gt;
         </source>
         <p>
+          Example:
+        </p>
+        <source>
+import java.util.Arrays;
+
+class Test2 {
+
+  String[] stringArray = {"foo", "bar"};
+
+  void fun() {
+    Arrays.sort(stringArray, String::
+      compareToIgnoreCase);  // violation, separator method reference on same line
+    Arrays.sort(stringArray, String
+      ::compareTo);  // OK
+  }
+
+}
+        </source>
+        <p>
           To configure the check for comma at the new line:
         </p>
         <source>
@@ -2142,6 +2158,29 @@ Arrays.sort(stringArray, String
   &lt;property name="tokens" value="COMMA"/&gt;
   &lt;property name="option" value="nl"/&gt;
 &lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+class Test3 {
+
+  String s;
+
+  int a,
+    b;  // violation, separator comma on same line
+
+  public void foo(int a,
+                     int b) {  // violation, separator comma on the same line
+    int r
+      , t; // OK
+  }
+
+  public void bar(int p
+                    , int q) {  // OK
+  }
+
+}
         </source>
       </subsection>
 


### PR DESCRIPTION
Fixes #7628
![pr10_1](https://user-images.githubusercontent.com/43749360/79215110-d5fc4600-7e68-11ea-93fe-c3f1a26c344e.PNG)
![pr10_2](https://user-images.githubusercontent.com/43749360/79215126-d8f73680-7e68-11ea-8eb2-1a284c1b5c59.PNG)
![pr10_3](https://user-images.githubusercontent.com/43749360/79215133-d98fcd00-7e68-11ea-9f08-7545c4d49d49.PNG)


Default Example:
```
$ cat config.xml
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <module name="SeparatorWrap">
    </module>
  </module>
</module>

$ cat Test.java
import java.io.
         IOException; // OK

class Test {

  String s;

  public void foo(int a,
                    int b) { // OK
  }

  public void bar(int p
                    , int q) { // violation, separator comma on new line
    if (s
          .isEmpty()) { // violation, separator dot on new line
    }
  }

}

$ java -jar checkstyle-8.30-all.jar -c config.xml Test.java
Starting audit...
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\Test.java:13:21: ',' should be on the previous line. [SeparatorWrap]
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\Test.java:15:11: '.' should be on the previous line. [SeparatorWrap]
Audit done.
Checkstyle ends with 2 errors.
```

Non-Default Example 1:
```
$ cat config2.xml
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <module name="SeparatorWrap">
                <property name="tokens" value="METHOD_REF"/>
                <property name="option" value="nl"/>
    </module>
  </module>
</module>

$ cat Test2.java
import java.util.Arrays;

class Test2 {

  String[] stringArray = {"foo", "bar"};

  void fun() {
        Arrays.sort(stringArray, String::
      compareToIgnoreCase);  // violation, separator method reference on same line
    Arrays.sort(stringArray, String
      ::compareTo);  // OK
  }

}

$ java -jar checkstyle-8.30-all.jar -c config2.xml Test2.java
Starting audit...
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\Test2.java:8:40: '::' should be on a new line. [SeparatorWrap]
Audit done.
Checkstyle ends with 1 errors.
```

Non-Default Example 2:
```
$ cat config3.xml
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <module name="SeparatorWrap">
                <property name="tokens" value="COMMA"/>
                <property name="option" value="nl"/>
    </module>
  </module>
</module>

$ cat Test3.java
class Test3 {

  String s;

  int a,
    b;  // violation, separator comma on same line

  public void foo(int a,
                     int b) {  // violation, separator comma on the same line
    int r
      , t; // OK
  }

  public void bar(int p
                    , int q) {  // OK
  }

}

$ java -jar checkstyle-8.30-all.jar -c config3.xml Test3.java
Starting audit...
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\Test3.java:5:8: ',' should be on a new line. [SeparatorWrap]
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\Test3.java:8:24: ',' should be on a new line. [SeparatorWrap]
Audit done.
Checkstyle ends with 2 errors.
```