### PR TITLE
Issue #8855: set up cirrus ci

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -219,6 +219,7 @@ chr
 ci
 cidfile
 circleci
+cirrusci
 Claira
 classdataabstractioncoupling
 classfanoutcomplexity
@@ -337,6 +338,7 @@ dghj
 Dgpg
 Dgui
 dhj
+Dhttp
 Diachenko
 dirname
 distelli
@@ -1435,6 +1437,7 @@ Wifi
 wiki
 wikipedia
 wiktionary
+windowsservercore
 woff
 wontfix
 wordpress

--- a/.ci/validation.cmd
+++ b/.ci/validation.cmd
@@ -1,0 +1,40 @@
+@echo off
+
+::----------------------------------------------------------------------
+:: Validation script to run on local for windows users.
+:: Example of usage
+:: ./.ci/validation.cmd  verify_without_checkstyle
+::----------------------------------------------------------------------
+
+SET OPTION=%1
+
+if "%OPTION%" == "sevntu" (
+  call mvn -e verify -DskipTests -DskipITs -Dpmd.skip=true^
+    -Dspotbugs.skip=true -Djacoco.skip=true -Dxml.skip=true^
+    || goto :ERROR
+  goto :END_CASE
+)
+
+if "%OPTION%" ==  "verify_without_checkstyle" (
+  call mvn -e verify -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true^
+    || goto :ERROR
+  goto :END_CASE
+)
+
+if "%OPTION%" ==  "site_without_verify" (
+  call mvn -e -Pno-validations site^
+    || goto :ERROR
+  goto :END_CASE
+)
+
+echo  Unexpected argument %OPTION%
+SET ERRORLEVEL=-1
+goto :END_CASE
+
+:END_CASE
+  VER > NUL
+  EXIT /b %ERRORLEVEL%
+
+:ERROR
+echo validation failed with error code #%ERRORLEVEL%.
+exit /b %ERRORLEVEL%

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,62 @@
+task:
+  name: Windows build
+  windows_container:
+    image: cirrusci/windowsservercore:2019
+  clone_script:
+    - git config core.autocrlf
+    - git clone --recursive
+          https://x-access-token:%CIRRUS_REPO_CLONE_TOKEN%@github.com/%CIRRUS_REPO_FULL_NAME%.git
+          %CIRRUS_WORKING_DIR%/ci
+    - cd ci
+    - git fetch origin pull/%CIRRUS_PR%/head:pull/%CIRRUS_PR%
+    - git reset --hard %CIRRUS_CHANGE_IN_REPO%
+  choco_cache:
+    # should be under %CIRRUS_WORKING_DIR%
+    folder: .chocolatey
+  maven_cache:
+    # should be under %CIRRUS_WORKING_DIR%
+    folder: .m2
+  matrix:
+    - name: Cirrus - JDK11
+      env:
+        OPENJDK_VERSION: "11.0.2.01"
+        OPENJDK_PATH: "jdk-11.0.2"
+    - name: Cirrus - JDK14
+      env:
+        OPENJDK_VERSION: "14.0.2"
+        OPENJDK_PATH: "jdk-14.0.2"
+    - name: Cirrus - JDK15
+      env:
+        OPENJDK_VERSION: "15.0.0"
+        OPENJDK_PATH: "jdk-15"
+  env:
+    # disable ANSI output for picocli (may affect tests)
+    NO_COLOR: "1"
+    # https://stackoverflow.com/questions/42024619/maven-build-gets-connection-reset-when-downloading-artifacts
+    MAVEN_OPTS:
+      - -Dhttp.keepAlive=false
+        -Dmaven.repo.local=%CIRRUS_WORKING_DIR%/.m2
+        -Dmaven.wagon.http.retryHandler.count=3
+        -Dmaven.wagon.http.pool=false
+    MAVEN_VERSION: "3.6.3"
+    PATH: "%PATH%;C:/Program Files/OpenJDK/%OPENJDK_PATH%/bin;\
+      C:/ProgramData/chocolatey/lib/maven/apache-maven-%MAVEN_VERSION%/bin;\
+      C:/ProgramData/chocolatey/bin"
+  install_script:
+    - choco config set cacheLocation %CIRRUS_WORKING_DIR%/.chocolatey
+    - choco upgrade -y chocolatey
+    - choco install -y ant
+    - choco install -y maven --version %MAVEN_VERSION%
+    - choco install -y openjdk --version %OPENJDK_VERSION%
+    - choco install -y xsltproc
+    - choco install -y xmlstarlet
+  version_script:
+    - set
+    - ant -version
+    - java --version
+    - mvn --version
+    - xsltproc --version
+    - xml --version
+  test_script:
+    - cd ci
+    - .ci/validation.cmd verify_without_checkstyle


### PR DESCRIPTION
Issue #8855 Windows build at Cirrus CI

Notes:

* We need to use custom clone script due to `core.autocrlf` option;
* Maven and Chocolatey cache should be under the working directory;
* The command `refreshenv` does [not work](https://cirrus-ci.org/guide/windows/#environment-variables), we should set `PATH` variable manually;
* The tests `MainTest` and `PrepertiesGeneratorTest` fails since `picocli` is unable to figure out right ANSI mode. Interesting, that Appveyor is not affected by this bug. Solved with `NO_COLOR` environment variable;
* During the process I found a nice solution for connection reset problem that appears in all CI's.