### PR TITLE
Issue #8490: Full Records support check update for AtclauseOrderCheck

### DIFF
--- a/config/ant-phase-verify.xml
+++ b/config/ant-phase-verify.xml
@@ -221,6 +221,8 @@
           <exclude name="**/asttreestringprinter/**/*"/>
           <!-- Indentation checks use "warn" -->
           <exclude name="**/resources-noncompilable/**/checks/indentation/**/*"/>
+          <!-- BlockComment test files do not need 'ok', 'violation, or 'Config:' comments -->
+          <exclude name="**/utils/blockcommentposition/**/*"/>
 
         </fileset>
       </path>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
@@ -65,7 +65,11 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
  * CTOR_DEF</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
- * VARIABLE_DEF</a>.
+ * VARIABLE_DEF</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+ * RECORD_DEF</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
+ * COMPACT_CTOR_DEF</a>.
  * </li>
  * <li>
  * Property {@code tagOrder} - Specify the order by tags.
@@ -139,7 +143,9 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck {
         TokenTypes.ENUM_DEF,
         TokenTypes.METHOD_DEF,
         TokenTypes.CTOR_DEF,
-        TokenTypes.VARIABLE_DEF
+        TokenTypes.VARIABLE_DEF,
+        TokenTypes.RECORD_DEF,
+        TokenTypes.COMPACT_CTOR_DEF
     );
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPosition.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPosition.java
@@ -44,7 +44,8 @@ public final class BlockCommentPosition {
         return isOnClass(blockComment)
                 || isOnInterface(blockComment)
                 || isOnEnum(blockComment)
-                || isOnAnnotationDef(blockComment);
+                || isOnAnnotationDef(blockComment)
+                || isOnRecord(blockComment);
     }
 
     /**
@@ -57,6 +58,18 @@ public final class BlockCommentPosition {
         return isOnPlainToken(blockComment, TokenTypes.CLASS_DEF, TokenTypes.LITERAL_CLASS)
                 || isOnTokenWithModifiers(blockComment, TokenTypes.CLASS_DEF)
                 || isOnTokenWithAnnotation(blockComment, TokenTypes.CLASS_DEF);
+    }
+
+    /**
+     * Node is on record definition.
+     *
+     * @param blockComment DetailAST
+     * @return true if node is before class
+     */
+    public static boolean isOnRecord(DetailAST blockComment) {
+        return isOnPlainToken(blockComment, TokenTypes.RECORD_DEF, TokenTypes.LITERAL_RECORD)
+            || isOnTokenWithModifiers(blockComment, TokenTypes.RECORD_DEF)
+            || isOnTokenWithAnnotation(blockComment, TokenTypes.RECORD_DEF);
     }
 
     /**
@@ -130,7 +143,8 @@ public final class BlockCommentPosition {
                 || isOnField(blockComment)
                 || isOnConstructor(blockComment)
                 || isOnEnumConstant(blockComment)
-                || isOnAnnotationField(blockComment);
+                || isOnAnnotationField(blockComment)
+                || isOnCompactConstructor(blockComment);
     }
 
     /**
@@ -171,6 +185,18 @@ public final class BlockCommentPosition {
         return isOnPlainToken(blockComment, TokenTypes.CTOR_DEF, TokenTypes.IDENT)
                 || isOnTokenWithModifiers(blockComment, TokenTypes.CTOR_DEF)
                 || isOnTokenWithAnnotation(blockComment, TokenTypes.CTOR_DEF);
+    }
+
+    /**
+     * Node is on compact constructor, note that we don't need to check for a plain
+     * token here, since a compact constructor must be public.
+     *
+     * @param blockComment DetailAST
+     * @return true if node is before compact constructor
+     */
+    public static boolean isOnCompactConstructor(DetailAST blockComment) {
+        return isOnTokenWithModifiers(blockComment, TokenTypes.COMPACT_CTOR_DEF)
+                || isOnTokenWithAnnotation(blockComment, TokenTypes.COMPACT_CTOR_DEF);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckTest.java
@@ -133,4 +133,44 @@ public class AtclauseOrderCheckTest extends AbstractModuleTestSupport {
         verify(checkConfig, getPath("package-info.java"), expected);
     }
 
+    @Test
+    public void testAtclauseOrderRecords() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(AtclauseOrderCheck.class);
+        checkConfig.addAttribute("target", "CLASS_DEF , INTERFACE_DEF , ENUM_DEF , METHOD_DEF ,"
+            + " CTOR_DEF , VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF");
+
+        checkConfig.addAttribute("tagOrder", "@author, @version, @param, @return, @throws,"
+            + " @exception, @see, @since, @serial, @serialField, @serialData, @deprecated");
+
+        final String tagOrder = "[@author, @version, @param, @return, @throws, @exception,"
+            + " @see, @since, @serial, @serialField, @serialData, @deprecated]";
+
+        final String[] expected = {
+            "33: " + getCheckMessage(MSG_KEY, tagOrder),
+            "34: " + getCheckMessage(MSG_KEY, tagOrder),
+            "35: " + getCheckMessage(MSG_KEY, tagOrder),
+            "45: " + getCheckMessage(MSG_KEY, tagOrder),
+            "46: " + getCheckMessage(MSG_KEY, tagOrder),
+            "55: " + getCheckMessage(MSG_KEY, tagOrder),
+            "74: " + getCheckMessage(MSG_KEY, tagOrder),
+            "89: " + getCheckMessage(MSG_KEY, tagOrder),
+
+            };
+        verify(checkConfig, getNonCompilablePath("InputAtclauseOrderRecords.java"), expected);
+    }
+
+    @Test
+    public void testAtclauseOrderLotsOfRecords() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(AtclauseOrderCheck.class);
+        checkConfig.addAttribute("target", "CLASS_DEF , INTERFACE_DEF , ENUM_DEF , METHOD_DEF ,"
+            + " CTOR_DEF , VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF");
+
+        checkConfig.addAttribute("tagOrder", "@author, @version, @param, @return, @throws,"
+            + " @exception, @see, @since, @serial, @serialField, @serialData, @deprecated");
+
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verify(checkConfig, getNonCompilablePath("InputAtclauseOrderLotsOfRecords.java"), expected);
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPositionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPositionTest.java
@@ -29,13 +29,13 @@ import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 
-import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.JavaParser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
-public class BlockCommentPositionTest extends AbstractPathTestSupport {
+public class BlockCommentPositionTest extends AbstractModuleTestSupport {
 
     @Test
     public void testPrivateConstr() throws Exception {
@@ -76,6 +76,24 @@ public class BlockCommentPositionTest extends AbstractPathTestSupport {
         for (BlockCommentPositionTestMetadata metadata : metadataList) {
             final DetailAST ast = JavaParser.parseFile(new File(getPath(metadata.getFileName())),
                 JavaParser.Options.WITH_COMMENTS);
+            final int matches = getJavadocsCount(ast, metadata.getAssertion());
+            assertEquals(metadata.getMatchesNum(), matches, "Invalid javadoc count");
+        }
+    }
+
+    @Test
+    public void testJavaDocsRecognitionNonCompilable() throws Exception {
+        final List<BlockCommentPositionTestMetadata> metadataList = Arrays.asList(
+            new BlockCommentPositionTestMetadata("InputBlockCommentPositionOnRecord.java",
+                BlockCommentPosition::isOnRecord, 3),
+            new BlockCommentPositionTestMetadata("InputBlockCommentPositionOnCompactCtor.java",
+                BlockCommentPosition::isOnCompactConstructor, 3)
+        );
+
+        for (BlockCommentPositionTestMetadata metadata : metadataList) {
+            final DetailAST ast = JavaParser.parseFile(
+                new File(getNonCompilablePath(metadata.getFileName())),
+                    JavaParser.Options.WITH_COMMENTS);
             final int matches = getJavadocsCount(ast, metadata.getAssertion());
             assertEquals(metadata.getMatchesNum(), matches, "Invalid javadoc count");
         }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderLotsOfRecords.java
@@ -1,0 +1,294 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.annotation.Native;
+import java.nio.file.Files;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import org.w3c.dom.Node;
+
+/* Config:
+ *
+ * violateExecutionOnNonTightHtml = false
+ * target = {CLASS_DEF , INTERFACE_DEF , ENUM_DEF , METHOD_DEF , CTOR_DEF , VARIABLE_DEF,
+ * RECORD_DEF, COMPACT_CTOR_DEF}
+ * tagOrder = {@author, @version, @param,@return, @throws, @exception, @see, @since, @serial,
+ * @serialField, @serialData, @deprecated}
+ */
+public class InputAtclauseOrderLotsOfRecords {
+    public static int getRecord() {
+        return record;
+    }
+
+    // Simple Annotated Record components
+    public @interface NonNull1 {
+    }
+
+
+    /**
+     * Javadoc
+     *
+     */
+    public record AnnotatedBinaryNode(@Native @NonNull1 Node left, @NonNull1 Node right) {
+    }
+
+    public interface Coords {
+        public double x();
+
+        public double y();
+    }
+
+    /**
+     * @param r     not really a param
+     * @param theta not really a param
+     * @return
+     */
+    public record Polar(double r, double theta) implements Coords { // ok
+        @Override
+        public double x() {
+            return r * Math.cos(theta);
+        }
+
+        /**
+         * Javadoc
+         */
+        @Override
+        public double y() {
+            return r * Math.sin(theta);
+        }
+    }
+
+    /**
+     * Javadoc
+     */
+    public record Holder<T>(T t) {
+    }
+
+    public record HolderG<G>(G g) {
+
+        /**
+         * Javadoc here too
+         */
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            HolderG<?> holderG = (HolderG<?>) o;
+            return Objects.equals(g, holderG.g);
+        }
+
+        /**
+         *
+         * @return
+         */
+        @Override
+        public int hashCode() {
+            return Objects.hash(g);
+        }
+    }
+
+
+    // Basic Record declaration
+    public record Car(String color, String model) {
+    }
+
+    /**
+     * @param name1 not really a param
+     * @param name2 again
+     * @return
+     */
+    public record Thing(String name1, String name2) {
+        public Thing {
+            Objects.requireNonNull(name1);
+            Objects.requireNonNull(name2);
+        }
+    }
+
+    public record ThingAnnotatedConstructor(String name1, String name2) {
+        /**
+         *
+         * @param name1
+         * @param name2
+         */
+        @NonNull1
+        public ThingAnnotatedConstructor {
+            Objects.requireNonNull(name1);
+            Objects.requireNonNull(name2);
+        }
+    }
+
+    /**
+     * Javadoc here
+     */
+    public record OtherThing(String name, String address) {
+
+        /**
+         *
+         * @param name
+         * @param address
+         */
+        @Deprecated
+        public OtherThing{
+        }
+    }
+
+    public record Thing2(String name, String address) {
+        /**
+         * @param name
+         * @param address
+         * @deprecated
+         */
+        @Deprecated
+        public Thing2(String name, String address) {
+            this.name = name;
+            this.address = address;
+        }
+    }
+
+    public record Tricky(int record) {
+    }
+
+    // Records with static variable member
+    public record UnknownRecord(String known, String unknown) {
+        private static final String UNKNOWN = "Unknown";
+    }
+
+    public record Person(String name, String address) {
+        public static Person unnamed(String address) {
+            return new Person("Unnamed", address);
+        }
+    }
+
+    // Record definition with throws constructor
+    public record FXOrder(int units,
+                          String side,
+                          double price,
+                          LocalDateTime sentAt,
+                          int ttl) {
+        /**
+         * @param units  some unit
+         * @param side   some side
+         * @param price  some price
+         * @param sentAt some other thing
+         * @param ttl    other thing
+         */
+        public FXOrder {
+            if (units < 1) {
+                throw new IllegalArgumentException(
+                        "FXOrder units must be positive");
+            }
+            if (ttl < 0) {
+                throw new IllegalArgumentException(
+                        "FXOrder TTL must be positive, or 0 for market orders");
+            }
+            if (price <= 0.0) {
+                throw new IllegalArgumentException(
+                        "FXOrder price must be positive");
+            }
+        }
+    }
+
+    public boolean isLoggable(LogRecord record) {
+        String packageName = null;
+        return record.getLoggerName().startsWith(packageName);
+    }
+
+    private static void assertEquals(Level info, Level level) {
+    }
+
+    private static void record(LogRecord... logArray) {
+        for (LogRecord record : logArray) {
+            record.getLevel();
+        }
+    }
+
+    private static void checkRecord() {
+        LogRecord record;
+        record = new LogRecord(Level.ALL, "abc");
+        assertEquals(Level.INFO, record.getLevel());
+    }
+
+    record NoComps() {
+    }
+
+    record Record(Record record) {
+    }
+
+    record R5(String...args) {
+    }
+
+    record R6(long l, String...args) implements java.io.Serializable {
+    }
+
+    record R7(String s1, String s2, String...args) {
+    }
+
+    record RI(int...xs) {
+    }
+
+    record RII(int x, int...xs) {
+    }
+
+    /**
+     * Javadoc here
+     */
+    record RX(int[]xs) {
+    }
+
+    private static int record = 2;
+
+    public Class<Record[]> getRecordType() {
+        return Record[].class;
+    }
+
+    class LocalRecordHelper {
+        Class<?> m(int x) {
+            record R76(int x) {
+            }
+            return R.class;
+        }
+
+        private class R {
+            public R(int x) {
+            }
+        }
+    }
+
+    /**
+     * @deprecated
+     */
+    @Deprecated
+            record R1() implements Serializable {
+        private static final TimeUnit Path = null;
+        private static final long serialVersionUID = -2911897846173867769L;
+
+        public R1 {
+
+        }
+    }
+
+    record RR3(String...args) implements Serializable {
+        private static final boolean firstDataSetCreated = false;
+        private static final long serialVersionUID = -5626758281412733319L;
+
+        public RR3 {
+            if (firstDataSetCreated) {
+                ProcessHandle.current();
+            }
+        }
+    }
+
+    public static void main(String... args) {
+        String recordString = "record";
+        recordString = recordString.substring(record, 5);
+        Car sedan = new Car("rec", "sedan");
+        String s = UnknownRecord.UNKNOWN;
+        Person.unnamed("100 Linda Ln.");
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderRecords.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderRecords.java
@@ -1,0 +1,93 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
+
+import java.io.Serializable;
+
+/* Config:
+ *
+ * violateExecutionOnNonTightHtml = false
+ * target = {CLASS_DEF , INTERFACE_DEF , ENUM_DEF , METHOD_DEF , CTOR_DEF , VARIABLE_DEF,
+ * RECORD_DEF, COMPACT_CTOR_DEF}
+ * tagOrder = {@author, @version, @param,@return, @throws, @exception, @see, @since, @serial,
+ * @serialField, @serialData, @deprecated}
+ */
+public class InputAtclauseOrderRecords {
+    public record MyRecord(int x) implements Serializable {
+        private static final long serialVersionUID = 3928773301716751506L;
+
+        /**
+         * Some text.
+         *
+         * @param aString Some text. // should be a violation, but doesn't work w/ anno
+         * @return Some text.
+         * @throws Exception Some text.
+         */
+        String method(String aString) throws Exception {
+            return "null";
+        }
+
+        /**
+         * Some text.
+         *
+         * @since the other day
+         * @param aString Some text. // violation
+         * @return Some text. // violation
+         * @throws Exception Some text.
+         */
+        String method1(String aString) throws Exception {
+            return "null";
+        }
+
+        /**
+         * Some text.
+         *
+         * @since some time
+         * @param aString Some text. // violation
+         * @throws Exception Some text. // violation
+         * @serialData Some javadoc.
+         */
+        void method2(String aString) throws Exception {
+        }
+
+        /**
+         * Some text.
+         * @since since
+         * @throws Exception Some text. // should be a violation, but doesn't work w/ anno
+         * @since Some text.
+         */
+        void method3() throws Exception {
+        }
+    }
+
+}
+
+/**
+ * Some javadoc.
+ *
+ * @author max // should be a violation
+ * @version 1.0
+ * @since Some javadoc.
+ */
+record myOtherOtherRecord() {
+    /**
+     * @since Some javadoc.
+     * @author max // should be a violation
+     **/
+    public myOtherOtherRecord{}
+}
+
+/**
+ * Some javadoc.
+ *
+ * @author max // should be a violation
+ * @version 1.0
+ * @since Some javadoc.
+ */
+class myOtherOtherClass {
+        /**
+         * @since Some javadoc.
+         * @author max // should be a violation
+         **/
+    public myOtherOtherClass() {
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnCompactCtor.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnCompactCtor.java
@@ -1,0 +1,26 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.utils.blockcommentposition;
+
+public record InputBlockCommentPositionOnCompactCtor() {
+    /**
+     * I'm a javadoc
+     */
+    public InputBlockCommentPositionOnRecord{}
+}
+
+
+record InputBlockCommentPositionOnRecord1() {
+    /**
+     * I'm a javadoc
+     */
+    public InputBlockCommentPositionOnRecord1{}
+}
+
+
+record InputBlockCommentPositionOnRecord2() {
+    /**
+     * I'm a javadoc
+     */
+    @Deprecated
+    public InputBlockCommentPositionOnRecord2{}
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnCompactCtor.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnCompactCtor.java
@@ -5,7 +5,7 @@ public record InputBlockCommentPositionOnCompactCtor() {
     /**
      * I'm a javadoc
      */
-    public InputBlockCommentPositionOnRecord{}
+    public InputBlockCommentPositionOnCompactCtor{}
 }
 
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnRecord.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/utils/blockcommentposition/InputBlockCommentPositionOnRecord.java
@@ -1,0 +1,22 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.utils.blockcommentposition;
+/**
+ * I'm a javadoc
+ */
+public record InputBlockCommentPositionOnRecord() {
+}
+
+
+/**
+ * I'm a javadoc
+ */
+record InputBlockCommentPositionOnRecord1() {
+}
+
+
+/**
+ * I'm a javadoc
+ */
+@Deprecated
+record InputBlockCommentPositionOnRecord2() {
+}

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -77,6 +77,10 @@
                   CTOR_DEF</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
                   VARIABLE_DEF</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+                  RECORD_DEF</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
+                  COMPACT_CTOR_DEF</a>
               </td>
               <td>6.0</td>
             </tr>


### PR DESCRIPTION
Issue #8490: Full Records support check update for AtclauseOrderCheck

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/d2967a1cd1ca512393fad295ceac21ae/raw/792d8e6cd3be4a27777c53d06fa7ae49b04ca930/AtclauseOrderBase.xml

Diff Regression patch config: https://gist.githubusercontent.com/nmancus1/795d95a929b34d12ffefcaaaff3b02fe/raw/bfb376bdbbbd22d254871274b8931ba4f9ace8e4/AtclauseOrderPatch.xml

Please note that the first commit, https://github.com/checkstyle/checkstyle/commit/0cbac0f6af41b0eac5aa483a508d3a58236715b0 is not merged yet, and should not be reviewed here.