### PR TITLE
Issue #7651: add examples for NestedForDepth

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheck.java
@@ -41,13 +41,45 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <pre>
  * &lt;module name=&quot;NestedForDepth&quot;/&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * for(int i=0; i&lt;10; i++) {
+ *   for(int j=0; j&lt;i; j++) {
+ *     for(int k=0; k&lt;j; k++) { // violation, max allowed nested loop number is 1
+ *     }
+ *   }
+ * }
+ *
+ * for(int i=0; i&lt;10; i++) {
+ *   for(int j=0; j&lt;i; j++) { // ok
+ *   }
+ * }
+ * </pre>
  * <p>
- * To configure the check to allow nesting depth 3:
+ * To configure the check to allow nesting depth 2:
  * </p>
  * <pre>
  * &lt;module name=&quot;NestedForDepth&quot;&gt;
- *   &lt;property name=&quot;max&quot; value=&quot;3&quot;/&gt;
+ *   &lt;property name=&quot;max&quot; value=&quot;2&quot;/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * for(int i=0; i&lt;10; i++) {
+ *   for(int j=0; j&lt;i; j++) {
+ *     for(int k=0; k&lt;j; k++) {
+ *       for(int l=0; l&lt;k; l++) { // violation, max allowed nested loop number is 2
+ *       }
+ *     }
+ *    }
+ * }
+ *
+ * for(int i=0; i&lt;10; i++) {
+ *   for(int j=0; j&lt;i; j++) {
+ *     for(int k=0; k&lt;j; k++) { // ok
+ *     }
+ *   }
+ * }
  * </pre>
  * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -4028,14 +4028,45 @@ for (String line: lines) {
         <source>
 &lt;module name=&quot;NestedForDepth&quot;/&gt;
         </source>
+        <p>Example:</p>
+        <source>
+for(int i=0; i&lt;10; i++) {
+    for(int j=0; j&lt;i; j++) {
+        for(int k=0; k&lt;j; k++) { // violation, max allowed nested loop number is 1
+        }
+    }
+}
 
+for(int i=0; i&lt;10; i++) {
+    for(int j=0; j&lt;i; j++) { // ok
+    }
+}
+        </source>
         <p>
-          To configure the check to allow nesting depth 3:
+          To configure the check to allow nesting depth 2:
         </p>
         <source>
 &lt;module name=&quot;NestedForDepth&quot;&gt;
-  &lt;property name=&quot;max&quot; value=&quot;3&quot;/&gt;
+  &lt;property name=&quot;max&quot; value=&quot;2&quot;/&gt;
 &lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+for(int i=0; i&lt;10; i++) {
+    for(int j=0; j&lt;i; j++) {
+        for(int k=0; k&lt;j; k++) {
+            for(int l=0; l&lt;k; l++) { // violation, max allowed nested loop number is 2
+            }
+        }
+    }
+}
+
+for(int i=0; i&lt;10; i++) {
+    for(int j=0; j&lt;i; j++) {
+        for(int k=0; k&lt;j; k++) { // ok
+        }
+    }
+}
         </source>
       </subsection>
 


### PR DESCRIPTION
Issue #7651

![image](https://user-images.githubusercontent.com/812984/92593456-00a2cd00-f256-11ea-8523-b70c19a61902.png)

```
$ cat config.xml 
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE module PUBLIC
    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
    "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="TreeWalker">
        <module name="NestedForDepth"/>
    </module>
</module>
$ cat Test.java 
class Test {
 public void foo() {
    for(int i=0; i<10; i++) {
        for(int j=0; j<i; j++) {
            for(int k=0; k<j; k++) { // violation
            }
        }
    }

    for(int i=0; i<10; i++) {
        for(int j=0; j<i; j++) { // ok
        }
    }

 }
}
$ java $RUN_LOCALE -jar /var/tmp/checkstyle-8.33-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /var/tmp/Test.java:5:13: Nested for depth is 2 (max allowed is 1). [NestedForDepth]
Audit done.
Checkstyle ends with 1 errors.

 
$ cat config.xml 
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE module PUBLIC
    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
    "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="TreeWalker">
        <module name="NestedForDepth">
          <property name="max" value="2"/>
        </module>
    </module>
</module>
$ cat Test.java 
class Test {
 public void foo() {
    for(int i=0; i<10; i++) {
        for(int j=0; j<i; j++) {
            for(int k=0; k<j; k++) {
                for(int l=0; l<k; l++) { // violation
                }
            }
        }
    }

    for(int i=0; i<10; i++) {
        for(int j=0; j<i; j++) {
            for(int k=0; k<j; k++) { // ok
            }
        }
    }

 }
}
$ java $RUN_LOCALE -jar /var/tmp/checkstyle-8.33-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /var/tmp/Test.java:6:17: Nested for depth is 3 (max allowed is 2). [NestedForDepth]
Audit done.
Checkstyle ends with 1 errors.
```