### PR TITLE
Issue #7603: Update doc for MissingJavadocMethod

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java
@@ -112,6 +112,29 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * &lt;module name="MissingJavadocMethod"/&gt;
  * </pre>
  * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * public class Test {
+ *   public Test() {} // violation, missing javadoc for constructor
+ *   public void test() {} // violation, missing javadoc for method
+ *   &#47;**
+ *    * Some description here.
+ *    *&#47;
+ *   public void test2() {} // OK
+ *
+ *   &#64;Override
+ *   public String toString() { // OK
+ *     return "Some string";
+ *   }
+ *
+ *   private void test1() {} // OK
+ *   protected void test2() {} // OK
+ *   void test3() {} // OK
+ * }
+ * </pre>
+ *
+ * <p>
  * To configure the check for {@code private} scope:
  * </p>
  * <pre>
@@ -119,6 +142,13 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  *   &lt;property name="scope" value="private"/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public class Test {
+ *   private void test1() {} // violation, the private method is missing javadoc
+ * }
+ * </pre>
+ *
  * <p>
  * To configure the check for methods which are in {@code private}, but not in {@code protected}
  * scope:
@@ -129,6 +159,18 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  *   &lt;property name="excludeScope" value="protected"/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public class Test {
+ *   private void test1() {} // violation, the private method is missing javadoc
+ *   &#47;**
+ *    * Some description here
+ *    *&#47;
+ *   private void test1() {} // OK
+ *   protected void test2() {} // OK
+ * }
+ * </pre>
+ *
  * <p>
  * To configure the check for ignoring methods named {@code foo(),foo1(),foo2()}, etc.:
  * </p>
@@ -136,6 +178,59 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * &lt;module name="MissingJavadocMethod"&gt;
  *   &lt;property name="ignoreMethodNamesRegex" value="^foo.*$"/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public class Test {
+ *   public void test1() {} // violation, method is missing javadoc
+ *   public void foo() {} // OK
+ *   public void foobar() {} // OK
+ * }
+ * </pre>
+ *
+ * <p>
+ * To configure the check for ignoring missing javadoc for accessor methods:
+ * </p>
+ * <pre>
+ * &lt;module name="MissingJavadocMethod"&gt;
+ *   &lt;property name="allowMissingPropertyJavadoc" value="true"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public class Test {
+ *   private String text;
+ *
+ *   public void test() {} // violation, method is missing javadoc
+ *   public String getText() { return text; } // OK
+ *   public void setText(String text) { this.text = text; } // OK
+ * }
+ * </pre>
+ *
+ * <p>
+ * To configure the check with annotations that allow missed documentation:
+ * </p>
+ * <pre>
+ * &lt;module name="MissingJavadocMethod"&gt;
+ *   &lt;property name="allowedAnnotations" value="Override,Deprecated"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public class Test {
+ *   public void test() {} // violation, method is missing javadoc
+ *   &#64;Override
+ *   public void test1() {} // OK
+ *   &#64;Deprecated
+ *   public void test2() {} // OK
+ *   &#64;SuppressWarnings
+ *   public void test3() {} // violation, method is missing javadoc
+ *   &#47;**
+ *    * Some description here.
+ *    *&#47;
+ *   &#64;SuppressWarnings
+ *   public void test4() {} // OK
+ * }
  * </pre>
  *
  * @since 8.21

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -2266,6 +2266,28 @@ public boolean isSomething()
         <source>
 &lt;module name="MissingJavadocMethod"/&gt;
         </source>
+        <p>
+          Example:
+        </p>
+        <source>
+public class Test {
+  public Test() {} // violation, missing javadoc for constructor
+  public void test() {} // violation, missing javadoc for method
+  /**
+   * Some description here.
+   */
+  public void test2() {} // OK
+
+  @Override
+  public String toString() { // OK
+    return "Some string";
+  }
+
+  private void test1() {} // OK
+  protected void test2() {} // OK
+  void test3() {} // OK
+}
+        </source>
 
         <p>
           To configure the check for <code>private</code>
