### PR TITLE
Issue #8672: Switch expression syntax check update for MissingSwitchDefault

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheck.java
@@ -103,9 +103,9 @@ public class MissingSwitchDefaultCheck extends AbstractCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
-        final DetailAST firstCaseGroupAst = ast.findFirstToken(TokenTypes.CASE_GROUP);
+        final DetailAST firstSwitchMemberAst = findFirstSwitchMember(ast);
 
-        if (!containsDefaultSwitch(firstCaseGroupAst)) {
+        if (!containsDefaultSwitch(firstSwitchMemberAst)) {
             log(ast, MSG_KEY);
         }
     }
@@ -130,6 +130,20 @@ public class MissingSwitchDefaultCheck extends AbstractCheck {
         }
 
         return found;
+    }
+
+    /**
+     * Returns first CASE_GROUP or SWITCH_RULE ast.
+     *
+     * @param parent the switch statement we are checking
+     * @return ast of first switch member.
+     */
+    private static DetailAST findFirstSwitchMember(DetailAST parent) {
+        DetailAST switchMember = parent.findFirstToken(TokenTypes.CASE_GROUP);
+        if (switchMember == null) {
+            switchMember = parent.findFirstToken(TokenTypes.SWITCH_RULE);
+        }
+        return switchMember;
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheckTest.java
@@ -58,4 +58,19 @@ public class MissingSwitchDefaultCheckTest
         assertNotNull(check.getRequiredTokens(), "Required tokens should not be null");
     }
 
+    @Test
+    public void testMissingSwitchDefaultSwitchExpressions() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(MissingSwitchDefaultCheck.class);
+        final String[] expected = {
+            "12:9: " + getCheckMessage(MSG_KEY, "default"),
+            "21:16: " + getCheckMessage(MSG_KEY, "default"),
+            "35:16: " + getCheckMessage(MSG_KEY, "default"),
+            };
+        verify(
+            checkConfig,
+            getNonCompilablePath("InputMissingSwitchDefaultCheckSwitchExpressions.java"),
+            expected);
+    }
+
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefaultCheckSwitchExpressions.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefaultCheckSwitchExpressions.java
@@ -1,0 +1,76 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.coding.missingswitchdefault;
+
+/* Config:
+ *
+ * default
+ */
+public class InputMissingSwitchDefaultCheckSwitchExpressions {
+    enum Nums {ONE, TWO, THREE}
+
+    int howMany1(Nums k) {
+        switch (k) { // violation
+            case ONE:
+            case TWO:
+            case THREE:
+        }
+        return 5;
+    }
+
+    int howMany2(Nums k) {
+        return switch (k) { // violation
+            case ONE -> {
+                yield 4;
+            }
+            case TWO -> {
+                yield 42;
+            }
+            case THREE -> {
+                yield 99;
+            }
+        };
+    }
+
+    int howMany3(Nums k) {
+        return switch (k) { // violation
+            case ONE:
+                yield 3;
+            case TWO:
+                yield 5;
+            case THREE:
+                yield 9;
+        };
+    }
+
+    int howMany4(Nums k) {
+        return switch (k) { // ok
+            case ONE -> {
+                yield 4;
+            }
+            case TWO -> {
+                yield 42;
+            }
+            case THREE -> {
+                yield 99;
+            }
+            default -> {
+                yield 67;
+            }
+        };
+    }
+
+    int howMany5(Nums k) {
+        return switch (k) { // ok
+            case ONE:
+                yield 3;
+            case TWO:
+                yield 5;
+            case THREE:
+                yield 9;
+            default:
+                yield 22;
+        };
+    }
+
+}
+


### PR DESCRIPTION
Issue #8672: Switch expression syntax check update for MissingSwitchDefault

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/dcf15792d9f08da0e573e5bbda2185d0/raw/556901973a29f95b25f3a41e61a466aef4780b2e/MissingSwitchDefault.xml