### PR TITLE
Issue #8306: Javadoc Modification for Metadata Generation Support - 1

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/NoCodeInFileCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/NoCodeInFileCheck.java
@@ -59,6 +59,17 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *  block comment
  * *&#47;
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code nocode.in.file}
+ * </li>
+ * </ul>
  *
  * @since 8.33
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -47,10 +47,12 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <li>
  * Property {@code option} - Specify the policy on placement of a right curly brace
  * (<code>'}'</code>).
+ * Type is {@code com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyOption}.
  * Default value is {@code same}.
  * </li>
  * <li>
  * Property {@code tokens} - tokens to check
+ * Type is {@code int[]}.
  * Default value is:
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_TRY">
  * LITERAL_TRY</a>,
@@ -203,6 +205,23 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *   public void violate() { bar(); } // OK , because singleline
  * }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code line.alone}
+ * </li>
+ * <li>
+ * {@code line.break.before}
+ * </li>
+ * <li>
+ * {@code line.same}
+ * </li>
+ * </ul>
  *
  * @since 3.0
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
@@ -52,10 +52,13 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
  * <li>
  * Property {@code max} - Specify the maximum number of boolean operations
  * allowed in one expression.
+ * Type is {@code int}.
  * Default value is {@code 3}.
  * </li>
  * <li>
- * Property {@code tokens} - tokens to check Default value is:
+ * Property {@code tokens} - tokens to check
+ * Type is {@code int[]}.
+ * Default value is:
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">
  * LAND</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BAND">
@@ -139,6 +142,17 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
  *  }
  * </pre>
  *
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code booleanExpressionComplexity}
+ * </li>
+ * </ul>
  *
  * @since 3.4
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheck.java
@@ -48,10 +48,12 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <ul>
  * <li>
  * Property {@code max} - Specify the maximum threshold allowed.
+ * Type is {@code int}.
  * Default value is {@code 20}.
  * </li>
  * <li>
  * Property {@code excludedClasses} - Specify user-configured class names to ignore.
+ * Type is {@code java.lang.String[]}.
  * Default value is {@code ArrayIndexOutOfBoundsException, ArrayList, Boolean, Byte,
  * Character, Class, Deprecated, Deque, Double, Exception, Float, FunctionalInterface,
  * HashMap, HashSet, IllegalArgumentException, IllegalStateException,
@@ -64,11 +66,13 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <li>
  * Property {@code excludeClassesRegexps} - Specify user-configured regular
  * expressions to ignore classes.
+ * Type is {@code java.lang.String[]}.
  * Default value is {@code ^$}.
  * </li>
  * <li>
  * Property {@code excludedPackages} - Specify user-configured packages to ignore.
  * All excluded packages should end with a period, so it also appends a dot to a package name.
+ * Type is {@code java.lang.String[]}.
  * Default value is {@code {}}.
  * </li>
  * </ul>
@@ -318,6 +322,17 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * since the {@code a.b.c} was not added to the {@code excludedPackages}.
  * The {@code data} and {@code foo} members will be counted, as they are inside same file.
  * </p>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code classFanOutComplexity}
+ * </li>
+ * </ul>
  *
  * @since 3.4
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/CyclomaticComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/CyclomaticComplexityCheck.java
@@ -60,15 +60,18 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <ul>
  * <li>
  * Property {@code max} - Specify the maximum threshold allowed.
+ * Type is {@code int}.
  * Default value is {@code 10}.
  * </li>
  * <li>
  * Property {@code switchBlockAsSingleDecisionPoint} - Control whether to treat
  * the whole switch block as a single decision point.
+ * Type is {@code boolean}.
  * Default value is {@code false}.
  * </li>
  * <li>
  * Property {@code tokens} - tokens to check
+ * Type is {@code int[]}.
  * Default value is:
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_WHILE">
  * LITERAL_WHILE</a>,
@@ -220,6 +223,17 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *   }
  * }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code cyclomaticComplexity}
