### PR TITLE
Issue #7637: Update doc for EqualsAvoidNull

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -38,23 +38,9 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
  * </p>
  * <p>Rationale: Calling the {@code equals()} method on String literals
  * will avoid a potential {@code NullPointerException}. Also, it is
- * pretty common to see null checks right before equals comparisons,
- * which is not necessary in the example below.
+ * pretty common to see null checks right before equals comparisons
+ * but following this rule such checks are not required.
  * </p>
- * <p>
- * For example, this code:
- * </p>
- * <pre>
- * String nullString = null;
- * nullString.equals(&quot;My_Sweet_String&quot;);
- * </pre>
- * <p>
- * should be refactored to:
- * </p>
- * <pre>
- * String nullString = null;
- * &quot;My_Sweet_String&quot;.equals(nullString);
- * </pre>
  * <ul>
  * <li>
  * Property {@code ignoreEqualsIgnoreCase} - Control whether to ignore
@@ -68,6 +54,34 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
  * </p>
  * <pre>
  * &lt;module name=&quot;EqualsAvoidNull&quot;/&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * String nullString = null;
+ * nullString.equals("My_Sweet_String");            // violation
+ * "My_Sweet_String".equals(nullString);            // OK
+ * nullString.equalsIgnoreCase("My_Sweet_String");  // violation
+ * "My_Sweet_String".equalsIgnoreCase(nullString);  // OK
+ * </pre>
+ * <p>
+ * To configure the check to allow ignoreEqualsIgnoreCase:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;EqualsAvoidNull&quot;&gt;
+ *   &lt;property name=&quot;ignoreEqualsIgnoreCase&quot; value=&quot;true&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * String nullString = null;
+ * nullString.equals("My_Sweet_String");            // violation
+ * "My_Sweet_String".equals(nullString);            // OK
+ * nullString.equalsIgnoreCase("My_Sweet_String");  // OK
+ * "My_Sweet_String".equalsIgnoreCase(nullString);  // OK
  * </pre>
  * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/EqualsAvoidNullCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/EqualsAvoidNullCheck.xml
@@ -12,23 +12,9 @@
  &lt;/p&gt;
  &lt;p&gt;Rationale: Calling the {@code equals()} method on String literals
  will avoid a potential {@code NullPointerException}. Also, it is
- pretty common to see null checks right before equals comparisons,
- which is not necessary in the example below.
- &lt;/p&gt;
- &lt;p&gt;
- For example, this code:
- &lt;/p&gt;
- &lt;pre&gt;
- String nullString = null;
- nullString.equals(&amp;quot;My_Sweet_String&amp;quot;);
- &lt;/pre&gt;
- &lt;p&gt;
- should be refactored to:
- &lt;/p&gt;
- &lt;pre&gt;
- String nullString = null;
- &amp;quot;My_Sweet_String&amp;quot;.equals(nullString);
- &lt;/pre&gt;</description>
+ pretty common to see null checks right before equals comparisons
+ but following this rule such checks are not required.
+ &lt;/p&gt;</description>
          <properties>
             <property default-value="false" name="ignoreEqualsIgnoreCase" type="boolean">
                <description>Control whether to ignore

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -1057,24 +1057,10 @@ public void foo() {
           Rationale: Calling the <code>equals()</code>
           method on String literals will avoid a potential
           <code>NullPointerException</code>. Also, it is pretty common to see null
-          checks right before equals comparisons, which is not necessary
-          in the example below.
+          checks right before equals comparisons but following this rule such checks
+          are not required.
         </p>
 
-        <p>
-          For example, this code:
-        </p>
-        <source>
-String nullString = null;
-nullString.equals(&quot;My_Sweet_String&quot;);
-        </source>
-
-        <p>should be refactored to:</p>
-
-        <source>
-String nullString = null;
-&quot;My_Sweet_String&quot;.equals(nullString);
-        </source>
       </subsection>
 
       <subsection name="Properties" id="EqualsAvoidNull_Properties">
@@ -1106,6 +1092,35 @@ String nullString = null;
         </p>
         <source>
 &lt;module name=&quot;EqualsAvoidNull&quot;/&gt;
+        </source>
+        <p>
+         Example:
+        </p>
+        <source>
+String nullString = null;
+nullString.equals("My_Sweet_String");            // violation
+"My_Sweet_String".equals(nullString);            // OK
+nullString.equalsIgnoreCase("My_Sweet_String");  // violation
+"My_Sweet_String".equalsIgnoreCase(nullString);  // OK
+        </source>
+
+        <p>
+         To configure the check to allow ignoreEqualsIgnoreCase:
+        </p>
+        <source>
+&lt;module name=&quot;EqualsAvoidNull&quot;&gt;
+  &lt;property name=&quot;ignoreEqualsIgnoreCase&quot; value=&quot;true&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+         Example:
+        </p>
+        <source>
+String nullString = null;
+nullString.equals("My_Sweet_String");            // violation
+"My_Sweet_String".equals(nullString);            // OK
+nullString.equalsIgnoreCase("My_Sweet_String");  // OK
+"My_Sweet_String".equalsIgnoreCase(nullString);  // OK
         </source>
       </subsection>
 


### PR DESCRIPTION
Issue #7637

![pr1](https://user-images.githubusercontent.com/23631699/95658666-7384b980-0b1c-11eb-9793-458031f3b43c.PNG)

![pr2](https://user-images.githubusercontent.com/23631699/95658667-74b5e680-0b1c-11eb-8154-b147e2a22ebb.PNG)

Example 1:
```
cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
        "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
       <module name="EqualsAvoidNull"/>
    </module>
</module>

cat Test.java
package main;

public class Test {
    public static void main(String[] args) {
        String nullString = null;
        nullString.equals("My_Sweet_String");            // violation
        "My_Sweet_String".equals(nullString);            // OK
        nullString.equalsIgnoreCase("My_Sweet_String");  // violation
        "My_Sweet_String".equalsIgnoreCase(nullString);  // OK
    }
}

java -jar checkstyle-8.36.2-all.jar -c config.xml Test.java
Starting audit...
[ERROR] D:\OpenSource\TestCommit\Test.java:6:26: String literal expressions should be on the left side of an equals comparison. [EqualsAvoidNull]
[ERROR] D:\OpenSource\TestCommit\Test.java:8:36: String literal expressions should be on the left side of an equalsIgnoreCase comparison. [EqualsAvoidNull]
Audit done.
Checkstyle ends with 2 errors.
```
Example 2:

```
cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
        "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
       <module name="EqualsAvoidNull">
           <property name="ignoreEqualsIgnoreCase" value="true"/>
       </module>
    </module>
</module>

cat Test.java
package main;

public class Test {
    public static void main(String[] args) {
        String nullString = null;
        nullString.equals("My_Sweet_String");            // violation
        "My_Sweet_String".equals(nullString);            // OK
        nullString.equalsIgnoreCase("My_Sweet_String");  // OK
        "My_Sweet_String".equalsIgnoreCase(nullString);  // O 
    }
}

java -jar checkstyle-8.36.2-all.jar -c config.xml Test.java
Starting audit...
[ERROR] D:\OpenSource\TestCommit\Test.java:6:26: String literal expressions should be on the left side of an equals comparison. [EqualsAvoidNull]
Audit done.
Checkstyle ends with 1 errors.
```

I have removed the example from the Description section and moved it with other examples in the Examples section