### PR TITLE
Issue #8328: Change name of checkstyle types to be close to real java types - misc

### DIFF
--- a/config/checkstyle_sevntu_checks.xml
+++ b/config/checkstyle_sevntu_checks.xml
@@ -125,7 +125,7 @@
             <!-- AccessModifier is in util package (should be moved to api package) to disallow
             its usage by API clients till https://github.com/checkstyle/checkstyle/issues/3511 -->
             <property name="forbiddenImportsExcludesRegexp"
-                      value="^com.puppycrawl.tools.checkstyle.checks.naming.AccessModifier$"/>
+                      value="^com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption$"/>
         </module>
         <module name="LineLengthExtended">
             <property name="max" value="100"/>

--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -102,7 +102,7 @@
            local-only="true"/>
     <!-- AccessModifier is in util package (should be moved to api package) to disallow
     its usage by API clients till https://github.com/checkstyle/checkstyle/issues/3511 -->
-    <allow class="com.puppycrawl.tools.checkstyle.checks.naming.AccessModifier"
+    <allow class="com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption"
            local-only="true"/>
 
     <allow class="com.puppycrawl.tools.checkstyle.Checker" local-only="true"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
@@ -45,7 +45,7 @@ import org.apache.commons.beanutils.converters.IntegerConverter;
 import org.apache.commons.beanutils.converters.LongConverter;
 import org.apache.commons.beanutils.converters.ShortConverter;
 
-import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifier;
+import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
@@ -165,7 +165,7 @@ public abstract class AutomaticBean
         cub.register(new SeverityLevelConverter(), SeverityLevel.class);
         cub.register(new ScopeConverter(), Scope.class);
         cub.register(new UriConverter(), URI.class);
