### PR TITLE
Issue #6916: enable parallel execution of unit tests

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -89,6 +89,7 @@
   <suppress checks="ClassFanOutComplexity" files="CheckstyleAntTask\.java"/>
   <suppress checks="ClassFanOutComplexity" files="CheckerTest\.java"/>
   <suppress checks="ClassFanOutComplexity" files="Checker\.java"/>
+  <suppress checks="ClassFanOutComplexity" files="XdocsPagesTest\.java"/>
   <!-- a lot of GUI elements is OK -->
   <suppress checks="ClassDataAbstractionCoupling" files="(TreeTable|MainFrame)\.java"/>
 

--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,8 @@
     <pitest.junit5.plugin.version>0.10</pitest.junit5.plugin.version>
     <sonar.test.exclusions>**/test/resources/**/*,**/it/resources/**/*</sonar.test.exclusions>
     <junit.version>5.7.0</junit.version>
+    <junit.parallel.mode>same_thread</junit.parallel.mode>
+    <junit.parallel.mode.classes>same_thread</junit.parallel.mode.classes>
   </properties>
 
   <dependencies>
@@ -1331,6 +1333,13 @@
             <include>com/google/**/*.java</include>
             <include>org/checkstyle/**/*.java</include>
           </includes>
+          <properties>
+            <configurationParameters>
+              junit.jupiter.execution.parallel.enabled = true
+              junit.jupiter.execution.parallel.mode.default = ${junit.parallel.mode}
+              junit.jupiter.execution.parallel.mode.classes.default = ${junit.parallel.mode.classes}
+            </configurationParameters>
+          </properties>
         </configuration>
         <executions>
           <execution>
@@ -1366,6 +1375,13 @@
           <includes>
             <include>com/puppycrawl/**/*.java</include>
           </includes>
+          <properties>
+            <configurationParameters>
+              junit.jupiter.execution.parallel.enabled = true
+              junit.jupiter.execution.parallel.mode.default = ${junit.parallel.mode}
+              junit.jupiter.execution.parallel.mode.classes.default = ${junit.parallel.mode.classes}
+            </configurationParameters>
+          </properties>
         </configuration>
       </plugin>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -60,6 +60,7 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
@@ -92,9 +93,11 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
  * CheckerTest.
+ * This test should be run isolated as it changes the global state (locale settings, class loader).
  *
  * @noinspection ClassWithTooManyDependencies
  */
