### PR TITLE
Issue #8516: Records Support check update for OuterTypeFilenameCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheck.java
@@ -62,6 +62,12 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *
  * }
  * </pre>
+ * <p>Example of record Foo in a file named Test.java</p>
+ * <pre>
+ * record Foo { // violation
+ *
+ * }
+ * </pre>
  * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
  * </p>
@@ -117,6 +123,7 @@ public class OuterTypeFilenameCheck extends AbstractCheck {
             TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,
             TokenTypes.ANNOTATION_DEF,
+            TokenTypes.RECORD_DEF,
         };
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheckTest.java
@@ -44,6 +44,7 @@ public class OuterTypeFilenameCheckTest extends AbstractModuleTestSupport {
             TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,
             TokenTypes.ANNOTATION_DEF,
+            TokenTypes.RECORD_DEF,
         };
         assertArrayEquals(expected, checkObj.getRequiredTokens(),
                 "Required tokens array differs from expected");
@@ -74,6 +75,7 @@ public class OuterTypeFilenameCheckTest extends AbstractModuleTestSupport {
             TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,
             TokenTypes.ANNOTATION_DEF,
+            TokenTypes.RECORD_DEF,
         };
         assertArrayEquals(expected, actual, "Acceptable tokens array differs from expected");
     }
@@ -140,6 +142,17 @@ public class OuterTypeFilenameCheckTest extends AbstractModuleTestSupport {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
         verify(checkConfig, getNonCompilablePath("package-info.java"), expected);
+    }
+
+    @Test
+    public void testOuterTypeFilenameRecords() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(OuterTypeFilenameCheck.class);
+
+        final String[] expected = {
+            "6:1: " + getCheckMessage(MSG_KEY),
+        };
+        verify(checkConfig,
+                getNonCompilablePath("InputOuterTypeFilenameRecord.java"), expected);
     }
 
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/outertypefilename/InputOuterTypeFilenameRecord.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/outertypefilename/InputOuterTypeFilenameRecord.java
@@ -1,0 +1,8 @@
+//non-compiled with javac: contains different class name by demand of test
+package com.puppycrawl.tools.checkstyle.checks.outertypefilename;
+/* Config:
+ * default
+ */
+public record IncorrectName(int x, int y, String str) { // violation
+
+}

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -1786,6 +1786,12 @@ enum Foo { // violation
 
 }
         </source>
+        <p>Example of record Foo in a file named Test.java</p>
+        <source>
+record Foo { // violation
+
+}
+        </source>
       </subsection>
 
       <subsection name="Example of Usage" id="OuterTypeFilename_Example_of_Usage">


### PR DESCRIPTION
Issue #8516: Records Support check update for OuterTypeFilenameCheck

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/f52e3def2d2cee1831d1bf15b0258d86/raw/6820ccb5294a94cd5fa8b36eac8694639ac20c59/OuterTypeFilenameCheck.xml