### PR TITLE
Issue #8748: Create new check RecordComponentNumberCheck

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -1108,6 +1108,7 @@ README
 Readonly
 rebased
 rebasing
+recordcomponentnumber
 recordtypeparametername
 redundantimport
 redundantmodifier

--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -701,6 +701,7 @@
     <module name="MethodLength"/>
     <module name="OuterTypeNumber"/>
     <module name="ParameterNumber"/>
+    <module name="RecordComponentNumber"/>
 
     <!-- Whitespace -->
     <module name="EmptyForInitializerPad"/>

--- a/pom.xml
+++ b/pom.xml
@@ -1909,6 +1909,9 @@
                 <param>com.puppycrawl.tools.checkstyle.checks.NoCodeInFileCheck*</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck*</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck*</param>
+                <param>
+                  com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheck*
+                </param>
                 <param>com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder*</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck*</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck*</param>
@@ -1928,6 +1931,9 @@
                 <param>com.puppycrawl.tools.checkstyle.checks.NoCodeInFileCheckTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheckTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheckTest</param>
+                <param>
+                  com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheckTest
+                </param>
                 <param>com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolderTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.TodoCommentCheckTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheckTest</param>

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionRecordComponentNumberTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionRecordComponentNumberTest.java
@@ -1,0 +1,94 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package org.checkstyle.suppressionxpathfilter;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheck;
+
+public class XpathRegressionRecordComponentNumberTest extends AbstractXpathTestSupport {
+
+    private final String checkName = RecordComponentNumberCheck.class.getSimpleName();
+
+    @Override
+    protected String getCheckName() {
+        return checkName;
+    }
+
+    @Test
+    public void testOne() throws Exception {
+        final File fileToProcess = new File(getNonCompilablePath(
+                "SuppressionXpathRecordComponentNumber1.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(RecordComponentNumberCheck.class);
+
+        final String[] expectedViolation = {
+            "8:1: " + getCheckMessage(RecordComponentNumberCheck.class,
+                    RecordComponentNumberCheck.MSG_KEY,
+                    15, 8),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/RECORD_DEF[./IDENT[@text='SuppressionXpathRecordComponentNumber1']]",
+            "/RECORD_DEF[./IDENT[@text='SuppressionXpathRecordComponentNumber1']]"
+                    + "/MODIFIERS",
+            "/RECORD_DEF[./IDENT[@text='SuppressionXpathRecordComponentNumber1']]"
+                    + "/MODIFIERS/LITERAL_PUBLIC"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testTwo() throws Exception {
+        final File fileToProcess = new File(getNonCompilablePath(
+                "SuppressionXpathRecordComponentNumber2.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(RecordComponentNumberCheck.class);
+        moduleConfig.addAttribute("max", "1");
+
+        final String[] expectedViolation = {
+            "9:5: " + getCheckMessage(RecordComponentNumberCheck.class,
+                    RecordComponentNumberCheck.MSG_KEY,
+                    2, 1),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRecordComponentNumber2']]"
+                    + "/OBJBLOCK/RECORD_DEF[./IDENT[@text='MyRecord']]",
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRecordComponentNumber2']]"
+                    + "/OBJBLOCK/RECORD_DEF[./IDENT[@text='MyRecord']]/MODIFIERS",
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRecordComponentNumber2']]"
+                    + "/OBJBLOCK/RECORD_DEF[./IDENT[@text='MyRecord']]/MODIFIERS"
+                    + "/LITERAL_PUBLIC"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+}

--- a/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/recordcomponentnumber/SuppressionXpathRecordComponentNumber1.java
+++ b/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/recordcomponentnumber/SuppressionXpathRecordComponentNumber1.java
@@ -1,0 +1,15 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.sizes.recordcomponentnumber;
+
+/* Config:
+ *
+ * max = 8
+ */
+public record SuppressionXpathRecordComponentNumber1(int x, int y, int z, // warn
+                                                int a, int b, int c,
+                                                int d, int e, int f,
+                                                int g, int h, int i,
+                                                int j, int k,
+                                                 String... myVarargs) {
+
+}

--- a/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/recordcomponentnumber/SuppressionXpathRecordComponentNumber2.java
+++ b/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/recordcomponentnumber/SuppressionXpathRecordComponentNumber2.java
@@ -1,0 +1,10 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.sizes.recordcomponentnumber;
+
+/* Config:
+ *
+ * max = 1
+ */
+public class SuppressionXpathRecordComponentNumber2 {
+    public record MyRecord(int x, int y) { } // warn
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -793,6 +793,8 @@ public class PackageObjectFactory implements ModuleFactory {
                 BASE_PACKAGE + ".checks.sizes.OuterTypeNumberCheck");
         NAME_TO_FULL_MODULE_NAME.put("ParameterNumberCheck",
                 BASE_PACKAGE + ".checks.sizes.ParameterNumberCheck");
+        NAME_TO_FULL_MODULE_NAME.put("RecordComponentNumberCheck",
+                BASE_PACKAGE + ".checks.sizes.RecordComponentNumberCheck");
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/RecordComponentNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/RecordComponentNumberCheck.java
@@ -1,0 +1,241 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.sizes;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.puppycrawl.tools.checkstyle.StatelessCheck;
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption;
+import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
+
+/**
+ * <p>
+ * Checks the number of record components in the
+ * <a href="https://docs.oracle.com/javase/specs/jls/se14/preview/specs/records-jls.html#jls-8.10.1">
+ * header</a> of a record definition.
+ * </p>
+ * <ul>
+ * <li>
+ * Property {@code max} - Specify the maximum number of components allowed in the header of a
+ * record definition.
+ * Type is {@code int}.
+ * Default value is {@code 8}.
+ * </li>
+ * <li>
+ * Property {@code accessModifiers} - Access modifiers of record definitions where
+ * the number of record components should be checked.
+ * Type is {@code com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption[]}.
+ * Default value is {@code public, protected, package, private}.
+ * </li>
+ * </ul>
+ * <p>
+ * To configure the check:
+ * </p>
+ * <pre>
+ * &lt;module name="RecordComponentNumber"/&gt;
+ * </pre>
+ * <p>
+ * Java code example:
+ * </p>
+ * <pre>
+ * public record MyRecord1(int x, int y) { // ok, 2 components
+ *     ...
+ * }
+ *
+ * record MyRecord2(int x, int y, String str,
+ *                           Node node, Order order, Data data
+ *                           String location, Date date, Image image) { // violation, 9 components
+ *     ...
+ * }
+ * </pre>
+ * <p>
+ * To configure the check to allow 5 record components at all access modifier levels
+ * for record definitions:
+ * </p>
+ * <pre>
+ * &lt;module name="RecordComponentNumber"&gt;
+ *   &lt;property name="max" value="5"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Java code example:
+ * </p>
+ * <pre>
+ * public record MyRecord1(int x, int y, String str) { // ok, 3 components
+ *     ...
+ * }
+ *
+ * public record MyRecord2(int x, int y, String str,
+ *                           Node node, Order order, Data data) { // violation, 6 components
+ *     ...
+ * }
+ * </pre>
+ * <p>
+ * To configure the check to allow 10 record components for a public record definition,
+ * but 3 for private record definitions:
+ * </p>
+ * <pre>
+ * &lt;module name="RecordComponentNumber"&gt;
+ *   &lt;property name="max" value="3"/&gt;
+ *   &lt;property name="accessModifiers" value="private"/&gt;
+ * &lt;/module&gt;
+ * &lt;module name="RecordComponentNumber"&gt;
+ *   &lt;property name="max" value="10"/&gt;
+ *   &lt;property name="accessModifiers" value="public"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Java code example:
+ * </p>
+ * <pre>
+ * public record MyRecord1(int x, int y, String str) { // ok, public record definition allowed 10
+ *     ...
+ * }
+ *
+ * private record MyRecord2(int x, int y, String str, Node node) { // violation
+ *     ...                                // private record definition allowed 3 components
+ * }
+ * </pre>
+ * <p>
+ * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
+ * </p>
+ * <p>
+ * Violation Message Keys:
+ * </p>
+ * <ul>
+ * <li>
+ * {@code too.many.components}
+ * </li>
+ * </ul>
+ *
+ * @since 8.36
+ */
+@StatelessCheck
+public class RecordComponentNumberCheck extends AbstractCheck {
+
+    /**
+     * A key is pointing to the warning message text in "messages.properties"
+     * file.
+     */
+    public static final String MSG_KEY = "too.many.components";
+
+    /** Default maximum number of allowed components. */
+    private static final int DEFAULT_MAX_COMPONENTS = 8;
+
+    /** Specify the maximum number of components allowed in the header of a record definition. */
+    private int max = DEFAULT_MAX_COMPONENTS;
+
+    /**
+     * Access modifiers of record definitions where the number
+     * of record components should be checked.
+     */
+    private AccessModifierOption[] accessModifiers = {
+        AccessModifierOption.PUBLIC,
+        AccessModifierOption.PROTECTED,
+        AccessModifierOption.PACKAGE,
+        AccessModifierOption.PRIVATE,
+    };
+
+    /**
+     * Setter to specify the maximum number of components allowed in the header
+     * of a record definition.
+     *
+     * @param value the maximum allowed.
+     */
+    public void setMax(int value) {
+        max = value;
+    }
+
+    /**
+     * Setter to access modifiers of record definitions where the number of record
+     * components should be checked.
+     *
+     * @param accessModifiers access modifiers of record definitions which should be checked.
+     */
+    public void setAccessModifiers(AccessModifierOption... accessModifiers) {
+        this.accessModifiers =
+                Arrays.copyOf(accessModifiers, accessModifiers.length);
+    }
+
+    @Override
+    public int[] getDefaultTokens() {
+        return getAcceptableTokens();
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return new int[] {
+            TokenTypes.RECORD_DEF,
+        };
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return getAcceptableTokens();
+    }
+
+    @Override
+    public void visitToken(DetailAST ast) {
+        final DetailAST modifiers =
+            ast.findFirstToken(TokenTypes.MODIFIERS);
+        final AccessModifierOption accessModifier =
+            CheckUtil.getAccessModifierFromModifiersToken(modifiers);
+
+        if (matchAccessModifiers(accessModifier)) {
+            final DetailAST recordComponents =
+                ast.findFirstToken(TokenTypes.RECORD_COMPONENTS);
+            final int componentCount = countComponents(recordComponents);
+
+            if (componentCount > max) {
+                log(ast, MSG_KEY, componentCount, max);
+            }
+        }
+    }
+
+    /**
+     * Method to count the number of record components in this record definition.
+     *
+     * @param recordComponents the ast to check
+     * @return the number of record components in this record definition
+     */
+    private static int countComponents(DetailAST recordComponents) {
+        final AtomicInteger count = new AtomicInteger(0);
+        TokenUtil.forEachChild(recordComponents,
+            TokenTypes.RECORD_COMPONENT_DEF,
+            node -> count.getAndIncrement());
+        return count.get();
+    }
+
+    /**
+     * Checks whether a record definition has the correct access modifier to be checked.
+     *
+     * @param accessModifier the access modifier of the record definition.
+     * @return whether the record definition matches the expected access modifier.
+     */
+    private boolean matchAccessModifiers(final AccessModifierOption accessModifier) {
+        return Arrays.stream(accessModifiers)
+                .anyMatch(modifier -> modifier == accessModifier);
+    }
+}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/sizes/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/sizes/messages.properties
@@ -5,6 +5,7 @@ maxLen.method=Method length is {0,number,integer} lines (max allowed is {1,numbe
 maxLineLen=Line is longer than {0,number,integer} characters (found {1,number,integer}).
 maxOuterTypes=Outer types defined is {0,number,integer} (max allowed is {1,number,integer}).
 maxParam=More than {0,number,integer} parameters (found {1,number,integer}).
+too.many.components=Number of record components is {0,number,integer} (max allowed is {1,number,integer}).
 too.many.methods=Total number of methods is {0,number,integer} (max allowed is {1,number,integer}).
 too.many.packageMethods=Number of package methods is {0,number,integer} (max allowed is {1,number,integer}).
 too.many.privateMethods=Number of private methods is {0,number,integer} (max allowed is {1,number,integer}).

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/sizes/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/sizes/messages_de.properties
@@ -5,6 +5,7 @@ maxLen.method=Methode ist {0,number,integer} Zeilen lang (Obergrenze ist {1,numb
 maxLineLen=Zeile ist {1,number,integer} Zeichen lang (Obergrenze ist {0,number,integer}).
 maxOuterTypes=Anzahl äußerer Typen beträgt {0,number,integer} (Obergrenze ist {1,number,integer}).
 maxParam=Konstruktor/Methode hat {1,number,integer} Parameter (Obergrenze ist {0,number,integer}).
+too.many.components=Die Anzahl der beträgt {0,number,integer} (maximal zulässig ist {1,number,integer}).
 too.many.methods=Klasse hat insgesamt {0,number,integer} Methoden (Obergrenze ist {1,number,integer}).
 too.many.packageMethods=Klasse hat {0,number,integer} Methoden mit Sichtbarkeit ''package'' (Obergrenze ist {1,number,integer}).
 too.many.privateMethods=Klasse hat {0,number,integer} Methoden mit Sichtbarkeit ''private'' (Obergrenze ist {1,number,integer}).

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/sizes/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/sizes/messages_es.properties
@@ -5,6 +5,7 @@ maxLen.method=El tamaño del método es {0,number,integer} líneas (máximas per
 maxLineLen=La línea es mayor de {0,number,integer} caracteres (encontrado {1,number,integer}).
 maxOuterTypes=Tipos exterior definida es {0, number, integer} (máximo permitido es {1, number, integer}).
 maxParam=Más de {0,number,integer} parámetros (encontrado {1,number,integer}).
+too.many.components=El número de componentes de registro es {0,number,integer} (el máximo permitido es {1,number,integer}).
 too.many.methods=Número total de métodos es {0, number, integer} (máximo permitido es {1, number, integer}).
 too.many.packageMethods=Número de métodos de paquetes es {0, number, integer} (máximo permitido es {1, number, integer}).
 too.many.privateMethods=Número de métodos privados es {0, number, integer} (máximo permitido es {1, number, integer}).

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/sizes/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/sizes/messages_fi.properties
@@ -5,6 +5,7 @@ maxLen.method=Metodin pituus on {0,number,integer} riviä (suurin sallittu on {1
 maxLineLen=Rivi on pidempi kuin {0,number,integer} merkkiä (löydetty {1,number,integer}).
 maxOuterTypes=Ulompi määritettyihin on {0, number, integer} (max sallittu on {1, number, integer}).
 maxParam=Enemmän kuin {0,number,integer} parametriä (löydetty {1,number,integer}).
+too.many.components=Komponenttien lukumäärä on {0,number,integer} (suurin sallittu on {1,number,integer}).
 too.many.methods=Kokonaismäärä menetelmien on {0, number, integer} (max sallittu on {1, number, integer}).
 too.many.packageMethods=Määrä pakettien menetelmien on {0, number, integer} (max sallittu on {1, number, integer}).
 too.many.privateMethods=Joukko yksityisiä menetelmien on {0, number, integer} (max sallittu on {1, number, integer}).

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/sizes/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/sizes/messages_fr.properties
@@ -5,6 +5,7 @@ maxLen.method=La méthode contient {0,number,integer} lignes alors que le maximu
 maxLineLen=La ligne excède {0,number,integer} caractères (trouvé {1,number,integer}).
 maxOuterTypes=Le nombre de types externes est de {0, number, integer} alors que le maximum autorisé est de {1, number, integer}.
 maxParam=La méthode ou le constructeur a plus de {0,number,integer} paramètres (trouvé {1,number,integer}).
+too.many.components=Le nombre de composants d''enregistrement est {0, number, integer} (le maximum autorisé est {1, number, integer}).
 too.many.methods=Le nombre total de méthodes est de {0, number, integer} alors que le maximum autorisé est de {1, number, integer}.
 too.many.packageMethods=Le nombre de méthodes de package est de {0, number, integer} alors que le maximum autorisé est de {1, number, integer}.
 too.many.privateMethods=Le nombre de méthodes privées est de {0, number, integer} alors que le maximum autorisé est de {1, number, integer}.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/sizes/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/sizes/messages_ja.properties
@@ -5,6 +5,7 @@ maxLen.method=メソッドが {0,number,integer} 行あります（最大 {1,num
 maxLineLen=行が {0,number,integer} 文字を超えています （{1,number,integer} 個見つかりました）。
 maxOuterTypes=外側の型が {0,number,integer} 個（最大 {1,number,integer} 個まで）定義されています。
 maxParam=パラメータ数が {0,number,integer} を超えています（{1,number,integer} 個見つかりました）。
+too.many.components=レコードコンポーネントの数は {0,number,integer} （最大 {1,number,integer} 個まで）です。
 too.many.methods=メソッド数の合計が {0,number,integer} （最大 {1,number,integer} 個まで）です。
 too.many.packageMethods=package メソッドの数が {0,number,integer}（最大 {1,number,integer} 個まで）です。
 too.many.privateMethods=private メソッドの数が {0,number,integer} （最大 {1,number,integer} 個まで）です。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/sizes/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/sizes/messages_pt.properties
@@ -5,6 +5,7 @@ maxLen.method=O método tem {0,number,integer} linhas (o máximo permitido é {1
 maxLineLen=A linha contém mais do que {0,number,integer} caracteres (foram encontrados {1,number,integer}).
 maxOuterTypes=O número de tipos externos definidos é {0, number, integer} (o máximo permitido é {1, number, integer}).
 maxParam=Existe mais do que {0,number,integer} parâmetros (encontrado {1,number,integer}).
+too.many.components=O número de componentes de registro é {0, number,integer} (o máximo permitido é {1,number,integer}).
 too.many.methods=O número total de métodos é {0, number, integer} (o máximo permitido é {1, number, integer}).
 too.many.packageMethods=O número de métodos com visibilidade de pacote é {0, number, integer} (o máximo permitido é {1, number, integer}).
 too.many.privateMethods=O número de métodos privados é {0, number, integer} (o máximo permitido é {1, number, integer}).

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/sizes/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/sizes/messages_tr.properties
@@ -11,7 +11,7 @@ maxLineLen = Satır {0,number,integer} değerinden daha uzun ({1,number,integer}
 maxOuterTypes = Tanımlanan dış tür sayısı  {0,number,integer} (maksimum izin verilen değer {1,number,integer}).
 
 maxParam = {0,number,integer} değerinden daha fazla parametre mevcut {1,number,integer} değer bulundu).
-
+too.many.components=kayıt bileşenlerinin sayısı{0,number,integer} ''dır (izin verilen maks. {1,number,integer}).
 too.many.methods          = Toplam metot sayısı {0,number,integer} (maksimum izin verilen değer {1,number,integer}).
 too.many.packageMethods   = Toplam ''package'' erişimli metot sayısı {0,number,integer} (maksimum izin verilen değer {1,number,integer}).
 too.many.privateMethods   = Toplam ''private'' metot sayısı {0,number,integer} (maksimum izin verilen değer {1,number,integer}).

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/sizes/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/sizes/messages_zh.properties
@@ -5,6 +5,7 @@ maxLen.method=方法 {0,number,integer} 行（最多： {1,number,integer} 行�
 maxLineLen=本行字符数 {1,number,integer}个，最多：{0,number,integer}个。
 maxOuterTypes=Outer types defined is {0,number,integer} （最多： {1,number,integer}）。
 maxParam=参数共： {1,number,integer}个，最多：{0,number,integer}个。
+too.many.components=记录组件的数量为: {0,number,integer}（允许的最大值为: {1,number,integer}）。
 too.many.methods=方法总数： {0,number,integer} （最多： {1,number,integer}）。
 too.many.packageMethods=包方法总数：{0,number,integer} （最多： {1,number,integer}）。
 too.many.privateMethods=private 方法总数： {0,number,integer} （最多： {1,number,integer}）。

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/RecordComponentNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/RecordComponentNumberCheckTest.java
@@ -1,0 +1,168 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.sizes;
+
+import static com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheck.MSG_KEY;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+
+public class RecordComponentNumberCheckTest extends AbstractModuleTestSupport {
+
+    @Override
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber";
+    }
+
+    @Test
+    public void testGetRequiredTokens() {
+        final RecordComponentNumberCheck checkObj = new RecordComponentNumberCheck();
+        final int[] actual = checkObj.getRequiredTokens();
+        final int[] expected = {
+            TokenTypes.RECORD_DEF,
+        };
+
+        assertArrayEquals(expected, actual, "Default required tokens are invalid");
+
+    }
+
+    @Test
+    public void testGetAcceptableTokens() {
+        final RecordComponentNumberCheck checkObj = new RecordComponentNumberCheck();
+        final int[] actual = checkObj.getAcceptableTokens();
+        final int[] expected = {
+            TokenTypes.RECORD_DEF,
+        };
+
+        assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
+    }
+
+    @Test
+    public void testDefault() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(RecordComponentNumberCheck.class);
+
+        final int max = 8;
+
+        final String[] expected = {
+            "53:5: " + getCheckMessage(MSG_KEY, 14, max),
+            "66:9: " + getCheckMessage(MSG_KEY, 14, max),
+            "72:13: " + getCheckMessage(MSG_KEY, 14, max),
+            "78:17: " + getCheckMessage(MSG_KEY, 11, max),
+            "97:5: " + getCheckMessage(MSG_KEY, 15, max),
+            "118:5: " + getCheckMessage(MSG_KEY, 15, max),
+            "128:5: " + getCheckMessage(MSG_KEY, 15, max),
+        };
+
+        verify(checkConfig,
+                getNonCompilablePath("InputRecordComponentNumber.java"), expected);
+    }
+
+    @Test
+    public void testRecordComponentNumberTopLevel1() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(RecordComponentNumberCheck.class);
+
+        final int max = 8;
+
+        final String[] expected = {
+            "8:1: " + getCheckMessage(MSG_KEY, 15, max),
+        };
+
+        verify(checkConfig,
+                getNonCompilablePath("InputRecordComponentNumberTopLevel1.java"),
+                expected);
+    }
+
+    @Test
+    public void testRecordComponentNumberTopLevel2() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(RecordComponentNumberCheck.class);
+
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verify(checkConfig,
+                getNonCompilablePath("InputRecordComponentNumberTopLevel2.java"),
+                expected);
+    }
+
+    @Test
+    public void testRecordComponentNumberMax1() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(RecordComponentNumberCheck.class);
+        checkConfig.addAttribute("max", "1");
+
+        final int max = 1;
+
+        final String[] expected = {
+            "25:5: " + getCheckMessage(MSG_KEY, 2, max),
+            "29:5: " + getCheckMessage(MSG_KEY, 3, max),
+            "33:5: " + getCheckMessage(MSG_KEY, 5, max),
+            "49:5: " + getCheckMessage(MSG_KEY, 7, max),
+            "54:5: " + getCheckMessage(MSG_KEY, 14, max),
+            "63:9: " + getCheckMessage(MSG_KEY, 3, max),
+            "67:9: " + getCheckMessage(MSG_KEY, 14, max),
+            "73:13: " + getCheckMessage(MSG_KEY, 14, max),
+            "79:17: " + getCheckMessage(MSG_KEY, 6, max),
+            "93:5: " + getCheckMessage(MSG_KEY, 4, max),
+            "97:5: " + getCheckMessage(MSG_KEY, 15, max),
+            "107:5: " + getCheckMessage(MSG_KEY, 3, max),
+            "111:5: " + getCheckMessage(MSG_KEY, 6, max),
+            "122:5: " + getCheckMessage(MSG_KEY, 2, max),
+        };
+
+        verify(checkConfig,
+                getNonCompilablePath("InputRecordComponentNumberMax1.java"), expected);
+    }
+
+    @Test
+    public void testRecordComponentNumberMax20() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(RecordComponentNumberCheck.class);
+        checkConfig.addAttribute("max", "20");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verify(checkConfig,
+                getNonCompilablePath("InputRecordComponentNumberMax20.java"), expected);
+    }
+
+    @Test
+    public void testRecordComponentNumberPrivateModifier() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(RecordComponentNumberCheck.class);
+        checkConfig.addAttribute("accessModifiers", "private");
+
+        final int max = 8;
+
+        final String[] expected = {
+            "67:9: " + getCheckMessage(MSG_KEY, 14, max),
+            "73:13: " + getCheckMessage(MSG_KEY, 14, max),
+            "119:5: " + getCheckMessage(MSG_KEY, 15, max),
+        };
+
+        verify(checkConfig,
+            getNonCompilablePath("InputRecordComponentNumberPrivateModifier.java"), expected);
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumber.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumber.java
@@ -1,0 +1,146 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.sizes.recordcomponentnumber;
+
+import java.awt.Point;
+import java.awt.Shape;
+import java.util.ArrayDeque;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import org.w3c.dom.Node;
+
+/* Config:
+ *
+ * max = 8
+ */
+public class InputRecordComponentNumber {
+
+    public record TestRecord1(int x){
+        public TestRecord1{
+
+        }
+    }
+
+    public record TestRecord2(int x, int y){ // ok
+
+    }
+
+    public record TestRecord3(String str, int x, int y){ // ok
+
+    }
+
+    public record TestRecord4(Node node, // ok
+                              Point x,
+                              Point y,
+                              int translation,
+                              Shape square){
+        private static ArrayDeque<String> myDeque = new ArrayDeque<>();
+        public TestRecord4 {
+            try {
+                myDeque.add(x.toString());
+                myDeque.add(y.toString());
+            } catch (Exception ignored) {
+
+            }
+        }
+    }
+
+    public record TestRecord5(int x, int y, int z, // ok
+                              int a, int b, int c, int d){
+
+    }
+
+    public record TestRecord6(int x, int y, int z, // violation
+                              int a, int b, int c,
+                              int d, int e, int f,
+                              int g, int h, int i,
+                              int j, int k){
+
+    }
+    public record TestRecord7(int y){ // ok
+
+        record InnerRecordOk(int x, int y, int z){ // ok
+
+        }
+
+        private record InnerRecordBad(int x, int y, int z, // violation
+                                      int a, int b, int c,
+                                      int d, int e, int f,
+                                      int g, int h, int i,
+                                      int j, int k){
+
+            private record InnerRecordCeptionBad(int x, int y, int z, // violation
+                                                 int a, int b, int c,
+                                                 int d, int e, int f,
+                                                 int g, int h, int i,
+                                                 int j, int k) {
+
+                public record InnerPublicBad(int[] arr, // violation
+                                             LinkedHashMap<String, Node> linkedHashMap,
+                                             int x,
+                                             ArrayDeque<Node> arrayDeque,
+                                             List<String> myList,
+                                             List<String> myOtherList,
+                                             int a, int b, int c, int d, int e) {
+
+
+                }
+            }
+
+        }
+    }
+
+    public record TestRecord8(int x, int y, int z, String... myVarargs){ // ok
+
+    }
+
+    public record TestRecord9(int x, int y, int z, // violation
+                              int a, int b, int c,
+                              int d, int e, int f,
+                              int g, int h, int i,
+                              int j, int k, String... myVarargs){
+
+    }
+
+    public record TestRecord10(String... myVarargs){} // ok
+
+    public record TestRecord11(int[] arr, LinkedHashMap<String, Node> linkedHashMap, int x){} // ok
+
+    public record TestRecord12(int[] arr, // ok
+                               LinkedHashMap<String, Node> linkedHashMap,
+                               int x,
+                               ArrayDeque<Node> arrayDeque,
+                               List<String> myList,
+                               List<String> myOtherList){
+
+    }
+
+    private static record MyPrivateRecord1(int x, int y, int z, // violation
+                                           int a, int b, int c,
+                                           int d, int e, int f,
+                                           int g, int h, int i,
+                                           int j, int k, String... myVarargs) {}
+
+    private static record MyPrivateRecord2(int x, int y) {} // ok
+
+    protected static record MyProtectedRecord1(int x, int y) {} // ok
+
+    protected static record MyProtectedRecord2(int x, int y, int z, // violation
+                                               int a, int b, int c,
+                                               int d, int e, int f,
+                                               int g, int h, int i,
+                                               int j, int k, String... myVarargs) {}
+
+    class LocalRecordHelper {
+        Class<?> m(int x) {
+            record R76 (int x) { }
+            return R76.class;
+        }
+
+        private class R {
+            public R(int x) {
+            }
+        }
+    }
+
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberMax1.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberMax1.java
@@ -1,0 +1,124 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.sizes.recordcomponentnumber;
+
+/* Config:
+ *
+ * max = 1
+ */
+
+import java.awt.Point;
+import java.awt.Shape;
+import java.util.ArrayDeque;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import org.w3c.dom.Node;
+
+public class InputRecordComponentNumberMax1 {
+
+    public record TestRecord1(int x){ // ok
+        public TestRecord1{
+
+        }
+    }
+
+    public record TestRecord2(int x, int y){ // violation
+
+    }
+
+    public record TestRecord3(String str, int x, int y){ // violation
+
+    }
+
+    public record TestRecord4(Node node, // violation
+                              Point x,
+                              Point y,
+                              int translation,
+                              Shape square){
+        private static ArrayDeque<String> myDeque = new ArrayDeque<>();
+        public TestRecord4 {
+            try {
+                myDeque.add(x.toString());
+                myDeque.add(y.toString());
+            } catch (Exception ignored) {
+
+            }
+        }
+    }
+
+    public record TestRecord5(int x, int y, int z, // violation
+                              int a, int b, int c, int d){
+
+    }
+
+    public record TestRecord6(int x, int y, int z, // violation
+                              int a, int b, int c,
+                              int d, int e, int f,
+                              int g, int h, int i,
+                              int j, int k){
+
+    }
+    public record TestRecord7(int y){ // ok
+
+        record InnerRecordOk(int x, int y, int z){ // violation
+
+        }
+
+        private record InnerRecordBad(int x, int y, int z, // violation
+                                      int a, int b, int c,
+                                      int d, int e, int f,
+                                      int g, int h, int i,
+                                      int j, int k){
+
+            private record InnerRecordCeptionBad(int x, int y, int z, // violation
+                                                 int a, int b, int c,
+                                                 int d, int e, int f,
+                                                 int g, int h, int i,
+                                                 int j, int k) {
+
+                public record InnerPublicBad(int[] arr, // violation
+                                             LinkedHashMap<String, Node> linkedHashMap,
+                                             int x,
+                                             ArrayDeque<Node> arrayDeque,
+                                             List<String> myList,
+                                             List<String> myOtherList) {
+
+
+                }
+            }
+
+        }
+    }
+
+    public record TestRecord8(int x, int y, int z, String... myVarargs){ // violation
+
+    }
+
+    public record TestRecord9(int x, int y, int z, // violation
+                              int a, int b, int c,
+                              int d, int e, int f,
+                              int g, int h, int i,
+                              int j, int k, String... myVarargs){
+
+    }
+
+    public record TestRecord10(String... myVarargs){} // ok
+
+    public record TestRecord11(int[] arr, // violation
+                               LinkedHashMap<String, Node> linkedHashMap,
+                               int x){}
+
+    public record TestRecord12(int[] arr, // violation
+                               LinkedHashMap<String, Node> linkedHashMap,
+                               int x,
+                               ArrayDeque<Node> arrayDeque,
+                               List<String> myList,
+                               List<String> myOtherList){
+
+    }
+
+    private static record MyPrivateRecord1() {} // ok
+
+    private static record MyPrivateRecord2(int x, int y) {} // violation
+
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberMax20.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberMax20.java
@@ -1,0 +1,121 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.sizes.recordcomponentnumber;
+
+import java.awt.Point;
+import java.awt.Shape;
+import java.util.ArrayDeque;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import org.w3c.dom.Node;
+
+/* Config:
+ *
+ * max = 20
+ */
+
+public class InputRecordComponentNumberMax20 {
+
+    public record TestRecord1(int x){ // ok
+        public TestRecord1{
+
+        }
+    }
+
+    public record TestRecord2(int x, int y){ // ok
+
+    }
+
+    public record TestRecord3(String str, int x, int y){ // ok
+
+    }
+
+    public record TestRecord4(Node node, // ok
+                              Point x,
+                              Point y,
+                              int translation,
+                              Shape square){
+        private static ArrayDeque<String> myDeque = new ArrayDeque<>();
+        public TestRecord4 {
+            try {
+                myDeque.add(x.toString());
+                myDeque.add(y.toString());
+            } catch (Exception ignored) {
+
+            }
+        }
+    }
+
+    public record TestRecord5(int x, int y, int z, // ok
+                              int a, int b, int c, int d){
+
+    }
+
+    public record TestRecord6(int x, int y, int z, // ok
+                              int a, int b, int c,
+                              int d, int e, int f,
+                              int g, int h, int i,
+                              int j, int k){
+
+    }
+    public record TestRecord7(int y){ // ok
+
+        record InnerRecordOk(int x, int y, int z){ // ok
+
+        }
+
+        private record InnerRecordBad(int x, int y, int z, // ok
+                                      int a, int b, int c,
+                                      int d, int e, int f,
+                                      int g, int h, int i,
+                                      int j, int k){
+
+            private record InnerRecordCeptionBad(int x, int y, int z, // ok
+                                                 int a, int b, int c,
+                                                 int d, int e, int f,
+                                                 int g, int h, int i,
+                                                 int j, int k) {
+
+                public record InnerPublicBad(int[] arr, // ok
+                                             LinkedHashMap<String, Node> linkedHashMap,
+                                             int x,
+                                             ArrayDeque<Node> arrayDeque,
+                                             List<String> myList,
+                                             List<String> myOtherList) {
+
+
+                }
+            }
+
+        }
+    }
+
+    public record TestRecord8(int x, int y, int z, String... myVarargs){ // ok
+
+    }
+
+    public record TestRecord9(int x, int y, int z, // ok
+                              int a, int b, int c,
+                              int d, int e, int f,
+                              int g, int h, int i,
+                              int j, int k, String... myVarargs){
+
+    }
+
+    public record TestRecord10(String... myVarargs){} // ok
+
+    public record TestRecord11(int[] arr, LinkedHashMap<String, Node> linkedHashMap, int x){} // ok
+    public record TestRecord12(int[] arr, // ok
+                               LinkedHashMap<String, Node> linkedHashMap,
+                               int x,
+                               ArrayDeque<Node> arrayDeque,
+                               List<String> myList,
+                               List<String> myOtherList){
+
+    }
+
+    private static record MyPrivateRecord1() {} // ok
+
+    private static record MyPrivateRecord2(int x, int y) {} // ok
+
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberPrivateModifier.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberPrivateModifier.java
@@ -1,0 +1,147 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.sizes.recordcomponentnumber;
+
+import java.awt.Point;
+import java.awt.Shape;
+import java.util.ArrayDeque;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import org.w3c.dom.Node;
+
+/* Config:
+ *
+ * max = 8
+ * accessModifiers = private
+ */
+public class InputRecordComponentNumberPrivateModifier {
+
+    public record TestRecord1(int x){
+        public TestRecord1{
+
+        }
+    }
+
+    public record TestRecord2(int x, int y){ // ok
+
+    }
+
+    public record TestRecord3(String str, int x, int y){ // ok
+
+    }
+
+    public record TestRecord4(Node node, // ok
+                              Point x,
+                              Point y,
+                              int translation,
+                              Shape square){
+        private static ArrayDeque<String> myDeque = new ArrayDeque<>();
+        public TestRecord4 {
+            try {
+                myDeque.add(x.toString());
+                myDeque.add(y.toString());
+            } catch (Exception ignored) {
+
+            }
+        }
+    }
+
+    public record TestRecord5(int x, int y, int z, // ok
+                              int a, int b, int c, int d){
+
+    }
+
+    public record TestRecord6(int x, int y, int z,// ok
+                              int a, int b, int c,
+                              int d, int e, int f,
+                              int g, int h, int i,
+                              int j, int k){
+
+    }
+    public record TestRecord7(int y){ // ok
+
+        record InnerRecordOk(int x, int y, int z){ // ok
+
+        }
+
+        private record InnerRecordBad(int x, int y, int z,// violation
+                                      int a, int b, int c,
+                                      int d, int e, int f,
+                                      int g, int h, int i,
+                                      int j, int k){
+
+            private record InnerRecordCeptionBad(int x, int y, int z,// violation
+                                                 int a, int b, int c,
+                                                 int d, int e, int f,
+                                                 int g, int h, int i,
+                                                 int j, int k) {
+
+                public record InnerPublicBad(int[] arr,// ok
+                                             LinkedHashMap<String, Node> linkedHashMap,
+                                             int x,
+                                             ArrayDeque<Node> arrayDeque,
+                                             List<String> myList,
+                                             List<String> myOtherList,
+                                             int a, int b, int c, int d, int e) {
+
+
+                }
+            }
+
+        }
+    }
+
+    public record TestRecord8(int x, int y, int z, String... myVarargs){ // ok
+
+    }
+
+    public record TestRecord9(int x, int y, int z,// ok
+                              int a, int b, int c,
+                              int d, int e, int f,
+                              int g, int h, int i,
+                              int j, int k, String... myVarargs){
+
+    }
+
+    public record TestRecord10(String... myVarargs){} // ok
+
+    public record TestRecord11(int[] arr, LinkedHashMap<String, Node> linkedHashMap, int x){} // ok
+
+    public record TestRecord12(int[] arr, // ok
+                               LinkedHashMap<String, Node> linkedHashMap,
+                               int x,
+                               ArrayDeque<Node> arrayDeque,
+                               List<String> myList,
+                               List<String> myOtherList){
+
+    }
+
+    private static record MyPrivateRecord1(int x, int y, int z,// ok
+                                           int a, int b, int c,
+                                           int d, int e, int f,
+                                           int g, int h, int i,
+                                           int j, int k, String... myVarargs) {}
+
+    private static record MyPrivateRecord2(int x, int y) {} // violation
+
+    protected static record MyProtectedRecord1(int x, int y) {} // ok
+
+    protected static record MyProtectedRecord2(int x, int y, int z, // ok
+                                               int a, int b, int c,
+                                               int d, int e, int f,
+                                               int g, int h, int i,
+                                               int j, int k, String... myVarargs) {}
+
+    class LocalRecordHelper {
+        Class<?> m(int x) {
+            record R76 (int x) { }
+            return R76.class;
+        }
+
+        private class R {
+            public R(int x) {
+            }
+        }
+    }
+
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberTopLevel1.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberTopLevel1.java
@@ -1,0 +1,15 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.sizes.recordcomponentnumber;
+
+/* Config:
+ *
+ * max = 8
+ */
+public record InputRecordComponentNumberTopLevel1(int x, int y, int z, // violation
+                                                int a, int b, int c,
+                                                int d, int e, int f,
+                                                int g, int h, int i,
+                                                int j, int k,
+                                                 String... myVarargs) {
+
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberTopLevel2.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/recordcomponentnumber/InputRecordComponentNumberTopLevel2.java
@@ -1,0 +1,10 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.sizes.recordcomponentnumber;
+
+/* Config:
+ *
+ * max = 8
+ */
+public record InputRecordComponentNumberTopLevel2<T>() { // ok
+
+}

--- a/src/xdocs/checks.xml
+++ b/src/xdocs/checks.xml
@@ -732,6 +732,10 @@
             </td>
           </tr>
           <tr>
+            <td><a href="config_sizes.html#RecordComponentNumber">RecordComponentNumber</a></td>
+            <td>Checks the number of record components in the header of a record definition.</td>
+          </tr>
+          <tr>
             <td>
               <a href="config_naming.html#RecordTypeParameterName">RecordTypeParameterName</a>
             </td>

--- a/src/xdocs/config_sizes.xml
+++ b/src/xdocs/config_sizes.xml
@@ -1071,5 +1071,162 @@ public void needsLotsOfParameters(int a,
       </subsection>
     </section>
 
+    <section name="RecordComponentNumber">
+      <p>Since Checkstyle 8.36</p>
+      <subsection name="Description" id="RecordComponentNumber_Description">
+        <p>
+          Checks the number of record components in the
+          <a href="https://docs.oracle.com/javase/specs/jls/se14/preview/specs/records-jls.html#jls-8.10.1">
+          header
+          </a>
+          of a record definition.
+        </p>
+      </subsection>
+
+      <subsection name="Properties" id="RecordComponentNumber_Properties">
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>max</td>
+              <td>
+                Specify the maximum number of components allowed in the header
+                of a record definition.
+              </td>
+              <td><a href="property_types.html#int">int</a></td>
+              <td><code>8</code></td>
+              <td>8.36</td>
+            </tr>
+            <tr>
+              <td>accessModifiers</td>
+              <td>
+                Access modifiers of record definitions where the number of record
+                components should be checked.
+              </td>
+              <td><a href="property_types.html#AccessModifierOption.5B.5D">AccessModifierOption[]
+              </a>
+              </td>
+              <td><code>public, protected, package, private</code></td>
+              <td>8.36</td>
+            </tr>
+          </table>
+        </div>
+      </subsection>
+
+      <subsection name="Examples" id="RecordComponentNumber_Examples">
+        <p>
+          To configure the check:
+        </p>
+        <source>
+&lt;module name="RecordComponentNumber"/&gt;
+        </source>
+        <p>
+          Java code example:
+        </p>
+        <source>
+ public record MyRecord1(int x, int y) { // ok, 2 components
+     ...
+ }
+
+ record MyRecord2(int x, int y, String str,
+                           Node node, Order order, Data data
+                           String location, Date date, Image image) { // violation, 9 components
+     ...
+ }
+
+        </source>
+        <p>
+          To configure the check to allow 5 record components at all access modifier
+          levels for record definitions:
+        </p>
+        <source>
+&lt;module name="RecordComponentNumber"&gt;
+  &lt;property name="max" value="5"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Java code example:
+        </p>
+        <source>
+ public record MyRecord1(int x, int y, String str) { // ok, 3 components
+     ...
+ }
+
+ public record MyRecord2(int x, int y, String str,
+                           Node node, Order order, Data data) { // violation, 6 components
+     ...
+ }
+
+        </source>
+        <p>
+          To configure the check to allow 10 record components for a public record definition,
+          but 3 for private record definitions:
+        </p>
+        <source>
+&lt;module name="RecordComponentNumber"&gt;
+  &lt;property name="max" value="3"/&gt;
+  &lt;property name="accessModifiers" value="private"/&gt;
+&lt;/module&gt;
+&lt;module name="RecordComponentNumber"&gt;
+  &lt;property name="max" value="10"/&gt;
+  &lt;property name="accessModifiers" value="public"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Java code example:
+        </p>
+        <source>
+ public record MyRecord1(int x, int y, String str) { // ok, public record definition allowed 10
+     ...
+ }
+
+ private record MyRecord2(int x, int y, String str, Node node) { // violation
+     ...                                // private record definition allowed 3 components
+ }
+
+        </source>
+      </subsection>
+
+      <subsection name="Example of Usage" id="RecordComponentNumber_Example_of_Usage">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Aconfig+filename%3Acheckstyle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+RecordComponentNumber">
+              Checkstyle Style</a>
+          </li>
+        </ul>
+      </subsection>
+
+      <subsection name="Violation Messages" id="RecordComponentNumber_Violation_Messages">
+        <ul>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fsizes+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22too.many.components%22">
+              too.many.components</a>
+          </li>
+        </ul>
+        <p>
+          All messages can be customized if the default message doesn't suit you.
+          Please <a href="config.html#Custom_messages">see the documentation</a> to learn how to.
+        </p>
+      </subsection>
+
+      <subsection name="Package" id="RecordComponentNumber_Package">
+        <p>
+          com.puppycrawl.tools.checkstyle.checks.sizes
+        </p>
+      </subsection>
+
+      <subsection name="Parent Module" id="RecordComponentNumber_Parent_Module">
+        <p>
+          <a href="config.html#TreeWalker">TreeWalker</a>
+        </p>
+      </subsection>
+    </section>
+
   </body>
 </document>


### PR DESCRIPTION
Issue #8748 : Create new check RecordComponentNumberCheck

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/497dbdc31fe7a09cd960fc255972fb65/raw/c68be9ca06b61e1f279705c8b915386e701803c0/RecordComponentNumberCheckBase.xml

Diff Regression patch config: https://gist.githubusercontent.com/nmancus1/e40c93aa8c632af54f63a8c3347821da/raw/2734393e077ea5f2deb69f3570e0200452ab31fe/RecordComponentNumberCheckPatch.xml

Contribution PR: https://github.com/checkstyle/contribution/pull/500

Link to site: https://nmancus1.github.io/site_recordcomponentnumber/

~~First check regression report, before modifying ScopeUtil.java: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/full-records-RecordComponentNumberCheck_2020133606/reports/diff/index.html~~

Second check regression report, after merging #8598: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/full-records-RecordComponentNumberCheck_2020114210/reports/diff/index.html