### PR TITLE
minor: Fix typo in JavadocMethodCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -717,9 +717,9 @@ public class JavadocMethodCheck extends AbstractCheck {
     private static List<ExceptionInfo> combineExceptionInfo(List<ExceptionInfo> list1,
                                                      List<ExceptionInfo> list2) {
         final List<ExceptionInfo> result = new ArrayList<>(list1);
-        for (ExceptionInfo expectionInfo : list2) {
-            if (result.stream().noneMatch(item -> isExceptionInfoSame(item, expectionInfo))) {
-                result.add(expectionInfo);
+        for (ExceptionInfo exceptionInfo : list2) {
+            if (result.stream().noneMatch(item -> isExceptionInfoSame(item, exceptionInfo))) {
+                result.add(exceptionInfo);
             }
         }
         return result;


### PR DESCRIPTION
Minor spelling fix `expectionInfo` -> `exceptionInfo`

From https://github.com/checkstyle/checkstyle/pull/7955#discussion_r409555197