### PR TITLE
Issue #8604: fix master build failure due to leaked pitest coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2821,8 +2821,8 @@
                   com.puppycrawl.tools.checkstyle.XmlLoader$LoadExternalDtdFeatureProvider
                 </avoidCallsTo>
               </avoidCallsTo>
-              <coverageThreshold>99</coverageThreshold>
-              <mutationThreshold>99</mutationThreshold>
+              <coverageThreshold>100</coverageThreshold>
+              <mutationThreshold>100</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavaParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavaParser.java
@@ -99,7 +99,6 @@ public final class JavaParser {
         final TokenStreamSelector selector = new TokenStreamSelector();
         lexer.selector = selector;
         textBlockLexer.selector = selector;
-        selector.addInputStream(filter, "filter");
         selector.addInputStream(textBlockLexer, "textBlockLexer");
         selector.select(filter);
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavaParserTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavaParserTest.java
@@ -180,6 +180,26 @@ public class JavaParserTest extends AbstractModuleTestSupport {
                 counter.blockComments.toArray(), "Invalid block comments");
     }
 
+    @Test
+    public void testJava14TextBlocks() throws Exception {
+        final DetailAST root =
+            JavaParser.parseFile(new File(
+                    getNonCompilablePath("InputJavaParserTextBlocks.java")),
+                JavaParser.Options.WITHOUT_COMMENTS);
+
+        final Optional<DetailAST> textBlockContent = TestUtil.findTokenInAstByPredicate(root,
+            ast -> ast.getType() == TokenTypes.TEXT_BLOCK_CONTENT);
+
+        assertTrue(textBlockContent.isPresent(), "Text block content should be present");
+
+        final DetailAST content = textBlockContent.get();
+        final String expectedContents = "\n                 string";
+
+        assertEquals(5, content.getLineNo(), "Unexpected line number");
+        assertEquals(32, content.getColumnNo(), "Unexpected column number");
+        assertEquals(expectedContents, content.getText(), "Unexpected text block content");
+    }
+
     private static final class CountComments {
         private final List<String> lineComments = new ArrayList<>();
         private final List<String> blockComments = new ArrayList<>();

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserTextBlocks.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/javaparser/InputJavaParserTextBlocks.java
@@ -1,0 +1,7 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.javaparser;
+
+public class InputJavaParserTextBlocks {
+    String textBlockString = """
+                 string""";
+}


### PR DESCRIPTION
Issue #8604: fix master build failure due to leaked pitest coverage

The issue is that there were no tests included in `pitest-common-2` that exercised the text block lexer code within JavaParser.java.  I simply added a UT to check text block content, and now pitest is happy. Note that I have reverted the previous hack and restored coverage minimum back to 100%.

Five successful pitest-common-2 runs:
https://nmancus1.github.io/pitest-common-2/202008070835/
https://nmancus1.github.io/pitest-common-2/202008070836/
https://nmancus1.github.io/pitest-common-2/202008070838/
https://nmancus1.github.io/pitest-common-2/202008070839/
https://nmancus1.github.io/pitest-common-2/202008070841/