### PR TITLE
Issue #8616: Text Blocks syntax check update for MultipleStringLiterals

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages.properties
@@ -36,6 +36,7 @@ missing.switch.default=switch without \"default\" clause.
 modified.control.variable=Control variable ''{0}'' is modified.
 multiple.statements.line=Only one statement per line allowed.
 multiple.string.literal=The String {0} appears {1} times in the file.
+multiple.string.literal.text.block=The String \"{0}\" appears {1} times in the file.
 multiple.variable.declarations=Only one variable definition per line allowed.
 multiple.variable.declarations.comma=Each variable declaration must be in its own statement.
 nested.for.depth=Nested for depth is {0,number,integer} (max allowed is {1,number,integer}).

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_de.properties
@@ -36,6 +36,7 @@ missing.switch.default=In der switch-Anweisung fehlt der \"default\"-Zweig.
 modified.control.variable=Die Kontrollvariable ''{0}'' sollte nicht verändert werden.
 multiple.statements.line=Es ist nur eine Anweisung pro Zeile erlaubt.
 multiple.string.literal=Der String {0} wird in dieser Datei {1}-mal verwendet.
+multiple.string.literal.text.block=Der String \\"{0}\\" wird in dieser Datei {1}-mal verwendet.
 multiple.variable.declarations=Es ist nur eine Variablendefinition pro Zeile erlaubt.
 multiple.variable.declarations.comma=Jede Variablendeklaration muss in einer eigenen Anweisung erfolgen.
 nested.for.depth=Die for-Schleife hat eine Schachtelungstiefe von {0,number,integer} (Obergrenze ist {1,number,integer}).

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_es.properties
@@ -36,6 +36,7 @@ missing.switch.default=switch sin etiqueta \"default\".
 modified.control.variable=Se modifica la variable de control ''{0}''.
 multiple.statements.line=Sólo una declaración por línea permitido.
 multiple.string.literal=La cadena {0} aparece {1} veces en el fichero.
+multiple.string.literal.text.block=La cadena \\"{0}\\" aparece {1} veces en el fichero.
 multiple.variable.declarations=Sólo se permite una definición de variable por línea.
 multiple.variable.declarations.comma=Cada declaración de variable debe estar en su línea.
 nested.for.depth=Anidado para la profundidad es {0, number, integer} (máximo permitido es {1, number, integer}).

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_fi.properties
@@ -36,6 +36,7 @@ missing.switch.default=vaihtaa ilman \"default\" lauseke.
 modified.control.variable=Ohjaussuure ''{0}'' on muutettu.
 multiple.statements.line=Vain yksi lausunto riville sallittu.
 multiple.string.literal=String {0} ilmestyy {1} kertoja tiedostossa.
+multiple.string.literal.text.block=String \\"{0}\\" ilmestyy {1} kertoja tiedostossa.
 multiple.variable.declarations=Vain yksi muuttuja määritelmä riville sallittu.
 multiple.variable.declarations.comma=Jokainen muuttuja ilmoitus on oltava oman lausuntonsa.
 nested.for.depth=Sisäkkäisiä syvyys on {0, number, integer} (max sallittu on {1, number, integer}).

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_fr.properties
@@ -36,6 +36,7 @@ missing.switch.default=Il manque le cas \"default\" dans le bloc \"switch\".
 modified.control.variable=La variable de contrôle ''{0}'' est modifiée.
 multiple.statements.line=Une seule instruction par ligne autorisée.
 multiple.string.literal=La chaîne {0} apparaît {1} fois dans le fichier.
+multiple.string.literal.text.block=La chaîne \\"{0}\\" apparaît {1} fois dans le fichier.
 multiple.variable.declarations=Ne déclarez pas plus d''une variable par ligne.
 multiple.variable.declarations.comma=Chaque déclaration de variable doit faire l''objet d''une instruction à part.
 nested.for.depth=Le nombre de ''for'' imbriqués est de {0, number, integer}, alors que le maximum autorisé est de {1, number, integer}.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_ja.properties
