### PR TITLE
Issue: #7728 Update AbstractChecks to log DetailAST - CustomImportOrder

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/CustomImportOrderTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing/CustomImportOrderTest.java
@@ -48,17 +48,17 @@ public class CustomImportOrderTest extends AbstractGoogleModuleTestSupport {
     @Test
     public void testCustomImport1() throws Exception {
         final String[] expected = {
-            "4: " + getCheckMessage(clazz, MSG_LEX, "java.awt.Button.ABORT",
+            "4:1: " + getCheckMessage(clazz, MSG_LEX, "java.awt.Button.ABORT",
                 "java.io.File.createTempFile"),
-            "6: " + getCheckMessage(clazz, MSG_LINE_SEPARATOR, "java.awt.Button"),
-            "8: " + getCheckMessage(clazz, MSG_LEX, "java.awt.Dialog", "java.awt.Frame"),
-            "12: " + getCheckMessage(clazz, MSG_LEX, "java.io.File", "javax.swing.JTable"),
-            "13: " + getCheckMessage(clazz, MSG_LEX, "java.io.IOException", "javax.swing.JTable"),
-            "14: " + getCheckMessage(clazz, MSG_LEX, "java.io.InputStream", "javax.swing.JTable"),
-            "15: " + getCheckMessage(clazz, MSG_LEX, "java.io.Reader", "javax.swing.JTable"),
-            "17: " + getCheckMessage(clazz, MSG_SEPARATED_IN_GROUP,
+            "6:1: " + getCheckMessage(clazz, MSG_LINE_SEPARATOR, "java.awt.Button"),
+            "8:1: " + getCheckMessage(clazz, MSG_LEX, "java.awt.Dialog", "java.awt.Frame"),
+            "12:1: " + getCheckMessage(clazz, MSG_LEX, "java.io.File", "javax.swing.JTable"),
+            "13:1: " + getCheckMessage(clazz, MSG_LEX, "java.io.IOException", "javax.swing.JTable"),
+            "14:1: " + getCheckMessage(clazz, MSG_LEX, "java.io.InputStream", "javax.swing.JTable"),
+            "15:1: " + getCheckMessage(clazz, MSG_LEX, "java.io.Reader", "javax.swing.JTable"),
+            "17:1: " + getCheckMessage(clazz, MSG_SEPARATED_IN_GROUP,
                 "com.google.common.base.Ascii"),
-            "17: " + getCheckMessage(clazz, MSG_LEX, "com.google.common.base.Ascii",
+            "17:1: " + getCheckMessage(clazz, MSG_LEX, "com.google.common.base.Ascii",
                 "javax.swing.JTable"),
         };
 
@@ -72,22 +72,22 @@ public class CustomImportOrderTest extends AbstractGoogleModuleTestSupport {
     @Test
     public void testCustomImport2() throws Exception {
         final String[] expected = {
-            "4: " + getCheckMessage(clazz, MSG_LEX, "java.awt.Button.ABORT",
+            "4:1: " + getCheckMessage(clazz, MSG_LEX, "java.awt.Button.ABORT",
                 "java.io.File.createTempFile"),
-            "9: " + getCheckMessage(clazz, MSG_LEX, "java.util.*", "java.util.StringTokenizer"),
-            "11: " + getCheckMessage(clazz, MSG_LEX, "java.util.concurrent.*",
+            "9:1: " + getCheckMessage(clazz, MSG_LEX, "java.util.*", "java.util.StringTokenizer"),
+            "11:1: " + getCheckMessage(clazz, MSG_LEX, "java.util.concurrent.*",
                 "java.util.concurrent.AbstractExecutorService"),
-            "13: " + getCheckMessage(clazz, MSG_SEPARATED_IN_GROUP,
+            "13:1: " + getCheckMessage(clazz, MSG_SEPARATED_IN_GROUP,
                 "com.google.checkstyle.test.chapter2filebasic.rule21filename.*"),
-            "13: " + getCheckMessage(clazz, MSG_LEX,
+            "13:1: " + getCheckMessage(clazz, MSG_LEX,
                 "com.google.checkstyle.test.chapter2filebasic.rule21filename.*",
                 "java.util.concurrent.AbstractExecutorService"),
-            "14: " + getCheckMessage(clazz, MSG_LEX,
+            "14:1: " + getCheckMessage(clazz, MSG_LEX,
                 "com.google.checkstyle.test.chapter3filestructure.rule3sourcefile.*",
                 "java.util.concurrent.AbstractExecutorService"),
-            "16: " + getCheckMessage(clazz, MSG_SEPARATED_IN_GROUP,
+            "16:1: " + getCheckMessage(clazz, MSG_SEPARATED_IN_GROUP,
                 "com.google.common.reflect.*"),
-            "16: " + getCheckMessage(clazz, MSG_LEX, "com.google.common.reflect.*",
+            "16:1: " + getCheckMessage(clazz, MSG_LEX, "com.google.common.reflect.*",
                 "java.util.concurrent.AbstractExecutorService"),
         };
 
@@ -101,22 +101,22 @@ public class CustomImportOrderTest extends AbstractGoogleModuleTestSupport {
     @Test
     public void testCustomImport3() throws Exception {
         final String[] expected = {
-            "4: " + getCheckMessage(clazz, MSG_LINE_SEPARATOR, "java.awt.Dialog"),
-            "5: " + getCheckMessage(clazz, MSG_NONGROUP_EXPECTED, STATIC,
+            "4:1: " + getCheckMessage(clazz, MSG_LINE_SEPARATOR, "java.awt.Dialog"),
+            "5:1: " + getCheckMessage(clazz, MSG_NONGROUP_EXPECTED, STATIC,
                 "javax.swing.WindowConstants.*"),
-            "7: " + getCheckMessage(clazz, MSG_SEPARATED_IN_GROUP,
+            "7:1: " + getCheckMessage(clazz, MSG_SEPARATED_IN_GROUP,
                 "com.google.checkstyle.test.chapter2filebasic.rule21filename.*"),
-            "7: " + getCheckMessage(clazz, MSG_LEX,
+            "7:1: " + getCheckMessage(clazz, MSG_LEX,
                 "com.google.checkstyle.test.chapter2filebasic.rule21filename.*", "java.awt.Dialog"),
-            "8: " + getCheckMessage(clazz, MSG_LEX, "com.google.common.reflect.*",
+            "8:1: " + getCheckMessage(clazz, MSG_LEX, "com.google.common.reflect.*",
                 "java.awt.Dialog"),
-            "9: " + getCheckMessage(clazz, MSG_LEX,
+            "9:1: " + getCheckMessage(clazz, MSG_LEX,
                 "com.google.checkstyle.test.chapter3filestructure.rule3sourcefile.*",
                 "java.awt.Dialog"),
-            "11: " + getCheckMessage(clazz, MSG_NONGROUP_EXPECTED, STATIC,
+            "11:1: " + getCheckMessage(clazz, MSG_NONGROUP_EXPECTED, STATIC,
                 "java.io.File.createTempFile"),
-            "13: " + getCheckMessage(clazz, MSG_LEX, "java.util.*", "java.util.StringTokenizer"),
-            "15: " + getCheckMessage(clazz, MSG_LEX, "java.util.concurrent.*",
+            "13:1: " + getCheckMessage(clazz, MSG_LEX, "java.util.*", "java.util.StringTokenizer"),
+            "15:1: " + getCheckMessage(clazz, MSG_LEX, "java.util.concurrent.*",
                 "java.util.concurrent.AbstractExecutorService"),
         };
 
@@ -130,11 +130,11 @@ public class CustomImportOrderTest extends AbstractGoogleModuleTestSupport {
     @Test
     public void testCustomImport4() throws Exception {
         final String[] expected = {
-            "7: " + getCheckMessage(clazz, MSG_SEPARATED_IN_GROUP,
+            "7:1: " + getCheckMessage(clazz, MSG_SEPARATED_IN_GROUP,
                 "javax.swing.WindowConstants.*"),
-            "15: " + getCheckMessage(clazz, MSG_SEPARATED_IN_GROUP,
+            "15:1: " + getCheckMessage(clazz, MSG_SEPARATED_IN_GROUP,
                 "java.util.StringTokenizer"),
-            "17: " + getCheckMessage(clazz, MSG_SEPARATED_IN_GROUP,
+            "17:1: " + getCheckMessage(clazz, MSG_SEPARATED_IN_GROUP,
                 "java.util.concurrent.AbstractExecutorService"),
         };
 
@@ -148,15 +148,15 @@ public class CustomImportOrderTest extends AbstractGoogleModuleTestSupport {
     @Test
     public void testCustomImport5() throws Exception {
         final String[] expected = {
-            "9: " + getCheckMessage(clazz, MSG_SEPARATED_IN_GROUP,
+            "9:1: " + getCheckMessage(clazz, MSG_SEPARATED_IN_GROUP,
                 "javax.swing.WindowConstants.*"),
-            "13: " + getCheckMessage(clazz, MSG_LINE_SEPARATOR,
+            "13:1: " + getCheckMessage(clazz, MSG_LINE_SEPARATOR,
                 "com.google.checkstyle.test.chapter2filebasic.rule21filename.*"),
-            "17: " + getCheckMessage(clazz, MSG_SEPARATED_IN_GROUP,
+            "17:1: " + getCheckMessage(clazz, MSG_SEPARATED_IN_GROUP,
                 "com.google.common.reflect.*"),
-            "21: " + getCheckMessage(clazz, MSG_SEPARATED_IN_GROUP,
+            "21:1: " + getCheckMessage(clazz, MSG_SEPARATED_IN_GROUP,
                 "java.util.StringTokenizer"),
-            "25: " + getCheckMessage(clazz, MSG_SEPARATED_IN_GROUP,
+            "25:1: " + getCheckMessage(clazz, MSG_SEPARATED_IN_GROUP,
                 "java.util.concurrent.AbstractExecutorService"),
         };
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionCustomImportOrderTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionCustomImportOrderTest.java
@@ -1,0 +1,179 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck;
+
+public class XpathRegressionCustomImportOrderTest extends AbstractXpathTestSupport {
+
+    private final String checkName = CustomImportOrderCheck.class.getSimpleName();
+
+    @Override
+    protected String getCheckName() {
+        return checkName;
+    }
+
+    @Test
+    public void testOne() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionCustomImportOrderOne.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(CustomImportOrderCheck.class);
+        moduleConfig.addAttribute("customImportOrderRules", "STATIC###STANDARD_JAVA_PACKAGE");
+        moduleConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
+
+        final String[] expectedViolation = {
+            "4:1: " + getCheckMessage(CustomImportOrderCheck.class,
+                        CustomImportOrderCheck.MSG_LEX, "java.lang.Math.PI",
+                        "java.util.Arrays.sort"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/STATIC_IMPORT[./DOT/IDENT[@text='PI']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testTwo() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionCustomImportOrderTwo.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(CustomImportOrderCheck.class);
+        moduleConfig.addAttribute("customImportOrderRules", "STATIC###STANDARD_JAVA_PACKAGE");
+
+        final String[] expectedViolation = {
+            "5:1: " + getCheckMessage(CustomImportOrderCheck.class,
+                        CustomImportOrderCheck.MSG_LINE_SEPARATOR, "java.io.File"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/IMPORT[./DOT/IDENT[@text='File']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testThree() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionCustomImportOrderThree.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(CustomImportOrderCheck.class);
+        moduleConfig.addAttribute("customImportOrderRules", "STATIC###STANDARD_JAVA_PACKAGE");
+
+        final String[] expectedViolation = {
+            "5:1: " + getCheckMessage(CustomImportOrderCheck.class,
+                        CustomImportOrderCheck.MSG_SEPARATED_IN_GROUP, "java.lang.Math.PI"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/STATIC_IMPORT[./DOT/IDENT[@text='PI']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testFour() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionCustomImportOrderFour.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(CustomImportOrderCheck.class);
+        moduleConfig.addAttribute("customImportOrderRules", "STATIC###STANDARD_JAVA_PACKAGE");
+
+        final String[] expectedViolation = {
+            "5:1: " + getCheckMessage(CustomImportOrderCheck.class,
+                        CustomImportOrderCheck.MSG_NONGROUP_IMPORT,
+                        "com.puppycrawl.tools.checkstyle.api.DetailAST"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/IMPORT[./DOT/IDENT[@text='DetailAST']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testFive() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionCustomImportOrderFive.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(CustomImportOrderCheck.class);
+        moduleConfig.addAttribute("customImportOrderRules", "STATIC###STANDARD_JAVA_PACKAGE");
+
+        final String[] expectedViolation = {
+            "7:1: " + getCheckMessage(CustomImportOrderCheck.class,
+                        CustomImportOrderCheck.MSG_NONGROUP_EXPECTED, "STATIC",
+                        "java.lang.Math.PI"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/STATIC_IMPORT[./DOT/IDENT[@text='PI']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testSix() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionCustomImportOrderSix.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(CustomImportOrderCheck.class);
+        moduleConfig.addAttribute("customImportOrderRules",
+            "STATIC###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE");
+
+        final String[] expectedViolation = {
+            "6:1: " + getCheckMessage(CustomImportOrderCheck.class,
+                        CustomImportOrderCheck.MSG_ORDER, "THIRD_PARTY_PACKAGE",
+                        "STANDARD_JAVA_PACKAGE",
+                        "com.puppycrawl.tools.checkstyle.api.DetailAST"),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/IMPORT[./DOT/IDENT[@text='DetailAST']]"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/customimportorder/SuppressionXpathRegressionCustomImportOrderFive.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/customimportorder/SuppressionXpathRegressionCustomImportOrderFive.java
@@ -1,0 +1,13 @@
+package org.checkstyle.suppressionxpathfilter.customimportorder;
+
+import static java.util.Arrays.sort;
+
+import java.io.File;
+import java.io.FileInputStream;
+import static java.lang.Math.PI; // warn
+import java.util.HashMap;
+import java.util.Scanner;
+
+public class SuppressionXpathRegressionCustomImportOrderFive {
+	// code
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/customimportorder/SuppressionXpathRegressionCustomImportOrderFour.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/customimportorder/SuppressionXpathRegressionCustomImportOrderFour.java
@@ -1,0 +1,14 @@
+package org.checkstyle.suppressionxpathfilter.customimportorder;
+
+import static java.util.Arrays.sort;
+import static java.lang.Math.PI;
+import com.puppycrawl.tools.checkstyle.api.DetailAST; // warn
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.HashMap;
+import java.util.Scanner;
+
+public class SuppressionXpathRegressionCustomImportOrderFour {
+	// code
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/customimportorder/SuppressionXpathRegressionCustomImportOrderOne.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/customimportorder/SuppressionXpathRegressionCustomImportOrderOne.java
@@ -1,0 +1,13 @@
+package org.checkstyle.suppressionxpathfilter.customimportorder;
+
+import static java.util.Arrays.sort;
+import static java.lang.Math.PI; // warn
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.HashMap;
+import java.util.Scanner;
+
+public class SuppressionXpathRegressionCustomImportOrderOne {
+	// code
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/customimportorder/SuppressionXpathRegressionCustomImportOrderSix.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/customimportorder/SuppressionXpathRegressionCustomImportOrderSix.java
@@ -1,0 +1,15 @@
+package org.checkstyle.suppressionxpathfilter.customimportorder;
+
+import static java.util.Arrays.sort;
+import static java.lang.Math.PI;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST; // warn
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.HashMap;
+import java.util.Scanner;
+
+public class SuppressionXpathRegressionCustomImportOrderSix {
+	// code
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/customimportorder/SuppressionXpathRegressionCustomImportOrderThree.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/customimportorder/SuppressionXpathRegressionCustomImportOrderThree.java
@@ -1,0 +1,14 @@
+package org.checkstyle.suppressionxpathfilter.customimportorder;
+
+import static java.util.Arrays.sort;
+
+import static java.lang.Math.PI; // warn
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.HashMap;
+import java.util.Scanner;
+
+public class SuppressionXpathRegressionCustomImportOrderThree {
+	// code
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/customimportorder/SuppressionXpathRegressionCustomImportOrderTwo.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/customimportorder/SuppressionXpathRegressionCustomImportOrderTwo.java
@@ -1,0 +1,12 @@
+package org.checkstyle.suppressionxpathfilter.customimportorder;
+
+import static java.util.Arrays.sort;
+import static java.lang.Math.PI;
+import java.io.File; // warn
+import java.io.FileInputStream;
+import java.util.HashMap;
+import java.util.Scanner;
+
+public class SuppressionXpathRegressionCustomImportOrderTwo {
+	// code
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -44,9 +44,6 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * </p>
  * <ul id="SuppressionXpathFilter_IncompatibleChecks">
  * <li>
- * CustomImportOrder
- * </li>
- * <li>
  * EmptyLineSeparator
  * </li>
  * <li>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -78,21 +78,21 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
                 "STATIC###SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE");
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
-            "4: " + getCheckMessage(MSG_LEX, "java.awt.Button.ABORT",
+            "4:1: " + getCheckMessage(MSG_LEX, "java.awt.Button.ABORT",
                 "java.io.File.createTempFile"),
-            "5: " + getCheckMessage(MSG_LEX, "java.awt.print.Paper.*",
+            "5:1: " + getCheckMessage(MSG_LEX, "java.awt.print.Paper.*",
                 "java.io.File.createTempFile"),
-            "8: " + getCheckMessage(MSG_ORDER, STD, SAME, "java.awt.Button"),
-            "9: " + getCheckMessage(MSG_ORDER, STD, SAME, "java.awt.Frame"),
-            "10: " + getCheckMessage(MSG_ORDER, STD, SAME, "java.awt.Dialog"),
-            "11: " + getCheckMessage(MSG_ORDER, STD, SAME, "java.awt.color.ColorSpace"),
-            "12: " + getCheckMessage(MSG_ORDER, STD, SAME, "java.awt.event.ActionEvent"),
-            "13: " + getCheckMessage(MSG_ORDER, STD, SAME, "javax.swing.JComponent"),
-            "14: " + getCheckMessage(MSG_ORDER, STD, SAME, "javax.swing.JTable"),
-            "15: " + getCheckMessage(MSG_ORDER, STD, SAME, "java.io.File"),
-            "16: " + getCheckMessage(MSG_ORDER, STD, SAME, "java.io.IOException"),
-            "17: " + getCheckMessage(MSG_ORDER, STD, SAME, "java.io.InputStream"),
-            "18: " + getCheckMessage(MSG_ORDER, STD, SAME, "java.io.Reader"),
+            "8:1: " + getCheckMessage(MSG_ORDER, STD, SAME, "java.awt.Button"),
+            "9:1: " + getCheckMessage(MSG_ORDER, STD, SAME, "java.awt.Frame"),
+            "10:1: " + getCheckMessage(MSG_ORDER, STD, SAME, "java.awt.Dialog"),
+            "11:1: " + getCheckMessage(MSG_ORDER, STD, SAME, "java.awt.color.ColorSpace"),
+            "12:1: " + getCheckMessage(MSG_ORDER, STD, SAME, "java.awt.event.ActionEvent"),
+            "13:1: " + getCheckMessage(MSG_ORDER, STD, SAME, "javax.swing.JComponent"),
+            "14:1: " + getCheckMessage(MSG_ORDER, STD, SAME, "javax.swing.JTable"),
+            "15:1: " + getCheckMessage(MSG_ORDER, STD, SAME, "java.io.File"),
+            "16:1: " + getCheckMessage(MSG_ORDER, STD, SAME, "java.io.IOException"),
+            "17:1: " + getCheckMessage(MSG_ORDER, STD, SAME, "java.io.InputStream"),
+            "18:1: " + getCheckMessage(MSG_ORDER, STD, SAME, "java.io.Reader"),
         };
 
         verify(checkConfig, getPath("InputCustomImportOrderDefault.java"), expected);
@@ -111,17 +111,17 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
                 "STATIC###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE");
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
-            "4: " + getCheckMessage(MSG_LEX, "java.awt.Button.ABORT",
+            "4:1: " + getCheckMessage(MSG_LEX, "java.awt.Button.ABORT",
                 "java.io.File.createTempFile"),
-            "5: " + getCheckMessage(MSG_LEX, "java.awt.print.Paper.*",
+            "5:1: " + getCheckMessage(MSG_LEX, "java.awt.print.Paper.*",
                 "java.io.File.createTempFile"),
-            "10: " + getCheckMessage(MSG_LEX, "java.awt.Dialog", "java.awt.Frame"),
-            "15: " + getCheckMessage(MSG_LEX, "java.io.File", "javax.swing.JTable"),
-            "16: " + getCheckMessage(MSG_LEX, "java.io.IOException", "javax.swing.JTable"),
-            "17: " + getCheckMessage(MSG_LEX, "java.io.InputStream", "javax.swing.JTable"),
-            "18: " + getCheckMessage(MSG_LEX, "java.io.Reader", "javax.swing.JTable"),
-            "22: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "com.google.common.collect.*"),
-            "22: " + getCheckMessage(MSG_LEX, "com.google.common.collect.*",
+            "10:1: " + getCheckMessage(MSG_LEX, "java.awt.Dialog", "java.awt.Frame"),
+            "15:1: " + getCheckMessage(MSG_LEX, "java.io.File", "javax.swing.JTable"),
+            "16:1: " + getCheckMessage(MSG_LEX, "java.io.IOException", "javax.swing.JTable"),
+            "17:1: " + getCheckMessage(MSG_LEX, "java.io.InputStream", "javax.swing.JTable"),
+            "18:1: " + getCheckMessage(MSG_LEX, "java.io.Reader", "javax.swing.JTable"),
+            "22:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "com.google.common.collect.*"),
+            "22:1: " + getCheckMessage(MSG_LEX, "com.google.common.collect.*",
                 "com.puppycrawl.tools.*"),
         };
 
@@ -140,18 +140,18 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
                 "STATIC###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE###SAME_PACKAGE(3)");
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
-            "4: " + getCheckMessage(MSG_LEX, "java.awt.Button.ABORT",
+            "4:1: " + getCheckMessage(MSG_LEX, "java.awt.Button.ABORT",
                 "java.io.File.createTempFile"),
-            "5: " + getCheckMessage(MSG_LEX, "java.awt.print.Paper.*",
+            "5:1: " + getCheckMessage(MSG_LEX, "java.awt.print.Paper.*",
                 "java.io.File.createTempFile"),
-            "10: " + getCheckMessage(MSG_LEX, "java.awt.Dialog", "java.awt.Frame"),
-            "15: " + getCheckMessage(MSG_LEX, "java.io.File", "javax.swing.JTable"),
-            "16: " + getCheckMessage(MSG_LEX, "java.io.IOException", "javax.swing.JTable"),
-            "17: " + getCheckMessage(MSG_LEX, "java.io.InputStream", "javax.swing.JTable"),
-            "18: " + getCheckMessage(MSG_LEX, "java.io.Reader", "javax.swing.JTable"),
-            "20: " + getCheckMessage(MSG_ORDER, SAME, THIRD, "com.puppycrawl.tools.*"),
-            "22: " + getCheckMessage(MSG_NONGROUP_IMPORT, "com.google.common.collect.*"),
-            "23: " + getCheckMessage(MSG_LINE_SEPARATOR, "org.junit.*"),
+            "10:1: " + getCheckMessage(MSG_LEX, "java.awt.Dialog", "java.awt.Frame"),
+            "15:1: " + getCheckMessage(MSG_LEX, "java.io.File", "javax.swing.JTable"),
+            "16:1: " + getCheckMessage(MSG_LEX, "java.io.IOException", "javax.swing.JTable"),
+            "17:1: " + getCheckMessage(MSG_LEX, "java.io.InputStream", "javax.swing.JTable"),
+            "18:1: " + getCheckMessage(MSG_LEX, "java.io.Reader", "javax.swing.JTable"),
+            "20:1: " + getCheckMessage(MSG_ORDER, SAME, THIRD, "com.puppycrawl.tools.*"),
+            "22:1: " + getCheckMessage(MSG_NONGROUP_IMPORT, "com.google.common.collect.*"),
+            "23:1: " + getCheckMessage(MSG_LINE_SEPARATOR, "org.junit.*"),
         };
 
         verify(checkConfig, getPath("InputCustomImportOrderDefault.java"), expected);
@@ -163,7 +163,7 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
                 createModuleConfig(CustomImportOrderCheck.class);
         checkConfig.addAttribute("customImportOrderRules", "");
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.List"),
+            "5:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.List"),
         };
 
         verify(checkConfig, getPath("InputCustomImportOrderEmptyRule.java"), expected);
@@ -178,20 +178,21 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
                 "STANDARD_JAVA_PACKAGE");
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
-            "4: " + getCheckMessage(MSG_LEX, "java.awt.Button.ABORT",
+            "4:1: " + getCheckMessage(MSG_LEX, "java.awt.Button.ABORT",
                 "java.io.File.createTempFile"),
-            "7: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.List"),
-            "7: " + getCheckMessage(MSG_LEX, "java.util.List", "javax.swing.WindowConstants.*"),
-            "8: " + getCheckMessage(MSG_LEX, "java.util.StringTokenizer",
+            "7:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.List"),
+            "7:1: " + getCheckMessage(MSG_LEX, "java.util.List", "javax.swing.WindowConstants.*"),
+            "8:1: " + getCheckMessage(MSG_LEX, "java.util.StringTokenizer",
                 "javax.swing.WindowConstants.*"),
-            "9: " + getCheckMessage(MSG_LEX, "java.util.*", "javax.swing.WindowConstants.*"),
-            "10: " + getCheckMessage(MSG_LEX, "java.util.concurrent.AbstractExecutorService",
+            "9:1: " + getCheckMessage(MSG_LEX, "java.util.*", "javax.swing.WindowConstants.*"),
+            "10:1: " + getCheckMessage(MSG_LEX, "java.util.concurrent.AbstractExecutorService",
                 "javax.swing.WindowConstants.*"),
-            "11: " + getCheckMessage(MSG_LEX, "java.util.concurrent.*",
+            "11:1: " + getCheckMessage(MSG_LEX, "java.util.concurrent.*",
                 "javax.swing.WindowConstants.*"),
-            "14: " + getCheckMessage(MSG_LEX, "com.*", "com.puppycrawl.tools.*"),
-            "16: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "com.google.common.base.*"),
-            "16: " + getCheckMessage(MSG_LEX, "com.google.common.base.*", "com.puppycrawl.tools.*"),
+            "14:1: " + getCheckMessage(MSG_LEX, "com.*", "com.puppycrawl.tools.*"),
+            "16:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "com.google.common.base.*"),
+            "16:1: " + getCheckMessage(MSG_LEX, "com.google.common.base.*",
+                "com.puppycrawl.tools.*"),
         };
 
         verify(checkConfig, getPath("InputCustomImportOrderDefault2.java"), expected);
@@ -206,15 +207,18 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
                 "STATIC###SAME_PACKAGE(3)");
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_LEX, "java.util.*", "java.util.StringTokenizer"),
-            "6: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
-            "7: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC, "java.awt.Button.ABORT"),
-            "8: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC, "javax.swing.WindowConstants.*"),
-            "9: " + getCheckMessage(MSG_LEX, "com.puppycrawl.tools.*", "java.util.StringTokenizer"),
-            "10: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME,
+            "5:1: " + getCheckMessage(MSG_LEX, "java.util.*", "java.util.StringTokenizer"),
+            "6:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
+            "7:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC, "java.awt.Button.ABORT"),
+            "8:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC,
+                "javax.swing.WindowConstants.*"),
+            "9:1: " + getCheckMessage(MSG_LEX, "com.puppycrawl.tools.*",
+                "java.util.StringTokenizer"),
+            "10:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME,
                 "java.util.concurrent.AbstractExecutorService"),
-            "11: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC, "java.io.File.createTempFile"),
-            "12: " + getCheckMessage(MSG_LEX, "com.*", "java.util.StringTokenizer"),
+            "11:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC,
+                "java.io.File.createTempFile"),
+            "12:1: " + getCheckMessage(MSG_LEX, "com.*", "java.util.StringTokenizer"),
         };
 
         verify(checkConfig, getNonCompilablePath("InputCustomImportOrderSamePackage.java"),
@@ -231,15 +235,18 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
                 "STATIC###SAME_PACKAGE(3)");
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_LEX, "java.util.*", "java.util.StringTokenizer"),
-            "6: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
-            "7: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC, "java.awt.Button.ABORT"),
-            "8: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC, "javax.swing.WindowConstants.*"),
-            "9: " + getCheckMessage(MSG_LEX, "com.puppycrawl.tools.*", "java.util.StringTokenizer"),
-            "10: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME,
+            "5:1: " + getCheckMessage(MSG_LEX, "java.util.*", "java.util.StringTokenizer"),
+            "6:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
+            "7:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC, "java.awt.Button.ABORT"),
+            "8:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC,
+                "javax.swing.WindowConstants.*"),
+            "9:1: " + getCheckMessage(MSG_LEX, "com.puppycrawl.tools.*",
+                "java.util.StringTokenizer"),
+            "10:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME,
                 "java.util.concurrent.AbstractExecutorService"),
-            "11: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC, "java.io.File.createTempFile"),
-            "12: " + getCheckMessage(MSG_LEX, "com.*", "java.util.StringTokenizer"),
+            "11:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC,
+                "java.io.File.createTempFile"),
+            "12:1: " + getCheckMessage(MSG_LEX, "com.*", "java.util.StringTokenizer"),
         };
 
         verify(checkConfig, getNonCompilablePath("InputCustomImportOrderSamePackage.java"),
@@ -255,9 +262,9 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
                 "STATIC###STANDARD_JAVA_PACKAGE");
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
         final String[] expected = {
-            "4: " + getCheckMessage(MSG_LEX, "java.io.File.createTempFile",
+            "4:1: " + getCheckMessage(MSG_LEX, "java.io.File.createTempFile",
                 "javax.swing.WindowConstants.*"),
-            "8: " + getCheckMessage(MSG_LEX, "com.*", "com.puppycrawl.tools.*"),
+            "8:1: " + getCheckMessage(MSG_LEX, "com.*", "com.puppycrawl.tools.*"),
         };
 
         verify(checkConfig, getPath("InputCustomImportOrder_NoSeparator.java"), expected);
@@ -287,7 +294,7 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("customImportOrderRules",
                 "STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE");
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_NONGROUP_EXPECTED, THIRD, "org.w3c.dom.Node"),
+            "5:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, THIRD, "org.w3c.dom.Node"),
         };
 
         verify(checkConfig,
@@ -304,20 +311,20 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("sortImportsInGroupAlphabetically", "true");
 
         final String[] expected = {
-            "7: " + getCheckMessage(MSG_LEX, "java.awt.Button.ABORT",
+            "7:1: " + getCheckMessage(MSG_LEX, "java.awt.Button.ABORT",
                 "java.io.File.createTempFile"),
-            "10: " + getCheckMessage(MSG_ORDER, STD, THIRD, "java.awt.Button"),
-            "11: " + getCheckMessage(MSG_ORDER, STD, THIRD, "java.awt.Frame"),
-            "12: " + getCheckMessage(MSG_ORDER, STD, THIRD, "java.awt.Dialog"),
-            "13: " + getCheckMessage(MSG_ORDER, STD, THIRD, "java.awt.event.ActionEvent"),
-            "14: " + getCheckMessage(MSG_ORDER, STD, THIRD, "javax.swing.JComponent"),
-            "15: " + getCheckMessage(MSG_ORDER, STD, THIRD, "javax.swing.JTable"),
-            "16: " + getCheckMessage(MSG_ORDER, STD, THIRD, "java.io.File"),
-            "17: " + getCheckMessage(MSG_ORDER, STD, THIRD, "java.io.IOException"),
-            "18: " + getCheckMessage(MSG_ORDER, STD, THIRD, "java.io.InputStream"),
-            "19: " + getCheckMessage(MSG_ORDER, STD, THIRD, "java.io.Reader"),
-            "23: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "com.google.common.*"),
-            "23: " + getCheckMessage(MSG_LEX, "com.google.common.*", "com.puppycrawl.tools.*"),
+            "10:1: " + getCheckMessage(MSG_ORDER, STD, THIRD, "java.awt.Button"),
+            "11:1: " + getCheckMessage(MSG_ORDER, STD, THIRD, "java.awt.Frame"),
+            "12:1: " + getCheckMessage(MSG_ORDER, STD, THIRD, "java.awt.Dialog"),
+            "13:1: " + getCheckMessage(MSG_ORDER, STD, THIRD, "java.awt.event.ActionEvent"),
+            "14:1: " + getCheckMessage(MSG_ORDER, STD, THIRD, "javax.swing.JComponent"),
+            "15:1: " + getCheckMessage(MSG_ORDER, STD, THIRD, "javax.swing.JTable"),
+            "16:1: " + getCheckMessage(MSG_ORDER, STD, THIRD, "java.io.File"),
+            "17:1: " + getCheckMessage(MSG_ORDER, STD, THIRD, "java.io.IOException"),
+            "18:1: " + getCheckMessage(MSG_ORDER, STD, THIRD, "java.io.InputStream"),
+            "19:1: " + getCheckMessage(MSG_ORDER, STD, THIRD, "java.io.Reader"),
+            "23:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "com.google.common.*"),
+            "23:1: " + getCheckMessage(MSG_LEX, "com.google.common.*", "com.puppycrawl.tools.*"),
         };
 
         verify(checkConfig, getNonCompilablePath("InputCustomImportOrderDefaultPackage.java"),
@@ -346,7 +353,7 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("customImportOrderRules",
                 "SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE###STATIC###SPECIAL_IMPORTS");
         final String[] expected = {
-            "11: " + getCheckMessage(MSG_ORDER, THIRD, SPECIAL,
+            "11:1: " + getCheckMessage(MSG_ORDER, THIRD, SPECIAL,
                 "com.google.common.collect.HashMultimap"),
         };
 
@@ -363,7 +370,7 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("customImportOrderRules",
             "STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS");
         final String[] expected = {
-            "4: " + getCheckMessage(MSG_LEX, "java.util.Map",
+            "4:1: " + getCheckMessage(MSG_LEX, "java.util.Map",
                 "java.util.Map.Entry"),
         };
 
@@ -381,7 +388,7 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("customImportOrderRules",
             "STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE");
         final String[] expected = {
-            "8: " + getCheckMessage(MSG_ORDER, THIRD, SPECIAL,
+            "8:1: " + getCheckMessage(MSG_ORDER, THIRD, SPECIAL,
                 "com.google.common.annotations.Beta"),
         };
 
@@ -413,7 +420,7 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("customImportOrderRules",
                 "STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE");
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_LINE_SEPARATOR,
+            "5:1: " + getCheckMessage(MSG_LINE_SEPARATOR,
                     "com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck"),
         };
 
@@ -457,16 +464,16 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("customImportOrderRules",
                 "SAME_PACKAGE(2)");
         final String[] expected = {
-            "8: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.*"),
-            "9: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.List"),
-            "10: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.StringTokenizer"),
-            "11: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
-            "12: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME,
+            "8:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.*"),
+            "9:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.List"),
+            "10:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.StringTokenizer"),
+            "11:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
+            "12:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME,
                 "java.util.concurrent.AbstractExecutorService"),
-            "13: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME,
+            "13:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME,
                 "java.util.concurrent.locks.LockSupport"),
-            "14: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.regex.Pattern"),
-            "15: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.regex.Matcher"),
+            "14:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.regex.Pattern"),
+            "15:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.regex.Matcher"),
             };
 
         verify(checkConfig, getNonCompilablePath("InputCustomImportOrderSamePackageDepth25.java"),
@@ -482,10 +489,10 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("customImportOrderRules",
                 "SAME_PACKAGE(3)");
         final String[] expected = {
-            "11: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
-            "12: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME,
+            "11:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME, "java.util.concurrent.*"),
+            "12:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME,
                 "java.util.concurrent.AbstractExecutorService"),
-            "13: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME,
+            "13:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME,
                 "java.util.concurrent.locks.LockSupport"),
             };
 
@@ -502,7 +509,7 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("customImportOrderRules",
                 "SAME_PACKAGE(4)");
         final String[] expected = {
-            "13: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME,
+            "13:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SAME,
                 "java.util.concurrent.locks.LockSupport"),
             };
 
@@ -650,9 +657,9 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
 
         createChecker(checkConfig);
         final String[] expected = {
-            "8: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.awt.Button"),
-            "20: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "com.puppycrawl.tools.*"),
-            "22: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "com.google.common.collect.*"),
+            "8:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.awt.Button"),
+            "20:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "com.puppycrawl.tools.*"),
+            "22:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "com.google.common.collect.*"),
         };
         verify(checkConfig, getPath("InputCustomImportOrderDefault.java"), expected);
     }
@@ -668,19 +675,19 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("thirdPartyPackageRegExp",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.*Javadoc*");
         final String[] expected = {
-            "9: " + getCheckMessage(MSG_ORDER, THIRD, STD,
+            "9:1: " + getCheckMessage(MSG_ORDER, THIRD, STD,
                 "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocNodeImpl"),
-            "13: " + getCheckMessage(MSG_LINE_SEPARATOR,
+            "13:1: " + getCheckMessage(MSG_LINE_SEPARATOR,
                 "com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck"),
-            "19: " + getCheckMessage(MSG_LINE_SEPARATOR,
+            "19:1: " + getCheckMessage(MSG_LINE_SEPARATOR,
                 "com.puppycrawl.tools.checkstyle.checks.javadoc.InvalidJavadocTag"),
-            "21: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STD,
+            "21:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STD,
                 "com.puppycrawl.tools.checkstyle.checks.javadoc.WriteTagCheck"),
-            "25: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SPECIAL,
+            "25:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SPECIAL,
                 "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTag"),
-            "26: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STD,
+            "26:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STD,
                 "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck"),
-            "27: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STD,
+            "27:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STD,
                 "com.puppycrawl.tools.checkstyle.checks.javadoc.NonEmptyAtclauseDescriptionCheck"),
             };
 
@@ -744,7 +751,7 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
 
         createChecker(checkConfig);
         final String[] expected = {
-            "4: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STD, "org.junit.Test"),
+            "4:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STD, "org.junit.Test"),
         };
         verify(checkConfig,
             getPath("InputCustomImportOrder_MultiplePatternMultipleImport.java"),
@@ -762,10 +769,10 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
 
         createChecker(checkConfig);
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.*"),
-            "7: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.HashMap"),
-            "11: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "javax.net.ServerSocketFactory"),
-            "14: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "javax.net.SocketFactory"),
+            "5:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.*"),
+            "7:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.HashMap"),
+            "11:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "javax.net.ServerSocketFactory"),
+            "14:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "javax.net.SocketFactory"),
         };
         verify(checkConfig, getNonCompilablePath("InputCustomImportOrderNoPackage.java"),
             expected);
@@ -782,10 +789,10 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
 
         createChecker(checkConfig);
         final String[] expected = {
-            "7: " + getCheckMessage(MSG_LINE_SEPARATOR,
+            "7:1: " + getCheckMessage(MSG_LINE_SEPARATOR,
                 "com.sun.accessibility.internal.resources.*"),
-            "11: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Arrays"),
-            "19: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
+            "11:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Arrays"),
+            "19:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
                 "org.apache.commons.beanutils.converters.ArrayConverter"),
         };
         verify(checkConfig, getNonCompilablePath("InputCustomImportOrderNoPackage2.java"),
@@ -804,11 +811,11 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
 
         createChecker(checkConfig);
         final String[] expected = {
-            "6: " + getCheckMessage(MSG_LINE_SEPARATOR,
+            "6:1: " + getCheckMessage(MSG_LINE_SEPARATOR,
                 "java.util.Map"),
-            "14: " + getCheckMessage(MSG_LINE_SEPARATOR,
+            "14:1: " + getCheckMessage(MSG_LINE_SEPARATOR,
                 "org.apache.*"),
-            "18: " + getCheckMessage(MSG_LINE_SEPARATOR,
+            "18:1: " + getCheckMessage(MSG_LINE_SEPARATOR,
                 "antlr.*"),
         };
         verify(checkConfig, getNonCompilablePath("InputCustomImportOrderNoPackage3.java"),
@@ -828,13 +835,13 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
 
         createChecker(checkConfig);
         final String[] expected = {
-            "1: " + getCheckMessage(MSG_LINE_SEPARATOR,
+            "1:112: " + getCheckMessage(MSG_LINE_SEPARATOR,
                 "java.util.Map"),
-            "2: " + getCheckMessage(MSG_LINE_SEPARATOR,
+            "2:1: " + getCheckMessage(MSG_LINE_SEPARATOR,
                 "com.google.common.annotations.Beta"),
-            "9: " + getCheckMessage(MSG_LINE_SEPARATOR,
+            "9:1: " + getCheckMessage(MSG_LINE_SEPARATOR,
                 "com.puppycrawl.tools.*"),
-            "13: " + getCheckMessage(MSG_LINE_SEPARATOR,
+            "13:1: " + getCheckMessage(MSG_LINE_SEPARATOR,
                 "antlr.*"),
         };
         verify(checkConfig, getPath("InputCustomImportOrderSingleLine.java"),
@@ -851,7 +858,7 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
 
         createChecker(checkConfig);
         final String[] expected = {
-            "2: " + getCheckMessage(MSG_LINE_SEPARATOR,
+            "2:118: " + getCheckMessage(MSG_LINE_SEPARATOR,
                 "java.util.Map"),
         };
         verify(checkConfig, getNonCompilablePath("InputCustomImportOrderSingleLine2.java"),
@@ -871,21 +878,21 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
 
         createChecker(checkConfig);
         final String[] expected = {
-            "8: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
+            "8:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
                 "javax.swing.WindowConstants.*"),
-            "11: " + getCheckMessage(MSG_LINE_SEPARATOR,
+            "11:1: " + getCheckMessage(MSG_LINE_SEPARATOR,
                 "java.awt.Button"),
-            "15: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
+            "15:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
                 "java.awt.Dialog"),
-            "21: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
+            "21:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
                 "com.google.common.*"),
-            "27: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
+            "27:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
                 "org.apache.commons.collections.*"),
-            "32: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
+            "32:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
                 "com.puppycrawl.tools.checkstyle.checks.imports.AbstractImportRule"),
-            "38: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
+            "38:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
                 "antlr.Token"),
-            "40: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
+            "40:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
                 "antlr.collections.AST"),
         };
         verify(checkConfig,
@@ -903,13 +910,13 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
 
         createChecker(checkConfig);
         final String[] expected = {
-            "5: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC,
+            "5:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC,
                 "java.util.Collections.*"),
-            "6: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC,
+            "6:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STATIC,
                 "java.lang.String.CASE_INSENSITIVE_ORDER"),
-            "9: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
+            "9:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP,
                 "java.net.Socket"),
-            "9: " + getCheckMessage(MSG_LEX, "java.net.Socket",
+            "9:1: " + getCheckMessage(MSG_LEX, "java.net.Socket",
                 "java.util.*"),
         };
         verify(checkConfig, getNonCompilablePath("InputCustomImportOrderViolationsSameLine.java"),
@@ -928,12 +935,12 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
 
         createChecker(checkConfig);
         final String[] expected = {
-            "18: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.BitSet"),
-            "33: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.HashSet"),
-            "37: " + getCheckMessage(MSG_LINE_SEPARATOR, "org.apache.tools.ant.*"),
-            "42: " + getCheckMessage(MSG_LINE_SEPARATOR, "com.puppycrawl.tools.checkstyle.*"),
-            "46: " + getCheckMessage(MSG_LINE_SEPARATOR, "antlr.*"),
-            "49: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "antlr.Token"),
+            "18:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.BitSet"),
+            "33:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.HashSet"),
+            "37:1: " + getCheckMessage(MSG_LINE_SEPARATOR, "org.apache.tools.ant.*"),
+            "42:1: " + getCheckMessage(MSG_LINE_SEPARATOR, "com.puppycrawl.tools.checkstyle.*"),
+            "46:1: " + getCheckMessage(MSG_LINE_SEPARATOR, "antlr.*"),
+            "49:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "antlr.Token"),
         };
         verify(checkConfig, getPath("InputCustomImportOrderSpanMultipleLines.java"), expected);
     }
@@ -954,15 +961,15 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
 
         createChecker(checkConfig);
         final String[] expected = {
-            "9: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STD, "java.awt.Button"),
-            "10: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STD, "java.awt.Dialog"),
-            "11: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STD, "java.io.InputStream"),
-            "13: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SPECIAL, "javax.swing.JComponent"),
-            "14: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SPECIAL, "javax.swing.JTable"),
-            "16: " + getCheckMessage(MSG_NONGROUP_EXPECTED, THIRD, "org.junit.Test"),
-            "17: " + getCheckMessage(MSG_NONGROUP_EXPECTED, THIRD,
+            "9:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STD, "java.awt.Button"),
+            "10:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STD, "java.awt.Dialog"),
+            "11:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, STD, "java.io.InputStream"),
+            "13:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SPECIAL, "javax.swing.JComponent"),
+            "14:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, SPECIAL, "javax.swing.JTable"),
+            "16:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, THIRD, "org.junit.Test"),
+            "17:1: " + getCheckMessage(MSG_NONGROUP_EXPECTED, THIRD,
                 "org.powermock.api.mockito.PowerMockito"),
-            "21: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "sun.tools.java.ArrayType"),
+            "21:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "sun.tools.java.ArrayType"),
         };
         verify(checkConfig,
             getNonCompilablePath("InputCustomImportOrderEclipseDefaultPositive.java"), expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -55,7 +55,6 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
     // till https://github.com/checkstyle/checkstyle/issues/5777
     public static final Set<String> INCOMPATIBLE_CHECK_NAMES =
         Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
-            "CustomImportOrder",
             "EmptyLineSeparator",
             "Indentation",
             "JavadocMethod",

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -919,7 +919,6 @@ public class UserService {
           Currently, filter does not support the following checks:
         </p>
         <ul id="SuppressionXpathFilter_IncompatibleChecks">
-          <li>CustomImportOrder</li>
           <li>EmptyLineSeparator</li>
           <li>Indentation</li>
           <li>JavadocMethod</li>


### PR DESCRIPTION
Issue: #7728 Update AbstractChecks to log DetailAST - CustomImportOrder

Diff report
https://developerhb.github.io/diff/index.html

Logs Modified - **6**

https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java#L576

https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java#L619

https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java#L633

https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java#L717

https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java#L720

https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java#L723

**One Function Modified** - `logWrongImportGroupOrder`

**One Class Modified** - `ImportDetails` 