### PR TITLE
Issue #7685: Update doc for AvoidStaticImport

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
@@ -61,6 +61,13 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <pre>
  * &lt;module name="AvoidStaticImport"/&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * import static java.lang.Math.pow;          // violation
+ * import static java.lang.System.*;          // violation
+ * import java.io.File;                       // OK
+ * import java.util.*;                        // OK
+ * </pre>
  * <p>
  * To configure the check so that the {@code java.lang.System.out} member and all
  * members from {@code java.lang.Math} are allowed:
@@ -69,6 +76,14 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * &lt;module name="AvoidStaticImport"&gt;
  *   &lt;property name="excludes" value="java.lang.System.out,java.lang.Math.*"/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * import static java.lang.Math.*;            // OK
+ * import static java.lang.System.out;        // OK
+ * import static java.lang.Integer.parseInt;  // violation
+ * import java.io.*;                          // OK
+ * import java.util.*;                        // OK
  * </pre>
  * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -265,6 +265,15 @@ import java.net.*;                // violation
 &lt;module name="AvoidStaticImport"/&gt;
         </source>
         <p>
+          Example:
+        </p>
+        <source>
+import static java.lang.Math.pow;          // violation
+import static java.lang.System.*;          // violation
+import java.io.File;                       // OK
+import java.util.*;                        // OK
+        </source>
+        <p>
           To configure the check so that the <code>java.lang.System.out</code>
           member and all members from <code>java.lang.Math</code> are allowed:
         </p>
@@ -272,6 +281,16 @@ import java.net.*;                // violation
 &lt;module name="AvoidStaticImport"&gt;
   &lt;property name="excludes" value="java.lang.System.out,java.lang.Math.*"/&gt;
 &lt;/module&gt;
+        </source>
+        <p>
+         Example:
+        </p>
+        <source>
+import static java.lang.Math.*;            // OK
+import static java.lang.System.out;        // OK
+import static java.lang.Integer.parseInt;  // violation
+import java.io.*;                          // OK
+import java.util.*;                        // OK
         </source>
       </subsection>
 


### PR DESCRIPTION
Issue #7685

![exampletwo](https://user-images.githubusercontent.com/23631699/94930385-9b45a300-04c6-11eb-9ef5-53c62617fd5d.PNG)

Output of example 1:

    $ cat config.xml
    <?xml version="1.0"?>
    <!DOCTYPE 
    module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
    "https://checkstyle.org/dtds/configuration_1_3.dtd">
    <module name="Checker">
      <module name="TreeWalker">
        <module name="AvoidStaticImport"/>    
      </module>
    </module>

    $ cat Test.java
    import static java.lang.Math.pow;          // violation
    import static java.lang.System.out;        // violation
    import java.io.*;                          // OK
    import java.util.*;                        // OK

    $ java -jar checkstyle-8.36.2-all.jar -c config.xml Test.java
    Starting audit...
    [ERROR] D:\OpenSource\TestCommit\Test.java:1:29: Using a static member import should be avoided - java.lang.Math.pow. [AvoidStaticImport]
    [ERROR] D:\OpenSource\TestCommit\Test.java:2:31: Using a static member import should be avoided - java.lang.System.out. [AvoidStaticImport]
    Audit done.
    Checkstyle ends with 2 errors.

Output of example 2:

    $ cat config.xml
    <?xml version="1.0"?>
    <!DOCTYPE 
    module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
    "https://checkstyle.org/dtds/configuration_1_3.dtd">
    <module name="Checker">
      <module name="TreeWalker">
        <module name="AvoidStaticImport">    
            <property name="excludes" value="java.lang.System.out,java.lang.Math.*"/>
        </module>
      </module>
    </module>

    $ cat Test.java
    import static java.lang.Math.*;            // OK
    import static java.lang.System.out;        // OK
    import static java.lang.Integer.parseInt;  // violation
    import java.io.*;                          // OK
    import java.util.*;                        // OK

    $ java -jar checkstyle-8.36.2-all.jar -c config.xml Test.java
    Starting audit...
    [ERROR] D:\OpenSource\TestCommit\Test.java:3:32: Using a static member import should be avoided - java.lang.Integer.parseInt. [AvoidStaticImport]
    Audit done.
    Checkstyle ends with 1 errors.