### PR TITLE
Issue #8306: Javadoc Modification for Metadata Generation Support - 5

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
@@ -45,6 +45,7 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * <li>
  * Property {@code onlyObjectReferences} - control whether only explicit
  * initializations made to null for objects should be checked.
+ * Type is {@code boolean}.
  * Default value is {@code false}.
  * </li>
  * </ul>
@@ -92,6 +93,17 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  *   }
  * }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code explicit.init}
+ * </li>
+ * </ul>
  *
  * @since 3.2
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -48,10 +48,12 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * Property {@code validateEnhancedForLoopVariable} - Control whether to check
  * <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-14.html#jls-14.14.2">
  * enhanced for-loop</a> variable.
+ * Type is {@code boolean}.
  * Default value is {@code false}.
  * </li>
  * <li>
  * Property {@code tokens} - tokens to check
+ * Type is {@code int[]}.
  * Default value is:
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
  * VARIABLE_DEF</a>.
@@ -121,6 +123,17 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  *   }
  * }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code final.variable}
+ * </li>
+ * </ul>
  *
  * @since 3.2
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheck.java
@@ -100,6 +100,17 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *   }
  * }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code assignment.inner.avoid}
+ * </li>
+ * </ul>
  *
  * @since 3.0
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheck.java
@@ -63,6 +63,17 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *    break;
  * }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code missing.switch.default}
+ * </li>
+ * </ul>
  *
  * @since 3.1
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterTypeMemberDeclarationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterTypeMemberDeclarationCheck.java
@@ -39,6 +39,7 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * <ul>
  * <li>
  * Property {@code tokens} - tokens to check
+ * Type is {@code int[]}.
  * Default value is:
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
  * CLASS_DEF</a>,
@@ -96,6 +97,17 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  *     }
  * }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code unnecessary.semicolon}
+ * </li>
+ * </ul>
  *
  * @since 8.24
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonInTryWithResourcesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonInTryWithResourcesCheck.java
@@ -33,6 +33,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <li>
  * Property {@code allowWhenNoBraceAfterSemicolon} -
  * Allow unnecessary semicolon if closing paren is not on the same line.
+ * Type is {@code boolean}.
  * Default value is {@code true}.
  * </li>
  * </ul>
@@ -80,6 +81,17 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *     }
  * }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code unnecessary.semicolon}
+ * </li>
+ * </ul>
  *
  * @since 8.22
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
@@ -55,10 +55,12 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
  * <ul>
  * <li>
  * Property {@code headerFile} - Specify the name of the file containing the required header.
+ * Type is {@code java.net.URI}.
  * Default value is {@code null}.
  * </li>
  * <li>
  * Property {@code charset} - Specify the character encoding to use when reading the headerFile.
+ * Type is {@code java.lang.String}.
  * Default value is the charset property of the parent
  * <a href="https://checkstyle.org/config.html#Checker">Checker</a> module.
  * </li>
@@ -66,14 +68,17 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
  * Property {@code header} - Specify the required header specified inline.
  * Individual header lines must be separated by the string {@code "\n"}
  * (even on platforms with a different line separator), see examples below.
+ * Type is {@code java.lang.String}.
  * Default value is {@code null}.
  * </li>
  * <li>
  * Property {@code ignoreLines} - Specify the line numbers to ignore.
+ * Type is {@code int[]}.
  * Default value is {@code {}}.
  * </li>
  * <li>
  * Property {@code fileExtensions} - Specify the file type extension of files to process.
+ * Type is {@code java.lang.String[]}.
  * Default value is {@code all files}.
  * </li>
  * </ul>
@@ -111,6 +116,20 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
  *     value="// Copyright (C) 2004 MyCompany\n// All rights reserved"/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.Checker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code header.mismatch}
+ * </li>
+ * <li>
+ * {@code header.missing}
+ * </li>
+ * </ul>
  *
  * @since 6.9
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
@@ -98,10 +98,12 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <ul>
  * <li>
  * Property {@code headerFile} - Specify the name of the file containing the required header.
+ * Type is {@code java.net.URI}.
  * Default value is {@code null}.
  * </li>
  * <li>
  * Property {@code charset} - Specify the character encoding to use when reading the headerFile.
+ * Type is {@code java.lang.String}.
  * Default value is the charset property of the parent
  * <a href="https://checkstyle.org/config.html#Checker">Checker</a> module.
  * </li>
@@ -112,14 +114,17 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * For header lines containing {@code "\n\n"} checkstyle will
  * forcefully expect an empty line to exist. See examples below.
  * Regular expressions must not span multiple lines.
+ * Type is {@code java.lang.String}.
  * Default value is {@code null}.
  * </li>
  * <li>
  * Property {@code multiLines} - Specify the line numbers to repeat (zero or more times).
+ * Type is {@code int[]}.
  * Default value is {@code {}}.
  * </li>
  * <li>
  * Property {@code fileExtensions} - Specify the file type extension of files to process.
+ * Type is {@code java.lang.String[]}.
  * Default value is {@code all files}.
  * </li>
  * </ul>
@@ -188,6 +193,20 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <u>Note</u>: {@code ignoreLines} property has been removed from this check to simplify it.
  * To make some line optional use "^.*$" regexp for this line.
  * </p>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.Checker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code header.mismatch}
