### PR TITLE
Issue #8889: fix NonEmptyAtclauseDescriptionCheck for empty descriptions

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 
 /**
@@ -127,7 +128,26 @@ public class NonEmptyAtclauseDescriptionCheck extends AbstractJavadocCheck {
     private static boolean isEmptyTag(DetailNode tagNode) {
         final DetailNode tagDescription =
                 JavadocUtil.findFirstToken(tagNode, JavadocTokenTypes.DESCRIPTION);
-        return tagDescription == null;
+        return tagDescription == null
+            || hasOnlyEmptyText(tagDescription);
+    }
+
+    /**
+     * Tests if description node is empty (has only new lines and blank strings).
+     *
+     * @param description description node.
+     * @return true, if description node has only new lines and blank strings.
+     */
+    private static boolean hasOnlyEmptyText(DetailNode description) {
+        boolean result = true;
+        for (DetailNode child : description.getChildren()) {
+            if (child.getType() != JavadocTokenTypes.TEXT
+                    || !CommonUtil.isBlank(child.getText())) {
+                result = false;
+                break;
+            }
+        }
+        return result;
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheckTest.java
@@ -84,6 +84,7 @@ public class NonEmptyAtclauseDescriptionCheckTest
             "92: " + getCheckMessage(MSG_KEY),
             "93: " + getCheckMessage(MSG_KEY),
             "120: " + getCheckMessage(MSG_KEY),
+            "129: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputNonEmptyAtclauseDescription.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/nonemptyatclausedescription/InputNonEmptyAtclauseDescription.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/nonemptyatclausedescription/InputNonEmptyAtclauseDescription.java
@@ -123,4 +123,19 @@ class InputNonEmptyAtclauseDescription
         {
                 return 1;
         }
+
+        /**
+         * @param a xxx
+         * @return
+         */     // ^ violation
+        int foo(int a) {
+                return a;
+        }
+
+        /**
+         * @return {@code 1}
+         */     // ^ ok
+        int bar() {
+                return 1;
+        }
 }


### PR DESCRIPTION
Closes #8889 

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/e3988f8092d919b5cbe70f5359c4d9e8/raw/a0f6f5860f8025c19868061dee6e0e40960b992f/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/strkkk/a6e04b73158d1ef6f563dd5aab753361/raw/c89894fe9b9c5bd8a3ddc7c17023340806449941/constant_name