### PR TITLE
Issue #8270: Pitest Issue: Indentation - ArrayInitHandler

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -134,7 +134,6 @@ pitest-indentation)
   "AbstractExpressionHandler.java.html:<td class='covered'><pre><span  class='survived'>            if (colNum == null || thisLineColumn &#60; colNum) {</span></pre></td></tr>"
   "AbstractExpressionHandler.java.html:<td class='covered'><pre><span  class='survived'>        if (currLine &#60; realStart) {</span></pre></td></tr>"
   "AbstractExpressionHandler.java.html:<td class='covered'><pre><span  class='survived'>            if (toTest.getColumnNo() &#60; first.getColumnNo()) {</span></pre></td></tr>"
-  "ArrayInitHandler.java.html:<td class='covered'><pre><span  class='survived'>        if (firstChildPos &#62;= 0) {</span></pre></td></tr>"
   "BlockParentHandler.java.html:<td class='covered'><pre><span  class='survived'>        return getIndentCheck().getLineWrappingIndentation();</span></pre></td></tr>"
   "CommentsIndentationCheck.java.html:<td class='covered'><pre><span  class='survived'>            &#38;&#38; root.getFirstChild().getFirstChild().getFirstChild().getNextSibling() != null;</span></pre></td></tr>"
   "CommentsIndentationCheck.java.html:<td class='covered'><pre><span  class='survived'>                if (isUsingOfObjectReferenceToInvokeMethod(blockBody)) {</span></pre></td></tr>"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java
@@ -29,6 +29,11 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 public class ArrayInitHandler extends BlockParentHandler {
 
     /**
+     * Constant to define that the required character does not exist at any position.
+     */
+    private static final int NOT_EXIST = -1;
+
+    /**
      * Construct an instance of this handler with the given indentation check,
      * abstract syntax tree, and parent handler.
      *
@@ -99,7 +104,8 @@ public class ArrayInitHandler extends BlockParentHandler {
         final int lcurlyPos = expandedTabsColumnNo(getLeftCurly());
         final int firstChildPos =
             getNextFirstNonBlankOnLineAfter(firstLine, lcurlyPos);
-        if (firstChildPos >= 0) {
+
+        if (firstChildPos != NOT_EXIST) {
             expectedIndent = IndentLevel.addAcceptable(expectedIndent, firstChildPos, lcurlyPos
                     + getLineWrappingIndentation());
         }
@@ -108,14 +114,14 @@ public class ArrayInitHandler extends BlockParentHandler {
 
     /**
      * Returns column number of first non-blank char after
-     * specified column on specified line or -1 if
+     * specified column on specified line or {@code NOT_EXIST} if
      * such char doesn't exist.
      *
      * @param lineNo   number of line on which we search
      * @param columnNo number of column after which we search
      *
      * @return column number of first non-blank char after
-     *         specified column on specified line or -1 if
+     *         specified column on specified line or {@code NOT_EXIST} if
      *         such char doesn't exist.
      */
     private int getNextFirstNonBlankOnLineAfter(int lineNo, int columnNo) {
@@ -128,7 +134,7 @@ public class ArrayInitHandler extends BlockParentHandler {
         }
 
         if (realColumnNo == lineLength) {
-            realColumnNo = -1;
+            realColumnNo = NOT_EXIST;
         }
         return realColumnNo;
     }


### PR DESCRIPTION
Resolves Issue #8270 
idea:
`getNextFirstNonBlankOnLineAfter(int,int)` return first non-blank column on the same line after the position of the second argument provided.
Its a private class and its scope is only `ArrayInitHandler.java` and thus it is used only at one place inside `getChildrenExpectedIndent()`

The pupose of use is to get first non-blank cloumn number after lcurly position. It should return -1 if there are only blank lines after lcurly.

Practically it is not possible to have any column after lcurly to be at 0th position(being on the same line for lcurly). Thus the contional mutation is survived on `>= 0` clause.

Modifying it to check condition for `!= -1` kills the mutation.