+@Isolated
 public class CheckerTest extends AbstractModuleTestSupport {
 
     @TempDir

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGeneratorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGeneratorTest.java
@@ -38,12 +38,18 @@ import org.itsallcode.junit.sysextensions.SystemOutGuard.SysOut;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import antlr.MismatchedTokenException;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
+/**
+ * Test for CLI wrapper for the Checker.
+ * This test should be run isolated as it changes the global state (output handler).
+ */
 @ExtendWith({SystemErrGuard.class, SystemOutGuard.class})
+@Isolated
 public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
 
     private static final String EOL = System.lineSeparator();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -60,6 +60,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.api.AuditListener;
@@ -69,7 +70,13 @@ import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.internal.testmodules.TestRootModuleChecker;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
+/**
+ * Test for CLI wrapper for the Checker.
+ * This test should be run isolated as it changes the global state (output handler,
+ * locale settings, class loader).
+ */
 @ExtendWith({ExitGuard.class, SystemErrGuard.class, SystemOutGuard.class})
+@Isolated
 public class MainTest {
 
     private static final String SHORT_USAGE = String.format(Locale.ROOT,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListenerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAuditListenerTest.java
@@ -31,6 +31,7 @@ import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
@@ -47,6 +48,10 @@ import com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCheck;
 import com.puppycrawl.tools.checkstyle.internal.utils.CloseAndFlushTestByteArrayOutputStream;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
+/**
+ * This test should be run isolated as it changes the global state (output handler).
+ */
+@Isolated
 public class XpathFileGeneratorAuditListenerTest {
 
     /** OS specific line separator. */

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/LocalizedMessageTest.java
@@ -43,6 +43,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junitpioneer.jupiter.DefaultLocale;
 import org.powermock.reflect.Whitebox;
 
@@ -53,9 +54,11 @@ import nl.jqno.equalsverifier.EqualsVerifierReport;
  * Custom class loader is needed to pass URLs to pretend these are loaded from the classpath
  * though we can't add/change the files for testing. The class loader is nested in this class,
  * so the custom class loader we are using is safe.
+ * This test should be run isolated as it changes the global state (locale settings, class loader).
  *
  * @noinspection ClassLoaderInstantiation
  */
+@Isolated
 public class LocalizedMessageTest {
 
     private static final Locale DEFAULT_LOCALE = Locale.getDefault();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/ScopeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/ScopeTest.java
@@ -26,11 +26,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junitpioneer.jupiter.DefaultLocale;
 
 /**
  * Test cases for {@link Scope} enumeration.
+ * This test should be run isolated as it changes the global state (locale settings).
  */
+@Isolated
 public class ScopeTest {
 
     /* Additional test for jacoco, since valueOf()

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/SeverityLevelTest.java
@@ -24,11 +24,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junitpioneer.jupiter.DefaultLocale;
 
 /**
  * Test cases for {@link SeverityLevel} enumeration.
+ * This test should be run isolated as it changes the global state (locale settings).
  */
+@Isolated
 public class SeverityLevelTest {
 
     /* Additional test for jacoco, since valueOf()

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
@@ -43,6 +43,7 @@ import java.util.TreeSet;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.powermock.reflect.Whitebox;
 
 import com.google.common.collect.ImmutableMap;
@@ -59,6 +60,10 @@ import com.puppycrawl.tools.checkstyle.api.MessageDispatcher;
 import com.puppycrawl.tools.checkstyle.internal.utils.XmlUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
+/**
+ * This test should be run isolated as it changes the global state (locale settings).
+ */
+@Isolated
 public class TranslationCheckTest extends AbstractXmlTestSupport {
 
     @TempDir

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -54,7 +55,11 @@ import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 
+/**
+ * This test should be run isolated as it changes the global state (output handler).
+ */
 @ExtendWith(SystemErrGuard.class)
+@Isolated
 public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
 
     @TempDir

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -67,6 +67,7 @@ import java.util.stream.Stream;
 
 import org.apache.commons.beanutils.PropertyUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -90,6 +91,10 @@ import com.puppycrawl.tools.checkstyle.internal.utils.XdocUtil;
 import com.puppycrawl.tools.checkstyle.internal.utils.XmlUtil;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
+/**
+ * This test should be run isolated as it changes the global state (locale settings).
+ */
+@Isolated
 public class XdocsPagesTest {
 
     private static final Path AVAILABLE_CHECKS_PATH = Paths.get("src/xdocs/checks.xml");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/AuditEventDefaultFormatterPowerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/AuditEventDefaultFormatterPowerTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 import org.junit.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -33,6 +34,10 @@ import com.puppycrawl.tools.checkstyle.AuditEventFormatter;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
 
+/**
+ * This test should be run isolated as it uses Powermock.
+ */
+@Isolated
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(AuditEvent.class)
 public class AuditEventDefaultFormatterPowerTest {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/CheckstyleAntTaskPowerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/CheckstyleAntTaskPowerTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.junit.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -46,6 +47,10 @@ import com.puppycrawl.tools.checkstyle.Definitions;
 import com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 
+/**
+ * This test should be run isolated as it uses Powermock.
+ */
+@Isolated
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(CheckstyleAntTask.class)
 public class CheckstyleAntTaskPowerTest extends AbstractPathTestSupport {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/CommonUtilPowerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/CommonUtilPowerTest.java
@@ -30,6 +30,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 
 import org.junit.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -39,6 +40,10 @@ import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtilTest;
 
+/**
+ * This test should be run isolated as it uses Powermock.
+ */
+@Isolated
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ CommonUtil.class, CommonUtilTest.class })
 public class CommonUtilPowerTest {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/ConfigurationLoaderPowerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/ConfigurationLoaderPowerTest.java
@@ -26,6 +26,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 import java.util.Properties;
 
 import org.junit.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -39,6 +40,10 @@ import com.puppycrawl.tools.checkstyle.PropertiesExpander;
 import com.puppycrawl.tools.checkstyle.ThreadModeSettings;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 
+/**
+ * This test should be run isolated as it uses Powermock.
+ */
+@Isolated
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({DefaultConfiguration.class, ConfigurationLoader.class})
 public class ConfigurationLoaderPowerTest extends AbstractPathTestSupport {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/DefaultLoggerPowerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/DefaultLoggerPowerTest.java
@@ -29,6 +29,7 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import com.puppycrawl.tools.checkstyle.DefaultLogger;
 import com.puppycrawl.tools.checkstyle.Definitions;
@@ -37,6 +38,10 @@ import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
+/**
+ * This test should be run isolated as it uses Powermock.
+ */
+@Isolated
 public class DefaultLoggerPowerTest {
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/HeaderCheckPowerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/HeaderCheckPowerTest.java
@@ -27,6 +27,7 @@ import static org.mockito.ArgumentMatchers.any;
 import java.io.IOException;
 
 import org.junit.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -37,6 +38,10 @@ import com.puppycrawl.tools.checkstyle.checks.header.AbstractHeaderCheck;
 import com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck;
 import com.puppycrawl.tools.checkstyle.checks.header.HeaderCheckTest;
 
+/**
+ * This test should be run isolated as it uses Powermock.
+ */
+@Isolated
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ HeaderCheck.class, HeaderCheckTest.class, AbstractHeaderCheck.class })
 public class HeaderCheckPowerTest extends AbstractModuleTestSupport {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/ImportControlLoaderPowerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/ImportControlLoaderPowerTest.java
@@ -28,6 +28,7 @@ import java.net.URI;
 import java.net.URL;
 
 import org.junit.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.runner.RunWith;
 import org.mockito.BDDMockito;
 import org.mockito.Mockito;
@@ -39,6 +40,10 @@ import org.xml.sax.SAXParseException;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.checks.imports.ImportControlLoader;
 
+/**
+ * This test should be run isolated as it uses Powermock.
+ */
+@Isolated
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ImportControlLoader.class, URI.class})
 public class ImportControlLoaderPowerTest {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/JavadocPackageCheckPowerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/JavadocPackageCheckPowerTest.java
@@ -25,12 +25,17 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 
 import org.junit.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocPackageCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
+/**
+ * This test should be run isolated as it uses Powermock.
+ */
+@Isolated
 public class JavadocPackageCheckPowerTest extends AbstractModuleTestSupport {
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/MainFrameModelPowerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/MainFrameModelPowerTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -40,6 +41,10 @@ import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.gui.MainFrameModel;
 import com.puppycrawl.tools.checkstyle.gui.MainFrameModel.ParseMode;
 
+/**
+ * This test should be run isolated as it uses Powermock.
+ */
+@Isolated
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(ParseMode.class)
 public class MainFrameModelPowerTest extends AbstractModuleTestSupport {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/MainPowerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/MainPowerTest.java
@@ -28,6 +28,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.SystemErrRule;
 import org.junit.contrib.java.lang.system.SystemOutRule;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -35,6 +36,10 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import com.puppycrawl.tools.checkstyle.Main;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
+/**
+ * This test should be run isolated as it uses Powermock.
+ */
+@Isolated
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Main.class, CommonUtil.class})
 public class MainPowerTest {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/PackageObjectFactoryPowerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/PackageObjectFactoryPowerTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.junit.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
@@ -41,6 +42,10 @@ import org.powermock.reflect.Whitebox;
 import com.puppycrawl.tools.checkstyle.PackageObjectFactory;
 import com.puppycrawl.tools.checkstyle.utils.ModuleReflectionUtil;
 
+/**
+ * This test should be run isolated as it uses Powermock.
+ */
+@Isolated
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore(value = "com.puppycrawl.tools.checkstyle.api.*", globalIgnore = false)
 @PrepareForTest(ModuleReflectionUtil.class)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/PropertyCacheFilePowerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/PropertyCacheFilePowerTest.java
@@ -45,6 +45,7 @@ import java.util.Set;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -58,6 +59,10 @@ import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
+/**
+ * This test should be run isolated as it uses Powermock.
+ */
+@Isolated
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ PropertyCacheFile.class, ByteStreams.class,
         CommonUtil.class})

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/RegexpOnFilenameCheckPowerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/RegexpOnFilenameCheckPowerTest.java
@@ -25,12 +25,17 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 
 import org.junit.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.checks.regexp.RegexpOnFilenameCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
+/**
+ * This test should be run isolated as it uses Powermock.
+ */
+@Isolated
 public class RegexpOnFilenameCheckPowerTest extends AbstractModuleTestSupport {
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/TreeWalkerPowerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/TreeWalkerPowerTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -46,6 +47,10 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.checks.indentation.CommentsIndentationCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.TypeNameCheck;
 
+/**
+ * This test should be run isolated as it uses Powermock.
+ */
+@Isolated
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(TreeWalker.class)
 public class TreeWalkerPowerTest extends AbstractModuleTestSupport {


### PR DESCRIPTION
Issue #6916

Test execution mode set to same_thread (sequential) by default.

(add this to wiki) To enable parallel execution run `mvn verify -Djunit.parallel.mode=concurrent` or `mvn verify -Djunit.parallel.mode.classes=concurrent`

Some tests that changes the global state (and may affect all other tests) are excplicitly marked as `@Isolated`.
All powermock-based tests still use JUnit4 and run sequentially.