+ * </li>
+ * </ul>
  *
  * @since 3.2
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
@@ -56,16 +56,19 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <li>
  * Property {@code methodMaximum} - Specify the maximum allowed number of
  * non commenting lines in a method.
+ * Type is {@code int}.
  * Default value is {@code 50}.
  * </li>
  * <li>
  * Property {@code classMaximum} - Specify the maximum allowed number of
  * non commenting lines in a class.
+ * Type is {@code int}.
  * Default value is {@code 1500}.
  * </li>
  * <li>
  * Property {@code fileMaximum} - Specify the maximum allowed number of
  * non commenting lines in a file including all top level and nested classes.
+ * Type is {@code int}.
  * Default value is {@code 2000}.
  * </li>
  * </ul>
@@ -159,6 +162,23 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *   }
  * }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code ncss.class}
+ * </li>
+ * <li>
+ * {@code ncss.file}
+ * </li>
+ * <li>
+ * {@code ncss.method}
+ * </li>
+ * </ul>
  *
  * @since 3.5
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheck.java
@@ -109,6 +109,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <ul>
  * <li>
  * Property {@code max} - Specify the maximum threshold allowed.
+ * Type is {@code int}.
  * Default value is {@code 200}.
  * </li>
  * </ul>
@@ -215,6 +216,17 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * public abstract void print(String str);
  * }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code npathComplexity}
+ * </li>
+ * </ul>
  *
  * @since 3.4
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheck.java
@@ -33,23 +33,28 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * </p>
  * <ul>
  * <li>
- * Property {@code format} - Specifies valid identifiers. Default value is
- * {@code "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"}.
+ * Property {@code format} - Specifies valid identifiers.
+ * Type is {@code java.util.regex.Pattern}.
+ * Default value is {@code "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$"}.
  * </li>
  * <li>
  * Property {@code applyToPublic} - Controls whether to apply the check to public member.
+ * Type is {@code boolean}.
  * Default value is {@code true}.
  * </li>
  * <li>
  * Property {@code applyToProtected} - Controls whether to apply the check to protected member.
+ * Type is {@code boolean}.
  * Default value is {@code true}.
  * </li>
  * <li>
  * Property {@code applyToPackage} - Controls whether to apply the check to package-private member.
+ * Type is {@code boolean}.
  * Default value is {@code true}.
  * </li>
  * <li>
  * Property {@code applyToPrivate} - Controls whether to apply the check to private member.
+ * Type is {@code boolean}.
  * Default value is {@code true}.
  * </li>
  * </ul>
@@ -105,6 +110,17 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  *                                                 // pattern '^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$'
  * }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code name.invalidPattern}
+ * </li>
+ * </ul>
  *
  * @since 3.0
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/InterfaceTypeParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/InterfaceTypeParameterNameCheck.java
@@ -28,7 +28,9 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </p>
  * <ul>
  * <li>
- * Property {@code format} - Specifies valid identifiers. Default value is {@code "^[A-Z]$"}.
+ * Property {@code format} - Specifies valid identifiers.
+ * Type is {@code java.util.regex.Pattern}.
+ * Default value is {@code "^[A-Z]$"}.
  * </li>
  * </ul>
  * <p>
@@ -58,6 +60,17 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * interface ThirdInterface&lt;type&gt; {} // violation, name 'type' must
  *                                         // match pattern '^[a-zA-Z]$'
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code name.invalidPattern}
+ * </li>
+ * </ul>
  *
  * @since 5.8
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheck.java
@@ -32,11 +32,14 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * </p>
  * <ul>
  * <li>
- * Property {@code format} - Specifies valid identifiers. Default value is
- * {@code "^[a-z][a-zA-Z0-9]*$"}.
+ * Property {@code format} - Specifies valid identifiers.
+ * Type is {@code java.util.regex.Pattern}.
+ * Default value is {@code "^[a-z][a-zA-Z0-9]*$"}.
  * </li>
  * <li>
