### PR TITLE
Issue #8227: Resolve Pitest Issues - AbstractJavadocCheck (1)

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -165,7 +165,6 @@ pitest-indentation)
 pitest-javadoc)
   mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;
   declare -a ignoredItems=(
-  "AbstractJavadocCheck.java.html:<td class='covered'><pre><span  class='survived'>            Arrays.sort(acceptableJavadocTokens);</span></pre></td></tr>"
   "AbstractJavadocCheck.java.html:<td class='covered'><pre><span  class='survived'>        beginJavadocTree(root);</span></pre></td></tr>"
   "AbstractJavadocCheck.java.html:<td class='covered'><pre><span  class='survived'>        finishJavadocTree(root);</span></pre></td></tr>"
   "AbstractJavadocCheck.java.html:<td class='covered'><pre><span  class='survived'>        javadocTokens.clear();</span></pre></td></tr>"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -185,10 +185,10 @@ public abstract class AbstractJavadocCheck extends AbstractCheck {
                     Arrays.stream(getDefaultJavadocTokens()).boxed().collect(Collectors.toList()));
         }
         else {
-            final int[] acceptableJavadocTokens = getAcceptableJavadocTokens();
-            Arrays.sort(acceptableJavadocTokens);
+            final Set<Integer> acceptableJavadocTokens = Arrays.stream(getAcceptableJavadocTokens())
+                    .boxed().collect(Collectors.toSet());
             for (Integer javadocTokenId : javadocTokens) {
-                if (Arrays.binarySearch(acceptableJavadocTokens, javadocTokenId) < 0) {
+                if (!acceptableJavadocTokens.contains(javadocTokenId)) {
                     final String message = String.format(Locale.ROOT, "Javadoc Token \"%s\" was "
                             + "not found in Acceptable javadoc tokens list in check %s",
                             JavadocUtil.getTokenName(javadocTokenId), getClass().getName());


### PR DESCRIPTION
Resolves one of the items in #8227 

Regression report: https://wltan.github.io/checkstyle-reports/2020-05-21/abstractjavadoc-diff/
New pitest report: https://wltan.github.io/checkstyle-reports/2020-05-21/abstractjavadoc-pitest/

Some notes about performance:
- It is not clear if there will be any performance difference with these changes. This is because `Collectors.toSet()` does not guarantee the type and hence implementation of the set.
- Regardless of implementation, I highly doubt that there will be any noticeable difference, as the amount of tokens to be processed is very small.
- Nevertheless, if we really want to be confident of our performance bound I can make an easy change to use a `HashSet` supplier instead of `Collectors.toSet()` at the cost of slightly more complex code.