### PR TITLE
 force compile package-info.java which will make build fast by Incremental Compilation

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -1480,6 +1480,7 @@ xpathfilter
 xpathfilterelement
 xpathmapper
 xpathquerygenerator
+Xpkginfo
 xright
 xsd
 Xshow

--- a/pom.xml
+++ b/pom.xml
@@ -716,6 +716,12 @@
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>
+          <compilerArgs>
+            <!-- always compile package-info.java for useIncrementalCompilation
+            ref: https://stackoverflow.com/questions/6770455/maven-compiling-package-info-java-to-package-info-class
+            -->
+            <compilerArg>-Xpkginfo:always</compilerArg>
+          </compilerArgs>
         </configuration>
         <!-- till https://github.com/checkstyle/checkstyle/issues/2160
         <executions>


### PR DESCRIPTION
add compilerArg `-Xpkginfo:always` for useIncrementalCompilation which make build fast

useIncrementalCompilation will not work for some java not compiled (package-info.java).
try `mvn package -X ` will find thest files by key word "recompiling the module!"

maven will not compile package-info.java without any annotation with Retention=RUNTIME

ref:
https://stackoverflow.com/questions/6770455/maven-compiling-package-info-java-to-package-info-class
https://github.com/jenkinsci/jenkins/pull/4759


