### PR TITLE
config: ensured all maven commands print the stack  trace

### DIFF
--- a/.ci/idea_inspection.bat
+++ b/.ci/idea_inspection.bat
@@ -40,7 +40,7 @@ mkdir .idea\scopes
 copy config\intellij-idea-inspection-scope.xml .idea\scopes
 
 ::Execute compilation of Checkstyle to generate all source files
-mvn compile
+mvn -e compile
 
 ::Launch inspections
 "%IDEA_LOCATION%" inspect %PROJECT_DIR% %INSPECTIONS_PATH% %RESULTS_DIR% -%NOISE_LVL%

--- a/.ci/shippable.sh
+++ b/.ci/shippable.sh
@@ -21,7 +21,7 @@ function checkout_from {
 function build_checkstyle {
   if [[ "$SHIPPABLE" == "true" ]]; then
     echo "Build checkstyle ..."
-    mvn clean install -Pno-validations
+    mvn -e clean install -Pno-validations
   fi
 }
 

--- a/.ci/sonar.sh
+++ b/.ci/sonar.sh
@@ -8,7 +8,7 @@ curl -X POST -u admin:admin \
 mvn -e sonar:sonar -P sonar -Dsonar.language=java -Dsonar.profile=checkstyle-profile
 
 # Uncomment following to get HTML report.
-# mvn sonar:sonar -Dsonar.analysis.mode=preview -Dsonar.issuesReport.html.enable=true \
+# mvn -e sonar:sonar -Dsonar.analysis.mode=preview -Dsonar.issuesReport.html.enable=true \
 #        -Dsonar.language=java -Dsonar.profile=checkstyle-profile
 
 

--- a/.ci/wercker.sh
+++ b/.ci/wercker.sh
@@ -74,7 +74,7 @@ no-error-orekit)
   # checkout to version that Orekit expects
   SHA_HIPPARCHUS="1fb""fb8a2a259a9""7a23e2a387e8fd""c5e0a8402e77"
   git checkout $SHA_HIPPARCHUS
-  mvn install -DskipTests
+  mvn -e install -DskipTests
   cd -
   checkout_from https://github.com/CS-SI/Orekit.git
   cd .ci-temp/Orekit
@@ -96,7 +96,7 @@ no-error-xwiki)
   cd .ci-temp/xwiki-commons
   SHA_XWIKI="4fa""a8a49de3a70b""ba9c6c3849784e5d""fb642fa8d"
   git checkout $SHA_XWIKI
-  mvn -f xwiki-commons-tools/xwiki-commons-tool-verification-resources/pom.xml \
+  mvn -e -f xwiki-commons-tools/xwiki-commons-tool-verification-resources/pom.xml \
     install -DskipTests -Dcheckstyle.version=${CS_POM_VERSION}
   mvn -e test-compile checkstyle:check@default -Dcheckstyle.version=${CS_POM_VERSION}
   cd ..
@@ -213,7 +213,7 @@ no-error-strata)
   cd .ci-temp/Strata
   STRATA_CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${checkstyle.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
-  mvn install -e -B -Dstrict -DskipTests \
+  mvn -e install -B -Dstrict -DskipTests \
      -Dforbiddenapis.skip=true -Dcheckstyle.version=${CS_POM_VERSION} \
      -Dcheckstyle.config.suffix="-v$STRATA_CS_POM_VERSION"
   cd ../

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
               ls -la
               java -version
               mvn --version
-              mvn -Ppitest-metrics dependency:go-offline
+              mvn -e -Ppitest-metrics dependency:go-offline
             else
               echo "build is skipped ..."
             fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -344,7 +344,7 @@ script:
       fi
       if [[ $USE_MAVEN_REPO == 'true' && ! -d "~/.m2" ]]; then
        echo "Maven local repo cache is not found, initializing it ..."
-       mvn -B install -Pno-validations;
+       mvn -e -B install -Pno-validations;
       fi
       echo "eval of CMD is starting";
       echo "CMD=$CMD";

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,7 +77,7 @@ pipeline {
       parallel {
         stage('Package') {
           steps {
-            sh "mvn -B package"
+            sh "mvn -e -B package"
           }
         }
       }


### PR DESCRIPTION
Identified at https://github.com/checkstyle/checkstyle/pull/8099#issuecomment-613768780 ,

I made sure all maven commands print the stack trace so we can look at and identify any issues in any maven commands.

I ensured all maven commands were covered by running the regular expression `(mvn [^-])|(mvn \-[^e])` and ensure nothing besides `mvn --version` showed up.