### PR TITLE
Issue #8617: Text Blocks syntax check update for StringLiteralEquality

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
@@ -111,12 +111,11 @@ public class StringLiteralEqualityCheck extends AbstractCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
-        // no need to check for nulls here, == and != always have two children
-        final DetailAST firstChild = ast.getFirstChild();
-        final DetailAST secondChild = firstChild.getNextSibling();
+        final boolean hasStringLiteralChild =
+            ast.findFirstToken(TokenTypes.STRING_LITERAL) != null
+                || ast.findFirstToken(TokenTypes.TEXT_BLOCK_LITERAL_BEGIN) != null;
 
-        if (firstChild.getType() == TokenTypes.STRING_LITERAL
-                || secondChild.getType() == TokenTypes.STRING_LITERAL) {
+        if (hasStringLiteralChild) {
             log(ast, MSG_KEY, ast.getText());
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheckTest.java
@@ -48,6 +48,21 @@ public class StringLiteralEqualityCheckTest
     }
 
     @Test
+    public void testStringLiteralEqualityTextBlocks() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(StringLiteralEqualityCheck.class);
+        final String[] expected = {
+            "12:34: " + getCheckMessage(MSG_KEY, "=="),
+            "20:21: " + getCheckMessage(MSG_KEY, "=="),
+            "23:24: " + getCheckMessage(MSG_KEY, "!="),
+            "26:34: " + getCheckMessage(MSG_KEY, "=="),
+            };
+        verify(checkConfig,
+            getNonCompilablePath("InputStringLiteralEqualityCheckTextBlocks.java"),
+            expected);
+    }
+
+    @Test
     public void testTokensNotNull() {
         final StringLiteralEqualityCheck check = new StringLiteralEqualityCheck();
         assertNotNull(check.getAcceptableTokens(), "Acceptable tokens should not be null");

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/stringliteralequality/InputStringLiteralEqualityCheckTextBlocks.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/stringliteralequality/InputStringLiteralEqualityCheckTextBlocks.java
@@ -1,0 +1,33 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.coding.stringliteralequality;
+
+/* Config:
+ *
+ * default
+ */
+public class InputStringLiteralEqualityCheckTextBlocks {
+    void method() {
+        String status1 = "pending";
+
+        boolean flag1 = (status1 == "done"); // violation
+
+        boolean flag2 = (status1.equals("done")); // ok
+
+
+        String status2 = """
+                pending""";
+
+        if (status2 == """
+                done""") {} // violation
+
+        while (status2 != """
+                done""") {} // violation
+
+        boolean flag3 = (status2 == """
+                done"""); // violation
+
+        boolean flag4 = (status2.equals("""
+                done""")); // ok
+
+    }
+}


### PR DESCRIPTION
Issue #8617: Text Blocks syntax check update for StringLiteralEquality

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/e04f556bfc30cd0a6d3a99552b9db694/raw/669aa65ecaa1cec614065c547494d357a8fa7655/StringLiteralEquality.xml