### PR TITLE
Issue #8523: Records support check update for EmptyLineSeparatorCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -93,7 +93,11 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
  * CTOR_DEF</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
- * VARIABLE_DEF</a>.
+ * VARIABLE_DEF</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+ * RECORD_DEF</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
+ * COMPACT_CTOR_DEF</a>.
  * </li>
  * </ul>
  * <p>
@@ -383,6 +387,8 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
             TokenTypes.METHOD_DEF,
             TokenTypes.CTOR_DEF,
             TokenTypes.VARIABLE_DEF,
+            TokenTypes.RECORD_DEF,
+            TokenTypes.COMPACT_CTOR_DEF,
         };
     }
 
@@ -485,7 +491,8 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
         return astType == TokenTypes.STATIC_INIT
                 || astType == TokenTypes.INSTANCE_INIT
                 || astType == TokenTypes.METHOD_DEF
-                || astType == TokenTypes.CTOR_DEF;
+                || astType == TokenTypes.CTOR_DEF
+                || astType == TokenTypes.COMPACT_CTOR_DEF;
     }
 
     /**
@@ -820,7 +827,8 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
      */
     private static boolean isTypeField(DetailAST variableDef) {
         final int parentType = variableDef.getParent().getParent().getType();
-        return parentType == TokenTypes.CLASS_DEF;
+        return parentType == TokenTypes.CLASS_DEF
+                || parentType == TokenTypes.RECORD_DEF;
     }
 
 }

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -135,7 +135,8 @@
     <module name="EmptyLineSeparator">
       <property name="tokens"
                value="PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
-                    STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+                    STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, RECORD_DEF,
+                    COMPACT_CTOR_DEF"/>
       <property name="allowNoEmptyLineBetweenFields" value="true"/>
     </module>
     <module name="SeparatorWrap">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -225,6 +225,8 @@ public class EmptyLineSeparatorCheckTest
             TokenTypes.METHOD_DEF,
             TokenTypes.CTOR_DEF,
             TokenTypes.VARIABLE_DEF,
+            TokenTypes.RECORD_DEF,
+            TokenTypes.COMPACT_CTOR_DEF,
         };
         assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
     }
@@ -425,6 +427,50 @@ public class EmptyLineSeparatorCheckTest
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig,
                 getPath("InputEmptyLineSeparatorNoViolationOnEmptyLineBeforeComments.java"),
