### PR TITLE
Issue #8544: format xml sources (xdocs non-checks)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1357,7 +1357,9 @@
               <!-- till https://github.com/checkstyle/checkstyle/issues/8544 -->
               <excludes>
                 <exclude>.ci/travis/decoration-1.0.0.xsd</exclude>
-                <exclude>src/xdocs/*</exclude>
+                <exclude>src/xdocs/config_*</exclude>
+                <!-- Requires <b>{</b> indented more than the enclosing <pre> tag. -->
+                <exclude>src/xdocs/property_types.xml</exclude>
                 <exclude>src/main/resources/*</exclude>
                 <exclude>config/default_sonar_profile.xml</exclude>
                 <exclude>config/intellij-idea-inspection-scope.xml</exclude>

--- a/src/xdocs/beginning_development.xml
+++ b/src/xdocs/beginning_development.xml
@@ -134,8 +134,8 @@
         </source>
       </div>
       <p>
-           10) Only after all content is finished and testing is done - send a
-          <a href="https://help.github.com/articles/using-pull-requests/">Pull Request</a>
+         10) Only after all content is finished and testing is done - send a
+        <a href="https://help.github.com/articles/using-pull-requests/">Pull Request</a>
       </p>
     </section>
   </body>

--- a/src/xdocs/checks.xml
+++ b/src/xdocs/checks.xml
@@ -17,21 +17,21 @@
 
   <body>
     <section name="Standard Checks">
-    <p>
-      The Standard Checkstyle Checks are applicable to general Java coding style
-      and require no external libraries. The standard checks are included in
-      the base distribution.
-    </p>
+      <p>
+        The Standard Checkstyle Checks are applicable to general Java coding style
+        and require no external libraries. The standard checks are included in
+        the base distribution.
+      </p>
 
-    <p>
-      The site navigation menu lets you browse the individual checks by functionality.
-    </p>
+      <p>
+        The site navigation menu lets you browse the individual checks by functionality.
+      </p>
 
-    <p>
-      Checkstyle provides many checks that you can apply to your
-      source code. Below is an alphabetical reference, the site
-      navigation menu provides a reference organized by functionality.
-    </p>
+      <p>
+        Checkstyle provides many checks that you can apply to your
+        source code. Below is an alphabetical reference, the site
+        navigation menu provides a reference organized by functionality.
+      </p>
       <div class="wrapper">
         <table>
           <tr>
@@ -355,7 +355,8 @@
             <td><a href="config_coding.html#InnerAssignment">InnerAssignment</a></td>
             <td>
               Checks for assignments in subexpressions, such as in
-            <code>String s = Integer.toString(i = 2);</code>.</td>
+              <code>String s = Integer.toString(i = 2);</code>.
+            </td>
           </tr>
           <tr>
             <td><a href="config_design.html#InnerTypeLast">InnerTypeLast</a></td>
@@ -408,7 +409,8 @@
           </tr>
           <tr>
             <td>
-              <a href="config_javadoc.html#JavadocMissingWhitespaceAfterAsterisk">JavadocMissingWhitespaceAfterAsterisk</a></td>
+              <a href="config_javadoc.html#JavadocMissingWhitespaceAfterAsterisk">JavadocMissingWhitespaceAfterAsterisk</a>
+            </td>
             <td>Checks that there is at least one whitespace after the leading asterisk.</td>
           </tr>
           <tr>
@@ -813,9 +815,12 @@
               conform to a specified pattern.</td>
           </tr>
           <tr>
-            <td><a href="config_coding.html#StringLiteralEquality">StringLiteralEquality</a></td>
+            <td>
+              <a href="config_coding.html#StringLiteralEquality">StringLiteralEquality</a>
+            </td>
             <td>Checks that string literals are not used with
-            <code>==</code> or <code>&#33;=</code>.</td>
+              <code>==</code> or <code>&#33;=</code>.
+            </td>
           </tr>
           <tr>
             <td><a href="config_javadoc.html#SummaryJavadoc">SummaryJavadoc</a></td>
@@ -948,10 +953,10 @@
     </section>
 
     <section name="Holder Checks">
-    <p>
-      These checks aren't normal checks and are usually associated with a specialized filter
-      to gather information the filter can't get on it's own.
-    </p>
+      <p>
+        These checks aren't normal checks and are usually associated with a specialized filter
+        to gather information the filter can't get on it's own.
+      </p>
 
       <div class="wrapper">
         <table>

--- a/src/xdocs/cmdline.xml.vm
+++ b/src/xdocs/cmdline.xml.vm
@@ -35,7 +35,7 @@
     <section name="Command line usage">
       <p>
 
-      <source>
+        <source>
 java -D&lt;property&gt;=&lt;value&gt;  \
      com.puppycrawl.tools.checkstyle.Main \
      -c &lt;configurationFile&gt; \
@@ -45,7 +45,7 @@ java -D&lt;property&gt;=&lt;value&gt;  \
      [-V | --version] [-b | --branch-matching-xpath &lt;xpathQuery&gt;] [-h | --help] \
      [-e | --exclude &lt;excludedPath&gt;] [-E | --executeIgnoredModules] [-d | --debug] \
      [-x | --exclude-regexp &lt;excludedPathPattern&gt;] \ file...
-      </source>
+        </source>
       </p>
 
       <p>
@@ -175,12 +175,11 @@ java -D&lt;property&gt;=&lt;value&gt;  \
 
     <section name="Download and Run">
       <p>
-          It is possible to run Checkstyle directly from the JAR file using
-          the <code>-jar</code> option. Download latest
-          <a href=
-            "https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${projectVersion}/checkstyle-${projectVersion}-all.jar">
-          checkstyle-${projectVersion}-all.jar</a>.
-          An example of run would be:
+        It is possible to run Checkstyle directly from the JAR file using
+        the <code>-jar</code> option. Download latest
+        <a href="https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${projectVersion}/checkstyle-${projectVersion}-all.jar">
+        checkstyle-${projectVersion}-all.jar</a>.
+        An example of run would be:
       </p>
       <div class="wrap-content">
         <source>
@@ -199,13 +198,12 @@ java -D&lt;property&gt;=&lt;value&gt;  \
             google_checks.xml</a>
       </p>
       <p>
-          To run <a href="writingchecks.html#The_Checkstyle_SDK_Gui">Checkstyle UI viewer</a>
-          for AST tree directly from the JAR file using
-          the <code>-jar</code> option. Download latest
-          <a href=
-            "https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${projectVersion}/checkstyle-${projectVersion}-all.jar">
-          checkstyle-${projectVersion}-all.jar</a>.
-          An example of run would be (path to java file is optional):
+        To run <a href="writingchecks.html#The_Checkstyle_SDK_Gui">Checkstyle UI viewer</a>
+        for AST tree directly from the JAR file using
+        the <code>-jar</code> option. Download latest
+        <a href="https://github.com/checkstyle/checkstyle/releases/download/checkstyle-${projectVersion}/checkstyle-${projectVersion}-all.jar">
+        checkstyle-${projectVersion}-all.jar</a>.
+        An example of run would be (path to java file is optional):
       </p>
       <div class="wrap-content">
         <source>

--- a/src/xdocs/config.xml
+++ b/src/xdocs/config.xml
@@ -221,7 +221,7 @@
         the following configuration document element gives property
         <code>headerFile</code> the value of command line
         property <code>checkstyle.header.file</code>:
-     </p>
+      </p>
 
       <source>
 &lt;module name=&quot;Header&quot;&gt;
@@ -480,7 +480,7 @@
   ...
 &lt;/module&gt;
         </source>
-          <p>OR</p>
+        <p>OR</p>
         <source>
 &lt;module name=&quot;Checker&quot;&gt;
   &lt;property name=&quot;fileExtensions&quot; value=&quot;&quot;/&gt;
@@ -601,7 +601,7 @@
   ...
 &lt;/module&gt;
         </source>
-          <p>OR</p>
+        <p>OR</p>
         <source>
 &lt;module name=&quot;TreeWalker&quot;&gt;
   &lt;property name=&quot;fileExtensions&quot; value=&quot;&quot;/&gt;

--- a/src/xdocs/contributing.xml
+++ b/src/xdocs/contributing.xml
@@ -163,14 +163,14 @@
 
       <p>
         <b>ATTENTION:</b>The commit message must adhere to a certain format.
-         It should be "Issue #Number: Brief single-line message", where NUMBER is the issue number
-         at Github
-         (see
-         <a href="https://github.com/checkstyle/checkstyle/commit/9303fd9d971eb55cdfd62686ba2f5698edb2c83e">
-         an example</a>).
-         Small changes of configuration files, documentation fixes, etc. can be contributed by
-         starting the commit message with one of "minor:", "config:", "infra:", "doc:",
-         "dependency:" or "spelling:", followed by a space and a brief single-line message.
+        It should be "Issue #Number: Brief single-line message", where NUMBER is the issue number
+        at Github
+        (see
+        <a href="https://github.com/checkstyle/checkstyle/commit/9303fd9d971eb55cdfd62686ba2f5698edb2c83e">
+        an example</a>).
+        Small changes of configuration files, documentation fixes, etc. can be contributed by
+        starting the commit message with one of "minor:", "config:", "infra:", "doc:",
+        "dependency:" or "spelling:", followed by a space and a brief single-line message.
       </p>
 
       <p>

--- a/src/xdocs/index.xml.vm
+++ b/src/xdocs/index.xml.vm
@@ -151,275 +151,280 @@
       </p>
 
       <subsection name="Active Tools" >
-          <div class="wrapper">
-              <table>
-                  <tr>
-                      <th>IDE / Build tool</th>
-                      <th>Main/Initial Author</th>
-                      <th>Available from</th>
-                      <th>Remarks</th>
-                  </tr>
-                  <tr>
-                      <td>
-                          <a href="https://www.atlassian.com/software/bitbucket">
-                              Bitbucket Server</a>
-                      </td>
-                      <td>Stephan Bechter</td>
-                      <td>
-                          <a href="https://marketplace.atlassian.com/apps/1214095/checkstyles-for-bitbucket-server">
-                              Checkstyle for Bitbucket Server
-                          </a>
-                      </td>
-                      <td/>
-                  </tr>
-                  <tr>
-                      <td>
-                          <a href="https://www.codacy.com/">Codacy</a>
-                      </td>
-                      <td>João Machado</td>
-                      <td>
-                          <a href="https://github.com/codacy/codacy-checkstyle/">
-                              codacy-checkstyle
-                          </a>
-                      </td>
-                      <td>
-                          Provides analysis per commit and per pull request. Supports CheckStyle
-                          config files.
-                      </td>
-                  </tr>
-                  <tr>
-                      <td><a href="https://www.eclipse.org/">Eclipse/RAD/RDz</a></td>
-                      <td>Christian Wulf</td>
-                      <td>
-                         <a href="https://github.com/ChristianWulf/qa-eclipse-plugin">
-                            Lightweight Eclipse Plugin for Quality Assurance Tools
-                         </a>
-                      </td>
-                      <td>Alternative to the Eclipse-CS plugin.
-                         Allows to use custom checks directly without providing
-                         an Eclipse Fragment plugin for that purpose.
-                      </td>
-                  </tr>
-                  <tr>
-                      <td><a href="https://www.eclipse.org/">Eclipse/RAD/RDz</a></td>
-                      <td>David Schneider</td>
-                      <td>
-                          <a href="https://checkstyle.org/eclipse-cs/#!/">Eclipse-CS Home Page</a>
-                      </td>
-                      <td>
-                          In 2007 was awarded
-                          <a href="https://www.eclipse.org/org/press-release/20070306eclipsecommunityawards.php">
-                              Best Open Source Eclipse-based Developer tool
-                          </a>.
-                      </td>
-                  </tr>
-                  <tr>
-                      <td><a href="https://gradle.org">Gradle</a></td>
-                      <td>Hans Dockter (initial author)</td>
-                      <td>Checkstyle supported out of the box</td>
-                      <td><a href="https://docs.gradle.org/current/userguide/checkstyle_plugin.html">
-                          Gradle Checkstyle docs</a></td>
-                  </tr>
-                  <tr>
-                      <td><a href="https://www.jetbrains.com/idea/">IntelliJ IDEA</a></td>
-                      <td>James Shiell</td>
-                      <td>
-                          <a href="https://github.com/jshiell/checkstyle-idea">
-                              Checkstyle-idea Project Page</a>
-                      </td>
-                      <td>Provides real-time and on-demand scanning.</td>
-                  </tr>
-                  <tr>
-                      <td><a href="https://www.jgrasp.org/">jGRASP</a></td>
-                      <td>Larry Barowski</td>
-                      <td><a href="https://www.jgrasp.org/">jGRASP Home Page</a></td>
-                      <td/>
-                  </tr>
-                  <tr>
-                      <td><a href="https://www.eclipse.org/">Eclipse/RAD/RDz</a></td>
-                      <td>Roman Ivanov</td>
-                      <td>
-                          <a href="https://github.com/sevntu-checkstyle">Project Page</a>
-                      </td>
-                      <td>
-                          Extension for Eclipse-CS plugin and also an incubator for
-                          Checkstyle checks that are not present in main stream of
-                          Checkstyle. See the
-                          <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/wiki">Wiki</a>
-                          and
-                          <a href="http://sevntu-checkstyle.github.io/sevntu.checkstyle/">Blog</a>
-                          .
-                      </td>
-                  </tr>
-                  <tr>
-                      <td><a href="https://www.eclipse.org/">Eclipse/RAD/RDz</a></td>
-                      <td>Jan Burkhardt</td>
-                      <td>
-                          <a href="https://github.com/bjrke/JSR305CheckstylePlugin">Project Page</a>
-                      </td>
-                      <td>
-                          Extension for Eclipse-CS plugin which ensures nullness annotations on
-                          methods and constructors (JSR305).
-                      </td>
-                  </tr>
-                  <tr>
-                      <td><a href="https://bitbucket.org/atlassian/bamboo-checkstyle-plugin">
-                          Bamboo Checkstyle plug-in</a></td>
-                      <td>Atlassian (formerly by Ross Rowe and Stephan Paulicke)</td>
-                      <td><a href="https://bitbucket.org/atlassian/bamboo-checkstyle-plugin">
-                          Bamboo Checkstyle plug-in Home Page</a></td>
-                      <td>An add-on that will parse and record CheckStyle reports and report your
-                          style violations over time.</td>
-                  </tr>
-                  <tr>
-                      <td>
-                          <a href="https://codeclimate.com/">Code Climate</a>
-                      </td>
-                      <td>Sivakumar Kailasam</td>
-                      <td>
-                          <a href="https://github.com/sivakumar-kailasam/codeclimate-checkstyle">
-                              codeclimate-checkstyle
-                          </a>
-                      </td>
-                      <td/>
-                  </tr>
-                  <tr>
-                      <td><a href="https://wiki.jenkins.io/display/JENKINS/Checkstyle+Plugin">Jenkins
-                      Checkstyle plug-in</a></td>
-                      <td/>
-                      <td><a href="https://wiki.jenkins.io/display/JENKINS/Checkstyle+Plugin">Jenkins
-                      Checkstyle plug-in Home Page</a></td>
-                      <td>This plug-in is supported by the Static Analysis Collector plug-in that
-                      collects different analysis results and shows the results in aggregated trend
-                      graphs.</td>
-                  </tr>
-                  <tr>
-                      <td><a href="http://maven.apache.org/">Maven</a></td>
-                      <td>Vincent Massol</td>
-                      <td>Checkstyle supported out of the box</td>
-                      <td><a href="http://maven.apache.org/plugins/maven-checkstyle-plugin/checkstyle.html">
-                          example report</a></td>
-                  </tr>
-                  <tr>
-                      <td><a href="http://tide.olympe.in/">tIDE</a></td>
-                      <td/>
-                      <td>Built in</td>
-                      <td/>
-                  </tr>
-                  <tr>
-                      <td><a href="https://netbeans.org/">NetBeans</a></td>
-                      <td>Petr Hejl</td>
-                      <td>
-                          <a href="https://www.sickboy.cz/checkstyle/">Checkstyle Beans</a>
-                      </td>
-                      <td>
-                          Problems with source code are displayed as annotations of
-                          the source
-                      </td>
-                  </tr>
-                  <tr>
-                      <td><a href="https://netbeans.org/">NetBeans</a></td>
-                      <td/>
-                      <td>
-                          <a href="http://sqe-team.github.io">Software Quality Environment (SQE)</a>
-                      </td>
-                      <td/>
-                  </tr>
-                  <tr>
-                      <td><a href="https://www.sonarqube.org/">SonarQube</a></td>
-                      <td>Freddy Mallet (initial author)</td>
-                      <td><a href="https://github.com/checkstyle/sonar-checkstyle">
-                          Checkstyle SonarQube repository</a></td>
-                      <td><a href="https://sonarcloud.io/projects">Demo site of SonarQube</a></td>
-                  </tr>
-                  <tr>
-                      <td><a href="http://www.jedit.org/">jEdit</a></td>
-                      <td>Todd Papaioannou</td>
-                      <td><a href="http://plugins.jedit.org/plugins/?CheckStylePlugin">
-                          JEdit CheckStylePlugin</a></td>
-                      <td/>
-                  </tr>
-                  <tr>
-                      <td><a href="https://www.scm-manager.org/">SCM-Manager</a></td>
-                      <td/>
-                      <td><a href="http://plugins.scm-manager.org/scm-plugin-backend/page/index.html">
-                          SCM-Manager Plugin Page</a></td>
-                      <td/>
-                  </tr>
-                  <tr>
-                      <td><a href="https://www.jetbrains.com/idea/">IntelliJ IDEA</a></td>
-                      <td>Jakub Slawinski</td>
-                      <td>
-                          <a href="https://plugins.jetbrains.com/plugin/4594-qaplug">QAPlug</a>
-                      </td>
-                      <td>Provides quality assurance features.</td>
-                  </tr>
-                  <tr>
-                      <td><a href="https://www.jarchitect.com">JArchitect</a></td>
-                      <td/>
-                      <td><a href="https://www.jarchitect.com">JArchitect Home Page</a></td>
-                      <td>Imports XML result files from CheckStyle.</td>
-                  </tr>
-                  <tr>
-                      <td><a href="https://www.scala-sbt.org/">SBT</a></td>
-                      <td>Andrew Johnson</td>
-                      <td><a href="https://github.com/etsy/sbt-checkstyle-plugin">
-                          sbt-checkstyle-plugin Project Page</a></td>
-                      <td>SBT plugin for running Checkstyle on Java source files in an SBT
-                        project</td>
-                  </tr>
-                  <tr>
-                      <td><a href="https://github.com/nidi3/code-assert">code-assert</a></td>
-                      <td>Stefan Niederhauser</td>
-                      <td><a href="https://github.com/nidi3/code-assert#checkstyle-checks">
-                          code-assert</a></td>
-                      <td>Assert that the java code of a project satisfies certain checks. Launch
-                          checkstyle validation from UTs</td>
-                  </tr>
-                  <tr>
-                      <td><a href="http://jdee.sourceforge.net/">Emacs JDE</a></td>
-                      <td>Markus Mohnen</td>
-                      <td>Part of the standard JDEE distribution -
-                          <a href="https://github.com/jdee-emacs/jdee"/>
-                      </td>
-                      <td><a href="https://github.com/jdee-emacs/jdee/blob/master/jdee-checkstyle.el">
-                          configuration could be seen at jdee-checkstyle.el</a></td>
-                  </tr>
-                  <tr>
-                      <td><a href="https://code.visualstudio.com/">Visual Studio Code</a></td>
-                      <td>Sheng Chen</td>
-                      <td><a href="https://marketplace.visualstudio.com/items?itemName=shengchen.vscode-checkstyle">
-                          vscode-checkstyle</a></td>
-                      <td>Checkstyle for Microsoft Visual Studio Code</td>
-                  </tr>
-              </table>
-          </div>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>IDE / Build tool</th>
+              <th>Main/Initial Author</th>
+              <th>Available from</th>
+              <th>Remarks</th>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://www.atlassian.com/software/bitbucket">
+                  Bitbucket Server
+                </a>
+              </td>
+              <td>Stephan Bechter</td>
+              <td>
+                <a href="https://marketplace.atlassian.com/apps/1214095/checkstyles-for-bitbucket-server">
+                  Checkstyle for Bitbucket Server
+                </a>
+              </td>
+              <td/>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://www.codacy.com/">Codacy</a>
+              </td>
+              <td>João Machado</td>
+              <td>
+                <a href="https://github.com/codacy/codacy-checkstyle/">
+                  codacy-checkstyle
+                </a>
+              </td>
+              <td>
+                  Provides analysis per commit and per pull request. Supports CheckStyle
+                  config files.
+              </td>
+            </tr>
+            <tr>
+              <td><a href="https://www.eclipse.org/">Eclipse/RAD/RDz</a></td>
+              <td>Christian Wulf</td>
+              <td>
+                <a href="https://github.com/ChristianWulf/qa-eclipse-plugin">
+                  Lightweight Eclipse Plugin for Quality Assurance Tools
+                </a>
+              </td>
+              <td>Alternative to the Eclipse-CS plugin.
+                 Allows to use custom checks directly without providing
+                 an Eclipse Fragment plugin for that purpose.
+              </td>
+            </tr>
+            <tr>
+              <td><a href="https://www.eclipse.org/">Eclipse/RAD/RDz</a></td>
+              <td>David Schneider</td>
+              <td>
+                <a href="https://checkstyle.org/eclipse-cs/#!/">Eclipse-CS Home Page</a>
+              </td>
+              <td>
+                In 2007 was awarded
+                <a href="https://www.eclipse.org/org/press-release/20070306eclipsecommunityawards.php">
+                  Best Open Source Eclipse-based Developer tool
+                </a>.
+              </td>
+            </tr>
+            <tr>
+              <td><a href="https://gradle.org">Gradle</a></td>
+              <td>Hans Dockter (initial author)</td>
+              <td>Checkstyle supported out of the box</td>
+              <td>
+                <a href="https://docs.gradle.org/current/userguide/checkstyle_plugin.html">
+                  Gradle Checkstyle docs
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td><a href="https://www.jetbrains.com/idea/">IntelliJ IDEA</a></td>
+              <td>James Shiell</td>
+              <td>
+                <a href="https://github.com/jshiell/checkstyle-idea">
+                  Checkstyle-idea Project Page
+                </a>
+              </td>
+              <td>Provides real-time and on-demand scanning.</td>
+            </tr>
+            <tr>
+              <td><a href="https://www.jgrasp.org/">jGRASP</a></td>
+              <td>Larry Barowski</td>
+              <td><a href="https://www.jgrasp.org/">jGRASP Home Page</a></td>
+              <td/>
+            </tr>
+            <tr>
+              <td><a href="https://www.eclipse.org/">Eclipse/RAD/RDz</a></td>
+              <td>Roman Ivanov</td>
+              <td>
+                <a href="https://github.com/sevntu-checkstyle">Project Page</a>
+              </td>
+              <td>
+                Extension for Eclipse-CS plugin and also an incubator for
+                Checkstyle checks that are not present in main stream of
+                Checkstyle. See the
+                <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/wiki">Wiki</a>
+                and
+                <a href="http://sevntu-checkstyle.github.io/sevntu.checkstyle/">Blog</a>
+                .
+              </td>
+            </tr>
+            <tr>
+              <td><a href="https://www.eclipse.org/">Eclipse/RAD/RDz</a></td>
+              <td>Jan Burkhardt</td>
+              <td>
+                <a href="https://github.com/bjrke/JSR305CheckstylePlugin">Project Page</a>
+              </td>
+              <td>
+                Extension for Eclipse-CS plugin which ensures nullness annotations on
+                methods and constructors (JSR305).
+              </td>
+            </tr>
+            <tr>
+              <td><a href="https://bitbucket.org/atlassian/bamboo-checkstyle-plugin">
+                Bamboo Checkstyle plug-in</a></td>
+              <td>Atlassian (formerly by Ross Rowe and Stephan Paulicke)</td>
+              <td><a href="https://bitbucket.org/atlassian/bamboo-checkstyle-plugin">
+                Bamboo Checkstyle plug-in Home Page</a></td>
+              <td>An add-on that will parse and record CheckStyle reports and report your
+                style violations over time.</td>
+            </tr>
+            <tr>
+              <td>
+                <a href="https://codeclimate.com/">Code Climate</a>
+              </td>
+              <td>Sivakumar Kailasam</td>
+              <td>
+                <a href="https://github.com/sivakumar-kailasam/codeclimate-checkstyle">
+                  codeclimate-checkstyle
+                </a>
+              </td>
+              <td/>
+            </tr>
+            <tr>
+              <td><a href="https://wiki.jenkins.io/display/JENKINS/Checkstyle+Plugin">Jenkins
+              Checkstyle plug-in</a></td>
+              <td/>
+              <td><a href="https://wiki.jenkins.io/display/JENKINS/Checkstyle+Plugin">Jenkins
+              Checkstyle plug-in Home Page</a></td>
+              <td>This plug-in is supported by the Static Analysis Collector plug-in that
+              collects different analysis results and shows the results in aggregated trend
+              graphs.</td>
+            </tr>
+            <tr>
+              <td><a href="http://maven.apache.org/">Maven</a></td>
+              <td>Vincent Massol</td>
+              <td>Checkstyle supported out of the box</td>
+              <td><a href="http://maven.apache.org/plugins/maven-checkstyle-plugin/checkstyle.html">
+                  example report</a></td>
+            </tr>
+            <tr>
+              <td><a href="http://tide.olympe.in/">tIDE</a></td>
+              <td/>
+              <td>Built in</td>
+              <td/>
+            </tr>
+            <tr>
+              <td><a href="https://netbeans.org/">NetBeans</a></td>
+              <td>Petr Hejl</td>
+              <td>
+                <a href="https://www.sickboy.cz/checkstyle/">Checkstyle Beans</a>
+              </td>
+              <td>
+                  Problems with source code are displayed as annotations of
+                  the source
+              </td>
+            </tr>
+            <tr>
+              <td><a href="https://netbeans.org/">NetBeans</a></td>
+              <td/>
+              <td>
+                <a href="http://sqe-team.github.io">Software Quality Environment (SQE)</a>
+              </td>
+              <td/>
+            </tr>
+            <tr>
+              <td><a href="https://www.sonarqube.org/">SonarQube</a></td>
+              <td>Freddy Mallet (initial author)</td>
+              <td><a href="https://github.com/checkstyle/sonar-checkstyle">
+                  Checkstyle SonarQube repository</a></td>
+              <td><a href="https://sonarcloud.io/projects">Demo site of SonarQube</a></td>
+            </tr>
+            <tr>
+              <td><a href="http://www.jedit.org/">jEdit</a></td>
+              <td>Todd Papaioannou</td>
+              <td><a href="http://plugins.jedit.org/plugins/?CheckStylePlugin">
+                  JEdit CheckStylePlugin</a></td>
+              <td/>
+            </tr>
+            <tr>
+              <td><a href="https://www.scm-manager.org/">SCM-Manager</a></td>
+              <td/>
+              <td><a href="http://plugins.scm-manager.org/scm-plugin-backend/page/index.html">
+                  SCM-Manager Plugin Page</a></td>
+              <td/>
+            </tr>
+            <tr>
+              <td><a href="https://www.jetbrains.com/idea/">IntelliJ IDEA</a></td>
+              <td>Jakub Slawinski</td>
+              <td>
+                <a href="https://plugins.jetbrains.com/plugin/4594-qaplug">QAPlug</a>
+              </td>
+              <td>Provides quality assurance features.</td>
+            </tr>
+            <tr>
+              <td><a href="https://www.jarchitect.com">JArchitect</a></td>
+              <td/>
+              <td><a href="https://www.jarchitect.com">JArchitect Home Page</a></td>
+              <td>Imports XML result files from CheckStyle.</td>
+            </tr>
+            <tr>
+              <td><a href="https://www.scala-sbt.org/">SBT</a></td>
+              <td>Andrew Johnson</td>
+              <td><a href="https://github.com/etsy/sbt-checkstyle-plugin">
+                  sbt-checkstyle-plugin Project Page</a></td>
+              <td>SBT plugin for running Checkstyle on Java source files in an SBT
+                project</td>
+            </tr>
+            <tr>
+              <td><a href="https://github.com/nidi3/code-assert">code-assert</a></td>
+              <td>Stefan Niederhauser</td>
+              <td><a href="https://github.com/nidi3/code-assert#checkstyle-checks">
+                  code-assert</a></td>
+              <td>Assert that the java code of a project satisfies certain checks. Launch
+                  checkstyle validation from UTs</td>
+            </tr>
+            <tr>
+              <td><a href="http://jdee.sourceforge.net/">Emacs JDE</a></td>
+              <td>Markus Mohnen</td>
+              <td>Part of the standard JDEE distribution -
+                <a href="https://github.com/jdee-emacs/jdee"/>
+              </td>
+              <td><a href="https://github.com/jdee-emacs/jdee/blob/master/jdee-checkstyle.el">
+                  configuration could be seen at jdee-checkstyle.el</a></td>
+            </tr>
+            <tr>
+              <td><a href="https://code.visualstudio.com/">Visual Studio Code</a></td>
+              <td>Sheng Chen</td>
+              <td><a href="https://marketplace.visualstudio.com/items?itemName=shengchen.vscode-checkstyle">
+                  vscode-checkstyle</a></td>
+              <td>Checkstyle for Microsoft Visual Studio Code</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <subsection name="Inactive / Old Tools" >
-          <div class="wrapper">
-              <table>
-                  <tr>
-                      <th>IDE / Build tool</th>
-                      <th>Main/Initial Author</th>
-                      <th>Available from</th>
-                      <th>Remarks</th>
-                  </tr>
-                  <tr>
-                      <td><a href="http://qalab.sourceforge.net/">QALab</a></td>
-                      <td>Benoit Xhenseval</td>
-                      <td><a href="http://qalab.sourceforge.net/">QALab Home Page</a></td>
-                      <td>Supports tracking Checkstyle statistics over time.</td>
-                  </tr>
-                  <tr>
-                      <td><a href="https://vim.sourceforge.io/">Vim editor</a></td>
-                      <td>Xandy Johnson</td>
-                      <td><a href="https://vim.sourceforge.io/scripts/script.php?script_id=448">
-                          Plugin Homepage</a></td>
-                      <td>Vim file-type plug-in</td>
-                  </tr>
-              </table>
-          </div>
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>IDE / Build tool</th>
+              <th>Main/Initial Author</th>
+              <th>Available from</th>
+              <th>Remarks</th>
+            </tr>
+            <tr>
+              <td><a href="http://qalab.sourceforge.net/">QALab</a></td>
+              <td>Benoit Xhenseval</td>
+              <td><a href="http://qalab.sourceforge.net/">QALab Home Page</a></td>
+              <td>Supports tracking Checkstyle statistics over time.</td>
+            </tr>
+            <tr>
+              <td><a href="https://vim.sourceforge.io/">Vim editor</a></td>
+              <td>Xandy Johnson</td>
+              <td><a href="https://vim.sourceforge.io/scripts/script.php?script_id=448">
+                  Plugin Homepage</a></td>
+              <td>Vim file-type plug-in</td>
+            </tr>
+          </table>
+        </div>
       </subsection>
 
       <p>

--- a/src/xdocs/property_types.xml
+++ b/src/xdocs/property_types.xml
@@ -24,11 +24,11 @@
     </section>
 
     <section name="Overview">
-    <p>
-      Checkstyle is configured using properties, which are string
-      representations. This document describes how these string
-      representations are mapped to typed properties.
-    </p>
+      <p>
+        Checkstyle is configured using properties, which are string
+        representations. This document describes how these string
+        representations are mapped to typed properties.
+      </p>
     </section>
 
     <section name="boolean">
@@ -587,7 +587,7 @@
     if (condition) {
         ...
                 </pre>
-             </div>
+              </div>
               But for a statement spanning multiple lines, Checkstyle will
               enforce:
               <div class="wrapper">
@@ -891,7 +891,7 @@
         array comma. The following table describes the valid options:
       </p>
 
-        <div class="wrapper">
+      <div class="wrapper">
         <table summary="trailingArrayComma options">
           <tr>
             <td>Option</td>

--- a/src/xdocs/writingchecks.xml
+++ b/src/xdocs/writingchecks.xml
@@ -79,11 +79,13 @@
         and plug it into the Checkstyle framework.
       </p>
 
-      <p> This chapter is organized as a tour that takes you
-      through the process step by step and explains both the theoretical
-      foundations and the
-      <a href="apidocs/com/puppycrawl/tools/checkstyle/api/package-summary.html">Checkstyle
-      API</a> along the way.  </p>
+      <p>
+        This chapter is organized as a tour that takes you
+        through the process step by step and explains both the theoretical
+        foundations and the
+        <a href="apidocs/com/puppycrawl/tools/checkstyle/api/package-summary.html">Checkstyle
+          API</a> along the way.
+      </p>
 
     </section>
 
@@ -116,13 +118,13 @@
       </p>
 
     </section>
-      <section name="Tool to print Java tree structure">
-          <p>
-              Checkstyle can print Abstract Syntax Tree for Java trees. You need to run checkstyle
-              jar file with <b>-t</b> or <b>-T</b> argument, providing java file.
-          </p>
-          <p>For example, here is MyClass.java file:</p>
-          <source><![CDATA[
+    <section name="Tool to print Java tree structure">
+      <p>
+        Checkstyle can print Abstract Syntax Tree for Java trees. You need to run checkstyle
+        jar file with <b>-t</b> or <b>-T</b> argument, providing java file.
+      </p>
+      <p>For example, here is MyClass.java file:</p>
+      <source><![CDATA[
 /**
  * My <b>class</b>.
  * @see AbstractClass
@@ -131,24 +133,24 @@ public class MyClass {
 
 }
       ]]></source>
-        <div class="wrapper">
-          <table style="table-layout: fixed;">
-              <tr>
-                  <td>
-                      1) Using -t as parameter.
-                      <br />
-                      java -jar checkstyle-X.XX-all.jar -t MyClass.java
-                  </td>
-                  <td>
-                      2) Using -T as parameter.
-                      <br />
-                      java -jar checkstyle-X.XX-all.jar -T MyClass.java
-                  </td>
-              </tr>
+      <div class="wrapper">
+        <table style="table-layout: fixed;">
+          <tr>
+            <td>
+              1) Using -t as parameter.
+              <br />
+              java -jar checkstyle-X.XX-all.jar -t MyClass.java
+            </td>
+            <td>
+              2) Using -T as parameter.
+              <br />
+              java -jar checkstyle-X.XX-all.jar -T MyClass.java
+            </td>
+          </tr>
 
-              <tr>
-                  <td>
-                      <source><![CDATA[
+          <tr>
+            <td>
+              <source><![CDATA[
 CLASS_DEF -> CLASS_DEF [5:0]
 |--MODIFIERS -> MODIFIERS [5:0]
 |   `--LITERAL_PUBLIC -> public [5:0]
@@ -157,10 +159,11 @@ CLASS_DEF -> CLASS_DEF [5:0]
 `--OBJBLOCK -> OBJBLOCK [5:21]
     |--LCURLY -> { [5:21]
     `--RCURLY -> } [7:0]
-          ]]></source>
-                  </td>
-                  <td>
-                      <source><![CDATA[
+ ]]>
+              </source>
+            </td>
+            <td>
+              <source><![CDATA[
 CLASS_DEF -> CLASS_DEF [5:0]
 |--MODIFIERS -> MODIFIERS [5:0]
 |   |--BLOCK_COMMENT_BEGIN -> /* [1:0]
@@ -172,17 +175,18 @@ CLASS_DEF -> CLASS_DEF [5:0]
 `--OBJBLOCK -> OBJBLOCK [5:21]
     |--LCURLY -> { [5:21]
     `--RCURLY -> } [7:0]
-          ]]></source>
-                  </td>
-              </tr>
-          </table>
-        </div>
-          <p>
-            As you can see very small java file transforms to a huge Abstract Syntax Tree, because
-            that is the most detailed tree including all components of the java file: object block,
-            comments, modifiers, etc.
-          </p>
-      </section>
+]]>
+              </source>
+            </td>
+          </tr>
+        </table>
+      </div>
+      <p>
+        As you can see very small java file transforms to a huge Abstract Syntax Tree, because
+        that is the most detailed tree including all components of the java file: object block,
+        comments, modifiers, etc.
+      </p>
+    </section>
 
     <section name="The Checkstyle SDK Gui">
 
@@ -209,28 +213,30 @@ CLASS_DEF -> CLASS_DEF [5:0]
         </span>
       </p>
 
-      <p> In the leftmost column you can open and close branches
-      of the tree, the remaining columns display information about each node
-      in the tree.  The second column displays a token type for each node. As
-      you navigate from the root of the tree to one of the leafs, you&#39;ll
-      notice that the token type denotes smaller and smaller units of your
-      source file, i.e. close to the root you might see the token type
-      <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>
-      (a node that represents a class definition) while you will see token
-      types like IDENT (an identifier) near the leaves of the tree.  </p>
+      <p>
+        In the leftmost column you can open and close branches
+        of the tree, the remaining columns display information about each node
+        in the tree.  The second column displays a token type for each node. As
+        you navigate from the root of the tree to one of the leafs, you&#39;ll
+        notice that the token type denotes smaller and smaller units of your
+        source file, i.e. close to the root you might see the token type
+        <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">CLASS_DEF</a>
+        (a node that represents a class definition) while you will see token
+        types like IDENT (an identifier) near the leaves of the tree.
+      </p>
 
       <p>
-       In the bottom of frame you can find buttons "Open File", "Reload File"
-       and dropdown list with parse modes to choose. First one opens file
-       choose window. After choosing file tree that corresponds to java source
-       file builds in frame. Notice that only files with ".java" extension
-       can be opened. Second one reloads chosen file from file system and
-       rebuilds source code tree. Dropdown list allow to choose one of three
-       parse modes: "PLAIN JAVA", "JAVA WITH COMMENTS", "JAVA WITH JAVADOC AND COMMENTS".
-       "PLAIN JAVA" mode uses to show java source code without comments. In
-       "JAVA WITH COMMENTS" you can see also comments blocks on the tree. When
-       "JAVA WITH JAVADOC AND COMMENTS" chosen javadoc tree builds and attaches
-       for every comment block, that contains javadoc.
+        In the bottom of frame you can find buttons "Open File", "Reload File"
+        and dropdown list with parse modes to choose. First one opens file
+        choose window. After choosing file tree that corresponds to java source
+        file builds in frame. Notice that only files with ".java" extension
+        can be opened. Second one reloads chosen file from file system and
+        rebuilds source code tree. Dropdown list allow to choose one of three
+        parse modes: "PLAIN JAVA", "JAVA WITH COMMENTS", "JAVA WITH JAVADOC AND COMMENTS".
+        "PLAIN JAVA" mode uses to show java source code without comments. In
+        "JAVA WITH COMMENTS" you can see also comments blocks on the tree. When
+        "JAVA WITH JAVADOC AND COMMENTS" chosen javadoc tree builds and attaches
+        for every comment block, that contains javadoc.
       </p>
 
       <p>
@@ -273,41 +279,51 @@ CLASS_DEF -> CLASS_DEF [5:0]
         way to write plugins.
       </p>
 
-      <p> Hence Checkstyle&#39;s AST classes do not have any
-      methods that implement checking functionality. Instead,
-      Checkstyle&#39;s
-      <a href="apidocs/com/puppycrawl/tools/checkstyle/TreeWalker.html">TreeWalker</a>
-      takes a set of objects that conform to a
-      <a href="apidocs/com/puppycrawl/tools/checkstyle/api/AbstractCheck.html">AbstractCheck</a>
-      interface. OK, you&#39;re right - actually it&#39;s not an interface
-      but an abstract class to provide some helper methods. A Check provides
-      methods that take an AST as an argument and perform the checking process
-      for that AST, most prominently
-      <a href="apidocs/com/puppycrawl/tools/checkstyle/api/AbstractCheck.html#visitToken-com.puppycrawl.tools.checkstyle.api.DetailAST-">
-              <code>visitToken()</code></a>.  </p>
+      <p>
+        Hence Checkstyle&#39;s AST classes do not have any
+        methods that implement checking functionality. Instead,
+        Checkstyle&#39;s
+        <a href="apidocs/com/puppycrawl/tools/checkstyle/TreeWalker.html">TreeWalker</a>
+        takes a set of objects that conform to a
+        <a href="apidocs/com/puppycrawl/tools/checkstyle/api/AbstractCheck.html">AbstractCheck</a>
+        interface. OK, you&#39;re right - actually it&#39;s not an interface
+        but an abstract class to provide some helper methods. A Check provides
+        methods that take an AST as an argument and perform the checking process
+        for that AST, most prominently
+        <a href="apidocs/com/puppycrawl/tools/checkstyle/api/AbstractCheck.html#visitToken-com.puppycrawl.tools.checkstyle.api.DetailAST-">
+          <code>visitToken()</code>
+        </a>.
+      </p>
 
-      <p> It is important to understand that the individual
-      Checks do no drive the AST traversal (it possible to traverse itself, but not recommended).
-      Instead, the TreeWalker initiates
-      a recursive descend from the root of the AST to the leaf nodes and calls
-      the Check methods. The traversal is done using a
-      <a href="https://en.wikipedia.org/wiki/Tree_traversal">tree traversal (depth-first)</a>
-      algorithm.  </p>
+      <p>
+        It is important to understand that the individual
+        Checks do no drive the AST traversal (it possible to traverse itself, but not recommended).
+        Instead, the TreeWalker initiates
+        a recursive descend from the root of the AST to the leaf nodes and calls
+        the Check methods. The traversal is done using a
+        <a href="https://en.wikipedia.org/wiki/Tree_traversal">tree traversal (depth-first)</a>
+        algorithm.
+      </p>
 
-      <p> Before any visitor method is called, the TreeWalker will call
-      <a href="apidocs/com/puppycrawl/tools/checkstyle/api/AbstractCheck.html#beginTree-com.puppycrawl.tools.checkstyle.api.DetailAST-">
-              <code>beginTree()</code></a> to give the Check a chance to do
-      some initialization. Then, when performing the recursive descend from
-      the root to the leaf nodes, the <code>visitToken()</code>
-      method is called. Unlike the basic examples in the pattern book, there
-      is a <code>visitToken()</code> counterpart called
-      <a href="apidocs/com/puppycrawl/tools/checkstyle/api/AbstractCheck.html#leaveToken-com.puppycrawl.tools.checkstyle.api.DetailAST-">
-              <code>leaveToken()</code></a>. The TreeWalker will call that
-      method to signal that the subtree below the node has been processed and
-      the TreeWalker is backtracking from the node. After the root node has
-      been left, the TreeWalker will call
-      <a href="apidocs/com/puppycrawl/tools/checkstyle/api/AbstractCheck.html#finishTree-com.puppycrawl.tools.checkstyle.api.DetailAST-">
-              <code>finishTree()</code></a>.  </p>
+      <p>
+        Before any visitor method is called, the TreeWalker will call
+        <a href="apidocs/com/puppycrawl/tools/checkstyle/api/AbstractCheck.html#beginTree-com.puppycrawl.tools.checkstyle.api.DetailAST-">
+          <code>beginTree()</code>
+        </a> to give the Check a chance to do
+        some initialization. Then, when performing the recursive descend from
+        the root to the leaf nodes, the <code>visitToken()</code>
+        method is called. Unlike the basic examples in the pattern book, there
+        is a <code>visitToken()</code> counterpart called
+        <a href="apidocs/com/puppycrawl/tools/checkstyle/api/AbstractCheck.html#leaveToken-com.puppycrawl.tools.checkstyle.api.DetailAST-">
+          <code>leaveToken()</code>
+        </a>. The TreeWalker will call that
+        method to signal that the subtree below the node has been processed and
+        the TreeWalker is backtracking from the node. After the root node has
+        been left, the TreeWalker will call
+        <a href="apidocs/com/puppycrawl/tools/checkstyle/api/AbstractCheck.html#finishTree-com.puppycrawl.tools.checkstyle.api.DetailAST-">
+          <code>finishTree()</code>
+        </a>.
+      </p>
 
     </section>
 
@@ -648,8 +664,9 @@ public class MethodLimitCheck extends AbstractCheck
       </p>
       <ul>
         <li>Java code should be written with
-        <a href="https://en.wikipedia.org/wiki/ASCII">ASCII</a> characters only, no UTF-8
-        support.</li>
+          <a href="https://en.wikipedia.org/wiki/ASCII">ASCII</a> characters only, no UTF-8
+          support.
+        </li>
         <li>To get valid violations, code have to be compilable, in other case you can get not easy
         to understand parse errors.</li>
         <li>You cannot determine the type of an expression.
@@ -683,15 +700,15 @@ public class MethodLimitCheck extends AbstractCheck
       to get inner structure, or you are going to validate non "*.java" files.
       </p>
 
-      <p> Writing a FileSetCheck is pretty straightforward: Just
-      inherit from
-      <a href="apidocs/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.html">
-              AbstractFileSetCheck</a>
-      and override the abstract
-      <a href="apidocs/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.html#processFiltered-java.io.File-com.puppycrawl.tools.checkstyle.api.FileText-">
-              <code>processFiltered(java.io.File, java.util.List)</code></a> method and you&#39;re
-      done. A very simple example could fire a violation if the number of files
-      exceeds a certain limit. Here is a FileSetCheck that does just that:</p>
+      <p>
+        Writing a FileSetCheck is pretty straightforward: Just inherit from
+        <a href="apidocs/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.html">
+        AbstractFileSetCheck</a>and override the abstract
+        <a href="apidocs/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.html#processFiltered-java.io.File-com.puppycrawl.tools.checkstyle.api.FileText-">
+          <code>processFiltered(java.io.File, java.util.List)</code>
+        </a> method and you&#39;re done. A very simple example could fire a violation if the number
+        of files exceeds a certain limit. Here is a FileSetCheck that does just that:
+      </p>
 
       <source>
 package com.mycompany.checks;
@@ -747,44 +764,44 @@ public class LimitImplementationFiles extends AbstractFileSetCheck
 
     </section>
 
-      <section name="Declare check's external resource locations">
-       <p>
-         Checkstyle can cache external configuration resources of any kind which are used by your
-         check. If you want to do such a thing, you should implement
-         <a href="apidocs/com/puppycrawl/tools/checkstyle/api/ExternalResourceHolder.html">
-             ExternalResourceHolder</a>
-         interface. Such module must declare external resource locations as a set of Strings
-         which will be returned from
-         <a href="apidocs/com/puppycrawl/tools/checkstyle/api/ExternalResourceHolder.html#getExternalResourceLocations--">
-           getExternalResourceLocations</a>
-         method. This will allow Checkstyle to invalidate (clear) cache when the content of at
-         least one external configuration resource of your check is changed.
-       </p>
-       <p>
-         ATTENTION!
-       </p>
-       <ul>
-         <li>
-           If
-           <a href="apidocs/com/puppycrawl/tools/checkstyle/api/ExternalResourceHolder.html#getExternalResourceLocations--">
-             getExternalResourceLocations</a>
-           return null, there will be NullPointerException in
-           <a href="apidocs/com/puppycrawl/tools/checkstyle/Checker.html">
-             Checker</a>.
-           Such behaviour will signal that your module (check or filter) is designed incorrectly.
-         </li>
-         <li>
-           It makes sense to return an empty set from
-           <a href="apidocs/com/puppycrawl/tools/checkstyle/api/ExternalResourceHolder.html#getExternalResourceLocations--">
-             getExternalResourceLocations</a>
-           only for composite modules like
-           <a href="apidocs/com/puppycrawl/tools/checkstyle/TreeWalker.html">
-             TreeWalker</a>.
-         </li>
-       </ul>
-      </section>
+    <section name="Declare check's external resource locations">
+      <p>
+        Checkstyle can cache external configuration resources of any kind which are used by your
+        check. If you want to do such a thing, you should implement
+        <a href="apidocs/com/puppycrawl/tools/checkstyle/api/ExternalResourceHolder.html">
+            ExternalResourceHolder</a>
+        interface. Such module must declare external resource locations as a set of Strings
+        which will be returned from
+        <a href="apidocs/com/puppycrawl/tools/checkstyle/api/ExternalResourceHolder.html#getExternalResourceLocations--">
+          getExternalResourceLocations</a>
+        method. This will allow Checkstyle to invalidate (clear) cache when the content of at
+        least one external configuration resource of your check is changed.
+      </p>
+      <p>
+        ATTENTION!
+      </p>
+      <ul>
+        <li>
+          If
+          <a href="apidocs/com/puppycrawl/tools/checkstyle/api/ExternalResourceHolder.html#getExternalResourceLocations--">
+            getExternalResourceLocations</a>
+          return null, there will be NullPointerException in
+          <a href="apidocs/com/puppycrawl/tools/checkstyle/Checker.html">
+            Checker</a>.
+          Such behaviour will signal that your module (check or filter) is designed incorrectly.
+        </li>
+        <li>
+          It makes sense to return an empty set from
+          <a href="apidocs/com/puppycrawl/tools/checkstyle/api/ExternalResourceHolder.html#getExternalResourceLocations--">
+            getExternalResourceLocations</a>
+          only for composite modules like
+          <a href="apidocs/com/puppycrawl/tools/checkstyle/TreeWalker.html">
+            TreeWalker</a>.
+        </li>
+      </ul>
+    </section>
 
-      <section name="Huh? I can&#39;t figure it out!">
+    <section name="Huh? I can&#39;t figure it out!">
       <p>
         That&#39;s probably our fault, and it means that we have to provide
         better documentation. Please do not hesitate to ask questions on

--- a/src/xdocs/writingjavadocchecks.xml.vm
+++ b/src/xdocs/writingjavadocchecks.xml.vm
@@ -34,15 +34,13 @@
       the one closest to the definition, right above it, with the javadoc identifier will be used.
       </p>
       <p>
-      Javadoc comments should contain: a short summary (the first sentence), an optional
-      documentation section, an optional tag section.
-      The first sentence has a special meaning and should be clear, punchy, short, and is ended by
-      a period symbol.
-      Immediately after the first sentence, the main description could begin, which may be followed
-      by the tag section.
-      The tag section starts with the first block tag, which is defined by the first <code>@</code>
-      character that begins a line (ignoring leading asterisks, white space, and leading separator
-      <code>/**</code>).
+        Javadoc comments should contain: a short summary (the first sentence), an optional
+        documentation section, an optional tag section. The first sentence has a special meaning
+        and should be clear, punchy, short, and is ended by a period symbol.
+        Immediately after the first sentence, the main description could begin,
+        which may be followed by the tag section. The tag section starts with the first block tag,
+        which is defined by the first <code>@</code> character that begins a line
+        (ignoring leading asterisks, white space, and leading separator <code>/**</code>).
       </p>
       <p>For example, here is java file:</p>
       <source><![CDATA[
@@ -98,10 +96,11 @@ public class MyClass {
       a method is not a javadoc comment and skipped by Sun/Oracle javadoc tool and by our javadoc
       comment matcher, but such comment will be in AST.
       </p>
-      <p>You can find different types of documentation generation tools similar to javadoc on the
-      Internet. Such tools rely on specific Identifier: "!", "#", "$".
-      Comments look like <code>"/*! some comment */"</code> , <code>"/*# some comment */"</code> ,
-      <code>"/*$ some comment */"</code>. Such multiline comments are not a javadoc.
+      <p>
+        You can find different types of documentation generation tools similar to javadoc on the
+        Internet. Such tools rely on specific Identifier: "!", "#", "$".
+        Comments look like <code>"/*! some comment */"</code> , <code>"/*# some comment */"</code> ,
+        <code>"/*$ some comment */"</code>. Such multiline comments are not a javadoc.
       </p>
     </section>
 
