### PR TITLE
Issue 8283 fix import tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1411,6 +1411,10 @@
             <exclude>**/Input*</exclude>
             <!-- tests need forbidden apis to test the main code fully -->
             <exclude>**/XpathFileGeneratorAuditListenerTest.class</exclude>
+            <!-- These tests uses java.lang.reflect.AccessibleObject.isAccessible
+              which has no Java 8 compatible workaround. -->
+            <exclude>**/AllChecksTest.class</exclude>
+            <exclude>**/XdocsPagesTest.class</exclude>
           </excludes>
         </configuration>
         <executions>

--- a/src/it/resources/com/google/checkstyle/test/chapter6programpractice/rule64finalizers/InputNoFinalizeExtend.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter6programpractice/rule64finalizers/InputNoFinalizeExtend.java
@@ -36,7 +36,7 @@ class WithoutTryCatchFinalizer {
 }
 
 // public finalizer
-class PublicFinalizer {
+class InputPublicFinalizer {
 
     public static void doStuff() {
         // This method do some stuff
@@ -52,7 +52,7 @@ class PublicFinalizer {
 }
 
 // unless (or worse) finalizer
-class SuperFinalizer {
+class InputSuperFinalizer {
 
     protected void finalize() throws Throwable { //warn
         super.finalize();
@@ -60,7 +60,7 @@ class SuperFinalizer {
 }
 
 // public finalizer
-class StaticFinalizer {
+class InputStaticFinalizer {
 
     public static void doStuff() {
         // This method do some stuff

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/hiddenfield/SuppressionXpathRegressionHiddenFieldOne.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/hiddenfield/SuppressionXpathRegressionHiddenFieldOne.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public class SuppressionXpathRegressionHiddenFieldOne {
     List<Integer> numbers = Arrays.asList(1, 2, 3, 4, 5, 6);
-    Integer value = new Integer(1);
+    Integer value = Integer.valueOf(1);
     {
         numbers.forEach((Integer value) -> String.valueOf(value)); //warn
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -122,7 +122,7 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
             "18:1: " + getCheckMessage(MSG_LEX, "java.io.Reader", "javax.swing.JTable"),
             "22:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "com.google.common.collect.*"),
             "22:1: " + getCheckMessage(MSG_LEX, "com.google.common.collect.*",
-                "com.puppycrawl.tools.*"),
+                "com.puppycrawl.tools.checkstyle.*"),
         };
 
         verify(checkConfig, getPath("InputCustomImportOrderDefault.java"), expected);
@@ -149,7 +149,7 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
             "16:1: " + getCheckMessage(MSG_LEX, "java.io.IOException", "javax.swing.JTable"),
             "17:1: " + getCheckMessage(MSG_LEX, "java.io.InputStream", "javax.swing.JTable"),
             "18:1: " + getCheckMessage(MSG_LEX, "java.io.Reader", "javax.swing.JTable"),
-            "20:1: " + getCheckMessage(MSG_ORDER, SAME, THIRD, "com.puppycrawl.tools.*"),
+            "20:1: " + getCheckMessage(MSG_ORDER, SAME, THIRD, "com.puppycrawl.tools.checkstyle.*"),
             "22:1: " + getCheckMessage(MSG_NONGROUP_IMPORT, "com.google.common.collect.*"),
             "23:1: " + getCheckMessage(MSG_LINE_SEPARATOR, "org.junit.*"),
         };
@@ -189,10 +189,11 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
                 "javax.swing.WindowConstants.*"),
             "11:1: " + getCheckMessage(MSG_LEX, "java.util.concurrent.*",
                 "javax.swing.WindowConstants.*"),
-            "14:1: " + getCheckMessage(MSG_LEX, "com.*", "com.puppycrawl.tools.*"),
+            "14:1: " + getCheckMessage(MSG_LEX, "com.puppycrawl.tools.checkstyle.*",
+                "com.puppycrawl.tools.checkstyle.checks.*"),
             "16:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "com.google.common.base.*"),
             "16:1: " + getCheckMessage(MSG_LEX, "com.google.common.base.*",
-                "com.puppycrawl.tools.*"),
+                "com.puppycrawl.tools.checkstyle.checks.*"),
         };
 
         verify(checkConfig, getPath("InputCustomImportOrderDefault2.java"), expected);
@@ -264,7 +265,8 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "4:1: " + getCheckMessage(MSG_LEX, "java.io.File.createTempFile",
                 "javax.swing.WindowConstants.*"),
-            "8:1: " + getCheckMessage(MSG_LEX, "com.*", "com.puppycrawl.tools.*"),
+            "8:1: " + getCheckMessage(MSG_LEX, "com.puppycrawl.tools.checkstyle.*",
+                "com.puppycrawl.tools.checkstyle.checks.*"),
         };
 
         verify(checkConfig, getPath("InputCustomImportOrder_NoSeparator.java"), expected);
@@ -658,7 +660,7 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
         createChecker(checkConfig);
         final String[] expected = {
             "8:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.awt.Button"),
-            "20:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "com.puppycrawl.tools.*"),
+            "20:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "com.puppycrawl.tools.checkstyle.*"),
             "22:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "com.google.common.collect.*"),
         };
         verify(checkConfig, getPath("InputCustomImportOrderDefault.java"), expected);
@@ -840,7 +842,7 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
             "2:1: " + getCheckMessage(MSG_LINE_SEPARATOR,
                 "com.google.common.annotations.Beta"),
             "9:1: " + getCheckMessage(MSG_LINE_SEPARATOR,
-                "com.puppycrawl.tools.*"),
+                "com.puppycrawl.tools.checkstyle.*"),
             "13:1: " + getCheckMessage(MSG_LINE_SEPARATOR,
                 "antlr.*"),
         };

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -395,7 +395,7 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("groups", "org, java");
         checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
         final String[] expected = {
-            "6:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.*"),
+            "6:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.antlr.v4.runtime.*"),
             "8:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
         };
 
