### PR TITLE
Issue #8576: Text Blocks syntax check update for IllegalTokenText

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
@@ -92,6 +92,22 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * }
  * </pre>
  * <p>
+ * To configure the check to forbid string literal text blocks containing {@code """}:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;IllegalTokenText&quot;&gt;
+ *   &lt;property name=&quot;tokens&quot; value=&quot;TEXT_BLOCK_CONTENT&quot;/&gt;
+ *   &lt;property name=&quot;format&quot; value='&quot;'/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public void myTest() {
+ *     final String quote = """
+ *                \""""; // violation
+ * }
+ * </pre>
+ * <p>
  * To configure the check to forbid leading zeros in an integer literal,
  * other than zero and a hex literal:
  * </p>
@@ -168,6 +184,7 @@ public class IllegalTokenTextCheck
             TokenTypes.COMMENT_CONTENT,
             TokenTypes.STRING_LITERAL,
             TokenTypes.CHAR_LITERAL,
+            TokenTypes.TEXT_BLOCK_CONTENT,
         };
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckTest.java
@@ -104,6 +104,44 @@ public class IllegalTokenTextCheckTest
     }
 
     @Test
+    public void testIllegalTokenTextTextBlocks() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(IllegalTokenTextCheck.class);
+        checkConfig.addAttribute("tokens", "STRING_LITERAL, TEXT_BLOCK_CONTENT");
+        checkConfig.addAttribute("format", "a href");
+
+        final String[] expected = {
+            "13:28: " + getCheckMessage(MSG_KEY, "a href"),
+            "16:32: " + getCheckMessage(MSG_KEY, "a href"),
+            "28:37: " + getCheckMessage(MSG_KEY, "a href"),
+            "33:37: " + getCheckMessage(MSG_KEY, "a href"),
+            "39:54: " + getCheckMessage(MSG_KEY, "a href"),
+            };
+        verify(checkConfig,
+            getNonCompilablePath("InputIllegalTokenTextTextBlocks.java"), expected);
+    }
+
+    @Test
+    public void testIllegalTokenTextTextBlocksQuotes() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(IllegalTokenTextCheck.class);
+        checkConfig.addAttribute("tokens", "STRING_LITERAL, TEXT_BLOCK_CONTENT");
+        checkConfig.addAttribute("format", "\"");
+
+        final String[] expected = {
+            "13:28: " + getCheckMessage(MSG_KEY, "\""),
+            "14:33: " + getCheckMessage(MSG_KEY, "\""),
+            "16:32: " + getCheckMessage(MSG_KEY, "\""),
+            "18:36: " + getCheckMessage(MSG_KEY, "\""),
+            "28:37: " + getCheckMessage(MSG_KEY, "\""),
+            "33:37: " + getCheckMessage(MSG_KEY, "\""),
+            "39:42: " + getCheckMessage(MSG_KEY, "\""),
+            };
+        verify(checkConfig,
+            getNonCompilablePath("InputIllegalTokenTextTextBlocksQuotes.java"), expected);
+    }
+
+    @Test
     public void testTokensNotNull() {
         final IllegalTokenTextCheck check = new IllegalTokenTextCheck();
         assertNotNull(check.getAcceptableTokens(), "Acceptable tokens should not be null");
@@ -157,7 +195,8 @@ public class IllegalTokenTextCheckTest
             TokenTypes.IDENT,
             TokenTypes.COMMENT_CONTENT,
             TokenTypes.STRING_LITERAL,
-            TokenTypes.CHAR_LITERAL
+            TokenTypes.CHAR_LITERAL,
+            TokenTypes.TEXT_BLOCK_CONTENT
         );
         for (int tokenType : allowedTokens) {
             assertTrue(tokenTypesWithMutableText.contains(tokenType),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -138,7 +138,7 @@ public class AllChecksTest extends AbstractModuleTestSupport {
         // we have no need to block specific token text
         CHECKSTYLE_TOKENS_IN_CONFIG_TO_IGNORE.put("IllegalTokenText",
                 Stream.of("NUM_DOUBLE", "NUM_FLOAT", "NUM_INT", "NUM_LONG", "IDENT",
-                    "COMMENT_CONTENT", "STRING_LITERAL", "CHAR_LITERAL")
+                    "COMMENT_CONTENT", "STRING_LITERAL", "CHAR_LITERAL", "TEXT_BLOCK_CONTENT")
                     .collect(Collectors.toSet()));
         // we do not use this check as it is deprecated
         CHECKSTYLE_TOKENS_IN_CONFIG_TO_IGNORE.put("WriteTag",
@@ -231,7 +231,7 @@ public class AllChecksTest extends AbstractModuleTestSupport {
         GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("IllegalTokenText", Stream.of(
                 // all other java tokens and text are allowed
                 "NUM_DOUBLE", "NUM_FLOAT", "NUM_INT", "NUM_LONG", "IDENT",
-                "COMMENT_CONTENT", "STRING_LITERAL", "CHAR_LITERAL")
+                "COMMENT_CONTENT", "STRING_LITERAL", "CHAR_LITERAL", "TEXT_BLOCK_CONTENT")
                 .collect(Collectors.toSet()));
         GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("OperatorWrap", Stream.of(
                 // specifically allowed via '4.5.1 Where to break' because the following are

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextTextBlocks.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextTextBlocks.java
@@ -1,0 +1,43 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.coding.illegaltokentext;
+
+/* Config:
+ *
+ * format  = "a href"
+ * ignoreCase = false
+ * message = false
+ * tokens = {STRING_LITERAL, TEXT_BLOCK_CONTENT}
+ */
+public class InputIllegalTokenTextTextBlocks {
+    public void methodWithLiterals() {
+        final String ref = "<a href=\""; // violation
+        final String refCase1 = "<A hReF=\""; // ok
+
+        final String ref2 = """
+                <a href=\""""; // violation
+        final String refCase2 = """
+                <A hReF=\""""; // ok
+
+        String escape = """
+                <html>\u000D\u000A\n
+                    <body>\u000D\u000A\n
+                        <p>Hello, world</p>\u000D\u000A\n
+                    </body>\u000D\u000A\n
+                </html>\u000D\u000A
+                """;
+        String testMoreEscapes = """
+                fun with a href\n
+                whitespace\t\r
+                and other escapes \"""
+                """; // violation
+        String evenMoreEscapes = """
+                \b \f \\ \0 \1 \2 \r \r\n \\r\\n \\''
+                \\11 \\57 \n\\n\n\\\n\n \\ ""a "a
+                \\uffffa href \\' \\\' \'
+                """;
+        String concat = """
+                The quick brown fox""" + "  \n" + """
+                jumps over the lazy dog a href
+                """; // violation
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextTextBlocksQuotes.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextTextBlocksQuotes.java
@@ -1,0 +1,43 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.coding.illegaltokentext;
+
+/* Config:
+ *
+ * format  = "\""
+ * ignoreCase = false
+ * message = false
+ * tokens = {STRING_LITERAL, TEXT_BLOCK_CONTENT}
+ */
+public class InputIllegalTokenTextTextBlocksQuotes {
+    public void methodWithLiterals() {
+        final String ref = "<a href=\""; // violation
+        final String refCase1 = "<A hReF=\""; // violation
+
+        final String ref2 = """
+                <a href=\""""; // violation
+        final String refCase2 = """
+                <A hReF=\""""; // violation
+
+        String escape = """
+                <html>\u000D\u000A\n
+                    <body>\u000D\u000A\n
+                        <p>Hello, world</p>\u000D\u000A\n
+                    </body>\u000D\u000A\n
+                </html>\u000D\u000A
+                """;
+        String testMoreEscapes = """
+                fun with\n
+                whitespace\t\r
+                and other escapes \"""
+                """; // violation
+        String evenMoreEscapes = """
+                \b \f \\ \0 \1 \2 \r \r\n \\r\\n \\''
+                \\11 \\57 \n\\n\n\\\n\n \\ ""a "a
+                \\uffff \\' \\\' \'
+                """; // violation
+        String concat = """
+                The quick brown fox""" + "  \n" + """
+                jumps over the lazy dog
+                """; // violation
+    }
+}

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -2546,6 +2546,8 @@ public native void myTest(); // violation
                 STRING_LITERAL</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CHAR_LITERAL">
                 CHAR_LITERAL</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TEXT_BLOCK_CONTENT">
+                TEXT_BLOCK_CONTENT</a>
                 .
               </td>
               <td>empty</td>
@@ -2589,6 +2591,23 @@ public void myTest() {
 public void myTest() {
     String test = "a href"; // violation
     String test2 = "A href"; // violation, case is ignored
+}
+        </source>
+        <p>
+          To configure the check to forbid string literal text blocks containing
+          <code>&quot;&quot;&quot;</code>:
+        </p>
+        <source>
+&lt;module name=&quot;IllegalTokenText&quot;&gt;
+    &lt;property name=&quot;tokens&quot; value=&quot;TEXT_BLOCK_CONTENT&quot;/&gt;
+    &lt;property name=&quot;format&quot; value=&apos;&quot;&apos;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public void myTest() {
+    final String quote = """
+               \""""; // violation
 }
         </source>
         <p>


### PR DESCRIPTION
Issue #8576: Text Blocks syntax check update for IllegalTokenText

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/d90a520a3fb437338ebe3aa8a9d38658/raw/1255542f2554faccc82686fb31a200ce5a321237/IllegalTokenTextBase.xml

Diff Regression patch config: https://gist.githubusercontent.com/nmancus1/f3228845e6fc39bef184da0c2e543017/raw/0ca5929b2da9a056286c5c8a21c0a9a5d4febb4f/IllegalTokenTextPatch.xml