### PR TITLE
Issue #8494: Full Records support check update for JavadocTypeCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -108,7 +108,9 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
  * ENUM_DEF</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
- * ANNOTATION_DEF</a>.
+ * ANNOTATION_DEF</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+ * RECORD_DEF</a>.
  * </li>
  * </ul>
  * <p>
@@ -343,6 +345,7 @@ public class JavadocTypeCheck
             TokenTypes.CLASS_DEF,
             TokenTypes.ENUM_DEF,
             TokenTypes.ANNOTATION_DEF,
+            TokenTypes.RECORD_DEF,
         };
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -57,6 +57,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
             TokenTypes.CLASS_DEF,
             TokenTypes.ENUM_DEF,
             TokenTypes.ANNOTATION_DEF,
+            TokenTypes.RECORD_DEF,
         };
 
         assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
@@ -396,5 +397,20 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
         verify(checkConfig,
             getNonCompilablePath("InputJavadocTypeAllowedAnnotations.java"),
             expected);
+    }
+
+    @Test
+    public void testJavadocTypeRecords() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(JavadocTypeCheck.class);
+        checkConfig.addAttribute("authorFormat", "ABC");
+        final String[] expected = {
+            "22:1: " + getCheckMessage(MSG_MISSING_TAG, "@author"),
+            "31:1: " + getCheckMessage(MSG_MISSING_TAG, "@author"),
+            "40:1: " + getCheckMessage(MSG_MISSING_TAG, "@author"),
+            "53:1: " + getCheckMessage(MSG_TAG_FORMAT, "@author", "ABC"),
+            "63:1: " + getCheckMessage(MSG_MISSING_TAG, "@author"),
+            };
+        verify(checkConfig, getNonCompilablePath("InputJavadocTypeRecords.java"), expected);
     }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecords.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecords.java
@@ -1,0 +1,69 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
+
+/* Config:
+ *
+ * scope = private
+ * excludeScope = null
+ * authorFormat = null
+ * versionFormat = null
+ * allowMissingParamTags = false
+ * allowUnknownTags = false
+ * allowedAnnotations = Generated
+ * tokens = {INTERFACE_DEF , CLASS_DEF , ENUM_DEF , ANNOTATION_DEF, RECORD_DEF}
+ */
+
+/**
+ * Testing author and version tag patterns
+ * ***    @author  Nick Mancuso
+ *
+ * @version 8.35
+ */
+class InputJavadocTypeRecords { // violation
+}
+
+/**
+ * Testing author and version tag patterns
+ * ***    @author  Nick Mancuso
+ *
+ * @version 8.37
+ */
+record MyRecord1() { // violation
+
+}
+
+/**
+ * Testing author and version tag patterns (there are not tags :)
+ * SomeText @author  Nick Mancuso
+ * *@version 8.37
+ */
+record MyRecord2() { // violation
+
+    public MyRecord2 {
+    }
+}
+
+/**
+ * Testing author and version tag patterns.
+ * tags are multi line ones
+ *
+ * @author Nick Mancuso
+ * @version 8.37
+ */
+record MyRecord3() { // violation
+
+}
+
+/**
+ * Testing author and version tag patterns
+ * ***    @author  Nick Mancuso
+ *
+ * @version 8.37
+ */
+record MyRecord4() { // violation
+
+}
+
+record MyRecord5() { // ok
+
+}

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -1948,6 +1948,8 @@ public class Test {
                   ENUM_DEF</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
                   ANNOTATION_DEF</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+                  RECORD_DEF</a>
                   .
               </td>
               <td>
@@ -1959,6 +1961,8 @@ public class Test {
                   ENUM_DEF</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
                   ANNOTATION_DEF</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+                  RECORD_DEF</a>
                   .
               </td>
               <td>3.0</td>


### PR DESCRIPTION
Issue #8494: Full Records support check update for JavadocTypeCheck

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/05d5537a7a3347085535bc8627d23412/raw/0a9bf4f4ac1a674a4d58e5fe10be127385c57119/JavadocType.xml