### PR TITLE
Issue #7562: Add default config example for ClassTypeParameterName

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ClassTypeParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ClassTypeParameterNameCheck.java
@@ -39,22 +39,47 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <pre>
  * &lt;module name="ClassTypeParameterName"/&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * class MyClass1&lt;T&gt; {}        // OK
+ * class MyClass2&lt;t&gt; {}        // violation
+ * class MyClass3&lt;abc&gt; {}      // violation
+ * class MyClass4&lt;LISTENER&gt; {} // violation
+ * class MyClass5&lt;RequestT&gt; {} // violation
+ * </pre>
  * <p>
- * An example of how to configure the check for names that are only a single
- * letter is:
+ * To configure the check for names that are uppercase word:
  * </p>
- * <p>Configuration:</p>
  * <pre>
  * &lt;module name="ClassTypeParameterName"&gt;
- *   &lt;property name="format" value="^[a-zA-Z]$"/&gt;
+ *   &lt;property name="format" value="^[A-Z]{2,}$"/&gt;
  * &lt;/module&gt;
  * </pre>
  * <p>Example:</p>
  * <pre>
- * class MyClass1&lt;T&gt; {} // OK
- * class MyClass2&lt;t&gt; {} // OK
- * class MyClass3&lt;abc&gt; {} // violation, the class type parameter
- *                              // name should match the regular expression "^[a-zA-Z]$"
+ * class MyClass1&lt;T&gt; {}        // violation
+ * class MyClass2&lt;t&gt; {}        // violation
+ * class MyClass3&lt;abc&gt; {}      // violation
+ * class MyClass4&lt;LISTENER&gt; {} // OK
+ * class MyClass5&lt;RequestT&gt; {} // violation
+ * </pre>
+ * <p>
+ * To configure the check for names that are camel case word with T as suffix (
+ * <a href="https://checkstyle.org/styleguides/google-java-style-20180523/javaguide.html#s5.2.8-type-variable-names">
+ * Google Style</a>):
+ * </p>
+ * <pre>
+ * &lt;module name="ClassTypeParameterName"&gt;
+ *   &lt;property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * class MyClass1&lt;T&gt; {}        // violation
+ * class MyClass2&lt;t&gt; {}        // violation
+ * class MyClass3&lt;abc&gt; {}      // violation
+ * class MyClass4&lt;LISTENER&gt; {} // violation
+ * class MyClass5&lt;RequestT&gt; {} // OK
  * </pre>
  * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -732,21 +732,46 @@ public class MyTest {
         <source>
 &lt;module name=&quot;ClassTypeParameterName&quot;/&gt;
         </source>
+        <p>Example:</p>
+        <source>
+class MyClass1&lt;T&gt; {}        // OK
+class MyClass2&lt;t&gt; {}        // violation
+class MyClass3&lt;abc&gt; {}      // violation
+class MyClass4&lt;LISTENER&gt; {} // violation
+class MyClass5&lt;RequestT&gt; {} // violation
+        </source>
         <p>
-          An example of how to configure the check for names that are only a single letter is:
+          To configure the check for names that are uppercase word:
         </p>
-        <p>Configuration:</p>
         <source>
 &lt;module name=&quot;ClassTypeParameterName&quot;&gt;
-  &lt;property name="format" value="^[a-zA-Z]$"/&gt;
+  &lt;property name="format" value="^[A-Z]{2,}$"/&gt;
 &lt;/module&gt;
         </source>
         <p>Example:</p>
         <source>
-class MyClass1&lt;T&gt; {} // OK
-class MyClass2&lt;t&gt; {} // OK
-class MyClass3&lt;abc&gt; {} // violation, the class type parameter
-                             // name should match the regular expression "^[a-zA-Z]$"
+class MyClass1&lt;T&gt; {}        // violation
+class MyClass2&lt;t&gt; {}        // violation
+class MyClass3&lt;abc&gt; {}      // violation
+class MyClass4&lt;LISTENER&gt; {} // OK
+class MyClass5&lt;RequestT&gt; {} // violation
+        </source>
+        <p>
+          To configure the check for names that are camel case word with T as suffix
+          (<a href="https://checkstyle.org/styleguides/google-java-style-20180523/javaguide.html#s5.2.8-type-variable-names">Google Style</a>):
+        </p>
+        <source>
+&lt;module name=&quot;ClassTypeParameterName&quot;&gt;
+  &lt;property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+class MyClass1&lt;T&gt; {}        // violation
+class MyClass2&lt;t&gt; {}        // violation
+class MyClass3&lt;abc&gt; {}      // violation
+class MyClass4&lt;LISTENER&gt; {} // violation
+class MyClass5&lt;RequestT&gt; {} // OK
         </source>
       </subsection>
 


### PR DESCRIPTION
Issue #7562

![pr](https://user-images.githubusercontent.com/23631699/96448942-664e8580-1214-11eb-9853-079e72e63d80.PNG)

```
$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
        "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
       <module name="ClassTypeParameterName">
       </module>
    </module>
</module>

$ cat Test.java
class MyClass1<T> {}   // OK
class MyClass2<t> {}   // violation

$ java -jar checkstyle-8.36.2-all.jar -c config.xml Test.java
Starting audit...
[ERROR] D:\OpenSource\TestCommit\Test.java:2:16: Name 't' must match pattern '^[A-Z]$'. [ClassTypeParameterName]
Audit done.
Checkstyle ends with 1 errors.
```