### PR TITLE
Issue #8618: Text Blocks syntax check update for UnnecessaryParentheses

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheckTest.java
@@ -154,6 +154,29 @@ public class UnnecessaryParenthesesCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testUnnecessaryParenthesesTextBlocks() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(UnnecessaryParenthesesCheck.class);
+        final String[] expected = {
+            "13:27: " + getCheckMessage(MSG_STRING, "\"this\""),
+            "13:38: " + getCheckMessage(MSG_STRING, "\"that\""),
+            "13:49: " + getCheckMessage(MSG_STRING, "\"other\""),
+            "14:27: " + getCheckMessage(MSG_STRING, "\"\\n     "
+                + "           this\""),
+            "16:20: " + getCheckMessage(MSG_STRING, "\"\\n     "
+                + "           that\""),
+            "18:20: " + getCheckMessage(MSG_STRING, "\"\\n     "
+                + "           other\""),
+            "20:27: " + getCheckMessage(MSG_STRING, "\"\\n                this i...\""),
+            "21:40: " + getCheckMessage(MSG_STRING, "\"\\n                and an...\""),
+            };
+        verify(checkConfig,
+            getNonCompilablePath(
+                "InputUnnecessaryParenthesesCheckTextBlocks.java"),
+            expected);
+    }
+
+    @Test
     public void testTokensNotNull() {
         final UnnecessaryParenthesesCheck check = new UnnecessaryParenthesesCheck();
         assertNotNull(check.getAcceptableTokens(), "Acceptable tokens should not be null");

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesCheckTextBlocks.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesCheckTextBlocks.java
@@ -1,0 +1,24 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.coding.unnecessaryparentheses;
+
+/* Config:
+ *
+ * tokens = {EXPR , IDENT , NUM_DOUBLE , NUM_FLOAT , NUM_INT , NUM_LONG , STRING_LITERAL ,
+ *  LITERAL_NULL , LITERAL_FALSE , LITERAL_TRUE , ASSIGN , BAND_ASSIGN , BOR_ASSIGN ,
+ *  BSR_ASSIGN , BXOR_ASSIGN , DIV_ASSIGN , MINUS_ASSIGN , MOD_ASSIGN , PLUS_ASSIGN ,
+ *  SL_ASSIGN , SR_ASSIGN , STAR_ASSIGN , LAMBDA, TEXT_BLOCK_BEGIN}
+ */
+public class InputUnnecessaryParenthesesCheckTextBlocks {
+    void method() {
+        String string1 = ("this") + ("that") + ("other"); // violation
+        String string2 = ("""
+                this""")
+                + ("""
+                that""")
+                + ("""
+                other"""); // should be violation
+        String string3 = ("""
+                this is a test.""") + ("""
+                and another line""");
+    }
+}

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -6089,6 +6089,8 @@ class C {
                   STAR_ASSIGN</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
                   LAMBDA</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TEXT_BLOCK_LITERAL_BEGIN">
+                TEXT_BLOCK_LITERAL_BEGIN</a>
                   .
               </td>
               <td>
@@ -6138,6 +6140,8 @@ class C {
                   STAR_ASSIGN</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
                   LAMBDA</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TEXT_BLOCK_LITERAL_BEGIN">
+                  TEXT_BLOCK_LITERAL_BEGIN</a>
                   .
               </td>
               <td>3.4</td>


### PR DESCRIPTION
Issue #8618: Text Blocks syntax check update for UnnecessaryParentheses

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/867268e2ebbb122e77e1640bee93b8b2/raw/6316c24398eea59d85f9601a3c35c62f362efb76/UnnecessaryParentheses.xml