### PR TITLE
Issue #8879: fix local variable detection in resource node

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
@@ -266,7 +266,7 @@ public final class ScopeUtil {
         }
 
         if (node.getType() == TokenTypes.RESOURCE) {
-            localVariableDef = true;
+            localVariableDef = node.getChildCount() > 1;
         }
         return localVariableDef;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheckTest.java
@@ -114,4 +114,15 @@ public class LocalFinalVariableNameCheckTest
         verify(checkConfig, getPath("InputLocalFinalVariableNameTryResources.java"), expected);
     }
 
+    @Test
+    public void testTryWithResourcesJava9() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(LocalFinalVariableNameCheck.class);
+        checkConfig.addAttribute("format", "[a-z]+");
+
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getNonCompilablePath(
+            "InputLocalFinalVariableNameTryResourcesJava9.java"), expected);
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtilTest.java
@@ -166,7 +166,18 @@ public class ScopeUtilTest {
 
     @Test
     public void testIsLocalVariableDefResource() {
-        assertTrue(ScopeUtil.isLocalVariableDef(getNode(TokenTypes.RESOURCE)), "invalid result");
+        final DetailAstImpl node = getNode(TokenTypes.RESOURCE);
+        final DetailAstImpl modifiers = new DetailAstImpl();
+        modifiers.setType(TokenTypes.MODIFIERS);
+        node.addChild(modifiers);
+        final DetailAstImpl ident = new DetailAstImpl();
+        ident.setType(TokenTypes.IDENT);
+        node.addChild(ident);
+        assertTrue(ScopeUtil.isLocalVariableDef(node), "invalid result");
+        final DetailAstImpl resourceWithIdent = getNode(TokenTypes.RESOURCE);
+        resourceWithIdent.addChild(ident);
+        assertFalse(ScopeUtil.isLocalVariableDef(resourceWithIdent), "invalid result");
+        assertFalse(ScopeUtil.isLocalVariableDef(getNode(TokenTypes.RESOURCE)), "invalid result");
     }
 
     @Test

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/InputLocalFinalVariableNameTryResourcesJava9.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/InputLocalFinalVariableNameTryResourcesJava9.java
@@ -1,0 +1,26 @@
+//non-compiled with javac: Compilable with Java9
+package com.puppycrawl.tools.checkstyle.checks.naming.localfinalvariablename;
+
+/*
+ * Config:
+ * format = "^[a-z]+$"
+ */
+public class InputLocalFinalVariableNameTryResourcesJava9 {
+    private static final Lock LOCK = new Lock();
+
+    public void foo() {
+        LOCK.lock();
+        try (LOCK) { // ok
+        }
+    }
+}
+
+class Lock implements AutoCloseable {
+
+    public void lock() {
+    }
+
+    @Override
+    public void close() {
+    }
+}


### PR DESCRIPTION
Closes #8879 

Issue is in common method for local variable definition detection, thus several checks are affected.

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/strkkk/ac73db2366737f5a2d9ac0b3a39e81fa/raw/88d42f4621b0802ae77b8bc50e20d437afa5b763/8879.xml

Reg report (checks that invoke this method directly or via isClassDeclarationDef method)
https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/8879_local_variable_false_positive_2020151659/reports/diff/index.html

It shows that some other false positives have been fixed and also one NPE