@@ -409,7 +409,7 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("option", "top");
         checkConfig.addAttribute("groups", "org, java");
         final String[] expected = {
-            "6:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.*"),
+            "6:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.antlr.v4.runtime.*"),
             "8:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
         };
         verify(checkConfig, getPath("InputImportOrderStaticGroupOrder.java"), expected);
@@ -553,7 +553,7 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("option", "top");
         checkConfig.addAttribute("groups", "org, java");
         final String[] expected = {
-            "6:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.*"),
+            "6:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.antlr.v4.runtime.*"),
             "8:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
             "9:1: " + getCheckMessage(MSG_ORDERING, "org.junit.Test"),
         };
@@ -568,7 +568,7 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("groups", "org, java");
         checkConfig.addAttribute("sortStaticImportsAlphabetically", "true");
         final String[] expected = {
-            "6:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.*"),
+            "6:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "org.antlr.v4.runtime.*"),
             "8:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.Set"),
             "9:1: " + getCheckMessage(MSG_ORDERING, "org.junit.Test"),
         };

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/covariantequals/InputCovariantEquals.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/covariantequals/InputCovariantEquals.java
@@ -67,7 +67,7 @@ class InputCovariant4
     }
 }
 
-class AnonymousIC
+class InputAnonymousIC
 {
     Comparable comp = new Comparable()
         {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeStarImports.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeStarImports.java
@@ -1,9 +1,9 @@
 package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
 
-import java.*;
+import java.net.*;
 import java.util.*;
 import org.antlr.v4.runtime.*;
-import com.*;
+import com.puppycrawl.tools.checkstyle.*;
 //configuration "illegalClassNames": List
 public class InputIllegalTypeStarImports
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumber.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumber.java
@@ -133,7 +133,7 @@ class ComplexAndFlagged
     };
 }
 
-class ComplexButNotFlagged
+class InputComplexButNotFlagged
 {
     // according to user feedback this is typical code that should not be flagged
     public final double SpecialSum = 2 + 1e10, SpecialDifference = 4 - java.lang.Math.PI;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/superfinalize/InputSuperFinalizeVariations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/superfinalize/InputSuperFinalizeVariations.java
@@ -29,7 +29,7 @@ class NoSuperFinalize
     }
 }
 
