### PR TITLE
minor: fix nondex issue in token ordering from Indentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1430,7 +1430,7 @@
       <plugin>
         <groupId>edu.illinois</groupId>
         <artifactId>nondex-maven-plugin</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2</version>
       </plugin>
     </plugins>
   </build>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -442,7 +442,12 @@ public class AllChecksTest extends AbstractModuleTestSupport {
 
     private static void validateDefaultTokens(Configuration checkConfig, AbstractCheck check,
                                               Set<String> configTokens) {
-        if (Arrays.equals(check.getDefaultTokens(), check.getRequiredTokens())) {
+        final int[] defaultTokens = check.getDefaultTokens();
+        final int[] requiredTokens = check.getRequiredTokens();
+        Arrays.sort(defaultTokens);
+        Arrays.sort(requiredTokens);
+
+        if (Arrays.equals(defaultTokens, requiredTokens)) {
             configTokens.addAll(
                     CheckUtil.getTokenNameSet(check.getDefaultTokens()));
         }


### PR DESCRIPTION
Identified at https://travis-ci.org/github/checkstyle/checkstyle/jobs/675893545#L3230 and resulted from merging https://github.com/checkstyle/checkstyle/pull/8099 ,

I believe the issue is from IndentationCheck and that it generates its list of tokens using a Set, which doesn't guarantee order. Nondex runs could clearly be seen randomizing the list of tokens, so I fixed it by sorting the tokens.

How to debug nondex issues (This is not by all means a detailed guide):

I found that right after the test failures, nondex reports commands that can be used to directly re-run the failure for debugging.
Example: https://travis-ci.org/github/checkstyle/checkstyle/jobs/675893545#L3237-L3238
> `mvn nondex:nondex  -DnondexFilter='.*' -DnondexMode=FULL -DnondexSeed=933178 -DnondexStart=0 -DnondexEnd=9223372036854775807 -DnondexPrintstack=false -DnondexDir="/home/travis/build/checkstyle/checkstyle/.nondex" -DnondexJarDir="/home/travis/build/checkstyle/checkstyle/.nondex" -DnondexExecid=KSFBHLJqhU3VzpVTwCrofpz33iuNv66h8ERN4hf2Zg= -DnondexLogging=CONFIG`

I used this command and added many console print outs to determine how the check was failing and compared it to the normal run without nondex. This is what lead me to the sorting issue. Since many runs always pointed back to IndentationCheck, I could make the deduction that it is because of the Set IndentationCheck uses to build its list of tokens.