### PR TITLE
Issue #8118: Enforce -e for all maven commands

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ matrix:
 environment:
   global:
     CMD: " "
-  # We do matrix as AppVeyor could fail to finish simple "mvn verify"
+  # We do matrix as AppVeyor could fail to finish simple "mvn -e verify"
   #    if he loose maven cache (happens from time to time)
   matrix:
     # checkstyle and sevntu.checkstyle

--- a/config/checkstyle_non_main_files_checks.xml
+++ b/config/checkstyle_non_main_files_checks.xml
@@ -23,6 +23,12 @@
                value="^(?!(.*href=|.*http(s)?:|import |(.* )?package |.* files=|.*\.dtd)).{101,}$"/>
       <property name="message" value="Line should not be longer than 100 symbols"/>
     </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="(mvn [^-])|(mvn \-(?!v)(?!-v)[^e])"/>
+        <property name="fileExtensions" value="sh, yml"/>
+        <property name="message"
+     value="mvn execution should be with '-e' option to produce error message in case of problem"/>
+    </module>
     <!-- check the number of testCases -->
     <module name="RegexpSingleline">
       <property name="id" value="numberOfTestCasesInXpath"/>


### PR DESCRIPTION
Issue #8118: Enforce -e for all maven commands
I add RegexpSingleline to finish this task and I change 
```java
(mvn [^-])|(mvn \-[^e])
```
to 
```java
(mvn [^-])|(mvn \-[^e\-v])
```
to avoid false positive on 
```java
mvn --version
mvn -version
```