### PR TITLE
Issue #8633: LineLengthCheck.fileExtensions default value and similar usages should be changed to empty string

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
@@ -81,7 +81,7 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
  * <li>
  * Property {@code fileExtensions} - Specify the file type extension of the files to check.
  * Type is {@code java.lang.String[]}.
- * Default value is {@code all files}.
+ * Default value is {@code ""}.
  * </li>
  * </ul>
  * <p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
@@ -79,7 +79,7 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
  * <li>
  * Property {@code fileExtensions} - Specify the file type extension of files to process.
  * Type is {@code java.lang.String[]}.
- * Default value is {@code all files}.
+ * Default value is {@code ""}.
  * </li>
  * </ul>
  * <p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
@@ -125,7 +125,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <li>
  * Property {@code fileExtensions} - Specify the file type extension of files to process.
  * Type is {@code java.lang.String[]}.
- * Default value is {@code all files}.
+ * Default value is {@code ""}.
  * </li>
  * </ul>
  * <p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheck.java
@@ -69,7 +69,7 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
  * <li>
  * Property {@code fileExtensions} - Specify the file type extension of files to process.
  * Type is {@code java.lang.String[]}.
- * Default value is {@code all files}.
+ * Default value is {@code ""}.
  * </li>
  * </ul>
  * <p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheck.java
@@ -98,7 +98,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * specified, then only files that match these types are examined with the other
  * patterns.
  * Type is {@code java.lang.String[]}.
- * Default value is {@code all files}.</li>
+ * Default value is {@code ""}.</li>
  * </ul>
  *
  * <p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheck.java
@@ -64,7 +64,7 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
  * <li>
  * Property {@code fileExtensions} - Specify the file type extension of files to process.
  * Type is {@code java.lang.String[]}.
- * Default value is {@code all files}.
+ * Default value is {@code ""}.
  * </li>
  * </ul>
  * <p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheck.java
@@ -43,7 +43,7 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
  * <li>
  * Property {@code fileExtensions} - Specify the file type extension of files to process.
  * Type is {@code java.lang.String[]}.
- * Default value is {@code all files}.
+ * Default value is {@code ""}.
  * </li>
  * </ul>
  * <p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
@@ -54,7 +54,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <li>
  * Property {@code fileExtensions} - Specify file extensions that are accepted.
  * Type is {@code java.lang.String[]}.
- * Default value is {@code all files}.
+ * Default value is {@code ""}.
  * </li>
  * <li>
  * Property {@code ignorePattern} - Specify pattern for lines to ignore.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterCheck.java
@@ -53,7 +53,7 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
  * <li>
  * Property {@code fileExtensions} - Specify file type extension of files to process.
  * Type is {@code java.lang.String[]}.
- * Default value is {@code all files}.
+ * Default value is {@code ""}.
  * </li>
  * </ul>
  * <p>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -353,7 +353,8 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
 
     private static String emptyStringArrayDefaultValue(Node defaultValueNode) {
         String defaultValueText = getNodeText(defaultValueNode);
-        if ("{@code {}}".equals(defaultValueText)) {
+        if ("{@code {}}".equals(defaultValueText)
+            || "{@code all files}".equals(defaultValueText)) {
             defaultValueText = "{@code \"\"}";
         }
         return defaultValueText;


### PR DESCRIPTION
#8633 
```
<property name="fileExtensions" type="java.lang.String[]" default-value="all files">
          <description><![CDATA[Specify file extensions that are accepted.]]></description>
 </property>
```
`all files` is not good default value. We need to fix javadoc. It is what we mean and how it will be interpreted, but it is not a value

So, we need to replace it with `""`