### PR TITLE
Issue #8328: Change name of checkstyle types to be close to real java types - basic types

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
@@ -59,20 +59,20 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * Optional as long as {@code checks} or {@code id} is specified.
  * </li>
  * <li>
- * {@code id} - a <a href="https://checkstyle.org/property_types.html#string">string</a>
+ * {@code id} - a <a href="https://checkstyle.org/property_types.html#String">String</a>
  * matched against the <a href="https://checkstyle.org/config.html#Id">check id</a>
  * associated with an audit event.
  * Optional as long as {@code checks} or {@code message} is specified.
  * </li>
  * <li>
  * {@code lines} - a comma-separated list of values, where each value is an
- * <a href="https://checkstyle.org/property_types.html#integer">integer</a>
+ * <a href="https://checkstyle.org/property_types.html#int">int</a>
  * or a range of integers denoted by integer-integer.
  * It is optional.
  * </li>
  * <li>
  * {@code columns} - a comma-separated list of values, where each value is an
- * <a href="https://checkstyle.org/property_types.html#integer">integer</a>
+ * <a href="https://checkstyle.org/property_types.html#int">int</a>
  * or a range of integers denoted by integer-integer.
  * It is optional.
  * </li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -215,12 +215,12 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * Optional as long as {@code checks} or {@code id} is specified.
  * </li>
  * <li>
- * {@code id} - a <a href="https://checkstyle.org/property_types.html#string">string</a> matched against
+ * {@code id} - a <a href="https://checkstyle.org/property_types.html#String">String</a> matched against
  * the ID of the check associated with an audit event.
  * Optional as long as {@code checks} or {@code message} is specified.
  * </li>
  * <li>
