### PR TITLE
Issue #8306: Javadoc Modification for Metadata Generation Support - 10

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheck.java
@@ -93,6 +93,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <li>
  * Property {@code alwaysDemandTrailingComma} - Control whether to always check for a trailing
  * comma, even when an array is inline.
+ * Type is {@code boolean}.
  * Default value is {@code false}.
  * </li>
  * </ul>
@@ -179,6 +180,17 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *   2
  *   ,}; // OK
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code array.trailing.comma}
+ * </li>
+ * </ul>
  *
  * @since 3.2
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidNoArgumentSuperConstructorCallCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidNoArgumentSuperConstructorCallCheck.java
@@ -56,6 +56,17 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *     }
  * }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code super.constructor.call}
+ * </li>
+ * </ul>
  *
  * @since 8.29
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
@@ -46,6 +46,7 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
  * <ul>
  * <li>
  * Property {@code illegalClassNames} - Specify exception class names to reject.
+ * Type is {@code java.lang.String[]}.
  * Default value is {@code Error, Exception, RuntimeException, Throwable, java.lang.Error,
  * java.lang.Exception, java.lang.RuntimeException, java.lang.Throwable}.
  * </li>
@@ -129,6 +130,17 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
  *
  * }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code illegal.catch}
+ * </li>
+ * </ul>
  *
  * @since 3.2
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoArrayTrailingCommaCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoArrayTrailingCommaCheck.java
@@ -67,6 +67,17 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * };
  * String[] foo4 = { "FOO", "BAR" }; // OK
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code no.array.trailing.comma}
+ * </li>
+ * </ul>
  *
  * @since 8.28
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoEnumTrailingCommaCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoEnumTrailingCommaCheck.java
@@ -88,6 +88,17 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * enum Foo9 { FOO, BAR; } // OK
  * enum Foo10 { FOO, BAR } // OK
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code no.enum.trailing.comma}
+ * </li>
+ * </ul>
  *
  * @since 8.29
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
@@ -45,16 +45,19 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <ul>
  * <li>
  * Property {@code excludes} - Specify packages where star imports are allowed.
+ * Type is {@code java.lang.String[]}.
  * Default value is {@code {}}.
  * </li>
  * <li>
  * Property {@code allowClassImports} - Control whether to allow starred class
  * imports like {@code import java.util.*;}.
+ * Type is {@code boolean}.
  * Default value is {@code false}.
  * </li>
  * <li>
  * Property {@code allowStaticMemberImports} - Control whether to allow starred
  * static member imports like {@code import static org.junit.Assert.*;}.
+ * Type is {@code boolean}.
  * Default value is {@code false}.
  * </li>
  * </ul>
@@ -122,6 +125,17 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * import java.util.*;               // violation
  * import java.net.*;                // violation
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code import.avoidStar}
+ * </li>
+ * </ul>
  *
  * @since 3.0
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
@@ -51,6 +51,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * a star notation to be excluded such as {@code java.lang.Math.*} or specific
  * static members to be excluded like {@code java.lang.System.out} for a variable
  * or {@code java.lang.Math.random} for a method. See notes section for details.
+ * Type is {@code java.lang.String[]}.
  * Default value is {@code {}}.
  * </li>
  * </ul>
@@ -69,6 +70,17 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *   &lt;property name="excludes" value="java.lang.System.out,java.lang.Math.*"/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code import.avoidStatic}
+ * </li>
+ * </ul>
  *
  * @since 5.0
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -136,28 +136,35 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <ul>
  * <li>
  * Property {@code customImportOrderRules} - Specify format of order declaration
- * customizing by user. Default value is {@code ""}.
+ * customizing by user.
+ * Type is {@code java.lang.String}.
+ * Default value is {@code ""}.
  * </li>
  * <li>
  * Property {@code standardPackageRegExp} - Specify RegExp for STANDARD_JAVA_PACKAGE group imports.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code "^(java|javax)\."}.
  * </li>
  * <li>
  * Property {@code thirdPartyPackageRegExp} - Specify RegExp for THIRD_PARTY_PACKAGE group imports.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code ".*"}.
  * </li>
  * <li>
  * Property {@code specialImportsRegExp} - Specify RegExp for SPECIAL_IMPORTS group imports.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code "^$" (empty)}.
  * </li>
  * <li>
  * Property {@code separateLineBetweenGroups} - Force empty line separator between
  * import groups.
+ * Type is {@code boolean}.
  * Default value is {@code true}.
  * </li>
  * <li>
  * Property {@code sortImportsInGroupAlphabetically} - Force grouping alphabetically,
  * in <a href="https://en.wikipedia.org/wiki/ASCII#Order">ASCII sort order</a>.
+ * Type is {@code boolean}.
  * Default value is {@code false}.
  * </li>
  * </ul>
@@ -347,6 +354,32 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *   &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;^android\.&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code custom.import.order}
+ * </li>
+ * <li>
+ * {@code custom.import.order.lex}
+ * </li>
+ * <li>
+ * {@code custom.import.order.line.separator}
+ * </li>
+ * <li>
+ * {@code custom.import.order.nonGroup.expected}
+ * </li>
+ * <li>
+ * {@code custom.import.order.nonGroup.import}
+ * </li>
+ * <li>
+ * {@code custom.import.order.separated.internally}
+ * </li>
+ * </ul>
  *
  * @since 5.8
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
@@ -109,12 +109,14 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Property {@code file} - Specify the location of the file containing the
  * import control configuration. It can be a regular file, URL or resource path.
  * It will try loading the path as a URL first, then as a file, and finally as a resource.