- * Property {@code tokens} - tokens to check Default value is:
+ * Property {@code tokens} - tokens to check
+ * Type is {@code int[]}.
+ * Default value is:
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
  * VARIABLE_DEF</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PARAMETER_DEF">
@@ -100,6 +103,17 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  *   }
  * }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code name.invalidPattern}
+ * </li>
+ * </ul>
  *
  * @since 3.0
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/TypeNameCheck.java
@@ -28,27 +28,34 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </p>
  * <ul>
  * <li>
- * Property {@code format} - Specifies valid identifiers. Default value is
- * {@code "^[A-Z][a-zA-Z0-9]*$"}.
+ * Property {@code format} - Specifies valid identifiers.
+ * Type is {@code java.util.regex.Pattern}.
+ * Default value is {@code "^[A-Z][a-zA-Z0-9]*$"}.
  * </li>
  * <li>
  * Property {@code applyToPublic} - Controls whether to apply the check to public member.
+ * Type is {@code boolean}.
  * Default value is {@code true}.
  * </li>
  * <li>
  * Property {@code applyToProtected} - Controls whether to apply the check to protected member.
+ * Type is {@code boolean}.
  * Default value is {@code true}.
  * </li>
  * <li>
  * Property {@code applyToPackage} - Controls whether to apply the check to package-private member.
+ * Type is {@code boolean}.
  * Default value is {@code true}.
  * </li>
  * <li>
  * Property {@code applyToPrivate} - Controls whether to apply the check to private member.
+ * Type is {@code boolean}.
  * Default value is {@code true}.
  * </li>
  * <li>
- * Property {@code tokens} - tokens to check Default value is:
+ * Property {@code tokens} - tokens to check
+ * Type is {@code int[]}.
+ * Default value is:
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
  * CLASS_DEF</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
@@ -111,6 +118,17 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * interface SecondName {} // violation, name 'SecondName'
  *                         // must match pattern '^I_[a-zA-Z0-9]*$'
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code name.invalidPattern}
+ * </li>
+ * </ul>
  *
  * @since 3.0
  */

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -25,12 +25,17 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -42,6 +47,7 @@ import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import com.google.common.collect.ImmutableMap;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -50,7 +56,18 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.Scope;
+import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.checks.LineSeparatorOption;
+import com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck;
+import com.puppycrawl.tools.checkstyle.checks.blocks.BlockOption;
+import com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyOption;
+import com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyOption;
+import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderOption;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationOption;
+import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption;
+import com.puppycrawl.tools.checkstyle.checks.whitespace.PadOption;
+import com.puppycrawl.tools.checkstyle.checks.whitespace.WrapOption;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.internal.utils.XdocUtil;
 import com.puppycrawl.tools.checkstyle.internal.utils.XmlUtil;
