### PR TITLE
Issue #8569: fix ConstantNameCheck and MethodNameCheck for interfaces

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractAccessControlNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractAccessControlNameCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.naming;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
 
 /**
  * Abstract class for checking a class member (field/method)'s name conforms to
@@ -81,18 +82,34 @@ public abstract class AbstractAccessControlNameCheck
      * @return true if we should check such member.
      */
     protected boolean shouldCheckInScope(DetailAST modifiers) {
-        final boolean isPublic = modifiers
-                .findFirstToken(TokenTypes.LITERAL_PUBLIC) != null;
         final boolean isProtected = modifiers
                 .findFirstToken(TokenTypes.LITERAL_PROTECTED) != null;
         final boolean isPrivate = modifiers
                 .findFirstToken(TokenTypes.LITERAL_PRIVATE) != null;
+        final boolean isPublic = isPublic(modifiers);
+
         final boolean isPackage = !(isPublic || isProtected || isPrivate);
 
         return applyToPublic && isPublic
                 || applyToProtected && isProtected
                 || applyToPackage && isPackage
                 || applyToPrivate && isPrivate;
+    }
+
+    /**
+     * Checks if given modifiers has public access.
+     * There are 2 cases - it is either has explicit modifier, or it is
+     * in annotation or interface.
+     *
+     * @param modifiers - modifiers to check
+     * @return true if public
+     */
+    private static boolean isPublic(DetailAST modifiers) {
+        return modifiers.findFirstToken(TokenTypes.LITERAL_PUBLIC) != null
+                || ScopeUtil.isInAnnotationBlock(modifiers)
+                || ScopeUtil.isInInterfaceBlock(modifiers)
+                    // interface methods can be private
+                    && modifiers.findFirstToken(TokenTypes.LITERAL_PRIVATE) == null;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheck.java
@@ -153,12 +153,12 @@ public class ConstantNameCheck
 
         final DetailAST modifiersAST =
             ast.findFirstToken(TokenTypes.MODIFIERS);
-        final boolean isStatic = modifiersAST.findFirstToken(TokenTypes.LITERAL_STATIC) != null;
-        final boolean isFinal = modifiersAST.findFirstToken(TokenTypes.FINAL) != null;
-
-        if (isStatic && isFinal && shouldCheckInScope(modifiersAST)
-                || ScopeUtil.isInAnnotationBlock(ast)
-                || ScopeUtil.isInInterfaceBlock(ast)
+        final boolean isStaticFinal =
+            modifiersAST.findFirstToken(TokenTypes.LITERAL_STATIC) != null
+                && modifiersAST.findFirstToken(TokenTypes.FINAL) != null
+            || ScopeUtil.isInAnnotationBlock(ast)
+            || ScopeUtil.isInInterfaceBlock(ast);
+        if (isStaticFinal && shouldCheckInScope(modifiersAST)
                         && !ScopeUtil.isInCodeBlock(ast)) {
             // Handle the serialVersionUID and serialPersistentFields constants
             // which are used for Serialization. Cannot enforce rules on it. :-)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheckTest.java
@@ -145,6 +145,16 @@ public class ConstantNameCheckTest
     }
 
     @Test
+    public void testIntoInterfaceExcludePublic() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(ConstantNameCheck.class);
+        checkConfig.addAttribute("applyToPublic", "false");
+
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputConstantNameInterfaceIgnorePublic.java"), expected);
+    }
+
+    @Test
     public void testStaticMethodInInterface()
             throws Exception {
         final DefaultConfiguration checkConfig =

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckTest.java
@@ -170,6 +170,40 @@ public class MethodNameCheckTest
     }
 
     @Test
+    public void testInterfacesExcludePublic() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(MethodNameCheck.class);
+        checkConfig.addAttribute("applyToPublic", "false");
+        final String pattern = "^[a-z][a-zA-Z0-9]*$";
+
+        final String[] expected = {
+            "10:18: " + getCheckMessage(MSG_INVALID_PATTERN, "PrivateMethod", pattern),
+            "12:25: " + getCheckMessage(MSG_INVALID_PATTERN, "PrivateMethod2", pattern),
+        };
+
+        verify(checkConfig, getNonCompilablePath("InputMethodNamePublicMethodsInInterfaces.java"),
+            expected);
+    }
+
+    @Test
+    public void testInterfacesExcludePrivate() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(MethodNameCheck.class);
+        checkConfig.addAttribute("applyToPrivate", "false");
+        final String pattern = "^[a-z][a-zA-Z0-9]*$";
+
+        final String[] expected = {
+            "14:18: " + getCheckMessage(MSG_INVALID_PATTERN, "DefaultMethod", pattern),
+            "17:25: " + getCheckMessage(MSG_INVALID_PATTERN, "DefaultMethod2", pattern),
+            "20:10: " + getCheckMessage(MSG_INVALID_PATTERN, "PublicMethod", pattern),
+            "22:17: " + getCheckMessage(MSG_INVALID_PATTERN, "PublicMethod2", pattern),
+        };
+
+        verify(checkConfig, getNonCompilablePath("InputMethodNamePrivateMethodsInInterfaces.java"),
+            expected);
+    }
+
+    @Test
     public void testGetAcceptableTokens() {
         final MethodNameCheck methodNameCheckObj = new MethodNameCheck();
         final int[] actual = methodNameCheckObj.getAcceptableTokens();

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNamePrivateMethodsInInterfaces.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNamePrivateMethodsInInterfaces.java
@@ -1,0 +1,24 @@
+//non-compiled with javac: Compilable with Java9
+package com.puppycrawl.tools.checkstyle.checks.naming.methodname;
+
+/*
+ * Config:
+ * applyToPrivate = false
+ */
+public interface InputMethodNamePrivateMethodsInInterfaces {
+
+    private void PrivateMethod() {} // ok
+
+    private static void PrivateMethod2() {} // ok
+
+    default void DefaultMethod() { // violation
+    }
+
+    public default void DefaultMethod2() { // violation
+    }
+
+    void PublicMethod(); // violation
+
+    public void PublicMethod2(); // violation
+
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNamePublicMethodsInInterfaces.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNamePublicMethodsInInterfaces.java
@@ -1,0 +1,24 @@
+//non-compiled with javac: Compilable with Java9
+package com.puppycrawl.tools.checkstyle.checks.naming.methodname;
+
+/*
+ * Config:
+ * applyToPublic = false
+ */
+public interface InputMethodNamePublicMethodsInInterfaces {
+
+    private void PrivateMethod() {} // violation
+
+    private static void PrivateMethod2() {} // violation
+
+    default void DefaultMethod() { // ok
+    }
+
+    public default void DefaultMethod2() { // ok
+    }
+
+    void PublicMethod(); // ok
+
+    public void PublicMethod2(); // ok
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/InputConstantName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/InputConstantName.java
@@ -6,4 +6,6 @@ public class InputConstantName
 {
     private static final long serialVersionUID = 1L; //should be ignored
     private static final ObjectStreamField[] serialPersistentFields = {}; // should be ignored too
+    static int value1 = 10;
+    final int value2 = 10;
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/InputConstantNameInterfaceIgnorePublic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/constantname/InputConstantNameInterfaceIgnorePublic.java
@@ -1,0 +1,15 @@
+package com.puppycrawl.tools.checkstyle.checks.naming.constantname;
+
+/*
+* Config:
+* applyToPublic = false
+*/
+public interface InputConstantNameInterfaceIgnorePublic {
+    int __MAX_SIZE = 1024; // ok
+    public int __MAX_SIZE2 = 1024; // ok
+}
+
+@interface Anno {
+    int __MAX_SIZ1E = 1024; // ok
+    public int __MAX_SIZE2 = 1024; // ok
+}


### PR DESCRIPTION
#8569

Fixed ConstantName check to correctly detect constants + MethodName check is extended with test case for private methods in interface

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties
Diff Regression config: https://gist.githubusercontent.com/strkkk/a6e04b73158d1ef6f563dd5aab753361/raw/74f66fa883a25f37a0689fbe4ab293d66c236417/constant_name
