### PR TITLE
minor: add text blocks input (#7103)

### DIFF
--- a/config/ant-phase-verify.xml
+++ b/config/ant-phase-verify.xml
@@ -152,6 +152,8 @@
          <exclude name="**/InputJava14InstanceofWithPatternMatching.java"/>
          <!-- Cannot parse until Java 14 support -->
          <exclude name="**/InputJava14Records.java"/>
+         <!-- until https://github.com/checkstyle/checkstyle/issues/7103 -->
+         <exclude name="**/InputJava14TextBlocks.java"/>
         </fileset>
       </path>
       <formatter type="plain"/>

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java14/InputJava14TextBlocks.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/grammar/java14/InputJava14TextBlocks.java
@@ -1,0 +1,87 @@
+//non-compiled with javac: Compilable with Java14
+
+public class InputJava14TextBlocks
+{
+    private static final CharSequence type = "type";
+
+    static {
+        String doubleQuotes = """
+                ""
+                """;
+        String oneDoubleQuote = """
+                "
+                """;
+        String empty = """
+                """;
+        String oneSingleQuote = """
+                '
+                """;
+        String escape = """
+                <html>\u000D\u000A\n
+                    <body>\u000D\u000A\n
+                        <p>Hello, world</p>\u000D\u000A\n
+                    </body>\u000D\u000A\n
+                </html>\u000D\u000A
+                """;
+        String testMoreEscapes = """
+                fun with\n
+                whitespace\t\r
+                and other escapes \"""
+                """;
+        String sqlQuery = """
+                SELECT `EMP_ID`, `LAST_NAME` FROM `EMPLOYEE_TB`
+                WHERE `CITY` = 'INDIANAPOLIS'
+                ORDER BY `EMP_ID`, `LAST_NAME`;
+                """;
+        String concat = """
+                The quick brown fox""" + "  \n" + """
+                jumps over the lazy dog
+                """;
+        String someCode = """
+                function hello() {
+                 print('"Hello, world"');
+                }
+                hello();
+                """;
+        String multiLineStr =
+                """
+                SELECT * FROM USERS
+                WHERE USER_ID = '1'
+                """;
+        String textBlockCeption =
+                """
+                String text = \"""
+                A text block inside a text block
+                \""";
+                """;
+        String code1 = """
+              public void print($type o) {
+                  System.out.println(Objects.toString(o));
+              }
+              """.replace("$type", type);
+        String code2 = String.format("""
+              public void print(%s o) {
+                  System.out.println(Objects.toString(o));
+              }
+              """, type);
+    }
+
+    public String getFormattedText(String parameter) {
+        return """
+            Some parameter: %s
+            """.formatted(parameter);
+    }
+
+    public String getIgnoredNewLines() {
+        return """
+            This is a long test which looks to \
+            have a newline but actually does not""";
+    }
+
+    public String getEscapedSpaces() {
+        return """
+            line 1·······
+            line 2·······\s
+            """;
+    }
+}


### PR DESCRIPTION
minor: add text blocks input 
In reference to #7103, this PR is for the input file to test the implementation of Java 14 text blocks.
Credit for most of the inputs goes to @strkkk, I also found a few more examples from https://www.baeldung.com/java-text-blocks and #7103.