### PR TITLE
minor: remove already covered check PatternVariableName(#8407)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1908,9 +1908,6 @@
                 <param>com.puppycrawl.tools.checkstyle.checks.NoCodeInFileCheck*</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck*</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck*</param>
-                <param>
-                  com.puppycrawl.tools.checkstyle.checks.naming.PatternVariableNameCheck*
-                </param>
                 <param>com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder*</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck*</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck*</param>
@@ -1930,9 +1927,6 @@
                 <param>com.puppycrawl.tools.checkstyle.checks.NoCodeInFileCheckTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheckTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheckTest</param>
-                <param>
-                  com.puppycrawl.tools.checkstyle.checks.naming.PatternVariableNameCheckTest
-                </param>
                 <param>com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolderTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.TodoCommentCheckTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheckTest</param>


### PR DESCRIPTION
minor: remove already covered check PatternVariableName(#8407)

Identified at https://github.com/checkstyle/checkstyle/pull/8586#discussion_r467624665

This check already has pitest coverage by https://github.com/checkstyle/checkstyle/blob/ebee876080d594ed64dcaba6f56441d05d08643e/pom.xml#L2462 , so we can remove it from here.