-class InnerFinalize
+class InputInnerFinalize
 {
     public void finalize()
     {
@@ -56,7 +56,7 @@ class TestNative {
     public native void finalize();
 }
 
-class OneMore {
+class InputOneMore {
 
     public void doSmt() throws Throwable {
         {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/InputVisibilityModifierIsStarImport.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/visibilitymodifier/InputVisibilityModifierIsStarImport.java
@@ -1,6 +1,6 @@
 package com.puppycrawl.tools.checkstyle.checks.design.visibilitymodifier;
 
-import com.puppycrawl.*;
+import com.puppycrawl.tools.checkstyle.*;
 
 public class InputVisibilityModifierIsStarImport {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderCompareImports.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderCompareImports.java
@@ -3,8 +3,8 @@ package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
 import java.util.Map.Entry;
 import java.util.Map;
 
-import com.google.common.*;
-import com.google.common.annotations.*;
+import com.google.common.base.*;
+import com.google.common.base.internal.*;
 
 public class InputCustomImportOrderCompareImports {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderDefault.java
@@ -17,7 +17,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 
-import com.puppycrawl.tools.*;
+import com.puppycrawl.tools.checkstyle.*;
 
 import com.google.common.collect.*;
 import org.junit.*;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderDefault2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderDefault2.java
@@ -10,8 +10,8 @@ import java.util.*; //warn, LEXIC, should be before javax.swing.WindowConstants.
 import java.util.concurrent.AbstractExecutorService; //warn, LEXIC, should be before javax.swing.WindowConstants.*
 import java.util.concurrent.*; //warn, LEXIC, should be before javax.swing.WindowConstants.*
 
-import com.puppycrawl.tools.*;
-import com.*; //warn, LEXIC, should be before com.puppycrawl.tools.*
+import com.puppycrawl.tools.checkstyle.checks.*;
+import com.puppycrawl.tools.checkstyle.*; //warn, LEXIC, should be before com.puppycrawl.tools.checkstyle.checks.*
 
 import com.google.common.base.*; //warn, SEPARATED_IN_GROUP, LEXIC, should be before com.puppycrawl.tools.*
 import org.junit.*;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderSingleLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderSingleLine.java
@@ -6,7 +6,7 @@ import org.junit.runner.*;
 import org.junit.validator.*;
 
 
-import com.puppycrawl.tools.*;
+import com.puppycrawl.tools.checkstyle.*;
 
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrder_NoSeparator.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrder_NoSeparator.java
@@ -4,8 +4,8 @@ import static javax.swing.WindowConstants.*;
 import static java.io.File.createTempFile;
 import java.util.*;
 import java.util.StringTokenizer;
-import com.puppycrawl.tools.*;
-import com.*;
+import com.puppycrawl.tools.checkstyle.checks.*;
+import com.puppycrawl.tools.checkstyle.*;
 import org.apache.commons.beanutils.*;
 
 public class InputCustomImportOrder_NoSeparator {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrder_OverlappingPatterns.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrder_OverlappingPatterns.java
@@ -20,7 +20,7 @@ import com.puppycrawl.tools.checkstyle.checks.javadoc.InvalidJavadocTag; // (J_T
 //import com.puppycrawl.tools.checkstyle.checks.javadoc.TagParser; // (__T)
 import com.puppycrawl.tools.checkstyle.checks.javadoc.WriteTagCheck; //warn, should be on STANDARD (_CT)
 
-import com.puppycrawl.tools.*;
+import com.puppycrawl.tools.checkstyle.*;
 //import com.puppycrawl.tools.checkstyle.checks.javadoc.HtmlTag; //warn, should be on SPECIAL (__T)
 import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTag; //warn, should be on SPECIAL (J_T)
 import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck; //warn, should be on STANDARD  (JC_)

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderStaticGroupOrder.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderStaticGroupOrder.java
@@ -3,7 +3,7 @@ package com.puppycrawl.tools.checkstyle.checks.imports.importorder;
 import static java.lang.Math.abs;
 import static org.antlr.v4.runtime.Recognizer.EOF;
 
-import org.*;
+import org.antlr.v4.runtime.*;
 
 import java.util.Set;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderStaticGroupOrderBottom.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderStaticGroupOrderBottom.java
@@ -1,6 +1,6 @@
 package com.puppycrawl.tools.checkstyle.checks.imports.importorder;
 
-import org.*;
+import org.antlr.v4.runtime.*;
 
 import java.util.Set;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderStaticGroupOrderBottom_Negative.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderStaticGroupOrderBottom_Negative.java
@@ -1,6 +1,6 @@
 package com.puppycrawl.tools.checkstyle.checks.imports.importorder;
 
-import org.*;
+import org.antlr.v4.runtime.*;
 
 import static java.lang.Math.PI;
 import static org.antlr.v4.runtime.Recognizer.EOF;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderStaticGroupOrderBottom_Negative2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderStaticGroupOrderBottom_Negative2.java
@@ -1,6 +1,6 @@
 package com.puppycrawl.tools.checkstyle.checks.imports.importorder;
 
-import org.*;
+import org.antlr.v4.runtime.*;
 
 import static java.lang.Math.PI;
 import static org.antlr.v4.runtime.Recognizer.EOF;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderStaticOnDemandGroupOrder.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderStaticOnDemandGroupOrder.java
@@ -3,7 +3,7 @@ package com.puppycrawl.tools.checkstyle.checks.imports.importorder;
 import static java.lang.Math.*;
 import static org.antlr.v4.runtime.CommonToken.*;
 
-import org.*;
+import org.antlr.v4.runtime.*;
 
 import java.util.Set;
 import org.junit.Test;


### PR DESCRIPTION
Issue #8283 

* Fix import order inputs
* Rename test classes with deprecated methods to have Input prefix
* Classes `AllChecksTest` and `XdocsPagesTest` are explicitly ignored