### PR TITLE
Issue #8619: Text Blocks syntax check update for SuppressWarningsHolder

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -25,6 +25,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
@@ -136,6 +137,16 @@ public class SuppressWarningsHolder
      */
     private static final ThreadLocal<List<Entry>> ENTRIES =
             ThreadLocal.withInitial(LinkedList::new);
+
+    /**
+     * Compiled pattern used to match whitespace in text block content.
+     */
+    private static final Pattern WHITESPACE = Pattern.compile("\\s+");
+
+    /**
+     * Compiled pattern used to match preceding newline in text block content.
+     */
+    private static final Pattern NEWLINE = Pattern.compile("\\n");
 
     /**
      * Returns the default alias for the source name of a check, which is the
@@ -474,6 +485,10 @@ public class SuppressWarningsHolder
             case TokenTypes.DOT:
                 expr = firstChild.getLastChild().getText();
                 break;
+            case TokenTypes.TEXT_BLOCK_LITERAL_BEGIN:
+                final String textBlockContent = firstChild.getFirstChild().getText();
+                expr = getContentWithoutPrecedingWhitespace(textBlockContent);
+                break;
             default:
                 // annotations with complex expressions cannot suppress warnings
         }
@@ -520,6 +535,18 @@ public class SuppressWarningsHolder
             childAST = childAST.getNextSibling();
         }
         return valueList;
+    }
+
+    /**
+     * Remove preceding newline and whitespace from the content of a text block.
+     *
+     * @param textBlockContent the actual text in a text block.
+     * @return content of text block with preceding whitespace and newline removed.
+     */
+    private static String getContentWithoutPrecedingWhitespace(String textBlockContent) {
+        final String contentWithNoPrecedingNewline =
+            NEWLINE.matcher(textBlockContent).replaceAll("");
+        return WHITESPACE.matcher(contentWithNoPrecedingNewline).replaceAll("");
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -48,6 +48,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck;
 import com.puppycrawl.tools.checkstyle.checks.whitespace.TypecastParenPadCheck;
@@ -435,6 +436,34 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
         final LocalizedMessage message = new LocalizedMessage(line, column, null, null, null,
                 moduleId, MemberNameCheck.class, "message");
         return new AuditEvent(source, "filename", message);
+    }
+
+    @Test
+    public void testSuppressWarningsTextBlocks() throws Exception {
+        final Configuration checkConfig = createModuleConfig(SuppressWarningsHolder.class);
+        final DefaultConfiguration treeWalker = createModuleConfig(TreeWalker.class);
+        final Configuration filter = createModuleConfig(SuppressWarningsFilter.class);
+        final DefaultConfiguration violationCheck = createModuleConfig(MemberNameCheck.class);
+
+        treeWalker.addChild(checkConfig);
+        treeWalker.addChild(violationCheck);
+
+        final DefaultConfiguration root = createRootConfig(treeWalker);
+        root.addChild(filter);
+
+        final String pattern = "^[a-z][a-zA-Z0-9]*$";
+
+        final String[] expected = {
+            "15:12: " + getCheckMessage(MemberNameCheck.class,
+                AbstractNameCheck.MSG_INVALID_PATTERN, "STRING3", pattern),
+            "17:12: " + getCheckMessage(MemberNameCheck.class,
+                AbstractNameCheck.MSG_INVALID_PATTERN, "STRING4", pattern),
+            "46:12: " + getCheckMessage(MemberNameCheck.class,
+                AbstractNameCheck.MSG_INVALID_PATTERN, "STRING8", pattern),
+            };
+
+        verify(root,
+            getNonCompilablePath("InputSuppressWarningsHolderTextBlocks.java"), expected);
     }
 
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderTextBlocks.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderTextBlocks.java
@@ -1,0 +1,48 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.suppresswarningsholder;
+
+/* Config:
+ * aliasList = null
+ */
+public class InputSuppressWarningsHolderTextBlocks {
+    @SuppressWarnings({"membername"})
+    String STRING1 = "string"; //ok, suppressed
+
+    @SuppressWarnings({"membername"})
+    String STRING2 = """
+            string"""; // ok, suppressed
+
+    String STRING3 = "string"; // violation
+
+    String STRING4 = """
+            string"""; // violation
+
+    @SuppressWarnings({"""
+            membername"""})
+    String STRING5 = """
+            string"""; // ok, suppressed
+
+    @SuppressWarnings({
+        """
+            membername
+        """
+    })
+    String STRING6 = """
+        string"""; // ok, suppressed
+
+    @SuppressWarnings({
+        """
+            checkstyle:membername
+        """
+    })
+    String STRING7 = """
+        string"""; // ok, suppressed
+
+    @SuppressWarnings({
+        """
+                checkstyle:misspelled
+        """
+    })
+    String STRING8 = """
+        string"""; // violation
+}


### PR DESCRIPTION
Issue #8619: Text Blocks syntax check update for SuppressWarningsHolder

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/33006852faa6fc91e8abccda0e2a98e5/raw/56dcb83c1cb3aecf93b549f39e7b9864d597375f/SuppressWarningsHolder.xml