### PR TITLE
Issue #8631: Proof of Java 14 syntax parsing by new CI build item

### DIFF
--- a/.ci/jsoref-spellchecker/exclude.pl
+++ b/.ci/jsoref-spellchecker/exclude.pl
@@ -13,6 +13,7 @@ my @excludes=qw(
   /releasenotes_old\.xml$
   /releasenotes\.xml$
   /.*_..\.translation[^/]*$
+  /jdk14-test-excluded-files\.list$
 );
 my $exclude = join "|", @excludes;
 while (<>) {

--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -754,6 +754,7 @@ Kordas
 Kotlin
 kused
 lambdaparametername
+langtools
 lbc
 LBRACK
 lbt
@@ -838,6 +839,7 @@ missingtag
 mixin
 mkdir
 mkordas
+mktemp
 MLINKCHECK
 mockfile
 mockito
@@ -1290,6 +1292,7 @@ technotes
 tected
 Testik
 testmodules
+testresults
 textarea
 textlevel
 Tfo

--- a/.ci/travis/openjdk14-test/jdk14-test-excluded-files.list
+++ b/.ci/travis/openjdk14-test/jdk14-test-excluded-files.list
@@ -1,0 +1,38 @@
+
+## This file contains all compilable files from
+## https://download.java.net/openjdk/testresults/14/archives/36/langtools-36-summary.txt
+## that Checkstyle cannot parse. When adding new files to exclude, make sure to create an issue
+## and link to it in this file so that we can track it. Once the issue is resolved, please remove
+## the file from this list to prove that Checkstyle can parse it.
+
+## https://github.com/checkstyle/checkstyle/issues/8650 ##
+jdk14/test/langtools/tools/javac/MethodParameters/UncommonParamNames.java
+
+## https://github.com/checkstyle/checkstyle/issues/8651 ##
+jdk14/test/langtools/tools/javac/TextBlockLang.java
+
+## https://github.com/checkstyle/checkstyle/issues/8652 ##
+jdk14/test/langtools/tools/javac/annotations/typeAnnotations/8013180/QualifiedName.java
+jdk14/test/langtools/tools/javac/parser/SingleCommaAnnotationValue.java
+jdk14/test/langtools/tools/javac/annotations/typeAnnotations/failures/CheckErrorsForSource7.java
+jdk14/test/langtools/tools/javac/annotations/typeAnnotations/failures/T8011722.java
+jdk14/test/langtools/tools/javac/annotations/typeAnnotations/newlocations/AllLocations.java
+jdk14/test/langtools/tools/javac/annotations/typeAnnotations/newlocations/NestedTypes.java
+jdk14/test/langtools/tools/javac/treeannotests/AnnoTreeTests.java
+
+## https://github.com/checkstyle/checkstyle/issues/8653 ##
+jdk14/test/langtools/tools/javac/enum/TrailingComma.java
+
+## Related to https://github.com/checkstyle/checkstyle/issues/8291 ##
+jdk14/test/langtools/tools/javac/lambda/speculative/NestedLambdaGenerics.java
+jdk14/test/langtools/tools/javac/lambda/speculative/NestedLambdaNoGenerics.java
+
+## https://github.com/checkstyle/checkstyle/issues/8654 ##
+jdk14/test/langtools/tools/javac/unicode/SupplementaryJavaID1.java
+jdk14/test/langtools/tools/javac/unicode/SupplementaryJavaID6.java
+
+## https://github.com/checkstyle/checkstyle/issues/8655 ##
+jdk14/test/langtools/tools/javac/unicode/UnicodeAtEOL.java
+
+## https://github.com/checkstyle/checkstyle/issues/8656 ##
+jdk14/test/langtools/tools/javac/unicode/UnicodeCommentDelimiter.java

--- a/.ci/travis/openjdk14-test/single-module-config.xml
+++ b/.ci/travis/openjdk14-test/single-module-config.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+
+  <!-- We will not run checks on -info.java files -->
+  <module name="BeforeExecutionExclusionFileFilter">
+    <property name="fileNamePattern" value="module\-info\.java$"/>
+  </module>
+
+  <!-- This allows us to exit with 0 if successful -->
+  <property name="severity" value="ignore"/>
+
+  <module name="TreeWalker">
+    <!-- Here we use simple module to prove that we can parse files -->
+    <module name="ClassTypeParameterName"/>
+  </module>
+</module>

--- a/.travis.yml
+++ b/.travis.yml
@@ -320,6 +320,11 @@ jobs:
           - USE_MAVEN_REPO="true"
           - CMD="./.ci/travis/travis.sh no-violation-test-josm"
 
+    # OpenJDK14 checkstyle run with one module config to prove that we can parse jdk14 syntax
+    - env:
+        - DESC="run checkstyle on jdk14 test inputs with single module in config"
+        - CMD=".ci/travis/travis.sh checkstyle-cli-run-openjdk14"
+
 script:
   - SKIP_FILES1=".github|codeship-*|buddy.yml|appveyor.yml|circleci"
   - SKIP_FILES2="|fast-forward-merge.sh|LICENSE|LICENSE.apache20|README.md|release.sh|RIGHTS.antlr"

--- a/config/ant-phase-verify.xml
+++ b/config/ant-phase-verify.xml
@@ -122,6 +122,9 @@
           <exclude name="**/InputJava14TextBlocks.txt"/>
           <exclude name="**/InputJava14SwitchExpression.txt"/>
 
+          <!-- Exclude list of files for openjdk checkstyle run in Travis -->
+          <exclude name="**/jdk14-test-files.list"/>
+
         </fileset>
       </path>
       <formatter type="plain"/>


### PR DESCRIPTION
Issue #8631: Proof of Java 14 syntax parsing by new CI build item

To prove that we can parse jdk14 syntax, we have taken the list of test files from https://download.java.net/openjdk/testresults/15/archives/24/langtools-24-summary.txt and created a Travis build item that builds the contributor's version of Checkstyle and executes Checkstyle on this list. 

The config used is a simple one so that we can execute this build quickly, just to show that we can parse all of these files.  The only module is `ClassTypeParameterName`. Also to speed things up, we will clone the openjdk14 repo with` --depth 1`.

I have added some comments to the list, to show future contributors where we can add more files as we find them.

Reviewers, please note that I have included the commits from https://github.com/checkstyle/checkstyle/pull/8449 so that this build item passes; without switch expression syntax support, it will not. 