### PR TITLE
Issue #8613: Text Blocks syntax check update for AvoidEscapedUnicodeChars

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -99,6 +99,8 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </p>
  * <pre>
  * String unitAbbrev = "&#92;u03bcs"; // Greek letter mu, "s"
+ * String textBlockUnitAbbrev = """
+ *          &#92;u03bcs"""; // Greek letter mu, "s"
  * </pre>
  * <p>An example of how to configure the check to allow using escapes
  * if trail comment is present:
@@ -327,7 +329,11 @@ public class AvoidEscapedUnicodeCharactersCheck
 
     @Override
     public int[] getRequiredTokens() {
-        return new int[] {TokenTypes.STRING_LITERAL, TokenTypes.CHAR_LITERAL};
+        return new int[] {
+            TokenTypes.STRING_LITERAL,
+            TokenTypes.CHAR_LITERAL,
+            TokenTypes.TEXT_BLOCK_CONTENT,
+        };
     }
 
     @Override
@@ -384,8 +390,14 @@ public class AvoidEscapedUnicodeCharactersCheck
      * @return true if trail comment is present after ast token.
      */
     private boolean hasTrailComment(DetailAST ast) {
+        int lineNo = ast.getLineNo();
+
+        // Since the trailing comment in the case of text blocks must follow the """ delimiter,
+        // we need to look for it after TEXT_BLOCK_LITERAL_END.
+        if (ast.getType() == TokenTypes.TEXT_BLOCK_CONTENT) {
+            lineNo = ast.getNextSibling().getLineNo();
+        }
         boolean result = false;
-        final int lineNo = ast.getLineNo();
         if (singlelineComments.containsKey(lineNo)) {
             result = true;
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
@@ -161,6 +161,7 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
         final int[] expected = {
             TokenTypes.STRING_LITERAL,
             TokenTypes.CHAR_LITERAL,
+            TokenTypes.TEXT_BLOCK_CONTENT,
         };
         assertArrayEquals(expected, checkObj.getRequiredTokens(),
                 "Required tokens differ from expected");
@@ -341,10 +342,56 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
     }
 
     @Test
+    public void testAvoidEscapedUnicodeCharactersTextBlocksAllowByComment() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(AvoidEscapedUnicodeCharactersCheck.class);
+        checkConfig.addAttribute("allowByTailComment", "true");
+        final String[] expected = {
+            "15:30: " + getCheckMessage(MSG_KEY),
+            "17:30: " + getCheckMessage(MSG_KEY),
+            "19:30: " + getCheckMessage(MSG_KEY),
+            "22:39: " + getCheckMessage(MSG_KEY),
+            "27:33: " + getCheckMessage(MSG_KEY),
+            "30:33: " + getCheckMessage(MSG_KEY),
+            "33:33: " + getCheckMessage(MSG_KEY),
+            "38:42: " + getCheckMessage(MSG_KEY),
+
+            };
+        verify(checkConfig,
+            getNonCompilablePath(
+                "InputAvoidEscapedUnicodeCharactersTextBlocksAllowByComment.java"),
+            expected);
+    }
+
+    @Test
+    public void testAvoidEscapedUnicodeCharactersTextBlocks() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(AvoidEscapedUnicodeCharactersCheck.class);
+        final String[] expected = {
+            "14:30: " + getCheckMessage(MSG_KEY),
+            "15:30: " + getCheckMessage(MSG_KEY),
+            "16:30: " + getCheckMessage(MSG_KEY),
+            "17:39: " + getCheckMessage(MSG_KEY),
+            "21:33: " + getCheckMessage(MSG_KEY),
+            "23:33: " + getCheckMessage(MSG_KEY),
+            "25:33: " + getCheckMessage(MSG_KEY),
+            "27:42: " + getCheckMessage(MSG_KEY),
+
+            };
+        verify(checkConfig,
+            getNonCompilablePath("InputAvoidEscapedUnicodeCharactersTextBlocks.java"),
+            expected);
+    }
+
+    @Test
     public void testGetAcceptableTokens() {
         final AvoidEscapedUnicodeCharactersCheck check = new AvoidEscapedUnicodeCharactersCheck();
         final int[] actual = check.getAcceptableTokens();
-        final int[] expected = {TokenTypes.STRING_LITERAL, TokenTypes.CHAR_LITERAL };
+        final int[] expected = {
+            TokenTypes.STRING_LITERAL,
+            TokenTypes.CHAR_LITERAL,
+            TokenTypes.TEXT_BLOCK_CONTENT,
+        };
         assertArrayEquals(expected, actual, "Acceptable tokens differ from expected");
     }
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersTextBlocks.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersTextBlocks.java
@@ -1,0 +1,31 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.avoidescapedunicodecharacters;
+
+/* Config:
+ *
+ * allowEscapesForControlCharacters = false
+ * allowByTailComment = false
+ * allowIfAllCharactersEscaped = false
+ * allowNonPrintableEscapes = false
+ */
+public class InputAvoidEscapedUnicodeCharactersTextBlocks {
+
+    public void multiplyString1() {
+        String unitAbbrev2 = "asd\u03bcsasd"; // violation
+        String unitAbbrev3 = "aBc\u03bcssdf\u03bc"; // violation
+        String unitAbbrev4 = "\u03bcaBc\u03bcssdf\u03bc"; // violation
+        String allCharactersEscaped = "\u03bc\u03bc"; // violation
+    }
+
+    public void multiplyString2() {
+        String unitAbbrev2 = """
+            asd\u03bcsasd"""; // violation
+        String unitAbbrev3 = """
+            aBc\u03bcssdf\u03bc"""; // violation
+        String unitAbbrev4 = """
+            \u03bcaBc\u03bcssdf\u03bc"""; // violation
+        String allCharactersEscaped = """
+            \u03bc\u03bc"""; // violation
+    }
+}
+

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersTextBlocksAllowByComment.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersTextBlocksAllowByComment.java
@@ -1,0 +1,41 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.avoidescapedunicodecharacters;
+
+/* Config:
+ *
+ * allowEscapesForControlCharacters = false
+ * allowByTailComment = true
+ * allowIfAllCharactersEscaped = false
+ * allowNonPrintableEscapes = false
+ */
+public class InputAvoidEscapedUnicodeCharactersTextBlocksAllowByComment {
+/** Note that "violation" comments cannot be on the same line for this config */
+    public void multiplyString1() {
+        // violation
+        String unitAbbrev2 = "asd\u03bcsasd";
+        // violation
+        String unitAbbrev3 = "aBc\u03bcssdf\u03bc";
+        // violation
+        String unitAbbrev4 = "\u03bcaBc\u03bcssdf\u03bc";
+        String unitAbbrev5 = "\u03bcs"; // Greek letter mu, "s" ok
+        // violation
+        String allCharactersEscaped = "\u03bc\u03bc";
+    }
+
+    public void multiplyString2() {
+        // violation
+        String unitAbbrev2 = """
+                asd\u03bcsasd""";
+        // violation
+        String unitAbbrev3 = """
+                aBc\u03bcssdf\u03bc""";
+        // violation
+        String unitAbbrev4 = """
+                \u03bcaBc\u03bcssdf\u03bc""";
+        String unitAbbrev5 = """
+                \u03bcs"""; // Greek letter mu, "s" ok
+        // violation
+        String allCharactersEscaped = """
+                \u03bc\u03bc""";
+    }
+}

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -250,6 +250,8 @@ return '\ufeff' + content; // byte order mark
         </p>
         <source>
 String unitAbbrev = "\u03bcs"; // Greek letter mu, "s"
+String textBlockUnitAbbrev = """
+          &#92;u03bcs"""; // Greek letter mu, "s"
         </source>
         <p>
           An example of how to configure the check to allow using escapes


### PR DESCRIPTION
Issue #8613: Text Blocks syntax check update for AvoidEscapedUnicodeChars

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/89652bf785843ea1deaeaa31839bb001/raw/cfa7c13108a4b07b7954869925c99be3717ea009/AvoidEscapedUnicodeCharacters.xml