- * {@code query} - a <a href="https://checkstyle.org/property_types.html#string">string</a> xpath query. It is optional.
+ * {@code query} - a <a href="https://checkstyle.org/property_types.html#String">String</a> xpath query. It is optional.
  * </li>
  * </ul>
  * <p>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -970,21 +970,21 @@ public class XdocsPagesTest {
             result = "Regular Expression";
         }
         else if (fieldClass == boolean.class) {
-            result = "Boolean";
+            result = "boolean";
         }
         else if (fieldClass == int.class) {
-            result = "Integer";
+            result = "int";
         }
         else if (fieldClass == int[].class) {
             if (isPropertyTokenType(sectionName, propertyName)) {
                 result = "subset of tokens TokenTypes";
             }
             else {
-                result = "Integer Set";
+                result = "int[]";
             }
         }
         else if (fieldClass == double[].class) {
-            result = "Number Set";
+            result = "double[]";
         }
         else if (fieldClass == String.class) {
             result = "String";
@@ -1004,7 +1004,7 @@ public class XdocsPagesTest {
                 result = "subset of tokens TokenTypes";
             }
             else {
-                result = "String Set";
+                result = "String[]";
             }
         }
         else if (fieldClass == URI.class) {

--- a/src/xdocs/config.xml
+++ b/src/xdocs/config.xml
@@ -314,7 +314,7 @@
             <tr>
               <td>basedir</td>
               <td>base directory name; stripped off in messages about files</td>
-              <td><a href="property_types.html#string">String</a></td>
+              <td><a href="property_types.html#String">String</a></td>
               <td><code>null</code></td>
               <td>3.0</td>
             </tr>
@@ -329,7 +329,7 @@
             <tr>
               <td>localeCountry</td>
               <td>locale country for messages</td>
-              <td><a href="property_types.html#string">String</a> (either
+              <td><a href="property_types.html#String">String</a> (either
               the empty string or an uppercase ISO 3166 2-letter code)</td>
               <td>default locale country for the Java Virtual Machine</td>
               <td>3.0</td>
@@ -337,7 +337,7 @@
             <tr>
               <td>localeLanguage</td>
               <td>locale language for messages</td>
-              <td><a href="property_types.html#string">String</a> (either
+              <td><a href="property_types.html#String">String</a> (either
               the empty string or a lowercase ISO 639 code)</td>
               <td>default locale language for the Java Virtual Machine</td>
               <td>3.0</td>
@@ -345,14 +345,14 @@
             <tr>
               <td>charset</td>
               <td>name of the file charset</td>
-              <td><a href="property_types.html#string">String</a></td>
+              <td><a href="property_types.html#String">String</a></td>
               <td><code>UTF-8</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>fileExtensions</td>
               <td>file extensions that are accepted</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>all files</code></td>
               <td>6.3</td>
             </tr>
@@ -367,7 +367,7 @@
               <td>haltOnException</td>
               <td>whether to stop execution of Checkstyle if a single file produces any kind of
               exception during verification</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>7.4</td>
             </tr>
@@ -375,7 +375,7 @@
               <td>tabWidth</td>
               <td>number of expanded spaces for a tab character (<code>'\t'</code>); used in
               messages and Checks that print violations on files with tabs</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>8</code></td>
               <td>8.19</td>
             </tr>
@@ -537,7 +537,7 @@
               property is typically only required if your Java source code
               is preprocessed before compilation and the original files do
               not have the extension <code>.java</code></td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>.java</code></td>
               <td>3.0</td>
             </tr>

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -69,7 +69,7 @@ public String getNameIfPresent() { ... }
             <tr>
               <td>allowSamelineMultipleAnnotations</td>
               <td>Allow annotation(s) to be located on the same line as target element.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
              <td><code>false</code></td>
               <td>6.0</td>
             </tr>
@@ -77,7 +77,7 @@ public String getNameIfPresent() { ... }
               <td>allowSamelineSingleParameterlessAnnotation</td>
               <td>Allow single parameterless annotation to be located on the same line as
                   target element.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>6.1</td>
             </tr>
@@ -85,7 +85,7 @@ public String getNameIfPresent() { ... }
               <td>allowSamelineParameterizedAnnotation</td>
               <td>Allow one and only parameterized annotation to be located on the same line as
                   target element.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>6.4</td>
             </tr>
@@ -710,7 +710,7 @@ class Bar implements Foo {
                 Control when to print violations if the Javadoc being examined by this check
                 violates the tight html rules defined at
                 <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>8.24</td>
             </tr>
@@ -829,7 +829,7 @@ public static final int COUNTER = 10; // violation
                 Enable java 5 compatibility mode.
               </td>
               <td>
-                <a href="property_types.html#boolean">Boolean</a>
+                <a href="property_types.html#boolean">boolean</a>
               </td>
               <td>
                 <code>false</code>
@@ -1235,7 +1235,7 @@ package com.example.annotations.packageannotation; //ok
               <td>aliasList</td>
               <td>Specify aliases for check names that can be used in code within
                   <code>SuppressWarnings</code>.</td>
-              <td><a href="property_types.html#stringSet">String Set</a>
+              <td><a href="property_types.html#String.5B.5D">String[]</a>
                   in a format of comma separated attribute=value entries.
               The attribute is the fully qualified name of the Check and value is its alias.</td>
               <td><code>null</code></td>

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -103,7 +103,7 @@ switch (a)
             <tr>
               <td>allowInSwitchCase</td>
               <td>Allow nested blocks if they are the only child of a switch case.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>3.2</td>
             </tr>
@@ -550,7 +550,7 @@ try {
             <tr>
               <td>ignoreEnums</td>
               <td>Allow to ignore enums when left curly brace policy is EOL.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>6.9</td>
             </tr>
@@ -749,14 +749,14 @@ try {
             <tr>
               <td>allowSingleLineStatement</td>
               <td>allow single-line statements without braces.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>6.5</td>
             </tr>
             <tr>
               <td>allowEmptyLoopBody</td>
               <td>allow loops with empty bodies.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>6.12.1</td>
             </tr>

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -109,7 +109,7 @@ return new int[] {
                   Control whether to always check for a trailing comma, even when an array is
                   inline.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>8.33</td>
             </tr>
@@ -684,14 +684,14 @@ public class A {
             <tr>
               <td>ignoreConstructors</td>
               <td>control whether to ignore constructors.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.2</td>
             </tr>
             <tr>
               <td>ignoreModifiers</td>
               <td>control whether to ignore modifiers (fields, ...).</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.2</td>
             </tr>
@@ -818,7 +818,7 @@ class K {
                 Control whether to allow <code>default</code> along with
                 <code>case</code> if they are not last.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>7.7</td>
             </tr>
@@ -1051,7 +1051,7 @@ String nullString = null;
               <td>
                 Control whether to ignore <code>String.equalsIgnoreCase(String)</code> invocations.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.4</td>
             </tr>
@@ -1266,7 +1266,7 @@ public static class Example6 {
               <td>onlyObjectReferences</td>
               <td>control whether only explicit initializations made to
                   null for objects should be checked.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>7.8</td>
             </tr>
@@ -1439,7 +1439,7 @@ case 6:
               <td>
                 Control whether the last case group must be checked.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>4.0</td>
             </tr>
@@ -1552,7 +1552,7 @@ case 6:
                 enhanced for-loop</a> variable.</td>
               <td>
                 <a
-                href="property_types.html#boolean">Boolean</a>
+                href="property_types.html#boolean">boolean</a>
               </td>
               <td>
                <code>
@@ -1752,7 +1752,7 @@ class PageBuilder {
             <tr>
               <td>ignoreConstructorParameter</td>
               <td>Control whether to ignore constructor parameters.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>3.2</td>
             </tr>
@@ -1762,7 +1762,7 @@ class PageBuilder {
               <td>
                 Allow to ignore the parameter of a property setter method.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>3.2</td>
             </tr>
@@ -1773,7 +1773,7 @@ class PageBuilder {
                 Allow to expand the definition of a setter method
                 to include methods that return the class' instance.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>6.3</td>
             </tr>
@@ -1781,7 +1781,7 @@ class PageBuilder {
             <tr>
               <td>ignoreAbstractMethods</td>
               <td>Control whether to ignore parameters of abstract methods.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>4.0</td>
             </tr>
@@ -1963,7 +1963,7 @@ class SomeClass
             <tr>
               <td>illegalClassNames</td>
               <td>Specify exception class names to reject.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>Error, Exception, RuntimeException, Throwable, java.lang.Error,
                 java.lang.Exception, java.lang.RuntimeException, java.lang.Throwable</code></td>
               <td>3.2</td>
@@ -2141,7 +2141,7 @@ try {
             <tr>
               <td>classes</td>
               <td>Specify fully qualified class names that should not be instantiated.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>{}</code></td>
               <td>3.0</td>
             </tr>
@@ -2241,7 +2241,7 @@ try {
             <tr>
               <td>illegalClassNames</td>
               <td>Specify throw class names to reject.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>Error, RuntimeException, Throwable, java.lang.Error,
                 java.lang.RuntimeException, java.lang.Throwable</code>
               </td>
@@ -2250,7 +2250,7 @@ try {
             <tr>
               <td>ignoredMethodNames</td>
               <td>Specify names of methods to ignore.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>finalize</code></td>
               <td>5.4</td>
             </tr>
@@ -2260,7 +2260,7 @@ try {
                 allow to ignore checking overridden methods (marked with <code>Override</code>
                 or <code>java.lang.Override</code> annotation).
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>6.4</td>
             </tr>
@@ -2479,7 +2479,7 @@ public native void myTest(); // violation
             <tr>
               <td>ignoreCase</td>
               <td>Control whether to ignore case when matching.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>3.2</td>
             </tr>
@@ -2487,7 +2487,7 @@ public native void myTest(); // violation
               <td>message</td>
               <td>Define the message which is used to notify about violations;
               if empty then the default message is used.</td>
-              <td><a href="property_types.html#string">String</a></td>
+              <td><a href="property_types.html#String">String</a></td>
               <td><code>&quot;&quot;</code></td>
               <td>3.2</td>
             </tr>
@@ -2649,7 +2649,7 @@ public void myTest() {
             <tr>
               <td>validateAbstractClassNames</td>
               <td>Control whether to validate abstract class names.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>6.10</td>
             </tr>
@@ -2657,7 +2657,7 @@ public void myTest() {
               <td>illegalClassNames</td>
               <td>Specify classes that should not be used as types in variable
               declarations, return values or parameters.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>HashMap, HashSet, LinkedHashMap, LinkedHashSet, TreeMap, TreeSet,
                 java.util.HashMap, java.util.HashSet, java.util.LinkedHashMap,
                 java.util.LinkedHashSet, java.util.TreeMap, java.util.TreeSet</code></td>
@@ -2666,14 +2666,14 @@ public void myTest() {
             <tr>
             <td>legalAbstractClassNames</td>
             <td>Define abstract classes that may be used as types. </td>
-            <td><a href="property_types.html#stringSet">String Set</a></td>
+            <td><a href="property_types.html#String.5B.5D">String[]</a></td>
             <td><code>{}</code></td>
             <td>4.2</td>
           </tr>
           <tr>
               <td>ignoredMethodNames</td>
               <td>Specify methods that should not be checked.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>getEnvironment, getInitialContext</code></td>
               <td>3.2</td>
             </tr>
@@ -3121,35 +3121,35 @@ static final Integer ANSWER_TO_THE_ULTIMATE_QUESTION_OF_LIFE = new Integer(42);
             <tr>
               <td>ignoreNumbers</td>
               <td>Specify non-magic numbers.</td>
-              <td><a href="property_types.html#intSet">Number Set</a></td>
+              <td><a href="property_types.html#double.5B.5D">double[]</a></td>
               <td><code>-1, 0, 1, 2</code></td>
               <td>3.1</td>
             </tr>
             <tr>
               <td>ignoreHashCodeMethod</td>
               <td>Ignore magic numbers in hashCode methods.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.3</td>
             </tr>
             <tr>
               <td>ignoreAnnotation</td>
               <td>Ignore magic numbers in annotation declarations.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
                 <td><code>false</code></td>
               <td>5.4</td>
             </tr>
             <tr>
                 <td>ignoreFieldDeclaration</td>
                 <td>Ignore magic numbers in field declarations.</td>
-                <td><a href="property_types.html#boolean">Boolean</a></td>
+                <td><a href="property_types.html#boolean">boolean</a></td>
                 <td><code>false</code></td>
                 <td>6.6</td>
             </tr>
             <tr>
               <td>ignoreAnnotationElementDefaults</td>
               <td>Ignore magic numbers in annotation elements defaults.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>8.23</td>
             </tr>
@@ -3592,7 +3592,7 @@ for (int i = 0; i &lt; 10;) {
                  enhanced for-loop</a> variable.</td>
              <td>
                <a
-                   href="property_types.html#boolean">Boolean</a>
+                   href="property_types.html#boolean">boolean</a>
              </td>
              <td>
                <code>
@@ -3703,7 +3703,7 @@ for (String line: lines) {
                 Specify the maximum number of occurrences to allow without generating a
                 warning.
               </td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>1</code></td>
               <td>3.5</td>
             </tr>
@@ -3902,7 +3902,7 @@ for (String line: lines) {
             <tr>
               <td>max</td>
               <td>Specify maximum allowed nesting depth.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>1</code></td>
               <td>5.3</td>
             </tr>
@@ -3982,7 +3982,7 @@ for (String line: lines) {
             <tr>
               <td>max</td>
               <td>Specify maximum allowed nesting depth.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>1</code></td>
               <td>3.2</td>
             </tr>
@@ -4062,7 +4062,7 @@ for (String line: lines) {
             <tr>
               <td>max</td>
               <td>Specify maximum allowed nesting depth.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>1</code></td>
               <td>3.2</td>
             </tr>
@@ -4669,7 +4669,7 @@ public class Test {
             <tr>
               <td>treatTryResourcesAsStatement</td>
               <td>Enable resources processing.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>8.23</td>
             </tr>
@@ -4877,7 +4877,7 @@ public void foo(String s, int i) {}
             <tr>
               <td>matchDirectoryStructure</td>
               <td>Control whether to check for directory and package name match.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>7.6.1</td>
             </tr>
@@ -5069,21 +5069,21 @@ public class AnnotationLocationCheck extends AbstractCheck {
             <tr>
               <td>checkFields</td>
               <td>Control whether to check references to fields.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>3.4</td>
             </tr>
             <tr>
               <td>checkMethods</td>
               <td>Control whether to check references to methods.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>3.4</td>
             </tr>
             <tr>
               <td>validateOnlyOverlapping</td>
               <td>Control whether to check only overlapping by variables or arguments.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>6.17</td>
             </tr>
@@ -5305,7 +5305,7 @@ class C {
               <td>
                 Specify maximum allowed number of return statements in non-void methods/lambdas.
               </td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>2</code></td>
               <td>3.2</td>
             </tr>
@@ -5313,7 +5313,7 @@ class C {
               <td>maxForVoid</td>
               <td>Specify maximum allowed number of return statements in void
                   methods/constructors/lambdas.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>1</code></td>
               <td>6.19</td>
             </tr>
@@ -6572,7 +6572,7 @@ enum NoSemicolon {
             <tr>
               <td>allowWhenNoBraceAfterSemicolon</td>
               <td>Allow unnecessary semicolon if closing paren is not on the same line.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>8.22</td>
             </tr>
@@ -6687,7 +6687,7 @@ class A {
               <td>allowedDistance</td>
               <td>Specify distance between declaration of variable and its first usage.
                   Values should be greater than 0.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>3</code></td>
               <td>5.8</td>
             </tr>
@@ -6706,7 +6706,7 @@ class A {
               <td>validateBetweenScopes</td>
               <td>Allow to calculate the distance between declaration of variable and its
                   first usage in the different scopes.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.8</td>
             </tr>
@@ -6714,7 +6714,7 @@ class A {
             <tr>
               <td>ignoreFinal</td>
               <td>Allow to ignore variables with a 'final' modifier.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.8</td>
             </tr>

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -159,7 +159,7 @@ public abstract class Plant {
               <td>
                 Specify annotations which allow the check to skip the method from validation.
               </td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>After, AfterClass, Before, BeforeClass, Test</code></td>
               <td>7.2</td>
             </tr>
@@ -543,7 +543,7 @@ class Test2 {
                 Control whether marker interfaces like Serializable are
                 allowed.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>3.1</td>
             </tr>
@@ -878,14 +878,14 @@ public class Foo { // OK, only one top-level class
             <tr>
               <td>max</td>
               <td>Specify maximum allowed number of throws statements.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>4</code></td>
               <td>3.2</td>
             </tr>
             <tr>
               <td>ignorePrivateMethods</td>
               <td>Allow private methods to be ignored.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>6.7</td>
             </tr>
@@ -1126,14 +1126,14 @@ class Test {
             <tr>
               <td>packageAllowed</td>
               <td>Control whether package visible members are allowed.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>3.0</td>
             </tr>
             <tr>
               <td>protectedAllowed</td>
               <td>Control whether protected members are allowed.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>3.0</td>
             </tr>
@@ -1147,21 +1147,21 @@ class Test {
             <tr>
               <td>allowPublicFinalFields</td>
               <td>Allow final fields to be declared as public.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>7.0</td>
             </tr>
             <tr>
               <td>allowPublicImmutableFields</td>
               <td>Allow immutable fields to be declared as public if defined in final class.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>6.4</td>
             </tr>
             <tr>
               <td>immutableClassCanonicalNames</td>
               <td>Specify immutable classes canonical names.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>java.io.File, java.lang.Boolean, java.lang.Byte, java.lang.Character,
                 java.lang.Double, java.lang.Float, java.lang.Integer, java.lang.Long,
                 java.lang.Short, java.lang.StackTraceElement, java.lang.String,
@@ -1176,7 +1176,7 @@ class Test {
                 Specify the list of annotations canonical names which ignore variables in
                 consideration.
               </td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>com.google.common.annotations.VisibleForTesting,
                 org.junit.ClassRule, org.junit.Rule</code></td>
               <td>6.5</td>

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -63,7 +63,7 @@
                  accepts an audit event if and only if there is not a match
                  between the event's severity level and property severity.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>3.2</td>
             </tr>
@@ -187,14 +187,14 @@
               <tr>
                   <td>checkCPP</td>
                   <td>Control whether to check C++ style comments (<code>//</code>).</td>
-                  <td><a href="property_types.html#boolean">Boolean</a></td>
+                  <td><a href="property_types.html#boolean">boolean</a></td>
                   <td><code>true</code></td>
                   <td>3.5</td>
               </tr>
               <tr>
                   <td>checkC</td>
                   <td>Control whether to check C style comments (<code>/* ... */</code>).</td>
-                  <td><a href="property_types.html#boolean">Boolean</a></td>
+                  <td><a href="property_types.html#boolean">boolean</a></td>
                   <td><code>true</code></td>
                   <td>3.5</td>
               </tr>
@@ -466,7 +466,7 @@ public class UserService {
               <td>
                 Specify the location of the <em>suppressions XML document</em> file.
               </td>
-              <td><a href="property_types.html#string">String</a></td>
+              <td><a href="property_types.html#String">String</a></td>
               <td><code>null</code></td>
               <td>3.2</td>
             </tr>
@@ -479,7 +479,7 @@ public class UserService {
                 <code>true</code> and file is not found, the filter accept all
                 audit events.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>6.15</td>
             </tr>
@@ -513,7 +513,7 @@ public class UserService {
           </li>
           <li>
             <code>id</code> -
-            a <a href="property_types.html#string">string</a>
+            a <a href="property_types.html#String">String</a>
             matched against the <a href="config.html#Id">check id</a> associated with an audit
             event. Optional as long as <code>checks</code> or <code>message</code>
             is specified.
@@ -521,13 +521,13 @@ public class UserService {
           <li>
             <code>lines</code> - a comma-separated list of
             values, where each value is
-            an <a href="property_types.html#integer">integer</a> or a
+            an <a href="property_types.html#int">int</a> or a
             range of integers denoted by integer-integer. It is optional.
           </li>
           <li>
             <code>columns</code> - a comma-separated list of
             values, where each value is
-            an <a href="property_types.html#integer">integer</a> or a
+            an <a href="property_types.html#int">int</a> or a
             range of integers denoted by integer-integer. It is optional.
           </li>
         </ul>
@@ -755,7 +755,7 @@ public class UserService {
               <td>id</td>
               <td>Specify a string matched against the ID of the check associated with an audit
                   event.</td>
-              <td><a href="property_types.html#string">String</a></td>
+              <td><a href="property_types.html#String">String</a></td>
               <td><code>null</code></td>
               <td>8.23</td>
             </tr>
@@ -763,7 +763,7 @@ public class UserService {
               <td>lines</td>
               <td>Specify a comma-separated list of values, where each value is an integer or a
                 range of integers denoted by integer-integer.</td>
-              <td><a href="property_types.html#string">String</a></td>
+              <td><a href="property_types.html#String">String</a></td>
               <td><code>null</code></td>
               <td>8.23</td>
             </tr>
@@ -771,7 +771,7 @@ public class UserService {
               <td>columns</td>
               <td>Specify a comma-separated list of values, where each value is an integer or a
                 range of integers denoted by integer-integer.</td>
-              <td><a href="property_types.html#string">String</a></td>
+              <td><a href="property_types.html#String">String</a></td>
               <td><code>null</code></td>
               <td>8.23</td>
             </tr>
@@ -1008,7 +1008,7 @@ public class UserService {
               <td>
                 Specify the location of the <em>suppressions XML document</em> file.
               </td>
-              <td><a href="property_types.html#string">String</a></td>
+              <td><a href="property_types.html#String">String</a></td>
               <td><code>null</code></td>
               <td>8.6</td>
             </tr>
@@ -1021,7 +1021,7 @@ public class UserService {
                 true and file is not found, the filter accepts all
                 audit events.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>8.6</td>
             </tr>
@@ -1069,13 +1069,13 @@ public class UserService {
           </li>
           <li>
             <code>id</code> -
-            a <a href="property_types.html#string">string</a>
+            a <a href="property_types.html#String">String</a>
             matched against the ID of the check associated with an audit
             event. Optional as long as <code>checks</code> or <code>message</code> is specified.
           </li>
           <li>
             <code>query</code> -
-            a <a href="property_types.html#string">string</a>
+            a <a href="property_types.html#String">String</a>
             xpath query. It is optional.
           </li>
         </ul>
@@ -1435,14 +1435,14 @@ CLASS_DEF -> CLASS_DEF [1:0]
               <td>id</td>
               <td>Define a string matched against the ID of the check associated with an audit
                   event.</td>
-              <td><a href="property_types.html#string">String</a></td>
+              <td><a href="property_types.html#String">String</a></td>
               <td><code>null</code></td>
               <td>8.18</td>
             </tr>
             <tr>
               <td>query</td>
               <td>Define a string xpath query.</td>
-              <td><a href="property_types.html#string">String</a></td>
+              <td><a href="property_types.html#String">String</a></td>
               <td><code>null</code></td>
               <td>8.18</td>
             </tr>
@@ -2024,14 +2024,14 @@ public static void foo() {
                 <tr>
                     <td>checkCPP</td>
                     <td>Control whether to check C++ style comments (<code>//</code>).</td>
-                    <td><a href="property_types.html#boolean">Boolean</a></td>
+                    <td><a href="property_types.html#boolean">boolean</a></td>
                     <td><code>true</code></td>
                     <td>5.0</td>
                 </tr>
                 <tr>
                     <td>checkC</td>
                     <td>Control whether to check C style comments (<code>/* ... */</code>).</td>
-                    <td><a href="property_types.html#boolean">Boolean</a></td>
+                    <td><a href="property_types.html#boolean">boolean</a></td>
                     <td><code>true</code></td>
                     <td>5.0</td>
                 </tr>

--- a/src/xdocs/config_header.xml
+++ b/src/xdocs/config_header.xml
@@ -83,7 +83,7 @@ line 5: ////////////////////////////////////////////////////////////////////
             <tr>
               <td>charset</td>
               <td>Specify the character encoding to use when reading the headerFile.</td>
-              <td><a href="property_types.html#string">String</a></td>
+              <td><a href="property_types.html#String">String</a></td>
               <td>the charset property of the parent
               <a href="config.html#Checker">Checker</a> module</td>
               <td>5.0</td>
@@ -95,21 +95,21 @@ line 5: ////////////////////////////////////////////////////////////////////
                 must be separated by the string <code>&quot;\n&quot;</code> (even on platforms with
                 a different line separator), see examples below.
               </td>
-              <td><a href="property_types.html#string">String</a></td>
+              <td><a href="property_types.html#String">String</a></td>
               <td><code>null</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>ignoreLines</td>
               <td>Specify the line numbers to ignore.</td>
-              <td><a href="property_types.html#intSet">Integer Set</a></td>
+              <td><a href="property_types.html#int.5B.5D">int[]</a></td>
               <td><code>{}</code></td>
               <td>3.2</td>
             </tr>
             <tr>
               <td>fileExtensions</td>
               <td>Specify the file type extension of files to process.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>all files</code></td>
               <td>6.9</td>
             </tr>
@@ -298,7 +298,7 @@ line 6: ^\W*$
             <tr>
               <td>charset</td>
               <td>Specify the character encoding to use when reading the headerFile.</td>
-              <td><a href="property_types.html#string">String</a></td>
+              <td><a href="property_types.html#String">String</a></td>
               <td>the charset property of the parent
               <a href="config.html#Checker">Checker</a> module</td>
               <td>5.0</td>
@@ -312,21 +312,21 @@ line 6: ^\W*$
                 <code>&quot;\n\n&quot;</code> checkstyle will forcefully expect an empty line to
                 exist. See examples below. Regular expressions must not span multiple lines.
               </td>
-              <td><a href="property_types.html#string">String</a></td>
+              <td><a href="property_types.html#String">String</a></td>
               <td><code>null</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>multiLines</td>
               <td>Specify the line numbers to repeat (zero or more times).</td>
-              <td><a href="property_types.html#intSet">Integer Set</a></td>
+              <td><a href="property_types.html#int.5B.5D">int[]</a></td>
               <td><code>{}</code></td>
               <td>3.4</td>
             </tr>
             <tr>
               <td>fileExtensions</td>
               <td>Specify the file type extension of files to process.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>all files</code></td>
               <td>6.9</td>
             </tr>

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -59,7 +59,7 @@
               <td>
                 Specify packages where star imports are allowed.
               </td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>{}</code></td>
               <td>3.2</td>
             </tr>
@@ -69,7 +69,7 @@
                 Control whether to allow starred class imports like
                 <code>import java.util.*;</code>.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.3</td>
             </tr>
@@ -79,7 +79,7 @@
                 Control whether to allow starred static member imports like
                 <code>import static org.junit.Assert.*;</code>.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.3</td>
             </tr>
@@ -248,7 +248,7 @@ import java.net.*;                // violation
                 members to be excluded like <code>java.lang.System.out</code> for a variable or
                 <code>java.lang.Math.random</code> for a method. See notes section for details.
               </td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>{}</code></td>
               <td>5.0</td>
             </tr>
@@ -426,7 +426,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
             <tr>
               <td>customImportOrderRules</td>
               <td>Specify format of order declaration customizing by user.</td>
-              <td><a href="property_types.html#string">String</a></td>
+              <td><a href="property_types.html#String">String</a></td>
               <td><code>""</code></td>
               <td>5.8</td>
             </tr>
@@ -454,7 +454,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
             <tr>
               <td>separateLineBetweenGroups</td>
               <td>Force empty line separator between import groups.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.8</td>
             </tr>
@@ -463,7 +463,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
               <td>Force grouping alphabetically, in
                   <a href="https://en.wikipedia.org/wiki/ASCII#Order">
                      ASCII sort order</a>.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.8</td>
             </tr>
@@ -722,7 +722,7 @@ import android.*;
                 is the part of package. If <b>regexp</b> property is set, then list of packages will
                 be interpreted as regular expressions. Note, all properties for match will be used.
               </td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>sun</code></td>
               <td>3.0</td>
             </tr>
@@ -732,7 +732,7 @@ import android.*;
                 import equals class name. If <b>regexp</b> property is set, then list of class names
                 will be interpreted as regular expressions. Note, all properties for match will be
                 used.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>{}</code></td>
               <td>7.8</td>
             </tr>
@@ -742,7 +742,7 @@ import android.*;
                 Control whether the <code>illegalPkgs</code> and <code>illegalClasses</code>
                 should be interpreted as regular expressions.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>7.8</td>
             </tr>
@@ -1508,7 +1508,7 @@ import java.util.stream.IntStream;
               <td>ordered</td>
               <td>control whether type imports within each group should be sorted.
                 It doesn't affect sorting for static imports.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td>true</td>
               <td>3.2</td>
             </tr>
@@ -1519,7 +1519,7 @@ import java.util.stream.IntStream;
                 blank line or comment and aren't separated internally.
                 It doesn't affect separations for static imports.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td>false</td>
               <td>3.2</td>
             </tr>
@@ -1531,7 +1531,7 @@ import java.util.stream.IntStream;
                 This property has effect only when the property <code>option</code>
                 is is set to <code>top</code> or <code>bottom</code>.
                 </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td>false</td>
               <td>8.12</td>
             </tr>
@@ -1542,7 +1542,7 @@ import java.util.stream.IntStream;
                 <a href="https://en.wikipedia.org/wiki/ASCII#Order">ASCII sort order</a>.
                 It affects both type imports and static imports.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td>true</td>
               <td>3.3</td>
             </tr>
@@ -1568,7 +1568,7 @@ import java.util.stream.IntStream;
                   control whether <b>static imports</b> located at <b>top</b> or
                   <b>bottom</b> are sorted within the group.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td>false</td>
               <td>6.5</td>
             </tr>
@@ -1577,7 +1577,7 @@ import java.util.stream.IntStream;
               <td>
                   control whether to use container ordering (Eclipse IDE term) for static
                   imports or not.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td>false</td>
               <td>7.1</td>
             </tr>
@@ -2017,7 +2017,7 @@ class FooBar {
             <tr>
               <td>processJavadoc</td>
               <td>Control whether to process Javadoc comments.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.4</td>
             </tr>

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -51,7 +51,7 @@
                 Control when to print violations if the Javadoc being examined by this check
                 violates the tight html rules defined at
                 <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>8.3</td>
             </tr>
@@ -80,7 +80,7 @@
             <tr>
               <td>tagOrder</td>
               <td>Specify the order by tags.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>&#64;author, &#64;deprecated, &#64;exception, &#64;param,
                 &#64;return, &#64;see, &#64;serial, &#64;serialData, &#64;serialField,
                 &#64;since, &#64;throws, &#64;version</code></td>
@@ -283,7 +283,7 @@ public class TestClass {
             <tr>
               <td>tags</td>
               <td>Specify the javadoc tags to process.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>author, deprecated, exception, hidden, param, provides, return,
                 see, serial, serialData, serialField, since, throws, uses, version</code></td>
               <td>8.24</td>
@@ -294,7 +294,7 @@ public class TestClass {
                 Control when to print violations if the Javadoc being examined by this check
                 violates the tight html rules defined at
                 <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>8.24</td>
             </tr>
@@ -664,14 +664,14 @@ public int checkReturnTag(final int aTagIndex,
             <tr>
               <td>allowedAnnotations</td>
               <td>Specify the list of annotations that allow missed documentation.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>Override</code></td>
               <td>6.0</td>
             </tr>
             <tr>
               <td>validateThrows</td>
               <td>Control whether to validate <code>throws</code> tags.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>6.0</td>
             </tr>
@@ -693,7 +693,7 @@ public int checkReturnTag(final int aTagIndex,
               <td>allowMissingParamTags</td>
               <td>Control whether to ignore violations when a method has parameters
               but does not have matching <code>param</code> tags in the javadoc.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>3.1</td>
             </tr>
@@ -701,7 +701,7 @@ public int checkReturnTag(final int aTagIndex,
               <td>allowMissingReturnTag</td>
               <td>Control whether to ignore violations when a method returns
               non-void type and does not have a <code>return</code> tag in the javadoc.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>3.1</td>
             </tr>
@@ -948,7 +948,7 @@ public Runnable printLater(String s) {
                 Control when to print violations if the Javadoc being examined by this check
                 violates the tight html rules defined at
                 <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>8.3</td>
             </tr>
@@ -1067,14 +1067,14 @@ class TestClass {
               <td>
                 Allow legacy <code>package.html</code> file to be used.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>fileExtensions</td>
               <td>Specify the file type extension of files to process.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>.java</code></td>
               <td>5.0</td>
             </tr>
@@ -1180,7 +1180,7 @@ class TestClass {
                 Control when to print violations if the Javadoc being examined by this check
                 violates the tight html rules defined at
                 <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>8.3</td>
             </tr>
@@ -1190,7 +1190,7 @@ class TestClass {
                 Control whether the &lt;p&gt; tag should be placed immediately before the first
                 word.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>6.9</td>
             </tr>
@@ -1401,7 +1401,7 @@ public class TestClass {
               <td>
                 Control whether to check the first sentence for proper end of sentence.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>3.2</td>
             </tr>
@@ -1419,14 +1419,14 @@ public class TestClass {
               <td>
                 Control whether to check if the Javadoc is missing a describing text.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>3.4</td>
             </tr>
             <tr>
               <td>checkHtml</td>
               <td>Control whether to check for incomplete HTML tags.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>3.2</td>
             </tr>
@@ -1708,14 +1708,14 @@ public class Test {
                 Control when to print violations if the Javadoc being examined by this check
                 violates the tight html rules defined at
                 <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>8.3</td>
             </tr>
             <tr>
               <td>offset</td>
               <td>Specify how many spaces to use for new indentation level.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>4</code></td>
               <td>6.0</td>
             </tr>
@@ -1905,14 +1905,14 @@ public class Test {
               <td>allowMissingParamTags</td>
               <td>Control whether to ignore violations when a class has type parameters
                   but does not have matching param tags in the Javadoc.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>4.0</td>
             </tr>
             <tr>
               <td>allowUnknownTags</td>
               <td>Control whether to ignore violations when a Javadoc tag is not recognised.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.1</td>
             </tr>
@@ -1922,7 +1922,7 @@ public class Test {
                 Specify the list of annotations that allow missed documentation.
                 Only short names are allowed, e.g. <code>Generated</code>.
               </td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>Generated</code></td>
               <td>8.15</td>
             </tr>
@@ -2274,14 +2274,14 @@ public boolean isSomething()
             <tr>
               <td>minLineCount</td>
               <td>Control the minimal amount of lines in method to allow no documentation.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>-1</code></td>
               <td>8.21</td>
             </tr>
             <tr>
               <td>allowedAnnotations</td>
               <td>Configure the list of annotations that allow missed documentation.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>Override</code></td>
               <td>8.21</td>
             </tr>
@@ -2305,7 +2305,7 @@ public boolean isSomething()
                 Control whether to allow missing Javadoc on accessor methods for
                 properties (setters and getters).
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>8.21</td>
             </tr>
@@ -2631,7 +2631,7 @@ package com.checkstyle.api; // violation
                 specify the list of annotations that allow missed documentation.
                 Only short names are allowed, e.g. <code>Generated</code>.
               </td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>Generated</code></td>
               <td>8.20</td>
             </tr>
@@ -2803,7 +2803,7 @@ class DatabaseConfiguration {}
                 Control when to print violations if the Javadoc being examined by this check
                 violates the tight html rules defined at
                 <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>8.3</td>
             </tr>
@@ -2938,21 +2938,21 @@ class DatabaseConfiguration {}
                 Control when to print violations if the Javadoc being examined by this check
                 violates the tight html rules defined at
                 <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>8.3</td>
             </tr>
             <tr>
               <td>ignoredTags</td>
               <td>Specify at-clauses which are ignored by the check.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>{}</code></td>
               <td>6.8</td>
             </tr>
             <tr>
               <td>ignoreInlineTags</td>
               <td>Control whether inline tags must be ignored.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>6.8</td>
             </tr>
@@ -3058,7 +3058,7 @@ class DatabaseConfiguration {}
                 Control when to print violations if the Javadoc being examined by this check
                 violates the tight html rules defined at
                 <a href="writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>8.3</td>
             </tr>
@@ -3072,7 +3072,7 @@ class DatabaseConfiguration {}
             <tr>
               <td>period</td>
               <td>Specify the period symbol at the end of first javadoc sentence.</td>
-              <td><a href="property_types.html#string">String</a></td>
+              <td><a href="property_types.html#String">String</a></td>
               <td><code>"."</code></td>
               <td>6.2</td>
             </tr>
@@ -3228,7 +3228,7 @@ public class TestClass {
             <tr>
               <td>tag</td>
               <td>Specify the name of tag.</td>
-              <td><a href="property_types.html#string">String</a></td>
+              <td><a href="property_types.html#String">String</a></td>
              <td><code>null</code></td>
              <td>4.2</td>
             </tr>

--- a/src/xdocs/config_metrics.xml
+++ b/src/xdocs/config_metrics.xml
@@ -66,7 +66,7 @@
                 Specify the maximum number of boolean operations allowed in one
                 expression.
               </td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>3</code></td>
               <td>3.4</td>
             </tr>
@@ -288,14 +288,14 @@ public class Test
             <tr>
               <td>max</td>
               <td>Specify the maximum threshold allowed.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>7</code></td>
               <td>3.4</td>
             </tr>
             <tr>
               <td>excludedClasses</td>
               <td>Specify user-configured class names to ignore.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>
                 ArrayIndexOutOfBoundsException, ArrayList, Boolean, Byte, Character,
                 Class, Deprecated, Deque, Double, Exception, Float, FunctionalInterface,
@@ -319,7 +319,7 @@ public class Test
             <tr>
               <td>excludedPackages</td>
               <td>Specify user-configured packages to ignore.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>{}</code></td>
               <td>7.7</td>
             </tr>
@@ -672,14 +672,14 @@ class Foo {
             <tr>
               <td>max</td>
               <td>Specify the maximum threshold allowed.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>20</code></td>
               <td>3.4</td>
             </tr>
             <tr>
               <td>excludedClasses</td>
               <td>Specify user-configured class names to ignore.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>
                 ArrayIndexOutOfBoundsException, ArrayList, Boolean, Byte, Character,
                 Class, Deprecated, Deque, Double, Exception, Float, FunctionalInterface,
@@ -706,7 +706,7 @@ class Foo {
                 Specify user-configured packages to ignore. All excluded packages
                 should end with a period, so it also appends a dot to a package name.
               </td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>{}</code></td>
               <td>7.7</td>
             </tr>
@@ -1065,14 +1065,14 @@ class Foo {
             <tr>
               <td>max</td>
               <td>Specify the maximum threshold allowed.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>10</code></td>
               <td>3.2</td>
             </tr>
             <tr>
               <td>switchBlockAsSingleDecisionPoint</td>
               <td>Control whether to treat the whole switch block as a single decision point.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>6.11</td>
             </tr>
@@ -1352,7 +1352,7 @@ class CyclomaticComplexity {
                 Specify the maximum allowed number of non commenting lines in a
                 method.
               </td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>50</code></td>
               <td>3.5</td>
             </tr>
@@ -1362,7 +1362,7 @@ class CyclomaticComplexity {
                 Specify the maximum allowed number of non commenting lines in a
                 class.
               </td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>1500</code></td>
               <td>3.5</td>
             </tr>
@@ -1372,7 +1372,7 @@ class CyclomaticComplexity {
                 Specify the maximum allowed number of non commenting lines in a
                 file including all top level and nested classes.
               </td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>2000</code></td>
               <td>3.5</td>
             </tr>
@@ -1626,7 +1626,7 @@ class Test2 {
             <tr>
               <td>max</td>
               <td>Specify the maximum threshold allowed.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>200</code></td>
               <td>3.4</td>
             </tr>

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -55,7 +55,7 @@
               <td>
                 Control whether to enforce Java style (true) or C style (false).
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>3.1</td>
             </tr>
@@ -186,28 +186,28 @@ public class MyClass {
              <tr>
                <td>allowEscapesForControlCharacters</td>
                <td>Allow use escapes for non-printable, control characters.</td>
-               <td><a href="property_types.html#boolean">Boolean</a></td>
+               <td><a href="property_types.html#boolean">boolean</a></td>
                <td><code>false</code></td>
                <td>5.8</td>
              </tr>
              <tr>
                <td>allowByTailComment</td>
                <td>Allow use escapes if trail comment is present.</td>
-               <td><a href="property_types.html#boolean">Boolean</a></td>
+               <td><a href="property_types.html#boolean">boolean</a></td>
                <td><code>false</code></td>
                <td>5.8</td>
              </tr>
              <tr>
                <td>allowIfAllCharactersEscaped</td>
                <td>Allow if all characters in literal are escaped.</td>
-               <td><a href="property_types.html#boolean">Boolean</a></td>
+               <td><a href="property_types.html#boolean">boolean</a></td>
                <td><code>false</code></td>
                <td>5.8</td>
              </tr>
              <tr>
                <td>allowNonPrintableEscapes</td>
                <td>Allow use escapes for non-printable, whitespace characters.</td>
-               <td><a href="property_types.html#boolean">Boolean</a></td>
+               <td><a href="property_types.html#boolean">boolean</a></td>
                <td><code>false</code></td>
                <td>5.8</td>
              </tr>
@@ -621,28 +621,28 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
             <tr>
               <td>minimumDepth</td>
               <td>Specify the minimum depth for descendant counts.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>0</code></td>
               <td>3.2</td>
             </tr>
             <tr>
               <td>maximumDepth</td>
               <td>Specify the maximum depth for descendant counts.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>java.lang.Integer.MAX_VALUE</code></td>
               <td>3.2</td>
             </tr>
             <tr>
               <td>minimumNumber</td>
               <td>Specify a minimum count for descendants.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>0</code></td>
               <td>3.2</td>
             </tr>
             <tr>
               <td>maximumNumber</td>
               <td>Specify a maximum count for descendants.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>java.lang.Integer.MAX_VALUE</code></td>
               <td>3.2</td>
             </tr>
@@ -652,21 +652,21 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
                 Control whether the number of tokens found should be calculated
                 from the sum of the individual token counts.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>minimumMessage</td>
               <td>Define the violation message when the minimum count is not reached.</td>
-              <td><a href="property_types.html#string">String</a></td>
+              <td><a href="property_types.html#String">String</a></td>
               <td><code>null</code></td>
               <td>3.2</td>
             </tr>
             <tr>
               <td>maximumMessage</td>
               <td>Define the violation message when the maximum count is exceeded.</td>
-              <td><a href="property_types.html#string">String</a></td>
+              <td><a href="property_types.html#String">String</a></td>
               <td><code>null</code></td>
               <td>3.2</td>
             </tr>
@@ -972,7 +972,7 @@ String unitAbbrev = "\u03bc\u03bc\u03bc";
             <tr>
               <td>ignorePrimitiveTypes</td>
               <td>Ignore primitive types as parameters.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>6.2</td>
             </tr>
@@ -1129,35 +1129,35 @@ if ((condition1 &amp;&amp; condition2)
               <td>
                 Specify how far new indentation level should be indented when on the next line.
               </td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>4</code></td>
               <td>3.1</td>
             </tr>
             <tr>
               <td>braceAdjustment</td>
               <td>Specify how far a braces should be indented when on the next line.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>0</code></td>
               <td>3.1</td>
             </tr>
             <tr>
               <td>caseIndent</td>
               <td>Specify how far a case label should be indented when on next line.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>4</code></td>
               <td>3.1</td>
             </tr>
             <tr>
               <td>throwsIndent</td>
               <td>Specify how far a throws clause should be indented when on next line.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>4</code></td>
               <td>5.7</td>
             </tr>
             <tr>
               <td>arrayInitIndent</td>
               <td>Specify how far an array initialisation should be indented when on next line.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>4</code></td>
               <td>5.8</td>
             </tr>
@@ -1166,7 +1166,7 @@ if ((condition1 &amp;&amp; condition2)
               <td>
                 Specify how far continuation line should be indented when line-wrapping is present.
               </td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>4</code></td>
               <td>5.9</td>
             </tr>
@@ -1175,7 +1175,7 @@ if ((condition1 &amp;&amp; condition2)
               <td>Force strict indent level in line wrapping case. If value is true, line wrap
                   indent have to be same as lineWrappingIndentation parameter. If value is false,
                   line wrap indent could be bigger on any value user would like.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>6.3</td>
             </tr>
@@ -1424,7 +1424,7 @@ StaticMethodCandidateCheck.name = Static Method Candidate
             <tr>
               <td>fileExtensions</td>
               <td>Specify the file type extension of the files to check.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>all files</code></td>
               <td>3.1</td>
             </tr>
@@ -1662,7 +1662,7 @@ This is a sample text file. // ok, this file is not specified in the config.
             <tr>
               <td>fileExtensions</td>
               <td>Specify file type extension of the files to check.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>.properties</code></td>
               <td>8.22</td>
             </tr>
@@ -2168,7 +2168,7 @@ messages.properties: Key 'ok' missing.
                 translation files are preprocessed and the original files
                 do not have the extension <code>.properties</code>
               </td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>.properties</code></td>
               <td>3.0</td>
             </tr>
@@ -2187,7 +2187,7 @@ messages.properties: Key 'ok' missing.
               <td>
                 Specify language codes of required translations which must exist in project.
               </td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>{}</code></td>
               <td>6.11</td>
             </tr>
@@ -2452,7 +2452,7 @@ public class Start {
             <tr>
               <td>fileExtensions</td>
               <td>Specify file type extension of the files to check.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>.properties</code></td>
               <td>5.7</td>
             </tr>

--- a/src/xdocs/config_modifier.xml
+++ b/src/xdocs/config_modifier.xml
@@ -70,7 +70,7 @@ public final class Person {
               <td>
                 Control whether to enforce that <code>static</code> is explicitly coded
                 on nested enums in classes.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>8.16</td>
             </tr>
@@ -79,7 +79,7 @@ public final class Person {
               <td>
                 Control whether to enforce that <code>static</code> is explicitly coded
                 on nested interfaces in classes.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>8.16</td>
             </tr>
@@ -243,7 +243,7 @@ public interface AddressFactory {
               <td>
                 Control whether to enforce that <code>public</code> is explicitly coded
                 on interface fields.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>8.12</td>
             </tr>
@@ -252,7 +252,7 @@ public interface AddressFactory {
               <td>
                 Control whether to enforce that <code>static</code> is explicitly coded
                 on interface fields.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>8.12</td>
             </tr>
@@ -261,7 +261,7 @@ public interface AddressFactory {
               <td>
                 Control whether to enforce that <code>final</code> is explicitly coded
                 on interface fields.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>8.12</td>
             </tr>
@@ -270,7 +270,7 @@ public interface AddressFactory {
               <td>
                 Control whether to enforce that <code>public</code> is explicitly coded
                 on interface methods.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>8.12</td>
             </tr>
@@ -279,7 +279,7 @@ public interface AddressFactory {
               <td>
                 Control whether to enforce that <code>abstract</code> is explicitly coded
                 on interface methods.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>8.12</td>
             </tr>
@@ -288,7 +288,7 @@ public interface AddressFactory {
               <td>
                 Control whether to enforce that <code>public</code> is explicitly coded
                 on interface nested types.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>8.12</td>
             </tr>
@@ -297,7 +297,7 @@ public interface AddressFactory {
               <td>
                 Control whether to enforce that <code>static</code> is explicitly coded
                 on interface nested types.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>8.12</td>
             </tr>

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -79,7 +79,7 @@
                <td>Indicate the number of consecutive capital letters allowed in targeted
                 identifiers (abbreviations in the classes, interfaces, variables and methods
                 names, ... ).</td>
-               <td><a href="property_types.html#integer">Integer</a></td>
+               <td><a href="property_types.html#int">int</a></td>
                <td><code>3</code></td>
                <td>5.8</td>
              </tr>
@@ -87,21 +87,21 @@
                <td>allowedAbbreviations</td>
                <td>Specify list of abbreviations that must be skipped for checking.
                Abbreviations should be separated by comma.</td>
-               <td><a href="property_types.html#stringSet">String Set</a></td>
+               <td><a href="property_types.html#String.5B.5D">String[]</a></td>
                <td><code>{}</code></td>
                <td>5.8</td>
              </tr>
              <tr>
                <td>ignoreFinal</td>
                <td>Allow to skip variables with <code>final</code> modifier.</td>
-               <td><a href="property_types.html#boolean">Boolean</a></td>
+               <td><a href="property_types.html#boolean">boolean</a></td>
                <td><code>true</code></td>
                <td>5.8</td>
              </tr>
              <tr>
                <td>ignoreStatic</td>
                <td>Allow to skip variables with <code>static</code> modifier.</td>
-               <td><a href="property_types.html#boolean">Boolean</a></td>
+               <td><a href="property_types.html#boolean">boolean</a></td>
                <td><code>true</code></td>
                <td>5.8</td>
              </tr>
@@ -109,7 +109,7 @@
                <td>ignoreStaticFinal</td>
                <td>Allow to skip variables with both <code>static</code>
                  and <code>final</code> modifiers.</td>
-               <td><a href="property_types.html#boolean">Boolean</a></td>
+               <td><a href="property_types.html#boolean">boolean</a></td>
                <td><code>true</code></td>
                <td>8.32</td>
              </tr>
@@ -117,7 +117,7 @@
                <td>ignoreOverriddenMethods</td>
                <td>Allow to ignore methods tagged with <code>@Override</code> annotation
                (that usually mean inherited name).</td>
-               <td><a href="property_types.html#boolean">Boolean</a></td>
+               <td><a href="property_types.html#boolean">boolean</a></td>
                <td><code>true</code></td>
                <td>5.8</td>
              </tr>
@@ -413,7 +413,7 @@ public class MyClass {
                 <code>abstract</code> modifier on classes that match the
                 name.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.3</td>
             </tr>
@@ -424,7 +424,7 @@ public class MyClass {
                 only useful if using the check to identify that match name
                 and do not have the <code>abstract</code> modifier.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.3</td>
             </tr>
@@ -805,14 +805,14 @@ class MyClass3&lt;abc&gt; {} // violation, the class type parameter
             <tr>
               <td>applyToPublic</td>
               <td>Controls whether to apply the check to public member.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>applyToProtected</td>
               <td>Controls whether to apply the check to protected member.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.0</td>
             </tr>
@@ -821,14 +821,14 @@ class MyClass3&lt;abc&gt; {} // violation, the class type parameter
               <td>
                 Controls whether to apply the check to package-private member.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>applyToPrivate</td>
               <td>Controls whether to apply the check to private member.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.0</td>
             </tr>
@@ -1323,7 +1323,7 @@ for (Object O : list) { // OK
                 </pre>
                   </div>
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.8</td>
             </tr>
@@ -1507,14 +1507,14 @@ class MyClass {
             <tr>
               <td>applyToPublic</td>
               <td>Controls whether to apply the check to public member.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>3.4</td>
             </tr>
             <tr>
               <td>applyToProtected</td>
               <td>Controls whether to apply the check to protected member.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>3.4</td>
             </tr>
@@ -1523,14 +1523,14 @@ class MyClass {
               <td>
                 Controls whether to apply the check to package-private member.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>3.4</td>
             </tr>
             <tr>
               <td>applyToPrivate</td>
               <td>Controls whether to apply the check to private member.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>3.4</td>
             </tr>
@@ -1703,21 +1703,21 @@ class MyClass {
                 </pre>
               </div>
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>applyToPublic</td>
               <td>Controls whether to apply the check to public member.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.1</td>
             </tr>
             <tr>
               <td>applyToProtected</td>
               <td>Controls whether to apply the check to protected member.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.1</td>
             </tr>
@@ -1726,14 +1726,14 @@ class MyClass {
               <td>
                 Controls whether to apply the check to package-private member.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.1</td>
             </tr>
             <tr>
               <td>applyToPrivate</td>
               <td>Controls whether to apply the check to private member.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.1</td>
             </tr>
@@ -2136,7 +2136,7 @@ public boolean equals(Object o) {
                   </pre>
                 </div>
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>6.12.1</td>
             </tr>
@@ -2320,14 +2320,14 @@ class MyClass {
             <tr>
               <td>applyToPublic</td>
               <td>Controls whether to apply the check to public member.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>applyToProtected</td>
               <td>Controls whether to apply the check to protected member.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.0</td>
             </tr>
@@ -2336,14 +2336,14 @@ class MyClass {
               <td>
                 Controls whether to apply the check to package-private member.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>applyToPrivate</td>
               <td>Controls whether to apply the check to private member.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.0</td>
             </tr>
@@ -2472,14 +2472,14 @@ class MyClass {
             <tr>
               <td>applyToPublic</td>
               <td>Controls whether to apply the check to public member.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>applyToProtected</td>
               <td>Controls whether to apply the check to protected member.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.0</td>
             </tr>
@@ -2488,14 +2488,14 @@ class MyClass {
               <td>
                 Controls whether to apply the check to package-private member.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>applyToPrivate</td>
               <td>Controls whether to apply the check to private member.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.0</td>
             </tr>

--- a/src/xdocs/config_regexp.xml
+++ b/src/xdocs/config_regexp.xml
@@ -93,14 +93,14 @@
               <td>message</td>
               <td>Specify message which is used to notify about violations,
                 if empty then the default (hard-coded) message is used.</td>
-              <td><a href="property_types.html#string">String</a></td>
+              <td><a href="property_types.html#String">String</a></td>
               <td><code>null</code></td>
               <td>4.0</td>
             </tr>
             <tr>
               <td>illegalPattern</td>
               <td>Control whether the pattern is required or illegal.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>4.0</td>
             </tr>
@@ -110,21 +110,21 @@
                 any negative value means no checking for duplicates, any positive
                 value is used as the maximum number of allowed duplicates, if the
                 limit is exceeded violations will be logged.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>0</code></td>
               <td>4.0</td>
             </tr>
             <tr>
               <td>errorLimit</td>
               <td>Specify the maximum number of violations before the check will abort.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>100</code></td>
               <td>4.0</td>
             </tr>
             <tr>
               <td>ignoreComments</td>
               <td>Control whether to ignore matches found within comments.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>4.0</td>
             </tr>
@@ -528,42 +528,42 @@ public static final int A_SETPOINT = 1;
               <td>message</td>
               <td>Specify the message which is used to notify about violations,
               if empty then default (hard-coded) message is used.</td>
-              <td><a href="property_types.html#string">String</a></td>
+              <td><a href="property_types.html#String">String</a></td>
               <td><code>null</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>ignoreCase</td>
               <td>Control whether to ignore case when searching.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>minimum</td>
               <td>Specify the minimum number of matches required in each file.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>0</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>maximum</td>
               <td>Specify the maximum number of matches required in each file.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>0</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>matchAcrossLines</td>
               <td>Control whether to match expressions across multiple lines.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>8.25</td>
             </tr>
             <tr>
               <td>fileExtensions</td>
               <td>Specify the file type extension of files to process.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>all files</code></td>
               <td>5.0</td>
             </tr>
@@ -757,14 +757,14 @@ void method() {
               <td>match</td>
               <td>Control whether to look for a match or mis-match on the file name, if the
               fileNamePattern is supplied, otherwise it is applied on the folderPattern.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>6.15</td>
             </tr>
             <tr>
               <td>ignoreFileNameExtensions</td>
               <td>Control whether to ignore the file extension for the file name match.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>6.15</td>
             </tr>
@@ -772,7 +772,7 @@ void method() {
               <td>fileExtensions</td>
               <td>Specify the file type extension of files to process. If this is specified, then
               only files that match these types are examined with the other patterns.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>all files</code></td>
               <td>6.15</td>
             </tr>
@@ -990,35 +990,35 @@ src/main/main_class.java  //violation, file names should be in Camel Case
               <td>message</td>
               <td>Specify the message which is used to notify about violations,
               if empty then default (hard-coded) message is used.</td>
-              <td><a href="property_types.html#string">String</a></td>
+              <td><a href="property_types.html#String">String</a></td>
               <td><code>null</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>ignoreCase</td>
               <td>Control whether to ignore case when searching.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>minimum</td>
               <td>Specify the minimum number of matches required in each file.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>0</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>maximum</td>
               <td>Specify the maximum number of matches required in each file.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>0</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>fileExtensions</td>
               <td>Specify the file type extension of files to process.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>all files</code></td>
               <td>5.0</td>
             </tr>
@@ -1216,35 +1216,35 @@ CREATE DATABASE MyDB;
               <td>message</td>
               <td>Specify the message which is used to notify about violations,
               if empty then default (hard-coded) message is used.</td>
-              <td><a href="property_types.html#string">String</a></td>
+              <td><a href="property_types.html#String">String</a></td>
               <td><code>null</code></td>
               <td>6.0</td>
             </tr>
             <tr>
               <td>ignoreCase</td>
               <td>Control whether to ignore case when searching.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>minimum</td>
               <td>Specify the minimum number of matches required in each file.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>0</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>maximum</td>
               <td>Specify the maximum number of matches required in each file.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>0</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>ignoreComments</td>
               <td>Control whether to ignore text in comments when searching.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.0</td>
             </tr>

--- a/src/xdocs/config_sizes.xml
+++ b/src/xdocs/config_sizes.xml
@@ -51,7 +51,7 @@
             <tr>
               <td>max</td>
               <td>Specify the maximum number of lines allowed.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>20</code></td>
               <td>3.2</td>
             </tr>
@@ -130,7 +130,7 @@
             <tr>
               <td>max</td>
               <td>Specify the maximum threshold allowed.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>30</code></td>
               <td>3.2</td>
             </tr>
@@ -248,14 +248,14 @@
             <tr>
               <td>max</td>
               <td>Specify the maximum number of lines allowed.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>2000</code></td>
               <td>3.2</td>
             </tr>
             <tr>
               <td>fileExtensions</td>
               <td>Specify the file type extension of files to process.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>all files</code></td>
               <td>5.0</td>
             </tr>
@@ -347,7 +347,7 @@
             <tr>
               <td>fileExtensions</td>
               <td>Specify file extensions that are accepted.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>all files</code></td>
               <td>8.24</td>
             </tr>
@@ -361,7 +361,7 @@
             <tr>
               <td>max</td>
               <td>Specify the maximum line length allowed.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>80</code></td>
               <td>3.0</td>
             </tr>
@@ -537,35 +537,35 @@ public class ExampleClass {
             <tr>
               <td>maxTotal</td>
               <td>Specify the maximum number of methods allowed at all scope levels.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>100</code></td>
               <td>5.3</td>
             </tr>
             <tr>
               <td>maxPrivate</td>
               <td>Specify the maximum number of <code>private</code> methods allowed.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>100</code></td>
               <td>5.3</td>
             </tr>
             <tr>
               <td>maxPackage</td>
               <td>Specify the maximum number of <code>package</code> methods allowed.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>100</code></td>
               <td>5.3</td>
             </tr>
             <tr>
               <td>maxProtected</td>
               <td>Specify the maximum number of <code>protected</code> methods allowed.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td>100</td>
               <td>5.3</td>
             </tr>
             <tr>
               <td>maxPublic</td>
               <td>Specify the maximum number of <code>public</code> methods allowed.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>100</code></td>
               <td>5.3</td>
             </tr>
@@ -716,7 +716,7 @@ public class ExampleClass {
             <tr>
               <td>max</td>
               <td>Specify the maximum number of lines allowed.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>150</code></td>
               <td>3.0</td>
             </tr>
@@ -726,7 +726,7 @@ public class ExampleClass {
                 Control whether to count empty lines and single line comments of the
                 form <code>//</code>.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>3.2</td>
             </tr>
@@ -854,7 +854,7 @@ public class ExampleClass {
             <tr>
               <td>max</td>
               <td>Specify the maximum number of outer types allowed.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>1</code></td>
               <td>5.0</td>
             </tr>
@@ -937,7 +937,7 @@ public class ExampleClass {
             <tr>
               <td>max</td>
               <td>Specify the maximum number of parameters allowed.</td>
-              <td><a href="property_types.html#integer">Integer</a></td>
+              <td><a href="property_types.html#int">int</a></td>
               <td><code>7</code></td>
               <td>3.0</td>
             </tr>
@@ -946,7 +946,7 @@ public class ExampleClass {
               <td>
                 Ignore number of parameters for methods with <code>@Override</code> annotation.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>6.2</td>
             </tr>

--- a/src/xdocs/config_system_properties.xml
+++ b/src/xdocs/config_system_properties.xml
@@ -28,7 +28,7 @@
         specifies the name of a file that can be used to cache details
         of files that pass Checkstyle. This can <i>significantly</i>
         increase the speed of checkstyle on successive runs. The
-        property type is <a href="property_types.html#string">string</a>
+        property type is <a href="property_types.html#String">String</a>
         and defaults to an empty string (which means no caching is done).
       </p>
     </section>
@@ -44,7 +44,7 @@
       <p>
         The property <code>checkstyle.locale.language</code> specifies the
         language to use in localising the output messages. The property
-        type is <a href="property_types.html#string">string</a> and
+        type is <a href="property_types.html#String">String</a> and
         defaults to the default system locale language.
       </p>
 
@@ -52,7 +52,7 @@
         The property <code>checkstyle.locale.country</code>
         specifies the country to use in localising the output
         messages. The property type is <a
-        href="property_types.html#string">string</a> and defaults to the
+        href="property_types.html#String">String</a> and defaults to the
         default system locale country.
       </p>
     </section>
@@ -65,7 +65,7 @@
         <code>c:\projects\checkstyle</code>, then a violation
         in the file <code>c:\projects\checkstyle\src\dir\subdir\File.java</code>
         will be reported as <code>src\dir\subdir\File.java</code>. The property type
-        is <a href="property_types.html#string">string</a> and defaults
+        is <a href="property_types.html#String">String</a> and defaults
         to an empty string.
       </p>
     </section>

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -254,21 +254,21 @@ for (Iterator foo = very.long.line.iterator();
             <tr>
               <td>allowNoEmptyLineBetweenFields</td>
               <td>Allow no empty line between fields.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.8</td>
             </tr>
             <tr>
               <td>allowMultipleEmptyLines</td>
               <td>Allow multiple empty lines between class members.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>6.3</td>
             </tr>
             <tr>
               <td>allowMultipleEmptyLinesInsideClassMembers</td>
               <td>Allow multiple empty lines inside class members.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>6.18</td>
             </tr>
@@ -575,14 +575,14 @@ class Test {
               <td>
                 Control whether to report on each line containing a tab, or just the first instance.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>fileExtensions</td>
               <td>Specify file type extension of files to process.</td>
-              <td><a href="property_types.html#stringSet">String Set</a></td>
+              <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>all files</code></td>
               <td>5.0</td>
             </tr>
@@ -815,7 +815,7 @@ Pair&lt;Integer, Integer &gt; p; // violation, "&gt;" preceded with whitespace
               <td>
                 Allow a line break between the identifier and left parenthesis.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>3.4</td>
             </tr>
@@ -1193,7 +1193,7 @@ import static java.math.BigInteger.ZERO;
               <td>
                 Control whether whitespace is allowed if the token is at a linebreak.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>3.0</td>
             </tr>
@@ -1358,7 +1358,7 @@ public void foo(final char @NotNull [] param) {} // No violation
               <td>
                 Control whether whitespace is allowed if the token is at a linebreak.
               </td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>3.0</td>
             </tr>
@@ -2394,7 +2394,7 @@ public long toMicros(long d) { return d / (C1 / C0); }
             <tr>
               <td>validateComments</td>
               <td>Control whether to validate whitespaces surrounding comments.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>6.19</td>
             </tr>
@@ -2866,42 +2866,42 @@ try {
             <tr>
               <td>allowEmptyConstructors</td>
               <td>Allow empty constructor bodies.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>4.0</td>
             </tr>
             <tr>
               <td>allowEmptyMethods</td>
               <td>Allow empty method bodies.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>4.0</td>
             </tr>
             <tr>
               <td>allowEmptyTypes</td>
               <td>Allow empty class, interface and enum bodies.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.8</td>
             </tr>
             <tr>
               <td>allowEmptyLoops</td>
               <td>Allow empty loop bodies.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>5.8</td>
             </tr>
             <tr>
               <td>allowEmptyLambdas</td>
               <td>Allow empty lambda bodies.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>6.14</td>
             </tr>
             <tr>
               <td>allowEmptyCatches</td>
               <td>Allow empty catch bodies.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>false</code></td>
               <td>7.6</td>
             </tr>
@@ -2910,7 +2910,7 @@ try {
               <td>Ignore whitespace around colon in
                 <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-14.html#jls-14.14.2">
                   enhanced for</a> loop.</td>
-              <td><a href="property_types.html#boolean">Boolean</a></td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
               <td>5.5</td>
             </tr>

--- a/src/xdocs/property_types.xml
+++ b/src/xdocs/property_types.xml
@@ -30,14 +30,21 @@
     </p>
     </section>
 
-    <section name="integer">
+    <section name="int">
       <p>
         This type represents an integer. The string representation is
         parsed using the <code>java.lang.Integer</code> class.
       </p>
     </section>
 
-    <section name="string">
+    <section name="double">
+      <p>
+        This type represents a double. The string representation is
+        parsed using the <code>java.lang.Double</code> class.
+      </p>
+    </section>
+
+    <section name="String">
       <p>
         This type represents a string. The literal string representation
         is used.
@@ -59,7 +66,7 @@
       <p>Anything else will map to <code>false</code>.</p>
     </section>
 
-    <section name="stringSet">
+    <section name="String[]">
       <p>
         This type represents a set of strings. The string representation
         is parsed as a set of comma (',') separated strings.
@@ -79,7 +86,7 @@
       </source>
     </section>
 
-    <section name="intSet">
+    <section name="int[]">
       <p>
         This type represents a set of integers. The string representation
         is parsed as a set of comma (',') separated integers that are parsed
@@ -97,6 +104,27 @@
       <source>
 &lt;property name=&quot;tokens&quot; value=&quot;42&quot;/&gt;
 &lt;property name=&quot;tokens&quot; value=&quot;666&quot;/&gt;
+      </source>
+    </section>
+
+    <section name="double[]">
+      <p>
+        This type represents a set of doubles. The string representation
+        is parsed as a set of comma (',') separated doubles that are parsed
+        using the <code>java.lang.Double</code> class.
+      </p>
+      <p>
+        Alternatively, a property of this type can be supplied multiple times which
+        is equivalent to a set of comma separated integers. For example, the
+        following:
+      </p>
+      <source>
+&lt;property name=&quot;tokens&quot; value=&quot;0.42,0.666&quot;/&gt;
+      </source>
+      <p>can instead be expressed as:</p>
+      <source>
+&lt;property name=&quot;tokens&quot; value=&quot;0.42&quot;/&gt;
+&lt;property name=&quot;tokens&quot; value=&quot;0.666&quot;/&gt;
       </source>
     </section>
 

--- a/src/xdocs/releasenotes_old.xml
+++ b/src/xdocs/releasenotes_old.xml
@@ -274,8 +274,8 @@
         </li>
         <li>
           Enhanced the property types
-          <a href="property_types.html#stringSet">stringSet</a> and
-          <a href="property_types.html#intSet">intSet</a> to support being
+          <a href="property_types.html#String.5B.5D">String[]</a> and
+          <a href="property_types.html#int.5B.5D">int[]</a> to support being
           supplied multiple times to construct the equivalent of a comma
           separated list.
         </li>


### PR DESCRIPTION
#8328 

Refactored
1. `integer -> Integer`
2. `boolean -> Boolean`
3. `integerSet -> int[]`
4. create `Double` and `double[]`
5. `stringSet -> String[]`