### PR TITLE
Issue #7600: Update doc for JavadocTagContinuationIndentation

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
@@ -51,12 +51,57 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
  * &lt;module name="JavadocTagContinuationIndentation"/&gt;
  * </pre>
  * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * &#47;**
+ *  * @tag comment
+ *  *  Indentation spacing is 1. Line with violation
+ *  *   Indentation spacing is 2. Line with violation
+ *  *     Indentation spacing is 4. OK
+ *  *&#47;
+ * public class Test {
+ * }
+ * </pre>
+ * <p>
  * To configure the check with two spaces indentation:
  * </p>
  * <pre>
  * &lt;module name="JavadocTagContinuationIndentation"&gt;
  *   &lt;property name="offset" value="2"/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * &#47;**
+ *  * @tag comment
+ *  * Indentation spacing is 0. Line with violation
+ *  *   Indentation spacing is 2. OK
+ *  *  Indentation spacing is 1. Line with violation
+ *  *&#47;
+ * public class Test {
+ * }
+ * </pre>
+ * <p>
+ * To configure the check to show violations for Tight-HTML Rules:
+ * </p>
+ * <pre>
+ * &lt;module name="JavadocTagContinuationIndentation"&gt;
+ *   &lt;property name="violateExecutionOnNonTightHtml" value="true"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * &#47;**
+ *  * &lt;p&gt; 'p' tag is unclosed. Line with violation, this html tag needs closing tag.
+ *  * &lt;p&gt; 'p' tag is closed&lt;/p&gt;. OK
+ *  *&#47;
+ * public class Test {
+ * }
  * </pre>
  *
  * @since 6.0

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -1651,12 +1651,57 @@ public class Test {
 &lt;module name=&quot;JavadocTagContinuationIndentation&quot;/&gt;
         </source>
         <p>
+          Example:
+        </p>
+        <source>
+&#47;**
+ * @tag comment
+ *  Indentation spacing is 1. Line with violation
+ *   Indentation spacing is 2. Line with violation
+ *     Indentation spacing is 4. OK
+ *&#47;
+public class Test {
+}
+        </source>
+        <p>
           To configure the check with two spaces indentation:
         </p>
         <source>
 &lt;module name=&quot;JavadocTagContinuationIndentation&quot;&gt;
   &lt;property name=&quot;offset&quot; value=&quot;2&quot;/&gt;
 &lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+&#47;**
+ * @tag comment
+ * Indentation spacing is 0. Line with violation
+ *   Indentation spacing is 2. OK
+ *  Indentation spacing is 1. Line with violation
+ *&#47;
+public class Test {
+}
+        </source>
+        <p>
+          To configure the check to show violations for Tight-HTML Rules:
+        </p>
+        <source>
+&lt;module name=&quot;JavadocTagContinuationIndentation&quot;&gt;
+  &lt;property name="violateExecutionOnNonTightHtml" value="true"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+&#47;**
+ * &lt;p&gt; 'p' tag is unclosed. Line with violation, this html tag needs closing tag.
+ * &lt;p&gt; 'p' tag is closed&lt;/p&gt;. OK
+ *&#47;
+public class Test {
+}
         </source>
       </subsection>
 


### PR DESCRIPTION
fixes #7600 

Website view:

![kkkk](https://user-images.githubusercontent.com/38028330/79508763-cd1d9700-8057-11ea-9de3-50df70a71ae9.png)



Default config:

```
kaustubh@dxtk:~$ cat Test.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">

<module name="Checker">
    <property name="charset" value="UTF-8"/>

    <module name="TreeWalker">
<module name="JavadocTagContinuationIndentation">

</module>
    </module>
</module>
kaustubh@dxtk:~$ cat Test.java
/**
 * @tag comment..
 *  Indentation spacing is 1 (violation)
 *   Indentation spacing is 2 (violation)
 *     Indentation spacing is 4 (OK)
 */
public class Test {
}
      
kaustubh@dxtk:~$ java -jar checkstyle-8.30-all.jar -c Test.xml Test.java
Starting audit...
[ERROR] /home/kaustubh/Test.java:3: Line continuation have incorrect indentation level, expected level should be 4. [JavadocTagContinuationIndentation]
[ERROR] /home/kaustubh/Test.java:4: Line continuation have incorrect indentation level, expected level should be 4. [JavadocTagContinuationIndentation]
Audit done.
Checkstyle ends with 2 errors.
```
Config 1:

```
kaustubh@dxtk:~$ cat Test.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">

<module name="Checker">
    <property name="charset" value="UTF-8"/>

    <module name="TreeWalker">
<module name="JavadocTagContinuationIndentation">
  <property name="offset" value="2"/>
</module>
    </module>
</module>
kaustubh@dxtk:~$ cat Test.java
/**
 * @tag comment..
 * Indentation spacing is 0 (violation)
 *   Indentation spacing is 2 (OK)
 *  Indentation spacing is 1 (violation)
 */
public class Test {
}
     
kaustubh@dxtk:~$ java -jar checkstyle-8.30-all.jar -c Test.xml Test.java
Starting audit...
[ERROR] /home/kaustubh/Test.java:3: Line continuation have incorrect indentation level, expected level should be 2. [JavadocTagContinuationIndentation]
[ERROR] /home/kaustubh/Test.java:5: Line continuation have incorrect indentation level, expected level should be 2. [JavadocTagContinuationIndentation]
Audit done.
Checkstyle ends with 2 errors.
```
Config 2:

```
kaustubh@dxtk:~$ cat Test.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">

<module name="Checker">
    <property name="charset" value="UTF-8"/>

    <module name="TreeWalker">
<module name="JavadocTagContinuationIndentation">
  <property name="violateExecutionOnNonTightHtml" value="true"/>
</module>
    </module>
</module>
kaustubh@dxtk:~$ cat Test.java
/**
 * <p>HTML tag is unclosed (violation)
 * <p>HTML tag is closed</p> (OK)
 */
public class Test {
}
        
kaustubh@dxtk:~$ java -jar checkstyle-8.30-all.jar -c Test.xml Test.java
Starting audit...
[ERROR] /home/kaustubh/Test.java:2: Unclosed HTML tag found: p [JavadocTagContinuationIndentation]
Audit done.
Checkstyle ends with 1 errors.

```

@strkkk, please review.