### PR TITLE
Issue #8306: Javadoc Modification for Metadata Generation Support - 9

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
@@ -74,10 +74,12 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * <ul>
  * <li>
  * Property {@code ignoreConstructors} - control whether to ignore constructors.
+ * Type is {@code boolean}.
  * Default value is {@code false}.
  * </li>
  * <li>
  * Property {@code ignoreModifiers} - control whether to ignore modifiers (fields, ...).
+ * Type is {@code boolean}.
  * Default value is {@code false}.
  * </li>
  * </ul>
@@ -119,6 +121,26 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  *   int b; &lt;-- &quot;Instance variable definition in wrong order&quot;
  * }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code declaration.order.access}
+ * </li>
+ * <li>
+ * {@code declaration.order.constructor}
+ * </li>
+ * <li>
+ * {@code declaration.order.instance}
+ * </li>
+ * <li>
+ * {@code declaration.order.static}
+ * </li>
+ * </ul>
  *
  * @since 3.2
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsHashCodeCheck.java
@@ -103,6 +103,20 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
  *     }
  * }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code equals.noEquals}
+ * </li>
+ * <li>
+ * {@code equals.noHashCode}
+ * </li>
+ * </ul>
  *
  * @since 3.0
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
@@ -88,11 +88,13 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <ul>
  * <li>
  * Property {@code checkLastCaseGroup} - Control whether the last case group must be checked.
+ * Type is {@code boolean}.
  * Default value is {@code false}.
  * </li>
  * <li>
  * Property {@code reliefPattern} - Define the RegExp to match the relief comment that suppresses
  * the warning about a fall through.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code "falls?[ -]?thr(u|ough)"}.
  * </li>
  * </ul>
@@ -110,6 +112,20 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *   &lt;property name=&quot;reliefPattern&quot; value=&quot;continue in next case&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code fall.through}
+ * </li>
+ * <li>
+ * {@code fall.through.last}
+ * </li>
+ * </ul>
  *
  * @since 3.4
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -80,36 +80,43 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <ul>
  * <li>
  * Property {@code validateAbstractClassNames} - Control whether to validate abstract class names.
+ * Type is {@code boolean}.
  * Default value is {@code false}.
  * </li>
  * <li>
  * Property {@code illegalClassNames} - Specify classes that should not be used
  * as types in variable declarations, return values or parameters.
+ * Type is {@code java.lang.String[]}.
  * Default value is {@code HashMap, HashSet, LinkedHashMap, LinkedHashSet, TreeMap,
  * TreeSet, java.util.HashMap, java.util.HashSet, java.util.LinkedHashMap,
  * java.util.LinkedHashSet, java.util.TreeMap, java.util.TreeSet}.
  * </li>
  * <li>
  * Property {@code legalAbstractClassNames} - Define abstract classes that may be used as types.
+ * Type is {@code java.lang.String[]}.
  * Default value is {@code {}}.
  * </li>
  * <li>
  * Property {@code ignoredMethodNames} - Specify methods that should not be checked.
+ * Type is {@code java.lang.String[]}.
  * Default value is {@code getEnvironment, getInitialContext}.
  * </li>
  * <li>
  * Property {@code illegalAbstractClassNameFormat} - Specify RegExp for illegal abstract class
  * names.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code "^(.*[.])?Abstract.*$"}.
  * </li>
  * <li>
  * Property {@code memberModifiers} - Control whether to check only methods and fields with any
  * of the specified modifiers.
  * This property does not affect method calls nor method references.
+ * Type is {@code int[]}.
  * Default value is no tokens.
  * </li>
  * <li>
  * Property {@code tokens} - tokens to check
+ * Type is {@code int[]}.
  * Default value is:
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
  * ANNOTATION_FIELD_DEF</a>,
@@ -272,6 +279,17 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *
  * }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code illegal.type}
+ * </li>
+ * </ul>
  *
  * @since 3.2
  *

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
@@ -62,6 +62,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Property {@code skipEnhancedForLoopVariable} - Control whether to check
  * <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-14.html#jls-14.14.2">
  * enhanced for-loop</a> variable.
+ * Type is {@code boolean}.
  * Default value is {@code false}.
  * </li>
  * </ul>
@@ -95,6 +96,17 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *   line = line.trim();   // it will skip this violation
  * }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code modified.control.variable}
+ * </li>
+ * </ul>
  *
  * @since 3.5
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedIfDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedIfDepthCheck.java
@@ -32,6 +32,7 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
  * <ul>
  * <li>
  * Property {@code max} - Specify maximum allowed nesting depth.
+ * Type is {@code int}.
  * Default value is {@code 1}.
  * </li>
  * </ul>
@@ -49,6 +50,17 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
  *   &lt;property name=&quot;max&quot; value=&quot;3&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code nested.if.depth}
+ * </li>
+ * </ul>
  *
  * @since 3.2
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheck.java
@@ -100,6 +100,17 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *
  * }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code simplify.boolReturn}
+ * </li>
+ * </ul>
  *
  * @since 3.0
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
@@ -70,6 +70,17 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * if (name == getName()) {}
  * // OK, limitation that check cannot tell runtime type returned from method call
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code string.literal.equality}
+ * </li>
+ * </ul>
  *
  * @since 3.2
  * @noinspection HtmlTagCanBeJavadocTag

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperCloneCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SuperCloneCheck.java
@@ -63,6 +63,17 @@ import com.puppycrawl.tools.checkstyle.StatelessCheck;
  *  }
  * }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code missing.super.call}
+ * </li>
+ * </ul>
  *
  * @since 3.2
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterOuterTypeDeclarationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterOuterTypeDeclarationCheck.java
@@ -39,6 +39,7 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * <ul>
  * <li>
  * Property {@code tokens} - tokens to check
+ * Type is {@code int[]}.
  * Default value is:
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
  * CLASS_DEF</a>,
@@ -104,6 +105,17 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  *
  * }; // OK
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code unnecessary.semicolon}
+ * </li>
+ * </ul>
  *
  * @since 8.31
  */

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -170,7 +170,17 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
                 "IllegalThrows",
                 "NoFinalizer",
                 "VariableDeclarationUsageDistance",
-                "PackageDeclaration"
+                "PackageDeclaration",
+                "ModifiedControlVariable",
+                "FallThrough",
+                "SuperClone",
+                "EqualsHashCode",
+                "StringLiteralEquality",
+                "NestedIfDepth",
+                "UnnecessarySemicolonAfterOuterTypeDeclaration",
+                "IllegalType",
+                "SimplifyBooleanReturn",
+                "DeclarationOrder"
         )));
 
     private static final Map<String, Class<?>> FULLY_QUALIFIED_CLASS_NAMES =


### PR DESCRIPTION
#8306 

Modified Files:
	                "ModifiedControlVariable",
                "FallThrough",
                "SuperClone",
                "EqualsHashCode",
                "StringLiteralEquality",
                "NestedIfDepth",
                "UnnecessarySemicolonAfterOuterTypeDeclaration",
                "IllegalType",
                "SimplifyBooleanReturn",
                "DeclarationOrder"