### PR TITLE
Issue #4358: DesignForExtension: Special comment

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
@@ -158,6 +160,11 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * skip the method from validation.
  * Default value is {@code After, AfterClass, Before, BeforeClass, Test}.
  * </li>
+ * <li>
+ * Property {@code requiredJavadocPhrase} - Specify the comment text pattern which qualifies as a
+ * valid javadoc for methods.
+ * Default value is {@code ".*"}.
+ * </li>
  * </ul>
  * <p>
  * To configure the check:
@@ -225,12 +232,26 @@ public class DesignForExtensionCheck extends AbstractCheck {
         "BeforeClass", "AfterClass", }).collect(Collectors.toSet());
 
     /**
+     * Specify the comment text pattern which qualifies as a valid javadoc for methods.
+     */
+    private Pattern requiredJavadocPhrase = Pattern.compile(".*");
+
+    /**
      * Setter to specify annotations which allow the check to skip the method from validation.
      *
      * @param ignoredAnnotations method annotations.
      */
     public void setIgnoredAnnotations(String... ignoredAnnotations) {
         this.ignoredAnnotations = Arrays.stream(ignoredAnnotations).collect(Collectors.toSet());
+    }
+
+    /**
+     * Setter to specify the comment text pattern which qualifies as a valid javadoc for methods.
+     *
+     * @param requiredJavadocPhrase method annotations.
+     */
+    public void setRequiredJavadocPhrase(Pattern requiredJavadocPhrase) {
+        this.requiredJavadocPhrase = requiredJavadocPhrase;
     }
 
     @Override
