### PR TITLE
infra: update spring-cloud-gcp to use maven-checkstyle-plugin 3.1.1

### DIFF
--- a/.ci/wercker.sh
+++ b/.ci/wercker.sh
@@ -247,6 +247,7 @@ no-error-spring-cloud-gcp)
   checkout_from https://github.com/googlecloudplatform/spring-cloud-gcp
   cd .ci-temp/spring-cloud-gcp
   mvn -e checkstyle:check@checkstyle-validation \
+   -Dmaven-checkstyle-plugin.version=3.1.1 \
    -Dpuppycrawl-tools-checkstyle.version=${CS_POM_VERSION}
   cd ..
   removeFolderWithProtectedFiles spring-cloud-gcp


### PR DESCRIPTION
to pass on checkstyle snapshot version

reproduced in local even on master code.

failure - https://app.wercker.com/checkstyle/checkstyle/runs/build/5f9aca9c237ec900081ffd52?step=5f9acae1fddfc1000855aa55


detected at https://github.com/checkstyle/checkstyle/pull/8939#issuecomment-719579267