### PR TITLE
doc: rectify RequireEmptyLineBeforeBlockTagGroupCheck javadoc

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/RequireEmptyLineBeforeBlockTagGroupCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/RequireEmptyLineBeforeBlockTagGroupCheck.java
@@ -38,7 +38,8 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
  * if the Javadoc being examined by this check violates the tight html rules defined at
  * <a href="https://checkstyle.org/writingjavadocchecks.html#Tight-HTML_rules">
  * Tight-HTML Rules</a>.
- * Type is {@code boolean}. Default value is {@code false}.
+ * Type is {@code boolean}.
+ * Default value is {@code false}.
  * </li>
  * </ul>
  * <p>


### PR DESCRIPTION
RequireEmptyLineBeforeBlockTagGroupCheck property javadoc didnt follow the template required for metadata generation.