### PR TITLE
Unambiguous limitation about ASCII

### DIFF
--- a/src/xdocs/writingchecks.xml
+++ b/src/xdocs/writingchecks.xml
@@ -663,9 +663,19 @@ public class MethodLimitCheck extends AbstractCheck
         There are basically only a few limits for Checkstyle:
       </p>
       <ul>
-        <li>Java code should be written with
-          <a href="https://en.wikipedia.org/wiki/ASCII">ASCII</a> characters only, no UTF-8
-          support.
+        <li>Java
+          <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.5">
+            tokens (identifiers, keywords)</a>
+          should be written with
+          <a href="https://en.wikipedia.org/wiki/ASCII">ASCII</a>
+          characters ONLY,
+          no
+          <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.3">
+            Unicode escape</a>
+          support in keywords and no
+          <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.1">
+            Unicode</a>
+          support in identifiers.
         </li>
         <li>To get valid violations, code have to be compilable, in other case you can get not easy
         to understand parse errors.</li>


### PR DESCRIPTION
Issue: #8551.

Commit message should be: “Issue #8551: Consider relaxing the stated limitation about UTF-8” (sorry, just saw it when opening the PR).

The issue does not have the “approved” label, but I understood the comment there (asking to suggest better wording and referring to the source code of the website) as inviting me to introduce a PR. I hope this is okay.
