### PR TITLE
Issue #8328: Change name of checkstyle types to be close to real java types - enums

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -35,52 +35,54 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </p>
  * <ul>
  * <li>
- * {@code ElementStyle.COMPACT_NO_ARRAY}
+ * {@code ElementStyleOption.COMPACT_NO_ARRAY}
  * </li>
  * <li>
- * {@code ElementStyle.COMPACT}
+ * {@code ElementStyleOption.COMPACT}
  * </li>
  * <li>
- * {@code ElementStyle.EXPANDED}
+ * {@code ElementStyleOption.EXPANDED}
  * </li>
  * </ul>
  * <p>
- * To not enforce an element style a {@code ElementStyle.IGNORE} type is provided.
+ * To not enforce an element style a {@code ElementStyleOption.IGNORE} type is provided.
  * The desired style can be set through the {@code elementStyle} property.
  * </p>
  * <p>
- * Using the {@code ElementStyle.EXPANDED} style is more verbose.
+ * Using the {@code ElementStyleOption.EXPANDED} style is more verbose.
  * The expanded version is sometimes referred to as "named parameters" in other languages.
  * </p>
  * <p>
- * Using the {@code ElementStyle.COMPACT} style is less verbose.
+ * Using the {@code ElementStyleOption.COMPACT} style is less verbose.
  * This style can only be used when there is an element called 'value' which is either
  * the sole element or all other elements have default values.
  * </p>
  * <p>
- * Using the {@code ElementStyle.COMPACT_NO_ARRAY} style is less verbose.
- * It is similar to the {@code ElementStyle.COMPACT} style but single value arrays are flagged.
+ * Using the {@code ElementStyleOption.COMPACT_NO_ARRAY} style is less verbose.
+ * It is similar to the {@code ElementStyleOption.COMPACT} style but single value arrays are
+ * flagged.
  * With annotations a single value array does not need to be placed in an array initializer.
  * </p>
  * <p>
  * The ending parenthesis are optional when using annotations with no elements.
- * To always require ending parenthesis use the {@code ClosingParens.ALWAYS} type.
- * To never have ending parenthesis use the {@code ClosingParens.NEVER} type.
- * To not enforce a closing parenthesis preference a {@code ClosingParens.IGNORE} type is provided.
+ * To always require ending parenthesis use the {@code ClosingParensOption.ALWAYS} type.
+ * To never have ending parenthesis use the {@code ClosingParensOption.NEVER} type.
+ * To not enforce a closing parenthesis preference a {@code ClosingParensOption.IGNORE} type is
+ * provided.
  * Set this through the {@code closingParens} property.
  * </p>
  * <p>
  * Annotations also allow you to specify arrays of elements in a standard format.
  * As with normal arrays, a trailing comma is optional.
- * To always require a trailing comma use the {@code TrailingArrayComma.ALWAYS} type.
- * To never have a trailing comma use the {@code TrailingArrayComma.NEVER} type.
- * To not enforce a trailing array comma preference a {@code TrailingArrayComma.IGNORE} type
+ * To always require a trailing comma use the {@code TrailingArrayCommaOption.ALWAYS} type.
+ * To never have a trailing comma use the {@code TrailingArrayCommaOption.NEVER} type.
+ * To not enforce a trailing array comma preference a {@code TrailingArrayCommaOption.IGNORE} type
  * is provided. Set this through the {@code trailingArrayComma} property.
  * </p>
  * <p>
- * By default the {@code ElementStyle} is set to {@code COMPACT_NO_ARRAY},
- * the {@code TrailingArrayComma} is set to {@code NEVER},
- * and the {@code ClosingParens} is set to {@code NEVER}.
+ * By default the {@code ElementStyleOption} is set to {@code COMPACT_NO_ARRAY},
+ * the {@code TrailingArrayCommaOption} is set to {@code NEVER},
+ * and the {@code ClosingParensOption} is set to {@code NEVER}.
  * </p>
  * <p>
  * According to the JLS, it is legal to include a trailing comma
