### PR TITLE
Issue #8842: Add rebase github action

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,0 +1,27 @@
+#------------------------------------------------------------------------------------
+# Github Action to rebase pull request.
+#
+# Workflow starts when pr comment created or edited
+#
+# Job will not work if:
+# 1. Patch branch name is 'master'
+# 2. There was an updates in github actions in target branch (restriction by github)
+#------------------------------------------------------------------------------------
+on:
+  issue_comment:
+    types: [created, edited]
+name: Automatic Rebase
+jobs:
+  rebase:
+    name: Rebase PR
+    if: github.event.issue.pull_request != '' && github.event.comment.body == 'GitHub, rebase'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the latest code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Automatic Rebase
+        uses: cirrus-actions/rebase@1.3.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Initial version to resolve #8842

Github action is triggered by additing (or editing) comment with content `GitHub, rebase`

There are 2 restrictions that I found during testing so far:
1. It wont work if patch branch name == 'master'
2. If there was changes in github workflows in target branch - `refusing to allow a GitHub App to create or update workflow without workflows permission`, it is a github restriction.

Second case is not very frequent since updates in workflows are not very frequent.
