### PR TITLE
Issue #8151: Update XpathRegressionAnonInnerLengthTest to have atleast 2 tests

### DIFF
--- a/config/checkstyle_non_main_files_suppressions.xml
+++ b/config/checkstyle_non_main_files_suppressions.xml
@@ -128,8 +128,6 @@
 
     <!-- Until https://github.com/checkstyle/checkstyle/issues/8151 -->
     <suppress  id="numberOfTestCasesInXpath"
-               files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionAnonInnerLengthTest.java"/>
-    <suppress  id="numberOfTestCasesInXpath"
                files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionAvoidDoubleBraceInitializationTest.java"/>
     <suppress  id="numberOfTestCasesInXpath"
                files="src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]XpathRegressionAvoidNoArgumentSuperConstructorCallTest.java"/>

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAnonInnerLengthTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAnonInnerLengthTest.java
@@ -38,6 +38,34 @@ public class XpathRegressionAnonInnerLengthTest extends AbstractXpathTestSupport
     }
 
     @Test
+    public void testDefault() throws Exception {
+        final File fileToProcess =
+            new File(getPath("SuppressionXpathRegressionAnonInnerLengthDefault.java"));
+
+        final DefaultConfiguration moduleConfig =
+            createModuleConfig(AnonInnerLengthCheck.class);
+
+        final String[] expectedViolation = {
+            "7:29: " + getCheckMessage(AnonInnerLengthCheck.class,
+                AnonInnerLengthCheck.MSG_KEY, 26, 20),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnonInnerLengthDefault']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]"
+                + "/SLIST/VARIABLE_DEF[./IDENT[@text='runnable']]"
+                + "/ASSIGN/EXPR",
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionAnonInnerLengthDefault']]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]"
+                + "/SLIST/VARIABLE_DEF[./IDENT[@text='runnable']]"
+                + "/ASSIGN/EXPR/LITERAL_NEW[./IDENT[@text='Runnable']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+            expectedXpathQueries);
+    }
+
+    @Test
     public void testMaxLength() throws Exception {
         final int maxLen = 5;
         final File fileToProcess =
@@ -65,5 +93,4 @@ public class XpathRegressionAnonInnerLengthTest extends AbstractXpathTestSupport
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
     }
-
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/anoninnerlength/SuppressionXpathRegressionAnonInnerLengthDefault.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/anoninnerlength/SuppressionXpathRegressionAnonInnerLengthDefault.java
@@ -1,0 +1,34 @@
+package org.checkstyle.suppressionxpathfilter.anoninnerlength;
+
+import java.util.Comparator;
+
+public class SuppressionXpathRegressionAnonInnerLengthDefault {
+    public void test() {
+        Runnable runnable = new Runnable() { // warn: inner class is 26 lines (max=20)
+            @Override
+            public void run() {
+                int x = 10;
+                String s = "";
+                switch (x) {
+                    case 1:
+                        s = "A";
+                        break;
+                    case 2:
+                        s = "B";
+                        break;
+                    case 3:
+                        s = "C";
+                        break;
+                    case 4:
+                        s = "D";
+                        break;
+                    case 5:
+                        s = "E";
+                        break;
+                    default:
+                        s = "X";
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
Resolves issue #8151 

Added a defaul config test in `XpathRegressionAnonInnerLengthTest`.