### PR TITLE
Issue #8606: add .ci-temp to exclude list for xml-maven-plugin:check-format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1382,6 +1382,7 @@
                 <exclude>src/xdocs/property_types.xml</exclude>
                 <!-- Temporary files -->
                 <exclude>target/**</exclude>
+                <exclude>.ci-temp/**</exclude>
                 <!-- Specially crafted test files -->
                 <exclude>src/test/resources/**</exclude>
                 <!-- Generated files -->


### PR DESCRIPTION
Issue #8606

tested:
```
 $ mvn verify
[INFO] Scanning for projects...
[INFO] Inspecting build with total of 1 modules...
[INFO] Installing Nexus Staging features:
[INFO]   ... total of 1 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
[INFO] 
[INFO] ------------------< com.puppycrawl.tools:checkstyle >-------------------
[INFO] Building checkstyle 8.36-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- tidy-maven-plugin:1.1.0:check (validate) @ checkstyle ---
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (enforce-maven) @ checkstyle ---
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (enforce-versions) @ checkstyle ---
[INFO] 
[INFO] --- xml-maven-plugin:1.0.2:check-format (default) @ checkstyle ---
[ERROR] /home/rivanov/java/github/romani/checkstyle/./.ci-temp/pom.xml:4,26: 
Delete 9 spaces. Expected 2 found 11 spaces before start element <modelVersion>
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.353 s
[INFO] Finished at: 2020-08-05T07:10:14-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.codehaus.mojo:xml-maven-plugin:1.0.2:check-format
 (default) on project checkstyle: There are XML formatting violations.
 Check the above log for details. -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
✘-1 ~/java/github/romani/checkstyle [8608-xml L|✔] 

# APPLY Change

~/java/github/romani/checkstyle [8608-xml L|✚ 1] 
07:10 $ git diff
diff --git a/pom.xml b/pom.xml
index 14eb80c..dab7b7f 100644
--- a/pom.xml
+++ b/pom.xml
@@ -1382,6 +1382,7 @@
                 <exclude>src/xdocs/property_types.xml</exclude>
                 <!-- Temporary files -->
                 <exclude>target/**</exclude>
+                <exclude>.ci-temp/**</exclude>
                 <!-- Specially crafted test files -->
                 <exclude>src/test/resources/**</exclude>
                 <!-- Generated files -->

✔ ~/java/github/romani/checkstyle [8608-xml L|✚ 1] 
$ mvn verify
[INFO] Scanning for projects...
[INFO] Inspecting build with total of 1 modules...
[INFO] Installing Nexus Staging features:
[INFO]   ... total of 1 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
[INFO] 
[INFO] ------------------< com.puppycrawl.tools:checkstyle >-------------------
[INFO] Building checkstyle 8.36-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- tidy-maven-plugin:1.1.0:check (validate) @ checkstyle ---
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (enforce-maven) @ checkstyle ---
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M3:enforce (enforce-versions) @ checkstyle ---
[INFO] 
[INFO] --- xml-maven-plugin:1.0.2:check-format (default) @ checkstyle ---
[INFO] 
[INFO] --- .....
```