### PR TITLE
Issue #8457: Full Records support check update for LeftCurlyCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -92,7 +92,11 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#OBJBLOCK">
  * OBJBLOCK</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">
- * STATIC_INIT</a>.
+ * STATIC_INIT</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+ * RECORD_DEF</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
+ * COMPACT_CTOR_DEF</a>.
  * </li>
  * </ul>
  * <p>
@@ -220,6 +224,8 @@ public class LeftCurlyCheck
             TokenTypes.METHOD_DEF,
             TokenTypes.OBJBLOCK,
             TokenTypes.STATIC_INIT,
+            TokenTypes.RECORD_DEF,
+            TokenTypes.COMPACT_CTOR_DEF,
         };
     }
 
@@ -236,6 +242,7 @@ public class LeftCurlyCheck
         switch (ast.getType()) {
             case TokenTypes.CTOR_DEF:
             case TokenTypes.METHOD_DEF:
+            case TokenTypes.COMPACT_CTOR_DEF:
                 startToken = skipModifierAnnotations(ast);
                 brace = ast.findFirstToken(TokenTypes.SLIST);
                 break;
@@ -244,6 +251,7 @@ public class LeftCurlyCheck
             case TokenTypes.ANNOTATION_DEF:
             case TokenTypes.ENUM_DEF:
             case TokenTypes.ENUM_CONSTANT_DEF:
+            case TokenTypes.RECORD_DEF:
                 startToken = skipModifierAnnotations(ast);
                 final DetailAST objBlock = ast.findFirstToken(TokenTypes.OBJBLOCK);
                 brace = objBlock;

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -80,7 +80,7 @@
                     INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, LITERAL_DEFAULT,
                     LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF,
                     LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF,
-                    OBJBLOCK, STATIC_INIT"/>
+                    OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF"/>
     </module>
     <module name="RightCurly">
       <property name="id" value="RightCurlySame"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
@@ -428,6 +428,8 @@ public class LeftCurlyCheckTest extends AbstractModuleTestSupport {
             TokenTypes.METHOD_DEF,
             TokenTypes.OBJBLOCK,
             TokenTypes.STATIC_INIT,
+            TokenTypes.RECORD_DEF,
+            TokenTypes.COMPACT_CTOR_DEF,
         };
         assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
     }
@@ -456,6 +458,22 @@ public class LeftCurlyCheckTest extends AbstractModuleTestSupport {
             "72:18: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 18),
         };
         verify(checkConfig, getPath("InputLeftCurlyCoverageIncrease.java"), expected);
+    }
+
+    @Test
+    public void testLeftCurlyRecordsAndCompactCtors() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(LeftCurlyCheck.class);
+        checkConfig.addAttribute("option", LeftCurlyOption.NLOW.toString());
+        final String[] expected = {
+            "18:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+            "20:9: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 9),
+            "30:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+            "32:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+            "39:9: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 9),
+            "52:5: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 5),
+            };
+        verify(checkConfig,
+            getNonCompilablePath("InputLeftCurlyRecordsAndCompactCtors.java"), expected);
     }
 
     @Test

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyRecordsAndCompactCtors.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyRecordsAndCompactCtors.java
@@ -1,0 +1,61 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+import org.w3c.dom.Node;
+
+/* Config:
+ * option = same
+ * tokens = {RECORD_DEF, COMPACT_CTOR_DEF, ANNOTATION_DEF , CLASS_DEF , CTOR_DEF ,
+ *  ENUM_CONSTANT_DEF , ENUM_DEF , INTERFACE_DEF , LAMBDA , LITERAL_CASE ,
+ *  LITERAL_CATCH , LITERAL_DEFAULT , LITERAL_DO , LITERAL_ELSE , LITERAL_FINALLY ,
+ *  LITERAL_FOR , LITERAL_IF , LITERAL_SWITCH , LITERAL_SYNCHRONIZED , LITERAL_TRY ,
+ *  LITERAL_WHILE , METHOD_DEF , OBJBLOCK , STATIC_INIT}
+ *
+ */
+public class InputLeftCurlyRecordsAndCompactCtors {
+
+    record MyTestRecord(String string, Record rec)
+    { // violation
+        private boolean inRecord(Object obj)
+        { // violation
+            int value = 0;
+            if (obj instanceof Integer i) {
+                value = i;
+            }
+            return value > 10;
+        }
+    }
+
+    record MyTestRecord2()
+    { // violation
+        MyTestRecord2(String one, String two, String three)
+    { // violation
+            this();
+        }
+    }
+
+    record MyTestRecord3(Integer i, Node node) {
+        public MyTestRecord3
+        { // violation
+            int x = 5;
+        }
+
+        public static void main(String... args) {
+            System.out.println("works!");
+        }
+    }
+
+    record MyTestRecord4() {
+    }
+
+    record MyTestRecord5()
+    { // violation
+        static MyTestRecord mtr =
+                new MyTestRecord("my string", new MyTestRecord4());
+    }
+
+    class MyTestClass {
+        private MyTestRecord mtr =
+                new MyTestRecord("my string", new MyTestRecord4());
+    }
+}

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -610,6 +610,10 @@ try {
                   OBJBLOCK</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">
                   STATIC_INIT</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+                  RECORD_DEF</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
+                  COMPACT_CTOR_DEF</a>
                 .
               </td>
 
@@ -658,6 +662,10 @@ try {
                   OBJBLOCK</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STATIC_INIT">
                   STATIC_INIT</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+                  RECORD_DEF</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
+                  COMPACT_CTOR_DEF</a>
                 .
               </td>
               <td>3.0</td>


### PR DESCRIPTION
Issue #8457: Full Records support check update for LeftCurlyCheck

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/a79c4ba878d218c00442fef08adadbc9/raw/5b01515badd240f5319f8ccbfe9f99869fde77f1/LeftCurly.xml