### PR TITLE
Issue #6658: Pitest increase mutation coverage for pitest-imports profile to 100% - PkgImportRule

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -77,7 +77,6 @@ pitest-imports)
   "PkgImportControl.java.html:<td class='covered'><pre><span  class='survived'>        if (alreadyRegex) {</span></pre></td></tr>"
   "PkgImportControl.java.html:<td class='covered'><pre><span  class='survived'>        if (regex || parent.regex) {</span></pre></td></tr>"
   "PkgImportControl.java.html:<td class='covered'><pre><span  class='survived'>        if (regex) {</span></pre></td></tr>"
-  "PkgImportRule.java.html:<td class='covered'><pre><span  class='survived'>        if (isRegExp()) {</span></pre></td></tr>"
   );
   checkPitestReport "${ignoredItems[@]}"
   ;;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgImportRuleTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgImportRuleTest.java
@@ -89,6 +89,22 @@ public class PkgImportRuleTest {
     }
 
     @Test
+    public void testPkgImportRuleNoRegexp() {
+        final PkgImportRule rule = new PkgImportRule(true, false, "(pkg|hallo)", false, false);
+        assertNotNull(rule, "Rule must not be null");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkga"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkg.a"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkg.a.b"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkg"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("halloa"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("hallo.a"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("hallo.a.b"), "Invalid access result");
+        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("hallo"), "Invalid access result");
+        assertEquals(AccessResult.ALLOWED, rule.verifyImport("(pkg|hallo).a"),
+                     "Invalid access result");
+    }
+
+    @Test
     public void testPkgImportRuleExactMatchRegexp() {
         final PkgImportRule rule = new PkgImportRule(true, false, "(pkg|hallo)", true, true);
         assertNotNull(rule, "Rule must not be null");


### PR DESCRIPTION
Issue #6658 

**Mutation:**

```java

boolean pkgMatch;

if (isRegExp()) {          // removed conditional - replaced eqality check with true
    pkgMatch = forImport.matches(pkgName + "\\..*");

    if (pkgMatch && exactMatch) {
        pkgMatch = !forImport.matches(pkgName + "\\..*\\..*");
    }
}

else {
    pkgMatch = forImport.startsWith(pkgName + ".");

    if (pkgMatch && exactMatch) {
        pkgMatch = forImport.indexOf('.',
        pkgName.length() + 1) == -1;
    }
}
 
return calculateResult(pkgMatch);
```

**Explanation:**
There should be a test where `regexp` is **false** but the `pkg name` is given in form of **regexp**.

**Solution:**
I added the following test.

```java
@Test
    public void testPkgImportRuleNoRegexp() {
        final PkgImportRule rule = new PkgImportRule(true, false, "(pkg|hallo)", false, false);
        assertNotNull(rule, "Rule must not be null");
        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkga"), "Invalid access result");
        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkg.a"), "Invalid access result");
        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkg.a.b"), "Invalid access result");
        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("pkg"), "Invalid access result");
        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("halloa"), "Invalid access result");
        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("hallo.a"), "Invalid access result");
        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("hallo.a.b"), "Invalid access result");
        assertEquals(AccessResult.UNKNOWN, rule.verifyImport("hallo"), "Invalid access result");
        assertEquals(AccessResult.ALLOWED, rule.verifyImport("(pkg|hallo).a"), "Invalid access result");
    }
```

**Pitest Report:**
https://developerhb.github.io/202010021102/com.puppycrawl.tools.checkstyle.checks.imports/index.html