### PR TITLE
Issue #8808: false positive with JavadocTypeCheck @param tags for Records

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -392,7 +392,7 @@ public class JavadocTypeCheck
      * @param ast a given node.
      * @return whether we should check a given node.
      */
-    private boolean shouldCheck(final DetailAST ast) {
+    private boolean shouldCheck(DetailAST ast) {
         final Scope customScope;
 
         if (ScopeUtil.isInInterfaceOrAnnotationBlock(ast)) {
@@ -467,8 +467,8 @@ public class JavadocTypeCheck
      * @param tags tags from the Javadoc comment for the type definition.
      * @param typeParamName the name of the type parameter
      */
-    private void checkTypeParamTag(final DetailAST ast,
-            final List<JavadocTag> tags, final String typeParamName) {
+    private void checkTypeParamTag(DetailAST ast,
+            List<JavadocTag> tags, String typeParamName) {
         boolean found = false;
         for (int i = tags.size() - 1; i >= 0; i--) {
             final JavadocTag tag = tags.get(i);
@@ -492,8 +492,8 @@ public class JavadocTypeCheck
      * @param typeParamNames names of type parameters
      */
     private void checkUnusedTypeParamTags(
-        final List<JavadocTag> tags,
-        final List<String> typeParamNames) {
+        List<JavadocTag> tags,
+        List<String> typeParamNames) {
         for (int i = tags.size() - 1; i >= 0; i--) {
             final JavadocTag tag = tags.get(i);
             if (tag.isParamTag()) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -374,11 +374,10 @@ public class JavadocTypeCheck
                     CheckUtil.getTypeParameterNames(ast);
 
                 if (!allowMissingParamTags) {
-                    // Check type parameters that should exist, do
-                    for (final String typeParamName : typeParamNames) {
-                        checkTypeParamTag(
-                            ast, tags, typeParamName);
-                    }
+
+                    typeParamNames.forEach(typeParamName -> {
+                        checkTypeParamTag(ast, tags, typeParamName);
+                    });
                 }
 
                 checkUnusedTypeParamTags(tags, typeParamNames);
@@ -444,8 +443,8 @@ public class JavadocTypeCheck
         if (formatPattern != null) {
             boolean hasTag = false;
             final String tagPrefix = "@";
-            for (int i = tags.size() - 1; i >= 0; i--) {
-                final JavadocTag tag = tags.get(i);
+
+            for (final JavadocTag tag :tags) {
                 if (tag.getTagName().equals(tagName)) {
                     hasTag = true;
                     if (!formatPattern.matcher(tag.getFirstArg()).find()) {
@@ -469,16 +468,14 @@ public class JavadocTypeCheck
      */
     private void checkTypeParamTag(DetailAST ast,
             List<JavadocTag> tags, String typeParamName) {
-        boolean found = false;
-        for (int i = tags.size() - 1; i >= 0; i--) {
-            final JavadocTag tag = tags.get(i);
-            if (tag.isParamTag()
-                && tag.getFirstArg().indexOf(OPEN_ANGLE_BRACKET
-                        + typeParamName + CLOSE_ANGLE_BRACKET) == 0) {
-                found = true;
-                break;
-            }
-        }
+        final String typeParamNameWithBrackets =
+            OPEN_ANGLE_BRACKET + typeParamName + CLOSE_ANGLE_BRACKET;
+
+        final boolean found = tags
+            .stream()
+            .filter(JavadocTag::isParamTag)
+            .anyMatch(tag -> tag.getFirstArg().indexOf(typeParamNameWithBrackets) == 0);
+
         if (!found) {
             log(ast, MSG_MISSING_TAG, JavadocTagInfo.PARAM.getText()
                 + " " + OPEN_ANGLE_BRACKET + typeParamName + CLOSE_ANGLE_BRACKET);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -37,10 +38,11 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
  * <p>
- * Checks the Javadoc comments for annotation/enum/class/interface definitions. By default, does
+ * Checks the Javadoc comments for type definitions. By default, does
  * not check for author or version tags. The scope to verify is specified using the {@code Scope}
  * class and defaults to {@code Scope.PRIVATE}. To verify another scope, set property
  * scope to one of the {@code Scope} constants. To define the format for an author
@@ -53,7 +55,7 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * as they should be redundant because of outer class.
  * </p>
  * <p>
- * Error messages about type parameters for which no param tags are present
+ * Error messages about type parameters and record components for which no param tags are present
  * can be suppressed by defining property {@code allowMissingParamTags}.
  * </p>
  * <ul>
@@ -238,6 +240,9 @@ public class JavadocTypeCheck
     /** Close angle bracket literal. */
     private static final String CLOSE_ANGLE_BRACKET = ">";
 
+    /** Space literal. */
+    private static final String SPACE = " ";
+
     /** Pattern to match type name within angle brackets in javadoc param tag. */
     private static final Pattern TYPE_NAME_IN_JAVADOC_TAG =
             Pattern.compile("\\s*<([^>]+)>.*");
@@ -372,15 +377,21 @@ public class JavadocTypeCheck
 
                 final List<String> typeParamNames =
                     CheckUtil.getTypeParameterNames(ast);
+                final List<String> recordComponentNames =
+                    getRecordComponentNames(ast);
 
                 if (!allowMissingParamTags) {
 
                     typeParamNames.forEach(typeParamName -> {
                         checkTypeParamTag(ast, tags, typeParamName);
                     });
+
+                    recordComponentNames.forEach(componentName -> {
+                        checkComponentParamTag(ast, tags, componentName);
+                    });
                 }
 
-                checkUnusedTypeParamTags(tags, typeParamNames);
+                checkUnusedParamTags(tags, typeParamNames, recordComponentNames);
             }
         }
     }
@@ -459,6 +470,29 @@ public class JavadocTypeCheck
     }
 
     /**
+     * Verifies that a record definition has the specified param tag for
+     * the specified record component name.
+     *
+     * @param ast the AST node for the record definition.
+     * @param tags tags from the Javadoc comment for the record definition.
+     * @param recordComponentName the name of the type parameter
+     */
+    private void checkComponentParamTag(DetailAST ast,
+                                        List<JavadocTag> tags,
+                                        String recordComponentName) {
+
+        final boolean found = tags
+            .stream()
+            .filter(JavadocTag::isParamTag)
+            .anyMatch(tag -> tag.getFirstArg().indexOf(recordComponentName) == 0);
+
+        if (!found) {
+            log(ast, MSG_MISSING_TAG, JavadocTagInfo.PARAM.getText()
+                + SPACE + recordComponentName);
+        }
+    }
+
+    /**
      * Verifies that a type definition has the specified param tag for
      * the specified type parameter name.
      *
@@ -478,41 +512,47 @@ public class JavadocTypeCheck
 
         if (!found) {
             log(ast, MSG_MISSING_TAG, JavadocTagInfo.PARAM.getText()
-                + " " + OPEN_ANGLE_BRACKET + typeParamName + CLOSE_ANGLE_BRACKET);
+                + SPACE + typeParamNameWithBrackets);
         }
     }
 
     /**
-     * Checks for unused param tags for type parameters.
+     * Checks for unused param tags for type parameters and record components.
      *
      * @param tags tags from the Javadoc comment for the type definition.
      * @param typeParamNames names of type parameters
+     * @param recordComponentNames list of record component names in this definition
      */
-    private void checkUnusedTypeParamTags(
+    private void checkUnusedParamTags(
         List<JavadocTag> tags,
-        List<String> typeParamNames) {
-        for (int i = tags.size() - 1; i >= 0; i--) {
-            final JavadocTag tag = tags.get(i);
-            if (tag.isParamTag()) {
-                final String typeParamName = extractTypeParamNameFromTag(tag);
+        List<String> typeParamNames,
+        List<String> recordComponentNames) {
 
-                if (!typeParamNames.contains(typeParamName)) {
+        for (final JavadocTag tag: tags) {
+            if (tag.isParamTag()) {
+                final String paramName = extractParamNameFromTag(tag);
+                final boolean found = typeParamNames.contains(paramName)
+                        || recordComponentNames.contains(paramName);
+
+                if (!found) {
+                    final String actualParamName =
+                        TYPE_NAME_IN_JAVADOC_TAG_SPLITTER.split(tag.getFirstArg())[0];
                     log(tag.getLineNo(), tag.getColumnNo(),
-                            MSG_UNUSED_TAG,
-                            JavadocTagInfo.PARAM.getText(),
-                            OPEN_ANGLE_BRACKET + typeParamName + CLOSE_ANGLE_BRACKET);
+                        MSG_UNUSED_TAG,
+                        JavadocTagInfo.PARAM.getText(), actualParamName);
                 }
             }
         }
+
     }
 
     /**
-     * Extracts type parameter name from tag.
+     * Extracts parameter name from tag.
      *
      * @param tag javadoc tag to extract parameter name
      * @return extracts type parameter name from tag
      */
-    private static String extractTypeParamNameFromTag(JavadocTag tag) {
+    private static String extractParamNameFromTag(JavadocTag tag) {
         final String typeParamName;
         final Matcher matchInAngleBrackets =
                 TYPE_NAME_IN_JAVADOC_TAG.matcher(tag.getFirstArg());
@@ -525,4 +565,24 @@ public class JavadocTypeCheck
         return typeParamName;
     }
 
+    /**
+     * Collects the record components in a record definition.
+     *
+     * @param node the possible record definition ast.
+     * @return the list of record components in this record definition.
+     */
+    private static List<String> getRecordComponentNames(DetailAST node) {
+        final DetailAST components = node.findFirstToken(TokenTypes.RECORD_COMPONENTS);
+        final List<String> componentList = new ArrayList<>();
+
+        if (components != null) {
+            TokenUtil.forEachChild(components,
+                TokenTypes.RECORD_COMPONENT_DEF, component -> {
+                    final DetailAST ident = component.findFirstToken(TokenTypes.IDENT);
+                    componentList.add(ident.getText());
+                });
+        }
+
+        return componentList;
+    }
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocTypeCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocTypeCheck.xml
@@ -5,7 +5,7 @@
              name="JavadocType"
              parent="com.puppycrawl.tools.checkstyle.TreeWalker">
          <description>&lt;p&gt;
- Checks the Javadoc comments for annotation/enum/class/interface definitions. By default, does
+ Checks the Javadoc comments for type definitions. By default, does
  not check for author or version tags. The scope to verify is specified using the {@code Scope}
  class and defaults to {@code Scope.PRIVATE}. To verify another scope, set property
  scope to one of the {@code Scope} constants. To define the format for an author
@@ -18,7 +18,7 @@
  as they should be redundant because of outer class.
  &lt;/p&gt;
  &lt;p&gt;
- Error messages about type parameters for which no param tags are present
+ Error messages about type parameters and record components for which no param tags are present
  can be suppressed by defining property {@code allowMissingParamTags}.
  &lt;/p&gt;</description>
          <properties>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -296,7 +296,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
             "11:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <C456>"),
             "44:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<C>"),
             "47:5: " + getCheckMessage(MSG_MISSING_TAG, "@param <B>"),
-            "60:5: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<x>"),
+            "60:5: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "x"),
         };
         verify(checkConfig, getPath("InputJavadocTypeTypeParamsTags.java"), expected);
     }
@@ -309,7 +309,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "7:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<D123>"),
             "44:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<C>"),
-            "60:5: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<x>"),
+            "60:5: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "x"),
         };
         verify(checkConfig, getPath("InputJavadocTypeTypeParamsTags.java"), expected);
     }
@@ -319,7 +319,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig =
                 createModuleConfig(JavadocTypeCheck.class);
         final String[] expected = {
-            "6:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<BAD>"),
+            "6:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "BAD"),
             "7:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<BAD>"),
         };
         verify(checkConfig,
@@ -412,5 +412,45 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
             "63:1: " + getCheckMessage(MSG_MISSING_TAG, "@author"),
         };
         verify(checkConfig, getNonCompilablePath("InputJavadocTypeRecords.java"), expected);
+    }
+
+    @Test
+    public void testJavadocTypeRecordComponents() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(JavadocTypeCheck.class);
+        checkConfig.addAttribute("scope", "protected");
+        checkConfig.addAttribute("allowMissingParamTags", "false");
+        checkConfig.addAttribute("allowUnknownTags", "false");
+
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verify(checkConfig,
+            getNonCompilablePath("InputJavadocTypeRecordComponents.java"), expected);
+    }
+
+    @Test
+    public void testJavadocTypeRecordComponents2() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(JavadocTypeCheck.class);
+        checkConfig.addAttribute("scope", "private");
+        checkConfig.addAttribute("allowMissingParamTags", "false");
+        checkConfig.addAttribute("allowUnknownTags", "false");
+
+        final String[] expected = {
+            "37:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <X>"),
+            "41:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "x"),
+            "52:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "notMyString"),
+            "55:1: " + getCheckMessage(MSG_MISSING_TAG, "@param myString"),
+            "55:1: " + getCheckMessage(MSG_MISSING_TAG, "@param myInt"),
+            "59:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "x"),
+            "61:1: " + getCheckMessage(MSG_MISSING_TAG, "@param myList"),
+            "68:1: " + getCheckMessage(MSG_MISSING_TAG, "@param X"),
+            "71:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "notMyString"),
+            "74:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <T>"),
+            "74:1: " + getCheckMessage(MSG_MISSING_TAG, "@param myInt"),
+            "74:1: " + getCheckMessage(MSG_MISSING_TAG, "@param myString"),
+        };
+        verify(checkConfig,
+            getNonCompilablePath("InputJavadocTypeRecordComponents2.java"), expected);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -410,7 +410,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
             "40:1: " + getCheckMessage(MSG_MISSING_TAG, "@author"),
             "53:1: " + getCheckMessage(MSG_TAG_FORMAT, "@author", "ABC"),
             "63:1: " + getCheckMessage(MSG_MISSING_TAG, "@author"),
