### PR TITLE
minor: fix control does not return to idea_inspection.bat after calli…

### DIFF
--- a/.ci/idea_inspection.bat
+++ b/.ci/idea_inspection.bat
@@ -40,7 +40,7 @@ mkdir .idea\scopes
 copy config\intellij-idea-inspection-scope.xml .idea\scopes
 
 ::Execute compilation of Checkstyle to generate all source files
-mvn -e compile
+call mvn -e compile
 
 ::Launch inspections
-"%IDEA_LOCATION%" inspect %PROJECT_DIR% %INSPECTIONS_PATH% %RESULTS_DIR% -%NOISE_LVL%
+call "%IDEA_LOCATION%" inspect %PROJECT_DIR% %INSPECTIONS_PATH% %RESULTS_DIR% -%NOISE_LVL%


### PR DESCRIPTION
This fixes the issue with idea_inspection.bat on Windows 7. After successful completion of `mvn compile` Idea was not launched.