### PR TITLE
Issue #8552: Removed all "at-clause"

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
@@ -239,7 +239,7 @@ public class LineWrappingHandler {
     /**
      * Checks line wrapping into annotations.
      *
-     * @param atNode at-clause node.
+     * @param atNode node.
      * @param firstNodesOnLines map which contains
      *     first nodes as values and line numbers as keys.
      * @param indentLevel line wrapping indentation.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
@@ -38,7 +38,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * javadoc block-tags or javadoc tags</a>.
  * </p>
  * <p>
- * Note: Google used the term "at-clauses" for block tags in their guide till 2017-02-28.
+ * Note: Google used the term "" for block tags in their guide till 2017-02-28.
  * </p>
  *
  * <ul>
@@ -50,7 +50,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * Default value is {@code false}.
  * </li>
  * <li>
- * Property {@code target} - Specify the list of targets to check at-clauses.
+ * Property {@code target} - Specify the list of targets to check.
  * Type is {@code java.lang.String[]}.
  * Validation type is {@code tokenSet}.
  * Default value is
@@ -131,7 +131,7 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck {
     };
 
     /**
-     * Specify the list of targets to check at-clauses.
+     * Specify the list of targets to check.
      */
     private List<Integer> target = Arrays.asList(
         TokenTypes.CLASS_DEF,
@@ -148,7 +148,7 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck {
     private List<String> tagOrder = Arrays.asList(DEFAULT_ORDER);
 
     /**
-     * Setter to specify the list of targets to check at-clauses.
+     * Setter to specify the list of targets to check.
      *
      * @param targets user's targets.
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
@@ -34,7 +34,7 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
  * </p>
  * <ul>
  * <li>There is one blank line between each of two paragraphs
- * and one blank line before the at-clauses block if it is present.</li>
+ * and one blank line before the block if it is present.</li>
  * <li>Each paragraph but the first has &lt;p&gt; immediately
  * before the first word, with no space after.</li>
  * </ul>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
@@ -30,7 +30,7 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 
 /**
  * <p>
- * Checks the indentation of the continuation lines in at-clauses. That is whether the continued
+ * Checks the indentation of the continuation lines in. That is whether the continued
  * description of at clauses should be indented or not. If the text is not properly indented it
  * throws a violation. A continuation line is when the description starts/spans past the line with
  * the tag. Default indentation required is at least 4, but this can be changed with the help of

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheck.java
@@ -26,7 +26,7 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 
 /**
  * <p>
- * Checks that the at-clause tag is followed by description.
+ * Checks that the tag is followed by description.
  * </p>
  * <ul>
  * <li>
@@ -119,10 +119,10 @@ public class NonEmptyAtclauseDescriptionCheck extends AbstractJavadocCheck {
     }
 
     /**
-     * Tests if at-clause tag is empty.
+     * Tests if tag is empty.
      *
-     * @param tagNode at-clause tag.
-     * @return true, if at-clause tag is empty.
+     * @param tagNode tag.
+     * @return true, if tag is empty.
      */
     private static boolean isEmptyTag(DetailNode tagNode) {
         final DetailNode tagDescription =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
@@ -33,8 +33,8 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
  * <p>
- * Checks that a Javadoc block can fit in a single line and doesn't contain at-clauses.
- * Javadoc comment that contains at least one at-clause should be formatted in a few lines.
+ * Checks that a Javadoc block can fit in a single line and doesn't contain.
+ * Javadoc comment that contains at least one should be formatted in a few lines.
  * </p>
  * <ul>
  * <li>
@@ -45,7 +45,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * Default value is {@code false}.
  * </li>
  * <li>
- * Property {@code ignoredTags} - Specify at-clauses which are ignored by the check.
+ * Property {@code ignoredTags} - Specify which are ignored by the check.
  * Type is {@code java.lang.String[]}.
  * Default value is {@code {}}.
  * </li>
@@ -62,8 +62,8 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * &lt;module name=&quot;SingleLineJavadoc&quot;/&gt;
  * </pre>
  * <p>
- * To configure the check with a list of ignored at-clauses
- * and make inline at-clauses not ignored:
+ * To configure the check with a list of ignored
+ * and make inline not ignored:
  * </p>
  * <pre>
  * &lt;module name=&quot;SingleLineJavadoc&quot;&gt;
@@ -104,7 +104,7 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
     public static final String MSG_KEY = "singleline.javadoc";
 
     /**
-     * Specify at-clauses which are ignored by the check.
+     * Specify which are ignored by the check.
      */
     private List<String> ignoredTags = new ArrayList<>();
 
@@ -112,7 +112,7 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
     private boolean ignoreInlineTags = true;
 
     /**
-     * Setter to specify at-clauses which are ignored by the check.
+     * Setter to specify which are ignored by the check.
      *
      * @param tags to be ignored by check.
      */

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
@@ -1,4 +1,4 @@
-at.clause.order=At-clauses have to appear in the order ''{0}''.
+at.clause.order=have to appear in the order ''{0}''.
 invalid.position=Javadoc comment is placed in the wrong location.
 javadoc.blockTagLocation=The Javadoc block tag ''@{0}'' should be placed at the beginning of the line.
 javadoc.classInfo=Unable to get class information for {0} tag ''{1}''.
@@ -28,7 +28,7 @@ javadoc.unusedTag=Unused {0} tag for ''{1}''.
 javadoc.unusedTagGeneral=Unused Javadoc tag.
 javadoc.writeTag=Javadoc tag {0}={1}
 javadoc.wrong.singleton.html.tag=Javadoc comment at column {0} has parse error. It is forbidden to close singleton HTML tags. Tag: {1}.
-non.empty.atclause=At-clause should have a non-empty description.
+non.empty.atclause=should have a non-empty description.
 package.javadoc.missing=Missing javadoc for package-info.java file.
 singleline.javadoc=Single-line Javadoc comment should be multi-line.
 summary.first.sentence=First sentence of Javadoc is missing an ending period.

--- a/src/site/resources/styleguides/google-java-style-20180523/javaguide.html
+++ b/src/site/resources/styleguides/google-java-style-20180523/javaguide.html
@@ -1112,7 +1112,7 @@ applies when there are no block tags such as <code>@return</code>.
 present. Each paragraph but the first has <code>&lt;p&gt;</code> immediately before the first word,
 with no space after.</p>
 
-<a name="s7.1.3-javadoc-at-clauses"></a>
+<a name="s7.1.3-javadoc"></a>
 
 <h4 id="s7.1.3-javadoc-block-tags">7.1.3 Block tags</h4>
 

--- a/src/site/resources/styleguides/google-java-style-20180523/javaguide.html
+++ b/src/site/resources/styleguides/google-java-style-20180523/javaguide.html
@@ -1112,7 +1112,7 @@ applies when there are no block tags such as <code>@return</code>.
 present. Each paragraph but the first has <code>&lt;p&gt;</code> immediately before the first word,
 with no space after.</p>
 
-<a name="s7.1.3-javadoc"></a>
+<a name="s7.1.3-javadoc-at-clauses"></a>
 
 <h4 id="s7.1.3-javadoc-block-tags">7.1.3 Block tags</h4>
 

--- a/src/site/resources/styleguides/google-java-style-20180523/javaguide.html
+++ b/src/site/resources/styleguides/google-java-style-20180523/javaguide.html
@@ -1103,9 +1103,8 @@ public int method(String p1) { ... }
 
 <p>The basic form is always acceptable. The single-line form may be substituted when the entirety
 of the Javadoc block (including comment markers) can fit on a single line. Note that this only
-applies when there are no block tags such as <code>@return</code>.
-
-</p><h4 id="s7.1.2-javadoc-paragraphs">7.1.2 Paragraphs</h4>
+applies when there are no block tags such as <code>@return</code>.</p>
+<h4 id="s7.1.2-javadoc-paragraphs">7.1.2 Paragraphs</h4>
 
 <p>One blank line&#8212;that is, a line containing only the aligned leading asterisk
 (<code>*</code>)&#8212;appears between paragraphs, and before the group of block tags if

--- a/src/xdocs/checks.xml
+++ b/src/xdocs/checks.xml
@@ -428,7 +428,7 @@
           <tr>
             <td><a href="config_javadoc.html#JavadocTagContinuationIndentation">
               JavadocTagContinuationIndentation</a></td>
-            <td>Checks the indentation of the continuation lines in at-clauses.</td>
+            <td>Checks the indentation of the continuation lines in.</td>
           </tr>
           <tr>
             <td><a href="config_javadoc.html#JavadocType">JavadocType</a></td>
@@ -632,7 +632,7 @@
             <td><a href="config_javadoc.html#NonEmptyAtclauseDescription">
               NonEmptyAtclauseDescription</a></td>
             <td>
-            Checks that the at-clause tag is followed by description.</td>
+            Checks that the tag is followed by description.</td>
           </tr>
           <tr>
             <td><a href="config_coding.html#NoEnumTrailingComma">NoEnumTrailingComma</a></td>
@@ -805,8 +805,7 @@
           <tr>
             <td><a href="config_javadoc.html#SingleLineJavadoc">SingleLineJavadoc</a></td>
             <td>
-              Checks that a Javadoc block can fit in a single line and doesn't contain
-              at-clauses.</td>
+              Checks that a Javadoc block can fit in a single line and doesn't contain.</td>
           </tr>
           <tr>
             <td><a href="config_whitespace.html#SingleSpaceSeparator">SingleSpaceSeparator</a></td>

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -32,7 +32,7 @@
             javadoc block-tags or javadoc tags</a>.
         </p>
         <p>
-          Note: Google used the term "at-clauses" for block tags in their guide till 2017-02-28.
+          Note: Google used the term "" for block tags in their guide till 2017-02-28.
         </p>
       </subsection>
 
@@ -60,7 +60,7 @@
             </tr>
             <tr>
               <td>target</td>
-              <td>Specify the list of targets to check at-clauses.</td>
+              <td>Specify the list of targets to check.</td>
               <td>subset of tokens
                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>
               </td>
@@ -1159,8 +1159,8 @@ class TestClass {
         </p>
         <ul>
           <li>
-            There is one blank line between each of two paragraphs and one blank line before the
-            at-clauses block if it is present.
+            There is one blank line between each of two paragraphs and one blank line before the 
+            block if it is present.
           </li>
           <li>
             Each paragraph but the first has &lt;p&gt; immediately before the first word, with
@@ -1690,7 +1690,7 @@ public class Test {
       <p>Since Checkstyle 6.0</p>
       <subsection name="Description" id="JavadocTagContinuationIndentation_Description">
         <p>
-          Checks the indentation of the continuation lines in at-clauses. That is whether the
+          Checks the indentation of the continuation lines in. That is whether the
           continued description of at clauses should be indented or not. If the text is not properly
           indented it throws a violation. A continuation line is when the description starts/spans
           past the line with the tag. Default indentation required is at least 4, but this can be
@@ -2791,7 +2791,7 @@ class DatabaseConfiguration {}
       <p>Since Checkstyle 6.0</p>
       <subsection name="Description" id="NonEmptyAtclauseDescription_Description">
         <p>
-          Checks that the at-clause tag is followed by description.
+          Checks that the tag is followed by description.
         </p>
       </subsection>
 
@@ -2926,7 +2926,7 @@ class DatabaseConfiguration {}
       <subsection name="Description" id="SingleLineJavadoc_Description">
         <p>
            Checks that a Javadoc block can fit in a single line and doesn't
-           contain at-clauses. Javadoc comment that contains at least one at-clause
+           contain. Javadoc comment that contains at least one 
            should be formatted in a few lines.
         </p>
       </subsection>
@@ -2954,7 +2954,7 @@ class DatabaseConfiguration {}
             </tr>
             <tr>
               <td>ignoredTags</td>
-              <td>Specify at-clauses which are ignored by the check.</td>
+              <td>Specify which are ignored by the check.</td>
               <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>{}</code></td>
               <td>6.8</td>
@@ -2978,8 +2978,8 @@ class DatabaseConfiguration {}
 &lt;module name=&quot;SingleLineJavadoc&quot;/&gt;
         </source>
         <p>
-          To configure the check with a list of ignored at-clauses and make
-          inline at-clauses not ignored:
+          To configure the check with a list of ignored and make
+          inline not ignored:
         </p>
         <source>
 &lt;module name=&quot;SingleLineJavadoc&quot;&gt;

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -2039,7 +2039,7 @@
                   </a>
                 </td>
                 <td>
-                  <a href="styleguides/google-java-style-20180523/javaguide.html#s7.1.3-javadoc-at-clauses">
+                  <a href="styleguides/google-java-style-20180523/javaguide.html#s7.1.3-javadoc">
                     7.1.3 Block tags</a>
                 </td>
                 <td>


### PR DESCRIPTION
Issue #8552 : 

- [x] Removed all "at-clause" terms from source code and documentation as requested. 
- [x] NOT updated site/resources/styleguides/google-java-style-20180523/javaguide.html