### PR TITLE
Issue #8660: UnnecessaryParentheses throws NPE on switch expression syntax

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
@@ -423,7 +423,7 @@ public class UnnecessaryParenthesesCheck extends AbstractCheck {
     private static boolean isLambdaSingleParameterSurrounded(DetailAST ast) {
         final DetailAST firstChild = ast.getFirstChild();
         boolean result = false;
-        if (firstChild.getType() == TokenTypes.LPAREN) {
+        if (firstChild != null && firstChild.getType() == TokenTypes.LPAREN) {
             final DetailAST parameters = firstChild.getNextSibling();
             if (parameters.getChildCount(TokenTypes.PARAMETER_DEF) == 1
                     && !parameters.getFirstChild().findFirstToken(TokenTypes.TYPE).hasChildren()) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheckTest.java
@@ -131,6 +131,29 @@ public class UnnecessaryParenthesesCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testUnnecessaryParenthesesSwitchExpression() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(UnnecessaryParenthesesCheck.class);
+        final String[] expected = {
+            "16:50: " + getCheckMessage(MSG_ASSIGN),
+            "19:19: " + getCheckMessage(MSG_LITERAL, 2),
+            "20:58: " + getCheckMessage(MSG_ASSIGN),
+            "25:28: " + getCheckMessage(MSG_ASSIGN),
+            "27:24: " + getCheckMessage(MSG_IDENT, "case7"),
+            "31:28: " + getCheckMessage(MSG_ASSIGN),
+            "41:50: " + getCheckMessage(MSG_ASSIGN),
+            "43:19: " + getCheckMessage(MSG_LITERAL, 2),
+            "44:58: " + getCheckMessage(MSG_ASSIGN),
+            "48:28: " + getCheckMessage(MSG_ASSIGN),
+            "53:28: " + getCheckMessage(MSG_ASSIGN),
+        };
+        verify(checkConfig,
+                getNonCompilablePath(
+                        "InputUnnecessaryParenthesesCheckSwitchExpression.java"),
+                expected);
+    }
+
+    @Test
     public void testTokensNotNull() {
         final UnnecessaryParenthesesCheck check = new UnnecessaryParenthesesCheck();
         assertNotNull(check.getAcceptableTokens(), "Acceptable tokens should not be null");

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesCheckSwitchExpression.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesCheckSwitchExpression.java
@@ -1,0 +1,63 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.coding.unnecessaryparentheses;
+
+/* Config:
+ *
+ * tokens = {EXPR , IDENT , NUM_DOUBLE , NUM_FLOAT , NUM_INT , NUM_LONG , STRING_LITERAL ,
+ *  LITERAL_NULL , LITERAL_FALSE , LITERAL_TRUE , ASSIGN , BAND_ASSIGN , BOR_ASSIGN ,
+ *  BSR_ASSIGN , BXOR_ASSIGN , DIV_ASSIGN , MINUS_ASSIGN , MOD_ASSIGN , PLUS_ASSIGN ,
+ *  SL_ASSIGN , SR_ASSIGN , STAR_ASSIGN , LAMBDA }
+ */
+
+public class InputUnnecessaryParenthesesCheckSwitchExpression {
+    MathOperation2 tooManyParens(int k) {
+        return switch (k) {
+            case 1 -> {
+                MathOperation2 case5 = (a, b) -> (a + b); // violation
+                yield case5;
+            }
+            case (2) -> { // violation
+                MathOperation2 case6 = (int a, int b) -> (a + b); // violation
+                yield case6;
+            }
+            case 3 -> {
+                MathOperation2 case7 = (int a, int b) -> {
+                    return (a + b); // violation
+                };
+                yield (case7); // violation
+            }
+            default -> {
+                MathOperation2 case8 = (int x, int y) -> {
+                    return (x + y); // violation
+                };
+                yield case8;
+            }
+        };
+    }
+
+    MathOperation2 tooManyParens2(int k) {
+       switch (k) {
+            case 1 -> {
+                MathOperation2 case5 = (a, b) -> (a + b); // violation
+            }
+            case (2) -> { // violation
+                MathOperation2 case6 = (int a, int b) -> (a + b); // violation
+            }
+            case 3 -> {
+                MathOperation2 case7 = (int a, int b) -> {
+                    return (a + b + 2 ); // violation
+                };
+            }
+            default -> {
+                MathOperation2 case8 = (int x, int y) -> {
+                    return (x + y); // violation
+                };
+            }
+        };
+       return (a, b) -> 0;
+    }
+
+    interface MathOperation2 {
+        int operation(int a, int b);
+    }
+}


### PR DESCRIPTION
Issue #8660: UnnecessaryParentheses throws NPE on switch exprssion syntax

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/5de2b363978aeb1feb327d52e1247ef9/raw/ef539479d35662261a6672434d0ff4f724fbccb0/UnnecessaryParentheses.xml