### PR TITLE
Issue #8306: Javadoc Modification for Metadata Generation Support - 6

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidDoubleBraceInitializationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidDoubleBraceInitializationCheck.java
@@ -90,6 +90,17 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *     };
  * }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code avoid.double.brace.init}
+ * </li>
+ * </ul>
  *
  * @since 8.30
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/CovariantEqualsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/CovariantEqualsCheck.java
@@ -104,6 +104,17 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
  *   }
  * }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code covariant.equals}
+ * </li>
+ * </ul>
  *
  * @since 3.2
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -59,6 +59,7 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
  * <li>
  * Property {@code ignoreEqualsIgnoreCase} - Control whether to ignore
  * {@code String.equalsIgnoreCase(String)} invocations.
+ * Type is {@code boolean}.
  * Default value is {@code false}.
  * </li>
  * </ul>
@@ -68,6 +69,20 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
  * <pre>
  * &lt;module name=&quot;EqualsAvoidNull&quot;/&gt;
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code equals.avoid.null}
+ * </li>
+ * <li>
+ * {@code equalsIgnoreCase.avoid.null}
+ * </li>
+ * </ul>
  *
  * @since 5.0
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -76,28 +76,34 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * <li>
  * Property {@code ignoreFormat} - Define the RegExp for names of variables
  * and parameters to ignore.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code null}.
  * </li>
  * <li>
  * Property {@code ignoreConstructorParameter} - Control whether to ignore constructor parameters.
+ * Type is {@code boolean}.
  * Default value is {@code false}.
  * </li>
  * <li>
  * Property {@code ignoreSetter} - Allow to ignore the parameter of a property setter method.
+ * Type is {@code boolean}.
  * Default value is {@code false}.
  * </li>
  * <li>
  * Property {@code setterCanReturnItsClass} - Allow to expand the definition of a setter method
  * to include methods that return the class' instance.
+ * Type is {@code boolean}.
  * Default value is {@code false}.
  * </li>
  * <li>
  * Property {@code ignoreAbstractMethods} - Control whether to ignore parameters
  * of abstract methods.
+ * Type is {@code boolean}.
  * Default value is {@code false}.
  * </li>
  * <li>
  * Property {@code tokens} - tokens to check
+ * Type is {@code int[]}.
  * Default value is:
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
  * VARIABLE_DEF</a>,
@@ -174,6 +180,17 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  *   &lt;property name=&quot;setterCanReturnItsClass&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code hidden.field}
+ * </li>
+ * </ul>
  *
  * @since 3.0
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -57,10 +57,12 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <ul>
  * <li>
  * Property {@code classes} - Specify fully qualified class names that should not be instantiated.
+ * Type is {@code java.lang.String[]}.
  * Default value is {@code {}}.
  * </li>
  * <li>
  * Property {@code tokens} - tokens to check
+ * Type is {@code int[]}.
  * Default value is:
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
  * CLASS_DEF</a>.
@@ -74,6 +76,17 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *   &lt;property name=&quot;classes&quot; value=&quot;java.lang.Boolean&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code instantiation.avoid}
+ * </li>
+ * </ul>
  *
  * @since 3.0
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
@@ -44,16 +44,19 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <li>
  * Property {@code allowedDuplicates} - Specify the maximum number of occurrences
  * to allow without generating a warning.
+ * Type is {@code int}.
  * Default value is {@code 1}.
  * </li>
  * <li>
  * Property {@code ignoreStringsRegexp} - Specify RegExp for ignored strings (with quotation marks).
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code "^""$"}.
  * </li>
  * <li>
  * Property {@code ignoreOccurrenceContext} - Specify token type names where duplicate
  * strings are ignored even if they don't match ignoredStringsRegexp. This allows you to
  * exclude syntactical contexts like annotations or static initializers from the check.
+ * Type is {@code int[]}.
  * Default value is {@code ANNOTATION}.
  * </li>
  * </ul>
