### PR TITLE
PropertiesExpander init support property resolver

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java
@@ -21,8 +21,12 @@ package com.puppycrawl.tools.checkstyle;
 
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Resolves external properties from an
@@ -31,6 +35,8 @@ import java.util.Properties;
  */
 public final class PropertiesExpander
     implements PropertyResolver {
+    /** Var expression pattern, ie: ${config_loc}. */
+    private static final Pattern VAR_EXPR_PATTERN = Pattern.compile("\\$\\{([^\\s}]+)}");
 
     /** The underlying values. */
     private final Map<String, String> values;
@@ -49,8 +55,28 @@ public final class PropertiesExpander
         values = new HashMap<>(properties.size());
         for (Enumeration<?> e = properties.propertyNames(); e.hasMoreElements();) {
             final String name = (String) e.nextElement();
-            values.put(name, properties.getProperty(name));
+            String value = properties.getProperty(name);
+            value = resolveValue(properties, name, value, new HashSet<>());
+            values.put(name, value);
         }
+    }
+
+    private static String resolveValue(Properties properties, String name,
+            String value, Set<String> resolveKeys) {
+        String result = value;
+        final Matcher matcher = VAR_EXPR_PATTERN.matcher(value);
+        if (matcher.find()) {
+            resolveKeys.add(name);
+            final String key = matcher.group(1);
+            String keyValue = properties.getProperty(key);
+            if (keyValue != null) {
+                if (!resolveKeys.contains(key)) {
+                    keyValue = resolveValue(properties, key, keyValue, resolveKeys);
+                }
+                result = matcher.replaceFirst(Matcher.quoteReplacement(keyValue));
+            }
+        }
+        return result;
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertiesExpanderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertiesExpanderTest.java
@@ -57,4 +57,29 @@ public class PropertiesExpanderTest {
                 "Invalid checkstyle property");
     }
 
+    @Test
+    public void testVarExpressionProperties() {
+        final Properties properties = new Properties();
+        properties.setProperty("var1", "v1");
+        properties.setProperty("test", "${var1}/checkstyle");
+        properties.setProperty("test2", "${var2}");
+        properties.setProperty("test3", "${var1}/checkstyle");
+        properties.setProperty("var4", "${var5}");
+        properties.setProperty("var5", "${var4}");
+        final PropertiesExpander expander = new PropertiesExpander(properties);
+        assertEquals(properties.getProperty("var1"), expander.resolve("var1"),
+                "Invalid var1 property");
+
+        assertEquals(properties.getProperty("var1") + "/checkstyle", expander.resolve("test"),
+                "Invalid test property");
+        assertEquals(properties.getProperty("test2"), expander.resolve("test2"),
+                "Invalid tet2 property");
+        assertEquals("v1/checkstyle", expander.resolve("test3"),
+                "Invalid test3 property");
+        assertEquals("${var5}", expander.resolve("var4"),
+                "Invalid var4 property");
+        assertEquals(properties.getProperty("var5"), expander.resolve("var5"),
+            "Invalid var4 property");
+
+    }
 }


### PR DESCRIPTION
so we an using expression (ie:${basedir}) in checkstyle.properties
