### PR TITLE
Issue #8785: Set tokenTypesSet as validationType for non base token properties

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java
@@ -44,7 +44,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <li>
  * Property {@code limitedTokens} - Specify set of tokens with limited occurrences as descendants.
  * Type is {@code java.lang.String[]}.
- * Validation type is {@code tokenSet}.
+ * Validation type is {@code tokenTypesSet}.
  * Default value is {@code ""}.
  * </li>
  * <li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -118,7 +118,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <li>
  * Property {@code tokens} - tokens to check
  * Type is {@code java.lang.String[]}.
- * Validation type is {@code tokenSet}.
+ * Validation type is {@code tokenTypesSet}.
  * Default value is:
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#ANNOTATION_FIELD_DEF">
  * ANNOTATION_FIELD_DEF</a>,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
@@ -81,7 +81,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * Property {@code constantWaiverParentToken} - Specify tokens that are allowed in the AST path
  * from the number literal to the enclosing constant definition.
  * Type is {@code java.lang.String[]}.
- * Validation type is {@code tokenSet}.
+ * Validation type is {@code tokenTypesSet}.
  * Default value is
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TYPECAST">
  * TYPECAST</a>,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
@@ -58,7 +58,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * strings are ignored even if they don't match ignoredStringsRegexp. This allows you to
  * exclude syntactical contexts like annotations or static initializers from the check.
  * Type is {@code java.lang.String[]}.
- * Validation type is {@code tokenSet}.
+ * Validation type is {@code tokenTypesSet}.
  * Default value is {@code ANNOTATION}.
  * </li>
  * </ul>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
@@ -52,7 +52,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <li>
  * Property {@code target} - Specify the list of targets to check at-clauses.
  * Type is {@code java.lang.String[]}.
- * Validation type is {@code tokenSet}.
+ * Validation type is {@code tokenTypesSet}.
  * Default value is
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#CLASS_DEF">
  * CLASS_DEF</a>,

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/DescendantTokenCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/DescendantTokenCheck.xml
@@ -19,7 +19,7 @@
             <property default-value=""
                       name="limitedTokens"
                       type="java.lang.String[]"
-                      validation-type="tokenSet">
+                      validation-type="tokenTypesSet">
                <description>Specify set of tokens with limited occurrences as descendants.</description>
             </property>
             <property default-value="0" name="minimumDepth" type="int">

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/IllegalTypeCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/IllegalTypeCheck.xml
@@ -85,7 +85,7 @@
             <property default-value="ANNOTATION_FIELD_DEF,CLASS_DEF,INTERFACE_DEF,METHOD_CALL,METHOD_DEF,METHOD_REF,PARAMETER_DEF,VARIABLE_DEF,PATTERN_VARIABLE_DEF,RECORD_DEF,RECORD_COMPONENT_DEF"
                       name="tokens"
                       type="java.lang.String[]"
-                      validation-type="tokenSet">
+                      validation-type="tokenTypesSet">
                <description>tokens to check</description>
             </property>
          </properties>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/MagicNumberCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/MagicNumberCheck.xml
@@ -44,7 +44,7 @@
             <property default-value="TYPECAST,METHOD_CALL,EXPR,ARRAY_INIT,UNARY_MINUS,UNARY_PLUS,ELIST,STAR,ASSIGN,PLUS,MINUS,DIV,LITERAL_NEW"
                       name="constantWaiverParentToken"
                       type="java.lang.String[]"
-                      validation-type="tokenSet">
+                      validation-type="tokenTypesSet">
                <description>Specify tokens that are allowed in the AST path
  from the number literal to the enclosing constant definition.</description>
             </property>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/MultipleStringLiteralsCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/MultipleStringLiteralsCheck.xml
@@ -24,7 +24,7 @@
             <property default-value="ANNOTATION"
                       name="ignoreOccurrenceContext"
                       type="java.lang.String[]"
-                      validation-type="tokenSet">
+                      validation-type="tokenTypesSet">
                <description>Specify token type names where duplicate
  strings are ignored even if they don't match ignoredStringsRegexp. This allows you to
  exclude syntactical contexts like annotations or static initializers from the check.</description>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/AtclauseOrderCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/AtclauseOrderCheck.xml
@@ -23,7 +23,7 @@
             <property default-value="CLASS_DEF,INTERFACE_DEF,ENUM_DEF,METHOD_DEF,CTOR_DEF,VARIABLE_DEF,RECORD_DEF,COMPACT_CTOR_DEF"
                       name="target"
                       type="java.lang.String[]"
-                      validation-type="tokenSet">
+                      validation-type="tokenTypesSet">
                <description>Specify the list of targets to check at-clauses.</description>
             </property>
             <property default-value="@author, @deprecated, @exception, @param, @return, @see, @serial, @serialData, @serialField, @since, @throws, @version"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -121,6 +121,15 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
             "SuppressionXpathSingleFilter - message",
         }).collect(Collectors.toSet()));
 
+    private static final Set<String> NON_BASE_TOKEN_PROPERTIES = Collections.unmodifiableSet(
+        Arrays.stream(new String[] {
+            "AtclauseOrder - target",
+            "DescendantToken - limitedTokens",
+            "IllegalType - tokens",
+            "MagicNumber - constantWaiverParentToken",
+            "MultipleStringLiterals - ignoreOccurrenceContext",
+        }).collect(Collectors.toSet()));
+
     private static final List<List<Node>> CHECK_PROPERTIES = new ArrayList<>();
     private static final Map<String, String> CHECK_PROPERTY_DOC = new HashMap<>();
     private static final Map<String, String> CHECK_TEXT = new HashMap<>();
@@ -323,11 +332,9 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
             }
             result.append(" Type is {@code ").append(typeText).append("}.");
 
-            if (isPropertyTokenType) {
-                result.append(" Validation type is {@code tokenSet}.");
-            }
-            else if (PATTERN_EXCEPTIONS.contains(checkName + " - " + propertyName)) {
-                result.append(" Validation type is {@code java.util.regex.Pattern}.");
+            final String validationType = getValidationType(isPropertyTokenType, propertyName);
+            if (validationType != null) {
+                result.append(validationType);
             }
 
             if (propertyName.endsWith("token") || propertyName.endsWith("tokens")) {
@@ -349,6 +356,20 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
         result.append("\n</ul>");
 
         return result.toString();
+    }
+
+    private static String getValidationType(boolean isPropertyTokenType, String propertyName) {
+        String result = null;
+        if (NON_BASE_TOKEN_PROPERTIES.contains(checkName + " - " + propertyName)) {
+            result = " Validation type is {@code tokenTypesSet}.";
+        }
+        else if (PATTERN_EXCEPTIONS.contains(checkName + " - " + propertyName)) {
+            result = " Validation type is {@code java.util.regex.Pattern}.";
+        }
+        else if (isPropertyTokenType) {
+            result = " Validation type is {@code tokenSet}.";
+        }
+        return result;
     }
 
     private static String emptyStringArrayDefaultValue(Node defaultValueNode) {


### PR DESCRIPTION
#8785 

`AtclauseOrderCheck` is now working in Sonarqube plugin:
<img width="1013" alt="Screenshot 2020-09-05 at 3 53 41 AM" src="https://user-images.githubusercontent.com/23253816/92288935-688ea600-ef2c-11ea-9767-7a190567db5c.png">