@@ -60,6 +77,53 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
+    // Files which have modified Javadoc required for Metadata Generation Project, for eventual
+    // migration
+    private static final Set<String> MODIFIED_JAVADOC_FILES =
+        Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+                "NoCodeInFile",
+                "BooleanExpressionComplexity",
+                "ClassFanOutComplexity",
+                "CyclomaticComplexity",
+                "JavaNCSS",
+                "NPathComplexity",
+                "ConstantName",
+                "InterfaceTypeParameterName",
+                "LocalFinalVariableName",
+                "TypeName",
+                "RightCurly"
+        )));
+
+    private static final Map<String, Class<?>> FULLY_QUALIFIED_CLASS_NAMES =
+            ImmutableMap.<String, Class<?>>builder()
+            .put("int", int.class)
+            .put("int[]", int[].class)
+            .put("boolean", boolean.class)
+            .put("double", double.class)
+            .put("double[]", double[].class)
+            .put("String", String.class)
+            .put("String[]", String[].class)
+            .put("Regular Expression", String.class)
+            .put("Regular Expressions", String[].class)
+            .put("Pattern", Pattern.class)
+            .put("Pattern[]", Pattern[].class)
+            .put("AccessModifierOption[]", AccessModifierOption[].class)
+            .put("BlockOption", BlockOption.class)
+            .put("ClosingParensOption", AnnotationUseStyleCheck.ClosingParensOption.class)
+            .put("ElementStyleOption", AnnotationUseStyleCheck.ElementStyleOption.class)
+            .put("File", File.class)
+            .put("ImportOrderOption", ImportOrderOption.class)
+            .put("JavadocContentLocationOption", JavadocContentLocationOption.class)
+            .put("LeftCurlyOption", LeftCurlyOption.class)
+            .put("LineSeparatorOption", LineSeparatorOption.class)
+            .put("PadOption", PadOption.class)
+            .put("RightCurlyOption", RightCurlyOption.class)
+            .put("Scope", Scope.class)
+            .put("SeverityLevel", SeverityLevel.class)
+            .put("TrailingArrayCommaOption", AnnotationUseStyleCheck.TrailingArrayCommaOption.class)
+            .put("Uri", URI.class)
+            .put("WrapOption", WrapOption.class).build();
+
     private static final List<List<Node>> CHECK_PROPERTIES = new ArrayList<>();
     private static final Map<String, String> CHECK_PROPERTY_DOC = new HashMap<>();
     private static final Map<String, String> CHECK_TEXT = new HashMap<>();
@@ -168,12 +232,43 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
                 CHECK_TEXT.put(subSectionName, createPropertiesText());
                 break;
             case "Example of Usage":
-            case "Error Messages":
+            case "Violation Messages":
+                CHECK_TEXT.put(subSectionName,
+                        createViolationMessagesText(getViolationMessages(subSection)));
+                break;
             case "Package":
             case "Parent Module":
+                CHECK_TEXT.put(subSectionName, createParentText(subSection));
+                break;
             default:
                 break;
         }
