### PR TITLE
minor: remove invalid bitbucket plugin from list of active tools

### DIFF
--- a/src/xdocs/index.xml.vm
+++ b/src/xdocs/index.xml.vm
@@ -161,20 +161,6 @@
             </tr>
             <tr>
               <td>
-                <a href="https://www.atlassian.com/software/bitbucket">
-                  Bitbucket Server
-                </a>
-              </td>
-              <td>Stephan Bechter</td>
-              <td>
-                <a href="https://marketplace.atlassian.com/apps/1214095/checkstyles-for-bitbucket-server">
-                  Checkstyle for Bitbucket Server
-                </a>
-              </td>
-              <td/>
-            </tr>
-            <tr>
-              <td>
                 <a href="https://www.codacy.com/">Codacy</a>
               </td>
               <td>João Machado</td>


### PR DESCRIPTION
Remove bitbucket plugin from list of active tools.

Original link https://marketplace.atlassian.com/apps/1214095/checkstyles-for-bitbucket-server leads to 404 page, also there is no plugin in list of bitbucket apps.
![изображение](https://user-images.githubusercontent.com/8901354/97785713-cf8cac00-1bb7-11eb-888d-2b3d3db9c6dd.png)

