### PR TITLE
Issue #7611: Update doc for InnerTypeLast

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/InnerTypeLastCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/InnerTypeLastCheck.java
@@ -36,6 +36,20 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * <pre>
  * &lt;module name=&quot;InnerTypeLast&quot;/&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * class Test {
+ *     private String s; // OK
+ *     class InnerTest1 {}
+ *     public void test() {} // violation, method should be declared before inner types.
+ * }
+ *
+ * class Test2 {
+ *     private String s; // OK
+ *     public void test() {} // OK
+ *     class InnerTest1 {}
+ * }
+ * </pre>
  *
  * @since 5.2
  */

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -452,6 +452,20 @@ class UtilityClass { // violation, class only has a static field
         <source>
 &lt;module name=&quot;InnerTypeLast&quot;/&gt;
         </source>
+        <p>Example:</p>
+        <source>
+class Test {
+    private String s; // OK
+    class InnerTest1 {}
+    public void test() {} // violation, method should be declared before inner types.
+}
+
+class Test2 {
+    private String s; // OK
+    public void test() {} // OK
+    class InnerTest1 {}
+}
+        </source>
       </subsection>
 
       <subsection name="Example of Usage" id="InnerTypeLast_Example_of_Usage">


### PR DESCRIPTION
Fixes #7611 

### Website Screenshot
<img width="1256" alt="Screen Shot 2020-04-19 at 5 59 19 AM" src="https://user-images.githubusercontent.com/36587580/79675241-edd62000-8202-11ea-9563-600dc98bf29e.png">

### Console Output
```
gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="TreeWalker">
        <module name="InnerTypeLast"/>
    </module>
</module>gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ java -jar target/checkstyle-8.32-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /Users/gauravpunjabi/Coding/Open Source/checkstyle/Test.java:4:5: Fields and methods should be before inner classes. [InnerTypeLast]
[ERROR] /Users/gauravpunjabi/Coding/Open Source/checkstyle/Test.java:16:5: Fields and methods should be before inner classes. [InnerTypeLast]
[ERROR] /Users/gauravpunjabi/Coding/Open Source/checkstyle/Test.java:18:5: Fields and methods should be before inner classes. [InnerTypeLast]
Audit done.
Checkstyle ends with 3 errors.
```