### PR TITLE
Issue #7566: Add default config example for AbbreviationAsWordInName

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
@@ -93,10 +93,67 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </li>
  * </ul>
  * <p>
- * Default configuration
+ * To configure the check:
  * </p>
  * <pre>
  * &lt;module name="AbbreviationAsWordInName"/&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * public class MyClass extends SuperClass { // OK, camel case
+ *   int CURRENT_COUNTER; // violation, at most 4 consecutive capital letters allowed
+ *   static int GLOBAL_COUNTER; // OK, static is ignored
+ *   final Set&lt;String&gt; stringsFOUND = new HashSet&lt;&gt;(); // OK, final is ignored
+ *
+ *   &#64;Override
+ *   void printCOUNTER() { // OK, overridden method is ignored
+ *     System.out.println(CURRENT_COUNTER); // OK, only definitions are checked
+ *   }
+ *
+ *   void incrementCOUNTER() { // violation, at most 4 consecutive capital letters allowed
+ *     CURRENT_COUNTER++; // OK, only definitions are checked
+ *   }
+ *
+ *   static void incrementGLOBAL() { // violation, static method is not ignored
+ *     GLOBAL_COUNTER++; // OK, only definitions are checked
+ *   }
+ *
+ * }
+ * </pre>
+ * <p>
+ * To configure to include static variables and methods tagged with
+ * {@code @Override} annotation.
+ * </p>
+ * <p>Configuration:</p>
+ * <pre>
+ * &lt;module name="AbbreviationAsWordInName"&gt;
+ *   &lt;property name="ignoreStatic" value="false"/&gt;
+ *   &lt;property name="ignoreOverriddenMethods" value="false"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public class MyClass extends SuperClass { // OK, camel case
+ *   int CURRENT_COUNTER; // violation, at most 4 consecutive capital letters allowed
+ *   static int GLOBAL_COUNTER; // violation, static is not ignored
+ *   final Set&lt;String&gt; stringsFOUND = new HashSet&lt;&gt;(); // OK, final is ignored
+ *
+ *   &#64;Override
+ *   void printCOUNTER() { // violation, overridden method is not ignored
+ *     System.out.println(CURRENT_COUNTER); // OK, only definitions are checked
+ *   }
+ *
+ *   void incrementCOUNTER() { // violation, at most 4 consecutive capital letters allowed
+ *     CURRENT_COUNTER++; // OK, only definitions are checked
+ *   }
+ *
+ *   static void incrementGLOBAL() { // violation, at most 4 consecutive capital letters allowed
+ *     GLOBAL_COUNTER++; // OK, only definitions are checked
+ *   }
+ *
+ * }
  * </pre>
  * <p>
  * To configure to check all variables and identifiers

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -153,11 +153,64 @@
       </subsection>
 
       <subsection name="Examples" id="AbbreviationAsWordInName_Examples">
-       <p>
-         Default configuration
-       </p>
+       <p>To configure the check:</p>
        <source>
 &lt;module name="AbbreviationAsWordInName"/&gt;
+       </source>
+       <p>Example:</p>
+       <source>
+public class MyClass extends SuperClass { // OK, camel case
+  int CURRENT_COUNTER; // violation, at most 4 consecutive capital letters allowed
+  static int GLOBAL_COUNTER; // OK, static is ignored
+  final Set&lt;String&gt; stringsFOUND = new HashSet&lt;&gt;(); // OK, final is ignored
+
+  &#64;Override
+  void printCOUNTER() { // OK, overridden method is ignored
+    System.out.println(CURRENT_COUNTER); // OK, only definitions are checked
+  }
+
+  void incrementCOUNTER() { // violation, at most 4 consecutive capital letters allowed
+    CURRENT_COUNTER++; // OK, only definitions are checked
+  }
+
+  static void incrementGLOBAL() { // violation, static method is not ignored
+    GLOBAL_COUNTER++; // OK, only definitions are checked
+  }
+
+}
+       </source>
+       <p>
+         To configure to include static variables and
+         methods tagged with <code>@Override</code> annotation.
+       </p>
+       <p>Configuration:</p>
+       <source>
+&lt;module name="AbbreviationAsWordInName"&gt;
+  &lt;property name="ignoreStatic" value="false"/&gt;
+  &lt;property name="ignoreOverriddenMethods" value="false"/&gt;
+&lt;/module&gt;
+       </source>
+       <p>Example:</p>
+       <source>
+public class MyClass extends SuperClass { // OK, camel case
+  int CURRENT_COUNTER; // violation, at most 4 consecutive capital letters allowed
+  static int GLOBAL_COUNTER; // violation, static is not ignored
+  final Set&lt;String&gt; stringsFOUND = new HashSet&lt;&gt;(); // OK, final is ignored
+
+  &#64;Override
+  void printCOUNTER() { // violation, overridden method is not ignored
+    System.out.println(CURRENT_COUNTER); // OK, only definitions are checked
+  }
+
+  void incrementCOUNTER() { // violation, at most 4 consecutive capital letters allowed
+    CURRENT_COUNTER++; // OK, only definitions are checked
+  }
+
+  static void incrementGLOBAL() { // violation, at most 4 consecutive capital letters allowed
+    GLOBAL_COUNTER++; // OK, only definitions are checked
+  }
+
+}
        </source>
        <p>
           To configure to check all variables and identifiers


