### PR TITLE
Issue #7570: Update doc for AnnotationOnSameLine

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationOnSameLineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationOnSameLineCheck.java
@@ -56,19 +56,72 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * &lt;module name=&quot;AnnotationOnSameLine&quot;/&gt;
  * </pre>
  * <p>
- * Example to allow annotations on the same line
+ * Example:
  * </p>
  * <pre>
- * &#64;Override public int toString() { ... } // no violations
- * &#64;Before &#64;Override public void set() { ... } // no violation
+ * class Foo {
+ *
+ *   &#64;SuppressWarnings("deprecation")  // violation, annotation should be on the same line
+ *   public Foo() {
+ *   }
+ *
+ *   &#64;SuppressWarnings("unchecked") public void fun2() {  // OK
+ *   }
+ *
+ * }
+ *
+ * &#64;SuppressWarnings("unchecked") class Bar extends Foo {  // OK
+ *
+ *   &#64;Deprecated public Bar() {  // OK
+ *   }
+ *
+ *   &#64;Override  // violation, annotation should be on the same line
+ *   public void fun1() {
+ *   }
+ *
+ *   &#64;Before &#64;Override public void fun2() {  // OK
+ *   }
+ *
+ *   &#64;SuppressWarnings("deprecation")  // violation, annotation should be on the same line
+ *   &#64;Before public void fun3() {
+ *   }
+ *
+ * }
  * </pre>
  * <p>
- * Example to disallow annotations on previous line
+ * To configure the check to check for annotations applied on
+ * interfaces, variables and constructors:
  * </p>
  * <pre>
- * &#64;SuppressWarnings("deprecation") // violation
- * &#64;Override // violation
- * public int foo() { ... }
+ * &lt;module name=&quot;AnnotationOnSameLine&quot;&gt;
+ *   &lt;property name=&quot;tokens&quot;
+ *       value=&quot;INTERFACE_DEF, VARIABLE_DEF, CTOR_DEF&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * &#64;Deprecated interface Foo {  // OK
+ *
+ *   void doSomething();
+ *
+ * }
+ *
+ * class Bar implements Foo {
+ *
+ *   &#64;SuppressWarnings("deprecation")  // violation, annotation should be on the same line
+ *   public Bar() {
+ *   }
+ *
+ *   &#64;Override  // OK
+ *   public void doSomething() {
+ *   }
+ *
+ *   &#64;Nullable  // violation, annotation should be on the same line
+ *   String s;
+ *
+ * }
  * </pre>
  *
  * @since 8.2

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -365,19 +365,72 @@ public boolean equals(Object obj) { return true; }
 &lt;module name=&quot;AnnotationOnSameLine&quot;/&gt;
         </source>
         <p>
-          Example to allow annotations on the same line
+          Example:
         </p>
         <source>
-@Override public int toString() { ... } // no violations
-@Before @Override public void set() { ... } // no violation
+class Foo {
+
+  @SuppressWarnings("deprecation")  // violation, annotation should be on the same line
+  public Foo() {
+  }
+
+  @SuppressWarnings("unchecked") public void fun2() {  // OK
+  }
+
+}
+
+@SuppressWarnings("unchecked") class Bar extends Foo {  // OK
+
+  @Deprecated public Bar() {  // OK
+  }
+
+  @Override  // violation, annotation should be on the same line
+  public void fun1() {
+  }
+
+  @Before @Override public void fun2() {  // OK
+  }
+
+  @SuppressWarnings("deprecation")  // violation, annotation should be on the same line
+  @Before public void fun3() {
+  }
+
+}
         </source>
         <p>
-          Example to disallow annotations on previous line
+          To configure the check to check for annotations applied on
+          interfaces, variables and constructors:
         </p>
         <source>
-@SuppressWarnings("deprecation") // violation
-@Override // violation
-public int foo() { ... }
+&lt;module name=&quot;AnnotationOnSameLine&quot;&gt;
+  &lt;property name=&quot;tokens&quot;
+      value=&quot;INTERFACE_DEF, VARIABLE_DEF, CTOR_DEF&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+@Deprecated interface Foo {  // OK
+
+  void doSomething();
+
+}
+
+class Bar implements Foo {
+
+  @SuppressWarnings("deprecation")  // violation, annotation should be on the same line
+  public Bar() {
+  }
+
+  @Override  // OK
+  public void doSomething() {
+  }
+
+  @Nullable  // violation, annotation should be on the same line
+  String s;
+
+}
         </source>
       </subsection>
 


### PR DESCRIPTION
Fixes #7570
![annotation1](https://user-images.githubusercontent.com/43749360/79849156-bbcde500-83df-11ea-837e-950926d1afc6.PNG)
![annotation2](https://user-images.githubusercontent.com/43749360/79849160-bcff1200-83df-11ea-8762-9f348893f284.PNG)


Default Example:
```
$ cat configAnnotation.xml
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <module name="AnnotationOnSameLine">
    </module>
  </module>
</module>

$ cat annotation1.java
class Foo {

  @SuppressWarnings("deprecation")  // violation, annotation should be on the same line
  public Foo() {
  }

  public void fun1() {
  }

  @SuppressWarnings("unchecked") public void fun2() {  // OK
  }

}

@SuppressWarnings("unchecked") class Bar extends Foo {  // OK

  @Deprecated public Bar() {  // OK
  }

  @Override  // violation, annotation should be on the same line
  public void fun1() {
  }

  @Before @Override public void fun2() {  // OK
  }

  @SuppressWarnings("deprecation")  // violation, annotation should be on the same line
  @Before public void fun3() {
  }

}

$ java -jar checkstyle-8.30-all.jar -c configAnnotation.xml annotation1.java
Starting audit...
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\annotation1.java:3: Annotation 'SuppressWarnings' should be on the same line with its target. [AnnotationOnSameLine]
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\annotation1.java:20: Annotation 'Override' should be on the same line with its target. [AnnotationOnSameLine]
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\annotation1.java:27: Annotation 'SuppressWarnings' should be on the same line with its target. [AnnotationOnSameLine]
Audit done.
Checkstyle ends with 3 errors.
```

Non-Default Example:
```
$ cat configAnnotation2.xml
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <module name="AnnotationOnSameLine">
        <property name="tokens" value="INTERFACE_DEF, VARIABLE_DEF, CTOR_DEF"/>
    </module>
  </module>
</module>

$ cat annotation2.java
@Deprecated interface Foo {  // OK

  void doSomething();

}

class Bar implements Foo {

  @SuppressWarnings("deprecation")  // violation, annotation should be on the same line
  public Bar() {
  }

  @Override
  public void doSomething() {
  }

  @Nullable  // violation, annotation should be on the same line
  String s;

}

$ java -jar checkstyle-8.30-all.jar -c configAnnotation2.xml annotation2.java
Starting audit...
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\annotation2.java:9: Annotation 'SuppressWarnings' should be on the same line with its target. [AnnotationOnSameLine]
[ERROR] C:\Users\Shrey\Desktop\Checkstyle jar\annotation2.java:17: Annotation 'Nullable' should be on the same line with its target. [AnnotationOnSameLine]
Audit done.
Checkstyle ends with 2 errors.
```