### PR TITLE
Issue 7979  Resolve Pitest Issues - JavadocMethodCheck (7)

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -177,7 +177,6 @@ pitest-javadoc)
   "JavadocMethodCheck.java.html:<td class='covered'><pre><span  class='survived'>                 child != null;</span></pre></td></tr>"
   "JavadocMethodCheck.java.html:<td class='covered'><pre><span  class='survived'>                if (child.getType() == TokenTypes.TYPE_PARAMETER) {</span></pre></td></tr>"
   "JavadocMethodCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (classInfo != null) {</span></pre></td></tr>"
-  "JavadocMethodCheck.java.html:<td class='covered'><pre><span  class='survived'>        currentTypeParams.clear();</span></pre></td></tr>"
   "JavadocMethodCheck.java.html:<td class='covered'><pre><span  class='survived'>        while (iterator.hasNext()) {</span></pre></td></tr>"
   "JavadocTagInfo.java.html:<td class='covered'><pre><span  class='survived'>            .collect(Collectors.toMap(JavadocTagInfo::getName, tagName -&#62; tagName)));</span></pre></td></tr>"
   "JavadocTagInfo.java.html:<td class='covered'><pre><span  class='survived'>            .collect(Collectors.toMap(JavadocTagInfo::getText, tagText -&#62; tagText)));</span></pre></td></tr>"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -380,7 +380,6 @@ public class JavadocMethodCheck extends AbstractCheck {
     @Override
     public void beginTree(DetailAST rootAST) {
         currentClassName = "";
-        currentTypeParams.clear();
     }
 
     @Override


### PR DESCRIPTION
Fix Issue #7979 

As per my knowledge we can see for each JavadocMethodCheck a new instance will be created so whenever this method is called a new object itself will be created of `currentTypeParams`

Pitest report: 
https://harsh-kukreja.github.io/JavadocMethodCheckPitestReport/com.puppycrawl.tools.checkstyle.checks.javadoc/JavadocMethodCheck.java.html#org.pitest.mutationtest.report.html.SourceFile@18b9ce_383


Hardcoded commit: 
https://github.com/checkstyle/checkstyle/commit/d2b3b319b15aa9b5efa41fce812e9c533c826f5c

Diff report:
https://harsh-kukreja.github.io/issue-7979/index.html
