### PR TITLE
Issue #5711: JavadocTagContinuationIndentation: no violation with block tag starting the line

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
@@ -175,16 +175,44 @@ public class JavadocTagContinuationIndentationCheck extends AbstractJavadocCheck
             final List<DetailNode> textNodes = getAllNewlineNodes(ast);
             for (DetailNode newlineNode : textNodes) {
                 final DetailNode textNode = JavadocUtil.getNextSibling(newlineNode);
-                if (textNode.getType() == JavadocTokenTypes.TEXT) {
-                    final String text = textNode.getText();
-                    if (!CommonUtil.isBlank(text.trim())
-                            && (text.length() <= offset
-                                    || !text.substring(1, offset + 1).trim().isEmpty())) {
-                        log(textNode.getLineNumber(), MSG_KEY, offset);
-                    }
+                if (textNode.getType() == JavadocTokenTypes.TEXT && isViolation(textNode)) {
+                    log(textNode.getLineNumber(), MSG_KEY, offset);
                 }
             }
         }
+    }
+
+    /**
+     * Checks if a text node meets the criteria for a violation.
+     * If the text is shorter than {@code offset} characters, then a violation is
+     * detected if the text is not blank or the next node is not a newline.
+     * If the text is longer than {@code offset} characters, then a violation is
+     * detected if any of the first {@code offset} characters are not blank.
+     *
+     * @param textNode the node to check.
+     * @return true if the node has a violation.
+     */
+    private boolean isViolation(DetailNode textNode) {
+        boolean result = false;
+        final String text = textNode.getText();
+        if (text.length() <= offset) {
+            if (CommonUtil.isBlank(text)) {
+                final DetailNode nextNode = JavadocUtil.getNextSibling(textNode);
+                if (nextNode != null && nextNode.getType() != JavadocTokenTypes.NEWLINE) {
+                    // text is blank but line hasn't ended yet
+                    result = true;
+                }
+            }
+            else {
+                // text is not blank
+                result = true;
+            }
+        }
+        else if (!CommonUtil.isBlank(text.substring(1, offset + 1))) {
+            // first offset number of characters are not blank
+            result = true;
+        }
+        return result;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
@@ -109,4 +109,26 @@ public class JavadocTagContinuationIndentationCheckTest
                 expected);
     }
 
+    @Test
+    public void testBlockTag() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(JavadocTagContinuationIndentationCheck.class);
+        checkConfig.addAttribute("offset", "4");
+        final String[] expected = {
+            "17: " + getCheckMessage(MSG_KEY, 4),
+            "28: " + getCheckMessage(MSG_KEY, 4),
+            "38: " + getCheckMessage(MSG_KEY, 4),
+            "58: " + getCheckMessage(MSG_KEY, 4),
+            "60: " + getCheckMessage(MSG_KEY, 4),
+            "70: " + getCheckMessage(MSG_KEY, 4),
+            "71: " + getCheckMessage(MSG_KEY, 4),
+            "72: " + getCheckMessage(MSG_KEY, 4),
+            "82: " + getCheckMessage(MSG_KEY, 4),
+            "83: " + getCheckMessage(MSG_KEY, 4),
+            "84: " + getCheckMessage(MSG_KEY, 4),
+        };
+        verify(checkConfig, getPath("InputJavadocTagContinuationIndentationBlockTag.java"),
+                expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationBlockTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationBlockTag.java
@@ -1,0 +1,102 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctagcontinuationindentation;
+
+import java.io.Serializable;
+
+/**
+ * Config:
+ * offset = 4
+ */
+public class InputJavadocTagContinuationIndentationBlockTag {
+
+    /**
+     * Example from issue 5711.
+     * Returns the value represented by the specified string of the specified
+     * type. Returns 0 for types other than float, double, int, and long.
+     * @param text the string to be parsed.
+     * @param type the token type of the text. Should be a constant of
+     * {@link TokenTypes}. // violation
+     * @return the double value represented by the string argument.
+     */
+    public static double parseDouble(String text, int type) {
+        return 0;
+    }
+
+    /**
+     * Javadoc.
+     *
+     * @param x this line is normal
+     * {@code this} line is wrongly indented // violation
+     */
+    public void newlineThenBlockTag(int x) {
+        // do stuff
+    }
+
+    /**
+     * Not enough indentation.
+     *
+     * @param x this line is normal
+     *   {@code this} line is wrongly indented // violation
+     */
+    public void partialIndent(int x) {
+        // do stuff
+    }
+
+    /**
+     * There can be a newline but nothing follows it.
+     *
+     * @param x input
+     * @return itself
+     * */ // ok
+    public int identity(int x) {
+        return x;
+    }
+
+    /**
+     * Javadoc.
+     *
+     * @param args // ok
+     * {@code this} line is not correctly indented // violation
+     *     {@code this} // ok
+     * <pre>this line is not correctly indented</pre> // violation
+     */
+    public void multipleLines1(String args) {
+        // do stuff
+    }
+
+    /**
+     * Javadoc.
+     *
+     * @return false always // ok
+     * {@code this} line is not correctly indented // violation
+     * {@code this} line is not correctly indented // violation
+     * <pre>this line is not correctly indented</pre> // violation
+     */
+    public boolean isMultipleLines2() {
+        return false;
+    }
+
+    /**
+     * Javadoc from regression test case (apache-ant).
+     *
+     * @param c the command line which will be configured
+     * if the commandline is initially null, the function is a noop
+     * otherwise the function append to the commandline arguments concerning
+     * <ul> // violation, not correctly indented
+     * <li> // ok, inside a HTML element
+     * cvs package // ok, inside a HTML element
+     * </li> // ok, inside a HTML element
+     * <li> // ok, inside a HTML element
+     * compression // ok, inside a HTML element
+     * </li> // ok, inside a HTML element
+     * <li> // ok, inside a HTML element
+     * quiet or reallyquiet // ok, inside a HTML element
+     * </li> // ok, inside a HTML element
+     * <li>cvsroot</li> // ok, inside a HTML element
+     * <li>noexec</li> // ok, inside a HTML element
+     * </ul> // ok, inside a HTML element
+     */
+    public String regressionNestedHtml(CharSequence c) {
+        return "";
+    }
+
+}


### PR DESCRIPTION
Fixes #5711, resolves #8183

Similar to #8002, the problem is with the logic behind how a violation is determined. Previously we only checked the `TEXT` node itself. If the `TEXT` is only a short whitespace (not enough indentation), we ignored it when in fact we need to check if there is a non-newline token (such as a `JAVADOC_INLINE_TAG `) immediately after it.

~~Regression: https://wltan.github.io/checkstyle-reports/2020-05-10/javadoctagcont-blocktag/
There are violations within Checkstyle itself which were not previously detected due to this issue. They can be found in the regression report as well. I've fixed those violations to use the correct indentation, in a separate commit so it's easier to tell from the main changes, and I'll squash it back into one commit if requested after review.~~

Internal violations have been merged, and manual regression report is deprecated.

Diff Regression projects: https://raw.githubusercontent.com/wltan/checkstyle-reports/master/auto-generate/pr-8177/projects-to-test-on.properties
Diff Regression config: https://raw.githubusercontent.com/wltan/checkstyle-reports/master/auto-generate/pr-8177/my_check.xml