### PR TITLE
Issue #7811: Update doc of AvoidDoubleBraceInitialization

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidDoubleBraceInitializationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidDoubleBraceInitializationCheck.java
@@ -60,18 +60,18 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </p>
  * <pre>
  * class MyClass {
- *   List list1 = new ArrayList&lt;Object&gt; { // violation
- *     {
- *       add(new Object());
- *     }
- *   };
- *   List list2 = new ArrayList&lt;Object&gt; { // violation, comments and semicolons are ignored
- *     ;
- *     // my comment
- *     {
- *       add(new Object());
- *     }
- *   };
+ *     List&lt;Integer&gt; list1 = new ArrayList&lt;&gt;() { // violation
+ *         {
+ *             add(1);
+ *         }
+ *     };
+ *     List&lt;String&gt; list2 = new ArrayList&lt;&gt;() { // violation
+ *         ;
+ *         // comments and semicolons are ignored
+ *         {
+ *             add("foo");
+ *         }
+ *     };
  * }
  * </pre>
  * <p>
@@ -82,12 +82,12 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </p>
  * <pre>
  * class MyClass {
- *  List list = new ArrayList&lt;Object&gt; { // OK as it is not pure double brace pattern
- *     private int field;
- *     {
- *       add(new Object());
- *     }
- *   };
+ *     List&lt;Object&gt; list = new ArrayList&lt;&gt;() { // OK, not pure double brace pattern
+ *         private int field;
+ *         {
+ *             add(new Object());
+ *         }
+ *     };
  * }
  * </pre>
  *

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -209,18 +209,18 @@ int[] a2 = new int[]{
         </p>
         <source>
 class MyClass {
-  List list1 = new ArrayList&lt;Object&gt; { // violation
-    {
-      add(new Object());
-    }
-  };
-  List list2 = new ArrayList&lt;Object&gt; { // violation, comments and semicolons are ignored
-    ;
-    // my comment
-    {
-      add(new Object());
-    }
-  };
+    List&lt;Integer&gt; list1 = new ArrayList&lt;&gt;() { // violation
+        {
+            add(1);
+        }
+    };
+    List&lt;String&gt; list2 = new ArrayList&lt;&gt;() { // violation
+        ;
+        // comments and semicolons are ignored
+        {
+            add("foo");
+        }
+    };
 }
         </source>
         <p>
@@ -231,12 +231,12 @@ class MyClass {
         </p>
           <source>
 class MyClass {
-  List list = new ArrayList&lt;Object&gt; { // OK as it is not pure double brace pattern
-     private int field;
-     {
-       add(new Object());
-     }
-  };
+    List&lt;Object&gt; list = new ArrayList&lt;&gt;() { // OK, not pure double brace pattern
+        private int field;
+        {
+            add(new Object());
+        }
+    };
 }
           </source>
       </subsection>


### PR DESCRIPTION
Fix #7811: upadate doc of AvoidDoubleBraceInitialization to make example compilable

## New site
![image](https://user-images.githubusercontent.com/53135010/79832749-a86d4a80-83dc-11ea-98c6-672567837c2b.png)


## Additional notes
- The old example was using raw type `List` for no apparent reason, so I updated it to a more 'standard' usage.
- Examples have been re-indented to +4 spaces per level. Previously there was an inconsistency in the second example some lines were +3 instead.
- The explanation comments were moved around or tweaked slightly due to the line length limit.

## CLI runs
Note that import statements were added to make the input files compilable, but it is omitted in documentation for the site.

Example 1:
```
D:\checkstyletest>type config.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <property name="severity" value="error"/>
    <module name="TreeWalker">
        <module name="AvoidDoubleBraceInitialization">
        </module>

    </module>
</module>

D:\checkstyletest>cd test 

D:\checkstyletest\test>type MyClass.java 
import java.util.ArrayList;
import java.util.List;

class MyClass {
    List<Integer> list1 = new ArrayList<>() { // violation
        {
            add(1);
        }
    };
    List<String> list2 = new ArrayList<>() { // violation
        ;
        // comments and semicolons are ignored
        {
            add("foo");
        }
    };
}

D:\checkstyletest\test>javac MyClass.java 

D:\checkstyletest\test>cd ..\ 

D:\checkstyletest>set RUN_LOCALE="-Duser.language=en -Duser.country=US" 

D:\checkstyletest>java -jar "-Duser.language=en -Duser.country=US" checkstyle-8.31-all.jar -c config.xml test\MyClass.java 
Starting audit...
[ERROR] D:\checkstyletest\test\MyClass.java:5:45: Avoid double brace initialization. [AvoidDoubleBraceInitialization]
[ERROR] D:\checkstyletest\test\MyClass.java:10:44: Avoid double brace initialization. [AvoidDoubleBraceInitialization]
Audit done.
```

Example 2:
```
D:\checkstyletest>type config.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <property name="severity" value="error"/>
    <module name="TreeWalker">
        <module name="AvoidDoubleBraceInitialization">
        </module>

    </module>
</module>

D:\checkstyletest>cd test 

D:\checkstyletest\test>type MyClass.java 
import java.util.ArrayList;
import java.util.List;

class MyClass {
    List<Object> list = new ArrayList<>() { // OK, not pure double brace pattern
        private int field;
        {
            add(new Object());
        }
    };
}

D:\checkstyletest\test>javac MyClass.java 

D:\checkstyletest\test>cd ..\ 

D:\checkstyletest>set RUN_LOCALE="-Duser.language=en -Duser.country=US" 

D:\checkstyletest>java -jar "-Duser.language=en -Duser.country=US" checkstyle-8.31-all.jar -c config.xml test\MyClass.java 
Starting audit...
Audit done.
```