### PR TITLE
Issue #8345: Add TokenUtil.isTypeDeclaration method

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheck.java
@@ -24,6 +24,7 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
  * <p>
@@ -156,10 +157,7 @@ public class OneTopLevelClassCheck extends AbstractCheck {
      * @return true if the node is a type (class, enum, interface, annotation) definition.
      */
     private static boolean isTypeDef(DetailAST node) {
-        return node.getType() == TokenTypes.CLASS_DEF
-                || node.getType() == TokenTypes.ENUM_DEF
-                || node.getType() == TokenTypes.INTERFACE_DEF
-                || node.getType() == TokenTypes.ANNOTATION_DEF;
+        return TokenUtil.isTypeDeclaration(node.getType());
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
@@ -444,11 +444,8 @@ public class CommentsIndentationCheck extends AbstractCheck {
      * @return true if the statement is a kind of definition.
      */
     private static boolean isDefinition(DetailAST previousSibling) {
-        return previousSibling.getType() == TokenTypes.METHOD_DEF
-            || previousSibling.getType() == TokenTypes.CLASS_DEF
-            || previousSibling.getType() == TokenTypes.INTERFACE_DEF
-            || previousSibling.getType() == TokenTypes.ENUM_DEF
-            || previousSibling.getType() == TokenTypes.ANNOTATION_DEF;
+        return TokenUtil.isTypeDeclaration(previousSibling.getType())
+            || previousSibling.getType() == TokenTypes.METHOD_DEF;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfo.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfo.java
@@ -28,6 +28,7 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
  * This enum defines the various Javadoc tags and there properties.
@@ -75,10 +76,7 @@ public enum JavadocTagInfo {
         public boolean isValidOn(final DetailAST ast) {
             final int astType = ast.getType();
             return astType == TokenTypes.PACKAGE_DEF
-                || astType == TokenTypes.CLASS_DEF
-                || astType == TokenTypes.INTERFACE_DEF
-                || astType == TokenTypes.ENUM_DEF
-                || astType == TokenTypes.ANNOTATION_DEF;
+                || TokenUtil.isTypeDeclaration(astType);
         }
 
     },
@@ -349,10 +347,7 @@ public enum JavadocTagInfo {
         public boolean isValidOn(final DetailAST ast) {
             final int astType = ast.getType();
             return astType == TokenTypes.PACKAGE_DEF
-                || astType == TokenTypes.CLASS_DEF
-                || astType == TokenTypes.INTERFACE_DEF
-                || astType == TokenTypes.ENUM_DEF
-                || astType == TokenTypes.ANNOTATION_DEF;
+                || TokenUtil.isTypeDeclaration(astType);
         }
 
     };

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
@@ -70,10 +70,7 @@ public final class ScopeUtil {
              token != null;
              token = token.getParent()) {
             final int type = token.getType();
-            if (type == TokenTypes.CLASS_DEF
-                || type == TokenTypes.INTERFACE_DEF
-                || type == TokenTypes.ANNOTATION_DEF
-                || type == TokenTypes.ENUM_DEF) {
+            if (TokenUtil.isTypeDeclaration(type)) {
                 final DetailAST mods =
                     token.findFirstToken(TokenTypes.MODIFIERS);
                 final Scope modScope = getScopeFromMods(mods);
@@ -139,11 +136,7 @@ public final class ScopeUtil {
             if (type == tokenType) {
                 returnValue = true;
             }
-            else if (type == TokenTypes.CLASS_DEF
-                || type == TokenTypes.ENUM_DEF
-                || type == TokenTypes.INTERFACE_DEF
-                || type == TokenTypes.ANNOTATION_DEF
-                || type == TokenTypes.LITERAL_NEW) {
+            else if (type == TokenTypes.LITERAL_NEW || TokenUtil.isTypeDeclaration(type)) {
                 break;
             }
         }
@@ -230,10 +223,7 @@ public final class ScopeUtil {
         for (DetailAST parent = node.getParent();
              parent != null;
              parent = parent.getParent()) {
-            if (parent.getType() == TokenTypes.CLASS_DEF
-                || parent.getType() == TokenTypes.INTERFACE_DEF
-                || parent.getType() == TokenTypes.ANNOTATION_DEF
-                || parent.getType() == TokenTypes.ENUM_DEF) {
+            if (TokenUtil.isTypeDeclaration(parent.getType())) {
                 returnValue = false;
                 break;
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java
@@ -269,4 +269,19 @@ public final class TokenUtil {
         return ast1.getLineNo() == ast2.getLineNo();
     }
 
+    /**
+     * Is type declaration token type (CLASS_DEF, INTERFACE_DEF,
+     * ANNOTATION_DEF, ENUM_DEF, RECORD_DEF).
+     *
+     * @param type
+     *        token type.
+     * @return true if type is type declaration token type.
+     */
+    public static boolean isTypeDeclaration(int type) {
+        return type == TokenTypes.CLASS_DEF
+                || type == TokenTypes.INTERFACE_DEF
+                || type == TokenTypes.ANNOTATION_DEF
+                || type == TokenTypes.ENUM_DEF
+                || type == TokenTypes.RECORD_DEF;
+    }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
@@ -277,4 +277,18 @@ public class TokenUtilTest {
         assertEquals(secondSibling, firstChild, "Mismatched child node");
     }
 
+    @Test
+    public void testIsTypeDeclaration() {
+        assertTrue(TokenUtil.isTypeDeclaration(TokenTypes.CLASS_DEF),
+                "Should return true when valid type passed");
+        assertTrue(TokenUtil.isTypeDeclaration(TokenTypes.INTERFACE_DEF),
+                "Should return true when valid type passed");
+        assertTrue(TokenUtil.isTypeDeclaration(TokenTypes.ANNOTATION_DEF),
+                "Should return true when valid type passed");
+        assertTrue(TokenUtil.isTypeDeclaration(TokenTypes.ENUM_DEF),
+                "Should return true when valid type passed");
+        assertTrue(TokenUtil.isTypeDeclaration(TokenTypes.RECORD_DEF),
+                "Should return true when valid type passed");
+    }
+
 }


### PR DESCRIPTION
Issue #8345: Add TokenUtil.isTypeDeclaration method

~~Reviewers, I have added the records support commits to this so we can immediately add `TokenTypes.RECORD_DEF` to `TokenUtil.isTypeDeclaration()`.  I will rebase once we merge #8293.~~  The second commit is the refactoring of `ScopeUtil.java` to use `TokenUtil.isTypeDeclaration()`.