### PR TITLE
[[Feature]] Allow for use of DO_WHILE, LITERAL_CATCH, LITERAL_FOR, LITERAL_IF, and LITERAL_WHILE with NoWhitespaceAfter

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
@@ -143,11 +143,16 @@ public class NoWhitespaceAfterCheck extends AbstractCheck {
             TokenTypes.UNARY_PLUS,
             TokenTypes.BNOT,
             TokenTypes.LNOT,
+            TokenTypes.DO_WHILE,
             TokenTypes.DOT,
             TokenTypes.TYPECAST,
             TokenTypes.ARRAY_DECLARATOR,
             TokenTypes.INDEX_OP,
+            TokenTypes.LITERAL_CATCH,
+            TokenTypes.LITERAL_FOR,
+            TokenTypes.LITERAL_IF,
             TokenTypes.LITERAL_SYNCHRONIZED,
+            TokenTypes.LITERAL_WHILE,
             TokenTypes.METHOD_REF,
         };
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
@@ -181,6 +181,36 @@ public class NoWhitespaceAfterCheckTest
     }
 
     @Test
+    public void testCatch() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(NoWhitespaceAfterCheck.class);
+        checkConfig.addAttribute("tokens", "LITERAL_CATCH");
+        final String[] expected = {
+            "21:11: " + getCheckMessage(MSG_KEY, "catch"),
+        };
+        verify(checkConfig, getPath("InputNoWhitespaceAfterCatch.java"), expected);
+    }
+
+    @Test
+    public void testFor() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(NoWhitespaceAfterCheck.class);
+        checkConfig.addAttribute("tokens", "LITERAL_FOR");
+        final String[] expected = {
+            "20:9: " + getCheckMessage(MSG_KEY, "for"),
+        };
+        verify(checkConfig, getPath("InputNoWhitespaceAfterFor.java"), expected);
+    }
+
+    @Test
+    public void testIf() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(NoWhitespaceAfterCheck.class);
+        checkConfig.addAttribute("tokens", "LITERAL_IF");
+        final String[] expected = {
+            "15:9: " + getCheckMessage(MSG_KEY, "if"),
+        };
+        verify(checkConfig, getPath("InputNoWhitespaceAfterIf.java"), expected);
+    }
+
+    @Test
     public void testSynchronized() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(NoWhitespaceAfterCheck.class);
         checkConfig.addAttribute("tokens", "LITERAL_SYNCHRONIZED");
@@ -188,6 +218,26 @@ public class NoWhitespaceAfterCheckTest
             "14:9: " + getCheckMessage(MSG_KEY, "synchronized"),
         };
         verify(checkConfig, getPath("InputNoWhitespaceAfterSynchronized.java"), expected);
