### PR TITLE
Issue #7892: add empty .ci-temp validation for travis

### DIFF
--- a/.ci/test-spelling-unknown-words.sh
+++ b/.ci/test-spelling-unknown-words.sh
@@ -71,6 +71,7 @@ diff_output=$(diff -U1 "$whitelist_path" "$run_output" |grep -v "$spellchecker" 
 
 if [ -z "$diff_output" ]; then
   echo "No new words and misspellings found."
+  rm $dict
   exit 0
 fi
 
@@ -83,6 +84,7 @@ if [ -z "$new_output" ]; then
   echo "patch '$whitelist_path' <<EOF"
   echo "$diff_output"
   echo "EOF"
+  rm $dict
   sleep 5
   exit 1
 fi
@@ -92,5 +94,6 @@ printDetails
 echo "patch $whitelist_path <<EOF"
 echo "$diff_output"
 echo "EOF"
+rm $dict
 sleep 5
 exit 1

--- a/.ci/travis/travis.sh
+++ b/.ci/travis/travis.sh
@@ -305,7 +305,7 @@ no-exception-test-guava)
   mvn -e clean install -Pno-validations
   cd .ci-temp/contribution/checkstyle-tester
   export MAVEN_OPTS="-Xmx2048m"
-  groovy ./launch.groovy --listOfProjects projects-to-test-on.properties
+  groovy ./launch.groovy --listOfProjects projects-to-test-on.properties \
      --config checks-nonjavadoc-error.xml --checkstyleVersion $CS_POM_VERSION
   cd ../..
   removeFolderWithProtectedFiles contribution

--- a/.travis.yml
+++ b/.travis.yml
@@ -400,3 +400,17 @@ after_success:
         sleep 5s
         false
       fi
+  - |
+    set -e
+    fail=0
+    mkdir -p .ci-temp
+    if [ -z "$(ls -A .ci-temp)" ]; then
+        echo "Empty .ci-temp/ validation did not find any warnings."
+    else
+        echo "Directory .ci-temp/ is not empty. Verification failed."
+        echo "Contents of .ci-temp/:"
+        fail=1
+    fi
+    ls -A .ci-temp
+    sleep 5s
+    exit $fail


### PR DESCRIPTION
Update for #7892: Add validation for empty .ci-temp folder after CI runs

Travis cut logs if scripts finish execution abnormally:
 https://travis-ci.community/t/log-are-truncated-when-my-script-exits-abnormally/5878/4 Note that the OP is stating that this happens when script exits normally or with error.