+ * </li>
+ * <li>
+ * {@code header.missing}
+ * </li>
+ * </ul>
  *
  * @since 6.9
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
@@ -34,10 +34,12 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <ul>
  * <li>
  * Property {@code max} - Specify the maximum threshold allowed.
+ * Type is {@code int}.
  * Default value is {@code 30}.
  * </li>
  * <li>
  * Property {@code tokens} - tokens to check
+ * Type is {@code int[]}.
  * Default value is:
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
  * CTOR_DEF</a>,
@@ -64,6 +66,17 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *   &lt;property name="tokens" value="CTOR_DEF,METHOD_DEF"/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code executableStatementCount}
+ * </li>
+ * </ul>
  *
  * @since 3.2
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheck.java
@@ -38,15 +38,19 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <ul>
  * <li>
  * Property {@code max} - Specify the maximum number of lines allowed.
+ * Type is {@code int}.
  * Default value is {@code 150}.
  * </li>
  * <li>
  * Property {@code countEmpty} - Control whether to count empty lines and single
  * line comments of the form {@code //}.
+ * Type is {@code boolean}.
  * Default value is {@code true}.
  * </li>
  * <li>
- * Property {@code tokens} - tokens to check Default value is:
+ * Property {@code tokens} - tokens to check
+ * Type is {@code int[]}.
+ * Default value is:
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
  * METHOD_DEF</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
@@ -79,6 +83,17 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *   &lt;property name="countEmpty" value="false"/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code maxLen.method}
+ * </li>
+ * </ul>
  *
  * @since 3.0
  */

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -120,7 +120,17 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
                 "LineLength",
                 "OuterTypeNumber",
                 "FileLength",
-                "MethodCount"
+                "MethodCount",
+                "ExecutableStatementCount",
+                "MethodLength",
+                "RegexpHeader",
+                "Header",
+                "ExplicitInitialization",
+                "InnerAssignment",
+                "UnnecessarySemicolonAfterTypeMemberDeclaration",
+                "UnnecessarySemicolonInTryWithResources",
+                "FinalLocalVariable",
+                "MissingSwitchDefault"
         )));
 
     private static final Map<String, Class<?>> FULLY_QUALIFIED_CLASS_NAMES =
@@ -150,7 +160,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
             .put("Scope", Scope.class)
             .put("SeverityLevel", SeverityLevel.class)
             .put("TrailingArrayCommaOption", AnnotationUseStyleCheck.TrailingArrayCommaOption.class)
-            .put("Uri", URI.class)
+            .put("URI", URI.class)
             .put("WrapOption", WrapOption.class).build();
 
     private static final List<List<Node>> CHECK_PROPERTIES = new ArrayList<>();

--- a/src/xdocs/config_header.xml
+++ b/src/xdocs/config_header.xml
@@ -76,7 +76,7 @@ line 5: ////////////////////////////////////////////////////////////////////
             <tr>
               <td>headerFile</td>
               <td>Specify the name of the file containing the required header.</td>
-              <td><a href="property_types.html#Uri">URI</a></td>
+              <td><a href="property_types.html#URI">URI</a></td>
               <td><code>null</code></td>
               <td>3.2</td>
             </tr>
@@ -291,7 +291,7 @@ line 6: ^\W*$
             <tr>
               <td>headerFile</td>
               <td>Specify the name of the file containing the required header.</td>
-              <td><a href="property_types.html#Uri">URI</a></td>
+              <td><a href="property_types.html#URI">URI</a></td>
               <td><code>null</code></td>
               <td>3.2</td>
             </tr>

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -1060,7 +1060,7 @@ public class InputIllegalImport { }
                 It can be a regular file, URL or resource path. It will try loading
                 the path as a URL first, then as a file, and finally as a resource.
               </td>
-              <td><a href="property_types.html#Uri">URI</a></td>
+              <td><a href="property_types.html#URI">URI</a></td>
               <td><code>null</code></td>
               <td>4.0</td>
             </tr>

--- a/src/xdocs/property_types.xml
+++ b/src/xdocs/property_types.xml
@@ -380,7 +380,7 @@
 
     <section name="File">
       <p>
-        This type represents a local file. Unlike the <a href="#Uri">uri</a> type,
+        This type represents a local file. Unlike the <a href="#URI">uri</a> type,
         which implies read only and not modifiable access to the resource,
         a property of this type indicates files whose contents can be modified by Checkstyle.
       </p>
@@ -927,7 +927,7 @@
       </div>
     </section>
 
-    <section name="Uri">
+    <section name="URI">
       <p>
         This type represents a URI. The string representation is parsed using a custom
         routine to analyze what type of URI the string is.


### PR DESCRIPTION
#8306 

Modified Files:
                "ExecutableStatementCount",
                "MethodLength",
                "RegexpHeader",
                "Header",
                "ExplicitInitialization",
                "InnerAssignment",
                "UnnecessarySemicolonAfterTypeMemberDeclaration",
                "UnnecessarySemicolonInTryWithResources",
                "FinalLocalVariable",
                "MissingSwitchDefault"