### PR TITLE
Issue #8387: Add support for enhanced instanceof syntax for AbbreviationAsWordInNameCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
@@ -101,7 +101,9 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
  * VARIABLE_DEF</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
- * METHOD_DEF</a>.
+ * METHOD_DEF</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PATTERN_VARIABLE_DEF">
+ * PATTERN_VARIABLE_DEF</a>.
  * </li>
  * </ul>
  * <p>
@@ -396,6 +398,8 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
             TokenTypes.PARAMETER_DEF,
             TokenTypes.VARIABLE_DEF,
             TokenTypes.METHOD_DEF,
+            TokenTypes.PATTERN_VARIABLE_DEF,
+
         };
     }
 
@@ -411,6 +415,8 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
             TokenTypes.VARIABLE_DEF,
             TokenTypes.METHOD_DEF,
             TokenTypes.ENUM_CONSTANT_DEF,
+            TokenTypes.PATTERN_VARIABLE_DEF,
+
         };
     }
 

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -239,7 +239,7 @@
             <property name="allowedAbbreviationLength" value="1"/>
             <property name="tokens"
              value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
-                    PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF"/>
+                    PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF"/>
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheckTest.java
@@ -525,6 +525,51 @@ public class AbbreviationAsWordInNameCheckTest extends AbstractModuleTestSupport
                 expected);
     }
 
+    @Test
+    public void testAbbreviationAsWordInNameCheckEnhancedInstanceof()
+            throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(AbbreviationAsWordInNameCheck.class);
+
+        final int expectedCapitalCount = 4;
+
+        final String[] expected = {
+            "11:36: " + getWarningMessage("STRING", expectedCapitalCount),
+            "11:70: " + getWarningMessage("INTEGER", expectedCapitalCount),
+            "20:41: " + getWarningMessage("ssSTRING", expectedCapitalCount),
+            "24:35: " + getWarningMessage("XMLHTTP", expectedCapitalCount),
+        };
+
+        verify(checkConfig,
+                getNonCompilablePath(
+                        "InputAbbreviationAsWordInNameCheckEnhancedInstanceof.java"),
+                expected);
+    }
+
+    @Test
+    public void testAbbreviationAsWordInNameCheckEnhancedInstanceofAllowXml()
+            throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(AbbreviationAsWordInNameCheck.class);
+        checkConfig.addAttribute("allowedAbbreviations", "XML");
+        checkConfig.addAttribute("allowedAbbreviationLength", "1");
+
+        final int expectedCapitalCount = 2;
+
+        final String[] expected = {
+            "11:36: " + getWarningMessage("STRING", expectedCapitalCount),
+            "11:70: " + getWarningMessage("INTEGER", expectedCapitalCount),
+            "19:39: " + getWarningMessage("aTXT", expectedCapitalCount),
+            "20:41: " + getWarningMessage("ssSTRING", expectedCapitalCount),
+            "24:35: " + getWarningMessage("XMLHTTP", expectedCapitalCount),
+        };
+
+        verify(checkConfig,
+                getNonCompilablePath(
+                        "InputAbbreviationAsWordInNameCheckEnhancedInstanceof.java"),
+                expected);
+    }
+
     private String getWarningMessage(String typeName, int expectedCapitalCount) {
         return getCheckMessage(MSG_KEY, typeName, expectedCapitalCount);
     }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameCheckEnhancedInstanceof.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/abbreviationaswordinname/InputAbbreviationAsWordInNameCheckEnhancedInstanceof.java
@@ -1,0 +1,29 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.naming.abbreviationaswordinname;
+
+import java.util.ArrayList;
+import java.util.Locale;
+
+public class InputAbbreviationAsWordInNameCheckEnhancedInstanceof {
+
+    public void t(Object o1, Object o2) {
+        // Should cause two violations, STRING and INTEGER, capital letter count > allowed
+        if (!(o1 instanceof String STRING) && (o2 instanceof Integer INTEGER)) {}
+
+        ArrayList<Integer> arrayList = new ArrayList<Integer>();
+        if (arrayList instanceof ArrayList<Integer> aXML) { // ok when allowed "XML" abbreviation
+            System.out.println("Blah");
+        }
+
+        boolean result = (o1 instanceof String a1) ?
+                (o1 instanceof String aTXT) :   // violation, capital letter count > allowed
+                (!(o1 instanceof String ssSTRING)); // violation, capital letter count > allowed
+
+        String formatted;
+        // Violation, XMLHTTP capital letter count > allowed
+        if (o1 instanceof Integer XMLHTTP) formatted = String.format("int %d", XMLHTTP);
+        else if (o1 instanceof Byte bYT) formatted = String.format("byte %d", bYT); // ok
+        else formatted = String.format("Something else "+ o1.toString());
+
+    }
+}

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -144,6 +144,8 @@
                    METHOD_DEF</a>
                  , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
                    ENUM_CONSTANT_DEF</a>
+                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PATTERN_VARIABLE_DEF">
+                   PATTERN_VARIABLE_DEF</a>
                    .
                </td>
                <td>
@@ -163,6 +165,8 @@
                    VARIABLE_DEF</a>
                  , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
                    METHOD_DEF</a>
+                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PATTERN_VARIABLE_DEF">
+                   PATTERN_VARIABLE_DEF</a>
                    .
                </td>
                <td>5.8</td>


### PR DESCRIPTION
 Issue #8387: enhanced instanceof check validation for AbbreviationAsWordInNameCheck(#7290)

This PR will add support for Java 14 enhanced instanceof syntax to AbbreviationAsWordInNameCheck.

~~Reviewers, please note that the first commit is from the instanceof PR, #8401.~~
Commit has been dropped since #8401 was merged.
Check regression report: https://checkstyle-reports-java14.s3.amazonaws.com/reports/diff_instanceof-AbbreviationAsWordInNameCheck/index.html