### PR TITLE
Issue #8683: LambdaParameterName throws NPE parsing switch expressions

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LambdaParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LambdaParameterNameCheck.java
@@ -113,10 +113,11 @@ public class LambdaParameterNameCheck extends AbstractNameCheck {
     @Override
     public void visitToken(DetailAST ast) {
         final DetailAST parametersNode = ast.findFirstToken(TokenTypes.PARAMETERS);
-        if (parametersNode == null) {
+        if (parametersNode == null
+                && ast.getParent().getType() != TokenTypes.SWITCH_RULE) {
             super.visitToken(ast);
         }
-        else {
+        else if (parametersNode != null) {
             for (DetailAST parameterDef = parametersNode.getFirstChild();
                  parameterDef != null;
                  parameterDef = parameterDef.getNextSibling()) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LambdaParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LambdaParameterNameCheckTest.java
@@ -76,4 +76,24 @@ public class LambdaParameterNameCheckTest extends AbstractModuleTestSupport {
         verify(checkConfig, getPath("InputLambdaParameterName.java"), expected);
     }
 
+    @Test
+    public void testLambdaParameterNameSwitchExpression() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(LambdaParameterNameCheck.class);
+
+        final String pattern = "^[a-z][a-zA-Z0-9]*$";
+
+        final String[] expected = {
+            "13:35: " + getCheckMessage(MSG_INVALID_PATTERN, "Word", pattern),
+            "25:35: " + getCheckMessage(MSG_INVALID_PATTERN, "Word", pattern),
+            "30:31: " + getCheckMessage(MSG_INVALID_PATTERN, "Word", pattern),
+            "40:35: " + getCheckMessage(MSG_INVALID_PATTERN, "Word", pattern),
+            "51:35: " + getCheckMessage(MSG_INVALID_PATTERN, "Word", pattern),
+            };
+
+        verify(checkConfig,
+            getNonCompilablePath("InputLambdaParameterNameSwitchExpression.java"),
+            expected);
+    }
+
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/lambdaparametername/InputLambdaParameterNameSwitchExpression.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/lambdaparametername/InputLambdaParameterNameSwitchExpression.java
@@ -1,0 +1,59 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.naming.lambdaparametername;
+
+/* Config:
+ * format = "^[a-z][a-zA-Z0-9]*$"
+ */
+public class InputLambdaParameterNameSwitchExpression {
+    boolean method1(Nums k, String string) {
+        switch (k) {
+            case ONE:
+                Stream.of(string.split(" "))
+                        .map(word -> word.trim())
+                        .anyMatch(Word -> "in".equals(Word)); // violation
+                break;
+            default:
+        }
+        return false;
+    }
+
+    boolean method2(Nums k, String string) {
+        switch (k) {
+            case ONE -> {
+                Stream.of(string.split(" "))
+                        .map(word -> word.trim())
+                        .anyMatch(Word -> "in".equals(Word)); // violation
+                System.out.println("case one");
+            }
+            default -> Stream.of(string.split(" "))
+                    .map(word -> word.trim())
+                    .anyMatch(Word -> "in".equals(Word)); // violation
+        }
+        return true;
+    }
+
+    boolean method3(Nums k, String string) {
+        return switch (k) {
+            case ONE:
+                yield Stream.of(string.split(" "))
+                        .map(word -> word.trim())
+                        .anyMatch(Word -> "in".equals(Word)); // violation
+            default:
+                yield false;
+        };
+    }
+
+    boolean method4(Nums k, String string) {
+        return switch (k) {
+            case ONE -> {
+                yield Stream.of(string.split(" "))
+                        .map(word -> word.trim())
+                        .anyMatch(Word -> "in".equals(Word)); // violation
+            }
+            default -> { yield false; }
+        };
+    }
+
+
+    enum Nums {ONE, TWO, THREE}
+}


### PR DESCRIPTION
Issue #8683: LambdaParameterName throws NPE parsing switch expressions

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/afb38786f9df99a16c59211b424a650e/raw/cfe259bad04b032fca0430f0aad79538774ae21b/LambdaParameterName.xml