### PR TITLE
Issue #8168: remove from configs hardcode caused by MCHECKSTYLE-33

### DIFF
--- a/config/checkstyle_non_main_files_checks.xml
+++ b/config/checkstyle_non_main_files_checks.xml
@@ -6,7 +6,6 @@
 <module name="Checker">
     <property name="charset" value="UTF-8"/>
 
-    <!-- Hard coded until https://issues.apache.org/jira/browse/MCHECKSTYLE-332 is released. -->
     <property name="cacheFile" value="target/cache_non_main_files"/>
 
     <!-- Suppressions for resources -->

--- a/config/checkstyle_resources_checks.xml
+++ b/config/checkstyle_resources_checks.xml
@@ -7,7 +7,6 @@
     <property name="charset" value="UTF-8"/>
     <property name="haltOnException" value="false"/>
 
-    <!-- Hard coded until https://issues.apache.org/jira/browse/MCHECKSTYLE-332 is released. -->
     <property name="cacheFile" value="target/cache_resources"/>
 
     <!-- Suppressions for resources -->

--- a/config/checkstyle_sevntu_checks.xml
+++ b/config/checkstyle_sevntu_checks.xml
@@ -7,9 +7,6 @@
 <module name="Checker">
     <!-- All checks are from https://github.com/sevntu-checkstyle/sevntu.checkstyle project -->
 
-    <!-- Hard coded until https://issues.apache.org/jira/browse/MCHECKSTYLE-332 is released. -->
-    <property name="cacheFile" value="target/cachefile-sevntu"/>
-
     <!-- Filters -->
     <module name="SuppressionFilter">
         <property name="file" value="${project.basedir}/config/sevntu_suppressions.xml"/>

--- a/pom.xml
+++ b/pom.xml
@@ -626,6 +626,7 @@
               <logViolationsToConsole>true</logViolationsToConsole>
               <maxAllowedViolations>0</maxAllowedViolations>
               <violationSeverity>error</violationSeverity>
+              <cacheFile>${project.build.directory}/cachefile_sevntu</cacheFile>
               <propertyExpansion>project.basedir=${project.basedir}</propertyExpansion>
               <sourceDirectories>
                 <sourceDirectory>${project.basedir}/src</sourceDirectory>


### PR DESCRIPTION
Fixes #8168 

#### Changes
1. Removed `cacheFile` property from `config/checkstyle_sevntu_checks.xml`.
2. Removed false comments from other configurations, as discussed in this comment https://github.com/checkstyle/checkstyle/issues/8168#issuecomment-617875015 .
3. Modified configuration of plugin to have the name of config file as `cache_sevntu`

#### Output
```
gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ mvn clean install
[INFO] Scanning for projects...
[INFO] Inspecting build with total of 1 modules...
[INFO] Installing Nexus Staging features:
[INFO]   ... total of 1 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
..........
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  03:50 min
[INFO] Finished at: 2020-04-23T20:17:43+05:30
[INFO] ------------------------------------------------------------------------
gauravpunjabi@Gauravs-MacBook-Pro:~/Coding/Open Source/checkstyle$ ls target | grep "cache.*"
cache_non_main_files
cache_resources
cachefile
cachefile-test
cachefile_sevntu
```