@@ -36,6 +36,7 @@ missing.switch.default=\"default\" 節の無い switch 文です。
 modified.control.variable=制御変数 ''{0}'' が変更されています。
 multiple.statements.line=文は1行に1つだけにしてください。
 multiple.string.literal=文字列 {0} は、このファイルに {1} 回出現しています。
+multiple.string.literal.text.block=文字列 \\"{0}\\" は、このファイルに {1} 回出現しています。
 multiple.variable.declarations=変数の定義は1行に1つだけにしてください。
 multiple.variable.declarations.comma=変数の宣言はそれぞれ個別の文にしてください。
 nested.for.depth=ネストした for の深さが {0,number,integer} （最大 {1,number,integer} まで）です。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_pt.properties
@@ -36,6 +36,7 @@ missing.switch.default=\"switch\" sem a ramificação \"default\".
 modified.control.variable=Variável de controle ''{0}'' é modificada.
 multiple.statements.line=Apenas uma instrução por linha é permitida.
 multiple.string.literal=A String {0} aparece {1} vezes no arquivo.
+multiple.string.literal.text.block=A String \\"{0}\\" aparece {1} vezes no arquivo.
 multiple.variable.declarations=Apenas uma definição de variável por linha é permitida.
 multiple.variable.declarations.comma=Cada declaração de variável deve estar em sua própria instrução.
 nested.for.depth=A profundidade de aninhamento do \"for\" é {0, number, integer} (o máximo permitido é {1, number, integer}).

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_tr.properties
@@ -37,6 +37,7 @@ missing.switch.default=''default'' olmadan ''switch'' kullanılmış.
 modified.control.variable=Kontrol değişkeninin değeri ''{0}'' değiştirilmiş.
 multiple.statements.line=Her satırda sadece bir ifade olmalıdır.
 multiple.string.literal=''{0}'' değeri dosyada {1} defa kullanılmış.
+multiple.string.literal.text.block=''\\"{0}\\"'' değeri dosyada {1} defa kullanılmış.
 multiple.variable.declarations=Her satırda sadece bir değişken tanımlanmalı.
 multiple.variable.declarations.comma=Her değişken tanımı kendi ifadesinde yer almalı.
 nested.for.depth=İç içe kullanılan ''for'' sayısı {0,number,integer} (maksimum izin verilen değer {1,number,integer}).

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages_zh.properties
@@ -36,6 +36,7 @@ missing.switch.default=Switch 块未定义 default 。
 modified.control.variable=循环控制变量 ''{0}'' 不应在循环体内修改。
 multiple.statements.line=禁止一行有多句代码。
 multiple.string.literal=字符串： {0} 在本文件中出现了 {1} 次。
