### PR TITLE
Issue #8485: Full Records support check update for OneTopLevelClassCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheck.java
@@ -56,6 +56,10 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * class Foo2 { // violation, second top-level class
  *   // methods
  * }
+ *
+ * record Foo3 { // violation, third top-level "class"
+ *     // methods
+ * }
  * </pre>
  * <p>
  * An example of code without public top-level type:

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheckTest.java
@@ -213,4 +213,15 @@ public class OneTopLevelClassCheckTest extends AbstractModuleTestSupport {
         verify(checkConfig, getPath("InputOneTopLevelClassIndentation.java"), expected);
     }
 
+    @Test
+    public void testOneTopLevelClassRecords() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(OneTopLevelClassCheck.class);
+        final String[] expected = {
+            "11:1: " + getCheckMessage(MSG_KEY, "TestRecord1"),
+            "15:1: " + getCheckMessage(MSG_KEY, "TestRecord2"),
+            };
+        verify(checkConfig, getNonCompilablePath("InputOneTopLevelClassRecords.java"), expected);
+    }
+
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassRecords.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/onetoplevelclass/InputOneTopLevelClassRecords.java
@@ -1,0 +1,17 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.design.onetoplevelclass;
+
+/* Config:
+ *
+ * default
+ */
+public record InputOneTopLevelClassRecords() {
+}
+
+record TestRecord1() { // violation
+
+}
+
+record TestRecord2() { // violation
+
+}

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -776,6 +776,10 @@ public class Foo { // OK, first top-level class
 class Foo2 { // violation, second top-level class
   // methods
 }
+
+record Foo3 { // violation, third top-level "class"
+  // methods
+}
           </pre>
         </div>
         <p>


### PR DESCRIPTION
Issue #8485: Full Records support check update for OneTopLevelClassCheck

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/691e940210642826eebed0d8b53287df/raw/7911778dd15f17798934f98ccce9f578a4608793/OneTopLevelClass.xml

This check was already working, thanks again to `isTypeDeclaration()`, but here is a UT to make sure that it stays that way.