### PR TITLE
#8456: Full Records support check update for SuppressWarningsCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
@@ -97,7 +97,11 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
  * METHOD_DEF</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
- * CTOR_DEF</a>.
+ * CTOR_DEF</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
+ * COMPACT_CTOR_DEF</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+ * RECORD_DEF</a>.
  * </li>
  * </ul>
  * <p>
@@ -190,6 +194,8 @@ public class SuppressWarningsCheck extends AbstractCheck {
             TokenTypes.VARIABLE_DEF,
             TokenTypes.METHOD_DEF,
             TokenTypes.CTOR_DEF,
+            TokenTypes.COMPACT_CTOR_DEF,
+            TokenTypes.RECORD_DEF,
         };
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheckTest.java
@@ -1102,4 +1102,34 @@ public class SuppressWarningsCheckTest extends AbstractModuleTestSupport {
                 getNonCompilablePath("InputSuppressWarningsHolderNonConstant.java"), expected);
     }
 
+    @Test
+    public void testSuppressWarningsRecords() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(SuppressWarningsCheck.class);
+        checkConfig.addAttribute("format", "^unchecked$*|^unused$*|.*");
+
+        final String[] expected = {
+            "14:28: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, "unchecked"),
+            "14:41: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, "unused"),
+            "18:32: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, "unchecked"),
+            "18:45: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, ""),
+            "20:32: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, "   "),
+            "23:36: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, "unchecked"),
+            "23:49: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, ""),
+            "29:32: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, "unused"),
+            "32:36: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, "unforgiven"),
+            "32:50: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, "    un"),
+            "38:40: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, "unused"),
+            "43:32: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, "abcun"),
+            "50:31: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, ""),
+            "53:36: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, "unused"),
+            "53:46: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, "something else"),
+            "59:35: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, ""),
+            "62:36: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, "unchecked"),
+            "66:57: " + getCheckMessage(MSG_KEY_SUPPRESSED_WARNING_NOT_ALLOWED, "unchecked"),
+            };
+
+        verify(checkConfig,
+            getNonCompilablePath("InputSuppressWarningsRecords.java"), expected);
+    }
+
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarnings/InputSuppressWarningsRecords.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/annotation/suppresswarnings/InputSuppressWarningsRecords.java
@@ -1,0 +1,71 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.annotation.suppresswarnings;
+
+import java.lang.annotation.Documented;
+import java.util.HashMap;
+
+/* Config:
+ *
+ * format = "^unchecked$*|^unused$*|.*"
+ * tokens = {CLASS_DEF , INTERFACE_DEF , ENUM_DEF , ANNOTATION_DEF ,
+ * ANNOTATION_FIELD_DEF , ENUM_CONSTANT_DEF , PARAMETER_DEF ,
+ * VARIABLE_DEF , METHOD_DEF , CTOR_DEF, RECORD_DEF, COMPACT_CTOR_DEF}
+ */
+@SuppressWarnings(value = {"unchecked", "unused"}) // violation x2
+public record InputSuppressWarningsRecords
+        (String x) {
+
+    @SuppressWarnings(value = {"unchecked", ""}) // violation x2
+    public InputSuppressWarningsRecords{}
+    @SuppressWarnings(value = {"   "}) // violation
+    class Empty {
+
+        @SuppressWarnings(value = {"unchecked", ""}) // violation x2
+        public Empty() {
+
+        }
+    }
+
+    @SuppressWarnings(value = {"unused"}) // violation
+    enum Duh {
+
+        @SuppressWarnings(value = {"unforgiven", "    un"}) // violation x2
+        D;
+
+        public static void foo() {
+
+            Object myHashMap;
+            @SuppressWarnings(value = {"unused"}) int x = 42;  // violation
+
+        }
+    }
+
+    @SuppressWarnings(value = {"abcun"}) // violation
+    @Documented
+    @interface inter {
+        int cool();
+    }
+
+    @Documented
+    @SuppressWarnings(value = {}) // violation
+    @interface MoreSweetness {
+
+        @SuppressWarnings(value = {"unused", "something else"}) // violation x2
+        int cool();
+    }
+
+    public record MyRecord() {
+
+        @SuppressWarnings(value = {}) // violation
+        static int a = 1;
+
+        @SuppressWarnings(value = {"unchecked"}) // violation
+        @Deprecated
+        static int b = 1;
+
+        void doFoo(String s, @SuppressWarnings(value = {"unchecked"}) String y) { // violation
+
+        }
+    }
+
+}

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -1124,6 +1124,10 @@ package com.example.annotations.packageannotation; //ok
                     METHOD_DEF</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
                     CTOR_DEF</a>
+                , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
+                    COMPACT_CTOR_DEF</a>
+                , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+                    RECORD_DEF</a>
                   .
               </td>
 
@@ -1148,6 +1152,10 @@ package com.example.annotations.packageannotation; //ok
                     METHOD_DEF</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CTOR_DEF">
                     CTOR_DEF</a>
+                , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
+                    COMPACT_CTOR_DEF</a>
+                , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+                    RECORD_DEF</a>
                   .
               </td>
               <td>5.0</td>


### PR DESCRIPTION
#8456: Full Records support check update for SuppressWarningsCheck

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/539720a55feafa162cbecaa3175d7304/raw/237081cd7f8d93520e16563a387f1500894024be/SuppressWarnings.xml

Please note that commit https://github.com/checkstyle/checkstyle/pull/8752/commits/9794dca69cf8d8ab5645f6ec23c80191065ff6d6 is not under review here, but is needed for functionality of this check.