+multiple.string.literal.text.block=字符串： \\"{0}\\" 在本文件中出现了 {1} 次。
 multiple.variable.declarations=每一行只能定义一个变量。
 multiple.variable.declarations.comma=每一个变量的定义必须在它的声明处，且在同一行。
 nested.for.depth=至多{1,number,integer}层 for，目前{0,number,integer}层。

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheckTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import static com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheck.MSG_KEY;
+import static com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheck.MSG_KEY_TEXT_BLOCK;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
@@ -165,6 +166,40 @@ public class MultipleStringLiteralsCheckTest extends AbstractModuleTestSupport {
         createChecker(checkConfig);
         verify(checkConfig,
             getPath("InputMultipleStringLiterals.java"),
+            expected);
+    }
+
+    @Test
+    public void testMultiplestringLiteralsTextBlocks() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(MultipleStringLiteralsCheck.class);
+        checkConfig.addAttribute("ignoreStringsRegexp", null);
+        checkConfig.addAttribute("ignoreOccurrenceContext", "ANNOTATION");
+
+        final String[] expected = {
+            "11:22: " + getCheckMessage(MSG_KEY, "\"string\"", 2),
+            "14:25: " + getCheckMessage(MSG_KEY_TEXT_BLOCK, "\\n    "
+                + "        other string", 2),
+            "18:25: " + getCheckMessage(MSG_KEY_TEXT_BLOCK, "\\n    "
+                + "        other string\\n            ", 2),
+            "25:25: " + getCheckMessage(MSG_KEY_TEXT_BLOCK, "\\n    "
+                + "        <html>\\u000D\\u000A\\n\\n                <body>"
+                + "\\u000D\\u000A\\n\\n                    <p>Hello, world<"
+                + "/p>\\u000D\\u000A\\n\\n                </body>\\u000D\\u"
+                + "000A\\n\\n            </html>\\u000D\\u000A\\n            ", 2),
+            "32:34: " + getCheckMessage(MSG_KEY_TEXT_BLOCK, "\\n     "
+                + "       fun with\\n\\n            whitespace\\t\\r\\n   "
+                + "         and other escapes \\\"\"\"\\n            ", 2),
+            "37:34: " + getCheckMessage(MSG_KEY_TEXT_BLOCK, "\\n     "
+                + "       \\b \\f \\\\ \\0 \\1 \\2 \\r \\r\\n \\\\r\\\\n \\"
+                + "\\''\\n            \\\\11 \\\\57 \\n\\\\n\\n\\\\\\n\\n \\"
+                + "\\ \"\"a \"a\\n            \\\\uffff \\\\' \\\\\\' \\'\\n "
+                + "           ", 2),
+            };
+
+        createChecker(checkConfig);
+        verify(checkConfig,
+            getNonCompilablePath("InputMultipleStringLiteralsTextBlocks.java"),
             expected);
     }
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/multiplestringliterals/InputMultipleStringLiteralsTextBlocks.java
@@ -1,0 +1,59 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.coding.multiplestringliterals;
+
+/* Config:
+ *
+ * allowedDuplicates = 1
+ * ignoreStringsRegexp = null
+ * ignoreOccurrenceContext = ANNOTATION
+ */
+public class InputMultipleStringLiteralsTextBlocks {
+    String string1 = "string";
+    String string2 = "string"; // violation
+
+    String string3 = """
+            other string""";
+    String string4 = """
+            other string"""; // violation
+    String string5 = """
+            other string
+            """;
+    String string6 = """
+            other string
+            """; // violation
+
+    String escape1 = """
+            <html>\u000D\u000A\n
+                <body>\u000D\u000A\n
+                    <p>Hello, world</p>\u000D\u000A\n
+                </body>\u000D\u000A\n
+            </html>\u000D\u000A
+            """;
+    String testMoreEscapes1 = """
+            fun with\n
+            whitespace\t\r
+            and other escapes \"""
+            """;
+    String evenMoreEscapes1 = """
+            \b \f \\ \0 \1 \2 \r \r\n \\r\\n \\''
+            \\11 \\57 \n\\n\n\\\n\n \\ ""a "a
+            \\uffff \\' \\\' \'
+            """;
+    String escape2 = """
+            <html>\u000D\u000A\n
+                <body>\u000D\u000A\n
+                    <p>Hello, world</p>\u000D\u000A\n
+                </body>\u000D\u000A\n
+            </html>\u000D\u000A
+            """; // violation
+    String testMoreEscapes2 = """
+            fun with\n
+            whitespace\t\r
+            and other escapes \"""
+            """; // violation
+    String evenMoreEscapes2 = """
+            \b \f \\ \0 \1 \2 \r \r\n \\r\\n \\''
+            \\11 \\57 \n\\n\n\\\n\n \\ ""a "a
+            \\uffff \\' \\\' \'
+            """; // violation
+}

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -3850,6 +3850,11 @@ for (String line: lines) {
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22multiple.string.literal%22">
             multiple.string.literal</a>
           </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22multiple.string.literal.text.block%22">
+              multiple.string.literal.text.block
+            </a>
+          </li>
         </ul>
         <p>
           All messages can be customized if the default message doesn't suit you.


### PR DESCRIPTION
Issue #8616: Text Blocks syntax check update for MultipleStringLiterals

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/9e0d7214e926d73067bfc456e5d6ec71/raw/584f0319f0615ca7f2ffffc1585b53a2ef8db88a/MultipleStringLiterals.xml