### PR TITLE
Issue #8754: PMD shows WARN during build

### DIFF
--- a/.ci/travis/travis.sh
+++ b/.ci/travis/travis.sh
@@ -710,6 +710,23 @@ checkstyle-cli-run-openjdk14)
   exit $RESULT
   ;;
 
+spotbugs-and-pmd)
+  mkdir -p .ci-temp/spotbugs-and-pmd
+  CHECKSTYLE_DIR=$(pwd)
+  export MAVEN_OPTS='-Xmx2000m'
+  mvn -e clean test-compile pmd:check spotbugs:check
+  cd .ci-temp/spotbugs-and-pmd
+  grep "Processing_Errors" "$CHECKSTYLE_DIR/target/site/pmd.html" | cat > errors.log
+  RESULT=$(cat errors.log | wc -l)
+  if [[ $RESULT != 0 ]]; then
+    echo "Errors are detected in target/site/pmd.html."
+    sleep 5s
+  fi
+  cd ..
+  removeFolderWithProtectedFiles spotbugs-and-pmd
+  exit "$RESULT"
+;;
+
 *)
   echo "Unexpected argument: $1"
   sleep 5s

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,21 +69,21 @@ jobs:
     - jdk: openjdk8
       env:
         - DESC="spotbugs,pmd"
-        - CMD="export MAVEN_OPTS='-Xmx2000m' && mvn -e clean test-compile pmd:check spotbugs:check"
+        - CMD="./.ci/travis/travis.sh spotbugs-and-pmd"
         - USE_MAVEN_REPO="true"
 
     # spotbugs and pmd (openjdk11)
     - jdk: openjdk11
       env:
         - DESC="spotbugs,pmd"
-        - CMD="export MAVEN_OPTS='-Xmx2000m' && mvn -e clean test-compile pmd:check spotbugs:check"
+        - CMD="./.ci/travis/travis.sh spotbugs-and-pmd"
         - USE_MAVEN_REPO="true"
 
     # spotbugs and pmd (openjdk14)
     - jdk: openjdk14
       env:
         - DESC="spotbugs,pmd"
-        - CMD="export MAVEN_OPTS='-Xmx2000m' && mvn -e clean test-compile pmd:check spotbugs:check"
+        - CMD="./.ci/travis/travis.sh spotbugs-and-pmd"
         - USE_MAVEN_REPO="true"
 
     # eclipse static analysis

--- a/config/pmd-test.xml
+++ b/config/pmd-test.xml
@@ -177,7 +177,7 @@
                value="//ClassOrInterfaceDeclaration[@SimpleName='AssertGeneratedJavaLexer']
                         //MethodDeclaration[@Name='LA']
                     | //ClassOrInterfaceDeclaration[@SimpleName='AssertGenTextBlockLexer']
-                     //MethodDeclaration[@Name='LA'"/>
+                     //MethodDeclaration[@Name='LA']"/>
     </properties>
   </rule>
 


### PR DESCRIPTION
Issue #8754: PMD shows WARN during build

This PR fixes the PMD warning produced during execution of the `ShortMethodName` rule while using the using the pmd-test.xml ruleset specified in pom.xml.

Proof of builds failed for PMD processing errors:
https://travis-ci.org/github/checkstyle/checkstyle/jobs/721051353
https://travis-ci.org/github/checkstyle/checkstyle/jobs/721051354
https://travis-ci.org/github/checkstyle/checkstyle/jobs/721051355