@@ -2275,6 +2297,12 @@ public boolean isSomething()
 &lt;module name="MissingJavadocMethod"&gt;
   &lt;property name="scope" value="private"/&gt;
 &lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+  private void test1() {} // violation, the private method is missing javadoc
+}
         </source>
 
         <p>
@@ -2287,6 +2315,17 @@ public boolean isSomething()
   &lt;property name="excludeScope" value="protected"/&gt;
 &lt;/module&gt;
         </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+  private void test1() {} // violation, the private method is missing javadoc
+  /**
+   * Some description here
+   */
+  private void test1() {} // OK
+  protected void test2() {} // OK
+}
+        </source>
 
         <p>
           To configure the check for ignoring methods named <code>foo(),foo1(),foo2()</code>, etc.:
@@ -2295,6 +2334,59 @@ public boolean isSomething()
 &lt;module name="MissingJavadocMethod"&gt;
   &lt;property name="ignoreMethodNamesRegex" value="^foo.*$"/&gt;
 &lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+  public void test1() {} // violation, method is missing javadoc
+  public void foo() {} // OK
+  public void foobar() {} // OK
+}
+        </source>
+
+        <p>
+          To configure the check for ignoring missing javadoc for accessor methods:
+        </p>
+        <source>
+&lt;module name="MissingJavadocMethod"&gt;
+  &lt;property name="allowMissingPropertyJavadoc" value="true"/&gt;
+&lt;/module&gt;
+          </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+  private String text;
+
+  public void test() {} // violation, method is missing javadoc
+  public String getText() { return text; } // OK
+  public void setText(String text) { this.text = text; } // OK
+}
+        </source>
+
+        <p>
+          To configure the check with annotations that allow missed documentation:
+        </p>
+        <source>
+&lt;module name="MissingJavadocMethod"&gt;
+  &lt;property name="allowedAnnotations" value="Override,Deprecated"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+  public void test() {} // violation, method is missing javadoc
+  @Override
+  public void test1() {} // OK
+  @Deprecated
+  public void test2() {} // OK
+  @SuppressWarnings
+  public void test3() {} // violation, method is missing javadoc
+  /**
+   * Some description here.
+   */
+  @SuppressWarnings
+  public void test4() {} // OK
+}
         </source>
       </subsection>
 


### PR DESCRIPTION
Fixes #7603 

#### Screenshots
<img width="1262" alt="Screen Shot 2020-04-13 at 5 59 42 PM" src="https://user-images.githubusercontent.com/36587580/79120637-041e4f00-7db1-11ea-84e8-0b5caba616fb.png">
<img width="1256" alt="Screen Shot 2020-04-19 at 2 18 42 PM" src="https://user-images.githubusercontent.com/36587580/79683580-c6a24180-8248-11ea-95cc-75e9704ae0ab.png">
<img width="1262" alt="Screen Shot 2020-04-13 at 5 59 59 PM" src="https://user-images.githubusercontent.com/36587580/79120645-084a6c80-7db1-11ea-8b6c-b311cf74ed9e.png">
<img width="1246" alt="Screen Shot 2020-04-15 at 6 27 47 AM" src="https://user-images.githubusercontent.com/36587580/79287711-46937900-7ee2-11ea-8b18-1bf72b14fc71.png">

#### Console Output
1. Check with default config
```
gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ cat check.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="TreeWalker">
        <module name="MissingJavadocMethod"/>
    </module>
</module>gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ java -jar target/checkstyle-8.32-SNAPSHOT-all.jar -c check.xml Test.java
Starting audit...
[ERROR] /Users/gauravpunjabi/Coding/Open Source/checkstyle/Test.java:2:3: Missing a Javadoc comment. [MissingJavadocMethod]
[ERROR] /Users/gauravpunjabi/Coding/Open Source/checkstyle/Test.java:3:3: Missing a Javadoc comment. [MissingJavadocMethod]
Audit done.
Checkstyle ends with 2 errors.
```

