### PR TITLE
minor: move long travis job to execute it earlier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,13 @@ jobs:
         - SKIP_JOB_BY_FILES="false"
         - USE_MAVEN_REPO="true"
 
+    # No error testing - pmd
+    - jdk: openjdk11
+      env:
+        - DESC="no error test on pmd"
+        - USE_MAVEN_REPO="true"
+        - CMD="./.ci/travis/travis.sh no-error-pmd"
+
     # jacoco and codecov (openjdk8)
     - jdk: openjdk8
       env:
@@ -305,13 +312,6 @@ jobs:
     - env:
         - DESC="validate since javadoc tag if new module is created"
         - CMD="./.ci/travis/travis.sh check-since-version"
-
-    # No error testing - pmd
-    - jdk: openjdk11
-      env:
-          - DESC="no error test on pmd"
-          - USE_MAVEN_REPO="true"
-          - CMD="./.ci/travis/travis.sh no-error-pmd"
 
     # No violation testing - josm (ant task)
     - jdk: openjdk11


### PR DESCRIPTION
Travis is executing jobs from top to bottom.
The "no error test on pmd" job is taking a long time to execute (e.g. [here](https://travis-ci.org/github/checkstyle/checkstyle/builds/709174867) it is 16 minutes, two times slower than second longest job) and it is in the bottom of the job list, so it is often left as last job to finish travis build for PR.
By moving it up, it will help to get travis status for PR quicker.