### PR TITLE
minor: fix PatternVariableNameCheck code example indentation

### DIFF
--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -2339,63 +2339,63 @@ class MyClass {
         </p>
 
         <source>
-          &lt;module name="PatternVariableName"/&gt;
+ &lt;module name="PatternVariableName"/&gt;
         </source>
         <p>Code Example:</p>
         <source>
-          class MyClass {
-              MyClass(Object o1){
-                  if (o1 instanceof String STRING) { // violation, name 'STRING' must
-                  // match pattern '^[a-z][a-zA-Z0-9]*$'
-                  }
-                  if (o1 instanceof Integer num) { // OK
-                  }
-              }
-          }
+class MyClass {
+    MyClass(Object o1){
+        if (o1 instanceof String STRING) { // violation, name 'STRING' must
+        // match pattern '^[a-z][a-zA-Z0-9]*$'
+        }
+        if (o1 instanceof Integer num) { // OK
+        }
+    }
+}
         </source>
         <p>
           An example of how to configure the check for names that have a lower case letter,
           followed by letters and digits, optionally separated by underscore:
         </p>
         <source>
-          &lt;module name="PatternVariableName"&gt;
-          &lt;property name="format" value="^[a-z](_?[a-zA-Z0-9]+)*$"/&gt;
-          &lt;/module&gt;
+&lt;module name="PatternVariableName"&gt;
+    &lt;property name="format" value="^[a-z](_?[a-zA-Z0-9]+)*$"/&gt;
+&lt;/module&gt;
         </source>
         <p>Code Example:</p>
         <source>
-          class MyClass {
-              MyClass(Object o1){
-                  if (o1 instanceof String STR) { // violation, name 'STR' must
-                  // match pattern '^[a-z](_?[a-zA-Z0-9]+)*$'
-                  }
-                  if (o1 instanceof Integer num) { // OK
-                  }
-                  if (o1 instanceof Integer num_1) { // OK
-                  }
-              }
-          }
+class MyClass {
+    MyClass(Object o1){
+        if (o1 instanceof String STR) { // violation, name 'STR' must
+        // match pattern '^[a-z](_?[a-zA-Z0-9]+)*$'
+        }
+        if (o1 instanceof Integer num) { // OK
+        }
+        if (o1 instanceof Integer num_1) { // OK
+        }
+    }
+}
         </source>
         <p>
           An example of how to configure the check to that all variables have 3 or more
           chars in name:
         </p>
         <source>
-          &lt;module name="PatternVariableName"&gt;
-          &lt;property name="format" value="^[a-z][_a-zA-Z0-9]{2,}$"/&gt;
-          &lt;/module&gt;
+&lt;module name="PatternVariableName"&gt;
+    &lt;property name="format" value="^[a-z][_a-zA-Z0-9]{2,}$"/&gt;
+&lt;/module&gt;
         </source>
         <p>Code Example:</p>
         <source>
-          class MyClass {
-              MyClass(Object o1){
-                  if (o1 instanceof String s) { // violation, name 's' must
-                  // match pattern '^[a-z][_a-zA-Z0-9]{2,}$'
-                  }
-                  if (o1 instanceof Integer num) { // OK
-                  }
-              }
-          }
+class MyClass {
+    MyClass(Object o1){
+        if (o1 instanceof String s) { // violation, name 's' must
+        // match pattern '^[a-z][_a-zA-Z0-9]{2,}$'
+        }
+        if (o1 instanceof Integer num) { // OK
+        }
+    }
+}
         </source>
       </subsection>
 


### PR DESCRIPTION
Per discussion at https://github.com/checkstyle/checkstyle/pull/8586#discussion_r464095811, indentation needs to be fixed in code examples for PatternVariableNameCheck. 

Site link: https://nmancus1.github.io/site_PatternVariableNameCheck