### PR TITLE
make checkstyle.xml inheritable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2831,6 +2831,7 @@
                 <param>com.puppycrawl.tools.checkstyle.AuditEventDefaultFormatter*</param>
                 <param>com.puppycrawl.tools.checkstyle.ConfigurationLoader*</param>
                 <param>com.puppycrawl.tools.checkstyle.DefaultConfiguration*</param>
+                <param>com.puppycrawl.tools.checkstyle.InheritConfiguration*</param>
                 <param>com.puppycrawl.tools.checkstyle.DefaultContext*</param>
                 <param>com.puppycrawl.tools.checkstyle.DefaultLogger*</param>
                 <param>com.puppycrawl.tools.checkstyle.Definitions*</param>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -118,6 +118,18 @@ public final class ConfigurationLoader {
     private static final String DTD_CONFIGURATION_NAME_1_3 =
         "com/puppycrawl/tools/checkstyle/configuration_1_3.dtd";
 
+    /** The public ID for version 1_4 of the configuration dtd. */
+    private static final String DTD_PUBLIC_ID_1_4 =
+        "-//Puppy Crawl//DTD Check Configuration 1.4//EN";
+
+    /** The new public ID for version 1_4 of the configuration dtd. */
+    private static final String DTD_PUBLIC_CS_ID_1_4 =
+        "-//Checkstyle//DTD Checkstyle Configuration 1.4//EN";
+
+    /** The resource for version 1_4 of the configuration dtd. */
+    private static final String DTD_CONFIGURATION_NAME_1_4 =
+        "com/puppycrawl/tools/checkstyle/configuration_1_4.dtd";
+
     /** Prefix for the exception when unable to parse resource. */
     private static final String UNABLE_TO_PARSE_EXCEPTION_PREFIX = "unable to parse"
             + " configuration stream";
@@ -176,10 +188,12 @@ public final class ConfigurationLoader {
         map.put(DTD_PUBLIC_ID_1_1, DTD_CONFIGURATION_NAME_1_1);
         map.put(DTD_PUBLIC_ID_1_2, DTD_CONFIGURATION_NAME_1_2);
         map.put(DTD_PUBLIC_ID_1_3, DTD_CONFIGURATION_NAME_1_3);
+        map.put(DTD_PUBLIC_ID_1_4, DTD_CONFIGURATION_NAME_1_4);
         map.put(DTD_PUBLIC_CS_ID_1_0, DTD_CONFIGURATION_NAME_1_0);
         map.put(DTD_PUBLIC_CS_ID_1_1, DTD_CONFIGURATION_NAME_1_1);
         map.put(DTD_PUBLIC_CS_ID_1_2, DTD_CONFIGURATION_NAME_1_2);
         map.put(DTD_PUBLIC_CS_ID_1_3, DTD_CONFIGURATION_NAME_1_3);
+        map.put(DTD_PUBLIC_CS_ID_1_4, DTD_CONFIGURATION_NAME_1_4);
         return map;
     }
 
@@ -502,11 +516,12 @@ public final class ConfigurationLoader {
                 // create configuration
                 final String originalName = attributes.getValue(NAME);
                 final String name = threadModeSettings.resolveName(originalName);
-                final DefaultConfiguration conf =
-                    new DefaultConfiguration(name, threadModeSettings);
-
+                final DefaultConfiguration conf;
                 if (configuration == null) {
-                    configuration = conf;
+                    conf = createTopModule(attributes, name);
+                }
+                else {
+                    conf = new DefaultConfiguration(name, threadModeSettings);
                 }
 
                 // add configuration to it's parent
@@ -559,7 +574,9 @@ public final class ConfigurationLoader {
             if (qName.equals(MODULE)) {
                 final Configuration recentModule =
                     configStack.pop();
-
+                if (recentModule instanceof InheritConfiguration) {
+                    ((InheritConfiguration) recentModule).doMergeParent();
+                }
                 // get severity attribute if it exists
                 SeverityLevel level = null;
                 if (containsAttribute(recentModule, SEVERITY)) {
@@ -601,6 +618,28 @@ public final class ConfigurationLoader {
             final Optional<String> result = Arrays.stream(names)
                     .filter(name -> name.equals(attributeName)).findFirst();
             return result.isPresent();
+        }
+
+        private DefaultConfiguration createTopModule(final Attributes attributes,
+            final String name) {
+            final DefaultConfiguration conf;
+            final String parentConfig = attributes.getValue("parent");
+            if (parentConfig == null) {
+                conf = new DefaultConfiguration(name, threadModeSettings);
+            }
+            else {
+                final Configuration parent;
+                try {
+                    parent = loadConfiguration(parentConfig,
+                        overridePropsResolver, threadModeSettings);
+                }
+                catch (CheckstyleException ex) {
+                    throw new IllegalStateException(ex.getMessage(), ex);
+                }
+                conf = new InheritConfiguration(parent, name, threadModeSettings);
+            }
+            configuration = conf;
+            return conf;
         }
 
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
@@ -34,7 +34,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *
  * @noinspection SerializableHasSerializationMethods
  */
-public final class DefaultConfiguration implements Configuration {
+public class DefaultConfiguration implements Configuration {
 
     private static final long serialVersionUID = 1157875385356127169L;
 
@@ -44,6 +44,9 @@ public final class DefaultConfiguration implements Configuration {
     /** The name of this configuration. */
     private final String name;
 
+    /** The thread mode configuration. */
+    private final ThreadModeSettings threadModeSettings;
+
     /** The list of child Configurations. */
     private final List<Configuration> children = new ArrayList<>();
 
@@ -52,9 +55,6 @@ public final class DefaultConfiguration implements Configuration {
 
     /** The map containing custom messages. */
     private final Map<String, String> messages = new HashMap<>();
-
-    /** The thread mode configuration. */
-    private final ThreadModeSettings threadModeSettings;
 
     /**
      * Instantiates a DefaultConfiguration.
@@ -158,6 +158,12 @@ public final class DefaultConfiguration implements Configuration {
         return new HashMap<>(messages);
     }
 
+    @Override
+    public String[] getMessageNames() {
+        final Set<String> keySet = messages.keySet();
+        return keySet.toArray(CommonUtil.EMPTY_STRING_ARRAY);
+    }
+
     /**
      * Gets the thread mode configuration.
      *
@@ -167,4 +173,28 @@ public final class DefaultConfiguration implements Configuration {
         return threadModeSettings;
     }
 
+    @Override
+    public boolean containsAttribute(final String key) {
+        return attributeMap.containsKey(key);
+    }
+
+    @Override
+    public boolean containsMessage(final String key) {
+        return messages.containsKey(key);
+    }
+
+    @Override
+    public String getMessage(final String key) {
+        return messages.get(key);
+    }
+
+    /**
+     * Returns the attributeName value.
+     *
+     * @param attributeName - Attribute name.
+     * @return  The value of the attributeName.
+     */
+    protected String getTheAttribute(final String attributeName) {
+        return attributeMap.get(attributeName);
+    }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/InheritConfiguration.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/InheritConfiguration.java
@@ -1,0 +1,153 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+
+/**
+ * InheritConfiguration for inherit the config with parent attribute on root module.
+ *
+ * @noinspection SerializableHasSerializationMethods
+ */
+public final class InheritConfiguration extends DefaultConfiguration {
+
+    private static final long serialVersionUID = 2331785991766158817L;
+
+    /**
+     * The parent configuration.
+     */
+    private final Configuration parentConfig;
+
+    /**
+     * Instantiates a configuration with parent.
+     *
+     * @param parent The parent configuration.
+     * @param name the name for this InheritConfiguration.
+     * @param threadModeSettings the thread mode configuration.
+     */
+    public InheritConfiguration(final Configuration parent, final String name,
+        final ThreadModeSettings threadModeSettings) {
+        super(name, threadModeSettings);
+        parentConfig = parent;
+    }
+
+    //    /**
+    //     * Instantiates a configuration with parent.
+    //     *
+    //     * @param parent The parent configuration.
+    //     * @param name the name for this InheritConfiguration.
+    //     */
+    //    public InheritConfiguration(final Configuration parent, final String name) {
+    //        super(name);
+    //        parentConfig = parent;
+    //    }
+
+    /**
+     * Do merge for init.
+     *
+     * @throws IllegalStateException If doMergeParent error.
+     */
+    public void doMergeParent() {
+        doMergeParent((DefaultConfiguration) parentConfig, this);
+    }
+
+    /**
+     * Merge parent config to current config.
+     *
+     * @param parent Parent config.
+     * @param current  Current config.
+     */
+    public static void doMergeParent(final DefaultConfiguration parent,
+            final DefaultConfiguration current) {
+        mergeAttributes(parent, current);
+        mergeMessages(parent, current);
+        mergeChildren(parent, current);
+    }
+
+    private static void mergeChildren(final DefaultConfiguration parent,
+            final DefaultConfiguration current) {
+        final Configuration[] children = parent.getChildren();
+        final Map<String, Configuration> parents = toChildrenMap(children);
+
+        final Configuration[] currentChildren = current.getChildren();
+        final Map<String, Configuration> currents = toChildrenMap(currentChildren);
+        final Collection<String> addKeys = new ArrayList<>(parents.keySet());
+        addKeys.removeAll(currents.keySet());
+        for (final String id : addKeys) {
+            current.addChild(parents.get(id));
+        }
+        final Collection<String> mergeKeys = intersection(parents.keySet(), currents.keySet());
+        for (final String id : mergeKeys) {
+            final Configuration parentChild = parents.get(id);
+            final DefaultConfiguration currentChild = (DefaultConfiguration) currents.get(id);
+            doMergeParent((DefaultConfiguration) parentChild, currentChild);
+        }
+    }
+
+    private static void mergeMessages(final Configuration parent,
+            final DefaultConfiguration current) {
+        final String[] names = parent.getMessageNames();
+        for (final String key : names) {
+            if (!current.containsMessage(key)) {
+                current.addMessage(key, parent.getMessage(key));
+            }
+        }
+    }
+
+    private static void mergeAttributes(final DefaultConfiguration parent,
+            final DefaultConfiguration current) {
+        final String[] attributeNames = parent.getAttributeNames();
+        for (final String attr : attributeNames) {
+            if (!current.containsAttribute(attr)) {
+                current.addAttribute(attr, parent.getTheAttribute(attr));
+            }
+        }
+    }
+
+    private static Collection<String> intersection(final Collection<String> list1,
+        final Collection<String> list2) {
+        final List<String> ret = new ArrayList<>();
+        for (final String name : list1) {
+            if (list2.contains(name)) {
+                ret.add(name);
+            }
+        }
+        return ret;
+    }
+
+    private static Map<String, Configuration> toChildrenMap(
+            final Configuration... children) {
+        final Map<String, Configuration> map = new HashMap<>();
+        for (Configuration child : children) {
+            String id = ((DefaultConfiguration) child).getTheAttribute("id");
+            if (id == null) {
+                id = child.getName();
+            }
+            map.put(id, child);
+        }
+        return map;
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Configuration.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Configuration.java
@@ -67,4 +67,36 @@ public interface Configuration extends Serializable {
      */
     Map<String, String> getMessages();
 
+    /**
+     * The set of message names.
+     *
+     * @return The set of message names, never null.
+     */
+    String[] getMessageNames();
+
+    /**
+     * Returns true if its attribute contains a mapping for the specified key.
+     *
+     * @param key key whose presence in its attribute is to be tested
+     * @return true if its attribute contains a mapping for the specified key.
+     */
+    boolean containsAttribute(String key);
+
+    /**
+     * Returns true if its messages contains a mapping for the specified key.
+     *
+     * @param key key whose presence in its messages is to be tested
+     * @return true if its messages contains a mapping for the specified key.
+     */
+    boolean containsMessage(String key);
+
+    /**
+     * Returns the value to which the specified key is mapped in messages,
+     * or {@code null} if messages contains no mapping for the key.
+     *
+     * @param key key whose presence in its messages is to be tested
+     * @return the value to which the specified key is mapped, or
+     *         {@code null} if this map contains no mapping for the key
+     */
+    String getMessage(String key);
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/configuration_1_4.dtd
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/configuration_1_4.dtd
@@ -1,0 +1,57 @@
+<!-- Add the following to any file that is to be validated against this DTD:
+
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.4//EN"
+    "https://checkstyle.org/dtds/configuration_1_4.dtd">
+-->
+
+<!ELEMENT module (module|property|metadata|message)*>
+<!ATTLIST module
+    name NMTOKEN #REQUIRED
+    parent CDATA #IMPLIED
+>
+
+<!ELEMENT property EMPTY>
+<!ATTLIST property
+    name NMTOKEN #REQUIRED
+    value CDATA #REQUIRED
+    default CDATA #IMPLIED
+>
+
+<!--
+
+   Used to store metadata in the Checkstyle configuration file. This
+   information is ignored by Checkstyle. This may be useful if you want to
+   store plug-in specific information.
+
+   To avoid name clashes between different tools/plug-ins you are *strongly*
+   encouraged to prefix all names with your domain name. For example, use the
+   name "com.mycompany.parameter" instead of "parameter".
+
+   The prefix "com.puppycrawl." is reserved for Checkstyle.
+
+-->
+
+<!ELEMENT metadata EMPTY>
+<!ATTLIST metadata
+    name NMTOKEN #REQUIRED
+    value CDATA #REQUIRED
+>
+
+<!--
+   Can be used to replaced some generic Checkstyle messages with a custom
+   messages.
+
+   The 'key' attribute specifies for which actual Checkstyle message the
+   replacing should occur, look into Checkstyle's message.properties for
+   the according message keys.
+
+   The 'value' attribute defines the custom message patterns including
+   message parameter placeholders as defined in the original Checkstyle
+   messages (again see message.properties for reference).
+-->
+<!ELEMENT message EMPTY>
+<!ATTLIST message
+    key NMTOKEN #REQUIRED
+    value CDATA #REQUIRED
+>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -32,6 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
@@ -91,6 +92,134 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         attributes.setProperty("tabWidth", "4");
         attributes.setProperty("basedir", "basedir");
         verifyConfigNode(config, "Checker", 3, attributes);
+    }
+
+    @Test
+    public void testLoadInheritConfiguration() throws Exception {
+        final Properties props = new Properties();
+        props.setProperty("checkstyle.basedir", "basedir");
+        final String path = getPath("InputConfigurationLoaderInheritGoogleChecks.xml");
+        // load config that's only found in the classpath
+        final Configuration config = ConfigurationLoader.loadConfiguration(
+            path, new PropertiesExpander(props));
+
+        // verify the root
+        verifyConfigNode((DefaultConfiguration) config, "Checker", 5, null);
+    }
+
+    @Test
+    public void testLoadInheritConfigurationEmptyParent() throws Exception {
+        final Properties props = new Properties();
+        props.setProperty("checkstyle.basedir", "basedir");
+
+        final String path = getPath("InputConfigurationLoaderInheritEmptyEmpty.xml");
+        // load config that's only found in the classpath
+        final Configuration config = ConfigurationLoader.loadConfiguration(
+            path, new PropertiesExpander(props));
+
+        // verify the root
+        verifyConfigNode((DefaultConfiguration) config, "Checker", 0, null);
+    }
+
+    @Test
+    public void testLoadInheritConfigurationOne() throws Exception {
+        final Properties props = new Properties();
+        props.setProperty("checkstyle.basedir", "basedir");
+
+        final String path = getPath("InputConfigurationLoaderInherit1.xml");
+        // load config that's only found in the classpath
+        final Configuration config = ConfigurationLoader.loadConfiguration(
+            path, new PropertiesExpander(props));
+
+        final Properties attributes = new Properties();
+        attributes.setProperty("tabWidth", "4");
+        attributes.setProperty("basedir", "basedir");
+        // verify the root
+        verifyConfigNode((DefaultConfiguration) config, "Checker", 2, attributes);
+        final Map<String, String> messages = config.getMessages();
+        assertEquals(2, messages.size(), "messages not equals");
+    }
+
+    @Test
+    public void testLoadInheritConfigurationTwo() throws Exception {
+        final Properties props = new Properties();
+        props.setProperty("checkstyle.basedir", "basedir");
+
+        final String path = getPath("InputConfigurationLoaderInherit2.xml");
+        // load config that's only found in the classpath
+        final Configuration config = ConfigurationLoader.loadConfiguration(
+            path, new PropertiesExpander(props));
+
+        // verify the root
+        verifyConfigNode((DefaultConfiguration) config, "Checker", 2, null);
+        assertEquals(2, config.getMessages().size(), "messages not equals");
+    }
+
+    @Test
+    public void testLoadInheritConfigurationThree() throws Exception {
+        final Properties props = new Properties();
+        props.setProperty("checkstyle.basedir", "basedir");
+
+        final String path = getPath("InputConfigurationLoaderInherit3.xml");
+        // load config that's only found in the classpath
+        final Configuration config = ConfigurationLoader.loadConfiguration(
+            path, new PropertiesExpander(props));
+
+        final Properties attributes = new Properties();
+        attributes.setProperty("tabWidth", "2");
+        attributes.setProperty("basedir", "basedir");
+        attributes.setProperty("tabWidth1", "4");
+        // verify the root
+        verifyConfigNode((DefaultConfiguration) config, "Checker", 2, attributes);
+        final Map<String, String> messages = config.getMessages();
+        assertEquals(3, messages.size(), "messages not equals");
+        assertEquals("abc3", messages.get("message1"), "messages not equals");
+        assertEquals("abc1", messages.get("message2"), "messages not equals");
+        assertEquals("abc3", messages.get("message3"), "messages not equals");
+
+        final Configuration[] children = config.getChildren();
+        for (Configuration item : children) {
+            final String name = item.getName();
+            if ("TreeWalker".equals(name)) {
+                verifyConfigNode((DefaultConfiguration) item, "TreeWalker", 4, null);
+            }
+            if ("LineLength".equals(name)) {
+                assertEquals("140", item.getAttribute("max"), "max not equals");
+            }
+        }
+    }
+
+    @Test
+    public void testLoadInheritConfigurationOneFromParent() throws Exception {
+        final Properties props = new Properties();
+        props.setProperty("checkstyle.basedir", "basedir");
+
+        final String path = getPath("InputConfigurationLoaderInheritOneFromParent.xml");
+        // load config that's only found in the classpath
+        final Configuration config = ConfigurationLoader.loadConfiguration(
+            path, new PropertiesExpander(props));
+
+        final Properties attributes = new Properties();
+        attributes.setProperty("tabWidth", "4");
+        attributes.setProperty("basedir", "basedir");
+        // verify the root
+        verifyConfigNode((DefaultConfiguration) config, "Checker", 2, attributes);
+    }
+
+    @Test
+    public void testLoadInheritConfigurationNotFoundParent() throws Exception {
+        final Properties props = new Properties();
+        props.setProperty("checkstyle.basedir", "basedir");
+        final PropertiesExpander propertiesExpander = new PropertiesExpander(props);
+        final String path = getPath("InputConfigurationLoaderInheritErrorParent.xml");
+        try {
+            ConfigurationLoader.loadConfiguration(path, propertiesExpander);
+            fail("An exception is expected");
+        }
+        catch (IllegalStateException ex) {
+            assertEquals("Unable to find: not_found_checks.xml",
+                ex.getMessage(), "Invalid exception message");
+        }
     }
 
     @Test
@@ -309,14 +438,15 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         assertEquals(
                 childrenLength,
             config.getChildren().length, "children.length.");
-
-        final String[] attNames = config.getAttributeNames();
-        assertEquals(atts.size(), attNames.length, "attributes.length");
-
-        for (String attName : attNames) {
-            final String attribute = config.getAttribute(attName);
-            assertEquals(atts.getProperty(attName), attribute, "attribute[" + attName + "]");
+        if (atts != null) {
+            final String[] attNames = config.getAttributeNames();
+            assertEquals(atts.size(), attNames.length, "attributes.length");
+            for (String attName : attNames) {
+                final String attribute = config.getAttribute(attName);
+                assertEquals(atts.getProperty(attName), attribute, "attribute[" + attName + "]");
+            }
         }
+
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DefaultConfigurationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DefaultConfigurationTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Map;
@@ -110,4 +111,21 @@ public class DefaultConfigurationTest {
         assertEquals(multiThreadMode, config.getThreadModeSettings(), "Invalid thread mode");
     }
 
+    @Test
+    public void test4containsAttribute() {
+        final DefaultConfiguration config = new DefaultConfiguration("MyConfig");
+        final String key = "attribute";
+        config.addAttribute(key, "value");
+        assertTrue(config.containsAttribute(key), "Invalid attribute name");
+    }
+
+    @Test
+    public void test4containsMessage() {
+        final DefaultConfiguration config = new DefaultConfiguration("MyConfig");
+        final String key = "attribute";
+        final String value = "value";
+        config.addMessage(key, value);
+        assertTrue(config.containsMessage(key), "Invalid attribute name");
+        assertEquals(value, config.getMessage(key), "Invalid thread mode");
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/configurationloader/InputConfigurationLoaderInherit1.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/configurationloader/InputConfigurationLoaderInherit1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.4//EN"
+    "https://checkstyle.org/dtds/configuration_1_4.dtd">
+<module name="Checker"
+    parent="com/puppycrawl/tools/checkstyle/configurationloader/InputConfigurationLoaderEmpty.xml">
+    <property name="tabWidth" value="4" />
+    <property name="basedir" value="${checkstyle.basedir}" />
+    <module name="LineLength">
+         <property name="id" value="LineLength1"/>
+        <property name="fileExtensions" value="java" />
+        <property name="max" value="${checkstyle_LineLength_max}" default="130" />
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://" />
+    </module>
+    <module name="TreeWalker">
+        <module name="Indentation">
+            <property name="basicOffset" value="4" />
+            <property name="braceAdjustment" value="0" />
+            <property name="caseIndent" value="4" />
+            <property name="throwsIndent" value="4" />
+        </module>
+        <module name="NoWhitespaceAfter">
+            <property name="tokens" value="DOT" />
+            <property name="allowLineBreaks" value="true" />
+            <property name="id" value="NoWhitespaceAfter1"/>
+        </module>
+
+        <module name="MemberName">
+            <property name="format" value="^m[a-zA-Z0-9]*$" />
+            <message key="name.invalidPattern"
+                value="Member ''{0}'' must start with ''m'' (checked pattern ''{1}'')." />
+        </module>
+        <message key="message1" value="abc1" />
+        <message key="message2" value="abc1" />
+    </module>
+    <message key="message1" value="abc1" />
+    <message key="message2" value="abc1" />
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/configurationloader/InputConfigurationLoaderInherit2.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/configurationloader/InputConfigurationLoaderInherit2.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.4//EN"
+    "https://checkstyle.org/dtds/configuration_1_4.dtd">
+<module name="Checker"
+parent="com/puppycrawl/tools/checkstyle/configurationloader/InputConfigurationLoaderInherit1.xml">
+
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/configurationloader/InputConfigurationLoaderInherit3.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/configurationloader/InputConfigurationLoaderInherit3.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.4//EN"
+    "https://checkstyle.org/dtds/configuration_1_4.dtd">
+<module name="Checker"
+parent="com/puppycrawl/tools/checkstyle/configurationloader/InputConfigurationLoaderInherit2.xml">
+    <property name="tabWidth" value="2" />
+    <property name="tabWidth1" value="4" />
+    <module name="LineLength">
+        <property name="id" value="LineLength1"/>
+        <property name="max" value="140" />
+    </module>
+    <module name="TreeWalker">
+        <module name="MemberName">
+            <message key="method.name.equals.class.name"
+                value="Member ''{0}'' must start with ''m'' (checked pattern ''{1}'')." />
+            <message key="method.name.equals.class.name1" value="test" />
+        </module>
+        <module name="NoWhitespaceAfter">
+            <property name="tokens" value="DOT" />
+            <property name="allowLineBreaks" value="true" />
+            <property name="id" value="NoWhitespaceAfter3"/>
+        </module>
+    </module>
+    <message key="message1" value="abc3" />
+    <message key="message3" value="abc3" />
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/configurationloader/InputConfigurationLoaderInheritEmptyEmpty.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/configurationloader/InputConfigurationLoaderInheritEmptyEmpty.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.4//EN"
+    "https://checkstyle.org/dtds/configuration_1_4.dtd">
+<module name="Checker"
+    parent="com/puppycrawl/tools/checkstyle/configurationloader/InputConfigurationLoaderEmpty.xml">
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/configurationloader/InputConfigurationLoaderInheritErrorParent.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/configurationloader/InputConfigurationLoaderInheritErrorParent.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.4//EN"
+    "https://checkstyle.org/dtds/configuration_1_4.dtd">
+<module name="Checker" parent="not_found_checks.xml">
+  <property name="tabWidth" value="4" />
+  <module name="TreeWalker">
+    <module name="NoWhitespaceAfter">
+      <property name="tokens" value="DOT" />
+      <property name="allowLineBreaks" value="true" />
+    </module>
+  </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/configurationloader/InputConfigurationLoaderInheritGoogleChecks.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/configurationloader/InputConfigurationLoaderInheritGoogleChecks.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.4//EN"
+    "https://checkstyle.org/dtds/configuration_1_4.dtd">
+<module name="Checker" parent="google_checks.xml">
+  <property name="tabWidth" value="4" />
+  <property name="basedir" value="${checkstyle.basedir}" />
+  <module name="LineLength">
+    <property name="fileExtensions" value="java" />
+    <property name="max" value="${checkstyle_LineLength_max}" default="130" />
+    <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://" />
+  </module>
+  <module name="TreeWalker">
+    <module name="NoWhitespaceAfter">
+      <property name="tokens" value="DOT" />
+      <property name="allowLineBreaks" value="true" />
+    </module>
+
+    <module name="Indentation">
+      <property name="basicOffset" value="4" />
+      <property name="braceAdjustment" value="0" />
+      <property name="caseIndent" value="4" />
+      <property name="throwsIndent" value="4" />
+    </module>
+     <module name="MemberName">
+        <property name="format" value="^m[a-zA-Z0-9]*$"/>
+        <message key="name.invalidPattern"
+                 value="Member ''{0}'' must start with ''m'' (checked pattern ''{1}'')."/>
+     </module>
+  </module>
+</module>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/configurationloader/InputConfigurationLoaderInheritOneFromParent.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/configurationloader/InputConfigurationLoaderInheritOneFromParent.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC
+    "-//Checkstyle//DTD Checkstyle Configuration 1.4//EN"
+    "https://checkstyle.org/dtds/configuration_1_4.dtd">
+<module name="Checker"
+parent="com/puppycrawl/tools/checkstyle/configurationloader/InputConfigurationLoaderInherit1.xml">
+
+   <module name="TreeWalker">
+        <module name="MemberName">
+            <property name="format" value="^m[a-zA-Z0-9]*$"/>
+            <message key="name.invalidPattern"
+                     value="Member ''{0}'' must start with ''m'' (checked pattern ''{1}'')."/>
+        </module>
+    </module>
+</module>
+


### PR DESCRIPTION
so we  can reuse the IT asset(checkstyle.xml) , and  just add module need modify.

ie: base google_checks.xml 
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE module PUBLIC
    "-//Checkstyle//DTD Checkstyle Configuration 1.4//EN"
    "https://checkstyle.org/dtds/configuration_1_4.dtd">
<module name="Checker" parent="google_checks.xml">
  <property name="tabWidth" value="4" />
  <property name="basedir" value="${checkstyle.basedir}" />
  <module name="LineLength">
    <property name="fileExtensions" value="java" />
    <property name="max" value="${checkstyle_LineLength_max}" default="130" />
    <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://" />
  </module>
  <module name="TreeWalker">
    <module name="NoWhitespaceAfter">
      <property name="tokens" value="DOT" />
      <property name="allowLineBreaks" value="true" />
    </module>

    <module name="Indentation">
      <property name="basicOffset" value="4" />
      <property name="braceAdjustment" value="0" />
      <property name="caseIndent" value="4" />
      <property name="throwsIndent" value="4" />

    </module>
  </module>
</module>
```

------

Related discussion: #2873