### PR TITLE
CheckstyleAntTask support force localeLanguage so the tests can passed on os with non-english locale(ie:zh_CN)

### DIFF
--- a/config/ant-phase-verify.xml
+++ b/config/ant-phase-verify.xml
@@ -30,6 +30,7 @@
                 failOnViolation="false"
                 failureProperty="checkstyle.failure.property"
                 executeIgnoredModules="true"
+                localeLanguage="en"
                 >
       <fileset dir="src"
                includes="**/*"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java
@@ -116,6 +116,9 @@ public class CheckstyleAntTask extends Task {
      */
     private boolean executeIgnoredModules;
 
+    /** Locale language to report messages . **/
+    private String localeLanguage;
+
     ////////////////////////////////////////////////////////////////////////////
     // Setters for ANT specific attributes
     ////////////////////////////////////////////////////////////////////////////
@@ -138,6 +141,15 @@ public class CheckstyleAntTask extends Task {
      */
     public void setFailOnViolation(boolean fail) {
         failOnViolation = fail;
+    }
+
+    /**
+     * Sets locale language.
+     *
+     * @param localeLanguage the language to report messages
+     */
+    public void setLocaleLanguage(String localeLanguage) {
+        this.localeLanguage = localeLanguage;
     }
 
     /**
@@ -283,6 +295,9 @@ public class CheckstyleAntTask extends Task {
     public void execute() {
         final long startTime = System.currentTimeMillis();
 
+        if (localeLanguage != null) {
+            Locale.setDefault(new Locale(localeLanguage));
+        }
         try {
             final String version = CheckstyleAntTask.class.getPackage().getImplementationVersion();
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -37,6 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
@@ -95,6 +96,17 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         antTask.execute();
 
         assertTrue(TestRootModuleChecker.isProcessed(), "Checker is not processed");
+    }
+
+    @Test
+    public final void testNonEnglishLocale() throws IOException {
+        TestRootModuleChecker.reset();
+        final CheckstyleAntTask antTask = getCheckstyleAntTask(CUSTOM_ROOT_CONFIG_FILE);
+        antTask.setFile(new File(getPath(WARNING_INPUT)));
+        final String language = "zh";
+        antTask.setLocaleLanguage(language);
+        antTask.execute();
+        assertEquals(new Locale(language), Locale.getDefault(), "setLocaleLanguage not work!");
     }
 
     @Test


### PR DESCRIPTION
* without the feature, before build, we should set ENV by  `_JAVA_OPTIONS=-Duser.language=en` or `MAVEN_OPTS=-Duser.language=en`  on non-english os, otherwise the ant-phase-verify will failed(cause the default locale is not english)

* `-Duser.language=en` on mvn commandline will not work, but on _JAVA_OPTIONS OR MAVEN_OPTS will work.