+    }
+
+    @Test
+    public void testWhile() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(NoWhitespaceAfterCheck.class);
+        checkConfig.addAttribute("tokens", "LITERAL_WHILE");
+        final String[] expected = {
+            "21:9: " + getCheckMessage(MSG_KEY, "while"),
+        };
+        verify(checkConfig, getPath("InputNoWhitespaceAfterWhile.java"), expected);
+    }
+
+    @Test
+    public void testDoWhile() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(NoWhitespaceAfterCheck.class);
+        checkConfig.addAttribute("tokens", "DO_WHILE");
+        final String[] expected = {
+            "21:11: " + getCheckMessage(MSG_KEY, "while"),
+        };
+        verify(checkConfig, getPath("InputNoWhitespaceAfterDoWhile.java"), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -155,7 +155,8 @@ public class AllChecksTest extends AbstractModuleTestSupport {
                 .collect(Collectors.toSet()));
         CHECKSTYLE_TOKENS_IN_CONFIG_TO_IGNORE.put("NoWhitespaceAfter", Stream.of(
                 // whitespace after is preferred
-                "TYPECAST", "LITERAL_SYNCHRONIZED").collect(Collectors.toSet()));
+                "TYPECAST", "LITERAL_CATCH", "LITERAL_FOR", "LITERAL_IF",
+                "LITERAL_SYNCHRONIZED", "LITERAL_WHILE", "DO_WHILE").collect(Collectors.toSet()));
         CHECKSTYLE_TOKENS_IN_CONFIG_TO_IGNORE.put("SeparatorWrap", Stream.of(
                 // needs context to decide what type of parentheses should be separated or not
                 // which this check does not provide

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterCatch.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterCatch.java
@@ -1,0 +1,23 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespaceafter;
+
+class InputNoWhitespaceAfterCatch {
+    void method2()
+    {
+        try {
+            System.out.println("Test if brace on a new line preceeding works.");
+        } catch(final Exception e) {}
+    }
+
+    public void catch_() {
+        try {
+            System.out.println("Standard; this should work.");
+        } catch(final Exception e) {}
+        try {
+            System.out.println("New lines should also work.");
+        } catch
+            (final Exception e) {}
+        try {
+            System.out.println("Space: this should fail.");
+        } catch (final Exception e) {}
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterDoWhile.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterDoWhile.java
@@ -1,0 +1,23 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespaceafter;
+
+class InputNoWhitespaceAfterDoWhile {
+    void method2()
+    {
+        do {
+            System.out.println("Test if brace on a new line preceeding works.");
+        } while(false);
+    }
+
+    public void catch_() {
+        do {
+            System.out.println("Standard; this should work.");
+        } while(false);
+        do {
+            System.out.println("New lines should also work.");
+        } while
+            (false);
+        do {
+            System.out.println("Space: this should fail.");
+        } while (false);
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterFor.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterFor.java
@@ -1,0 +1,24 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespaceafter;
+
+class InputNoWhitespaceAfterFor {
+    void method2()
+    {
+        for(int temp = -1; temp < 0; temp++) {
+            temp++;
+            System.out.println("Test if brace on a new line preceeding works.");
+        }
+    }
+
+    public void while_() {
+        for(int temp = -1; temp < 0; temp++) {
+            System.out.println("'Should work.");
+        }
+        for
+            (int temp = -1; temp < 0; temp++) {
+            System.out.println("'Should also work.");
+        }
+        for (int temp = -1; temp < 0; temp++) {
+            System.out.println("This should fail.");
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterIf.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterIf.java
@@ -1,0 +1,17 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespaceafter;
+
+class InputNoWhitespaceAfterIf {
+    void method2()
+    {
+        if(true) {
+            System.out.println("Test if brace on a new line preceeding works.");
+        }
+    }
+
+    public void if_() {
+        if(false) { System.out.println("Standard; should work."); }
+        if
+            (true) { System.out.println("New lines should also work."); }
+        if (false) { System.out.println("Space: this should fail."); }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterWhile.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterWhile.java
@@ -1,0 +1,23 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespaceafter;
+
+class InputNoWhitespaceAfterWhile {
+    void method2()
+    {
+        int temp = -1;
+        while(temp < 0) {
+            temp++;
+            System.out.println("Test if brace on a new line preceeding works.");
+        }
+    }
+
+    public void while_() {
+        int temp1 = -1;
+        int temp2 = -1;
+        int temp3 = -1;
+
+        while(temp1 < 0) { temp1++; System.out.println("'Should work."); }
+        while
+            (temp2 < 0) { temp2++; System.out.println("'Should also work."); }
+        while (temp3 < 0) { temp3++; System.out.println("This should fail."); }
+    }
+}

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -1219,6 +1219,8 @@ import static java.math.BigInteger.ZERO;
                   BNOT</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LNOT">
                   LNOT</a>
+                , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DO_WHILE">
+                  DO_WHILE</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DOT">
                   DOT</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPECAST">
@@ -1227,8 +1229,16 @@ import static java.math.BigInteger.ZERO;
                   ARRAY_DECLARATOR</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INDEX_OP">
                   INDEX_OP</a>
+                , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_CATCH">
+                  LITERAL_CATCH</a>
+                , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_FOR">
+                  LITERAL_FOR</a>
+                , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_IF">
+                  LITERAL_IF</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SYNCHRONIZED">
                   LITERAL_SYNCHRONIZED</a>
+                , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
+                  LITERAL_WHILE</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_REF">
                   METHOD_REF</a>
                   .


### PR DESCRIPTION
There wasn't an issue I saw for this, any; I just prefer for these keywords to not have a space between themselves and the following open parenthesis and always had to remind myself that wasn't possible. So I figured I'd get things setup for such use to be added.