+                expected);
+    }
+
+    @Test
+    public void testEmptyLineSeparatorRecordsAndCompactCtors() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(EmptyLineSeparatorCheck.class);
+
+        final String[] expected = {
+            "2:1: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "package"),
+            "15:5: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "RECORD_DEF"),
+            "17:9: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
+            "18:9: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "COMPACT_CTOR_DEF"),
+            "19:9: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "CTOR_DEF"),
+            "20:9: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "STATIC_INIT"),
+            "22:5: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "RECORD_DEF"),
+            "23:5: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "CLASS_DEF"),
+            "25:9: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
+            "26:9: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "CTOR_DEF"),
+            "27:9: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "CTOR_DEF"),
+            "32:9: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "COMPACT_CTOR_DEF"),
+            "33:9: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "METHOD_DEF"),
+            "38:9: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "COMPACT_CTOR_DEF"),
+            "39:9: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "VARIABLE_DEF"),
+        };
+
+        verify(checkConfig,
+                getNonCompilablePath("InputEmptyLineSeparatorRecordsAndCompactCtors.java"),
+                expected);
+    }
+
+    @Test
+    public void testEmptyLineSeparatorRecordsAndCompactCtorsNoEmptyLines() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(EmptyLineSeparatorCheck.class);
+        checkConfig.addAttribute("allowMultipleEmptyLinesInsideClassMembers", "false");
+
+        final String[] expected = {
+            "2:1: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "package"),
+            "16: " + getCheckMessage(MSG_MULTIPLE_LINES_INSIDE),
+            "22: " + getCheckMessage(MSG_MULTIPLE_LINES_INSIDE),
+        };
+
+        verify(checkConfig,
+                getNonCompilablePath(
+                        "InputEmptyLineSeparatorRecordsAndCompactCtorsNoEmptyLines.java"),
                 expected);
     }
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorRecordsAndCompactCtors.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorRecordsAndCompactCtors.java
@@ -1,0 +1,67 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator; // violation
+
+/* Config:
+ * allowNoEmptyLineBetweenFields = false
+ * allowMultipleEmptyLines = true
+ * allowMultipleEmptyLinesInsideClassMembers = true
+ * tokens = {PACKAGE_DEF , IMPORT , STATIC_IMPORT , CLASS_DEF , INTERFACE_DEF , ENUM_DEF ,
+ *  STATIC_INIT , INSTANCE_INIT , METHOD_DEF , CTOR_DEF , VARIABLE_DEF,
+ *  RECORD_DEF, COMPACT_CTOR_DEF}
+ *
+ */
+public class InputEmptyLineSeparatorRecordsAndCompactCtors {
+    record InBetween1(int x, int y) {}
+    record MyRecord1(String foo) { // violation
+        public static final int FOO_CONST = 1;
+        public void method() {} // violation
+        public MyRecord1{} // violation
+        MyRecord1(int x){this("string");} // violation
+        static{} // violation
+    }
+    record InBetween2(int x, int y) {} // violation
+    class MyClass1 { // violation
+        public static final int FOO_CONST = 1;
+        public void method() {} // violation
+        public MyClass1(){} // violation
+        MyClass1(String foo){} // violation
+    }
+
+    record recordCompactCtors1(){
+        void method1(){}
+        public recordCompactCtors1{} // violation
+        void method2(){} // violation
+    }
+
+    record recordCompactCtors2(){
+        public static final int X = 1;
+        public recordCompactCtors2{} // violation
+        public static final int Y = 1; // violation
+    }
+
+    record MyRecord2(String foo) { // ok
+
+        public static final int FOO_CONST = 1;
+
+        public void method() {} // ok
+
+        public MyRecord2{} // ok
+
+        MyRecord2(int x){this("string");} // ok
+
+        static{} // ok
+    }
+
+    record InBetween3(int x, int y) {} // ok
+
+    class MyClass2 {
+
+        public static final int FOO_CONST = 1;
+
+        public void method() {} // ok
+
+        public MyClass2(){} // ok
+
+        MyClass2(String foo){} // ok
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorRecordsAndCompactCtorsNoEmptyLines.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorRecordsAndCompactCtorsNoEmptyLines.java
@@ -1,0 +1,25 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator; // violation
+
+/* Config:
+ * allowNoEmptyLineBetweenFields = false
+ * allowMultipleEmptyLines = true
+ * allowMultipleEmptyLinesInsideClassMembers = false
+ * tokens = {PACKAGE_DEF , IMPORT , STATIC_IMPORT , CLASS_DEF , INTERFACE_DEF , ENUM_DEF ,
+ *  STATIC_INIT , INSTANCE_INIT , METHOD_DEF , CTOR_DEF , VARIABLE_DEF,
+ *  RECORD_DEF, COMPACT_CTOR_DEF}
+ *
+ */
+public class InputEmptyLineSeparatorRecordsAndCompactCtorsNoEmptyLines {
+    public void foo() {
+
+
+    } // ^ violation
+
+    public record MyRecord1(){
+        public MyRecord1{
+
+
+        } // ^ violation
+    }
+}

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -295,6 +295,10 @@ for (Iterator foo = very.long.line.iterator();
                     CTOR_DEF</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
                     VARIABLE_DEF</a>
+                , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+                    RECORD_DEF</a>
+                , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
+                    COMPACT_CTOR_DEF</a>
                     .
               </td>
               <td>
@@ -320,6 +324,10 @@ for (Iterator foo = very.long.line.iterator();
                     CTOR_DEF</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
                     VARIABLE_DEF</a>
+                , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+                    RECORD_DEF</a>
+                , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
+                    COMPACT_CTOR_DEF</a>
                   .
               </td>
               <td>5.8</td>


### PR DESCRIPTION
Issue #8523: Records support check update for EmptyLineSeparatorCheck

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/bdaeb2e6be6d30243edaeb6f04e44a87/raw/bc4eff061891f13d2ec1cf2beeab87fd96e4cc93/EmptyLineSeparatorCheck.xml