+    }
+
+    private static List<String> getViolationMessages(Node subsection) {
+        final Node child = XmlUtil.getFirstChildElement(subsection);
+        final List<String> violationMessages = new ArrayList<>();
+        for (Node row : XmlUtil.getChildrenElements(child)) {
+            violationMessages.add(row.getTextContent().trim());
+        }
+        return violationMessages;
+    }
+
+    private static String createViolationMessagesText(List<String> violationMessages) {
+        final StringBuilder result = new StringBuilder(100);
+        result.append("\n<p>\nViolation Message Keys:\n</p>\n<ul>");
+
+        for (String msg : violationMessages) {
+            result.append("\n<li>\n{@code ").append(msg).append("}\n</li>");
+        }
+
+        result.append("\n</ul>");
+        return result.toString();
+    }
+
+    private static String createParentText(Node subsection) {
+        return "\n<p>\nParent is {@code com.puppycrawl.tools.checkstyle."
+                + XmlUtil.getFirstChildElement(subsection).getTextContent().trim() + "}\n</p>";
     }
 
     private static void populateProperties(Node subSection) {
@@ -213,6 +308,17 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
 
             result.append(temp);
             CHECK_PROPERTY_DOC.put(propertyName, temp);
+
+            if (MODIFIED_JAVADOC_FILES.contains(checkName)) {
+                String typeText = "int[]";
+                if (!property.get(2).getTextContent().contains("subset of tokens")) {
+                    final String typeName =
+                            property.get(2).getFirstChild().getFirstChild().getTextContent();
+                    typeText = FULLY_QUALIFIED_CLASS_NAMES.get(typeName).getTypeName();
+                }
+                result.append(" Type is {@code ").append(typeText).append("}.");
+
+            }
 
             if (propertyName.endsWith("token") || propertyName.endsWith("tokens")) {
                 result.append(" Default value is: ");
@@ -463,12 +569,21 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
         }
 
         private static void visitClass(DetailAST node) {
+            String parentText = "";
+            String violationMessagesText = "";
+            if (MODIFIED_JAVADOC_FILES.contains(checkName)) {
+                parentText = CHECK_TEXT.get("Parent Module");
+                violationMessagesText = CHECK_TEXT.get("Violation Messages");
+            }
+
             if (ScopeUtil.isInScope(node, Scope.PUBLIC)) {
                 assertEquals(CHECK_TEXT.get("Description")
                         + CHECK_TEXT.computeIfAbsent("Rule Description", unused -> "")
                         + CHECK_TEXT.computeIfAbsent("Notes", unused -> "")
                         + CHECK_TEXT.computeIfAbsent("Properties", unused -> "")
-                        + CHECK_TEXT.get("Examples") + " @since "
+                        + CHECK_TEXT.get("Examples")
+                        + parentText
+                        + violationMessagesText + " @since "
                         + CHECK_TEXT.get("since"), getJavaDocText(node),
                         checkName + "'s class-level JavaDoc");
             }

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -968,7 +968,7 @@ allowedFuture.addCallback(result -> {
             <tr>
               <td>option</td>
               <td>Specify the policy on placement of a right curly brace (<code>'}'</code>).</td>
-              <td><a href="property_types.html#RcurlyOption">RightCurlyOption</a></td>
+              <td><a href="property_types.html#RightCurlyOption">RightCurlyOption</a></td>
               <td><code>same</code></td>
               <td>3.0</td>
             </tr>

--- a/src/xdocs/property_types.xml
+++ b/src/xdocs/property_types.xml
@@ -177,14 +177,6 @@
       </p>
     </section>
 
-    <section name="regexp">
-      <p>
-        This type represents a regular expression. The string representation is parsed using
-        <a href="https://docs.oracle.com/javase/7/docs/api/index.html?java/util/regex/package-summary.html">
-        java.util.regex package</a>.
-      </p>
-    </section>
-
     <section name="short">
       <p>
         This type represents a short. The string representation is
@@ -541,7 +533,7 @@
       </div>
     </section>
 
-    <section name="LcurlyOption">
+    <section name="LeftCurlyOption">
       <p>
         This type represents the policy for checking the placement of a
         left curly brace (<code>'{'</code>). The following table
@@ -679,7 +671,7 @@
     <section name="Pattern">
       <p>
         This type represents a regular expression. The string representation is parsed using
-        <a href="https://docs.oracle.com/javase/7/docs/api/index.html?java/util/regex/package-summary.html">
+        <a href="https://docs.oracle.com/javase/8/docs/api/index.html?java/util/regex/package-summary.html">
         java.util.regex package</a>.
       </p>
     </section>
@@ -691,7 +683,15 @@
       </p>
     </section>
 
-    <section name="RcurlyOption">
+    <section name="RegularExpression">
+      <p>
+        This type represents a regular expression. The string representation is parsed using
+        <a href="https://docs.oracle.com/javase/8/docs/api/index.html?java/util/regex/package-summary.html">
+        java.util.regex package</a>.
+      </p>
+    </section>
+
+    <section name="RightCurlyOption">
       <p>
         This type represents the policy for checking the placement of a
         right curly brace (<code>'}'</code>) in blocks but not blocks of expressions.


### PR DESCRIPTION
#8306 

Added modified `XdocsJavadoc` UT.
Modified Files:
- `NoCodeInFileCheck`
- `RightCurlyCheck`
- `BooleanExpressionComplexityCheck`
- `ClassFanOutComplexityCheck`
- `CyclomaticComplexityCheck`
- `JavaNCSSCheck`
- `NPathComplexityCheck`
- `ConstantNameCheck`
- `InterfaceTypeParamterNameCheck`
- `LocalFinalVariableNameCheck`
- `TypeNameCheck`
Javadoc of `RightCurlyCheck`
Before:
![Screenshot_20200707_223928](https://user-images.githubusercontent.com/23253816/86817762-19023a00-c0a3-11ea-9db3-51a3f9b683fc.png)
After:
![Screenshot_20200707_223000](https://user-images.githubusercontent.com/23253816/86817691-fc660200-c0a2-11ea-908a-ad0c0004f25e.png)
