### PR TITLE
ci: move spring integration project validation to stable version

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -131,15 +131,16 @@ build:
           echo "build is skipped ..."
         fi
 
-  - script:
-      name: NoErrorTest - Spring Integration
-      code: |
-        if [[ $RUN_JOB == 1 ]]; then
-          echo "Command: ./.ci/wercker.sh no-error-spring-integration"
-          ./.ci/wercker.sh no-error-spring-integration
-        else
-          echo "build is skipped ..."
-        fi
+  # disabled as build is unstable for long time
+  # - script:
+  #     name: NoErrorTest - Spring Integration
+  #     code: |
+  #       if [[ $RUN_JOB == 1 ]]; then
+  #         echo "Command: ./.ci/wercker.sh no-error-spring-integration"
+  #         ./.ci/wercker.sh no-error-spring-integration
+  #       else
+  #         echo "build is skipped ..."
+  #       fi
 
   # Disabled as it result in "svn: E175002: Unexpected HTTP status 429 'Too Many Requests'"
   # even for "svn checkout -r 14923 ...."


### PR DESCRIPTION
https://app.wercker.com/checkstyle/checkstyle/runs/build/5f2abbebdac5630008ba5d27?step=5f2abc18052291000707439d

problems like:
```

> Task :spring-integration-core:compileJava
/pipeline/source/.ci-temp/spring-integration/spring-integration-core/src/main/java/org/springframework/integration/channel/FluxMessageChannel.java:28: error: cannot find symbol
import reactor.core.publisher.FluxIdentityProcessor;
                             ^
  symbol:   class FluxIdentityProcessor
  location: package reactor.core.publisher
/pipeline/source/.ci-temp/spring-integration/spring-integration-core/src/main/java/org/springframework/integration/channel/FluxMessageChannel.java:30: error: cannot find symbol
import reactor.core.publisher.Processors;
                             ^
  symbol:   class Processors
```