### PR TITLE
skip jacoco with maven test skipped

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,8 @@
     <pitest.junit5.plugin.version>0.10</pitest.junit5.plugin.version>
     <sonar.test.exclusions>**/test/resources/**/*,**/it/resources/**/*</sonar.test.exclusions>
     <junit.version>5.6.2</junit.version>
+    <skipTests>${maven.test.skip}</skipTests>
+    <jacoco.skip>${skipTests}</jacoco.skip>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
when `-Dmaven.test.skip` is set, there is no reason of `-DskipTests` to have different value, AND jacoco plugin goal should be skipped.

https://stackoverflow.com/a/21933970/1015848