### PR TITLE
support force load config on classpath by "classpath:" prefix (like spring)

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -187,8 +187,9 @@ pitest-tree-walker)
 pitest-utils)
   mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;
   declare -a ignoredItems=(
-  "CommonUtil.java.html:<td class='uncovered'><pre><span  class=''>                catch (final URISyntaxException ex) {</span></pre></td></tr>"
-  "CommonUtil.java.html:<td class='uncovered'><pre><span  class='survived'>                    throw new CheckstyleException(UNABLE_TO_FIND_EXCEPTION_PREFIX + filename, ex);</span></pre></td></tr>"
+  "CommonUtil.java.html:<td class='uncovered'><pre><span  class=''>        catch (final URISyntaxException ex) {</span></pre></td></tr>"
+  "CommonUtil.java.html:<td class='covered'><pre><span  class='survived'>            if (filename.charAt(0) != &#39;/&#39;) {</span></pre></td></tr>"
+  "CommonUtil.java.html:<td class='uncovered'><pre><span  class='survived'>            throw new CheckstyleException(UNABLE_TO_FIND_EXCEPTION_PREFIX + filename, ex);</span></pre></td></tr>"
   );
   checkPitestReport "${ignoredItems[@]}"
   ;;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
@@ -75,6 +75,9 @@ public final class CommonUtil {
     /** Symbols with which multiple comment ends. */
     private static final String BLOCK_MULTIPLE_COMMENT_END = "*/";
 
+    /** Pseudo URL prefix for loading from the class path: "classpath:". */
+    private static final String CLASSPATH_URL_PREFIX = "classpath:";
+
     /** Stop instances being created. **/
     private CommonUtil() {
     }
@@ -498,44 +501,55 @@ public final class CommonUtil {
      * @return resolved header file URI
      * @throws CheckstyleException on failure
      */
-    public static URI getUriByFilename(String filename) throws CheckstyleException {
+    public static URI getUriByFilename(final String filename) throws CheckstyleException {
         // figure out if this is a File or a URL
-        URI uri;
-        try {
-            final URL url = new URL(filename);
-            uri = url.toURI();
+        URI uri = null;
+        if (filename.startsWith(CLASSPATH_URL_PREFIX)) {
+            final String path = filename.substring(CLASSPATH_URL_PREFIX.length());
+            uri = toUri(path);
         }
-        catch (final URISyntaxException | MalformedURLException ignored) {
-            uri = null;
-        }
-
-        if (uri == null) {
-            final File file = new File(filename);
-            if (file.exists()) {
-                uri = file.toURI();
-            }
-            else {
-                // check to see if the file is in the classpath
+        else {
+            if (filename.charAt(0) != '/') {
                 try {
-                    final URL configUrl;
-                    if (filename.charAt(0) == '/') {
-                        configUrl = CommonUtil.class.getResource(filename);
-                    }
-                    else {
-                        configUrl = ClassLoader.getSystemResource(filename);
-                    }
-                    if (configUrl == null) {
-                        throw new CheckstyleException(UNABLE_TO_FIND_EXCEPTION_PREFIX + filename);
-                    }
-                    uri = configUrl.toURI();
+                    final URL url = new URL(filename);
+                    uri = url.toURI();
                 }
-                catch (final URISyntaxException ex) {
-                    throw new CheckstyleException(UNABLE_TO_FIND_EXCEPTION_PREFIX + filename, ex);
+                catch (final URISyntaxException | MalformedURLException ignored) {
+                    // ignored
+                }
+            }
+            if (uri == null) {
+                final File file = new File(filename);
+                if (file.exists()) {
+                    uri = file.toURI();
+                }
+                else {
+                    uri = toUri(filename);
                 }
             }
         }
 
         return uri;
+    }
+
+    private static URI toUri(final String filename) throws CheckstyleException {
+        // check to see if the file is in the classpath
+        try {
+            final URL configUrl;
+            if (filename.charAt(0) == '/') {
+                configUrl = CommonUtil.class.getResource(filename);
+            }
+            else {
+                configUrl = ClassLoader.getSystemResource(filename);
+            }
+            if (configUrl == null) {
+                throw new CheckstyleException(UNABLE_TO_FIND_EXCEPTION_PREFIX + filename);
+            }
+            return configUrl.toURI();
+        }
+        catch (final URISyntaxException ex) {
+            throw new CheckstyleException(UNABLE_TO_FIND_EXCEPTION_PREFIX + filename, ex);
+        }
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilTest.java
@@ -45,6 +45,7 @@ import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
@@ -474,6 +475,69 @@ public class CommonUtilTest extends AbstractPathTestSupport {
         final String content = IOUtils.toString(uri.toURL(), StandardCharsets.UTF_8);
         assertThat("Content mismatches for: " + uri,
                 content, startsWith("good"));
+    }
+
+    @Test
+    public void testGetUriByFilenameOnNotFound() {
+        final String filename = "/XXXX/InputCommonUtilTest_empty_checks.xml";
+        try {
+            CommonUtil.getUriByFilename(filename);
+            fail("CheckstyleException is expected");
+        }
+        catch (CheckstyleException expected) {
+            assertSame(CheckstyleException.class,
+                expected.getClass(), "Invalid exception cause");
+        }
+    }
+
+    @Test
+    public void testGetUriByFilenameOnErrorUrl() {
+        final String filename = "XXXX://InputCommonUtilTest_empty_checks.xml";
+        try {
+            CommonUtil.getUriByFilename(filename);
+            fail("CheckstyleException is expected");
+        }
+        catch (CheckstyleException expected) {
+            assertSame(CheckstyleException.class,
+                expected.getClass(), "Invalid exception cause");
+        }
+    }
+
+    @Test
+    public void testGetUriByFilenameByClasspathPrefix() throws CheckstyleException {
+        final String filename =
+            "classpath:/" + getPackageLocation() + "/InputCommonUtilTest_empty_checks.xml";
+        final URI uri = CommonUtil.getUriByFilename(filename);
+        assertThat("URI is null for: " + filename, uri, is(not(nullValue())));
+    }
+
+    @Test
+    public void testGetUriByFilenameByClasspathPrefixRelative() throws CheckstyleException {
+        final String filename =
+            "classpath:" + getPackageLocation() + "/InputCommonUtilTest_empty_checks.xml";
+        final URI uri = CommonUtil.getUriByFilename(filename);
+        assertThat("URI is null for: " + filename, uri, is(not(nullValue())));
+    }
+
+    @Test
+    public void testGetUriByFilenameByClasspathPrefixNotFound() {
+        final String filename = "classpath:/XXXX/InputCommonUtilTest_empty_checks.xml";
+        try {
+            CommonUtil.getUriByFilename(filename);
+            fail("CheckstyleException is expected");
+        }
+        catch (CheckstyleException expected) {
+            assertSame(CheckstyleException.class,
+                expected.getClass(), "Invalid exception cause");
+        }
+        try {
+            CommonUtil.getUriByFilename("classpath:XXXX/InputCommonUtilTest_empty_checks.xml");
+            fail("CheckstyleException is expected");
+        }
+        catch (CheckstyleException expected) {
+            assertSame(CheckstyleException.class,
+                expected.getClass(), "Invalid exception cause");
+        }
     }
 
     private static class TestCloseable implements Closeable {

--- a/src/xdocs/property_types.xml
+++ b/src/xdocs/property_types.xml
@@ -932,9 +932,11 @@
       <p>
         This type represents a URI. The string representation is parsed using a custom
         routine to analyze what type of URI the string is.
-        It can be a URL, regular file, or a resource path. It will try loading the path as
-        a URL first, then as a file that must exist, and then finally as a resource on the
-        classpath.
+        It can be a URL, regular file, or a resource path.
+        If it's with prefix 'classpath:' means load from classpath only.
+        If it's start with '/', then skip the URL check.
+        Then it will try loading the path as a URL first,
+        then as a file that must exist, and then finally as a resource on the classpath.
       </p>
     </section>
 


### PR DESCRIPTION
 and if start with '/' then skip URL logic