-            };
+        };
         verify(checkConfig, getNonCompilablePath("InputJavadocTypeRecords.java"), expected);
     }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordComponents.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordComponents.java
@@ -1,0 +1,17 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
+
+/* Config:
+ *
+ * scope = protected
+ * allowMissingParamTags = false
+ * allowUnknownTags = false
+ */
+
+/**
+ * My new record.
+ *
+ * @param value Sponge Bob rules the world!
+ */
+public record InputJavadocTypeRecordComponents(String value) { // ok
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordComponents2.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordComponents2.java
@@ -1,0 +1,74 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
+
+/* Config:
+ *
+ * scope = private
+ * allowMissingParamTags = false
+ * allowUnknownTags = false
+ */
+
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * My new record.
+ *
+ * @param value Sponge Bob rules the world!
+ */
+public record InputJavadocTypeRecordComponents2(String value) { // ok
+}
+
+/**
+ * @param myString my string
+ * @param myInt my int
+ */
+record MyRecord1(String myString, Integer myInt){}
+
+/**
+ * @author Nick Mancuso
+ * @param myHashMap my hash map!
+ */
+record MyRecord2(HashMap<String, String> myHashMap){}
+
+/**
+ *
+ */
+record MyRecord3<X>(){} // violation
+
+/**
+ *
+ * @param x // violation
+ */
+record MyRecord4(){}
+
+/**
+ * @author X
+ * @param <X>
+ */
+record MyRecord5<X>(){}
+
+/**
+ * @param notMyString // violation
+ * @param <X>
+ */
+record MyRecord6<X>(String myString, int myInt){} // violation x2
+
+/**
+ *
+ * @param x // violation
+ */
+record MyRecord7(List<String>myList){} // violation
+
+/**
+ * @author X
+ * @param <X>
+ * @param <T>
+ */
+record MyRecord8<X, T>(String X){} // violation
+
+/**
+ * @param notMyString // violation
+ * @param <X>
+ */
+record MyRecord9<X, T>(String myString, int myInt){} // violation x3

--- a/src/xdocs/checks.xml
+++ b/src/xdocs/checks.xml
@@ -443,7 +443,7 @@
           </tr>
           <tr>
             <td><a href="config_javadoc.html#JavadocType">JavadocType</a></td>
-            <td>Checks the Javadoc comments for annotation/enum/class/interface definitions.</td>
+            <td>Checks the Javadoc comments for type definitions.</td>
           </tr>
           <tr>
             <td><a href="config_javadoc.html#JavadocVariable">JavadocVariable</a></td>

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -1865,7 +1865,7 @@ public class Test {
       <p>Since Checkstyle 3.0</p>
       <subsection name="Description" id="JavadocType_Description">
         <p>
-          Checks the Javadoc comments for annotation/enum/class/interface definitions.
+          Checks the Javadoc comments for type definitions.
           By default, does not check for author or version tags. The
           scope to verify is specified using the <code>Scope</code>
           class and defaults to <code>Scope.PRIVATE</code>. To verify
@@ -1881,8 +1881,8 @@ public class Test {
           classes, as they should be redundant because of outer class.
         </p>
         <p>
-          Error messages about type parameters for which no param tags are
-          present can be suppressed by defining property
+          Error messages about type parameters and record components for which no
+          param tags are present can be suppressed by defining property
           <code>allowMissingParamTags</code>.
         </p>
       </subsection>


### PR DESCRIPTION
Issue #8808: false positive with JavadocTypeCheck @param tags for Records

Note that the changes in commit https://github.com/checkstyle/checkstyle/commit/df1ae95a1c114ecfd6402781668639cdd6593457 correspond to the following code:

```
/** @param x */
class Test {}
```
```
/**
 * InputJavadocTypeUnusedParamInJavadocForClass.
 *
 * @param BAD This is bad.
 * @param <BAD> This doesn't exist.
 * @param
 */
public class InputJavadocTypeUnusedParamInJavadocForClass {
}

```
In both of these cases, the check was adding the angle brackets to the output, assuming that they were for type parameters.  Now that the `@param` tag is overloaded for use with record components, there is no way to know the intent of an unused `@param` tag, so it is best to remove these angle brackets.  In any event, the original behavior of the check wasn't optimal anyway, since we really shouldn't be adding characters that don't exist to output. 

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/6e4314ef4f509d6ed5c7e0f59dfc3662/raw/93862649e0dce3fdced263cf3156f96b01ba6a59/JavadocType.xml