@@ -136,7 +138,7 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
     /**
      * Defines the styles for defining elements in an annotation.
      */
-    public enum ElementStyle {
+    public enum ElementStyleOption {
 
         /**
          * Expanded example
@@ -173,7 +175,7 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
      * elements in an annotation.
      *
      */
-    public enum TrailingArrayComma {
+    public enum TrailingArrayCommaOption {
 
         /**
          * With comma example
@@ -201,7 +203,7 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
      * elements in an annotation.
      *
      */
-    public enum ClosingParens {
+    public enum ClosingParensOption {
 
         /**
          * With parens example
@@ -269,18 +271,18 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
     /**
      * Define the annotation element styles.
      */
-    private ElementStyle elementStyle = ElementStyle.COMPACT_NO_ARRAY;
+    private ElementStyleOption elementStyle = ElementStyleOption.COMPACT_NO_ARRAY;
 
     // defaulting to NEVER because of the strange compiler behavior
     /**
      * Define the policy for trailing comma in arrays.
      */
-    private TrailingArrayComma trailingArrayComma = TrailingArrayComma.NEVER;
+    private TrailingArrayCommaOption trailingArrayComma = TrailingArrayCommaOption.NEVER;
 
     /**
      * Define the policy for ending parenthesis.
      */
-    private ClosingParens closingParens = ClosingParens.NEVER;
+    private ClosingParensOption closingParens = ClosingParensOption.NEVER;
 
     /**
      * Setter to define the annotation element styles.
@@ -288,7 +290,7 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
      * @param style string representation
      */
     public void setElementStyle(final String style) {
-        elementStyle = getOption(ElementStyle.class, style);
+        elementStyle = getOption(ElementStyleOption.class, style);
     }
 
     /**
@@ -297,7 +299,7 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
      * @param comma string representation
      */
     public void setTrailingArrayComma(final String comma) {
-        trailingArrayComma = getOption(TrailingArrayComma.class, comma);
+        trailingArrayComma = getOption(TrailingArrayCommaOption.class, comma);
     }
 
     /**
@@ -306,7 +308,7 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
      * @param parens string representation
      */
     public void setClosingParens(final String parens) {
-        closingParens = getOption(ClosingParens.class, parens);
+        closingParens = getOption(ClosingParensOption.class, parens);
     }
 
     /**
@@ -348,13 +350,13 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
     @Override
     public void visitToken(final DetailAST ast) {
         checkStyleType(ast);
-        checkCheckClosingParens(ast);
+        checkCheckClosingParensOption(ast);
         checkTrailingComma(ast);
     }
 
     /**
      * Checks to see if the
-     * {@link ElementStyle AnnotationElementStyle}
+     * {@link ElementStyleOption AnnotationElementStyleOption}
      * is correct.
      *
      * @param annotation the annotation token
@@ -386,7 +388,7 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
             annotation.getChildCount(TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR);
 
         if (valuePairCount == 0 && hasArguments(annotation)) {
-            log(annotation, MSG_KEY_ANNOTATION_INCORRECT_STYLE, ElementStyle.EXPANDED);
+            log(annotation, MSG_KEY_ANNOTATION_INCORRECT_STYLE, ElementStyleOption.EXPANDED);
         }
     }
 
@@ -419,7 +421,7 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
             && ANNOTATION_ELEMENT_SINGLE_NAME.equals(
                 valuePair.getFirstChild().getText())) {
             log(annotation, MSG_KEY_ANNOTATION_INCORRECT_STYLE,
-                ElementStyle.COMPACT);
+                ElementStyleOption.COMPACT);
         }
     }
 
@@ -436,7 +438,7 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
         if (arrayInit != null
             && arrayInit.getChildCount(TokenTypes.EXPR) == 1) {
             log(annotation, MSG_KEY_ANNOTATION_INCORRECT_STYLE,
-                ElementStyle.COMPACT_NO_ARRAY);
+                ElementStyleOption.COMPACT_NO_ARRAY);
         }
         // in expanded style with pairs
         else {
@@ -447,7 +449,7 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
                 if (nestedArrayInit != null
                     && nestedArrayInit.getChildCount(TokenTypes.EXPR) == 1) {
                     log(annotation, MSG_KEY_ANNOTATION_INCORRECT_STYLE,
-                        ElementStyle.COMPACT_NO_ARRAY);
+                        ElementStyleOption.COMPACT_NO_ARRAY);
                 }
                 ast = ast.getNextSibling();
             }
@@ -461,7 +463,7 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
      * @param annotation the annotation token
      */
     private void checkTrailingComma(final DetailAST annotation) {
-        if (trailingArrayComma != TrailingArrayComma.IGNORE) {
+        if (trailingArrayComma != TrailingArrayCommaOption.IGNORE) {
             DetailAST child = annotation.getFirstChild();
 
             while (child != null) {
@@ -494,7 +496,7 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
         // comma can be null if array is empty
         final DetailAST comma = rCurly.getPreviousSibling();
 
-        if (trailingArrayComma == TrailingArrayComma.ALWAYS) {
+        if (trailingArrayComma == TrailingArrayCommaOption.ALWAYS) {
             if (comma == null || comma.getType() != TokenTypes.COMMA) {
                 log(rCurly, MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING);
             }
@@ -510,11 +512,11 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
      *
      * @param ast the annotation token
      */
-    private void checkCheckClosingParens(final DetailAST ast) {
-        if (closingParens != ClosingParens.IGNORE) {
+    private void checkCheckClosingParensOption(final DetailAST ast) {
+        if (closingParens != ClosingParensOption.IGNORE) {
             final DetailAST paren = ast.getLastChild();
 
-            if (closingParens == ClosingParens.ALWAYS) {
+            if (closingParens == ClosingParensOption.ALWAYS) {
                 if (paren.getType() != TokenTypes.RPAREN) {
                     log(ast, MSG_KEY_ANNOTATION_PARENS_MISSING);
                 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -56,7 +56,8 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </li>
  * <li>
  * arrange static imports: ensures the relative order between type imports and static imports
- * (see <a href="https://checkstyle.org/property_types.html#importOrder">import orders</a>)
+ * (see
+ * <a href="https://checkstyle.org/property_types.html#ImportOrderOption">ImportOrderOption</a>)
  * </li>
  * </ul>
  * <ul>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckTest.java
@@ -48,10 +48,10 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
      * valueOf() is uncovered.
      */
     @Test
-    public void testElementStyleValueOf() {
-        final AnnotationUseStyleCheck.ElementStyle option =
-            AnnotationUseStyleCheck.ElementStyle.valueOf("COMPACT");
-        assertEquals(AnnotationUseStyleCheck.ElementStyle.COMPACT, option,
+    public void testElementStyleOptionValueOf() {
+        final AnnotationUseStyleCheck.ElementStyleOption option =
+            AnnotationUseStyleCheck.ElementStyleOption.valueOf("COMPACT");
+        assertEquals(AnnotationUseStyleCheck.ElementStyleOption.COMPACT, option,
                 "Invalid valueOf result");
     }
 
@@ -60,10 +60,10 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
      * valueOf() is uncovered.
      */
     @Test
-    public void testTrailingArrayCommaValueOf() {
-        final AnnotationUseStyleCheck.TrailingArrayComma option =
-            AnnotationUseStyleCheck.TrailingArrayComma.valueOf("ALWAYS");
-        assertEquals(AnnotationUseStyleCheck.TrailingArrayComma.ALWAYS, option,
+    public void testTrailingArrayCommaOptionValueOf() {
+        final AnnotationUseStyleCheck.TrailingArrayCommaOption option =
+            AnnotationUseStyleCheck.TrailingArrayCommaOption.valueOf("ALWAYS");
+        assertEquals(AnnotationUseStyleCheck.TrailingArrayCommaOption.ALWAYS, option,
                 "Invalid valueOf result");
     }
 
@@ -72,10 +72,10 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
      * valueOf() is uncovered.
      */
     @Test
-    public void testClosingParensValueOf() {
-        final AnnotationUseStyleCheck.ClosingParens option =
-            AnnotationUseStyleCheck.ClosingParens.valueOf("ALWAYS");
-        assertEquals(AnnotationUseStyleCheck.ClosingParens.ALWAYS, option,
+    public void testClosingParensOptionValueOf() {
+        final AnnotationUseStyleCheck.ClosingParensOption option =
+            AnnotationUseStyleCheck.ClosingParensOption.valueOf("ALWAYS");
+        assertEquals(AnnotationUseStyleCheck.ClosingParensOption.ALWAYS, option,
                 "Invalid valueOf result");
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -82,20 +82,8 @@ import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.api.Scope;
-import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
-import com.puppycrawl.tools.checkstyle.checks.LineSeparatorOption;
-import com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck.ClosingParens;
-import com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck.ElementStyle;
-import com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck.TrailingArrayComma;
-import com.puppycrawl.tools.checkstyle.checks.blocks.BlockOption;
-import com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyOption;
-import com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyOption;
-import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderOption;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck;
-import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationOption;
 import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifier;
-import com.puppycrawl.tools.checkstyle.checks.whitespace.PadOption;
-import com.puppycrawl.tools.checkstyle.checks.whitespace.WrapOption;
 import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.internal.utils.XdocUtil;
@@ -1028,50 +1016,17 @@ public class XdocsPagesTest {
         else if (fieldClass == Pattern[].class) {
             result = "Regular Expressions";
         }
-        else if (fieldClass == SeverityLevel.class) {
-            result = "Severity";
-        }
         else if (fieldClass == Scope.class) {
             result = "Scope";
-        }
-        else if (fieldClass == ElementStyle.class) {
-            result = "Element Style";
-        }
-        else if (fieldClass == ClosingParens.class) {
-            result = "Closing Parens";
-        }
-        else if (fieldClass == TrailingArrayComma.class) {
-            result = "Trailing Comma";
-        }
-        else if (fieldClass == PadOption.class) {
-            result = "Pad Policy";
-        }
-        else if (fieldClass == WrapOption.class) {
-            result = "Wrap Operator Policy";
-        }
-        else if (fieldClass == BlockOption.class) {
-            result = "Block Policy";
-        }
-        else if (fieldClass == LeftCurlyOption.class) {
-            result = "Left Curly Brace Policy";
-        }
-        else if (fieldClass == RightCurlyOption.class) {
-            result = "Right Curly Brace Policy";
-        }
-        else if (fieldClass == LineSeparatorOption.class) {
-            result = "Line Separator Policy";
-        }
-        else if (fieldClass == ImportOrderOption.class) {
-            result = "Import Order Policy";
         }
         else if (fieldClass == AccessModifier[].class) {
             result = "Access Modifier Set";
         }
-        else if (fieldClass == JavadocContentLocationOption.class) {
-            result = "Javadoc Content Location";
-        }
         else if ("PropertyCacheFile".equals(fieldClass.getSimpleName())) {
             result = "File";
+        }
+        else if (fieldClass.isEnum()) {
+            result = fieldClass.getSimpleName();
         }
         else {
             fail("Unknown property type: " + fieldClass.getSimpleName());

--- a/src/xdocs/config.xml
+++ b/src/xdocs/config.xml
@@ -359,7 +359,7 @@
             <tr>
               <td>severity</td>
               <td>the default severity level of all violations</td>
-              <td><a href="property_types.html#severity">Severity</a></td>
+              <td><a href="property_types.html#SeverityLevel">SeverityLevel</a></td>
               <td><code>error</code></td>
               <td>3.1</td>
             </tr>
@@ -713,7 +713,7 @@
     <section name="Severity">
       <p>
         Each module has a <a
-        href="property_types.html#severity">severity</a> property that a
+        href="property_types.html#SeverityLevel">severity</a> property that a
         Checkstyle audit assigns to all violations of the check. The
         default severity level of a check is <code>error</code>.
       </p>

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -478,49 +478,50 @@ class Bar implements Foo {
           Annotations have three element styles starting with the least verbose.
         </p>
         <ul>
-          <li><code>ElementStyle.COMPACT_NO_ARRAY</code></li>
-          <li><code>ElementStyle.COMPACT</code></li>
-          <li><code>ElementStyle.EXPANDED</code></li>
+          <li><code>ElementStyleOption.COMPACT_NO_ARRAY</code></li>
+          <li><code>ElementStyleOption.COMPACT</code></li>
+          <li><code>ElementStyleOption.EXPANDED</code></li>
         </ul>
         <p>
-          To not enforce an element style a <code>ElementStyle.IGNORE</code> type is provided.
+          To not enforce an element style a <code>ElementStyleOption.IGNORE</code> type is provided.
           The desired style can be set through the <code>elementStyle</code> property.
         </p>
         <p>
-          Using the <code>ElementStyle.EXPANDED</code> style is more verbose.
+          Using the <code>ElementStyleOption.EXPANDED</code> style is more verbose.
           The expanded version is sometimes referred to as "named parameters" in other languages.
         </p>
         <p>
-          Using the <code>ElementStyle.COMPACT</code> style is less verbose.
+          Using the <code>ElementStyleOption.COMPACT</code> style is less verbose.
           This style can only be used when there is an element called 'value' which is either
           the sole element or all other elements have default values.
         </p>
         <p>
-          Using the <code>ElementStyle.COMPACT_NO_ARRAY</code> style is less verbose.
-          It is similar to the <code>ElementStyle.COMPACT</code> style but single value arrays
+          Using the <code>ElementStyleOption.COMPACT_NO_ARRAY</code> style is less verbose.
+          It is similar to the <code>ElementStyleOption.COMPACT</code> style but single value arrays
           are flagged.
           With annotations a single value array does not need to be placed in an array initializer.
         </p>
         <p>
           The ending parenthesis are optional when using annotations with no elements.
-          To always require ending parenthesis use the <code>ClosingParens.ALWAYS</code> type.
-          To never have ending parenthesis use the <code>ClosingParens.NEVER</code> type.
-          To not enforce a closing parenthesis preference a <code>ClosingParens.IGNORE</code>
+          To always require ending parenthesis use the <code>ClosingParensOption.ALWAYS</code> type.
+          To never have ending parenthesis use the <code>ClosingParensOption.NEVER</code> type.
+          To not enforce a closing parenthesis preference a <code>ClosingParensOption.IGNORE</code>
           type is provided. Set this through the <code>closingParens</code> property.
         </p>
         <p>
           Annotations also allow you to specify arrays of elements in a standard format.
           As with normal arrays, a trailing comma is optional.
-          To always require a trailing comma use the <code>TrailingArrayComma.ALWAYS</code> type.
-          To never have a trailing comma use the <code>TrailingArrayComma.NEVER</code> type.
-          To not enforce a trailing array comma preference a <code>TrailingArrayComma.IGNORE</code>
-          type is provided.
+          To always require a trailing comma use the <code>TrailingArrayCommaOption.ALWAYS</code>
+          type.
+          To never have a trailing comma use the <code>TrailingArrayCommaOption.NEVER</code> type.
+          To not enforce a trailing array comma preference a
+          <code>TrailingArrayCommaOption.IGNORE</code> type is provided.
           Set this through the <code>trailingArrayComma</code> property.
         </p>
         <p>
-          By default the <code>ElementStyle</code> is set to <code>COMPACT_NO_ARRAY</code>,
-          the <code>TrailingArrayComma</code> is set to <code>NEVER</code>,
-          and the <code>ClosingParens</code> is set to <code>NEVER</code>.
+          By default the <code>ElementStyleOption</code> is set to <code>COMPACT_NO_ARRAY</code>,
+          the <code>TrailingArrayCommaOption</code> is set to <code>NEVER</code>,
+          and the <code>ClosingParensOption</code> is set to <code>NEVER</code>.
         </p>
         <p>
           According to the JLS, it is legal to include a trailing comma
@@ -551,7 +552,7 @@ class Bar implements Foo {
                 Define the annotation element styles.
               </td>
               <td>
-                <a href="property_types.html#elementStyle">Element Style</a>
+                <a href="property_types.html#ElementStyleOption">ElementStyleOption</a>
               </td>
               <td>
                 <code>compact_no_array</code>
@@ -564,7 +565,7 @@ class Bar implements Foo {
                 Define the policy for ending parenthesis.
               </td>
               <td>
-                <a href="property_types.html#closingParens">Closing Parens</a>
+                <a href="property_types.html#ClosingParensOption">ClosingParensOption</a>
               </td>
               <td>
                 <code>never</code>
@@ -577,7 +578,7 @@ class Bar implements Foo {
                 Define the policy for trailing comma in arrays.
               </td>
               <td>
-                <a href="property_types.html#trailingArrayComma">Trailing Comma</a>
+                <a href="property_types.html#TrailingArrayCommaOption">TrailingArrayCommaOption</a>
               </td>
               <td>
                 <code>never</code>

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -201,7 +201,7 @@ switch (a) {
             <tr>
               <td>option</td>
               <td>specify the policy on block contents.</td>
-              <td><a href="property_types.html#block">Block Policy</a></td>
+              <td><a href="property_types.html#BlockOption">BlockOption</a></td>
               <td><code>statement</code></td>
               <td>3.0</td>
             </tr>
@@ -543,7 +543,7 @@ try {
             <tr>
               <td>option</td>
               <td>Specify the policy on placement of a left curly brace (<code>'{'</code>).</td>
-              <td><a href="property_types.html#lcurly">Left Curly Brace Policy</a></td>
+              <td><a href="property_types.html>SeverityLevel">LeftCurlyOption</a></td>
               <td><code>eol</code></td>
               <td>3.0</td>
             </tr>
@@ -968,7 +968,7 @@ allowedFuture.addCallback(result -> {
             <tr>
               <td>option</td>
               <td>Specify the policy on placement of a right curly brace (<code>'}'</code>).</td>
-              <td><a href="property_types.html#rcurly">Right Curly Brace Policy</a></td>
+              <td><a href="property_types.html#RcurlyOption">RightCurlyOption</a></td>
               <td><code>same</code></td>
               <td>3.0</td>
             </tr>

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -49,7 +49,7 @@
             <tr>
               <td>severity</td>
               <td>Specify the severity level of this filter.</td>
-              <td><a href="property_types.html#severity">Severity</a></td>
+              <td><a href="property_types.html#SeverityLevel">SeverityLevel</a></td>
               <td><code>error</code></td>
               <td>3.2</td>
             </tr>

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -1469,7 +1469,7 @@ import java.util.stream.IntStream;
           <a href="https://en.wikipedia.org/wiki/ASCII#Order">ASCII sort order</a></li>
           <li>arrange static imports: ensures the relative order between
           type imports and static imports (see
-          <a href="property_types.html#importOrder">import orders</a>)</li>
+          <a href="property_types.html#ImportOrderOption">ImportOrderOption</a>)</li>
         </ul>
       </subsection>
 
@@ -1486,7 +1486,7 @@ import java.util.stream.IntStream;
             <tr>
               <td>option</td>
               <td>specify policy on the relative order between type imports and static imports.</td>
-              <td><a href="property_types.html#importOrder">Import Order Policy</a></td>
+              <td><a href="property_types.html#ImportOrderOption">ImportOrderOption</a></td>
               <td><code>under</code></td>
               <td>5.0</td>
             </tr>

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -478,7 +478,8 @@ public void method();
               <td>location</td>
               <td>Specify the policy on placement of the Javadoc content.</td>
               <td>
-                <a href="property_types.html#javadocContentLocation">Javadoc Content Location</a>
+                <a href="property_types.html#JavadocContentLocationOption">
+                    JavadocContentLocationOption</a>
               </td>
               <td><code>second_line</code></td>
               <td>8.27</td>
@@ -3241,7 +3242,7 @@ public class TestClass {
             <tr>
               <td>tagSeverity</td>
               <td>Specify the severity level when tag is found and printed.</td>
-              <td><a href="property_types.html#severity">Severity</a></td>
+              <td><a href="property_types.html#SeverityLevel">SeverityLevel</a></td>
               <td><code>info</code></td>
               <td>4.2</td>
             </tr>

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -1417,7 +1417,7 @@ StaticMethodCandidateCheck.name = Static Method Candidate
             <tr>
               <td>lineSeparator</td>
               <td>Specify the type of line separator.</td>
-              <td><a href="property_types.html#lineSeparator">Line Separator Policy</a></td>
+              <td><a href="property_types.html#LineSeparatorOption">LineSeparatorOption</a></td>
               <td><code>lf_cr_crlf</code></td>
               <td>3.1</td>
             </tr>

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -51,7 +51,7 @@ for (
             <tr>
               <td>option</td>
               <td>Specify policy on how to pad an empty for iterator.</td>
-              <td><a href="property_types.html#parenPad">Pad Policy</a></td>
+              <td><a href="property_types.html#PadOption">PadOption</a></td>
               <td><code>nospace</code></td>
               <td>3.4</td>
             </tr>
@@ -148,7 +148,7 @@ for (Iterator foo = very.long.line.iterator();
            <tr>
              <td>option</td>
              <td>Specify policy on how to pad an empty for iterator.</td>
-             <td><a href="property_types.html#parenPad">Pad Policy</a></td>
+             <td><a href="property_types.html#PadOption">PadOption</a></td>
              <td><code>nospace</code></td>
              <td>3.0</td>
            </tr>
@@ -823,7 +823,7 @@ Pair&lt;Integer, Integer &gt; p; // violation, "&gt;" preceded with whitespace
               <td>option</td>
               <td>Specify policy on how to pad method parameter.</td>
               <td>
-                <a href="property_types.html#parenPad">Pad Policy</a>
+                <a href="property_types.html#PadOption">PadOption</a>
               </td>
               <td><code>nospace</code></td>
               <td>3.4</td>
@@ -1567,7 +1567,7 @@ Lists.charactersOf("foo")
               <td>option</td>
               <td>Specify policy on how to wrap lines.</td>
               <td>
-                <a href="property_types.html#wrapOp">Wrap Operator Policy</a>
+                <a href="property_types.html#WrapOption">WrapOption</a>
               </td>
               <td><code>nl</code></td>
               <td>3.0</td>
@@ -1882,7 +1882,7 @@ class Test {
             <tr>
               <td>option</td>
               <td>Specify policy on how to pad parentheses.</td>
-              <td><a href="property_types.html#parenPad">Pad Policy</a></td>
+              <td><a href="property_types.html#PadOption">PadOption</a></td>
               <td><code>nospace</code></td>
               <td>3.0</td>
             </tr>
@@ -2163,7 +2163,7 @@ try (Closeable resource = acquire(); ) // no check before right parenthesis
               <td>option</td>
               <td>Specify policy on how to wrap lines.</td>
               <td>
-                <a href="property_types.html#wrapOp">Wrap Operator Policy</a>
+                <a href="property_types.html#WrapOption">WrapOption</a>
               </td>
               <td><code>eol</code></td>
               <td>5.8</td>
@@ -2508,7 +2508,7 @@ float f1; // OK, 1 whitespace
             <tr>
               <td>option</td>
               <td>Specify policy on how to pad parentheses.</td>
-              <td><a href="property_types.html#parenPad">Pad Policy</a></td>
+              <td><a href="property_types.html#PadOption">PadOption</a></td>
               <td><code>nospace</code></td>
               <td>3.2</td>
             </tr>

--- a/src/xdocs/property_types.xml
+++ b/src/xdocs/property_types.xml
@@ -126,7 +126,7 @@
       </p>
     </section>
 
-    <section name="lineSeparator">
+    <section name="LineSeparatorOption">
       <p>
         This type represents the policy for line returns. The
         following table describes the valid options:
@@ -162,7 +162,7 @@
       </div>
     </section>
 
-    <section name="parenPad">
+    <section name="PadOption">
       <p>
         This type represents the policy for padding with white space. The
         following table describes the valid options:
@@ -191,7 +191,7 @@
       </div>
     </section>
 
-    <section name="wrapOp">
+    <section name="WrapOption">
       <p>
         This type represents the policy for wrapping lines.
         The following table describes the valid options:
@@ -231,7 +231,7 @@
       </div>
     </section>
 
-    <section name="block">
+    <section name="BlockOption">
       <p>
         This type represents the policy for checking block statements. The
         following table describes the valid options:
@@ -273,7 +273,7 @@
       </div>
     </section>
 
-    <section name="lcurly">
+    <section name="LcurlyOption">
       <p>
         This type represents the policy for checking the placement of a
         left curly brace (<code>'{'</code>). The following table
@@ -343,7 +343,7 @@
       </div>
     </section>
 
-    <section name="rcurly">
+    <section name="RcurlyOption">
       <p>
         This type represents the policy for checking the placement of a
         right curly brace (<code>'}'</code>) in blocks but not blocks of expressions.
@@ -506,7 +506,7 @@
       </ul>
     </section>
 
-    <section name="severity">
+    <section name="SeverityLevel">
       <p>
         This type represents the severity level of a check violation. The
         valid options are:
@@ -520,14 +520,14 @@
       </ul>
     </section>
 
-    <section name="importOrder">
+    <section name="ImportOrderOption">
       <p>
         This type represents the policy for checking imports order.
         The following table describes the valid options:
       </p>
 
       <div class="wrapper">
-        <table summary="import order options">
+        <table summary="ImportOrderOptions">
           <tr>
             <td>Option</td>
             <td>Definition</td>
@@ -613,7 +613,7 @@
       </div>
     </section>
 
-    <section name="elementStyle">
+    <section name="ElementStyleOption">
       <p>
         This type represents the policy for the styles for defining
         elements in an annotation. The following table
@@ -699,7 +699,7 @@
       </div>
     </section>
 
-    <section name="closingParens">
+    <section name="ClosingParensOption">
       <p>
         This type represents the policy for the styles for the ending
         parenthesis. The following table describes the valid options:
@@ -742,7 +742,7 @@
       </div>
     </section>
 
-    <section name="trailingArrayComma">
+    <section name="TrailingArrayCommaOption">
       <p>
         This type represents the policy for the styles for the trailing
         array comma. The following table describes the valid options:
@@ -785,14 +785,14 @@
       </div>
     </section>
 
-    <section name="javadocContentLocation">
+    <section name="JavadocContentLocationOption">
       <p>
         This type represents policy on placement of the Javadoc content.
         The following table describes the valid options:
       </p>
 
       <div class="wrapper">
-        <table summary="javadocContentLocation options">
+        <table summary="JavadocContentLocationOption options">
           <tr>
             <td>Option</td>
             <td>Definition</td>


### PR DESCRIPTION
#8328

Refactored - 
1. `ClosingParensOption`
2. `ElementStyleOption`
3. `TrailingArrayCommaOption`

All other enums already have `Option` suffix already and just required a bit of renaming in `property_types.html` related files