### PR TITLE
Issue #8810: DesignForExtension check crashes CheckStyle

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
@@ -274,7 +274,8 @@ public class DesignForExtensionCheck extends AbstractCheck {
                 && canBeOverridden(ast)
                 && (isNativeMethod(ast)
                     || !hasEmptyImplementation(ast))
-                && !hasIgnoredAnnotation(ast, ignoredAnnotations)) {
+                && !hasIgnoredAnnotation(ast, ignoredAnnotations)
+                && !ScopeUtil.isInRecordBlock(ast)) {
             final DetailAST classDef = getNearestClassOrEnumDefinition(ast);
             if (canBeSubclassed(classDef)) {
                 final String className = classDef.findFirstToken(TokenTypes.IDENT).getText();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheckTest.java
@@ -128,4 +128,14 @@ public class DesignForExtensionCheckTest
         verify(checkConfig, getPath("InputDesignForExtensionNativeMethods.java"), expected);
     }
 
+    @Test
+    public void testDesignForExtensionRecords() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(DesignForExtensionCheck.class);
+
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verify(checkConfig,
+            getNonCompilablePath("InputDesignForExtensionRecords.java"), expected);
+    }
+
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionRecords.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionRecords.java
@@ -1,0 +1,14 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.design.designforextension;
+
+/* Config:
+ *
+ * default
+ */
+public record InputDesignForExtensionRecords(String string) { // ok
+
+    @Override
+    public String toString() {
+        return string + "my string!";
+    }
+}


### PR DESCRIPTION
Issue #8810: DesignForExtension check crashes CheckStyle if an undocumented non-final method is present in a record

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/fbfe0d682ec1ff833ad9ebdfa83a80b0/raw/9aec986e9fb822e214e4e7a462c3bb3fcc7b3b8c/DesignForExtension.xml