### PR TITLE
Issue #8364: Add support for enhanced instanceof syntax to HiddenFieldCheck(#7290)

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -109,6 +109,8 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * VARIABLE_DEF</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
  * PARAMETER_DEF</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PATTERN_VARIABLE_DEF">
+ * PATTERN_VARIABLE_DEF</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
  * LAMBDA</a>.
  * </li>
@@ -243,6 +245,7 @@ public class HiddenFieldCheck
             TokenTypes.CLASS_DEF,
             TokenTypes.ENUM_DEF,
             TokenTypes.ENUM_CONSTANT_DEF,
+            TokenTypes.PATTERN_VARIABLE_DEF,
             TokenTypes.LAMBDA,
         };
     }
@@ -267,6 +270,7 @@ public class HiddenFieldCheck
         switch (type) {
             case TokenTypes.VARIABLE_DEF:
             case TokenTypes.PARAMETER_DEF:
+            case TokenTypes.PATTERN_VARIABLE_DEF:
                 processVariable(ast);
                 break;
             case TokenTypes.LAMBDA:
@@ -369,7 +373,8 @@ public class HiddenFieldCheck
         if (!ScopeUtil.isInInterfaceOrAnnotationBlock(ast)
             && !CheckUtil.isReceiverParameter(ast)
             && (ScopeUtil.isLocalVariableDef(ast)
-                || ast.getType() == TokenTypes.PARAMETER_DEF)) {
+                || ast.getType() == TokenTypes.PARAMETER_DEF
+                || ast.getType() == TokenTypes.PATTERN_VARIABLE_DEF)) {
             // local variable or parameter. Does it shadow a field?
             final DetailAST nameAST = ast.findFirstToken(TokenTypes.IDENT);
             final String name = nameAST.getText();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
@@ -412,6 +412,20 @@ public class HiddenFieldCheckTest
         verify(checkConfig, getPath("InputHiddenFieldReceiver.java"), expected);
     }
 
+    @Test
+    public void testHiddenFieldEnhancedInstanceof() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(HiddenFieldCheck.class);
+        checkConfig.addAttribute("tokens", "PATTERN_VARIABLE_DEF");
+
+        final String[] expected = {
+            "22:39: " + getCheckMessage(MSG_KEY, "price"),
+            "33:35: " + getCheckMessage(MSG_KEY, "hiddenStaticField"),
+        };
+        verify(checkConfig,
+                getNonCompilablePath("InputHiddenFieldEnhancedInstanceof.java"), expected);
+    }
+
     /**
      * We cannot reproduce situation when visitToken is called and leaveToken is not.
      * So, we have to use reflection to be sure that even in such situation

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldEnhancedInstanceof.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldEnhancedInstanceof.java
@@ -1,0 +1,39 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.coding.hiddenfield;
+
+import java.util.Locale;
+/* Config:
+ *
+ * ignoreFormat = null
+ * ignoreConstructorParameter = false
+ * ignoreSetter = false
+ * setterCanReturnItsClass = false
+ * ignoreAbstractMethods = false
+ * tokens = {VARIABLE_DEF , PARAMETER_DEF , LAMBDA, PATTERN_VARIABLE_DEF}
+ */
+public class InputHiddenFieldEnhancedInstanceof {
+
+    public class Keyboard {
+        private String model = null;
+        private final int price = 2;
+
+        // Pattern variable price hides field price
+        public boolean doStuff(Float f) { // violation
+            return f instanceof Float price &&
+                    price.floatValue() > 0 &&
+                    model != null &&
+                    price.intValue() == 5;
+        }
+    }
+
+    static final Object OBJ = "";
+    static String hiddenStaticField = "hiddenStaticField";
+    static {
+        // Pattern variable hiddenStaticField hides static field hiddenStaticField
+        if (OBJ instanceof String hiddenStaticField) { //violation
+            System.out.println(hiddenStaticField
+                    .toLowerCase(Locale.forLanguageTag(hiddenStaticField)));
+            boolean stringCheck = "test".equals(hiddenStaticField);
+        }
+    }
+}

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -1795,6 +1795,8 @@ class PageBuilder {
                   VARIABLE_DEF</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
                   PARAMETER_DEF</a>
+                , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PATTERN_VARIABLE_DEF">
+                  PATTERN_VARIABLE_DEF</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
                   LAMBDA</a>
                   .
@@ -1805,6 +1807,8 @@ class PageBuilder {
                   VARIABLE_DEF</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
                   PARAMETER_DEF</a>
+                , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PATTERN_VARIABLE_DEF">
+                  PATTERN_VARIABLE_DEF</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
                   LAMBDA</a>
                   .


### PR DESCRIPTION
 Issue #8364: Add support for enhanced instanceof syntax to HiddenFieldCheck(#7290)

~~Reviewers, please note that the first commit is from the instanceof PR, #8401.~~
Commit has been dropped now that #8401 was merged.

Check regression report: https://checkstyle-reports-java14.s3.amazonaws.com/reports/diff_instanceof-HiddenFieldCheck/index.html

