### PR TITLE
Issue #8498: Full Records support check update for MissingJavadocTypeCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheck.java
@@ -71,7 +71,9 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ENUM_DEF">
  * ENUM_DEF</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
- * ANNOTATION_DEF</a>.
+ * ANNOTATION_DEF</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+ * RECORD_DEF</a>.
  * </li>
  * </ul>
  * <p>
@@ -218,6 +220,7 @@ public class MissingJavadocTypeCheck extends AbstractCheck {
             TokenTypes.CLASS_DEF,
             TokenTypes.ENUM_DEF,
             TokenTypes.ANNOTATION_DEF,
+            TokenTypes.RECORD_DEF,
         };
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckTest.java
@@ -54,6 +54,7 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
             TokenTypes.CLASS_DEF,
             TokenTypes.ENUM_DEF,
             TokenTypes.ANNOTATION_DEF,
+            TokenTypes.RECORD_DEF,
         };
 
         assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
@@ -309,6 +310,27 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
         };
         verify(checkConfig,
             getPath("InputMissingJavadocTypeSkipAnnotations.java"),
+            expected);
+    }
+
+    @Test
+    public void testMissingJavadocTypeCheckRecords() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(MissingJavadocTypeCheck.class);
+        checkConfig.addAttribute("scope", "PRIVATE");
+        checkConfig.addAttribute("skipAnnotations", "NonNull1");
+
+        final String[] expected = {
+            "11:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "12:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "20:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "28:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "29:13: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "38:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            };
+        verify(checkConfig,
+            getNonCompilablePath("InputMissingJavadocTypeRecords.java"),
             expected);
     }
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeRecords.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeRecords.java
@@ -1,0 +1,38 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
+
+/* Config:
+ *
+ * scope = public
+ * excludeScope = null
+ * skipAnnotations = Generated
+ * tokens = {INTERFACE_DEF , CLASS_DEF , ENUM_DEF , ANNOTATION_DEF, RECORD_DEF}
+ */
+public record InputMissingJavadocTypeRecords() { // violation
+    class TestClass { // violation
+    }
+
+    //no javadoc here
+    record MyRecord1() { // violation
+
+    }
+
+    record MyRecord2(String myString) { // violation
+
+        public MyRecord2 {
+        }
+    }
+
+    @NonNull1
+    record MyRecord3(int x) { // ok due to annotation
+        protected record MyRecord4(int y) { // violation
+            private record MyRecord5(int z) { // violation
+
+            }
+
+
+        }
+    }
+}
+
+@interface NonNull1{} // violation

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -2657,6 +2657,8 @@ package com.checkstyle.api; // violation
                   ENUM_DEF</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
                   ANNOTATION_DEF</a>
+                , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+                  RECORD_DEF</a>
                   .
               </td>
               <td>
@@ -2668,6 +2670,8 @@ package com.checkstyle.api; // violation
                   ENUM_DEF</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_DEF">
                   ANNOTATION_DEF</a>
+                , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+                  RECORD_DEF</a>
                   .
               </td>
               <td>8.20</td>


### PR DESCRIPTION
Issue #8498: Full Records support check update for MissingJavadocTypeCheck

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/5f84eab1e6c2f1ffef90024fecc0658f/raw/3f0f3e4b677dd27bbe07959b1caba6475d514844/MissingJavadocType.xml