### PR TITLE
Issue #8779: Fix false positive for switch expressions in MissingSwitchDefault

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheck.java
@@ -35,7 +35,10 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * cases are covered, this should be expressed in the
  * default branch, e.g. by using an assertion. This way
  * the code is protected against later changes, e.g.
- * introduction of new types in an enumeration type.
+ * introduction of new types in an enumeration type. Note that
+ * the compiler requires switch expressions to be exhaustive,
+ * so this check does not enforce default branches on
+ * such expressions.
  * </p>
  * <p>
  * To configure the check:
@@ -105,7 +108,7 @@ public class MissingSwitchDefaultCheck extends AbstractCheck {
     public void visitToken(DetailAST ast) {
         final DetailAST firstSwitchMemberAst = findFirstSwitchMember(ast);
 
-        if (!containsDefaultSwitch(firstSwitchMemberAst)) {
+        if (!containsDefaultSwitch(firstSwitchMemberAst) && !isSwitchExpression(ast)) {
             log(ast, MSG_KEY);
         }
     }
@@ -144,6 +147,16 @@ public class MissingSwitchDefaultCheck extends AbstractCheck {
             switchMember = parent.findFirstToken(TokenTypes.SWITCH_RULE);
         }
         return switchMember;
+    }
+
+    /**
+     * Checks if this LITERAL_SWITCH token is part of a switch expression.
+     *
+     * @param ast the switch statement we are checking
+     * @return true if part of a switch expression
+     */
+    private static boolean isSwitchExpression(DetailAST ast) {
+        return ast.getParent().getType() == TokenTypes.EXPR;
     }
 
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/MissingSwitchDefaultCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/MissingSwitchDefaultCheck.xml
@@ -14,7 +14,10 @@
  cases are covered, this should be expressed in the
  default branch, e.g. by using an assertion. This way
  the code is protected against later changes, e.g.
- introduction of new types in an enumeration type.
+ introduction of new types in an enumeration type. Note that
+ the compiler requires switch expressions to be exhaustive,
+ so this check does not enforce default branches on
+ such expressions.
  &lt;/p&gt;</description>
          <message-keys>
             <message-key key="missing.switch.default"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheckTest.java
@@ -64,8 +64,6 @@ public class MissingSwitchDefaultCheckTest
             createModuleConfig(MissingSwitchDefaultCheck.class);
         final String[] expected = {
             "12:9: " + getCheckMessage(MSG_KEY, "default"),
-            "21:16: " + getCheckMessage(MSG_KEY, "default"),
-            "35:16: " + getCheckMessage(MSG_KEY, "default"),
         };
         verify(
             checkConfig,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheckTest.java
@@ -66,7 +66,7 @@ public class MissingSwitchDefaultCheckTest
             "12:9: " + getCheckMessage(MSG_KEY, "default"),
             "21:16: " + getCheckMessage(MSG_KEY, "default"),
             "35:16: " + getCheckMessage(MSG_KEY, "default"),
-            };
+        };
         verify(
             checkConfig,
             getNonCompilablePath("InputMissingSwitchDefaultCheckSwitchExpressions.java"),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheckTest.java
@@ -71,4 +71,18 @@ public class MissingSwitchDefaultCheckTest
             expected);
     }
 
+    @Test
+    public void testMissingSwitchDefaultSwitchExpressionsTwo() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(MissingSwitchDefaultCheck.class);
+        final String[] expected = {
+            "12:9: " + getCheckMessage(MSG_KEY, "default"),
+            "24:9: " + getCheckMessage(MSG_KEY, "default"),
+        };
+        verify(
+                checkConfig,
+                getNonCompilablePath("InputMissingSwitchDefaultCheckSwitchExpressionsTwo.java"),
+                expected);
+    }
+
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefaultCheckSwitchExpressions.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefaultCheckSwitchExpressions.java
@@ -18,7 +18,7 @@ public class InputMissingSwitchDefaultCheckSwitchExpressions {
     }
 
     int howMany2(Nums k) {
-        return switch (k) { // violation
+        return switch (k) { // ok
             case ONE -> {
                 yield 4;
             }
@@ -32,7 +32,7 @@ public class InputMissingSwitchDefaultCheckSwitchExpressions {
     }
 
     int howMany3(Nums k) {
-        return switch (k) { // violation
+        return switch (k) { // ok
             case ONE:
                 yield 3;
             case TWO:

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefaultCheckSwitchExpressionsTwo.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefaultCheckSwitchExpressionsTwo.java
@@ -1,0 +1,101 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.coding.missingswitchdefault;
+
+/* Config:
+ *
+ * default
+ */
+public class InputMissingSwitchDefaultCheckSwitchExpressionsTwo {
+    enum Nums {ONE, TWO, THREE}
+
+    int howMany1(Nums k) {
+        switch (k) { // violation
+            case ONE:
+                System.out.println("One!");
+            case TWO:
+                System.out.println("Two!");
+            case THREE:
+                System.out.println("Three!");
+        }
+        return 5;
+    }
+
+    int howMany2(Nums k) {
+        switch (k) { // violation
+            case ONE -> System.out.println("One!");
+            case TWO -> System.out.println("Two!");
+            case THREE -> System.out.println("Three!");
+        }
+        return 5;
+    }
+
+    int howMany3(Nums k) {
+        int x;
+        boolean bool = (switch (k) { // ok
+            case ONE -> {
+                x = 1;
+                yield true;
+            }
+            case TWO -> {
+                x = 2;
+                yield true;
+            }
+            case THREE -> {
+                x = 3;
+                yield false;
+            }
+        });
+        return 5;
+    }
+
+    int howMany4(Nums k) {
+        int x;
+        boolean bool = (switch (k) { // ok
+            case ONE: {
+                x = 1;
+                yield true;
+            }
+            case TWO: {
+                x = 2;
+                yield true;
+            }
+            case THREE: {
+                x = 3;
+                yield false;
+            }
+        });
+        return 5;
+    }
+
+    int howMany5(Nums k) {
+        return switch (k) { // ok
+            case ONE -> {
+                yield 4;
+            }
+            case TWO -> {
+                yield 42;
+            }
+            case THREE -> {
+                yield 99;
+            }
+            default -> {
+                yield 67;
+            }
+        };
+    }
+
+    int howMany6(Nums k) {
+        return switch (k) { // ok
+            case ONE: {
+                yield 4;
+            }
+            case TWO: {
+                yield 42;
+            }
+            case THREE: {
+                yield 99;
+            }
+        };
+    }
+
+}

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -3557,7 +3557,9 @@ abstract class AbstractExample { // OK
           currently possible cases are covered, this should be expressed in
           the default branch, e.g. by using an assertion. This way the code is
           protected against later changes, e.g. introduction of new types in an
-          enumeration type.
+          enumeration type. Note that the compiler requires switch expressions
+          to be exhaustive, so this check does not enforce default branches on
+          such expressions.
         </p>
       </subsection>
 


### PR DESCRIPTION
Issue #8779: Fix false positive for switch expressions in MissingSwitchDefault

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/dcf15792d9f08da0e573e5bbda2185d0/raw/556901973a29f95b25f3a41e61a466aef4780b2e/MissingSwitchDefault.xml