### PR TITLE
minor: fix violations from future EmptyLineBeforeAtClauseBlock (#6192)

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java
@@ -277,6 +277,7 @@ public abstract class AbstractCheck extends AbstractViolationReporter {
 
     /**
      * Returns the lines associated with the tree.
+     *
      * @return the file contents
      */
     public final String[] getLines() {
@@ -285,6 +286,7 @@ public abstract class AbstractCheck extends AbstractViolationReporter {
 
     /**
      * Returns the line associated with the tree.
+     *
      * @param index index of the line
      * @return the line from the file contents
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
@@ -77,6 +77,7 @@ public final class FileContents implements CommentListener {
 
     /**
      * Get the full text of the file.
+     *
      * @return an object containing the full text of the file
      */
     public FileText getText() {
@@ -85,6 +86,7 @@ public final class FileContents implements CommentListener {
 
     /**
      * Gets the lines in the file.
+     *
      * @return the lines in the file
      */
     public String[] getLines() {
@@ -93,6 +95,7 @@ public final class FileContents implements CommentListener {
 
     /**
      * Get the line from text of the file.
+     *
      * @param index index of the line
      * @return line from text of the file
      */
@@ -102,6 +105,7 @@ public final class FileContents implements CommentListener {
 
     /**
      * Gets the name of the file.
+     *
      * @return the name of the file
      */
     public String getFileName() {
@@ -200,6 +204,7 @@ public final class FileContents implements CommentListener {
      * Get a single line.
      * For internal use only, as getText().get(lineNo) is just as
      * suitable for external use and avoids method duplication.
+     *
      * @param lineNo the number of the line to get
      * @return the corresponding line, without terminator
      * @throws IndexOutOfBoundsException if lineNo is invalid
@@ -320,6 +325,7 @@ public final class FileContents implements CommentListener {
     /**
      * Returns a map of all the single line comments. The key is a line number,
      * the value is the comment {@link TextBlock} at the line.
+     *
      * @return the Map of comments
      */
     public Map<Integer, TextBlock> getSingleLineComments() {
@@ -330,6 +336,7 @@ public final class FileContents implements CommentListener {
      * Returns a map of all block comments. The key is the line number, the
      * value is a {@link List} of block comment {@link TextBlock}s
      * that start at that line.
+     *
      * @return the map of comments
      */
     public Map<Integer, List<TextBlock>> getBlockComments() {
@@ -338,6 +345,7 @@ public final class FileContents implements CommentListener {
 
     /**
      * Checks if the current file is a package-info.java file.
+     *
      * @return true if the package file.
      */
     public boolean inPackageInfo() {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
@@ -98,6 +98,7 @@ public final class FileText {
 
     /**
      * Copy constructor.
+     *
      * @param fileText to make copy of
      */
     public FileText(FileText fileText) {
@@ -215,6 +216,7 @@ public final class FileText {
     /**
      * Retrieves a line of the text by its number.
      * The returned line will not contain a trailing terminator.
+     *
      * @param lineNo the number of the line to get, starting at zero
      * @return the line with the given number
      */
@@ -283,6 +285,7 @@ public final class FileText {
 
     /**
      * Find positions of line breaks in the full text.
+     *
      * @return an array giving the first positions of each line.
      */
     private int[] findLineBreaks() {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
@@ -49,6 +49,7 @@ public final class FullIdent {
 
     /**
      * Creates a new FullIdent starting from the child of the specified node.
+     *
      * @param ast the parent node from where to start from
      * @return a {@code FullIdent} value
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessage.java
@@ -381,6 +381,7 @@ public final class LocalizedMessage
     /**
      * Indicates whether some other object is "equal to" this one.
      * Suppression on enumeration is needed so code stays consistent.
+     *
      * @noinspection EqualsCalledOnEnumConstant
      */
     // -@cs[CyclomaticComplexity] equals - a lot of fields to check.
@@ -447,6 +448,7 @@ public final class LocalizedMessage
 
     /**
      * Gets the translated message.
+     *
      * @return the translated message
      */
     public String getMessage() {
@@ -476,6 +478,7 @@ public final class LocalizedMessage
 
     /**
      * Returns the formatted custom message if one is configured.
+     *
      * @return the formatted custom message or {@code null}
      *          if there is no custom message
      */
@@ -492,6 +495,7 @@ public final class LocalizedMessage
      * Find a ResourceBundle for a given bundle name. Uses the classloader
      * of the class emitting this message, to be sure to get the correct
      * bundle.
+     *
      * @param bundleName the bundle name
      * @return a ResourceBundle
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/NoCodeInFileCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/NoCodeInFileCheck.java
@@ -59,6 +59,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *  block comment
  * *&#47;
  * </pre>
+ *
  * @since 8.33
  */
 @StatelessCheck

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheck.java
@@ -59,6 +59,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * public void foo(int i, String s) {}
  * public void foo(String s, int i) {}
  * </pre>
+ *
  * @since 5.8
  */
 @StatelessCheck

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -1030,6 +1030,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
          * <b>Note:</b> It can be different from <b>startLineNumber</b> when import statement span
          * multiple lines.
          * </p>
+         *
          * @return import end line from ast.
          */
         public int getEndLineNumber() {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/DetailAstSet.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/DetailAstSet.java
@@ -43,6 +43,7 @@ public class DetailAstSet {
 
     /**
      * Construct an instance of this class with {@code IndentationCheck} parameters.
+     *
      * @param indentCheck IndentationCheck parameters
      */
     public DetailAstSet(IndentationCheck indentCheck) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -789,6 +789,7 @@ public class JavadocMethodCheck extends AbstractCheck {
      * Checks if a 'throw' usage is contained within a block that should be ignored.
      * Such blocks consist of try (with catch) blocks, local classes, anonymous classes,
      * and lambda expressions. Note that a try block without catch is not considered.
+     *
      * @param methodBodyAst DetailAST node representing the method body
      * @param throwAst DetailAST node representing the 'throw' literal
      * @return true if throwAst is inside a block that should be ignored

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
@@ -177,6 +177,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
 
     /**
      * Determines whether or not the next line after empty line has paragraph tag in the beginning.
+     *
      * @param newline NEWLINE node.
      */
     private void checkEmptyLine(DetailNode newline) {
@@ -189,6 +190,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
 
     /**
      * Determines whether or not the line with paragraph tag has previous empty line.
+     *
      * @param tag html tag.
      */
     private void checkParagraphTag(DetailNode tag) {
@@ -206,6 +208,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
 
     /**
      * Returns nearest node.
+     *
      * @param node DetailNode node.
      * @return nearest node.
      */
@@ -220,6 +223,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
 
     /**
      * Determines whether or not the line is empty line.
+     *
      * @param newLine NEWLINE node.
      * @return true, if line is empty line.
      */
@@ -240,6 +244,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
 
     /**
      * Determines whether or not the line with paragraph tag is first line in javadoc.
+     *
      * @param paragraphTag paragraph tag.
      * @return true, if line with paragraph tag is first line in javadoc.
      */
@@ -262,6 +267,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
 
     /**
      * Finds and returns nearest empty line in javadoc.
+     *
      * @param node DetailNode node.
      * @return Some nearest empty line in javadoc.
      */
@@ -279,6 +285,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
 
     /**
      * Tests whether the paragraph tag is immediately followed by the text.
+     *
      * @param tag html tag.
      * @return true, if the paragraph tag is immediately followed by the text.
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
@@ -340,6 +340,7 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
 
     /**
      * Setter to allow to skip variables with both {@code static} and {@code final} modifiers.
+     *
      * @param ignoreStaticFinal
      *        Defines if ignore variables with both 'static' and 'final' modifiers or not.
      */
@@ -462,6 +463,7 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
 
     /**
      * Checks if a variable is to be ignored based on its modifiers.
+     *
      * @param modifiers modifiers of the variable to be checked
      * @return true if there is a modifier to be ignored
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/AbstractNode.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/AbstractNode.java
@@ -77,6 +77,7 @@ public abstract class AbstractNode implements NodeInfo {
 
     /**
      * Getter method for node depth.
+     *
      * @return depth
      */
     public int getDepth() {
@@ -85,6 +86,7 @@ public abstract class AbstractNode implements NodeInfo {
 
     /**
      * Setter method for node depth.
+     *
      * @param depth depth of node
      */
     public final void setDepth(int depth) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/AttributeNode.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/AttributeNode.java
@@ -51,6 +51,7 @@ public class AttributeNode extends AbstractNode {
     /**
      * Compares current object with specified for order.
      * Throws {@code UnsupportedOperationException} because functionality not required here.
+     *
      * @param nodeInfo another {@code NodeInfo} object
      * @return number representing order of current object to specified one
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/ElementNode.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/ElementNode.java
@@ -84,6 +84,7 @@ public class ElementNode extends AbstractNode {
 
     /**
      * Compares current object with specified for order.
+     *
      * @param other another {@code NodeInfo} object
      * @return number representing order of current object to specified one
      */
@@ -102,6 +103,7 @@ public class ElementNode extends AbstractNode {
 
     /**
      * Finds the ancestors of the children whose parent is their common ancestor.
+     *
      * @param other another {@code NodeInfo} object
      * @return {@code ElementNode} immediate children(also ancestors of the given children) of the
      *         common ancestor

--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/RootNode.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/RootNode.java
@@ -62,6 +62,7 @@ public class RootNode extends AbstractNode {
     /**
      * Compares current object with specified for order.
      * Throws {@code UnsupportedOperationException} because functionality not required here.
+     *
      * @param nodeInfo another {@code NodeInfo} object
      * @return number representing order of current object to specified one
      */


### PR DESCRIPTION
I took the violations from #7932 and I put together a small script to fix them for me: https://github.com/josephmate/FixAtClauseError . It takes the output from a build, searches for the missing newline checkstyle errors and inserts them.