### PR TITLE
Issue #6560: Explicitly specify default encoding to make unit tests more robust

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -328,6 +328,7 @@ detailast
 detailastimpl
 detailnodetreestringprinter
 Dexec
+Dfile
 dfn
 Dfoo
 Dforbiddenapis

--- a/pom.xml
+++ b/pom.xml
@@ -1229,6 +1229,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.2</version>
         <configuration>
+          <argLine>-Dfile.encoding=UTF-8</argLine>
           <systemPropertyVariables>
             <jacoco-agent.destfile>${project.build.directory}/jacoco.exec</jacoco-agent.destfile>
           </systemPropertyVariables>


### PR DESCRIPTION
Issue #6560

On platforms that had a default encoding different than UTF-8, some of the unit tests failed. This PR explicitly specifies the encoding for the unit tests so that they'll pass no matter what the platform's encoding is.