@@ -278,7 +299,7 @@ public class DesignForExtensionCheck extends AbstractCheck {
      * @param methodDef method definition token.
      * @return true if a method has a javadoc comment.
      */
-    private static boolean hasJavadocComment(DetailAST methodDef) {
+    private boolean hasJavadocComment(DetailAST methodDef) {
         return hasJavadocCommentOnToken(methodDef, TokenTypes.MODIFIERS)
                 || hasJavadocCommentOnToken(methodDef, TokenTypes.TYPE);
     }
@@ -290,7 +311,7 @@ public class DesignForExtensionCheck extends AbstractCheck {
      * @param tokenType token type.
      * @return true if a token has a javadoc comment.
      */
-    private static boolean hasJavadocCommentOnToken(DetailAST methodDef, int tokenType) {
+    private boolean hasJavadocCommentOnToken(DetailAST methodDef, int tokenType) {
         final DetailAST token = methodDef.findFirstToken(tokenType);
         return branchContainsJavadocComment(token);
     }
@@ -301,13 +322,13 @@ public class DesignForExtensionCheck extends AbstractCheck {
      * @param token tree token.
      * @return true if a javadoc comment exists under the token.
      */
-    private static boolean branchContainsJavadocComment(DetailAST token) {
+    private boolean branchContainsJavadocComment(DetailAST token) {
         boolean result = false;
         DetailAST curNode = token;
         while (curNode != null) {
             if (curNode.getType() == TokenTypes.BLOCK_COMMENT_BEGIN
                     && JavadocUtil.isJavadocComment(curNode)) {
-                result = true;
+                result = isValidJavadocComment(curNode);
                 break;
             }
 
@@ -322,8 +343,29 @@ public class DesignForExtensionCheck extends AbstractCheck {
             }
             curNode = toVisit;
         }
-
         return result;
+    }
+
+    /**
+     * Checks whether a javadoc follows the specified comment pattern.
+     *
+     * @param token tree token
+     * @return true if the javadoc comment of the specified token follows the given pattern
+     */
+    private boolean isValidJavadocComment(DetailAST token) {
+        final Pattern javadocStars = Pattern.compile("\\*\\s*");
+        final Pattern javadocWhiteSpaces = Pattern.compile("\\s+");
+        String javadoc = javadocWhiteSpaces
+                .matcher(javadocStars.matcher(JavadocUtil.getBlockCommentContent(token))
+                .replaceAll(""))
+                .replaceAll(" ");
+
+        final int firstTagIndex = javadoc.indexOf('@');
+        if (firstTagIndex != -1) {
+            javadoc = javadoc.substring(0, firstTagIndex);
+        }
+        final Matcher matcher = requiredJavadocPhrase.matcher(javadoc.trim());
+        return matcher.find();
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheckTest.java
@@ -128,4 +128,21 @@ public class DesignForExtensionCheckTest
         verify(checkConfig, getPath("InputDesignForExtensionNativeMethods.java"), expected);
     }
 
+    @Test
+    public void testRequiredJavadocPhrase() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(DesignForExtensionCheck.class);
+        checkConfig.addAttribute("requiredJavadocPhrase", "^This implementation.*\\.$");
+        final String[] expected = {
+            "30:5: " + getCheckMessage(MSG_KEY, "InputDesignForExtensionRequiredJavadocPhrase",
+                    "foo4"),
+            "33:5: " + getCheckMessage(MSG_KEY, "InputDesignForExtensionRequiredJavadocPhrase",
+                    "foo5"),
+            "40:5: " + getCheckMessage(MSG_KEY, "InputDesignForExtensionRequiredJavadocPhrase",
+                    "foo8"),
+            "43:5: " + getCheckMessage(MSG_KEY, "InputDesignForExtensionRequiredJavadocPhrase",
+                    "foo9"),
+        };
+        verify(checkConfig, getPath("InputDesignForExtensionRequiredJavadocPhrase.java"), expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionRequiredJavadocPhrase.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionRequiredJavadocPhrase.java
@@ -1,0 +1,59 @@
+package com.puppycrawl.tools.checkstyle.checks.design.designforextension;
+
+public class InputDesignForExtensionRequiredJavadocPhrase {
+
+    /**
+     * This implementation is for <p> some html code
+     * </p>.
+     *
+     * @param a
+     * @param b
+     * @return sum
+     */
+    public int foo1(int a, int b) {return a + b;}
+
+    /**
+     * This implementation is required for ...
+     *
+     * @param a
+     * @param b
+     * @return sum
+     */
+    public int foo2(int a, int b) {return a + b;}
+
+    /** This implementation is for ... */
+    public int foo3(int a, int b) {return a + b;}
+
+    /**
+     * Not This implementation
+     */
+    public int foo4(int a, int b) {return a + b;}
+
+    /** This method can safely be overridden. */
+    public int foo5(int a, int b) {return a + b;}
+
+    public final int foo6(int a) {return a - 2;}
+
+    protected final int foo7(int a) {return a - 2;}
+
+    /** */
+    public int foo8(int a) {return a - 2;}
+
+    // This implementation
+    public int foo9(int a, int b) {return a + b;}
+
+    @Deprecated
+    protected final int foo10(int a) {return a - 2;}
+
+    /**
+     * This
+     *          implementation is for <p> some html code
+     * </p>.
+     *
+     * @param a
+     * @param b
+     * @return sum
+     */
+    public int foo11(int a, int b) {return a + b;}
+}
+

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -163,6 +163,15 @@ public abstract class Plant {
               <td><code>After, AfterClass, Before, BeforeClass, Test</code></td>
               <td>7.2</td>
             </tr>
+            <tr>
+              <td>requiredJavadocPhrase</td>
+              <td>
+                Specify the comment text pattern which qualifies as a valid javadoc for methods.
+              </td>
+              <td><a href="property_types.html#regexp">Regular Expression</a></td>
+              <td><code>&quot;.*&quot;</code></td>
+              <td>8.33</td>
+            </tr>
           </table>
         </div>
         </subsection>


### PR DESCRIPTION
Resolves #4358 
Diff report: https://gaurabdg.github.io/checkstyle-tester-reports/regression/DesignForExtension/diff/
Note: For the patch config, I didn't set `requiredJavadocPhrase` to `.*` since there would have been a lot of errors because every repo has different method javadocs. An example has been shown in the new UT.