### PR TITLE
Issue #8492: Full Records support check update for JavadocMethodCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -148,7 +148,9 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
  * CTOR_DEF</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
- * ANNOTATION_FIELD_DEF</a>.
+ * ANNOTATION_FIELD_DEF</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
+ * COMPACT_CTOR_DEF</a>.
  * </li>
  * </ul>
  * <p>
@@ -457,6 +459,7 @@ public class JavadocMethodCheck extends AbstractCheck {
             TokenTypes.CLASS_DEF,
             TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,
+            TokenTypes.RECORD_DEF,
         };
     }
 
@@ -474,6 +477,8 @@ public class JavadocMethodCheck extends AbstractCheck {
             TokenTypes.METHOD_DEF,
             TokenTypes.CTOR_DEF,
             TokenTypes.ANNOTATION_FIELD_DEF,
+            TokenTypes.RECORD_DEF,
+            TokenTypes.COMPACT_CTOR_DEF,
         };
     }
 
@@ -486,7 +491,8 @@ public class JavadocMethodCheck extends AbstractCheck {
     public final void visitToken(DetailAST ast) {
         if (ast.getType() == TokenTypes.CLASS_DEF
                  || ast.getType() == TokenTypes.INTERFACE_DEF
-                 || ast.getType() == TokenTypes.ENUM_DEF) {
+                 || ast.getType() == TokenTypes.ENUM_DEF
+                 || ast.getType() == TokenTypes.RECORD_DEF) {
             processClass(ast);
         }
         else {
@@ -498,7 +504,8 @@ public class JavadocMethodCheck extends AbstractCheck {
     public final void leaveToken(DetailAST ast) {
         if (ast.getType() == TokenTypes.CLASS_DEF
             || ast.getType() == TokenTypes.INTERFACE_DEF
-            || ast.getType() == TokenTypes.ENUM_DEF) {
+            || ast.getType() == TokenTypes.ENUM_DEF
+            || ast.getType() == TokenTypes.RECORD_DEF) {
             // perhaps it was inner class
             final int dotIdx = currentClassName.lastIndexOf('$');
             currentClassName = currentClassName.substring(0, dotIdx);
@@ -563,13 +570,17 @@ public class JavadocMethodCheck extends AbstractCheck {
                 final boolean reportExpectedTags = !hasInheritDocTag
                     && !AnnotationUtil.containsAnnotation(ast, allowedAnnotations);
 
-                checkParamTags(tags, ast, reportExpectedTags);
+                // COMPACT_CTOR_DEF has no parameters
+                if (ast.getType() != TokenTypes.COMPACT_CTOR_DEF) {
+                    checkParamTags(tags, ast, reportExpectedTags);
+                }
                 final List<ExceptionInfo> throwed =
-                        combineExceptionInfo(getThrows(ast), getThrowed(ast));
+                    combineExceptionInfo(getThrows(ast), getThrowed(ast));
                 checkThrowsTags(tags, throwed, reportExpectedTags);
                 if (CheckUtil.isNonVoidMethod(ast)) {
                     checkReturnTag(tags, ast.getLineNo(), reportExpectedTags);
                 }
+
             }
 
             // Dump out all unused tags

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -314,7 +314,7 @@
       <property name="allowMissingParamTags" value="true"/>
       <property name="allowMissingReturnTag" value="true"/>
       <property name="allowedAnnotations" value="Override, Test"/>
-      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF"/>
+      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF"/>
     </module>
     <module name="MissingJavadocMethod">
       <property name="scope" value="public"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -58,6 +58,8 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
             TokenTypes.METHOD_DEF,
             TokenTypes.CTOR_DEF,
             TokenTypes.ANNOTATION_FIELD_DEF,
+            TokenTypes.RECORD_DEF,
+            TokenTypes.COMPACT_CTOR_DEF,
         };
 
         assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
@@ -485,11 +487,35 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testJavadocMethodRecordsAndCompactCtors() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(JavadocMethodCheck.class);
+        checkConfig.addAttribute("validateThrows", "true");
+        checkConfig.addAttribute("tokens", "METHOD_DEF , CTOR_DEF , ANNOTATION_FIELD_DEF,"
+            + " COMPACT_CTOR_DEF, RECORD_DEF, CLASS_DEF");
+
+        final String[] expected = {
+            "26:27: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "IllegalArgumentException"),
+            "39:27: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws",
+                "java.lang.IllegalArgumentException"),
+            "51: " + getCheckMessage(MSG_UNUSED_TAG_GENERAL),
+            "57:27: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "IllegalArgumentException"),
+            "67: " + getCheckMessage(MSG_UNUSED_TAG_GENERAL),
+            "73:27: " + getCheckMessage(MSG_EXPECTED_TAG, "@throws", "IllegalArgumentException"),
+            "83:12: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "properties"),
+            "86:35: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "myInt"),
+
+            };
+        verify(checkConfig,
+            getNonCompilablePath("InputJavadocMethodRecordsAndCompactCtors.java"), expected);
+    }
+
+    @Test
     public void testGetRequiredTokens() {
         final int[] expected = {
             TokenTypes.CLASS_DEF,
             TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,
+            TokenTypes.RECORD_DEF,
         };
         final JavadocMethodCheck check = new JavadocMethodCheck();
         final int[] actual = check.getRequiredTokens();

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecordsAndCompactCtors.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodRecordsAndCompactCtors.java
@@ -1,0 +1,94 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
+
+/* Config:
+ *
+ * allowedAnnotations = Override
+ * validateThrows = false
+ * scope = private
+ * excludeScope = null
+ * allowMissingParamTags = false
+ * allowMissingReturnTag = false
+ * tokens = {METHOD_DEF , CTOR_DEF , ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF, RECORD_DEF, CLASS_DEF}
+ */
+public class InputJavadocMethodRecordsAndCompactCtors {
+    // methods
+    public record MyRecord() {
+        /**
+         * exception is explitly thrown in code missed in javadoc
+         *
+         * @param properties some value
+         * @throws java.lang.IllegalStateException when argument is wrong // ok
+         */
+        public void doSomething4(String properties) {
+            // here is NPE possible
+            if (properties.charAt(0) == 0) {
+                throw new IllegalArgumentException("cannot have char with code 0"); // violation
+            }
+        }
+
+        /**
+         * exception is explitly thrown in code missed in javadoc
+         *
+         * @param properties some value
+         * @throws java.lang.IllegalStateException when argument is wrong // ok
+         */
+        public void doSomething5(String properties) {
+            // here is NPE possible
+            if (properties.charAt(0) == 0) {
+                throw new java.lang.IllegalArgumentException("cannot have char with code 0");
+            }                       // violation ^
+        }
+    }
+
+    // static field, compact ctor
+    public record MySecondRecord() {
+        static String props = "";
+
+        /**
+         * exception is explitly thrown in code missed in javadoc
+         *
+         * @param properties some value // violation
+         * @throws java.lang.IllegalStateException when argument is wrong // ok
+         */
+        public MySecondRecord {
+            // here is NPE possible
+            if (props.charAt(0) == 0) {
+                throw new IllegalArgumentException("cannot have char with code 0"); // violation
+            }
+        }
+    }
+
+    // Record component, compact ctor
+    public record MyThirdRecord(String myString) {
+        /**
+         * exception is explitly thrown in code missed in javadoc
+         *
+         * @param properties some value // violation
+         * @throws java.lang.IllegalStateException when argument is wrong // ok
+         */
+        public MyThirdRecord {
+            // here is NPE possible
+            if (myString.charAt(0) == 0) {
+                throw new IllegalArgumentException("cannot have char with code 0"); // violation
+            }
+        }
+    }
+
+    // Record component, ctor
+    public record MyFourthRecord(String myString) {
+        /**
+         * exception is explitly thrown in code missed in javadoc
+         *
+         * @param properties some value // violation
+         * @throws java.lang.IllegalStateException when argument is wrong // ok
+         */
+        public MyFourthRecord(int myInt) { // violation
+            this("my string");
+            // here is NPE possible
+            if (myString.charAt(0) == 0) {
+                throw new IllegalArgumentException("cannot have char with code 0");
+            }
+        }
+    }
+}

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -722,6 +722,8 @@ public int checkReturnTag(final int aTagIndex,
                   CTOR_DEF</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
                   ANNOTATION_FIELD_DEF</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
+                  COMPACT_CTOR_DEF</a>
                   .
               </td>
               <td>
@@ -731,6 +733,8 @@ public int checkReturnTag(final int aTagIndex,
                   CTOR_DEF</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
                   ANNOTATION_FIELD_DEF</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
+                  COMPACT_CTOR_DEF</a>
                   .
               </td>
               <td>3.0</td>


### PR DESCRIPTION
Issue #8492: Full Records support check update for JavadocMethodCheck

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/fe7e39629a7dce370804c1433e30519e/raw/3eefdc7da830c260414f113bafb1881239c72216/JavadocMethod.xml