### PR TITLE
Issue #8447: add ability to create single report

### DIFF
--- a/.github/workflows/diff_report.yml
+++ b/.github/workflows/diff_report.yml
@@ -22,7 +22,8 @@ on:
 jobs:
 # Parse PR Body, search for links to .properties and .xml files
   parse_body:
-    if: github.event.comment.body == 'report'
+    if: github.event.comment.body == 'diff report' ||
+        github.event.comment.body == 'single report'
     runs-on: ubuntu-latest
     outputs:
       project_link: ${{ steps.parse.outputs.project_link }}
@@ -89,19 +90,29 @@ jobs:
         ref: master
         path: contribution
 
-     - name: Relocate .xml and .properties 
+     - name: Prepare environment
        run: |
          mv config.xml ./contribution/checkstyle-tester/
          mv project.properties ./contribution/checkstyle-tester/
+         sudo apt install groovy
          
-     - name: Generate report
+     - name: Generate basic difference report
+       if: github.event.comment.body == 'diff report'
        run: |
+         cd contribution/checkstyle-tester
          bash
          REF="origin/${{needs.parse_body.outputs.branch}}"
          REPO="../../checkstyle"
-         cd contribution/checkstyle-tester
-         sudo apt install groovy
          groovy diff.groovy -r $REPO -b master -p $REF -c config.xml -l project.properties
+         
+     - name: Generate basic single report
+       if: github.event.comment.body == 'single report'
+       run: |
+         cd contribution/checkstyle-tester
+         bash
+         REF="origin/${{needs.parse_body.outputs.branch}}"
+         REPO="../../checkstyle"
+         groovy diff.groovy -r $REPO -p $REF -pc config.xml -l project.properties -m single
         
      - name: Configure AWS Credentials
        uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
Issue: #8447 
Update diff_report.yml file: added the ability to create report only for patch branch (for example, for new checks).

If issue comment is "diff report", then a basic difference report will be generated.
If issue comment is "single report", then a basic single report will be generated.

Example: https://github.com/OvchinnikovNV/checkstyle/pull/2