### PR TITLE
Issue #8493: Full Records support check update for JavadocStyleCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -147,7 +147,11 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#PACKAGE_DEF">
  * PACKAGE_DEF</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
- * VARIABLE_DEF</a>.
+ * VARIABLE_DEF</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+ * RECORD_DEF</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
+ * COMPACT_CTOR_DEF</a>.
  * </li>
  * </ul>
  * <p>
@@ -385,6 +389,8 @@ public class JavadocStyleCheck
             TokenTypes.METHOD_DEF,
             TokenTypes.PACKAGE_DEF,
             TokenTypes.VARIABLE_DEF,
+            TokenTypes.RECORD_DEF,
+            TokenTypes.COMPACT_CTOR_DEF,
         };
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
@@ -61,6 +61,8 @@ public class JavadocStyleCheckTest
             TokenTypes.METHOD_DEF,
             TokenTypes.PACKAGE_DEF,
             TokenTypes.VARIABLE_DEF,
+            TokenTypes.RECORD_DEF,
+            TokenTypes.COMPACT_CTOR_DEF,
         };
 
         assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
@@ -416,6 +418,34 @@ public class JavadocStyleCheckTest
             "418: " + getCheckMessage(MSG_NO_PERIOD),
         };
         verify(checkConfig, getPath("InputJavadocStyle.java"), expected);
+    }
+
+    @Test
+    public void testJavadocStyleRecordsAndCompactCtors() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(JavadocStyleCheck.class);
+        final String[] expected = {
+
+            "19: " + getCheckMessage(MSG_NO_PERIOD),
+            "39: " + getCheckMessage(MSG_NO_PERIOD),
+            "49:16: " + getCheckMessage(MSG_UNCLOSED_HTML,
+                "<b>This guy is missing end of bold tag // violation"),
+            "52:12: " + getCheckMessage(MSG_EXTRA_HTML, "</td>Extra tag "
+                + "shouldn't be here // violation"),
+            "53:54: " + getCheckMessage(MSG_EXTRA_HTML, "</style> // violation"),
+            "55:24: " + getCheckMessage(MSG_UNCLOSED_HTML, "<code>dummy. // violation"),
+            "67: " + getCheckMessage(MSG_NO_PERIOD),
+            "69:36: " + getCheckMessage(MSG_EXTRA_HTML, "</code> // violation and"
+                + " line below, too"),
+            "70: " + getCheckMessage(MSG_INCOMPLETE_TAG, "         * should fail <"),
+            "85:37: " + getCheckMessage(MSG_UNCLOSED_HTML, "<code> // violation"),
+            "92: " + getCheckMessage(MSG_NO_PERIOD),
+            "100: " + getCheckMessage(MSG_NO_PERIOD),
+            };
+
+        verify(checkConfig,
+            getNonCompilablePath("InputJavadocStyleRecordsAndCompactCtors.java"),
+            expected);
     }
 
     @Test

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleRecordsAndCompactCtors.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleRecordsAndCompactCtors.java
@@ -1,0 +1,106 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocstyle;
+/* Config:
+ *
+ * scope = private
+ * excludeScope = null
+ * checkFirstSentence = true
+ * endOfSentenceFormat = "([.?!][ \t\n\r\f<])|([.?!]$)"
+ * checkEmptyJavadoc = false
+ * checkHtml = true
+ * tokens = {ANNOTATION_DEF , ANNOTATION_FIELD_DEF , CLASS_DEF , CTOR_DEF , ENUM_CONSTANT_DEF ,
+ *  ENUM_DEF , INTERFACE_DEF , METHOD_DEF , PACKAGE_DEF , VARIABLE_DEF, RECORD_DEF,
+ *  COMPACT_CTOR_DEF}
+ */
+public class InputJavadocStyleRecordsAndCompactCtors {
+
+    public record MyRecord() {
+
+        /**
+         * This Javadoc is missing an ending period
+         */ // violation
+        private static String second;
+
+        /**
+         * We don't want {@link com.puppycrawl.tools.checkstyle.checks.JavadocStyleCheck}
+         * tags to stop the scan for the end of sentence.
+         *
+         * @see Something
+         */
+        public MyRecord() {
+        }
+
+        /**
+         * This is ok!
+         */
+        private void method1() {
+        }
+
+        /**
+         * // violation
+         * This should fail even.though.there are embedded periods
+         */
+        private void method4() {
+        }
+
+        /**
+         * Test HTML in Javadoc comment
+         * <dl>
+         * <dt><b>This guy is missing end of bold tag // violation
+         * <dd>The dt and dd don't require end tags.
+         * </dl>
+         * </td>Extra tag shouldn't be here // violation
+         * <style>this tag isn't supported in Javadoc</style> // violation
+         *
+         * @param arg1 <code>dummy. // violation
+         */
+        private void method5(int arg1) {
+        }
+    }
+
+    /**
+     * @param a A parameter
+     */
+    public record MySecondRecord() {
+        static String props = "";
+
+        /**
+         * // violation
+         * Public check should fail</code> // violation and line below, too
+         * should fail <
+         */
+        public void method8() {
+        }
+    }
+
+    /**
+     *
+     */
+    public record MyThirdRecord(String myString) {
+    }
+
+    public record MyFourthRecord(String myString) {
+        /**
+         * This Javadoc contains unclosed tag.
+         * <code>unclosed 'code' tag<code> // violation
+         */
+        private static void unclosedTag() {
+            System.out.println("stuff");
+        }
+
+        public MyFourthRecord {
+            /**
+             * No period at the end of this sentence // violation
+             */
+            String myOtherString = "mystring";
+        }
+    }
+
+    public record MyFifthRecord() {
+        /**
+         * No period here on compact ctor // violation
+         */
+        public MyFifthRecord {
+        }
+    }
+}

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -1461,6 +1461,10 @@ public class TestClass {
                   PACKAGE_DEF</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
                   VARIABLE_DEF</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+                  RECORD_DEF</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
+                  COMPACT_CTOR_DEF</a>
                   .
               </td>
               <td>
@@ -1484,6 +1488,10 @@ public class TestClass {
                   PACKAGE_DEF</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
                   VARIABLE_DEF</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+                  RECORD_DEF</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
+                  COMPACT_CTOR_DEF</a>
                   .
               </td>
               <td>3.2</td>


### PR DESCRIPTION
Issue #8493: Full Records support check update for JavadocStyleCheck

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/95d58c64cac571de4688100840caeedf/raw/7b5c7ff8c7f155875b84464fd882927cde6d4e6e/JavadocStyle.xml