### PR TITLE
infra: disable josm build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -313,12 +313,13 @@ jobs:
           - USE_MAVEN_REPO="true"
           - CMD="./.ci/travis/travis.sh no-error-pmd"
 
-    # No violation testing - josm (ant task)
-    - jdk: openjdk11
-      env:
-          - DESC="no violation testing on josm"
-          - USE_MAVEN_REPO="true"
-          - CMD="./.ci/travis/travis.sh no-violation-test-josm"
+    #  Disabled due to instability
+    #  No violation testing - josm (ant task)
+    # - jdk: openjdk11
+    #   env:
+    #      - DESC="no violation testing on josm"
+    #      - USE_MAVEN_REPO="true"
+    #      - CMD="./.ci/travis/travis.sh no-violation-test-josm"
 
     # OpenJDK14 checkstyle run with one module config to prove that we can parse jdk14 syntax
     - env:


### PR DESCRIPTION
infra: disable josm build

Identified in multiple builds:
https://travis-ci.org/github/checkstyle/checkstyle/builds/727817467
https://travis-ci.org/github/checkstyle/checkstyle/builds/725705597
https://travis-ci.org/github/checkstyle/checkstyle/jobs/724495852
...
```
https://oss.sonatype.org/content/repositories/snapshots/org/jacoco/org.jacoco.ant/0.8.6-SNAPSHOT/org.jacoco.ant-0.8.6-SNAPSHOT-nodeps.jar
[ivy:resolve] 		::::::::::::::::::::::::::::::::::::::::::::::
[ivy:resolve] 		::          UNRESOLVED DEPENDENCIES         ::
[ivy:resolve] 		::::::::::::::::::::::::::::::::::::::::::::::
[ivy:resolve] 		:: org.jacoco#org.jacoco.ant;0.8.6-SNAPSHOT: not found
[ivy:resolve] 		::::::::::::::::::::::::::::::::::::::::::::::
[ivy:resolve] 
[ivy:resolve] :: USE VERBOSE OR DEBUG MESSAGE LEVEL FOR MORE DETAILS
BUILD FAILED
```

Due to the instability of the josm travis job, we are disabling this for now. 