### PR TITLE
Issue #8476: Full Records support check update for UnnecessarySemicolonAfterTypeMember

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterTypeMemberDeclarationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterTypeMemberDeclarationCheck.java
@@ -63,7 +63,11 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
  * METHOD_DEF</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
- * ENUM_CONSTANT_DEF</a>.
+ * ENUM_CONSTANT_DEF</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
+ * COMPACT_CTOR_DEF</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+ * RECORD_DEF</a>.
  * </li>
  * </ul>
  * <p>
@@ -140,6 +144,8 @@ public final class UnnecessarySemicolonAfterTypeMemberDeclarationCheck extends A
             TokenTypes.CTOR_DEF,
             TokenTypes.METHOD_DEF,
             TokenTypes.ENUM_CONSTANT_DEF,
+            TokenTypes.COMPACT_CTOR_DEF,
+            TokenTypes.RECORD_DEF,
         };
     }
 
@@ -155,6 +161,7 @@ public final class UnnecessarySemicolonAfterTypeMemberDeclarationCheck extends A
             case TokenTypes.INTERFACE_DEF:
             case TokenTypes.ENUM_DEF:
             case TokenTypes.ANNOTATION_DEF:
+            case TokenTypes.RECORD_DEF:
                 checkTypeDefinition(ast);
                 break;
             case TokenTypes.VARIABLE_DEF:

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterTypeMemberDeclarationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonAfterTypeMemberDeclarationCheckTest.java
@@ -65,6 +65,26 @@ public class UnnecessarySemicolonAfterTypeMemberDeclarationCheckTest
     }
 
     @Test
+    public void testUnnecessarySemicolonAfterTypeMemberDeclarationRecords() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(UnnecessarySemicolonAfterTypeMemberDeclarationCheck.class);
+
+        final String[] expected = {
+            "9:5: " + getCheckMessage(MSG_SEMI),
+            "13:5: " + getCheckMessage(MSG_SEMI),
+            "17:5: " + getCheckMessage(MSG_SEMI),
+            "22:5: " + getCheckMessage(MSG_SEMI),
+            "28:5: " + getCheckMessage(MSG_SEMI),
+            "33:5: " + getCheckMessage(MSG_SEMI),
+            "35:5: " + getCheckMessage(MSG_SEMI),
+            };
+
+        verify(checkConfig,
+            getNonCompilablePath("InputUnnecessarySemicolonAfterTypeMemberDeclarationRecords.java"),
+            expected);
+    }
+
+    @Test
     public void testTokens() {
         final UnnecessarySemicolonAfterTypeMemberDeclarationCheck check =
             new UnnecessarySemicolonAfterTypeMemberDeclarationCheck();
@@ -80,6 +100,8 @@ public class UnnecessarySemicolonAfterTypeMemberDeclarationCheckTest
             TokenTypes.CTOR_DEF,
             TokenTypes.METHOD_DEF,
             TokenTypes.ENUM_CONSTANT_DEF,
+            TokenTypes.COMPACT_CTOR_DEF,
+            TokenTypes.RECORD_DEF,
         };
         assertArrayEquals(expected, check.getAcceptableTokens(),
                 "Acceptable required tokens are invalid");

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonaftertypememberdeclaration/InputUnnecessarySemicolonAfterTypeMemberDeclarationRecords.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicolonaftertypememberdeclaration/InputUnnecessarySemicolonAfterTypeMemberDeclarationRecords.java
@@ -1,0 +1,49 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.coding.unnecessarysemicolonaftertypememberdeclaration;
+
+/* Config:
+ *
+ * default
+ */
+public record InputUnnecessarySemicolonAfterTypeMemberDeclarationRecords() {
+    ; // violation
+
+    static {}
+
+    ; // violation, extra semicolon after init block
+
+    static {}
+
+    ; // violation, extra semicolon after static init block
+
+    public InputUnnecessarySemicolonAfterTypeMemberDeclarationRecords {
+    }
+
+    ; // violation, extra semicolon after compact constructor definition
+
+    public InputUnnecessarySemicolonAfterTypeMemberDeclarationRecords(Object o) {
+        this();
+    }
+
+    ; // violation, extra semicolon after constructor definition
+
+    void method() {
+    }
+
+    ; // violation, extra semicolon after method definition
+    static int field = 10;
+    ; // violation, extra semicolon after field declaration
+
+    static {
+        ; // no violation, it is empty statement inside init block
+    }
+
+    static {
+        ; // no violation, it is empty statement inside static init block
+    }
+
+    void anotherMethod() {
+        ; // no violation, it is empty statement
+        if (true) ; // no violation, it is empty statement
+    }
+}; // ok, this check does not apply to outer types

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -6448,6 +6448,10 @@ myList.stream()
                 METHOD_DEF</a>
                 , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
                 ENUM_CONSTANT_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
+                COMPACT_CTOR_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+                RECORD_DEF</a>
                   .
               </td>
               <td>
@@ -6473,6 +6477,10 @@ myList.stream()
                     METHOD_DEF</a>
                 , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_CONSTANT_DEF">
                     ENUM_CONSTANT_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
+                    COMPACT_CTOR_DEF</a>
+                , <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+                    RECORD_DEF</a>
                   .
               </td>
               <td>8.24</td>


### PR DESCRIPTION
Issue #8476: Full Records support check update for UnnecessarySemicolonAfterTypeMember

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/9362ea47ae8cdad27f177d6fe273ca07/raw/cdfdd2b26974ace11fe5eaa9c3cf099d0baa737b/UnnecessarySemicolonAfterTypeMemberDeclaration.xml