### PR TITLE
Issue #6036: LeftCurlyCheck: An empty line should not be treated as a…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -24,6 +24,7 @@ import java.util.Locale;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
@@ -379,8 +380,12 @@ public class LeftCurlyCheck
      * @param braceLine content of line with Brace
      */
     private void validateNewLinePosition(DetailAST brace, DetailAST startToken, String braceLine) {
-        // not on the same line
-        if (startToken.getLineNo() + 1 == brace.getLineNo()) {
+        // not on the same line and does not contain empty lines or comments in between
+        final FileContents fileContents = getFileContents();
+
+        if (startToken.getLineNo() + 1 == brace.getLineNo()
+            || fileContents.lineIsBlank(brace.getLineNo() - 2)
+            || fileContents.lineIsComment(brace.getLineNo() - 2)) {
             if (CommonUtil.hasWhitespaceBefore(brace.getColumnNo(), braceLine)) {
                 log(brace, MSG_KEY_LINE_PREVIOUS, OPEN_CURLY_BRACE, brace.getColumnNo() + 1);
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
@@ -67,6 +67,10 @@ public class LeftCurlyCheckTest extends AbstractModuleTestSupport {
             "14:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
             "18:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
             "22:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+            "67:9: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 9),
+            "75:13: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 13),
+            "89:9: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 9),
+            "103:13: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 13),
         };
         verify(checkConfig, getPath("InputLeftCurlyDefault.java"), expected);
     }
@@ -86,6 +90,13 @@ public class LeftCurlyCheckTest extends AbstractModuleTestSupport {
             "58:27: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 27),
             "59:23: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 23),
             "60:25: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 25),
+            "64:38: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 38),
+            "71:20: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 20),
+            "79:22: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 22),
+            "85:40: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 40),
+            "94:18: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 18),
+            "99:19: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 19),
+            "107:22: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 22),
         };
         verify(checkConfig, getPath("InputLeftCurlyDefault.java"), expected);
     }
@@ -107,6 +118,10 @@ public class LeftCurlyCheckTest extends AbstractModuleTestSupport {
             "45:12: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 12),
             "50:18: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 18),
             "55:20: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 20),
+            "67:9: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 9),
+            "75:13: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 13),
+            "89:9: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 9),
+            "103:13: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 13),
         };
         verify(checkConfig, getPath("InputLeftCurlyDefault.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyDefault.java
@@ -60,4 +60,54 @@ public class InputLeftCurlyDefault
             while(true) {/*foo*/}
         }
     }
+
+    public void testEmptyLineAfter() {
+        if(true)
+
+        { // violation
+        }
+
+        int x = 10;
+        switch (x) {
+            case 10:
+
+
+            { // violation
+                break;
+            }
+
+            case 20: {
+                break;
+            }
+        }
+    }
+
+    public void testWithCommentAfter() {
+        if(true)
+        // A block of comment here
+        // Another block of comment
+        { // violation
+
+        }
+
+        // A block of comment before brace
+        if(true) {
+        }
+
+        int x = 20;
+
+        switch(x) {
+            case 10:
+                // A block of comment here
+                // Another block of comment
+            { // violation
+                break;
+            }
+
+            case 20: {
+                break;
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes #6036 

### Proposed Solution
According to my code analysis, the problem was occurring due to this statement:
```
if (startToken.getLineNo() + 1  == brace.getLineNo()) {
```
The problem occurs when one or more empty lines are present between the expression and the LeftCurly, it fails this condition as the LeftCurly is not present on the immediate next line of its expression. We can solve this by changing the condition to `startToken.getLineNo() + 1  < brace.getLineNo()` and checking if the statement before brace is an empty statement or an comment. But this condition fails for this case:
```
case (1
           + 2):
{
```
This isn't a violation as the expression is being wrapped, so to avoid this we need to check if the statement before LeftCurly is a comment or blank. This can be done using the following condition:
```
fileContents.lineIsBlank(brace.getLineNo() - 2)
            || fileContents.lineIsComment(brace.getLineNo() - 2)
```

##### Final condition
```
if (startToken.getLineNo() + 1 == brace.getLineNo()
            || fileContents.lineIsBlank(brace.getLineNo() - 2)
            || fileContents.lineIsComment(brace.getLineNo() - 2)) {
```


I have added some new inputs to the test case for this scenario.

### Reports
1. Diff report with NLOW option: https://gaurav-punjabi.github.io/checkstyle/6036/index.html