+ * Type is {@code java.net.URI}.
  * Default value is {@code null}.
  * </li>
  * <li>
  * Property {@code path} - Specify the regular expression of file paths to which
  * this check should apply. Files that don't match the pattern will not be checked.
  * The pattern will be matched against the full absolute file path.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code ".*"}.
  * </li>
  * </ul>
@@ -424,6 +426,23 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *   &lt;allow class="java.util.Map.*" regex="true" /&gt;
  * &lt;/import-control&gt;
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code import.control.disallowed}
+ * </li>
+ * <li>
+ * {@code import.control.missing.file}
+ * </li>
+ * <li>
+ * {@code import.control.unknown.pkg}
+ * </li>
+ * </ul>
  *
  * @since 4.0
  */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -64,6 +64,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <li>
  * Property {@code option} - specify policy on the relative order between type imports and static
  * imports.
+ * Type is {@code com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderOption}.
  * Default value is {@code under}.
  * </li>
  * <li>
@@ -72,18 +73,21 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * (e.g. {@code /regexp/}). All type imports, which does not match any group, falls into an
  * additional group, located at the end.
  * Thus, the empty list of type groups (the default value) means one group for all type imports.
+ * Type is {@code java.lang.String[]}.
  * Default value is {@code {}}.
  * </li>
  * <li>
  * Property {@code ordered} - control whether type imports within each group should be
  * sorted.
  * It doesn't affect sorting for static imports.
+ * Type is {@code boolean}.
  * Default value is true.
  * </li>
  * <li>
  * Property {@code separated} - control whether type import groups should be separated
  * by, at least, one blank line or comment and aren't separated internally.
  * It doesn't affect separations for static imports.
+ * Type is {@code boolean}.
  * Default value is false.
  * </li>
  * <li>
@@ -91,6 +95,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * be separated by, at least, one blank line or comment and aren't separated internally.
  * This property has effect only when the property {@code option} is is set to {@code top}
  * or {@code bottom}.
+ * Type is {@code boolean}.
  * Default value is false.
  * </li>
  * <li>
@@ -98,6 +103,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * sensitive or not. Case sensitive sorting is in
  * <a href="https://en.wikipedia.org/wiki/ASCII#Order">ASCII sort order</a>.
  * It affects both type imports and static imports.
+ * Type is {@code boolean}.
  * Default value is true.
  * </li>
  * <li>
@@ -107,20 +113,24 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * an additional group, located at the end. Thus, the empty list of static groups (the default
  * value) means one group for all static imports. This property has effect only when the property
  * {@code option} is set to {@code top} or {@code bottom}.
+ * Type is {@code java.lang.String[]}.
  * Default value is {@code {}}.
  * </li>
  * <li>
  * Property {@code sortStaticImportsAlphabetically} - control whether
  * <b>static imports</b> located at <b>top</b> or <b>bottom</b> are sorted within the group.
+ * Type is {@code boolean}.
  * Default value is false.
  * </li>
  * <li>
  * Property {@code useContainerOrderingForStatic} - control whether to use container
  * ordering (Eclipse IDE term) for static imports or not.
+ * Type is {@code boolean}.
  * Default value is false.
  * </li>
  * <li>
  * Property {@code tokens} - tokens to check
+ * Type is {@code int[]}.
  * Default value is:
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_IMPORT">
  * STATIC_IMPORT</a>.
@@ -366,6 +376,23 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *
  * public class InputEclipseStaticImportsOrder { }
  * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code import.groups.separated.internally}
+ * </li>
+ * <li>
+ * {@code import.ordering}
+ * </li>
+ * <li>
+ * {@code import.separation}
+ * </li>
+ * </ul>
  *
  * @since 3.2
  */

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -180,7 +180,17 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
                 "UnnecessarySemicolonAfterOuterTypeDeclaration",
                 "IllegalType",
                 "SimplifyBooleanReturn",
-                "DeclarationOrder"
+                "DeclarationOrder",
+                "ArrayTrailingComma",
+                "NoEnumTrailingComma",
+                "IllegalCatch",
+                "AvoidNoArgumentSuperConstructorCall",
+                "NoArrayTrailingComma",
+                "ImportOrder",
+                "CustomImportOrder",
+                "AvoidStaticImport",
+                "ImportControl",
+                "AvoidStarImport"
         )));
 
     private static final Map<String, Class<?>> FULLY_QUALIFIED_CLASS_NAMES =


### PR DESCRIPTION
#8306

Modified Files:
                "ArrayTrailingComma",
                "NoEnumTrailingComma",
                "IllegalCatch",
                "AvoidNoArgumentSuperConstructorCall",
                "NoArrayTrailingComma",
                "ImportOrder",
                "CustomImportOrder",
                "AvoidStaticImport",
                "ImportControl",
                "AvoidStarImport"