### PR TITLE
doc: update link to moved javadoc-tool page

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfo.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfo.java
@@ -39,7 +39,7 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  *
  * and
  *
- * <a href="https://www.oracle.com/technetwork/java/javase/documentation/index-137868.html">
+ * <a href="https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html">
  * how to write</a>.
  * </p>
  *

--- a/src/main/resources/sun_checks.xml
+++ b/src/main/resources/sun_checks.xml
@@ -13,7 +13,7 @@
     - the Sun Code Conventions at https://www.oracle.com/technetwork/java/codeconvtoc-136057.html
 
     - the Javadoc guidelines at
-      https://www.oracle.com/technetwork/java/javase/documentation/index-137868.html
+      https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html
 
     - the JDK Api documentation https://docs.oracle.com/en/java/javase/11/
 


### PR DESCRIPTION
Linkcheck fails with
```xml
<td><i>
<a class="externalLink" href="https://www.oracle.com/technetwork/java/javase/documentation/index-137868.html">
https://www.oracle.com/technetwork/java/javase/documentation/index-137868.html</a>:
301 Moved Permanently</i></td></tr></table></td></tr>
```
Updated location is:
```
GET /technetwork/java/javase/documentation/index-137868.html HTTP/1.1

HTTP/1.1 301 Moved Permanently
Server: Oracle-HTTP-Server
Location: https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html
Content-Length: 7551
```

(Another links for javadoc-tool not fixed in #8221)