### PR TITLE
Issue #8661: IndentationCheck throws a NPE on switch expression

### DIFF
--- a/config/ant-phase-verify.xml
+++ b/config/ant-phase-verify.xml
@@ -219,6 +219,8 @@
           <exclude name="**/ant/**/*"/>
           <!-- No need to check ast String Printer input files -->
           <exclude name="**/asttreestringprinter/**/*"/>
+          <!-- Indentation checks use "warn" -->
+          <exclude name="**/resources-noncompilable/**/checks/indentation/**/*"/>
 
         </fileset>
       </path>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java
@@ -42,7 +42,11 @@ public class HandlerFactory {
     /** Cache for created method call handlers. */
     private final Map<DetailAST, AbstractExpressionHandler> createdHandlers = new HashMap<>();
 
-    /** Creates a HandlerFactory. */
+    /**
+     * Creates a HandlerFactory.
+     *
+     * @noinspection OverlyCoupledMethod
+     */
     public HandlerFactory() {
         register(TokenTypes.CASE_GROUP, CaseHandler.class);
         register(TokenTypes.LITERAL_SWITCH, SwitchHandler.class);
@@ -77,6 +81,7 @@ public class HandlerFactory {
         register(TokenTypes.LAMBDA, LambdaHandler.class);
         register(TokenTypes.ANNOTATION_DEF, ClassDefHandler.class);
         register(TokenTypes.ANNOTATION_FIELD_DEF, MethodDefHandler.class);
+        register(TokenTypes.SWITCH_RULE, SwitchRuleHandler.class);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LambdaHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LambdaHandler.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.indentation;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 /**
  * Handler for lambda expressions.
@@ -78,7 +79,9 @@ public class LambdaHandler extends AbstractExpressionHandler {
     public void checkIndentation() {
         // If the argument list is the first element on the line
         final DetailAST firstChild = getMainAst().getFirstChild();
-        if (getLineStart(firstChild) == expandedTabsColumnNo(firstChild)) {
+        final DetailAST parent = getMainAst().getParent();
+        if (parent.getType() != TokenTypes.SWITCH_RULE
+                && getLineStart(firstChild) == expandedTabsColumnNo(firstChild)) {
             final IndentLevel level = getIndent();
             if (!level.isAcceptable(expandedTabsColumnNo(firstChild))) {
                 logError(firstChild, "arguments", expandedTabsColumnNo(firstChild), level);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SwitchRuleHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SwitchRuleHandler.java
@@ -1,0 +1,76 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.checks.indentation;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+/**
+ * Handler for switch rules.
+ */
+public class SwitchRuleHandler extends AbstractExpressionHandler {
+
+    /**
+     * The child elements of a switch rule.
+     */
+    private static final int[] SWITCH_RULE_CHILDREN = {
+        TokenTypes.LITERAL_CASE,
+        TokenTypes.LITERAL_DEFAULT,
+        TokenTypes.LAMBDA,
+    };
+
+    /**
+     * Construct an instance of this handler with the given indentation check,
+     * abstract syntax tree, and parent handler.
+     *
+     * @param indentCheck the indentation check
+     * @param expr        the abstract syntax tree
+     * @param parent      the parent handler
+     */
+    public SwitchRuleHandler(IndentationCheck indentCheck,
+                       DetailAST expr, AbstractExpressionHandler parent) {
+        super(indentCheck, "case", expr, parent);
+    }
+
+    @Override
+    protected IndentLevel getIndentImpl() {
+        return new IndentLevel(getParent().getIndent(),
+            getIndentCheck().getCaseIndent());
+    }
+
+    /**
+     * Check the indentation of the case statement.
+     */
+    private void checkCase() {
+        checkChildren(getMainAst(), SWITCH_RULE_CHILDREN, getIndent(),
+            true, false);
+    }
+
+    @Override
+    public IndentLevel getSuggestedChildIndent(AbstractExpressionHandler child) {
+        return getIndent();
+    }
+
+    @Override
+    public void checkIndentation() {
+        checkCase();
+    }
+
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -2084,6 +2084,40 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         verifyWarns(checkConfig, getPath(fileName), expected);
     }
 
+    @Test
+    public void testIndentationSwitchExpression() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addAttribute("tabWidth", "4");
+        final String[] expected = {
+            "17:1: " + getCheckMessage(MSG_CHILD_ERROR, "case", 0, 12),
+            "18:9: " + getCheckMessage(MSG_CHILD_ERROR, "block", 8, 16),
+            "21:25: " + getCheckMessage(MSG_CHILD_ERROR, "case", 24, 12),
+            "22:9: " + getCheckMessage(MSG_CHILD_ERROR, "block", 8, 16),
+            "27:9: " + getCheckMessage(MSG_CHILD_ERROR, "block", 8, 20),
+            "29:1: " + getCheckMessage(MSG_CHILD_ERROR, "block", 0, 16),
+            "34:5: " + getCheckMessage(MSG_CHILD_ERROR, "block", 4, 20),
+            "44:1: " + getCheckMessage(MSG_CHILD_ERROR, "block", 0, 16),
+            "46:21: " + getCheckMessage(MSG_CHILD_ERROR, "case", 20, 12),
+            "47:1: " + getCheckMessage(MSG_CHILD_ERROR, "block", 0, 16),
+            "51:9: " + getCheckMessage(MSG_CHILD_ERROR, "block", 8, 20),
+            "56:33: " + getCheckMessage(MSG_CHILD_ERROR, "block", 32, 20),
+        };
+
+        verifyWarns(checkConfig,
+                getNonCompilablePath("InputIndentationCheckSwitchExpression.java"),
+                expected);
+    }
+
+    @Test
+    public void testIndentationSwitchExpressionCorrect() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addAttribute("tabWidth", "4");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWarns(checkConfig,
+            getNonCompilablePath("InputIndentationCheckSwitchExpressionCorrect.java"),
+            expected);
+    }
+
     private static final class IndentAudit implements AuditListener {
 
         private final IndentComment[] comments;

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckSwitchExpression.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckSwitchExpression.java
@@ -1,0 +1,67 @@
+//non-compiled with javac: Compilable with Java14                                   //indent:0 exp:0
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;             //indent:0 exp:0
+                                                                                  //indent:82 exp:82
+/* Config:                                                                          //indent:0 exp:0
+ *                                                                                  //indent:1 exp:1
+ * basicOffset = 4                                                                  //indent:1 exp:1
+ * braceAdjustment = 0                                                              //indent:1 exp:1
+ * caseIndent = 4                                                                   //indent:1 exp:1
+ * throwsIndent = 4                                                                 //indent:1 exp:1
+ * arrayInitIndent = 4                                                              //indent:1 exp:1
+ * lineWrappingIndentation = 4                                                      //indent:1 exp:1
+ * forceStrictCondition = false                                                     //indent:1 exp:1
+ */                                                                                 //indent:1 exp:1
+public class InputIndentationCheckSwitchExpression {                                //indent:0 exp:0
+    MathOperation2 tooManyParens(int k) {                                           //indent:4 exp:4
+        return switch (k) {                                                         //indent:8 exp:8
+case 1 -> {                                                                   //indent:0 exp:12 warn
+        MathOperation2 case5 = (a, b) -> (a + b);                             //indent:8 exp:16 warn
+                yield case5;                                                      //indent:16 exp:16
+            }                                                                     //indent:12 exp:12
+                        case (2) -> {                                        //indent:24 exp:12 warn
+        MathOperation2 case6 = (int a, int b) -> (a + b);                     //indent:8 exp:16 warn
+                yield case6;                                                      //indent:16 exp:16
+            }                                                                     //indent:12 exp:12
+            case 3 -> {                                                           //indent:12 exp:12
+                MathOperation2 case7 = (int a, int b) -> {                        //indent:16 exp:16
+        return (a + b);                                                       //indent:8 exp:20 warn
+                };                                                                //indent:16 exp:16
+System.out.println("yield!");                                                 //indent:0 exp:16 warn
+yield case7; /** this is not correct **/                                            //indent:0 exp:0
+            }                                                                     //indent:12 exp:12
+            default -> {                                                          //indent:12 exp:12
+                MathOperation2 case8 = (int x, int y) -> {                        //indent:16 exp:16
+    return (x + y);                                                           //indent:4 exp:20 warn
+                };                                                                //indent:16 exp:16
+                yield case8;                                                      //indent:16 exp:16
+            }                                                                     //indent:12 exp:12
+        };                                                                          //indent:8 exp:8
+    }                                                                               //indent:4 exp:4
+                                                                                  //indent:82 exp:82
+    MathOperation2 tooManyParens2(int k) {                                          //indent:4 exp:4
+        switch (k) {                                                                //indent:8 exp:8
+            case 1 -> {                                                           //indent:12 exp:12
+MathOperation2 case5 = (a, b) -> (a + b);                                     //indent:0 exp:16 warn
+            }                                                                     //indent:12 exp:12
+                    case (2) -> {                                            //indent:20 exp:12 warn
+MathOperation2 case6 = (int a, int b) -> (a + b);                             //indent:0 exp:16 warn
+            }                                                                     //indent:12 exp:12
+            case 3 -> {                                                           //indent:12 exp:12
+                MathOperation2 case7 = (int a, int b) -> {                        //indent:16 exp:16
+        return (a + b + 2);                                                   //indent:8 exp:20 warn
+                };                                                                //indent:16 exp:16
+            }                                                                     //indent:12 exp:12
+            default -> {                                                          //indent:12 exp:12
+                MathOperation2 case8 = (int x, int y) -> {                        //indent:16 exp:16
+                                return (x + y);                              //indent:32 exp:20 warn
+                };                                                                //indent:16 exp:16
+            }                                                                     //indent:12 exp:12
+        }                                                                           //indent:8 exp:8
+        return (a, b) -> 0;                                                         //indent:8 exp:8
+    }                                                                               //indent:4 exp:4
+                                                                                  //indent:82 exp:82
+    interface MathOperation2 {                                                      //indent:4 exp:4
+        int operation(int a, int b);                                                //indent:8 exp:8
+    }                                                                               //indent:4 exp:4
+}                                                                                   //indent:0 exp:0
+                                                                                  //indent:82 exp:82

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckSwitchExpressionCorrect.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckSwitchExpressionCorrect.java
@@ -1,0 +1,66 @@
+//non-compiled with javac: Compilable with Java14                                   //indent:0 exp:0
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;             //indent:0 exp:0
+                                                                                  //indent:82 exp:82
+/* Config:                                                                          //indent:0 exp:0
+ *                                                                                  //indent:1 exp:1
+ * basicOffset = 4                                                                  //indent:1 exp:1
+ * braceAdjustment = 0                                                              //indent:1 exp:1
+ * caseIndent = 4                                                                   //indent:1 exp:1
+ * throwsIndent = 4                                                                 //indent:1 exp:1
+ * arrayInitIndent = 4                                                              //indent:1 exp:1
+ * lineWrappingIndentation = 4                                                      //indent:1 exp:1
+ * forceStrictCondition = false                                                     //indent:1 exp:1
+ */                                                                                 //indent:1 exp:1
+public class InputIndentationCheckSwitchExpressionCorrect {                         //indent:0 exp:0
+    MathOperation2 tooManyParens(int k) {                                           //indent:4 exp:4
+        return switch (k) {                                                         //indent:8 exp:8
+            case 1 -> {                                                           //indent:12 exp:12
+                MathOperation2 case5 = (a, b) -> (a + b);                         //indent:16 exp:16
+                yield case5;                                                      //indent:16 exp:16
+            }                                                                     //indent:12 exp:12
+            case (2) -> {                                                         //indent:12 exp:12
+                MathOperation2 case6 = (int a, int b) -> (a + b);                 //indent:16 exp:16
+                yield case6;                                                      //indent:16 exp:16
+            }                                                                     //indent:12 exp:12
+            case 3 -> {                                                           //indent:12 exp:12
+                MathOperation2 case7 = (int a, int b) -> {                        //indent:16 exp:16
+                    return (a + b);                                               //indent:20 exp:20
+                };                                                                //indent:16 exp:16
+                yield (case7);                                                    //indent:16 exp:16
+            }                                                                     //indent:12 exp:12
+            default -> {                                                          //indent:12 exp:12
+                MathOperation2 case8 = (int x, int y) -> {                        //indent:16 exp:16
+                    return (x + y);                                               //indent:20 exp:20
+                };                                                                //indent:16 exp:16
+                yield case8;                                                      //indent:16 exp:16
+            }                                                                     //indent:12 exp:12
+        };                                                                          //indent:8 exp:8
+    }                                                                               //indent:4 exp:4
+                                                                                  //indent:82 exp:82
+    MathOperation2 tooManyParens2(int k) {                                          //indent:4 exp:4
+        switch (k) {                                                                //indent:8 exp:8
+            case 1 -> {                                                           //indent:12 exp:12
+                MathOperation2 case5 = (a, b) -> (a + b);                         //indent:16 exp:16
+            }                                                                     //indent:12 exp:12
+            case (2) -> {                                                         //indent:12 exp:12
+                MathOperation2 case6 = (int a, int b) -> (a + b);                 //indent:16 exp:16
+            }                                                                     //indent:12 exp:12
+            case 3 -> {                                                           //indent:12 exp:12
+                MathOperation2 case7 = (int a, int b) -> {                        //indent:16 exp:16
+                    return (a + b + 2);                                           //indent:20 exp:20
+                };                                                                //indent:16 exp:16
+            }                                                                     //indent:12 exp:12
+            default -> {                                                          //indent:12 exp:12
+                MathOperation2 case8 = (int x, int y) -> {                        //indent:16 exp:16
+                    return (x + y);                                               //indent:20 exp:20
+                };                                                                //indent:16 exp:16
+            }                                                                     //indent:12 exp:12
+        }                                                                           //indent:8 exp:8
+        return (a, b) -> 0;                                                         //indent:8 exp:8
+    }                                                                               //indent:4 exp:4
+                                                                                  //indent:82 exp:82
+    interface MathOperation2 {                                                      //indent:4 exp:4
+        int operation(int a, int b);                                                //indent:8 exp:8
+    }                                                                               //indent:4 exp:4
+}                                                                                   //indent:0 exp:0
+                                                                                  //indent:82 exp:82


### PR DESCRIPTION
Issue #8661: IndentationCheck throws a NPE on switch expression

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/68be3aca702f5825bfa909698e4dea74/raw/1c6320477615ddf0c35ef574994c95e3bffcaa7e/Indentation.xml

Please note that this PR only adds support for switch rules and fixes the NPE for #8661.  Support for yield statements will be handled separately at https://github.com/checkstyle/checkstyle/issues/8691