### PR TITLE
Issue #7498: add github actions file to generate diff report

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -28,6 +28,7 @@ Aleksey
 allchecks
 allclasses
 alot
+amazonaws
 ambig
 Amessages
 androidx
@@ -96,6 +97,7 @@ avoidnestedblocks
 avoidnoargumentsuperconstructorcall
 avoidstarimport
 avoidstaticimport
+aws
 awt
 backend
 backport
@@ -738,6 +740,7 @@ junitpioneer
 jvm
 jxr
 kailasam
+kate
 kazgroup
 kbd
 kclee
@@ -1064,6 +1067,7 @@ println
 priva
 programpractice
 Proguard
+proj
 propertycachefile
 propertyfile
 prot
@@ -1415,7 +1419,7 @@ woff
 wontfix
 wordpress
 workaround
-workflows
+workflow
 writetag
 writingchecks
 writingdoccomments

--- a/.github/workflows/diff_report.yml
+++ b/.github/workflows/diff_report.yml
@@ -1,0 +1,150 @@
+#------------------------------------------------------------------------------------
+# Github Action to generate Checkstyle report.
+# 
+# Workflow starts when:
+# 1) pull request  - opened, reopened, synchronized, edited
+# 2) issue comment - created
+#
+# Requirements:
+# 1) secrets.AWS_ACCESS_KEY_ID - access key for AWS S3 service user
+# 2) secrets.AWS_SECRET_ACCESS_KEY - security access key for AWS S3 service user
+#
+# If you need to change bucket name or region, change AWS_REGION and AWS_BUCKET_NAME variables.
+# For another bucket, you will need to change the secrets.
+#------------------------------------------------------------------------------------
+name: Diff-Report
+env:
+  AWS_REGION: us-east-2
+  AWS_BUCKET_NAME: "checkstyle-diff-reports"
+on: 
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+  issue_comment:
+    types: [created]
+
+jobs:
+# Parse PR Body, search pro, xml links
+  parse_body:
+    if: github.event_name == 'pull_request' || github.event.comment.body == 'report'
+    runs-on: ubuntu-latest
+    outputs:
+      proj_link: ${{ steps.parse.outputs.proj_link }}
+      config_link: ${{ steps.parse.outputs.config_link }}
+      user: ${{ steps.branch.outputs.user }}
+      branch: ${{ steps.branch.outputs.ref }}
+      
+    steps:
+    
+     - name: Issue comment action
+       if: github.event_name == 'issue_comment'
+       run: |
+        echo "${{github.event.issue.body}}" > text
+        echo "${{github.event.issue.user.login}}" > user
+        wget -q ${{github.event.issue.pull_request.url}} -O info.json
+        jq .head.ref info.json > branch
+       
+     - name: PR action
+       if: github.event_name == 'pull_request'
+       run: |
+        echo "${{github.event.pull_request.body}}" > text
+        echo ${{github.event.pull_request.user.login}} > user
+        echo ${{github.event.pull_request.head.ref}} > branch
+        
+     - name: Parse body
+       id: parse
+       run: |
+        grep "^Diff Regression projects:" text > temp || echo "" > temp
+        sed 's/Diff Regression projects: //' temp > proj
+        echo ::set-output name=proj_link::$(cat proj)
+        grep "^Diff Regression config:" text > temp || echo "" > temp
+        sed 's/Diff Regression config: //' temp > config
+        echo ::set-output name=config_link::$(cat config)
+        
+     - name: Set branch and head_label
+       id: branch
+       run: |
+        echo ::set-output name=user::$(cat user)
+        echo ::set-output name=ref::$(cat branch)
+      
+     - name: info
+       run: |
+        cat user
+        cat branch
+        echo ${{steps.branch.outputs.ref}}
+        echo ${{steps.branch.outputs.user}}:
+     
+  make_report:
+    runs-on: ubuntu-latest
+    needs: parse_body
+    if: needs.parse_body.outputs.proj_link != '' && needs.parse_body.outputs.config_link != ''
+    steps: 
+       
+     - name: Download files
+       run: |
+        wget -q ${{needs.parse_body.outputs.proj_link}} -O proj.properties
+        wget -q ${{needs.parse_body.outputs.config_link}} -O config.xml
+        
+     - name: Download checkstyle
+       uses: actions/checkout@v2
+       with:
+        repository: ${{needs.parse_body.outputs.user}}/checkstyle
+        ref: master
+        path: checkstyle
+        fetch-depth: 0
+        
+     - name: Check branches
+       run: |
+         cd checkstyle
+         git branch -r
+         cd ../
+     
+     - name: Download contribution
+       uses: actions/checkout@v2
+       with:
+        repository: checkstyle/contribution
+        path: contribution
+         
+     - name: Print branch
+       run: |
+         echo ${{needs.parse_body.outputs.branch}}
+         
+     - name: Relocate .xml and .properties 
+       run: |
+         mv config.xml ./contribution/checkstyle-tester/
+         mv proj.properties ./contribution/checkstyle-tester/
+         
+     - name: Generate report
+       run: |
+         bash
+         REF="origin/${{needs.parse_body.outputs.branch}}"
+         cd contribution/checkstyle-tester
+         sudo apt-get install mercurial
+         sudo apt install groovy
+         groovy diff.groovy -r ../../checkstyle -b master -p $REF -c config.xml -l proj.properties
+        
+     - name: Configure AWS Credentials
+       uses: aws-actions/configure-aws-credentials@v1
+       with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ env.AWS_REGION }}
+       
+     - name: Copy Report to AWS S3 Bucket
+       run: |
+        bash
+        TIME=`date +%Y%H%M%S`
+        FOLDER="${{needs.parse_body.outputs.branch}}_$TIME"
+        DIFF="./contribution/checkstyle-tester/reports/diff"
+        LINK="https://${{env.AWS_BUCKET_NAME}}.s3.${{env.AWS_REGION}}.amazonaws.com"
+        aws s3 cp $DIFF s3://${{env.AWS_BUCKET_NAME}}/$FOLDER/reports/diff/ --recursive
+        echo $LINK/$FOLDER/reports/diff/index.html > message
+        
+     - name: Set output
+       id: out
+       run: echo ::set-output name=message::$(cat message)   
+      
+     - name: Comment PR
+       uses:  kate2513/javascript-test-action@master 
+       with:
+        message: ${{steps.out.outputs.message}}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#7498
Adding .yml file, which generates diff report for every pull request.

Triggers on opening, reopening, editing and new commit of pull request and when someone write comment "report".
Also, the body of pull request should contain two lines:
Diff Regression projects: {{URI to file like projects-to-test-on.properties}}
Diff Regression config: {{URI to file like my_checks.xml}}

Result: new comment from github-actions bot with link on generated diff report

Requirements:
As it push reports to aws bucket you will need:
1) secrets.AWS_ACCESS_KEY_ID - access key for AWS S3 service user
2) secrets.AWS_SECRET_ACCESS_KEY - security access key for AWS S3 service user

3) secrets.GITHUB_TOKEN - to sent new comment by github-actions bot [built-in github token]
4) .yml file start working only when it is located on master branch, so you need to merge it to master.

An example of how it works I created on my second account: https://github.com/jack1515/checkstyle/pull/1
Example of pr with no links: https://github.com/jack1515/checkstyle/pull/3