### PR TITLE
Issue #8663: Switch expression syntax check update for LeftCurlyCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -272,7 +272,7 @@ public class LeftCurlyCheck
             case TokenTypes.LITERAL_CASE:
             case TokenTypes.LITERAL_DEFAULT:
                 startToken = ast;
-                brace = getBraceAsFirstChild(ast.getNextSibling());
+                brace = getBraceFromSwitchMember(ast);
                 break;
             default:
                 // ATTENTION! We have default here, but we expect case TokenTypes.METHOD_DEF,
@@ -288,6 +288,25 @@ public class LeftCurlyCheck
         if (brace != null) {
             verifyBrace(brace, startToken);
         }
+    }
+
+    /**
+     * Gets the brace of a switch statement/ expression member.
+     *
+     * @param ast {@code DetailAST}.
+     * @return {@code DetailAST} if the first child is {@code TokenTypes.SLIST},
+     * {@code null} otherwise.
+     */
+    private static DetailAST getBraceFromSwitchMember(DetailAST ast) {
+        final DetailAST brace;
+        final DetailAST parent = ast.getParent();
+        if (parent.getType() == TokenTypes.SWITCH_RULE) {
+            brace = parent.findFirstToken(TokenTypes.SLIST);
+        }
+        else {
+            brace = getBraceAsFirstChild(ast.getNextSibling());
+        }
+        return brace;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
@@ -365,6 +365,43 @@ public class LeftCurlyCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testLeftCurlySwitchExpressions() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(LeftCurlyCheck.class);
+        final String[] expected = {
+            "17:9: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 9),
+            "19:17: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 17),
+            "24:17: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 17),
+            "29:17: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 17),
+            "33:17: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 17),
+            "42:17: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 17),
+            "44:21: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 21),
+            "48:21: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 21),
+            "52:21: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 21),
+            "56:21: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 21),
+
+            };
+        verify(checkConfig,
+            getNonCompilablePath("InputLeftCurlyCheckSwitchExpressions.java"), expected);
+    }
+
+    @Test
+    public void testLeftCurlySwitchExpressionsNewLine() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(LeftCurlyCheck.class);
+        checkConfig.addAttribute("option", LeftCurlyOption.NL.toString());
+
+        final String[] expected = {
+            "14:58: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 58),
+            "15:25: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 25),
+            "40:25: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 25),
+            "51:23: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 23),
+
+            };
+        verify(checkConfig,
+            getNonCompilablePath("InputLeftCurlyCheckSwitchExpressionsNewLine.java"),
+            expected);
+    }
+
+    @Test
     public void testGetAcceptableTokens() {
         final LeftCurlyCheck check = new LeftCurlyCheck();
         final int[] actual = check.getAcceptableTokens();

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyCheckSwitchExpressions.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyCheckSwitchExpressions.java
@@ -1,0 +1,61 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+/* Config:
+ *
+ * option = eol
+ * ignoreEnums = true
+ * tokens = {ANNOTATION_DEF , CLASS_DEF , CTOR_DEF , ENUM_CONSTANT_DEF ,
+ *  ENUM_DEF , INTERFACE_DEF , LAMBDA , LITERAL_CASE , LITERAL_CATCH ,
+ *  LITERAL_DEFAULT , LITERAL_DO , LITERAL_ELSE , LITERAL_FINALLY ,
+ * LITERAL_FOR , LITERAL_IF , LITERAL_SWITCH , LITERAL_SYNCHRONIZED ,
+ *  LITERAL_TRY , LITERAL_WHILE , METHOD_DEF , OBJBLOCK , STATIC_INIT }
+ */
+public class InputLeftCurlyCheckSwitchExpressions {
+    int howMany1(int k) {
+        switch (k)
+        { // violation
+            case 1:
+                { // violation
+
+            }
+
+            case 2:
+                { // violation
+
+            }
+
+            case 3:
+                { // violation
+
+            }
+            default:
+                {   // violation
+
+            }
+        }
+        return k;
+    }
+
+    int howMany2(int k) {
+        return switch (k)
+                { // violation
+            case 1 ->
+                    {// violation
+                yield 2;
+            }
+            case 2 ->
+                    {// violation
+                yield 3;
+            }
+            case 3 ->
+                    {// violation
+                yield 4;
+            }
+            default ->
+                    {// violation
+                yield k;
+            }
+        };
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyCheckSwitchExpressionsNewLine.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyCheckSwitchExpressionsNewLine.java
@@ -1,0 +1,60 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+/* Config:
+ *
+ * option = nl
+ * ignoreEnums = true
+ * tokens = {ANNOTATION_DEF , CLASS_DEF , CTOR_DEF , ENUM_CONSTANT_DEF ,
+ *  ENUM_DEF , INTERFACE_DEF , LAMBDA , LITERAL_CASE , LITERAL_CATCH ,
+ *  LITERAL_DEFAULT , LITERAL_DO , LITERAL_ELSE , LITERAL_FINALLY ,
+ * LITERAL_FOR , LITERAL_IF , LITERAL_SWITCH , LITERAL_SYNCHRONIZED ,
+ *  LITERAL_TRY , LITERAL_WHILE , METHOD_DEF , OBJBLOCK , STATIC_INIT }
+ */
+public class InputLeftCurlyCheckSwitchExpressionsNewLine { // violation
+    int howMany1(int k) { // violation
+        switch (k)
+        {
+            case 1:
+                {
+
+            }
+
+            case 2:
+                {
+
+            }
+
+            case 3:
+                {
+
+            }
+            default:
+                {
+
+            }
+        }
+        return k;
+    }
+
+    int howMany2(int k) { // violation
+        return switch (k)
+                {
+            case 1 ->
+                    {
+                yield 2;
+            }
+            case 2 ->
+                    {
+                yield 3;
+            }
+            case 3 -> { // violation
+                yield 4;
+            }
+            default ->
+                    {
+                yield k;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Issue #8663: Switch expression syntax check update for LeftCurlyCheck

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/573e0d598453915a39c69b599523b33a/raw/485809d9a16f82f6f92d575a394da687f1c84aa6/LeftCurly.xml