### PR TITLE
minor: exclude from validation link to sonatype that demand authorization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1681,6 +1681,8 @@
             <excludedLink>https://www.manning.com/books/java-development-with-ant</excludedLink>
             <!-- permanent 403, but it works fine out of plugin execution -->
             <excludedLink>https://opencollective.com/*</excludedLink>
+            <!-- 405 Not Allowed, link present in generated website only -->
+            <excludedLink>https://oss.sonatype.org/service/local/staging/deploy/maven2/</excludedLink>
           </excludedLinks>
         </configuration>
       </plugin>


### PR DESCRIPTION
https://app.codeship.com/projects/124310/builds/70f426fe-f4ce-43c4-baba-c2c14e6caedb?line=c6567587-f064-4101-9934-5c987551d6f0&step=parallel_.ci%2Frun-link-check-plugin.sh


`2020-06-23 23:43:42
 system <td><i><a class="externalLink" href="https://oss.sonatype.org/service/local/staging/deploy/maven2/">https://oss.sonatype.org/service/local/staging/deploy/maven2/</a>: 405 Not Allowed</i></td></tr></table></td></tr>`

```
✔ ~/java/github/romani/checkstyle [master|✔] 
$ ag -Q "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
✘-1 ~/java/github/romani/checkstyle [master|✔] 
$ cd target/site/
✔ ~/java/github/romani/checkstyle/target/site [master|✔] 
$ ag -Q "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
distribution-management.html
139:<h3><a name="Repository_-_sonatype-nexus-staging"></a>Repository - sonatype-nexus-staging</h3><a name="Repository_-_sonatype-nexus-staging"></a><a class="externalLink" href="https://oss.sonatype.org/service/local/staging/deploy/maven2/">https://oss.sonatype.org/service/local/staging/deploy/maven2/</a></section><section>
```