### PR TITLE
Issue #5148: Add MissingJavadocType to google_checks.xml

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -1433,6 +1433,7 @@ webtoolkit
 Wellformedness
 wercker
 wget
+wherejavadocrequired
 wheretobreak
 whi
 Whitebox

--- a/.ci/travis/travis.sh
+++ b/.ci/travis/travis.sh
@@ -165,8 +165,8 @@ assembly-run-all-jar)
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo version:$CS_POM_VERSION
   mkdir -p .ci-temp
-  FOLDER=src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing
-  FILE=InputCustomImportOrderNoImports.java
+  FOLDER=src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired
+  FILE=InputMissingJavadocTypeCheckNoViolations.java
   java -jar target/checkstyle-$CS_POM_VERSION-all.jar -c /google_checks.xml \
         $FOLDER/$FILE > .ci-temp/output.log
   fail=0

--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/MissingJavadocTypeTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/MissingJavadocTypeTest.java
@@ -1,0 +1,64 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.google.checkstyle.test.chapter7javadoc.rule73wherejavadocrequired;
+
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck.MSG_JAVADOC_MISSING;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+
+public class MissingJavadocTypeTest extends AbstractGoogleModuleTestSupport {
+
+    @Override
+    protected String getPackageLocation() {
+        return "com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired";
+    }
+
+    @Test
+    public void testJavadocType() throws Exception {
+
+        final String[] expected = {
+            "3: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        };
+
+        final Configuration checkConfig = getModuleConfig("MissingJavadocType");
+        final String filePath = getPath("InputMissingJavadocTypeCheck.java");
+
+        final Integer[] warnList = getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
+    }
+
+    @Test
+    public void testJavadocTypeNoViolations() throws Exception {
+
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        final Configuration checkConfig = getModuleConfig("MissingJavadocType");
+        final String filePath = getPath("InputMissingJavadocTypeCheckNoViolations.java");
+
+        final Integer[] warnList = getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
+    }
+
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputMissingJavadocTypeCheck.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputMissingJavadocTypeCheck.java
@@ -1,0 +1,9 @@
+package com.google.checkstyle.test.chapter7javadoc.rule73wherejavadocrequired;
+
+public class InputMissingJavadocTypeCheck { //warn
+
+}
+
+class AdditionalClass { // OK, not public
+
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputMissingJavadocTypeCheckNoViolations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputMissingJavadocTypeCheckNoViolations.java
@@ -1,0 +1,8 @@
+package com.google.checkstyle.test.chapter7javadoc.rule73wherejavadocrequired;
+
+/**
+ * This is a Javadoc comment.
+ */
+public class InputMissingJavadocTypeCheckNoViolations { // OK
+
+}

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -328,6 +328,11 @@
       <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,
                                    COMPACT_CTOR_DEF"/>
     </module>
+    <module name="MissingJavadocType">
+        <property name="scope" value="public"/>
+        <property name="skipAnnotations" value=""/>
+        <property name="tokens" value="CLASS_DEF"/>
+    </module>
     <module name="MethodName">
       <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
       <message key="name.invalidPattern"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -254,6 +254,10 @@ public class AllChecksTest extends AbstractModuleTestSupport {
                 // whitespace is necessary between a type annotation and ellipsis
                 // according '4.6.2 Horizontal whitespace point 9'
                 "ELLIPSIS").collect(Collectors.toSet()));
+        GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("MissingJavadocType", Stream.of(
+                // only classes are specified in '7.3 Where Javadoc is used'
+                "INTERFACE_DEF", "ENUM_DEF", "ANNOTATION_DEF")
+                .collect(Collectors.toSet()));
         INTERNAL_MODULES = Definitions.INTERNAL_MODULES.stream()
                 .map(moduleName -> {
                     final String[] packageTokens = moduleName.split("\\.");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainViolationsForGoogle.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainViolationsForGoogle.java
@@ -1,5 +1,8 @@
 package com.puppycrawl.tools.checkstyle.main;
 
+/**
+ * A javadoc comment for the class.
+ */
 public class InputMainViolationsForGoogle {
   private String m_field; // violation
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainViolationsForGoogleSuppressions.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainViolationsForGoogleSuppressions.xml
@@ -6,11 +6,11 @@
   <suppress
          files="InputMainViolationsForGoogle.java"
          checks="MemberNameCheck"
-         lines="4"
+         lines="7"
   />
   <suppress
          files="InputMainViolationsForGoogle.java"
          checks="MethodNameCheck"
-         lines="6"
+         lines="9"
   />
 </suppressions>

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -2784,6 +2784,10 @@ class DatabaseConfiguration {}
       <subsection name="Example of Usage" id="MissingJavadocType_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingJavadocType">
+            Google Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig+filename%3Acheckstyle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingJavadocType">
             Checkstyle Style</a>
           </li>

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -2147,6 +2147,12 @@
                         src="images/ok_green.png"
                         alt="" />
                   </span>
+                  <a href="config_javadoc.html#MissingJavadocType">MissingJavadocType</a>
+                  <span class="wrapper inline">
+                    <img
+                        src="images/ok_green.png"
+                        alt="" />
+                  </span>
                   <a href="config_javadoc.html#MissingJavadocMethod">MissingJavadocMethod</a>
                   <span class="wrapper inline">
                     <img
@@ -2156,6 +2162,10 @@
                   <a href="config_javadoc.html#JavadocMethod">JavadocMethod</a>
                 </td>
                 <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingJavadocType">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/MissingJavadocTypeTest.java">
+                    test</a>
                   <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingJavadocMethod">
                     config</a><br/>
                   <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/MissingJavadocMethodTest.java">


### PR DESCRIPTION
Fix #5148

I added the following check to the Google Style config:
```xml
        <module name="MissingJavadocType">
            <property name="scope" value="public"/>
            <property name="skipAnnotations" value=""/>
            <property name="tokens" value="CLASS_DEF"/>
        </module>
```
Google Style rule for reference: https://google.github.io/styleguide/javaguide.html#s7.3-javadoc-where-required
Check documentation for reference: https://checkstyle.org/config_javadoc.html#MissingJavadocType

Some justifications for the properties used:
- `scope` - Default is already `public` but the rule specifically says "public class" so I thought it'd be best to explicitly state that.
- `skipAnnotations` - For **classes**, there is no such rule for exception by annotation. [Rule 7.3.2](https://google.github.io/styleguide/javaguide.html#s7.3.2-javadoc-exception-overrides) does not apply here as it is only for methods.
- `tokens` - Only classes are affected by this rule. It is not necessary to check other tokens.