@@ -119,8 +118,8 @@ public class MyClass {
       </p>
       <p>
         For more details about parsing of HTML into AST read
-          <a href="#HTML_Code_In_Javadoc_Comments">HTML Code In Javadoc Comments</a>
-          and <a href="#Javadoc_parser_behavior_for_current_HTML_version_and_new_HTML_version">
+        <a href="#HTML_Code_In_Javadoc_Comments">HTML Code In Javadoc Comments</a>
+        and <a href="#Javadoc_parser_behavior_for_current_HTML_version_and_new_HTML_version">
           Javadoc parser behavior
         </a>  section.
       </p>
@@ -128,21 +127,21 @@ public class MyClass {
 
     <section name="Tight-HTML rules">
       <p>
-      Every HTML tag should have matching end HTML tag or it is a
-          <a href="https://www.w3.org/TR/html/syntax.html#void-elements">void element</a>.
+        Every HTML tag should have matching end HTML tag or it is a
+        <a href="https://www.w3.org/TR/html/syntax.html#void-elements">void element</a>.
       </p>
       <p>
-      The only exceptions are HTML 4 tags whose end tag is optional (omittable) by
-      HTML specification (example is
-      <a href="https://www.w3.org/TR/html5/tabular-data.html#the-tr-element">TR</a>), so,
-      Checkstyle won't show error about missing end tag, however,
-      it leads to broken Tight-HTML structure and as a result
-      leads to not-nested content of the HTML tags in Abstract Syntax Tree of the Javadoc comment.
-      <br/>
-      In other words, if HTML tags are not closed Javadoc grammar cannot determine content
-      of these tags, so structure of the parse tree will not be nested like it is while using
-      <a href="#Tight-HTML_rules">Tight-HTML</a> code. It is done just to not fail on every
-      Javadoc comment, because there are tons of using unclosed tags, etc.
+        The only exceptions are HTML 4 tags whose end tag is optional (omittable) by
+        HTML specification (example is
+        <a href="https://www.w3.org/TR/html5/tabular-data.html#the-tr-element">TR</a>), so,
+        Checkstyle won't show error about missing end tag, however,
+        it leads to broken Tight-HTML structure and as a result
+        leads to not-nested content of the HTML tags in Abstract Syntax Tree of the Javadoc comment.
+        <br/>
+        In other words, if HTML tags are not closed Javadoc grammar cannot determine content
+        of these tags, so structure of the parse tree will not be nested like it is while using
+        <a href="#Tight-HTML_rules">Tight-HTML</a> code. It is done just to not fail on every
+        Javadoc comment, because there are tons of using unclosed tags, etc.
       </p>
       <p>
       Other rules:
@@ -151,10 +150,11 @@ public class MyClass {
         <li>Document Structure elements (DOCTYPE, &lt;html&gt;, &lt;body&gt;, etc) are
             not mandatory.</li>
         <li>Elements must always be closed, except HTML4 elements whose end tag is optional
-            (omittable) and HTML4
-            <a href="https://www.w3.org/TR/html/syntax.html#void-elements">void elements</a>.
-            See <a href="#HTML_Code_In_Javadoc_Comments">HTML Code In Javadoc Comments</a>
-            section</li>
+          (omittable) and HTML4
+          <a href="https://www.w3.org/TR/html/syntax.html#void-elements">void elements</a>.
+          See <a href="#HTML_Code_In_Javadoc_Comments">HTML Code In Javadoc Comments</a>
+          section
+        </li>
         <li>HTML elements can be either in lowercase or in uppercase</li>
         <li>Attribute names can be either in lowercase or in uppercase</li>
         <li>Attribute values can be either quoted or not be quoted</li>
@@ -180,8 +180,8 @@ public class MyClass {
           The array should contain int constants from
           <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html">
           JavadocTokenTypes</a> class. (There is also
-            <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">
-                TokenTypes</a> class in Checkstyle. Make sure you use
+          <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">
+              TokenTypes</a> class in Checkstyle. Make sure you use
           <a href="apidocs/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypes.html">
               JavadocTokenTypes</a> class in your Check, because the
           <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">
@@ -347,21 +347,21 @@ JAVADOC -> JAVADOC [0:0]
 
     <section name="Access Java AST from Javadoc Check">
       <p>
-      As you already know Javadoc parse tree is a result of parsing block comment. There is a
-      method to get the original block comment from Javadoc Check.
-      You may need this block comment to check its position or something else in java
-      <a href="apidocs/com/puppycrawl/tools/checkstyle/api/DetailAST.html">DetailAST</a> tree.
+        As you already know Javadoc parse tree is a result of parsing block comment. There is a
+        method to get the original block comment from Javadoc Check.
+        You may need this block comment to check its position or something else in java
+        <a href="apidocs/com/puppycrawl/tools/checkstyle/api/DetailAST.html">DetailAST</a> tree.
       </p>
       <p>
-      For example, to write a JavadocCheck that verifies @param tags in Javadoc comment of
-      a method definition, you also need all method's parameter names. To get method
-      definition AST you should access java
-      <a href="apidocs/com/puppycrawl/tools/checkstyle/api/DetailAST.html">DetailAST</a> tree
-      from javadoc Check. For this purpose use
-      <a href="apidocs/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.html#getBlockCommentAst--">
-          getBlockCommentAst()</a>
-      method that returns
-      <a href="apidocs/com/puppycrawl/tools/checkstyle/api/DetailAST.html">DetailAST</a> node.
+        For example, to write a JavadocCheck that verifies @param tags in Javadoc comment of
+        a method definition, you also need all method's parameter names. To get method
+        definition AST you should access java
+        <a href="apidocs/com/puppycrawl/tools/checkstyle/api/DetailAST.html">DetailAST</a> tree
+        from javadoc Check. For this purpose use
+        <a href="apidocs/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.html#getBlockCommentAst--">
+            getBlockCommentAst()</a>
+        method that returns
+        <a href="apidocs/com/puppycrawl/tools/checkstyle/api/DetailAST.html">DetailAST</a> node.
       </p>
       <p>
         Example:
@@ -398,8 +398,9 @@ class MyCheck extends AbstractJavadocCheck {
     <section name="HTML Code In Javadoc Comments">
       <p>
         Checkstyle supports HTML4 tags in Javadoc comments:
-          <a href="https://www.w3.org/TR/html4/index/elements.html">
-          all HTML4 elements</a>.
+        <a href="https://www.w3.org/TR/html4/index/elements.html">
+          all HTML4 elements
+        </a>.
       </p>
       <p>
         HTML4 is picked just to have a list of elements whose end tag is optional(omittable) and a
@@ -475,40 +476,41 @@ JAVADOC -> JAVADOC [0:0]
         ]]></source>
       </p>
 
-    <p>
-      Here is what you get if unknown tag doesn't have matching end tag (for example, HTML5 tag
-      &lt;audio&gt;): <br/>
-      Input:
-      <source>&lt;audio&gt;test</source>
-      Output:
-    </p>
-    <div class="wrap-content">
-      <source>
-        [ERROR:0] Javadoc comment at column 1 has parse error. Missed HTML close tag 'audio'.
-        Sometimes it means that close tag missed for one of previous tags.
-      </source>
-    </div>
-    <p>
-      As you see Javadoc parser prints error and doesn't build AST if unknown HTML tag doesn't
-      have matching end tag. If that a case please create an issue against Checkstyle to
-      upgrade parser.
-    </p>
+      <p>
+        Here is what you get if unknown tag doesn't have matching end tag (for example, HTML5 tag
+        &lt;audio&gt;): <br/>
+        Input:
+        <source>&lt;audio&gt;test</source>
+        Output:
+      </p>
+      <div class="wrap-content">
+        <source>
+          [ERROR:0] Javadoc comment at column 1 has parse error. Missed HTML close tag 'audio'.
+          Sometimes it means that close tag missed for one of previous tags.
+        </source>
+      </div>
+      <p>
+        As you see Javadoc parser prints error and doesn't build AST if unknown HTML tag doesn't
+        have matching end tag. If that a case please create an issue against Checkstyle to
+        upgrade parser.
+      </p>
 
-    <p>
-      There are also HTML tags that are marked as "Not supported in HTML5"
+      <p>
+        There are also HTML tags that are marked as "Not supported in HTML5"
         (<a href='https://www.w3schools.com/tags/default.asp'>HTML Element Reference</a>).
-      Checkstyle Javadoc parser can parse those tags too if they are written in
+        Checkstyle Javadoc parser can parse those tags too if they are written in
         <a href="#Tight-HTML_rules">Tight-HTML</a>.
-      <br/>
-      Example.
-      <br/>
-      Input:
-      <source><![CDATA[
+        <br/>
+        Example.
+        <br/>
+        Input:
+        <source><![CDATA[
 <acronym title="as soon as possible">ASAP</acronym>
-      ]]></source>
-      <br/>
-      Output:
-      <source><![CDATA[
+]]>
+        </source>
+        <br/>
+        Output:
+        <source><![CDATA[
 JAVADOC -> JAVADOC [0:0]
 |--HTML_ELEMENT -> HTML_ELEMENT [0:0]
 |   `--HTML_TAG -> HTML_TAG [0:0]
@@ -528,42 +530,45 @@ JAVADOC -> JAVADOC [0:0]
 |           |--HTML_TAG_NAME -> acronym [0:44]
 |           `--END -> > [0:51]
 `--EOF -> <EOF> [0:52]
-      ]]></source>
-    </p>
+]]>
+        </source>
+      </p>
 
-    <p>More examples:</p>
+      <p>More examples:</p>
 
-    <table style="table-layout: fixed;">
-      <tr>
-        <td>
-          1) Unclosed paragraph HTML tag. As you see in the tree, content of the paragraph tag is
-          not nested to this tag.
-          That is because HTML tags are not closed by pair tag &lt;/p&gt;, and Checkstyle requires
-          <a href="#Tight-HTML_rules">Tight-HTML</a> code to predictably parse Javadoc comments.
-        </td>
-        <td>
-          2) Here is correct version with open and closed HTML tags.
-        </td>
-      </tr>
+      <table style="table-layout: fixed;">
+        <tr>
+          <td>
+            1) Unclosed paragraph HTML tag. As you see in the tree, content of the paragraph tag is
+            not nested to this tag.
+            That is because HTML tags are not closed by pair tag &lt;/p&gt;, and Checkstyle requires
+            <a href="#Tight-HTML_rules">Tight-HTML</a> code to predictably parse Javadoc comments.
+          </td>
+          <td>
+            2) Here is correct version with open and closed HTML tags.
+          </td>
+        </tr>
 
-      <tr>
-        <td>
-          <source><![CDATA[
+        <tr>
+          <td>
+            <source><![CDATA[
 <p> First
 <p> Second
-          ]]></source>
-        </td>
-        <td>
-          <source><![CDATA[
+]]>
+            </source>
+          </td>
+          <td>
+            <source><![CDATA[
 <p> First </p>
 <p> Second </p>
-          ]]></source>
-        </td>
-      </tr>
+]]>
+            </source>
+          </td>
+        </tr>
 
-      <tr>
-        <td>
-          <source><![CDATA[
+        <tr>
+          <td>
+            <source><![CDATA[
 JAVADOC -> JAVADOC [0:0]
 |--HTML_ELEMENT -> HTML_ELEMENT [0:0]
 |   `--P_TAG_START -> P_TAG_START [0:0]
@@ -579,10 +584,11 @@ JAVADOC -> JAVADOC [0:0]
 |       `--END -> > [1:2]
 |--TEXT ->  Second [1:3]
 `--EOF -> <EOF> [1:10]
-          ]]></source>
-        </td>
-        <td>
-          <source><![CDATA[
+]]>
+            </source>
+          </td>
+          <td>
+            <source><![CDATA[
 JAVADOC -> JAVADOC [0:0]
 |--HTML_ELEMENT -> HTML_ELEMENT [0:0]
 |   `--PARAGRAPH -> PARAGRAPH [0:0]
@@ -610,12 +616,13 @@ JAVADOC -> JAVADOC [0:0]
 |           |--P_HTML_TAG_NAME -> p [1:13]
 |           `--END -> > [1:14]
 `--EOF -> <EOF> [1:15]
-          ]]></source>
-        </td>
-      </tr>
-    </table>
+]]>
+            </source>
+          </td>
+        </tr>
+      </table>
 
-    <p>
+      <p>
         Checks can also be configured to log violation on encountering non-tight HTML tags.
         <tt>violateExecutionOnNonTightHtml</tt> property can be used for this purpose in the checks
         that support it. A custom check needs to extend <tt>AbstractJavadocCheck</tt> for having
@@ -624,13 +631,13 @@ JAVADOC -> JAVADOC [0:0]
         skip processing of javadocs with non-tight HTML, method
         <tt>acceptJavadocWithNonTightHtml</tt> in class <tt>AbstractJavadocCheck</tt> can be
         overridden in the check. The following example illustrates how to use this property.
-    </p>
+      </p>
 
-    <p>
-    Input:
-    </p>
+      <p>
+        Input:
+      </p>
 
-    <source><![CDATA[
+      <source><![CDATA[
 /**
   * <body>
   * <p> This class is only meant for testing. </p>
@@ -662,11 +669,12 @@ JAVADOC -> JAVADOC [0:0]
       */
      private int field4;
 }
-    ]]></source>
+]]>
+      </source>
 
-    <p>
+      <p>
         Output with <tt>violateExecutionOnNonTightHtml</tt> set to false:
-    </p>
+      </p>
 
       <div class="wrapper">
         <table>
@@ -698,9 +706,9 @@ Checkstyle ends with 1 errors.
         </table>
       </div>
 
-    <p>
+      <p>
         Output with <tt>violateExecutionOnNonTightHtml</tt> set to true:
-    </p>
+      </p>
 
       <div class="wrapper">
         <table>
@@ -761,9 +769,10 @@ Checkstyle ends with 5 errors.
        Notice that only files with ".java" extension can be opened.
       </p>
       <p>
-       For detail reference you can see
-       <a href="https://checkstyle.org/writingchecks.html#The_Checkstyle_SDK_Gui">
-           Checkstyle GUI documentation</a>.
+        For detail reference you can see
+        <a href="https://checkstyle.org/writingchecks.html#The_Checkstyle_SDK_Gui">
+          Checkstyle GUI documentation
+        </a>.
       </p>
     </section>
 
@@ -842,10 +851,11 @@ Checkstyle ends with 5 errors.
 
     <section name="Examples of Javadoc Checks">
       <p>
-      The best source knowledge about how to write Javadoc Checks
-      could be taken from
-      <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fjava+repo%3Acheckstyle%2Fcheckstyle+%22extends+AbstractJavadocCheck%22">
-        existing Checks</a>.
+        The best source knowledge about how to write Javadoc Checks
+        could be taken from
+        <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fjava+repo%3Acheckstyle%2Fcheckstyle+%22extends+AbstractJavadocCheck%22">
+          existing Checks
+        </a>.
       </p>
     </section>
 
@@ -985,7 +995,7 @@ Checkstyle ends with 5 errors.
             </td>
             <td>No errors, GeneralToken</td>
             <td>No errors, GeneralToken</td>
-            </tr>
+          </tr>
           <tr>
             <td>
               <![CDATA[<qwerty>]]>


### PR DESCRIPTION
Issue #8544

Checkstyle all xdoc files (except the checks) were formatted with two spaces indented.

There is a questionable one: `property_types.xml`. We should discuss this.
To satisfy the rules, all `<b>}</b>` tags should be indented __more__ than the enclosing `<pre>` tag.

There is at least three options:

* remove `<b></b>` and keep only the comments
* add this file to the exception list (current)
* wrap long lines

Formatting for checks will be in in the next PR(s).