### PR TITLE
Issue #8407: new Check: PatternVariableName

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -1027,6 +1027,7 @@ Passembly
 pathcomplexity
 pathelement
 patreon
+patternvariablename
 Paulicke
 paypal
 pbludov

--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -674,6 +674,7 @@
       <property name="format" value="^(id)|([a-z][a-z0-9][a-zA-Z0-9]+)$"/>
     </module>
     <module name="TypeName"/>
+    <module name="PatternVariableName"/>
 
     <!-- Regexp -->
     <module name="Regexp"/>

--- a/pom.xml
+++ b/pom.xml
@@ -1892,6 +1892,9 @@
                 <param>com.puppycrawl.tools.checkstyle.checks.NoCodeInFileCheck*</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck*</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck*</param>
+                <param>
+                  com.puppycrawl.tools.checkstyle.checks.naming.PatternVariableNameCheck*
+                </param>
                 <param>com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder*</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck*</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck*</param>
@@ -1911,6 +1914,9 @@
                 <param>com.puppycrawl.tools.checkstyle.checks.NoCodeInFileCheckTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheckTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheckTest</param>
+                <param>
+                  com.puppycrawl.tools.checkstyle.checks.naming.PatternVariableNameCheckTest
+                </param>
                 <param>com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolderTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.TodoCommentCheckTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheckTest</param>

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/PatternVariableNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/PatternVariableNameTest.java
@@ -1,0 +1,68 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.google.checkstyle.test.chapter5naming.rule527localvariablenames;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+
+public class PatternVariableNameTest extends AbstractGoogleModuleTestSupport {
+
+    private static final String MSG_KEY = "name.invalidPattern";
+
+    @Override
+    protected String getPackageLocation() {
+        return "com/google/checkstyle/test/chapter5naming/rule527localvariablenames";
+    }
+
+    @Test
+    public void testPatternVariableName() throws Exception {
+        final Configuration checkConfig = getModuleConfig("PatternVariableName");
+        final String format = checkConfig.getAttribute("format");
+        final Map<String, String> messages = checkConfig.getMessages();
+        final String[] expected = {
+            "11:39: " + getCheckMessage(messages, MSG_KEY, "OTHER", format),
+            "21:34: " + getCheckMessage(messages, MSG_KEY, "Count", format),
+            "36:36: " + getCheckMessage(messages, MSG_KEY, "aA", format),
+            "37:42: " + getCheckMessage(messages, MSG_KEY, "a1_a", format),
+            "40:34: " + getCheckMessage(messages, MSG_KEY, "A_A", format),
+            "41:43: " + getCheckMessage(messages, MSG_KEY, "aa2_a", format),
+            "53:37: " + getCheckMessage(messages, MSG_KEY, "_a", format),
+            "59:43: " + getCheckMessage(messages, MSG_KEY, "_aa", format),
+            "63:41: " + getCheckMessage(messages, MSG_KEY, "aa_", format),
+            "68:38: " + getCheckMessage(messages, MSG_KEY, "aaa$aaa", format),
+            "69:36: " + getCheckMessage(messages, MSG_KEY, "$aaaaaa", format),
+            "70:37: " + getCheckMessage(messages, MSG_KEY, "aaaaaa$", format),
+            "77:41: " + getCheckMessage(messages, MSG_KEY, "_A_aa_B", format),
+
+        };
+
+        final String filePath =
+                getNonCompilablePath(
+                        "InputPatternVariableNameEnhancedInstanceofTestDefault.java");
+
+        final Integer[] warnList = getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
+    }
+
+}

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionPatternVariableNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionPatternVariableNameTest.java
@@ -1,0 +1,151 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck;
+import com.puppycrawl.tools.checkstyle.checks.naming.PatternVariableNameCheck;
+
+public class XpathRegressionPatternVariableNameTest extends AbstractXpathTestSupport {
+
+    private final String checkName = PatternVariableNameCheck.class.getSimpleName();
+
+    @Override
+    protected String getCheckName() {
+        return checkName;
+    }
+
+    @Test
+    public void testOne() throws Exception {
+        final File fileToProcess =
+                new File(getNonCompilablePath(
+                        "SuppressionXpathRegressionPatternVariableName1.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(PatternVariableNameCheck.class);
+        final String defaultPattern = "^[a-z][a-zA-Z0-9]*$";
+
+        final String[] expectedViolation = {
+            "6:33: " + getCheckMessage(PatternVariableNameCheck.class,
+                    AbstractNameCheck.MSG_INVALID_PATTERN,
+                    "STRING1", defaultPattern),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionPatternVariableName1']]"
+                + "/OBJBLOCK/CTOR_DEF[./IDENT[@text='MyClass']]/SLIST/LITERAL_IF/EXPR/"
+                + "LITERAL_INSTANCEOF[./IDENT[@text='o1']]/PATTERN_VARIABLE_DEF/"
+                + "IDENT[@text='STRING1']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testTwo() throws Exception {
+        final File fileToProcess =
+                new File(getNonCompilablePath(
+                        "SuppressionXpathRegressionPatternVariableName2.java"));
+
+        final String nonDefaultPattern = "^_[a-zA-Z0-9]*$";
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(PatternVariableNameCheck.class);
+        moduleConfig.addAttribute("format", nonDefaultPattern);
+
+        final String[] expectedViolation = {
+            "6:34: " + getCheckMessage(PatternVariableNameCheck.class,
+                    AbstractNameCheck.MSG_INVALID_PATTERN, "s", nonDefaultPattern),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionPatternVariableName2']]"
+                + "/OBJBLOCK/CTOR_DEF[./IDENT[@text='MyClass']]/SLIST/LITERAL_IF/EXPR/"
+                + "LITERAL_INSTANCEOF[./IDENT[@text='o1']]/"
+                + "PATTERN_VARIABLE_DEF/IDENT[@text='s']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testThree() throws Exception {
+        final File fileToProcess =
+                new File(getNonCompilablePath(
+                        "SuppressionXpathRegressionPatternVariableName3.java"));
+
+        final String nonDefaultPattern = "^[a-z](_?[a-zA-Z0-9]+)*$";
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(PatternVariableNameCheck.class);
+        moduleConfig.addAttribute("format", nonDefaultPattern);
+
+        final String[] expectedViolation = {
+            "6:34: " + getCheckMessage(PatternVariableNameCheck.class,
+                AbstractNameCheck.MSG_INVALID_PATTERN, "STR", nonDefaultPattern),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionPatternVariableName3']]"
+                    + "/OBJBLOCK/CTOR_DEF[./IDENT[@text='MyClass']]/SLIST/LITERAL_IF/"
+                    + "EXPR/LITERAL_INSTANCEOF[./IDENT[@text='o1']]/"
+                    + "PATTERN_VARIABLE_DEF/IDENT[@text='STR']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testFour() throws Exception {
+        final File fileToProcess =
+                new File(getNonCompilablePath(
+                        "SuppressionXpathRegressionPatternVariableName4.java"));
+
+        final String nonDefaultPattern = "^[a-z][_a-zA-Z0-9]{2,}$";
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(PatternVariableNameCheck.class);
+        moduleConfig.addAttribute("format", nonDefaultPattern);
+
+        final String[] expectedViolation = {
+            "6:34: " + getCheckMessage(PatternVariableNameCheck.class,
+                AbstractNameCheck.MSG_INVALID_PATTERN, "st", nonDefaultPattern),
+        };
+
+        final List<String> expectedXpathQueries = Collections.singletonList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionPatternVariableName1']]"
+                    + "/OBJBLOCK/CTOR_DEF[./IDENT[@text='MyClass']]/SLIST/LITERAL_IF/EXPR/"
+                    + "LITERAL_INSTANCEOF[./IDENT[@text='o1']]/"
+                    + "PATTERN_VARIABLE_DEF/IDENT[@text='st']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+}

--- a/src/it/resources-noncompilable/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputPatternVariableNameEnhancedInstanceofTestDefault.java
+++ b/src/it/resources-noncompilable/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/InputPatternVariableNameEnhancedInstanceofTestDefault.java
@@ -1,0 +1,79 @@
+//non-compiled with javac: Compilable with Java14
+package com.google.checkstyle.test.chapter5naming.rule527localvariablenames;
+
+import java.util.ArrayList;
+import java.util.Locale;
+
+public class InputPatternVariableNameEnhancedInstanceofTestDefault {
+    private Object obj;
+
+    static boolean doStuff(Object obj) {
+        return obj instanceof Integer OTHER && OTHER > 0; // warn
+    }
+
+    static {
+        Object o = "";
+        if (o instanceof String s) {
+            System.out.println(s.toLowerCase(Locale.forLanguageTag(s)));
+            boolean stringCheck = "test".equals(s);
+        }
+
+        if (o instanceof Integer Count) { // warn
+            int value = Count.byteValue();
+            if (Count.equals(value)) {
+                value = 25;
+            }
+        }
+    }
+
+    interface VoidPredicate {
+        public boolean get();
+    }
+
+    public void t(Object o1, Object o2) {
+        Object b;
+        Object c;
+        if (!(o1 instanceof String aA) // warn
+                && (o2 instanceof String a1_a)) { // warn
+        }
+
+        if (o1 instanceof String A_A // warn
+                || !(o2 instanceof String aa2_a)) { // warn
+        }
+        b = ((VoidPredicate) () -> o1 instanceof String s).get();
+
+        ArrayList<Integer> arrayList = new ArrayList<Integer>();
+        if (arrayList instanceof ArrayList<Integer> ai) {
+            System.out.println("Blah");
+        }
+
+        boolean result = (o1 instanceof String a) ?
+                (o1 instanceof String x) : (!(o1 instanceof String y));
+
+        if (!(o1 instanceof Integer _a) ? // warn
+                false : _a > 0) {
+            System.out.println("done");
+        }
+
+        {
+            while (!(o1 instanceof String _aa)) { // warn
+                L3:
+                break L3;
+            }
+            while (o1 instanceof String aa_) { // warn
+                aa_.length();
+            }
+        }
+
+        int x = o1 instanceof String aaa$aaa ? aaa$aaa.length() : 2; // warn
+        x = !(o1 instanceof String $aaaaaa) ? 2 : $aaaaaa.length(); // warn
+        for (; o1 instanceof String aaaaaa$; aaaaaa$.length()) { // warn
+            System.out.println(aaaaaa$);
+        }
+
+        do {
+            L4:
+            break L4;
+        } while (!(o1 instanceof String _A_aa_B)); // warn
+    }
+}

--- a/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/patternvariablename/SuppressionXpathRegressionPatternVariableName1.java
+++ b/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/patternvariablename/SuppressionXpathRegressionPatternVariableName1.java
@@ -1,0 +1,9 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.naming;
+
+public class SuppressionXpathRegressionPatternVariableName1 {
+   MyClass(Object o1){ 
+       if (o1 instanceof String STRING1) { // warning
+       }
+   }
+}

--- a/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/patternvariablename/SuppressionXpathRegressionPatternVariableName2.java
+++ b/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/patternvariablename/SuppressionXpathRegressionPatternVariableName2.java
@@ -1,0 +1,9 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.naming;
+
+public class SuppressionXpathRegressionPatternVariableName2 {
+    MyClass(Object o1){
+        if (o1 instanceof String s) { // warning
+        }
+    }
+}

--- a/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/patternvariablename/SuppressionXpathRegressionPatternVariableName3.java
+++ b/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/patternvariablename/SuppressionXpathRegressionPatternVariableName3.java
@@ -1,0 +1,9 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.naming;
+
+public class SuppressionXpathRegressionPatternVariableName3 {
+    MyClass(Object o1){ 
+        if (o1 instanceof String STR) { // warning
+        } 
+    }
+}

--- a/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/patternvariablename/SuppressionXpathRegressionPatternVariableName4.java
+++ b/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/patternvariablename/SuppressionXpathRegressionPatternVariableName4.java
@@ -1,0 +1,9 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.naming;
+
+public class SuppressionXpathRegressionPatternVariableName1 {
+    MyClass(Object o1){
+        if (o1 instanceof String st) { // warning
+        }
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -749,6 +749,8 @@ public class PackageObjectFactory implements ModuleFactory {
                 BASE_PACKAGE + ".checks.naming.StaticVariableNameCheck");
         NAME_TO_FULL_MODULE_NAME.put("TypeNameCheck",
                 BASE_PACKAGE + ".checks.naming.TypeNameCheck");
+        NAME_TO_FULL_MODULE_NAME.put("PatternVariableNameCheck",
+                BASE_PACKAGE + ".checks.naming.PatternVariableNameCheck");
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/PatternVariableNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/PatternVariableNameCheck.java
@@ -1,0 +1,137 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.naming;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+/**
+ * <p>
+ * Checks that pattern variable names conform to a specified pattern.
+ * </p>
+ * <ul>
+ * <li>
+ * Property {@code format} - Specifies valid identifiers. Type is {@code java.util.regex.Pattern}.
+ * Default value is {@code "^[a-z][a-zA-Z0-9]*$"}.
+ * </li>
+ * </ul>
+ * <p>
+ * An example of how to configure the check is:
+ * </p>
+ * <pre>
+ * &lt;module name="PatternVariableName"/&gt;
+ * </pre>
+ * <p>Code Example:</p>
+ * <pre>
+ * class MyClass {
+ *     MyClass(Object o1){
+ *         if (o1 instanceof String STRING) { // violation, name 'STRING' must
+ *                                            // match pattern '^[a-z][a-zA-Z0-9]*$'
+ *         }
+ *         if (o1 instanceof Integer num) { // OK
+ *         }
+ *     }
+ * }
+ * </pre>
+ * <p>
+ * An example of how to configure the check for names that have a lower case letter, followed by
+ * letters and digits, optionally separated by underscore:
+ * </p>
+ * <pre>
+ * &lt;module name="PatternVariableName"&gt;
+ *   &lt;property name="format" value="^[a-z](_?[a-zA-Z0-9]+)*$"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Code Example:</p>
+ * <pre>
+ * class MyClass {
+ *     MyClass(Object o1){
+ *         if (o1 instanceof String STR) { // violation, name 'STR' must
+ *                                         // match pattern '^[a-z](_?[a-zA-Z0-9]+)*$'
+ *         }
+ *         if (o1 instanceof Integer num) { // OK
+ *         }
+ *         if (o1 instanceof Integer num_1) { // OK
+ *         }
+ *     }
+ * }
+ * </pre>
+ * <p>
+ * An example of how to configure the check to that all variables have 3 or more chars in name:
+ * </p>
+ * <pre>
+ * &lt;module name="PatternVariableName"&gt;
+ *   &lt;property name="format" value="^[a-z][_a-zA-Z0-9]{2,}$"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Code Example:</p>
+ * <pre>
+ * class MyClass {
+ *     MyClass(Object o1){
+ *         if (o1 instanceof String s) { // violation, name 's' must
+ *                                       // match pattern '^[a-z][_a-zA-Z0-9]{2,}$'
+ *         }
+ *         if (o1 instanceof Integer num) { // OK
+ *         }
+ *     }
+ * }
+ * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code name.invalidPattern}
+ * </li>
+ * </ul>
+ * @since 8.36
+ */
+public class PatternVariableNameCheck extends AbstractNameCheck {
+
+    /** Creates a new {@code PatternVariableNameCheck} instance. */
+    public PatternVariableNameCheck() {
+        super("^[a-z][a-zA-Z0-9]*$");
+    }
+
+    @Override
+    public int[] getDefaultTokens() {
+        return getRequiredTokens();
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return getRequiredTokens();
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return new int[] {
+            TokenTypes.PATTERN_VARIABLE_DEF,
+        };
+    }
+
+    @Override
+    protected final boolean mustCheckName(DetailAST ast) {
+        return true;
+    }
+}

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -200,6 +200,11 @@
             <message key="name.invalidPattern"
              value="Local variable name ''{0}'' must match pattern ''{1}''."/>
         </module>
+        <module name="PatternVariableName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+                     value="Pattern variable name ''{0}'' must match pattern ''{1}''."/>
+        </module>
         <module name="ClassTypeParameterName">
             <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
             <message key="name.invalidPattern"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/PatternVariableNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/PatternVariableNameCheckTest.java
@@ -1,0 +1,106 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.naming;
+
+import static com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.MSG_INVALID_PATTERN;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+public class PatternVariableNameCheckTest
+        extends AbstractModuleTestSupport {
+
+    @Override
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename";
+    }
+
+    @Test
+    public void testGetAcceptableTokens() {
+        final PatternVariableNameCheck patternVariableNameCheck = new PatternVariableNameCheck();
+        final int[] expected = {TokenTypes.PATTERN_VARIABLE_DEF};
+
+        assertArrayEquals(expected, patternVariableNameCheck.getAcceptableTokens(),
+                "Default acceptable tokens are invalid");
+    }
+
+    @Test
+    public void testDefault() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(PatternVariableNameCheck.class);
+
+        final String pattern = "^[a-z][a-zA-Z0-9]*$";
+
+        final String[] expected = {
+            "15:39: " + getCheckMessage(MSG_INVALID_PATTERN, "OTHER", pattern),
+            "25:34: " + getCheckMessage(MSG_INVALID_PATTERN, "Count", pattern),
+            "40:36: " + getCheckMessage(MSG_INVALID_PATTERN, "S", pattern),
+            "41:42: " + getCheckMessage(MSG_INVALID_PATTERN, "STRING", pattern),
+            "44:34: " + getCheckMessage(MSG_INVALID_PATTERN, "STRING", pattern),
+            "45:43: " + getCheckMessage(MSG_INVALID_PATTERN, "STRING", pattern),
+            "57:37: " + getCheckMessage(MSG_INVALID_PATTERN, "INTEGER", pattern),
+            "63:43: " + getCheckMessage(MSG_INVALID_PATTERN, "Thing1", pattern),
+            "67:41: " + getCheckMessage(MSG_INVALID_PATTERN, "Thing2", pattern),
+        };
+        verify(checkConfig,
+                getNonCompilablePath(
+                        "InputPatternVariableNameEnhancedInstanceofTestDefault.java"),
+                expected);
+    }
+
+    @Test
+    public void testPatternVariableNameNoSingleChar() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(PatternVariableNameCheck.class);
+        checkConfig.addAttribute("format", "^[a-z][a-zA-Z0-9]+$");
+
+        final String pattern = "^[a-z][a-zA-Z0-9]+$";
+
+        final String[] expected = {
+            "15:39: " + getCheckMessage(MSG_INVALID_PATTERN, "OTHER", pattern),
+            "20:33: " + getCheckMessage(MSG_INVALID_PATTERN, "s", pattern),
+            "25:34: " + getCheckMessage(MSG_INVALID_PATTERN, "Count", pattern),
+            "40:36: " + getCheckMessage(MSG_INVALID_PATTERN, "S", pattern),
+            "41:42: " + getCheckMessage(MSG_INVALID_PATTERN, "STRING", pattern),
+            "43:34: " + getCheckMessage(MSG_INVALID_PATTERN, "STRING", pattern),
+            "44:43: " + getCheckMessage(MSG_INVALID_PATTERN, "STRING", pattern),
+            "46:57: " + getCheckMessage(MSG_INVALID_PATTERN, "s", pattern),
+            "53:48: " + getCheckMessage(MSG_INVALID_PATTERN, "a", pattern),
+            "54:39: " + getCheckMessage(MSG_INVALID_PATTERN, "x", pattern),
+            "55:43: " + getCheckMessage(MSG_INVALID_PATTERN, "y", pattern),
+            "57:37: " + getCheckMessage(MSG_INVALID_PATTERN, "INTEGER", pattern),
+            "62:43: " + getCheckMessage(MSG_INVALID_PATTERN, "Thing1", pattern),
+            "66:41: " + getCheckMessage(MSG_INVALID_PATTERN, "Thing2", pattern),
+            "71:38: " + getCheckMessage(MSG_INVALID_PATTERN, "j", pattern),
+            "72:36: " + getCheckMessage(MSG_INVALID_PATTERN, "j", pattern),
+            "73:37: " + getCheckMessage(MSG_INVALID_PATTERN, "j", pattern),
+            "80:41: " + getCheckMessage(MSG_INVALID_PATTERN, "s", pattern),
+        };
+
+        verify(checkConfig,
+                getNonCompilablePath(
+                        "InputPatternVariableNameEnhancedInstanceofNoSingleChar.java"),
+                expected);
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/InputPatternVariableNameEnhancedInstanceofNoSingleChar.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/InputPatternVariableNameEnhancedInstanceofNoSingleChar.java
@@ -1,0 +1,82 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.naming.patternvariablename;
+
+import java.util.ArrayList;
+import java.util.Locale;
+/*
+ * Config:
+ * tokens = PATTERN_VARIABLE_DEF
+ * format = "^[a-z][a-zA-Z0-9]+$"
+ */
+public class InputPatternVariableNameEnhancedInstanceofNoSingleChar {
+    private Object obj;
+
+    static boolean doStuff(Object obj) {
+        return obj instanceof Integer OTHER && OTHER > 0; // violation
+    }
+
+    static {
+        Object o = "";
+        if (o instanceof String s) { // violation
+            System.out.println(s.toLowerCase(Locale.forLanguageTag(s)));
+            boolean stringCheck = "test".equals(s);
+        }
+
+        if (o instanceof Integer Count) { // violation
+            int value = Count.byteValue();
+            if (Count.equals(value)) {
+                value = 25;
+            }
+        }
+    }
+
+    interface VoidPredicate {
+        public boolean get();
+    }
+
+    public void t(Object o1, Object o2) {
+        Object b;
+        Object c;
+        if (!(o1 instanceof String S) // violation
+                && (o2 instanceof String STRING)) { // violation
+        }
+        if (o1 instanceof String STRING //violation
+                || !(o2 instanceof String STRING)) { // violation
+        }
+        b = ((VoidPredicate) () -> o1 instanceof String s).get(); // violation
+
+        ArrayList<Integer> arrayList = new ArrayList<Integer>();
+        if (arrayList instanceof ArrayList<Integer> ai) {
+            System.out.println("Blah");
+        }
+
+        boolean result = (o1 instanceof String a) ? // violation
+                (o1 instanceof String x) // violation
+                : (!(o1 instanceof String y)); // violation
+
+        if (!(o1 instanceof Integer INTEGER) ? false : INTEGER > 0) { // violation
+            System.out.println("done");
+        }
+
+        {
+            while (!(o1 instanceof String Thing1)) { // violation
+                L3:
+                break L3;
+            }
+            while (o1 instanceof String Thing2) { // violation
+                Thing2.length();
+            }
+        }
+
+        int x = o1 instanceof String j ? j.length() : 2; // violation
+        x = !(o1 instanceof String j) ? 2 : j.length(); // violation
+        for (; o1 instanceof String j; j.length()) { // violation
+            System.out.println(j);
+        }
+
+        do {
+            L4:
+            break L4;
+        } while (!(o1 instanceof String s)); // violation
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/InputPatternVariableNameEnhancedInstanceofTestDefault.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/patternvariablename/InputPatternVariableNameEnhancedInstanceofTestDefault.java
@@ -1,0 +1,83 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.naming.patternvariablename;
+
+import java.util.ArrayList;
+import java.util.Locale;
+/*
+ * Config:
+ * tokens = PATTERN_VARIABLE_DEF
+ * format = "^[a-z][a-zA-Z0-9]*$"
+ */
+public class InputPatternVariableNameEnhancedInstanceofTestDefault {
+    private Object obj;
+
+    static boolean doStuff(Object obj) {
+        return obj instanceof Integer OTHER && OTHER > 0; // violation
+    }
+
+    static {
+        Object o = "";
+        if (o instanceof String s) {
+            System.out.println(s.toLowerCase(Locale.forLanguageTag(s)));
+            boolean stringCheck = "test".equals(s);
+        }
+
+        if (o instanceof Integer Count) { // violation
+            int value = Count.byteValue();
+            if (Count.equals(value)) {
+                value = 25;
+            }
+        }
+    }
+
+    interface VoidPredicate {
+        public boolean get();
+    }
+
+    public void t(Object o1, Object o2) {
+        Object b;
+        Object c;
+        if (!(o1 instanceof String S) // violation
+                && (o2 instanceof String STRING)) { // violation
+        }
+
+        if (o1 instanceof String STRING // violation
+                || !(o2 instanceof String STRING)) { // violation
+        }
+        b = ((VoidPredicate) () -> o1 instanceof String s).get();
+
+        ArrayList<Integer> arrayList = new ArrayList<Integer>();
+        if (arrayList instanceof ArrayList<Integer> ai) {
+            System.out.println("Blah");
+        }
+
+        boolean result = (o1 instanceof String a) ?
+                (o1 instanceof String x) : (!(o1 instanceof String y));
+
+        if (!(o1 instanceof Integer INTEGER) ? // violation
+                false : INTEGER > 0) {
+            System.out.println("done");
+        }
+
+        {
+            while (!(o1 instanceof String Thing1)) { // violation
+                L3:
+                break L3;
+            }
+            while (o1 instanceof String Thing2) { // violation
+                Thing2.length();
+            }
+        }
+
+        int x = o1 instanceof String j ? j.length() : 2;
+        x = !(o1 instanceof String j) ? 2 : j.length();
+        for (; o1 instanceof String j; j.length()) {
+            System.out.println(j);
+        }
+
+        do {
+            L4:
+            break L4;
+        } while (!(o1 instanceof String s));
+    }
+}

--- a/src/xdocs/checks.xml
+++ b/src/xdocs/checks.xml
@@ -724,6 +724,12 @@
             </td>
           </tr>
           <tr>
+            <td><a href="config_naming.html#PatternVariableName">PatternVariableName</a></td>
+            <td>
+              Checks that pattern variable names conform to a specified pattern.
+            </td>
+          </tr>
+          <tr>
             <td><a href="config_imports.html#RedundantImport">RedundantImport</a></td>
             <td>Checks for redundant import statements.</td>
           </tr>

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -2296,6 +2296,136 @@ class MyClass {
       </subsection>
     </section>
 
+    <section name="PatternVariableName">
+          <p>Since Checkstyle 8.36</p>
+          <subsection name="Description" id="PatternVariableName_Description">
+              <p>
+                  Checks that pattern variable names conform to a specified pattern.
+              </p>
+          </subsection>
+
+          <subsection name="Properties" id="PatternVariableName_Properties">
+              <div class="wrapper">
+                  <table>
+                      <tr>
+                          <th>name</th>
+                          <th>description</th>
+                          <th>type</th>
+                          <th>default value</th>
+                          <th>since</th>
+                      </tr>
+                      <tr>
+                          <td>format</td>
+                          <td>Specifies valid identifiers.</td>
+                          <td><a href="property_types.html#regexp">Pattern</a></td>
+                          <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
+                          <td>8.36</td>
+                      </tr>
+                  </table>
+              </div>
+          </subsection>
+
+          <subsection name="Examples" id="PatternVariableName_Examples">
+              <p>
+                  An example of how to configure the check is:
+              </p>
+
+              <source>
+                  &lt;module name="PatternVariableName"/&gt;
+              </source>
+              <p>Code Example:</p>
+              <source>
+                  class MyClass {
+                      MyClass(Object o1){
+                          if (o1 instanceof String STRING) { // violation, name 'STRING' must
+                          // match pattern '^[a-z][a-zA-Z0-9]*$'
+                          }
+                          if (o1 instanceof Integer num) { // OK
+                          }
+                      }
+                  }
+              </source>
+              <p>
+                  An example of how to configure the check for names that have a lower case letter,
+                  followed by letters and digits, optionally separated by underscore:
+              </p>
+              <source>
+                  &lt;module name="PatternVariableName"&gt;
+                  &lt;property name="format" value="^[a-z](_?[a-zA-Z0-9]+)*$"/&gt;
+                  &lt;/module&gt;
+              </source>
+              <p>Code Example:</p>
+              <source>
+                  class MyClass {
+                      MyClass(Object o1){
+                          if (o1 instanceof String STR) { // violation, name 'STR' must
+                          // match pattern '^[a-z](_?[a-zA-Z0-9]+)*$'
+                          }
+                          if (o1 instanceof Integer num) { // OK
+                          }
+                          if (o1 instanceof Integer num_1) { // OK
+                          }
+                      }
+                  }
+              </source>
+              <p>
+                  An example of how to configure the check to that all variables have 3 or more
+                  chars in name:
+              </p>
+              <source>
+                  &lt;module name="PatternVariableName"&gt;
+                  &lt;property name="format" value="^[a-z][_a-zA-Z0-9]{2,}$"/&gt;
+                  &lt;/module&gt;
+              </source>
+              <p>Code Example:</p>
+              <source>
+                  class MyClass {
+                      MyClass(Object o1){
+                          if (o1 instanceof String s) { // violation, name 's' must
+                          // match pattern '^[a-z][_a-zA-Z0-9]{2,}$'
+                          }
+                          if (o1 instanceof Integer num) { // OK
+                          }
+                      }
+                  }
+              </source>
+          </subsection>
+
+          <subsection name="Example of Usage" id="PatternVariableName_Example_of_Usage">
+              <ul>
+                  <li>
+                      <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+PatternVariableName">
+                          Google Style</a>
+                  </li>
+                  <li>
+                      <a href="https://github.com/search?q=path%3Aconfig+filename%3Acheckstyle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+PatternVariableName">
+                          Checkstyle Style</a>
+                  </li>
+              </ul>
+          </subsection>
+
+          <subsection name="Violation Messages" id="PatternVariableName_Violation_Messages">
+              <ul>
+                  <li>
+                      <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
+                          name.invalidPattern</a>
+                  </li>
+              </ul>
+              <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="config.html#Custom_messages">see the documentation</a> to learn how to.
+              </p>
+          </subsection>
+
+          <subsection name="Package" id="PatternVariableName_Package">
+              <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
+          </subsection>
+
+          <subsection name="Parent Module" id="PatternVariableName_Parent_Module">
+              <p> <a href="config.html#TreeWalker">TreeWalker</a> </p>
+          </subsection>
+      </section>
+
     <section name="StaticVariableName">
       <p>Since Checkstyle 3.0</p>
       <subsection name="Description" id="StaticVariableName_Description">

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -1707,12 +1707,22 @@
                     <img src="images/ok_green.png" alt="" />
                   </span>
                   <a href="config_naming.html#LocalVariableName">LocalVariableName</a>
+                  <br/>
+                  <span class="wrapper inline">
+                    <img src="images/ok_green.png" alt="" />
+                  </span>
+                  <a href="config_naming.html#PatternVariableName">PatternVariableName</a>
                 </td>
                 <td>
                   <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LocalVariableName">
                     config</a>
                   <br />
                   <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNameTest.java">
+                    test</a>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+PatternVariableName">
+                    config</a>
+                  <br />
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/PatternVariableNameTest.java">
                     test</a>
                 </td>
               </tr>


### PR DESCRIPTION
Issue #8407: new Check: PatternVariableName

We are introducing this check to ensure that pattern variable names conform to a predefined pattern.  Since I could not find mention of pattern variables in the sun or google style guides, I have omitted this check from those configurations.  I have added the check to `checkstyle_checks.xml`, using the default pattern `^[a-z][a-zA-Z0-9]*$`.

Check regression report : https://checkstyle-reports-java14.s3.amazonaws.com/reports/diff_check_patternvariablename/index.html
Contribution PR: https://github.com/checkstyle/contribution/pull/492