### PR TITLE
Issue #6209: activate no-error-spring-cloud-gcp in wercker 

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -521,6 +521,7 @@ Gjs
 google
 googleapis
 googleblog
+googlecloudplatform
 googleecommon
 googlegroups
 googlesource

--- a/.ci/wercker.sh
+++ b/.ci/wercker.sh
@@ -244,12 +244,10 @@ no-error-spring-cloud-gcp)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/romani/spring-cloud-gcp
+  checkout_from https://github.com/googlecloudplatform/spring-cloud-gcp
   cd .ci-temp/spring-cloud-gcp
-  git checkout romani-patch-1
-  mvn -e checkstyle:check@checkstyle-validation -P full-checkstyle \
-   -Dpuppycrawl-tools-checkstyle.version=${CS_POM_VERSION} \
-   -Dmaven-checkstyle-plugin.version=3.1.1
+  mvn -e checkstyle:check@checkstyle-validation \
+   -Dpuppycrawl-tools-checkstyle.version=${CS_POM_VERSION}
   cd ..
   removeFolderWithProtectedFiles spring-cloud-gcp
   ;;


### PR DESCRIPTION
Issue #6209

for googlecloudplatform/spring-cloud-gcp

based on advice at https://github.com/checkstyle/checkstyle/pull/8850#issuecomment-705151362

tested:
```
[INFO] 
[INFO] --- maven-checkstyle-plugin:3.1.1:check (checkstyle-validation) @ spring-cloud-gcp-core ---
[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
[INFO] Starting audit...
[ERROR] .ci-temp/spring-cloud-gcp/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/Credentials.java:20: Wrong order for 'java.util.ArrayList' import. [ImportOrder]
[ERROR] .ci-temp/spring-cloud-gcp/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/Credentials.java:30:29: '=' is not followed by whitespace. [WhitespaceAround]
[ERROR] .ci-temp/spring-cloud-gcp/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/Credentials.java:30:29: '=' is not preceded with whitespace. [WhitespaceAround]
[ERROR] .ci-temp/spring-cloud-gcp/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/Credentials.java:45:28: '...' is preceded with whitespace. [NoWhitespaceBefore]
[ERROR] .ci-temp/spring-cloud-gcp/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/Credentials.java:46:2: '{' at column 2 should be on the previous line. [LeftCurly]
[ERROR] .ci-temp/spring-cloud-gcp/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/Credentials.java:47:51: ';' is not followed by whitespace. [WhitespaceAfter]
[ERROR] .ci-temp/spring-cloud-gcp/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/Credentials.java:47:52: '}' is not preceded with whitespace. [WhitespaceAround]
Audit done.
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Spring Cloud GCP 2.0.0-SNAPSHOT:
[INFO] 
[INFO] Spring Cloud GCP ................................... SUCCESS [  0.645 s]
[INFO] Spring Cloud GCP Core Module ....................... FAILURE [  0.364 s]

```