### PR TITLE
Issue #8268: Cleanup .ci-temp folder after release notes generation

### DIFF
--- a/.ci/travis/xtr_releasenotes-gen.sh
+++ b/.ci/travis/xtr_releasenotes-gen.sh
@@ -80,3 +80,5 @@ cd checkstyle/src/xdocs
 echo
 echo "releasenotes.xml after commit:"
 head -n 100 releasenotes.xml
+cd ../../..
+find . -delete


### PR DESCRIPTION
Issue #8268: Cleanup .ci-temp folder after release notes generation
