### PR TITLE
Issue #8182: JavadocTagContinuationIndentation add strict enforcement of indentation

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheckTest.java
@@ -93,4 +93,21 @@ public class JavadocTagContinuationIndentationCheckTest
                 expected);
     }
 
+    @Test
+    public void testCheckWithForceStrictCondition() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(JavadocTagContinuationIndentationCheck.class);
+        checkConfig.addAttribute("forceStrictCondition", "true");
+
+        final String[] expected = {
+            "11: " + getCheckMessage(MSG_KEY, 4),
+            "19: " + getCheckMessage(MSG_KEY, 4),
+            "20: " + getCheckMessage(MSG_KEY, 4),
+            "22: " + getCheckMessage(MSG_KEY, 4),
+        };
+        verify(checkConfig,
+            getPath("InputJavadocTagContinuationIndentationForceStrictCondition.java"),
+            expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationForceStrictCondition.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctagcontinuationindentation/InputJavadocTagContinuationIndentationForceStrictCondition.java
@@ -1,0 +1,25 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctagcontinuationindentation;
+
+/**
+ * Config:
+ *  - forceStrictCondition = true
+ */
+class InputJavadocTagContinuationIndentationForceStrictCondition {
+        /**
+     * The client's first name.
+     * @serial Some javadoc.
+        *      Some javadoc. // violation
+     */
+    private String fFirstName;
+
+    /**
+     * Some description here.
+     *
+     * @param a Some description here.
+     * Line with indent 0. // violation
+     *   Line with indent 2. // violation
+     *     Line with indent 4. // OK
+     *         Line with indent 9. // violation
+     */
+    public void test(int a) {}
+}

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -1639,6 +1639,17 @@ public class Test {
               <td><code>4</code></td>
               <td>6.0</td>
             </tr>
+            <tr>
+              <td>forceStrictCondition</td>
+              <td>
+                Force strict indent level of the continuations lines in at-clauses. If value is
+                true, continuation lines indent have to be same as offset parameter. If value is
+                false, line wrap indent could be bigger on any value user would like.
+              </td>
+              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><code>false</code></td>
+              <td>8.33</td>
+            </tr>
           </table>
         </div>
       </subsection>
@@ -1699,6 +1710,27 @@ public class Test {
 &#47;**
  * &lt;p&gt; 'p' tag is unclosed. Line with violation, this html tag needs closing tag.
  * &lt;p&gt; 'p' tag is closed&lt;/p&gt;. OK
+ *&#47;
+public class Test {
+}
+        </source>
+        <p>
+          To configure the check with force strict condition:
+        </p>
+        <source>
+&lt;module name=&quot;JavadocTagContinuationIndentation&quot;&gt;
+  &lt;property name="forceStrictCondition" value="true"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+&#47;**
+ * @tag comment
+ *     Indentation spacing is 4. OK
+ *   Indentation spacing is 2. Line with violation
+ *      Indentation spacing is 5. Line with violation
  *&#47;
 public class Test {
 }


### PR DESCRIPTION
Fixes #8182 

#### 1. Site updates
<img width="1254" alt="Screen Shot 2020-04-26 at 10 06 08 PM" src="https://user-images.githubusercontent.com/36587580/80313684-2a5cd980-880a-11ea-8a51-36906572aff8.png">

#### Diff Regression Report
(Coming Soon)