### PR TITLE
Issue #8475: Full Records support check update for UnnecessarySemicolonAfterOuterType

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterOuterTypeDeclarationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterOuterTypeDeclarationCheck.java
@@ -49,7 +49,9 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
  * ENUM_DEF</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
- * ANNOTATION_DEF</a>.
+ * ANNOTATION_DEF</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+ * RECORD_DEF</a>.
  * </li>
  * </ul>
  * <p>
@@ -141,6 +143,7 @@ public final class UnnecessarySemicolonAfterOuterTypeDeclarationCheck extends Ab
             TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,
             TokenTypes.ANNOTATION_DEF,
+            TokenTypes.RECORD_DEF,
         };
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterOuterTypeDeclarationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterOuterTypeDeclarationCheckTest.java
@@ -55,6 +55,21 @@ public class UnnecessarySemicolonAfterOuterTypeDeclarationCheckTest
     }
 
     @Test
+    public void testUnnecessarySemicolonAfterOuterTypeDeclarationRecords() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(UnnecessarySemicolonAfterOuterTypeDeclarationCheck.class);
+
+        final String[] expected = {
+            "14:2: " + getCheckMessage(MSG_SEMI),
+            "20:2: " + getCheckMessage(MSG_SEMI),
+            };
+
+        verify(checkConfig,
+            getNonCompilablePath("InputUnnecessarySemicolonAfterOuterTypeDeclarationRecords.java"),
+            expected);
+    }
+
+    @Test
     public void testTokens() {
         final UnnecessarySemicolonAfterOuterTypeDeclarationCheck check =
             new UnnecessarySemicolonAfterOuterTypeDeclarationCheck();
@@ -63,6 +78,7 @@ public class UnnecessarySemicolonAfterOuterTypeDeclarationCheckTest
             TokenTypes.INTERFACE_DEF,
             TokenTypes.ENUM_DEF,
             TokenTypes.ANNOTATION_DEF,
+            TokenTypes.RECORD_DEF,
         };
         assertArrayEquals(expected, check.getAcceptableTokens(),
                 "Acceptable required tokens are invalid");

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonafteroutertypedeclaration/InputUnnecessarySemicolonAfterOuterTypeDeclarationRecords.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonafteroutertypedeclaration/InputUnnecessarySemicolonAfterOuterTypeDeclarationRecords.java
@@ -1,0 +1,20 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.coding.unnecessarysemicolonafteroutertypedeclaration;
+
+/* Config:
+ *
+ * tokens = {CLASS_DEF , INTERFACE_DEF , ENUM_DEF , ANNOTATION_DEF, RECORD_DEF}
+ */
+public record InputUnnecessarySemicolonAfterOuterTypeDeclarationRecords() {
+    public record MyInnerRecord() {
+
+    }
+
+    ; // ok, nested type declarations are ignored in this check
+}; // violation
+
+record OuterRecord() {
+    record InnerRecord() {
+
+    }; // ok
+}; // violation

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -6276,6 +6276,8 @@ myList.stream()
                 ENUM_DEF</a>
                 , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
                 ANNOTATION_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+                RECORD_DEF</a>
                   .
               </td>
               <td>
@@ -6287,6 +6289,8 @@ myList.stream()
                     ENUM_DEF</a>
                 , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
                     ANNOTATION_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+                    RECORD_DEF</a>
                   .
               </td>
               <td>8.31</td>


### PR DESCRIPTION
Issue #8475: Full Records support check update for UnnecessarySemicolonAfterOuterType

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/e42e92f84144f38a44eb06d66d68b8ac/raw/6adce6c8baf108228d2f0fcf37ea55a27b2cc39d/UnnecessarySemicolonAfterOuterTypeDeclaration.xml