### PR TITLE
Issue #5303: Extend doc of lcurly and rcurly values by linking styles

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -27,6 +27,7 @@ Agoogle
 Aleksey
 allchecks
 allclasses
+Allman
 alot
 ambig
 Amessages
@@ -1226,6 +1227,7 @@ stmt
 streamapi
 strictfp
 stringliteralequality
+Stroustrup
 Studman
 Styleable
 styleguide

--- a/src/xdocs/property_types.xml
+++ b/src/xdocs/property_types.xml
@@ -297,6 +297,9 @@
         ...
                 </pre>
               </div>
+              This policy of placement of the left curly brace follows the
+              <a href="https://en.wikipedia.org/wiki/Indentation_style#Variant:_Java">
+              Java variant of the K&amp;R style.</a>
             </td>
           </tr>
 
@@ -311,6 +314,9 @@
         ...
                 </pre>
               </div>
+              This policy of placement of the left curly brace follows the
+              <a href="https://en.wikipedia.org/wiki/Indentation_style#Allman_style">
+              Allman style.</a>
             </td>
           </tr>
 
@@ -327,6 +333,9 @@
         ...
                 </pre>
              </div>
+              This policy of placement of the left curly brace follows the
+              <a href="https://en.wikipedia.org/wiki/Indentation_style#Variant:_Java">
+              Java variant of the K&amp;R style.</a>
               But for a statement spanning multiple lines, Checkstyle will
               enforce:
               <div class="wrapper">
@@ -337,6 +346,9 @@
         ...
                 </pre>
               </div>
+              This policy of placement of the left curly brace follows the
+              <a href="https://en.wikipedia.org/wiki/Indentation_style#Allman_style">
+              Allman style.</a>
             </td>
           </tr>
         </table>
@@ -373,6 +385,9 @@
     <b>}</b>
                 </pre>
               </div>
+              This policy of placement of the right curly brace follows the
+              <a href="https://en.wikipedia.org/wiki/Indentation_style#Variant:_Stroustrup">
+              Stroustrup variant of the K&amp;R style.</a>
             </td>
           </tr>
 
@@ -465,6 +480,9 @@
     } else { ... <b>}</b> // OK, single-line multi-block statement
                 </pre>
               </div>
+              This policy of placement of the right curly brace follows the
+              <a href="https://en.wikipedia.org/wiki/Indentation_style#K&amp;R_style">
+              K&amp;R style.</a>
             </td>
           </tr>
 


### PR DESCRIPTION
Fixes #5303 

Added links to the respective styles for the different available options for lcurly and rcurly checks at the end of definitions of each available options.

Site after the update:
![1](https://user-images.githubusercontent.com/43749360/80388263-512d1580-88c7-11ea-9703-067ecbe8f6b6.PNG)
![2](https://user-images.githubusercontent.com/43749360/80388268-51c5ac00-88c7-11ea-8d1e-3559c052b6b7.PNG)
![3](https://user-images.githubusercontent.com/43749360/80388270-525e4280-88c7-11ea-8493-91c68fa9ab72.PNG)
