### PR TITLE
Issue #8552: change all 'at-clause' terms to 'block tag'

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
@@ -239,7 +239,7 @@ public class LineWrappingHandler {
     /**
      * Checks line wrapping into annotations.
      *
-     * @param atNode at-clause node.
+     * @param atNode block tag node.
      * @param firstNodesOnLines map which contains
      *     first nodes as values and line numbers as keys.
      * @param indentLevel line wrapping indentation.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
@@ -50,7 +50,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * Default value is {@code false}.
  * </li>
  * <li>
- * Property {@code target} - Specify the list of targets to check at-clauses.
+ * Property {@code target} - Specify the list of block tags targeted.
  * Type is {@code java.lang.String[]}.
  * Validation type is {@code tokenTypesSet}.
  * Default value is
@@ -135,7 +135,7 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck {
     };
 
     /**
-     * Specify the list of targets to check at-clauses.
+     * Specify the list of block tags targeted.
      */
     private List<Integer> target = Arrays.asList(
         TokenTypes.CLASS_DEF,
@@ -154,7 +154,7 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck {
     private List<String> tagOrder = Arrays.asList(DEFAULT_ORDER);
 
     /**
-     * Setter to specify the list of targets to check at-clauses.
+     * Setter to specify the list of block tags targeted.
      *
      * @param targets user's targets.
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
@@ -30,7 +30,7 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 
 /**
  * <p>
- * Checks the indentation of the continuation lines in at-clauses. That is whether the continued
+ * Checks the indentation of the continuation lines in block tags. That is whether the continued
  * description of at clauses should be indented or not. If the text is not properly indented it
  * throws a violation. A continuation line is when the description starts/spans past the line with
  * the tag. Default indentation required is at least 4, but this can be changed with the help of

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/NonEmptyAtclauseDescriptionCheck.java
@@ -27,7 +27,7 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 
 /**
  * <p>
- * Checks that the at-clause tag is followed by description.
+ * Checks that the block tag is followed by description.
  * </p>
  * <ul>
  * <li>
@@ -120,10 +120,10 @@ public class NonEmptyAtclauseDescriptionCheck extends AbstractJavadocCheck {
     }
 
     /**
-     * Tests if at-clause tag is empty.
+     * Tests if block tag is empty.
      *
-     * @param tagNode at-clause tag.
-     * @return true, if at-clause tag is empty.
+     * @param tagNode block tag.
+     * @return true, if block tag is empty.
      */
     private static boolean isEmptyTag(DetailNode tagNode) {
         final DetailNode tagDescription =

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
@@ -33,8 +33,8 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
  * <p>
- * Checks that a Javadoc block can fit in a single line and doesn't contain at-clauses.
- * Javadoc comment that contains at least one at-clause should be formatted in a few lines.
+ * Checks that a Javadoc block can fit in a single line and doesn't contain block tags.
+ * Javadoc comment that contains at least one block tag should be formatted in a few lines.
  * </p>
  * <ul>
  * <li>
@@ -45,7 +45,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * Default value is {@code false}.
  * </li>
  * <li>
- * Property {@code ignoredTags} - Specify at-clauses which are ignored by the check.
+ * Property {@code ignoredTags} - Specify block tags which are ignored by the check.
  * Type is {@code java.lang.String[]}.
  * Default value is {@code ""}.
  * </li>
@@ -62,8 +62,8 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * &lt;module name=&quot;SingleLineJavadoc&quot;/&gt;
  * </pre>
  * <p>
- * To configure the check with a list of ignored at-clauses
- * and make inline at-clauses not ignored:
+ * To configure the check with a list of ignored block tags
+ * and make inline tags not ignored:
  * </p>
  * <pre>
  * &lt;module name=&quot;SingleLineJavadoc&quot;&gt;
@@ -104,7 +104,7 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
     public static final String MSG_KEY = "singleline.javadoc";
 
     /**
-     * Specify at-clauses which are ignored by the check.
+     * Specify block tags which are ignored by the check.
      */
     private List<String> ignoredTags = new ArrayList<>();
 
@@ -112,7 +112,7 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
     private boolean ignoreInlineTags = true;
 
     /**
-     * Setter to specify at-clauses which are ignored by the check.
+     * Setter to specify block tags which are ignored by the check.
      *
      * @param tags to be ignored by check.
      */

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
@@ -1,4 +1,4 @@
-at.clause.order=At-clauses have to appear in the order ''{0}''.
+at.clause.order=Block tags have to appear in the order ''{0}''.
 invalid.position=Javadoc comment is placed in the wrong location.
 javadoc.blockTagLocation=The Javadoc block tag ''@{0}'' should be placed at the beginning of the line.
 javadoc.classInfo=Unable to get class information for {0} tag ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
@@ -1,4 +1,4 @@
-at.clause.order=@-Klauseln müssen in der folgenden Reihenfolge erscheinen: ''{0}''.
+at.clause.order=Block-Tags müssen in der folgenden Reihenfolge erscheinen: ''{0}''.
 invalid.position=Javadoc-Kommentar ist an der falschen Stelle platziert.
 javadoc.blockTagLocation=Das Javadoc-block-tag ''@{0}'' sollte sich am Anfang der Zeile befinden.
 javadoc.classInfo=Kann für das Tag ''{1}'' keine Klasseninformation zu {0} laden.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
@@ -1,4 +1,4 @@
-at.clause.order=Al-cláusulas tienen que aparecer en el orden ''{0}''.
+at.clause.order=Las etiquetas de bloque deben aparecer en el orden ''{0}''.
 invalid.position=El comentario de Javadoc se coloca en la ubicación incorrecta.
 javadoc.blockTagLocation=La etiqueta de bloque ''@{0}'' de Javadoc debe colocarse al principio de la línea.
 javadoc.classInfo=No se puede obtener la información de clase para {0} etiqueta ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
@@ -1,4 +1,4 @@
-at.clause.order=At-lausekkeet tarvitse esiintyä järjestyksessä ''{0}''.
+at.clause.order=Estotunnisteiden on oltava järjestyksessä ''{0}''.
 invalid.position=Javadoc-kommentti sijoitetaan väärään paikkaan.
 javadoc.blockTagLocation=Javadoc lohkon tunniste ''@{0}'' olisi sijoitettava rivin alkuun.
 javadoc.classInfo=Luokkatiedot ei saatavilla: {0} tagi ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
@@ -1,4 +1,4 @@
-at.clause.order=Les balises Javadoc doivent apparaître dans l''ordre ''{0}''.
+at.clause.order=Les balises de bloc doivent apparaître dans l''ordre ''{0}''.
 invalid.position=Le commentaire Javadoc est placé au mauvais endroit.
 javadoc.blockTagLocation=La balise Javadoc block ''@{0}'' doit être placée au début de la ligne.
 javadoc.classInfo=Impossible d''obtenir les informations relatives à la classe {1} pour la balise ''{0}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
@@ -1,4 +1,4 @@
-at.clause.order=Javadoc タグは ''{0}'' の順で並べてください。
+at.clause.order=ブロックタグは ''{0}'' 順番に表示する必要があります。
 invalid.position=Javadocのコメントが間違った場所に配置されています。
 javadoc.blockTagLocation=Javadocブロックタグ''@{0}''は、行の先頭に配置する必要があります。
 javadoc.classInfo={0} タグの ''{1}'' のクラス情報が取得できません。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
@@ -1,4 +1,4 @@
-at.clause.order=Cláusulas com `@` deveriam aparecer na ordem ''{0}''.
+at.clause.order=As tags de bloco devem aparecer no pedido ''{0}''.
 invalid.position=O comentário de Javadoc é colocado no local errado.
 javadoc.blockTagLocation=A tag de bloco Javadoc ''@{0}'' deve ser colocada no início da linha.
 javadoc.classInfo=Não foi possível obter informações de classe para {0} tag ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
@@ -1,4 +1,4 @@
-at.clause.order=Cümlecikleri At-düzen `görünmesi zorunda ''{0}''.
+at.clause.order=Blok etiketleri sırayla `görünmelidir ''{0}''.
 invalid.position=Javadoc yorumu yanlış yere yerleştirildi.
 javadoc.blockTagLocation=Javadoc blok etiketi ''@{0}'' satırın başına yerleştirilmelidir.
 javadoc.classInfo={0} etiketi ''{1}'' için sınıf bilgisi alınamıyor.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
@@ -1,4 +1,4 @@
-at.clause.order=@标签应按以下顺序出现：''{0}''。
+at.clause.order=阻止标签必须按顺序显示：''{0}''。
 invalid.position=Javadoc注释放在错误的位置。
 javadoc.blockTagLocation=Javadoc块标签''@{0}''应该放在行的开头。
 javadoc.classInfo=无法获得 {0} 标签的 ''{1}'' 类信息。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/AtclauseOrderCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/AtclauseOrderCheck.xml
@@ -24,7 +24,7 @@
                       name="target"
                       type="java.lang.String[]"
                       validation-type="tokenTypesSet">
-               <description>Specify the list of targets to check at-clauses.</description>
+               <description>Specify the list of block tags targeted.</description>
             </property>
             <property default-value="@author, @deprecated, @exception, @param, @return, @see, @serial, @serialData, @serialField, @since, @throws, @version"
                       name="tagOrder"

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocTagContinuationIndentationCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocTagContinuationIndentationCheck.xml
@@ -5,7 +5,7 @@
              name="JavadocTagContinuationIndentation"
              parent="com.puppycrawl.tools.checkstyle.TreeWalker">
          <description>&lt;p&gt;
- Checks the indentation of the continuation lines in at-clauses. That is whether the continued
+ Checks the indentation of the continuation lines in block tags. That is whether the continued
  description of at clauses should be indented or not. If the text is not properly indented it
  throws a violation. A continuation line is when the description starts/spans past the line with
  the tag. Default indentation required is at least 4, but this can be changed with the help of

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/NonEmptyAtclauseDescriptionCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/NonEmptyAtclauseDescriptionCheck.xml
@@ -5,7 +5,7 @@
              name="NonEmptyAtclauseDescription"
              parent="com.puppycrawl.tools.checkstyle.TreeWalker">
          <description>&lt;p&gt;
- Checks that the at-clause tag is followed by description.
+ Checks that the block tag is followed by description.
  &lt;/p&gt;</description>
          <properties>
             <property default-value="false"

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/SingleLineJavadocCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/SingleLineJavadocCheck.xml
@@ -5,8 +5,8 @@
              name="SingleLineJavadoc"
              parent="com.puppycrawl.tools.checkstyle.TreeWalker">
          <description>&lt;p&gt;
- Checks that a Javadoc block can fit in a single line and doesn't contain at-clauses.
- Javadoc comment that contains at least one at-clause should be formatted in a few lines.
+ Checks that a Javadoc block can fit in a single line and doesn't contain block tags.
+ Javadoc comment that contains at least one block tag should be formatted in a few lines.
  &lt;/p&gt;</description>
          <properties>
             <property default-value="false"
@@ -17,7 +17,7 @@
  &lt;a href="https://checkstyle.org/writingjavadocchecks.html#Tight-HTML_rules"&gt;Tight-HTML Rules&lt;/a&gt;.</description>
             </property>
             <property default-value="" name="ignoredTags" type="java.lang.String[]">
-               <description>Specify at-clauses which are ignored by the check.</description>
+               <description>Specify block tags which are ignored by the check.</description>
             </property>
             <property default-value="true" name="ignoreInlineTags" type="boolean">
                <description>Control whether inline tags must be ignored.</description>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/meta/javadocmetadatascraper/checks/javadoc/InputJavadocMetadataScraperAtclauseOrderCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/meta/javadocmetadatascraper/checks/javadoc/InputJavadocMetadataScraperAtclauseOrderCheck.java
@@ -50,7 +50,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * Default value is {@code false}.
  * </li>
  * <li>
- * Property {@code target} - Specify the list of targets to check at-clauses.
+ * Property {@code target} - Specify the list of block tags targeted.
  * Type is {@code java.lang.String[]}.
  * Validation type is {@code tokenSet}.
  * Default value is

--- a/src/xdocs/checks.xml
+++ b/src/xdocs/checks.xml
@@ -439,7 +439,7 @@
           <tr>
             <td><a href="config_javadoc.html#JavadocTagContinuationIndentation">
               JavadocTagContinuationIndentation</a></td>
-            <td>Checks the indentation of the continuation lines in at-clauses.</td>
+            <td>Checks the indentation of the continuation lines in block tags.</td>
           </tr>
           <tr>
             <td><a href="config_javadoc.html#JavadocType">JavadocType</a></td>
@@ -647,7 +647,7 @@
             <td><a href="config_javadoc.html#NonEmptyAtclauseDescription">
               NonEmptyAtclauseDescription</a></td>
             <td>
-            Checks that the at-clause tag is followed by description.</td>
+            Checks that the block tag is followed by description.</td>
           </tr>
           <tr>
             <td><a href="config_coding.html#NoEnumTrailingComma">NoEnumTrailingComma</a></td>
@@ -833,7 +833,7 @@
             <td><a href="config_javadoc.html#SingleLineJavadoc">SingleLineJavadoc</a></td>
             <td>
               Checks that a Javadoc block can fit in a single line and doesn't contain
-              at-clauses.</td>
+              block tags.</td>
           </tr>
           <tr>
             <td><a href="config_javadoc.html#RequireEmptyLineBeforeBlockTagGroup">

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -60,7 +60,7 @@
             </tr>
             <tr>
               <td>target</td>
-              <td>Specify the list of targets to check at-clauses.</td>
+              <td>Specify the list of block tags targeted.</td>
               <td>subset of tokens
                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>
               </td>
@@ -1706,7 +1706,8 @@ public class Test {
       <p>Since Checkstyle 6.0</p>
       <subsection name="Description" id="JavadocTagContinuationIndentation_Description">
         <p>
-          Checks the indentation of the continuation lines in at-clauses. That is whether the
+          Checks the indentation of the continuation lines in block tags.
+          That is whether the
           continued description of at clauses should be indented or not. If the text is not properly
           indented it throws a violation. A continuation line is when the description starts/spans
           past the line with the tag. Default indentation required is at least 4, but this can be
@@ -2819,7 +2820,7 @@ class DatabaseConfiguration {}
       <p>Since Checkstyle 6.0</p>
       <subsection name="Description" id="NonEmptyAtclauseDescription_Description">
         <p>
-          Checks that the at-clause tag is followed by description.
+          Checks that the block tag is followed by description.
         </p>
       </subsection>
 
@@ -3076,7 +3077,7 @@ public boolean testMethod(int firstParam) {
       <subsection name="Description" id="SingleLineJavadoc_Description">
         <p>
            Checks that a Javadoc block can fit in a single line and doesn't
-           contain at-clauses. Javadoc comment that contains at least one at-clause
+           contain block tags. Javadoc comment that contains at least one block tag
            should be formatted in a few lines.
         </p>
       </subsection>
@@ -3104,7 +3105,7 @@ public boolean testMethod(int firstParam) {
             </tr>
             <tr>
               <td>ignoredTags</td>
-              <td>Specify at-clauses which are ignored by the check.</td>
+              <td>Specify block tags which are ignored by the check.</td>
               <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>{}</code></td>
               <td>6.8</td>
@@ -3128,8 +3129,8 @@ public boolean testMethod(int firstParam) {
 &lt;module name=&quot;SingleLineJavadoc&quot;/&gt;
         </source>
         <p>
-          To configure the check with a list of ignored at-clauses and make
-          inline at-clauses not ignored:
+          To configure the check with a list of ignored block tags and make
+          inline tags not ignored:
         </p>
         <source>
 &lt;module name=&quot;SingleLineJavadoc&quot;&gt;


### PR DESCRIPTION
from sourcecode and documentation

Issue #8552

what is left (we do not need to fix it):
```
✔ ~/java/github/romani/checkstyle [8552-at-clause L|✔] 
08:58 $ ag "at-clauses"
src/test/resources/com/puppycrawl/tools/checkstyle/meta/javadocmetadatascraper/checks/javadoc/InputJavadocMetadataScraperAtclauseOrderCheck.java
41: * Note: Google used the term "at-clauses" for block tags in their guide till 2017-02-28.

src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
41: * Note: Google used the term "at-clauses" for block tags in their guide till 2017-02-28.

src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/AtclauseOrderCheck.xml
13: Note: Google used the term "at-clauses" for block tags in their guide till 2017-02-28.

src/xdocs/config_javadoc.xml
35:          Note: Google used the term "at-clauses" for block tags in their guide till 2017-02-28.

src/xdocs/google_style.xml
2064:                  <a href="styleguides/google-java-style-20180523/javaguide.html#s7.1.3-javadoc-at-clauses">

src/xdocs/releasenotes.xml
340:            missing blank line before at-clauses

src/site/resources/styleguides/google-java-style-20180523/javaguide.html
1115:<a name="s7.1.3-javadoc-at-clauses"></a>

```