-        cub.register(new RelaxedAccessModifierArrayConverter(), AccessModifier[].class);
+        cub.register(new RelaxedAccessModifierArrayConverter(), AccessModifierOption[].class);
     }
 
     /**
@@ -376,14 +376,15 @@ public abstract class AutomaticBean
     }
 
     /**
-     * A converter that converts strings to {@link AccessModifier}.
+     * A converter that converts strings to {@link AccessModifierOption}.
      * This implementation does not care whether the array elements contain characters like '_'.
      * The normal {@link ArrayConverter} class has problems with this character.
      */
     private static class RelaxedAccessModifierArrayConverter implements Converter {
 
         /** Constant for optimization. */
-        private static final AccessModifier[] EMPTY_MODIFIER_ARRAY = new AccessModifier[0];
+        private static final AccessModifierOption[] EMPTY_MODIFIER_ARRAY =
+                new AccessModifierOption[0];
 
         @SuppressWarnings("unchecked")
         @Override
@@ -391,11 +392,11 @@ public abstract class AutomaticBean
             // Converts to a String and trims it for the tokenizer.
             final StringTokenizer tokenizer = new StringTokenizer(
                 value.toString().trim(), COMMA_SEPARATOR);
-            final List<AccessModifier> result = new ArrayList<>();
+            final List<AccessModifierOption> result = new ArrayList<>();
 
             while (tokenizer.hasMoreTokens()) {
                 final String token = tokenizer.nextToken();
-                result.add(AccessModifier.getInstance(token.trim()));
+                result.add(AccessModifierOption.getInstance(token.trim()));
             }
 
             return result.toArray(EMPTY_MODIFIER_ARRAY);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -48,7 +48,7 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * Checks the Javadoc of a method or constructor.
  * The scope to verify is specified using the {@code Scope} class and defaults
  * to {@code Scope.PRIVATE}. To verify another scope, set property scope to
- * a different <a href="https://checkstyle.org/property_types.html#scope">scope</a>.
+ * a different <a href="https://checkstyle.org/property_types.html#Scope">scope</a>.
  * </p>
  * <p>
  * Violates parameters and type parameters for which no param tags are present can

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java
@@ -42,7 +42,7 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * Checks for missing Javadoc comments for a method or constructor. The scope to verify is
  * specified using the {@code Scope} class and defaults to {@code Scope.PUBLIC}. To verify
  * another scope, set property scope to a different
- * <a href="https://checkstyle.org/property_types.html#scope">scope</a>.
+ * <a href="https://checkstyle.org/property_types.html#Scope">scope</a>.
  * </p>
  * <p>
  * Javadoc is not required on a method that is tagged with the {@code @Override} annotation.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AccessModifierOption.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AccessModifierOption.java
@@ -27,7 +27,7 @@ import java.util.Locale;
  * https://docs.oracle.com/javase/specs/jls/se8/html/jls-6.html#jls-6.6
  *
  */
-public enum AccessModifier {
+public enum AccessModifierOption {
 
     /** Public access modifier. */
     PUBLIC,
@@ -52,13 +52,13 @@ public enum AccessModifier {
      * given access modifier name represented as a {@link String}.
      * The access modifier name can be formatted both as lower case or upper case string.
      * For example, passing PACKAGE or package as a modifier name
-     * will return {@link AccessModifier#PACKAGE}.
+     * will return {@link AccessModifierOption#PACKAGE}.
      *
      * @param modifierName access modifier name represented as a {@link String}.
      * @return the AccessModifier associated with given access modifier name.
      */
-    public static AccessModifier getInstance(String modifierName) {
-        return valueOf(AccessModifier.class, modifierName.trim().toUpperCase(Locale.ENGLISH));
+    public static AccessModifierOption getInstance(String modifierName) {
+        return valueOf(AccessModifierOption.class, modifierName.trim().toUpperCase(Locale.ENGLISH));
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
@@ -59,7 +59,8 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * Default value is {@code false}.
  * </li>
  * <li>
- * Property {@code accessModifiers} - Access modifiers of methods where parameters are checked.
+ * Property {@code accessModifiers} - Access modifiers of methods where parameters are
+ * checked.
  * Default value is {@code public, protected, package, private}.
  * </li>
  * </ul>
@@ -178,11 +179,11 @@ public class ParameterNameCheck extends AbstractNameCheck {
     private boolean ignoreOverridden;
 
     /** Access modifiers of methods where parameters are checked. */
-    private AccessModifier[] accessModifiers = {
-        AccessModifier.PUBLIC,
-        AccessModifier.PROTECTED,
-        AccessModifier.PACKAGE,
-        AccessModifier.PRIVATE,
+    private AccessModifierOption[] accessModifiers = {
+        AccessModifierOption.PUBLIC,
+        AccessModifierOption.PROTECTED,
+        AccessModifierOption.PACKAGE,
+        AccessModifierOption.PRIVATE,
     };
 
     /**
@@ -213,7 +214,7 @@ public class ParameterNameCheck extends AbstractNameCheck {
      *
      * @param accessModifiers access modifiers of methods which should be checked.
      */
-    public void setAccessModifiers(AccessModifier... accessModifiers) {
+    public void setAccessModifiers(AccessModifierOption... accessModifiers) {
         this.accessModifiers =
             Arrays.copyOf(accessModifiers, accessModifiers.length);
     }
@@ -254,11 +255,11 @@ public class ParameterNameCheck extends AbstractNameCheck {
      * @param ast the token of the method/constructor.
      * @return the access modifier of the method/constructor.
      */
-    private static AccessModifier getAccessModifier(final DetailAST ast) {
-        final AccessModifier accessModifier;
+    private static AccessModifierOption getAccessModifier(final DetailAST ast) {
+        final AccessModifierOption accessModifier;
 
         if (ScopeUtil.isInInterfaceOrAnnotationBlock(ast)) {
-            accessModifier = AccessModifier.PUBLIC;
+            accessModifier = AccessModifierOption.PUBLIC;
         }
         else {
             final DetailAST params = ast.getParent();
@@ -276,8 +277,9 @@ public class ParameterNameCheck extends AbstractNameCheck {
      * @param accessModifier the access modifier of the method.
      * @return whether the method matches the expected access modifier.
      */
-    private boolean matchAccessModifiers(final AccessModifier accessModifier) {
-        return Arrays.stream(accessModifiers).anyMatch(modifier -> modifier == accessModifier);
+    private boolean matchAccessModifiers(final AccessModifierOption accessModifier) {
+        return Arrays.stream(accessModifiers)
+                .anyMatch(modifier -> modifier == accessModifier);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifier;
+import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption;
 
 /**
  * Contains utility methods for the checks.
@@ -433,31 +433,32 @@ public final class CheckUtil {
     }
 
     /**
-     * Returns {@link AccessModifier} based on the information about access modifier
+     * Returns {@link AccessModifierOption} based on the information about access modifier
      * taken from the given token of type {@link TokenTypes#MODIFIERS}.
      *
      * @param modifiersToken token of type {@link TokenTypes#MODIFIERS}.
-     * @return {@link AccessModifier}.
+     * @return {@link AccessModifierOption}.
      * @throws IllegalArgumentException when expected non-null modifiersToken with type 'MODIFIERS'
      */
-    public static AccessModifier getAccessModifierFromModifiersToken(DetailAST modifiersToken) {
+    public static AccessModifierOption
+        getAccessModifierFromModifiersToken(DetailAST modifiersToken) {
         if (modifiersToken == null || modifiersToken.getType() != TokenTypes.MODIFIERS) {
             throw new IllegalArgumentException("expected non-null AST-token with type 'MODIFIERS'");
         }
 
         // default access modifier
-        AccessModifier accessModifier = AccessModifier.PACKAGE;
+        AccessModifierOption accessModifier = AccessModifierOption.PACKAGE;
         for (DetailAST token = modifiersToken.getFirstChild(); token != null;
              token = token.getNextSibling()) {
             final int tokenType = token.getType();
             if (tokenType == TokenTypes.LITERAL_PUBLIC) {
-                accessModifier = AccessModifier.PUBLIC;
+                accessModifier = AccessModifierOption.PUBLIC;
             }
             else if (tokenType == TokenTypes.LITERAL_PROTECTED) {
-                accessModifier = AccessModifier.PROTECTED;
+                accessModifier = AccessModifierOption.PROTECTED;
             }
             else if (tokenType == TokenTypes.LITERAL_PRIVATE) {
-                accessModifier = AccessModifier.PRIVATE;
+                accessModifier = AccessModifierOption.PRIVATE;
             }
         }
         return accessModifier;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
@@ -39,7 +39,7 @@ import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.DefaultContext;
-import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifier;
+import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption;
 
 public class AutomaticBeanTest {
 
@@ -182,7 +182,7 @@ public class AutomaticBeanTest {
         bean.setSeverityLevel(null);
         bean.setScope(null);
         bean.setUri(null);
-        bean.setAccessModifiers(AccessModifier.PACKAGE);
+        bean.setAccessModifiers(AccessModifierOption.PACKAGE);
 
         final DefaultConfiguration config = new DefaultConfiguration("bean");
         config.addAttribute("strings", "a, b, c");
@@ -198,9 +198,9 @@ public class AutomaticBeanTest {
         assertEquals(SeverityLevel.ERROR, bean.severityLevel, "invalid result");
         assertEquals(Scope.PUBLIC, bean.scope, "invalid result");
         assertEquals(new URI("http://github.com"), bean.uri, "invalid result");
-        assertArrayEquals(
-                new AccessModifier[] {AccessModifier.PUBLIC, AccessModifier.PRIVATE},
-                bean.accessModifiers, "invalid result");
+        assertArrayEquals(new AccessModifierOption[] {AccessModifierOption.PUBLIC,
+            AccessModifierOption.PRIVATE}, bean.accessModifiers,
+                "invalid result");
     }
 
     @Test
@@ -288,7 +288,7 @@ public class AutomaticBeanTest {
         private SeverityLevel severityLevel;
         private Scope scope;
         private URI uri;
-        private AccessModifier[] accessModifiers;
+        private AccessModifierOption[] accessModifiers;
 
         /**
          * Setter for strings.
@@ -340,8 +340,9 @@ public class AutomaticBeanTest {
          *
          * @param accessModifiers access modifiers.
          */
-        public void setAccessModifiers(AccessModifier... accessModifiers) {
-            this.accessModifiers = Arrays.copyOf(accessModifiers, accessModifiers.length);
+        public void setAccessModifiers(AccessModifierOption... accessModifiers) {
+            this.accessModifiers = Arrays.copyOf(accessModifiers,
+                    accessModifiers.length);
         }
 
         @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
@@ -142,7 +142,7 @@ public class ParameterNameCheckTest
         final DefaultConfiguration checkConfig =
             createModuleConfig(ParameterNameCheck.class);
         checkConfig.addAttribute("format", "^h$");
-        checkConfig.addAttribute("accessModifiers", AccessModifier.PUBLIC.toString());
+        checkConfig.addAttribute("accessModifiers", AccessModifierOption.PUBLIC.toString());
 
         final String pattern = "^h$";
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -83,7 +83,7 @@ import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck;
-import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifier;
+import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption;
 import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.internal.utils.XdocUtil;
@@ -1019,8 +1019,8 @@ public class XdocsPagesTest {
         else if (fieldClass == Scope.class) {
             result = "Scope";
         }
-        else if (fieldClass == AccessModifier[].class) {
-            result = "Access Modifier Set";
+        else if (fieldClass == AccessModifierOption[].class) {
+            result = "AccessModifierOption[]";
         }
         else if ("PropertyCacheFile".equals(fieldClass.getSimpleName())) {
             result = "File";
@@ -1239,7 +1239,7 @@ public class XdocsPagesTest {
                     result = value.toString().toLowerCase(Locale.ENGLISH);
                 }
             }
-            else if (fieldClass == AccessModifier[].class) {
+            else if (fieldClass == AccessModifierOption[].class) {
                 result = Arrays.toString((Object[]) value).replace("[", "").replace("]", "");
             }
             else {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
@@ -40,7 +40,7 @@ import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.JavaParser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifier;
+import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption;
 
 public class CheckUtilTest extends AbstractPathTestSupport {
 
@@ -271,24 +271,24 @@ public class CheckUtilTest extends AbstractPathTestSupport {
     @Test
     public void testGetAccessModifierFromModifiersToken() throws Exception {
         final DetailAST privateVariable = getNodeFromFile(TokenTypes.VARIABLE_DEF);
-        final AccessModifier modifierPrivate =
+        final AccessModifierOption modifierPrivate =
                 CheckUtil.getAccessModifierFromModifiersToken(privateVariable.getFirstChild());
-        assertEquals(AccessModifier.PRIVATE, modifierPrivate, "Invalid access modifier");
+        assertEquals(AccessModifierOption.PRIVATE, modifierPrivate, "Invalid access modifier");
 
         final DetailAST protectedVariable = privateVariable.getNextSibling();
-        final AccessModifier modifierProtected =
+        final AccessModifierOption modifierProtected =
                 CheckUtil.getAccessModifierFromModifiersToken(protectedVariable.getFirstChild());
-        assertEquals(AccessModifier.PROTECTED, modifierProtected, "Invalid access modifier");
+        assertEquals(AccessModifierOption.PROTECTED, modifierProtected, "Invalid access modifier");
 
         final DetailAST publicVariable = protectedVariable.getNextSibling();
-        final AccessModifier modifierPublic =
+        final AccessModifierOption modifierPublic =
                 CheckUtil.getAccessModifierFromModifiersToken(publicVariable.getFirstChild());
-        assertEquals(AccessModifier.PUBLIC, modifierPublic, "Invalid access modifier");
+        assertEquals(AccessModifierOption.PUBLIC, modifierPublic, "Invalid access modifier");
 
         final DetailAST packageVariable = publicVariable.getNextSibling();
-        final AccessModifier modifierPackage =
+        final AccessModifierOption modifierPackage =
                 CheckUtil.getAccessModifierFromModifiersToken(packageVariable.getFirstChild());
-        assertEquals(AccessModifier.PACKAGE, modifierPackage, "Invalid access modifier");
+        assertEquals(AccessModifierOption.PACKAGE, modifierPackage, "Invalid access modifier");
     }
 
     @Test

--- a/src/xdocs/config.xml
+++ b/src/xdocs/config.xml
@@ -322,7 +322,7 @@
               <td>cacheFile</td>
               <td>caches information about files that have checked OK; used
                   to avoid repeated checks of the same files</td>
-              <td><a href="property_types.html#file">File</a></td>
+              <td><a href="property_types.html#File">File</a></td>
               <td><code>null</code> (no cache file)</td>
               <td>6.16</td>
             </tr>

--- a/src/xdocs/config_header.xml
+++ b/src/xdocs/config_header.xml
@@ -76,7 +76,7 @@ line 5: ////////////////////////////////////////////////////////////////////
             <tr>
               <td>headerFile</td>
               <td>Specify the name of the file containing the required header.</td>
-              <td><a href="property_types.html#uri">URI</a></td>
+              <td><a href="property_types.html#Uri">URI</a></td>
               <td><code>null</code></td>
               <td>3.2</td>
             </tr>
@@ -291,7 +291,7 @@ line 6: ^\W*$
             <tr>
               <td>headerFile</td>
               <td>Specify the name of the file containing the required header.</td>
-              <td><a href="property_types.html#uri">URI</a></td>
+              <td><a href="property_types.html#Uri">URI</a></td>
               <td><code>null</code></td>
               <td>3.2</td>
             </tr>

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -1060,7 +1060,7 @@ public class InputIllegalImport { }
                 It can be a regular file, URL or resource path. It will try loading
                 the path as a URL first, then as a file, and finally as a resource.
               </td>
-              <td><a href="property_types.html#uri">URI</a></td>
+              <td><a href="property_types.html#Uri">URI</a></td>
               <td><code>null</code></td>
               <td>4.0</td>
             </tr>

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -578,7 +578,7 @@ public void method();
           to verify is specified using the <code>Scope</code> class and
           defaults to <code>Scope.PRIVATE</code>. To verify another
           scope, set property scope to a different
-          <a href="property_types.html#scope">scope</a>.
+          <a href="property_types.html#Scope">scope</a>.
         </p>
 
         <p>
@@ -678,14 +678,14 @@ public int checkReturnTag(final int aTagIndex,
             <tr>
               <td>scope</td>
               <td>Specify the visibility scope where Javadoc comments are checked.</td>
-              <td><a href="property_types.html#scope">Scope</a></td>
+              <td><a href="property_types.html#Scope">Scope</a></td>
               <td><code>private</code></td>
               <td>3.0</td>
             </tr>
             <tr>
               <td>excludeScope</td>
               <td>Specify the visibility scope where Javadoc comments are not checked.</td>
-              <td><a href="property_types.html#scope">Scope</a></td>
+              <td><a href="property_types.html#Scope">Scope</a></td>
               <td><code>null</code></td>
               <td>3.4</td>
             </tr>
@@ -1385,14 +1385,14 @@ public class TestClass {
             <tr>
               <td>scope</td>
               <td>Specify the visibility scope where Javadoc comments are checked.</td>
-              <td><a href="property_types.html#scope">Scope</a></td>
+              <td><a href="property_types.html#Scope">Scope</a></td>
               <td><code>private</code></td>
               <td>3.2</td>
             </tr>
             <tr>
               <td>excludeScope</td>
               <td>Specify the visibility scope where Javadoc comments are not checked.</td>
-              <td><a href="property_types.html#scope">Scope</a></td>
+              <td><a href="property_types.html#Scope">Scope</a></td>
               <td><code>null</code></td>
               <td>3.4</td>
             </tr>
@@ -1876,14 +1876,14 @@ public class Test {
             <tr>
               <td>scope</td>
               <td>Specify the visibility scope where Javadoc comments are checked.</td>
-              <td><a href="property_types.html#scope">Scope</a></td>
+              <td><a href="property_types.html#Scope">Scope</a></td>
               <td><code>private</code></td>
               <td>3.0</td>
             </tr>
             <tr>
               <td>excludeScope</td>
               <td>Specify the visibility scope where Javadoc comments are not checked.</td>
-              <td><a href="property_types.html#scope">Scope</a></td>
+              <td><a href="property_types.html#Scope">Scope</a></td>
               <td><code>null</code></td>
               <td>3.4</td>
             </tr>
@@ -2099,14 +2099,14 @@ class DatabaseConfiguration {}
             <tr>
               <td>scope</td>
               <td>Specify the visibility scope where Javadoc comments are checked.</td>
-              <td><a href="property_types.html#scope">Scope</a></td>
+              <td><a href="property_types.html#Scope">Scope</a></td>
               <td><code>private</code></td>
               <td>3.0</td>
             </tr>
             <tr>
               <td>excludeScope</td>
               <td>Specify the visibility scope where Javadoc comments are not checked.</td>
-              <td><a href="property_types.html#scope">Scope</a></td>
+              <td><a href="property_types.html#Scope">Scope</a></td>
               <td><code>null</code></td>
               <td>3.4</td>
             </tr>
@@ -2224,7 +2224,7 @@ class DatabaseConfiguration {}
           The scope to verify is specified using the <code>Scope</code> class and
           defaults to <code>Scope.PUBLIC</code>. To verify another
           scope, set property scope to a different
-          <a href="property_types.html#scope">scope</a>.
+          <a href="property_types.html#Scope">scope</a>.
         </p>
 
         <p>
@@ -2288,14 +2288,14 @@ public boolean isSomething()
             <tr>
               <td>scope</td>
               <td>Specify the visibility scope where Javadoc comments are checked.</td>
-              <td><a href="property_types.html#scope">Scope</a></td>
+              <td><a href="property_types.html#Scope">Scope</a></td>
               <td><code>public</code></td>
               <td>8.21</td>
             </tr>
             <tr>
               <td>excludeScope</td>
               <td>Specify the visibility scope where Javadoc comments are not checked.</td>
-              <td><a href="property_types.html#scope">Scope</a></td>
+              <td><a href="property_types.html#Scope">Scope</a></td>
               <td><code>null</code></td>
               <td>8.21</td>
             </tr>
@@ -2614,14 +2614,14 @@ package com.checkstyle.api; // violation
             <tr>
               <td>scope</td>
               <td>specify the visibility scope where Javadoc comments are checked.</td>
-              <td><a href="property_types.html#scope">Scope</a></td>
+              <td><a href="property_types.html#Scope">Scope</a></td>
               <td><code>public</code></td>
               <td>8.20</td>
             </tr>
             <tr>
               <td>excludeScope</td>
               <td>specify the visibility scope where Javadoc comments are not checked.</td>
-              <td><a href="property_types.html#scope">Scope</a></td>
+              <td><a href="property_types.html#Scope">Scope</a></td>
               <td><code>null</code></td>
               <td>8.20</td>
             </tr>

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -2143,7 +2143,9 @@ public boolean equals(Object o) {
             <tr>
               <td>accessModifiers</td>
               <td>Access modifiers of methods where parameters are checked.</td>
-              <td><a href="property_types.html#access_modifiers">Access Modifier Set</a></td>
+              <td><a href="property_types.html#AccessModifierOption.5B.5D">AccessModifierOption[]
+                </a>
+              </td>
               <td><code>public, protected, package, private</code></td>
               <td>7.5</td>
             </tr>

--- a/src/xdocs/property_types.xml
+++ b/src/xdocs/property_types.xml
@@ -108,7 +108,7 @@
       </p>
     </section>
 
-    <section name="uri">
+    <section name="Uri">
       <p>
         This type represents a URI. The string representation is parsed using a custom
         routine to analyze what type of URI the string is.
@@ -118,9 +118,9 @@
       </p>
     </section>
 
-    <section name="file">
+    <section name="File">
       <p>
-        This type represents a local file. Unlike the <a href="#uri">uri</a> type,
+        This type represents a local file. Unlike the <a href="#Uri">uri</a> type,
         which implies read only and not modifiable access to the resource,
         a property of this type indicates files whose contents can be modified by Checkstyle.
       </p>
@@ -472,7 +472,7 @@
       </div>
     </section>
 
-    <section name="scope">
+    <section name="Scope">
       <p>This type represents a Java scope. Checks use this to determine which
       methods/fields/classes will be examined by it's logic. The valid options are:</p>
 
@@ -495,7 +495,7 @@
       </p>
     </section>
 
-    <section name="access_modifiers">
+    <section name="AccessModifierOption[]">
       <p>This type represents Java access modifiers.</p>
 
       <ul>


### PR DESCRIPTION
#8328 

Types Refactored in first commit - 
1. Pattern
2. URI
3. File
4. Scope
5. AccessModifierOption[]