2. Check with private scope
```
gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ cat check.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="TreeWalker">
        <module name="MissingJavadocMethod">
            <property name="scope" value="private"/>
        </module>
    </module>
</module>gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ java -jar target/checkstyle-8.32-SNAPSHOT-all.jar -c check.xml Test.java
Starting audit...
[ERROR] /Users/gauravpunjabi/Coding/Open Source/checkstyle/Test.java:2:3: Missing a Javadoc comment. [MissingJavadocMethod]
[ERROR] /Users/gauravpunjabi/Coding/Open Source/checkstyle/Test.java:3:3: Missing a Javadoc comment. [MissingJavadocMethod]
Audit done.
Checkstyle ends with 2 errors.
```

3. Check with private scope, excluding protected scope
```
avpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ cat check.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="TreeWalker">
        <module name="MissingJavadocMethod">
            <property name="scope" value="private"/>
            <property name="excludeScope" value="protected"/>
        </module>
    </module>
</module>gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ java -jar target/checkstyle-8.32-SNAPSHOT-all.jar -c check.xml Test.java
Starting audit...
[ERROR] /Users/gauravpunjabi/Coding/Open Source/checkstyle/Test.java:2:3: Missing a Javadoc comment. [MissingJavadocMethod]
Audit done.
Checkstyle ends with 1 errors.
```

4. Check for ignoring methods starting with foo
```
vpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ cat check.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="TreeWalker">
        <module name="MissingJavadocMethod">
            <property name="ignoreMethodNamesRegex" value="^foo.*$"/>
        </module>
    </module>
</module>gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ java -jar target/checkstyle-8.32-SNAPSHOT-all.jar -c check.xml Test.java
Starting audit...
[ERROR] /Users/gauravpunjabi/Coding/Open Source/checkstyle/Test.java:2:3: Missing a Javadoc comment. [MissingJavadocMethod]
Audit done.
Checkstyle ends with 1 errors.
```

5. Check with allowMissingPropertyJavadoc set to true
```
acBook-Pro:~/Coding/Open Source/checkstyle$ cat check.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="TreeWalker">
        <module name="MissingJavadocMethod">
            <property name="allowMissingPropertyJavadoc" value="true"/>
        </module>
    </module>
</module>gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ java -jar target/checkstyle-8.32-SNAPSHOT-all.jar -c check.xml Test.java
Starting audit...
[ERROR] /Users/gauravpunjabi/Coding/Open Source/checkstyle/Test.java:4:3: Missing a Javadoc comment. [MissingJavadocMethod]
Audit done.
Checkstyle ends with 1 errors.
```

6. Check for only validating methods
```
gaurapunjabi@Gauravs-Macbook-Pro:~/Coding/Open Source/checkstyle$ cat check.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="TreeWalker">
        <module name="MissingJavadocMethod">
            <property name="tokens" value="METHOD_DEF"/>
        </module>
    </module>
</module>gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ java -jar target/checkstyle-8.32-SNAPSHOT-all.jar -c check.xml Test.java
Starting audit...
[ERROR] /Users/gauravpunjabi/Coding/Open Source/checkstyle/Test.java:3:3: Missing a Javadoc comment. [MissingJavadocMethod]
Audit done.
Checkstyle ends with 1 errors.
```

7. Check with allowedAnnotations
```
gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ cat config.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="TreeWalker">
        <module name="MissingJavadocMethod">
            <property name="allowedAnnotations" value="Deprecated,Override"/>
        </module>
    </module>
</module>
gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ java -jar target/checkstyle-8.32-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /Users/gauravpunjabi/Coding/Open Source/checkstyle/Test.java:2:9: Missing a Javadoc comment. [MissingJavadocMethod]
[ERROR] /Users/gauravpunjabi/Coding/Open Source/checkstyle/Test.java:5:9: Missing a Javadoc comment. [MissingJavadocMethod]
Audit done.
Checkstyle ends with 2 errors.
```