### PR TITLE
Issue #8895: FinalLocalVariable: NPE in records

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -33,6 +33,7 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
 import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
  * <p>
@@ -778,10 +779,8 @@ public class FinalLocalVariableCheck extends AbstractCheck {
      */
     private static DetailAST findFirstUpperNamedBlock(DetailAST ast) {
         DetailAST astTraverse = ast;
-        while (astTraverse.getType() != TokenTypes.METHOD_DEF
-                && astTraverse.getType() != TokenTypes.CLASS_DEF
-                && astTraverse.getType() != TokenTypes.ENUM_DEF
-                && astTraverse.getType() != TokenTypes.CTOR_DEF
+        while (!TokenUtil.isOfType(astTraverse, TokenTypes.METHOD_DEF, TokenTypes.CLASS_DEF,
+                TokenTypes.ENUM_DEF, TokenTypes.CTOR_DEF, TokenTypes.COMPACT_CTOR_DEF)
                 && !ScopeUtil.isClassFieldDef(astTraverse)) {
             astTraverse = astTraverse.getParent();
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
@@ -87,6 +87,17 @@ public class FinalLocalVariableCheckTest
     }
 
     @Test
+    public void testRecordsInput() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(FinalLocalVariableCheck.class);
+        final String[] expected = {
+            "15:17: " + getCheckMessage(MSG_KEY, "b"),
+        };
+        verify(checkConfig,
+            getNonCompilablePath("InputFinalLocalVariableCheckRecords.java"), expected);
+    }
+
+    @Test
     public void testParameter() throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(FinalLocalVariableCheck.class);

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableCheckRecords.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableCheckRecords.java
@@ -1,0 +1,19 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.coding.finallocalvariable;
+
+/* Config:
+ * default
+ */
+public record InputFinalLocalVariableCheckRecords(boolean t, boolean f) {
+    public InputFinalLocalVariableCheckRecords {
+        int a = 0; // ok
+        a = 1;
+    }
+
+    record bad(int i) {
+        public bad {
+            int b = 0; // violation
+        }
+    }
+}
+


### PR DESCRIPTION
Fix #8895 

As described [here](https://github.com/checkstyle/checkstyle/issues/8895#issuecomment-711096332), adding `&& astTraverse.getType() != TokenTypes.COMPACT_CTOR_DEF` solves the problem.

Diff Regression config: https://gist.githubusercontent.com/anhminhtran235/c74908614e3465fade5de3c1d33fad5e/raw/ec75fe33dd75befe6b23185b9521c93cebb1c18b/check.xml
Diff Regression projects: https://gist.githubusercontent.com/romani/cbc85ed26b809064dc260a246666743a/raw/a515faeb85836d1bb9987855cadc23fd3b63abfc/gistfile1.txt