### PR TITLE
Issue #8122: Google style should enforce space around enhanced for colon

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -6,7 +6,7 @@
 
 <suppressions>
   <!-- can't split long messages between lines -->
-  <suppress checks="RegexpSingleline" files="google_checks\.xml" lines="56,125"/>
+  <suppress checks="RegexpSingleline" files="google_checks\.xml" lines="56,126"/>
   <!-- don't validate generated files -->
   <suppress checks="RegexpSingleline" files="releasenotes\.xml"/>
   <suppress checks="RegexpSingleline" files="[\\/]meta[\\/]"/>

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/WhitespaceAroundTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/WhitespaceAroundTest.java
@@ -62,8 +62,12 @@ public class WhitespaceAroundTest extends AbstractGoogleModuleTestSupport {
             "118:19: " + getCheckMessage(messages, msgFollowed, "/"),
             "147:9: " + getCheckMessage(messages, msgFollowed, "assert"),
             "150:20: " + getCheckMessage(messages, msgPreceded, ":"),
-            "249:14: " + getCheckMessage(messages, msgPreceded, "->"),
-            "250:15: " + getCheckMessage(messages, msgFollowed, "->"),
+            "241:19: " + getCheckMessage(messages, msgFollowed, ":"),
+            "241:19: " + getCheckMessage(messages, msgPreceded, ":"),
+            "242:20: " + getCheckMessage(messages, msgFollowed, ":"),
+            "243:19: " + getCheckMessage(messages, msgPreceded, ":"),
+            "257:14: " + getCheckMessage(messages, msgPreceded, "->"),
+            "258:15: " + getCheckMessage(messages, msgFollowed, "->"),
         };
 
         final String filePath = getPath("InputWhitespaceAroundBasic.java");

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundBasic.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/InputWhitespaceAroundBasic.java
@@ -235,6 +235,14 @@ class SpecialCasesInForLoop
         int i = (int) ( 2 / 3 );
         return null;
     }
+
+    void forColon() {
+        int ll[] = new int[10];
+        for (int x:ll) {} // warn
+        for (int x :ll) {} // warn
+        for (int x: ll) {} // warn
+        for (int x : ll) {} // ok
+    }
 }
 
 /**

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -113,18 +113,19 @@
       <property name="allowEmptyMethods" value="true"/>
       <property name="allowEmptyTypes" value="true"/>
       <property name="allowEmptyLoops" value="true"/>
+      <property name="ignoreEnhancedForColon" value="false"/>
       <property name="tokens"
                value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR,
                     BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND,
                     LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY,
                     LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH, LITERAL_SYNCHRONIZED,
-                     LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN,
-                     NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR,
-                     SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT, TYPE_EXTENSION_AND"/>
+                    LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN,
+                    NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION, RCURLY, SL, SLIST, SL_ASSIGN, SR,
+                    SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT, TYPE_EXTENSION_AND"/>
       <message key="ws.notFollowed"
-             value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
+              value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
       <message key="ws.notPreceded"
-             value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+              value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
     </module>
     <module name="OneStatementPerLine"/>
     <module name="MultipleVariableDeclarations"/>


### PR DESCRIPTION
Resolves partially #8122 
Fixes point 1 of https://github.com/checkstyle/checkstyle/issues/8122#issuecomment-617849138

Diff Regression projects: https://gist.githubusercontent.com/shashwatj07/61f92a65743199b114ade179f1d113b0/raw/5bf68867fe066cacc3b7743669217f2f6e7f1c27/projects-to-test-on.properties
Diff Regression config: https://gist.githubusercontent.com/shashwatj07/4b4387bc73a204c6d59dda2f7dc9fd2a/raw/7520658954923b30aeb1b157a6e5cf4dc7ccfc19/config.xml