### PR TITLE
Issue #8811: FinalClass check crashes CheckStyle 

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
@@ -117,7 +117,7 @@ public class FinalClassCheck
                 break;
 
             case TokenTypes.CTOR_DEF:
-                if (!ScopeUtil.isInEnumBlock(ast)) {
+                if (!ScopeUtil.isInEnumBlock(ast) && !ScopeUtil.isInRecordBlock(ast)) {
                     final ClassDesc desc = classes.peek();
                     if (modifiers.findFirstToken(TokenTypes.LITERAL_PRIVATE) == null) {
                         desc.registerNonPrivateCtor();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
@@ -33,6 +33,7 @@ import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class FinalClassCheckTest
     extends AbstractModuleTestSupport {
@@ -87,6 +88,18 @@ public class FinalClassCheckTest
                 getNonCompilablePath(
                 "InputFinalClassClassWithPrivateCtorWithNestedExtendingClassWithoutPackage.java"),
                 expected);
+    }
+
+    @Test
+    public void testFinalClassConstructorInRecord() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(FinalClassCheck.class);
+
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verify(checkConfig,
+            getNonCompilablePath("InputFinalClassConstructorInRecord.java"),
+            expected);
     }
 
     @Test

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassConstructorInRecord.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassConstructorInRecord.java
@@ -1,0 +1,15 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.design.finalclass;
+
+/* Config:
+ *
+ * default
+ */
+public record InputFinalClassConstructorInRecord(String string) { // ok
+
+    public InputFinalClassConstructorInRecord {
+    }
+    public InputFinalClassConstructorInRecord(int x) {
+        this(String.valueOf(x));
+    }
+}


### PR DESCRIPTION
Issue #8811: FinalClass check crashes CheckStyle if there are multiple constructors in a record

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/92731df66f85c542f5f80c160273c981/raw/f9ea36e63bf9fde6f2193eca21fb06c755cc7f7a/FinalClass.xml
