### PR TITLE
Issue #7563: Add default config example for CatchParameterName

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/CatchParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/CatchParameterNameCheck.java
@@ -52,6 +52,37 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <pre>
  * &lt;module name="CatchParameterName"/&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public class MyTest {
+ *   public void myTest() {
+ *     try {
+ *       // ...
+ *     } catch (ArithmeticException e) { // OK
+ *       // ...
+ *     } catch (ArrayIndexOutOfBoundsException ex) { // OK
+ *       // ...
+ *     } catch (Throwable t) { // OK
+ *       // ...
+ *     } catch (IndexOutOfBoundsException e123) { // violation, digits
+ *                                // not allowed
+ *       // ...
+ *     } catch (NullPointerException ab) { // violation, should have at least
+ *                              // three characters if not e|t|ex
+ *       // ...
+ *     } catch (ArrayStoreException abc) { // OK
+ *       // ...
+ *     } catch (InterruptedException aBC) { // violation, first two characters
+ *                               // should be in lowercase
+ *       // ...
+ *     } catch (RuntimeException abC) { // OK
+ *       // ...
+ *     } catch (Exception abCD) { // OK
+ *       // ...
+ *     }
+ *   }
+ * }
+ * </pre>
  * <p>
  * An example of how to configure the check for names that begin with a lower case letter,
  * followed by any letters or digits is:
@@ -68,11 +99,11 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *   public void myTest() {
  *     try {
  *       // ...
- *     } catch (ArithmeticException ex) { //OK
+ *     } catch (ArithmeticException ex) { // OK
  *       // ...
- *     } catch (ArrayIndexOutOfBoundsException ex2) { //OK
+ *     } catch (ArrayIndexOutOfBoundsException ex2) { // OK
  *       // ...
- *     } catch (IOException thirdException) { //OK
+ *     } catch (IOException thirdException) { // OK
  *       // ...
  *     } catch (Exception FourthException) { // violation, the initial letter
  *                                           // should be lowercase

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -539,6 +539,38 @@ class AbstractThirdClass {} // OK, no "abstract" modifier
         <source>
 &lt;module name=&quot;CatchParameterName&quot;/&gt;
         </source>
+        <p>Example:
+        </p>
+        <source>
+public class MyTest {
+  public void myTest() {
+    try {
+      // ...
+    } catch (ArithmeticException e) { // OK
+      // ...
+    } catch (ArrayIndexOutOfBoundsException ex) { // OK
+      // ...
+    } catch (Throwable t) { // OK
+      // ...
+    } catch (IndexOutOfBoundsException e123) { // violation, digits
+                                               // not allowed
+      // ...
+    } catch (NullPointerException ab) { // violation, should have at least
+                                        // three characters if not e|t|ex
+      // ...
+    } catch (ArrayStoreException abc) { // OK
+      // ...
+    } catch (InterruptedException aBC) { // violation, first two characters
+                                         // should be in lowercase
+      // ...
+    } catch (RuntimeException abC) { // OK
+      // ...
+    } catch (Exception abCD) { // OK
+      // ...
+    }
+  }
+}
+        </source>
         <p>
           An example of how to configure the check for names that begin with
           a lower case letter, followed by any letters or digits is:
@@ -555,11 +587,11 @@ public class MyTest {
   public void myTest() {
     try {
       // ...
-    } catch (ArithmeticException ex) { //OK
+    } catch (ArithmeticException ex) { // OK
       // ...
-    } catch (ArrayIndexOutOfBoundsException ex2) { //OK
+    } catch (ArrayIndexOutOfBoundsException ex2) { // OK
       // ...
-    } catch (IOException thirdException) { //OK
+    } catch (IOException thirdException) { // OK
       // ...
     } catch (Exception FourthException) { // violation, the initial letter
                                           // should be lowercase


### PR DESCRIPTION
fixes: #7563 

**Website view:**
![cpn21](https://user-images.githubusercontent.com/38028330/80511982-7d659680-899a-11ea-83fd-6b833dae8794.png)



**Output:**

```
kaustubh@dxtkastb:~$ cat Test.java
public class MyTest {
  public void myTest() {
    try {
      // ...
    } catch (ArithmeticException e) { // OK
      // ...
    } catch (ArrayIndexOutOfBoundsException ex) { // OK
      // ...
    } catch (Throwable t) { // OK
      // ...
    } catch (IndexOutOfBoundsException e123) { // violation, digits
                                               // not allowed
      // ...
    } catch (NullPointerException ab) { // violation, should have at least
                                        // three characters if not e|t|ex
      // ...
    } catch (ArrayStoreException abc) { // OK
      // ...
    } catch (InterruptedException aBC) { // violation, first two characters
                                         // should be in lowercase
      // ...
    } catch (RuntimeException abC) { // OK
      // ...
    } catch (Exception abCD) { // OK
      // ...
    }
  }
}

kaustubh@dxtkastb:~$ cat Test.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="CatchParameterName"/>
    </module>
</module>

kaustubh@dxtkastb:~$ java -jar ckm.jar -c Test.xml Test.java
Starting audit...
[ERROR] /home/kaustubh/Test.java:11:40: Name 'e123' must match pattern '^(e|t|ex|[a-z][a-z][a-zA-Z]+)$'. [CatchParameterName]
[ERROR] /home/kaustubh/Test.java:14:35: Name 'ab' must match pattern '^(e|t|ex|[a-z][a-z][a-zA-Z]+)$'. [CatchParameterName]
[ERROR] /home/kaustubh/Test.java:19:35: Name 'aBC' must match pattern '^(e|t|ex|[a-z][a-z][a-zA-Z]+)$'. [CatchParameterName]
Audit done.
Checkstyle ends with 3 errors.

```