### PR TITLE
Issue #8117: False negative with validateThrows in JavadocMethod

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/AbstractGoogleModuleTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/AbstractGoogleModuleTestSupport.java
@@ -99,6 +99,7 @@ public abstract class AbstractGoogleModuleTestSupport extends AbstractItModuleTe
      * @param moduleName module name.
      * @param moduleId module id.
      * @return {@link Configuration} instance for the given module name.
+     * @throws IllegalStateException if there is a problem retrieving the module or config.
      */
     protected static Configuration getModuleConfig(String moduleName, String moduleId) {
         final Configuration result;

--- a/src/it/java/com/sun/checkstyle/test/base/AbstractSunModuleTestSupport.java
+++ b/src/it/java/com/sun/checkstyle/test/base/AbstractSunModuleTestSupport.java
@@ -99,6 +99,7 @@ public abstract class AbstractSunModuleTestSupport extends AbstractItModuleTestS
      * @param moduleName module name.
      * @param moduleId module id.
      * @return {@link Configuration} instance for the given module name.
+     * @throws IllegalStateException if there is a problem retrieving the module or config.
      */
     protected static Configuration getModuleConfig(String moduleName, String moduleId) {
         final Configuration result;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
@@ -62,6 +62,7 @@ public final class DetailNodeTreeStringPrinter {
      *
      * @param blockComment DetailAST
      * @return DetailNode tree
+     * @throws IllegalArgumentException if there is an error parsing the Javadoc.
      */
     public static DetailNode parseJavadocAsDetailNode(DetailAST blockComment) {
         final JavadocDetailNodeParser parser = new JavadocDetailNodeParser();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/SuppressionsStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/SuppressionsStringPrinter.java
@@ -59,6 +59,7 @@ public final class SuppressionsStringPrinter {
      * @param tabWidth length of the tab character
      * @return generated suppressions.
      * @throws IOException if the file could not be read.
+     * @throws IllegalStateException if suppressionLineColumnNumber is not of a valid format.
      * @throws CheckstyleException if the file is not a Java source.
      */
     public static String printSuppressions(File file, String suppressionLineColumnNumber,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java
@@ -79,6 +79,7 @@ public class XMLLogger
      *
      * @param outputStream the stream to write logs to.
      * @param outputStreamOptions if {@code CLOSE} stream should be closed in auditFinished()
+     * @throws IllegalArgumentException if outputStreamOptions is null.
      */
     public XMLLogger(OutputStream outputStream, OutputStreamOptions outputStreamOptions) {
         writer = new PrintWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -343,6 +343,8 @@ public class CheckstyleAntTask extends Task {
      * @param rootModule Root module to process files
      * @param warningCounter Root Module's counter of warnings
      * @param checkstyleVersion Checkstyle compile version
+     * @throws BuildException if the files could not be processed,
+     *     or if the build failed due to violations.
      */
     private void processFiles(RootModule rootModule, final SeverityLevelCounter warningCounter,
             final String checkstyleVersion) {
@@ -392,6 +394,7 @@ public class CheckstyleAntTask extends Task {
      * Creates new instance of the root module.
      *
      * @return new instance of the root module
+     * @throws BuildException if the root module could not be created.
      */
     private RootModule createRootModule() {
         final RootModule rootModule;
@@ -432,6 +435,7 @@ public class CheckstyleAntTask extends Task {
      * to the ANT task.
      *
      * @return the properties for property expansion expansion
+     * @throws BuildException if the properties file could not be loaded.
      */
     private Properties createOverridingProperties() {
         final Properties returnValue = new Properties();
@@ -466,6 +470,7 @@ public class CheckstyleAntTask extends Task {
      * Return the list of listeners set in this task.
      *
      * @return the list of listeners.
+     * @throws BuildException if the listeners could not be created.
      */
     private AuditListener[] getListeners() {
         final int formatterCount = Math.max(1, formatters.size());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
@@ -147,6 +147,7 @@ public final class FileText {
      * @param file the name of the file
      * @param charsetName the encoding to use when reading the file
      * @throws NullPointerException if the text is null
+     * @throws IllegalStateException if the charset is not supported.
      * @throws IOException if the file could not be read
      */
     public FileText(File file, String charsetName) throws IOException {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -367,6 +367,7 @@ public class SuppressWarningsHolder
      *
      * @param ast annotation token
      * @return list values
+     * @throws IllegalArgumentException if there is an unknown annotation value type.
      */
     private static List<String> getAllAnnotationValues(DetailAST ast) {
         // get values of annotation
@@ -404,6 +405,7 @@ public class SuppressWarningsHolder
      *
      * @param ast the AST node to get the child of
      * @return get target of annotation
+     * @throws IllegalArgumentException if there is an unexpected container type.
      */
     private static Optional<DetailAST> getAnnotationTarget(DetailAST ast) {
         final Optional<DetailAST> result;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java
@@ -232,6 +232,7 @@ public class MatchXpathCheck extends AbstractCheck {
      * Setter to specify Xpath query.
      *
      * @param query Xpath query.
+     * @throws IllegalStateException if creation of xpath expression fails
      */
     public void setQuery(String query) {
         this.query = query;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -1099,6 +1099,7 @@ public class ImportOrderCheck
      *
      * @param packageGroups a comma-separated list of package names/prefixes.
      * @return array of compiled patterns.
+     * @throws IllegalArgumentException if any of the package groups are not valid.
      */
     private static Pattern[] compilePatterns(String... packageGroups) {
         final Pattern[] patterns = new Pattern[packageGroups.length];

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -893,22 +893,27 @@ public class JavadocMethodCheck extends AbstractCheck {
      */
     public static List<DetailAST> findTokensInAstByType(DetailAST root, int astType) {
         final List<DetailAST> result = new ArrayList<>();
+        // iterative preorder depth-first search
         DetailAST curNode = root;
-        while (curNode != null) {
-            DetailAST toVisit = curNode.getFirstChild();
-            while (curNode != null && toVisit == null) {
-                toVisit = curNode.getNextSibling();
-                curNode = curNode.getParent();
-                if (curNode == root) {
-                    toVisit = null;
-                    break;
-                }
-            }
-            curNode = toVisit;
-            if (curNode != null && curNode.getType() == astType) {
+        do {
+            // process curNode
+            if (curNode.getType() == astType) {
                 result.add(curNode);
             }
-        }
+            // process children (if any)
+            if (curNode.hasChildren()) {
+                curNode = curNode.getFirstChild();
+                continue;
+            }
+            // backtrack to parent if last child, stopping at root
+            while (curNode != root && curNode.getNextSibling() == null) {
+                curNode = curNode.getParent();
+            }
+            // explore siblings if not root
+            if (curNode != root) {
+                curNode = curNode.getNextSibling();
+            }
+        } while (curNode != root);
         return result;
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -167,6 +167,7 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
      * should end with a period, so it also appends a dot to a package name.
      *
      * @param excludedPackages the list of packages to ignore.
+     * @throws IllegalArgumentException if there are invalid identifiers among the packages.
      */
     public final void setExcludedPackages(String... excludedPackages) {
         final List<String> invalidIdentifiers = Arrays.stream(excludedPackages)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
@@ -298,6 +298,7 @@ public class NoWhitespaceAfterCheck extends AbstractCheck {
      * @param ast
      *        , {@link TokenTypes#ARRAY_DECLARATOR ARRAY_DECLARATOR} node.
      * @return previous node by text order.
+     * @throws IllegalStateException if an unexpected token type is encountered.
      */
     private static DetailAST getArrayDeclaratorPreviousElement(DetailAST ast) {
         final DetailAST previousElement;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
@@ -407,6 +407,7 @@ public class SuppressWithPlainTextCommentFilter extends AutomaticBean implements
      *
      * @param fileName the name of the file.
      * @return {@link FileText} instance.
+     * @throws IllegalStateException if the file could not be read.
      */
     private static FileText getFileText(String fileName) {
         final File file = new File(fileName);
@@ -521,6 +522,7 @@ public class SuppressWithPlainTextCommentFilter extends AutomaticBean implements
          * @param columnNo suppression column number.
          * @param suppressionType suppression type.
          * @param filter the {@link SuppressWithPlainTextCommentFilter} with the context.
+         * @throws IllegalArgumentException if there is an error in the filter regex syntax.
          */
         /* package */ Suppression(
             String text,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java
@@ -78,6 +78,7 @@ public class XpathFilterElement implements TreeWalkerFilter {
      * @param message regular expression for messages.
      * @param moduleId the module id
      * @param query the xpath query
+     * @throws IllegalArgumentException if the xpath query is not expected.
      */
     public XpathFilterElement(String files, String checks,
                        String message, String moduleId, String query) {
@@ -127,6 +128,7 @@ public class XpathFilterElement implements TreeWalkerFilter {
      * @param message regular expression for messages.
      * @param moduleId the module id
      * @param query the xpath query
+     * @throws IllegalArgumentException if the xpath query is not correct.
      */
     public XpathFilterElement(Pattern files, Pattern checks, Pattern message,
                            String moduleId, String query) {
@@ -234,6 +236,7 @@ public class XpathFilterElement implements TreeWalkerFilter {
      *
      * @param event {@code TreeWalkerAuditEvent} object
      * @return list of nodes matching xpath expression given event
+     * @throws IllegalStateException if the xpath query could not be evaluated.
      */
     private List<Item> getItems(TreeWalkerAuditEvent event) {
         final RootNode rootNode;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentation.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentation.java
@@ -114,6 +114,7 @@ public class ParseTreeTablePresentation {
      *
      * @param column the column number
      * @return the type for column number {@code column}.
+     * @throws IllegalStateException if an unknown column index was specified.
      */
     // -@cs[ForbidWildcardAsReturnType] We need to satisfy javax.swing.table.AbstractTableModel
     // public Class<?> getColumnClass(int columnIndex) {...}
@@ -304,6 +305,7 @@ public class ParseTreeTablePresentation {
      * @param node DetailNode(Javadoc) node.
      * @param column column index.
      * @return value at specified column.
+     * @throws IllegalStateException if an unknown column index was specified.
      */
     private static Object getValueAtDetailNode(DetailNode node, int column) {
         final Object value;
@@ -337,6 +339,7 @@ public class ParseTreeTablePresentation {
      * @param ast DetailAST node.
      * @param column column index.
      * @return value at specified column.
+     * @throws IllegalStateException if an unknown column index was specified.
      */
     private static Object getValueAtDetailAST(DetailAST ast, int column) {
         final Object value;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java
@@ -68,6 +68,7 @@ public final class XmlMetaReader {
      * @param thirdPartyPackages list of fully qualified third party package names(can be only a
      *                           hint, e.g. for SevNTU it can be com.github.sevntu / com.github)
      * @return list of module details found in the classpath satisfying the above conditions
+     * @throws IllegalStateException if there was a problem reading the module metadata files
      */
     public static List<ModuleDetails> readAllModulesIncludingThirdPartyIfAny(
             String... thirdPartyPackages) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtil.java
@@ -312,6 +312,7 @@ public final class JavadocUtil {
      * @param id
      *        the ID of the token name to get
      * @return a token name
+     * @throws IllegalArgumentException if an unknown token ID was specified.
      */
     public static String getTokenName(int id) {
         final String name;
@@ -336,6 +337,7 @@ public final class JavadocUtil {
      * @param name
      *        the name of the token ID to get
      * @return a token ID
+     * @throws IllegalArgumentException if an unknown token name was specified.
      */
     public static int getTokenId(String name) {
         final Integer id = TOKEN_NAME_TO_VALUE.get(name);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -82,6 +82,43 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testThrowsDetection() throws Exception {
+        final DefaultConfiguration config = createModuleConfig(JavadocMethodCheck.class);
+        config.addAttribute("validateThrows", "true");
+        final String[] expected = {
+            "16:19: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws",
+                    "UnsupportedOperationException"),
+            "27:23: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws",
+                    "UnsupportedOperationException"),
+            "30:23: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws",
+                    "IllegalArgumentException"),
+            "43:23: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws",
+                    "UnsupportedOperationException"),
+            "47:23: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws",
+                    "IllegalArgumentException"),
+            "58:23: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws",
+                    "UnsupportedOperationException"),
+            "61:23: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws",
+                    "IllegalArgumentException"),
+            "72:23: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws",
+                    "UnsupportedOperationException"),
+            "75:23: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws",
+                    "IllegalArgumentException"),
+            "87:27: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws",
+                    "IllegalArgumentException"),
+            "101:31: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws",
+                    "IllegalArgumentException"),
+            "113:19: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws",
+                    "UnsupportedOperationException"),
+            "128:23: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws",
+                    "RuntimeException"),
+            "141:27: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws",
+                    "RuntimeException"),
+        };
+        verify(config, getPath("InputJavadocMethodThrowsDetection.java"), expected);
+    }
+
+    @Test
     public void testExtraThrows() throws Exception {
         final DefaultConfiguration config = createModuleConfig(JavadocMethodCheck.class);
         config.addAttribute("validateThrows", "true");
@@ -503,6 +540,7 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
             "73:27: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "IllegalArgumentException"),
             "83:12: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "properties"),
             "86:35: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "myInt"),
+            "90:27: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "IllegalArgumentException"),
 
             };
         verify(checkConfig,

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecordsAndCompactCtors.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecordsAndCompactCtors.java
@@ -87,7 +87,7 @@ public class InputJavadocMethodRecordsAndCompactCtors {
             this("my string");
             // here is NPE possible
             if (myString.charAt(0) == 0) {
-                throw new IllegalArgumentException("cannot have char with code 0");
+                throw new IllegalArgumentException("cannot have char with code 0"); // violation
             }
         }
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodThrowsDetection.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodThrowsDetection.java
@@ -1,0 +1,146 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
+
+/**
+ * Config:
+ * validateThrows = true
+ */
+public class InputJavadocMethodThrowsDetection {
+
+    void noJavadoc() {
+        // no javadoc, no violations
+        throw new UnsupportedOperationException(""); // ok
+    }
+
+    /** Simple, trivial case. */
+    void topLevel() {
+        throw new UnsupportedOperationException(""); // violation
+    }
+
+    /**
+     * Example raised in issue 8117.
+     *
+     * @param x some input for control flow statements
+     * @return 0 if there were no problems
+     */
+    int nestedWithinIf(int x) {
+        if (x > 0) {
+            throw new UnsupportedOperationException(""); // violation
+        }
+        if (x < 0) {
+            throw new IllegalArgumentException(""); // violation
+        }
+        return 0;
+    }
+
+    /**
+     * Some regression cases have comments in front.
+     *
+     * @param x some input for control flow statements
+     */
+    void nestedWithinIfLeadingComment(int x) {
+        if (x > 0) {
+            // some comment in front
+            throw new UnsupportedOperationException(""); // violation
+        }
+        if (x < 0) {
+            // some comment in front
+            throw new IllegalArgumentException(""); // violation
+        }
+    }
+
+    /**
+     * Check if-else block.
+     *
+     * @param x some input for control flow statements
+     */
+    void nestedWithinIfElse(int x) {
+        if (x > 0) {
+            throw new UnsupportedOperationException(""); // violation
+        }
+        else {
+            throw new IllegalArgumentException(""); // violation
+        }
+    }
+
+    /**
+     * Check if-else-if block.
+     *
+     * @param x some input for control flow statements
+     */
+    void nestedWithinIfElseIf(int x) {
+        if (x > 0) {
+            throw new UnsupportedOperationException(""); // violation
+        }
+        else if (x < 0) {
+            throw new IllegalArgumentException(""); // violation
+        }
+    }
+
+    /**
+     * Nesting inside 2 layers of if statements.
+     *
+     * @param x some input for control flow statements
+     */
+    void doubleNestedIf(int x) {
+        if (x >= 0) {
+            if (x <= 0) {
+                throw new IllegalArgumentException("0"); // violation
+            }
+        }
+    }
+
+    /**
+     * Nesting inside 3 layers of if statements.
+     *
+     * @param x some input for control flow statements
+     */
+    void tripleNestedIf(int x) {
+        if (x >= 0)
+            if (x <= 0)
+                if (x == 0)
+                    throw new IllegalArgumentException("0"); // violation
+    }
+
+    /**
+     * Throw outside but after if statement.
+     *
+     * @param x some input for control flow statements
+     */
+    void throwAfterIf(int x) {
+        if (x > 0) {
+            x = 0;
+        }
+        throw new UnsupportedOperationException(""); // violation
+    }
+
+    /**
+     * Throw in catch but after if statement.
+     *
+     * @param x some input for control flow statements
+     */
+    void tryCatchAfterIf(int x) {
+        if (x == 0) {
+            return;
+        }
+        try {
+            System.out.println("foo");
+        } catch (Exception e) {
+            throw new RuntimeException(e); // violation
+        }
+    }
+
+    /**
+     * Throw in try/catch inside if statement.
+     * @param x some input for control flow statements
+     */
+    void tryCatchWithinIf(int x) {
+        if (x == 0) {
+            try {
+                System.out.println("foo");
+            } catch (Exception e) {
+                throw new RuntimeException(e); // violation
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Fix #8117 

~~Regression: https://wltan.github.io/checkstyle-reports/2020-04-18/javadocmethod-traverse/~~

Diff Regression projects: https://raw.githubusercontent.com/wltan/checkstyle-reports/master/auto-generate/pr-8213/projects-to-test-on.properties
Diff Regression config: https://raw.githubusercontent.com/wltan/checkstyle-reports/master/auto-generate/pr-8213/my_check.xml

There are violations within Checkstyle's own code that were not detected previously. I have fixed those in a separate commit, so that it is easier to tell apart from the main bug fix.