@@ -89,6 +92,17 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *   &lt;property name=&quot;ignoreOccurrenceContext&quot; value=&quot;&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code multiple.string.literal}
+ * </li>
+ * </ul>
  *
  * @since 3.5
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleVariableDeclarationsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleVariableDeclarationsCheck.java
@@ -43,6 +43,20 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <pre>
  * &lt;module name="MultipleVariableDeclarations"/&gt;
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code multiple.variable.declarations}
+ * </li>
+ * <li>
+ * {@code multiple.variable.declarations.comma}
+ * </li>
+ * </ul>
  *
  * @since 3.4
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoCloneCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoCloneCheck.java
@@ -147,6 +147,17 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *
  * }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code avoid.clone.method}
+ * </li>
+ * </ul>
  *
  * @since 5.0
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java
@@ -53,19 +53,24 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <li>
  * Property {@code max} - Specify maximum allowed number of return statements
  * in non-void methods/lambdas.
+ * Type is {@code int}.
  * Default value is {@code 2}.
  * </li>
  * <li>
  * Property {@code maxForVoid} - Specify maximum allowed number of return statements
  * in void methods/constructors/lambdas.
+ * Type is {@code int}.
  * Default value is {@code 1}.
  * </li>
  * <li>
  * Property {@code format} - Specify method names to ignore.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code "^equals$"}.
  * </li>
  * <li>
- * Property {@code tokens} - tokens to check Default value is:
+ * Property {@code tokens} - tokens to check
+ * Type is {@code int[]}.
+ * Default value is:
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
  * CTOR_DEF</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
@@ -130,6 +135,20 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *   &lt;property name=&quot;tokens&quot; value=&quot;METHOD_DEF&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code return.count}
+ * </li>
+ * <li>
+ * {@code return.countVoid}
+ * </li>
+ * </ul>
  *
  * @since 3.2
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
@@ -52,6 +52,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <ul>
  * <li>
  * Property {@code tokens} - tokens to check
+ * Type is {@code int[]}.
  * Default value is:
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EXPR">
  * EXPR</a>,
@@ -126,6 +127,35 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *   .filter((s) -&gt; s.startsWith(&quot;c&quot;)) //violation
  *   .forEach(System.out::println);
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code unnecessary.paren.assign}
+ * </li>
+ * <li>
+ * {@code unnecessary.paren.expr}
+ * </li>
+ * <li>
+ * {@code unnecessary.paren.ident}
+ * </li>
+ * <li>
+ * {@code unnecessary.paren.lambda}
+ * </li>
+ * <li>
+ * {@code unnecessary.paren.literal}
+ * </li>
+ * <li>
+ * {@code unnecessary.paren.return}
+ * </li>
+ * <li>
+ * {@code unnecessary.paren.string}
+ * </li>
+ * </ul>
  *
  * @since 3.4
  */

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -130,7 +130,17 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
                 "UnnecessarySemicolonAfterTypeMemberDeclaration",
                 "UnnecessarySemicolonInTryWithResources",
                 "FinalLocalVariable",
-                "MissingSwitchDefault"
+                "MissingSwitchDefault",
+                "UnnecessaryParentheses",
+                "MultipleStringLiterals",
+                "MultipleVariableDeclarations",
+                "AvoidDoubleBraceInitialization",
+                "ReturnCount",
+                "CovariantEquals",
+                "EqualsAvoidNull",
+                "HiddenField",
+                "NoClone",
+                "IllegalInstantiation"
         )));
 
     private static final Map<String, Class<?>> FULLY_QUALIFIED_CLASS_NAMES =


### PR DESCRIPTION
#8306 

Modifield Files:
	                "UnnecessaryParentheses",
                "MultipleStringLiterals",
                "MultipleVariableDeclarations",
                "AvoidDoubleBraceInitialization",
                "ReturnCount",
                "CovariantEquals",
                "EqualsAvoidNull",
                "HiddenField",
                "NoClone",
                "IllegalInstantiation"