### PR TITLE
config: make semaphore ci commands easy to run on local

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -355,6 +355,7 @@ DOCTYPE
 documentationcomments
 donotignoreexceptions
 Dorekit
+Dorg
 DOTALL
 doubletag
 Dpi

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -17,7 +17,7 @@ blocks:
           - eval "export M2_CACHE_SIZE=$(du -s $HOME/.m2 | cut -f1)"
           - sudo apt-get update
           - sudo apt-get install -y ant groovy xsltproc xmlstarlet
-          - sem-version java 11
+          - export GRADLE_OPTS=-Dorg.gradle.console=plain
       epilogue:
         commands:
           - |
@@ -27,63 +27,55 @@ blocks:
               cache store m2 $HOME/.m2
             fi
       jobs:
-        - name: Check for missing pitests
-          priority:
-            - value: 10
-              when: true
-          commands:
-            - .ci/validation.sh check-missing-pitests
-
-        - name: Eclipse static analysis
-          priority:
-            - value: 10
-              when: true
-          commands:
-            - .ci/validation.sh eclipse-static-analysis
-
-        - name: Ensure that all Sevntu check are used
-          priority:
-            - value: 10
-              when: true
-          commands:
-            - .ci/validation.sh all-sevntu-checks
-
         - name: NonDex (openjdk8)
           priority:
-            - value: 80
+            - value: 90
               when: true
+          matrix:
+            - env_var: CMD
+              values:
+                - .ci/validation.sh nondex
           commands:
             - sem-version java 8 # NonDex only supports Java 8
-            - .ci/validation.sh nondex
+            - echo "eval of CMD is starting";
+            - echo "CMD=$CMD";
+            - eval $CMD;
+            - echo "eval of CMD is completed";
 
-        - name: No error test on pmd
-          priority:
-            - value: 80
-              when: true
-          commands:
-            - mvn -e install -Pno-validations
-            - .ci/validation.sh no-error-pmd
-
-        - name: No error test on Configurate
-          priority:
-            - value: 80
-              when: true
-          commands:
-            - sem-version java 14
-            - mvn -e install -Pno-validations
-            - .ci/validation.sh no-violation-test-configurate
-
-        - name: No violation testing on josm
-          commands:
-            - mvn -e install -Pno-validations
-            - .ci/validation.sh no-violation-test-josm
-
-        - name: No exception test
+        - name: Validation (openjdk11, fast pool)
           matrix:
-            - env_var: PROJECT
+            - env_var: CMD
               values:
-                - guava-with-google-checks
-                - guava-with-sun-checks
+                - .ci/validation.sh all-sevntu-checks
+                - .ci/validation.sh check-missing-pitests
+                - .ci/validation.sh eclipse-static-analysis
+                - mvn -e clean install -Pno-validations
+                    && .ci/no-exception-test.sh guava-with-google-checks
+                - mvn -e clean install -Pno-validations
+                    && .ci/no-exception-test.sh guava-with-sun-checks
+                - mvn -e clean install -Pno-validations
+                    && .ci/validation.sh no-violation-test-josm
           commands:
-            - mvn -e install -Pno-validations
-            - .ci/no-exception-test.sh $PROJECT
+            - sem-version java 11
+            - echo "eval of CMD is starting";
+            - echo "CMD=$CMD";
+            - eval $CMD;
+            - echo "eval of CMD is completed";
+
+        - name: Validation (openjdk11, slow pool)
+          priority:
+            - value: 80
+              when: true
+          matrix:
+            - env_var: CMD
+              values:
+                - mvn -e clean install -Pno-validations
+                    && .ci/validation.sh no-error-pmd
+                - mvn -e clean install -Pno-validations
+                    && .ci/validation.sh no-violation-test-configurate
+          commands:
+            - sem-version java 11
+            - echo "eval of CMD is starting";
+            - echo "CMD=$CMD";
+            - eval $CMD;
+            - echo "eval of CMD is completed";


### PR DESCRIPTION
From https://github.com/checkstyle/checkstyle/pull/8920#discussion_r515509604

> one day this execution will fail in CI in PR, contributor might not be very experienced in CI to figureout how to reproduce it on local, so we will share with him link to single line in config for simple copy and paste in terminal, and it works.

