### PR TITLE
Issue #8925: fix anchor links for front page subsections

### DIFF
--- a/src/xdocs/index.xml.vm
+++ b/src/xdocs/index.xml.vm
@@ -150,7 +150,7 @@
         many improvements since then. The known plug-ins are:
       </p>
 
-      <subsection name="Active Tools" >
+      <subsection name="Active Tools" id="Related_Tools_Active_Tools">
         <div class="wrapper">
           <table>
             <tr>
@@ -430,7 +430,7 @@
         </div>
       </subsection>
 
-      <subsection name="Inactive / Old Tools" >
+      <subsection name="Inactive / Old Tools" id="Related_Tools_Inactive_Old_Tools">
         <div class="wrapper">
           <table>
             <tr>


### PR DESCRIPTION
Closes #8925

Subsections were missing their ids, so js code to take link name was returning undefined
