### PR TITLE
Issue #7627: Update doc for ParenPad

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheck.java
@@ -101,18 +101,87 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * &lt;module name=&quot;ParenPad&quot;/&gt;
  * </pre>
  * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * class Foo {
+ *
+ *   int n;
+ *
+ *   public void fun() {  // OK
+ *     bar( 1);  // violation, space after left parenthesis
+ *   }
+ *
+ *   public void bar(int k ) {  // violation, space before right parenthesis
+ *     while (k &gt; 0) {  // OK
+ *     }
+ *
+ *     Test obj = new Test(k);  // OK
+ *   }
+ *
+ *   public void fun2() {  // OK
+ *     switch( n) {  // violation, space after left parenthesis
+ *       case 2:
+ *         bar(n);  // OK
+ *       default:
+ *         break;
+ *     }
+ *   }
+ *
+ * }
+ * </pre>
+ * <p>
  * To configure the check to require spaces for the
  * parentheses of constructor, method, and super constructor calls:
  * </p>
  * <pre>
  * &lt;module name=&quot;ParenPad&quot;&gt;
- *   &lt;property name=&quot;tokens&quot; value=&quot;CTOR_CALL, METHOD_CALL,
+ *   &lt;property name=&quot;tokens&quot; value=&quot;LITERAL_FOR, LITERAL_CATCH,
  *     SUPER_CTOR_CALL&quot;/&gt;
  *   &lt;property name=&quot;option&quot; value=&quot;space&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
  * <p>
- * The following cases not checked:
+ * Example:
+ * </p>
+ * <pre>
+ * class Foo {
+ *
+ *   int x;
+ *
+ *   public Foo(int n) {
+ *   }
+ *
+ *   public void fun() {
+ *     try {
+ *       System.out.println(x);
+ *     } catch( IOException e) {  // violation, no space before right parenthesis
+ *     } catch( Exception e ) {  // OK
+ *     }
+ *
+ *     for ( int i = 0; i &lt; x; i++ ) {  // OK
+ *     }
+ *   }
+ *
+ * }
+ *
+ * class Bar extends Foo {
+ *
+ *   public Bar() {
+ *     super(1 );  // violation, no space after left parenthesis
+ *   }
+ *
+ *   public Bar(int k) {
+ *     super( k ); // OK
+ *
+ *     for ( int i = 0; i &lt; k; i++) {  // violation, no space before right parenthesis
+ *     }
+ *   }
+ *
+ * }
+ * </pre>
+ * <p>
+ * The following cases are not checked:
  * </p>
  * <pre>
  * for ( ; i &lt; j; i++, j--) // no check after left parenthesis

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -1956,21 +1956,88 @@ class Test {
         <source>
 &lt;module name=&quot;ParenPad&quot;/&gt;
         </source>
+        <p>
+          Example:
+        </p>
+        <source>
+class Foo {
 
+  int n;
+
+  public void fun() {  // OK
+    bar( 1);  // violation, space after left parenthesis
+  }
+
+  public void bar(int k ) {  // violation, space before right parenthesis
+    while (k &gt; 0) {  // OK
+    }
+
+    Test obj = new Test(k);  // OK
+  }
+
+  public void fun2() {  // OK
+    switch( n) {  // violation, space after left parenthesis
+      case 2:
+        bar(n);  // OK
+      default:
+        break;
+    }
+  }
+
+}
+        </source>
         <p>
           To configure the check to require spaces for the parentheses of
           constructor, method, and super constructor calls:
         </p>
         <source>
 &lt;module name=&quot;ParenPad&quot;&gt;
-  &lt;property name=&quot;tokens&quot; value=&quot;CTOR_CALL, METHOD_CALL,
+  &lt;property name=&quot;tokens&quot; value=&quot;LITERAL_FOR, LITERAL_CATCH,
     SUPER_CTOR_CALL&quot;/&gt;
   &lt;property name=&quot;option&quot; value=&quot;space&quot;/&gt;
 &lt;/module&gt;
         </source>
-
         <p>
-          The following cases not checked:
+          Example:
+        </p>
+        <source>
+class Foo {
+
+  int x;
+
+  public Foo(int n) {
+  }
+
+  public void fun() {
+    try {
+      System.out.println(x);
+    } catch( IOException e) {  // violation, no space before right parenthesis
+    } catch( Exception e ) {  // OK
+    }
+
+    for ( int i = 0; i &lt; x; i++ ) {  // OK
+    }
+  }
+
+}
+
+class Bar extends Foo {
+
+  public Bar() {
+    super(1 );  // violation, no space after left parenthesis
+  }
+
+  public Bar(int k) {
+    super( k ); // OK
+
+    for ( int i = 0; i &lt; k; i++) {  // violation, no space before right parenthesis
+    }
+  }
+
+}
+        </source>
+        <p>
+          The following cases are not checked:
         </p>
         <source>
 for ( ; i &lt; j; i++, j--) // no check after left parenthesis


### PR DESCRIPTION
Fixes #7627
![1](https://user-images.githubusercontent.com/43749360/79980063-22c2cb00-84c0-11ea-8b0e-4673a8bc7657.PNG)
![2](https://user-images.githubusercontent.com/43749360/79979892-e0998980-84bf-11ea-8662-032efff60071.PNG)


Default Example:
```
$ cat config1.xml
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <module name="ParenPad">
    </module>
  </module>
</module>

$ cat Test1.java
class Foo {

  int n;

  public void fun() {  // OK
    bar( 1);  // violation, space after left parenthesis
  }

  public void bar(int k ) {  // violation, space before right parenthesis
    while (k > 0) {  // OK
    }

    Test obj = new Test(k);  // OK
  }

  public void fun2() {  // OK
    switch( n) {  // violation, space after left parenthesis
      case 2:
        bar(n);  // OK
      default:
        break;
    }
  }

}

$ java -jar ../checkstyle-8.30-all.jar -c config1.xml Test1.java
Starting audit...
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\parenPad\Test1.java:6:8: '(' is followed by whitespace. [ParenPad]
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\parenPad\Test1.java:9:25: ')' is preceded with whitespace. [ParenPad]
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\parenPad\Test1.java:17:11: '(' is followed by whitespace. [ParenPad]
Audit done.
Checkstyle ends with 3 errors.
```

Non-Default Example:
```
$ cat config2.xml
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <module name="ParenPad">
        <property name="tokens" value="LITERAL_FOR, LITERAL_CATCH, SUPER_CTOR_CALL"/>
                <property name="option" value="space"/>
    </module>
  </module>
</module>

$ cat Test2.java
class Foo {

  int x;

  public Foo(int n) {
  }

  public void fun() {
    try {
      System.out.println(x);
    } catch( IOException e) {  // violation, no space before right parenthesis
    } catch( Exception e ) {  // OK
    }

    for ( int i = 0; i < x; i++ ) {  // OK
    }
  }

}

class Bar extends Foo {

  public Bar() {
    super(1 );  // violation, no space after left parenthesis
  }

  public Bar(int k) {
    super( k ); // OK

    for ( int i = 0; i < k; i++) {  // violation, no space after before right parenthesis
    }
  }

}

$ java -jar ../checkstyle-8.30-all.jar -c config2.xml Test2.java
Starting audit...
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\parenPad\Test2.java:11:27: ')' is not preceded with whitespace. [ParenPad]
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\parenPad\Test2.java:24:10: '(' is not followed by whitespace. [ParenPad]
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\parenPad\Test2.java:30:32: ')' is not preceded with whitespace. [ParenPad]
Audit done.
Checkstyle ends with 3 errors.

```