### PR TITLE
Issue #8471: Full Records check update for OverloadMethodsDeclarationOrder

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheck.java
@@ -26,6 +26,7 @@ import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
  * <p>
@@ -102,10 +103,16 @@ public class OverloadMethodsDeclarationOrderCheck extends AbstractCheck {
     @Override
     public void visitToken(DetailAST ast) {
         final int parentType = ast.getParent().getType();
-        if (parentType == TokenTypes.CLASS_DEF
-                || parentType == TokenTypes.ENUM_DEF
-                || parentType == TokenTypes.INTERFACE_DEF
-                || parentType == TokenTypes.LITERAL_NEW) {
+
+        final int[] tokenTypes = {
+            TokenTypes.CLASS_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.INTERFACE_DEF,
+            TokenTypes.LITERAL_NEW,
+            TokenTypes.RECORD_DEF,
+        };
+
+        if (TokenUtil.isOfType(parentType, tokenTypes)) {
             checkOverloadMethodsGrouping(ast);
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheckTest.java
@@ -50,6 +50,21 @@ public class OverloadMethodsDeclarationOrderCheckTest
     }
 
     @Test
+    public void testOverloadMethodsDeclarationOrderRecords() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(OverloadMethodsDeclarationOrderCheck.class);
+
+        final String[] expected = {
+            "19:9: " + getCheckMessage(MSG_KEY, 13),
+            "39:9: " + getCheckMessage(MSG_KEY, 33),
+            "55:9: " + getCheckMessage(MSG_KEY, 48),
+            };
+        verify(checkConfig,
+            getNonCompilablePath("InputOverloadMethodsDeclarationOrderRecords.java"),
+            expected);
+    }
+
+    @Test
     public void testTokensNotNull() {
         final OverloadMethodsDeclarationOrderCheck check =
             new OverloadMethodsDeclarationOrderCheck();

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrderRecords.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrderRecords.java
@@ -1,0 +1,67 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.coding.overloadmethodsdeclarationorder;
+
+/* Config:
+ *
+ * default
+ */
+public class InputOverloadMethodsDeclarationOrderRecords {
+    record MyRecord1() {
+        public void foo(int i) {
+        }
+
+        public void foo(String s) {
+        }
+
+        public void notFoo() {
+        }
+
+        public void foo(int i, String s) { // violation
+        }
+
+        public void foo(String s, int i) {
+        }
+    }
+
+    record MyRecord2() {
+        public void foo(int i, String s) {
+        }
+
+        public void foo(String s, int i) {
+        }
+
+        public void foo(int i) {
+        }
+         public void notFoo(){
+
+         }
+
+        public void foo() { // violation
+        }
+
+        public MyRecord2{}
+
+
+    }
+
+    class MyClass {
+        public void foo(int i) {
+        }
+
+        public void notFoo() {
+        }
+
+
+        public void foo() { // violation
+        }
+
+        public MyClass() {
+        }
+
+        public void foo(int i, String s) {
+        }
+
+        public void foo(String s, int i) {
+        }
+    }
+}


### PR DESCRIPTION
Issue #8471: Full Records check update for OverloadMethodsDeclarationOrder

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/8288e98333d2e8c8498918c82a1517de/raw/fe5ae98fd76c60a136073bbfd631fcd39bc93018/OverloadMethodsDeclarationOrder.xml