### PR TITLE
 Issue #8488: Records Support Check update for UnusedImportsCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -194,6 +194,8 @@ public class UnusedImportsCheck extends AbstractCheck {
             TokenTypes.METHOD_DEF,
             TokenTypes.CTOR_DEF,
             TokenTypes.VARIABLE_DEF,
+            TokenTypes.RECORD_DEF,
+            TokenTypes.COMPACT_CTOR_DEF,
         };
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
@@ -180,6 +180,8 @@ public class UnusedImportsCheckTest extends AbstractModuleTestSupport {
             TokenTypes.METHOD_DEF,
             TokenTypes.CTOR_DEF,
             TokenTypes.VARIABLE_DEF,
+            TokenTypes.RECORD_DEF,
+            TokenTypes.COMPACT_CTOR_DEF,
         };
 
         assertArrayEquals(expected, actual, "Default required tokens are invalid");
@@ -205,6 +207,8 @@ public class UnusedImportsCheckTest extends AbstractModuleTestSupport {
             TokenTypes.METHOD_DEF,
             TokenTypes.CTOR_DEF,
             TokenTypes.VARIABLE_DEF,
+            TokenTypes.RECORD_DEF,
+            TokenTypes.COMPACT_CTOR_DEF,
         };
 
         assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
@@ -256,6 +260,18 @@ public class UnusedImportsCheckTest extends AbstractModuleTestSupport {
             "3:8: " + getCheckMessage(MSG_KEY, "module"),
         };
         verify(checkConfig, getNonCompilablePath("InputUnusedImportsSingleWordPackage.java"),
+                expected);
+    }
+
+    @Test
+    public void testRecordsAndCompactCtors() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(UnusedImportsCheck.class);
+        final String[] expected = {
+            "12:8: " + getCheckMessage(MSG_KEY, "javax.swing.JToolBar"),
+            "13:8: " + getCheckMessage(MSG_KEY, "javax.swing.JToggleButton"),
+        };
+        verify(checkConfig,
+                getNonCompilablePath("InputUnusedImportsRecordsAndCompactCtors.java"),
                 expected);
     }
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsRecordsAndCompactCtors.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsRecordsAndCompactCtors.java
@@ -1,0 +1,54 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.imports.unusedimports;
+
+import java.util.ArrayDeque; // ok
+import java.util.Arrays; // ok
+import java.util.Date;  // ok
+import java.util.HashMap;// ok
+import java.util.Iterator; // ok
+import java.util.LinkedHashSet; // ok
+import java.util.LinkedList; // ok
+import java.util.List;  // ok
+import javax.swing.JToolBar; // violation
+import javax.swing.JToggleButton; // violation
+
+import org.w3c.dom.Node; // ok
+
+/*
+ * Config:
+ * processJavadoc = true
+ */
+public class InputUnusedImportsRecordsAndCompactCtors {
+
+    /**
+     * {@link List}
+     */
+    record TestRecord1() {
+        // import usage in record body
+        static HashMap<String, Node> hashMap;
+        static ArrayDeque<Integer> arrayDeque;
+
+        /**
+         * {@link Date}
+         */
+        public TestRecord1{}
+    }
+
+    record TestRecord2() {
+
+        // import usage in compact ctor
+        public TestRecord2{
+            Arrays arrays;
+            Iterator<String> it;
+        }
+
+        TestRecord2(LinkedList<String> link) {
+            this();
+        }
+    }
+
+    record TestRecord3(LinkedHashSet<Integer> lhs) {
+
+    }
+
+}


### PR DESCRIPTION
 Issue #8488: Records Support Check update for UnusedImportsCheck

This PR updates UnusedImportsCheck to function as intended with Java 14 record definitions and compact constructors. 

Diff Regression projects: https://raw.githubusercontent.com/nmancus1/nmancus1.github.io/master/check-update-configs/projects-to-test-on.properties

Diff Regression config: https://raw.githubusercontent.com/nmancus1/nmancus1.github.io/master/check-update-configs/UnusedImports.xml