### PR DESCRIPTION
Fix #7566 

Although the title of the issue only asks for "default config example", there is one more property `ignoreOverriddenMethods` that was not covered by existing examples, so I've added that in as well.

The two examples added:
![image](https://user-images.githubusercontent.com/53135010/79638873-872d1400-81ba-11ea-88a7-f2647db2bdee.png)

```
D:\checkstyletest>type config.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <property name="severity" value="error"/>
    <module name="TreeWalker">
        <module name="AbbreviationAsWordInName"/>

    </module>
</module>

D:\checkstyletest>type test\*.java 
public class MyClass extends SuperClass { // OK, camel case
  int CURRENT_COUNTER; // violation, at most 4 consecutive capital letters allowed
  static int GLOBAL_COUNTER; // OK, static is ignored
  final Set<String> stringsFOUND = new HashSet<>(); // OK, final is ignored

  @Override
  void printCOUNTER() { // OK, overridden method is ignored
    System.out.println(CURRENT_COUNTER); // OK, only definitions are checked
  }

  void incrementCOUNTER() { // violation, at most 4 consecutive capital letters allowed
    CURRENT_COUNTER++; // OK, only definitions are checked
  }

  static void incrementGLOBAL() { // violation, static method is not ignored
    GLOBAL_COUNTER++; // OK, only definitions are checked
  }

}

D:\checkstyletest>set RUN_LOCALE="-Duser.language=en -Duser.country=US" 

D:\checkstyletest>java -jar "-Duser.language=en -Duser.country=US" checkstyle-8.31-all.jar -c config.xml test\*.java 
Starting audit...
[ERROR] D:\checkstyletest\test\Test.java:2:7: Abbreviation in name 'CURRENT_COUNTER' must contain no more than '4' consecutive capital letters. [AbbreviationAsWordInName]
[ERROR] D:\checkstyletest\test\Test.java:11:8: Abbreviation in name 'incrementCOUNTER' must contain no more than '4' consecutive capital letters. [AbbreviationAsWordInName]
[ERROR] D:\checkstyletest\test\Test.java:15:15: Abbreviation in name 'incrementGLOBAL' must contain no more than '4' consecutive capital letters. [AbbreviationAsWordInName]
Audit done.
```
```
D:\checkstyletest>type config.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <property name="severity" value="error"/>
    <module name="TreeWalker">
        <module name="AbbreviationAsWordInName">
            <property name="ignoreStatic" value="false"/>
            <property name="ignoreOverriddenMethods" value="false"/>
        </module>

    </module>
</module>

D:\checkstyletest>type test\*.java 
public class MyClass extends SuperClass { // OK, camel case
  int CURRENT_COUNTER; // violation, at most 4 consecutive capital letters allowed
  static int GLOBAL_COUNTER; // violation, static is not ignored
  final Set<String> stringsFOUND = new HashSet<>(); // OK, final is ignored

  @Override
  void printCOUNTER() { // violation, overridden method is not ignored
    System.out.println(CURRENT_COUNTER); // OK, only definitions are checked
  }

  void incrementCOUNTER() { // violation, at most 4 consecutive capital letters allowed
    CURRENT_COUNTER++; // OK, only definitions are checked
  }

  static void incrementGLOBAL() { // violation, at most 4 consecutive capital letters allowed
    GLOBAL_COUNTER++; // OK, only definitions are checked
  }

}

D:\checkstyletest>set RUN_LOCALE="-Duser.language=en -Duser.country=US" 

D:\checkstyletest>java -jar "-Duser.language=en -Duser.country=US" checkstyle-8.31-all.jar -c config.xml test\*.java 
Starting audit...
[ERROR] D:\checkstyletest\test\Test.java:2:7: Abbreviation in name 'CURRENT_COUNTER' must contain no more than '4' consecutive capital letters. [AbbreviationAsWordInName]
[ERROR] D:\checkstyletest\test\Test.java:3:14: Abbreviation in name 'GLOBAL_COUNTER' must contain no more than '4' consecutive capital letters. [AbbreviationAsWordInName]
[ERROR] D:\checkstyletest\test\Test.java:7:8: Abbreviation in name 'printCOUNTER' must contain no more than '4' consecutive capital letters. [AbbreviationAsWordInName]
[ERROR] D:\checkstyletest\test\Test.java:11:8: Abbreviation in name 'incrementCOUNTER' must contain no more than '4' consecutive capital letters. [AbbreviationAsWordInName]
[ERROR] D:\checkstyletest\test\Test.java:15:15: Abbreviation in name 'incrementGLOBAL' must contain no more than '4' consecutive capital letters. [AbbreviationAsWordInName]
Audit done.
```