### PR TITLE
infra: use stable version of pgjdbc 

### DIFF
--- a/.ci/wercker.sh
+++ b/.ci/wercker.sh
@@ -63,6 +63,8 @@ no-error-pgjdbc)
   echo CS_version: ${CS_POM_VERSION}
   checkout_from https://github.com/pgjdbc/pgjdbc.git
   cd .ci-temp/pgjdbc
+  # pgjdbc easily damage build, we should use stable versions
+  git checkout REL42.2.16
   ./gradlew --no-parallel --no-daemon checkstyleAll \
             -PenableMavenLocal -Pcheckstyle.version=${CS_POM_VERSION}
   cd ../


### PR DESCRIPTION
to not be affected by their build failures between releases

master build failure - https://app.wercker.com/checkstyle/checkstyle/runs/build/5f5a28d17e996800080b09e4?step=5f5a294a16cb6b0007e48909