### PR TITLE
minor: fix indentation in config examples

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -86,9 +86,9 @@
   </module>
   <module name="RegexpMultiline">
     <property name="id" value="noIndentationConfigExamples"/>
-    <property name="format" value="&lt;source&gt;\r?\n\s+&amp;lt;module "/>
+    <property name="format" value="&lt;source&gt;\r?\n\s+"/>
     <property name="fileExtensions" value="xml"/>
-    <property name="message" value="Module tag in config example should not be indented"/>
+    <property name="message" value="Content of source tag should not be Indented"/>
   </module>
   <module name="RegexpMultiline">
     <property name="id" value="noConsecutiveLines"/>

--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -85,6 +85,12 @@
     <property name="id" value="regexpMultilineDefault"/>
   </module>
   <module name="RegexpMultiline">
+    <property name="id" value="noIndentationConfigExamples"/>
+    <property name="format" value="&lt;source&gt;\r?\n\s+&amp;lt;module "/>
+    <property name="fileExtensions" value="xml"/>
+    <property name="message" value="Module tag in config example should not be indented"/>
+  </module>
+  <module name="RegexpMultiline">
     <property name="id" value="noConsecutiveLines"/>
     <property name="format" value="\r?\n[\t ]*\r?\n[\t ]*\r?\n"/>
     <property name="fileExtensions" value="java,xml,properties"/>

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -108,4 +108,9 @@
   <suppress id="noSourceforgeIoLinks" files="[\\/]sun_style.xml" lines="31"/>
   <suppress id="noSourceforgeIoLinks" files="[\\/]index.xml.vm"/>
 
+  <!-- usage of div class="wrap-content" render even indented content properly -->
+  <suppress id="noIndentationConfigExamples" files="[\\/]src[\\/]xdocs[\\/]writingchecks.xml"/>
+  <suppress id="noIndentationConfigExamples"
+    files="[\\/]src[\\/]xdocs[\\/]beginning_development.xml"/>
+
 </suppressions>

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -6194,11 +6194,11 @@ class C {
           The check will flag the following with warnings:
         </p>
         <source>
-    return (x);          // parens around identifier
-    return (x + 1);      // parens around return value
-    int x = (y / 2 + 1); // parens around assignment rhs
-    for (int i = (0); i &lt; 10; i++) {  // parens around literal
-    t -= (z + 1);        // parens around assignment rhs
+return (x);          // parens around identifier
+return (x + 1);      // parens around return value
+int x = (y / 2 + 1); // parens around assignment rhs
+for (int i = (0); i &lt; 10; i++) {  // parens around literal
+t -= (z + 1);        // parens around assignment rhs
         </source>
       </subsection>
 
@@ -6209,7 +6209,7 @@ class C {
           operator precedence and associativity; therefore it won't catch something like
         </p>
         <source>
-            int x = (a + b) + c;
+int x = (a + b) + c;
         </source>
         <p>
           In the above case, given that <em>a</em>, <em>b</em>, and <em>c</em> are all
@@ -6499,25 +6499,25 @@ myList.stream()
           Example:
         </p>
         <source>
- class A {
+class A {
 
-     class Nested {
+   class Nested {
 
-     }; // OK, nested type declarations are ignored
+   }; // OK, nested type declarations are ignored
 
- }; // violation
+}; // violation
 
- interface B {
+interface B {
 
- }; // violation
+}; // violation
 
- enum C {
+enum C {
 
- }; // violation
+}; // violation
 
- {@literal @}interface D {
+{@literal @}interface D {
 
- }; // violation
+}; // violation
         </source>
         <p>
            To configure the check to detect unnecessary semicolon only after top level class
@@ -6532,21 +6532,21 @@ myList.stream()
           Example:
         </p>
         <source>
- class A {
+class A {
 
- }; // violation
+}; // violation
 
- interface B {
+interface B {
 
- }; // OK
+}; // OK
 
- enum C {
+enum C {
 
- }; // OK
+}; // OK
 
- {@literal @}interface D {
+{@literal @}interface D {
 
- }; // OK
+}; // OK
         </source>
       </subsection>
 

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -1758,10 +1758,10 @@ for (int number : myNumbers) { // violation
           but do not validate loop variables:
         </p>
         <source>
- &lt;module name="FinalLocalVariable"&gt;
-   &lt;property name="tokens" value="VARIABLE_DEF,PARAMETER_DEF"/&gt;
-   &lt;property name="validateEnhancedForLoopVariable" value="false"/&gt;
- &lt;/module&gt;
+&lt;module name="FinalLocalVariable"&gt;
+  &lt;property name="tokens" value="VARIABLE_DEF,PARAMETER_DEF"/&gt;
+  &lt;property name="validateEnhancedForLoopVariable" value="false"/&gt;
+&lt;/module&gt;
         </source>
         <p>Example:</p>
         <source>
@@ -6524,9 +6524,9 @@ myList.stream()
            definitions:
         </p>
         <source>
- &lt;module name=&quot;UnnecessarySemicolonAfterOuterTypeDeclaration&quot;&gt;
-   &lt;property name=&quot;tokens&quot; value=&quot;CLASS_DEF&quot;/&gt;
- &lt;/module&gt;
+&lt;module name=&quot;UnnecessarySemicolonAfterOuterTypeDeclaration&quot;&gt;
+  &lt;property name=&quot;tokens&quot; value=&quot;CLASS_DEF&quot;/&gt;
+&lt;/module&gt;
         </source>
         <p>
           Example:

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -1271,15 +1271,15 @@ CLASS_DEF -> CLASS_DEF [1:0]
         <p>Next example is about suppressing method with certain annotation by its name and
         element value.</p>
         <source>
-        public class InputTest {
-            @Generated("first") // should not be suppressed
-            public void test1() {
-            }
+public class InputTest {
+    @Generated("first") // should not be suppressed
+    public void test1() {
+    }
 
-            @Generated("second") // should be suppressed
-            public void test2() {
-            }
-        }
+    @Generated("second") // should be suppressed
+    public void test2() {
+    }
+}
         </source>
         <p>First of all we need to look at AST tree printed by our CLI tool: </p>
         <source>

--- a/src/xdocs/config_metrics.xml
+++ b/src/xdocs/config_metrics.xml
@@ -165,20 +165,20 @@ public class Test
         </source>
         <p>Code Example:</p>
         <source>
-  public class Test
+public class Test
+{
+  public static void main(String ... args)
   {
-    public static void main(String ... args)
-    {
-      boolean a = true;
-      boolean b = false;
+    boolean a = true;
+    boolean b = false;
 
-      boolean c = (!a &amp;&amp; b) | (a || !b) ^ a;    // OK, 1(&amp;&amp;) + 1(||) + 1(^) = 3
-                                                // | is ignored here
+    boolean c = (!a &amp;&amp; b) | (a || !b) ^ a;    // OK, 1(&amp;&amp;) + 1(||) + 1(^) = 3
+                                              // | is ignored here
 
-      boolean d = a ^ (a || b) ^ (b || a) &amp; a; // violation, 1(^) + 1(||) + 1(^) + 1(||) = 4
-                                               // &amp; is ignored here
-    }
+    boolean d = a ^ (a || b) ^ (b || a) &amp; a; // violation, 1(^) + 1(||) + 1(^) + 1(||) = 4
+                                             // &amp; is ignored here
   }
+}
         </source>
       </subsection>
 

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -3020,11 +3020,11 @@ class MyClass {
         </source>
         <p>Code Example:</p>
         <source>
- public interface FirstName {} // OK
- protected class SecondName {} // OK
- enum Third_Name {} // violation, name 'Third_Name' must match pattern '^[A-Z][a-zA-Z0-9]*$'
- private class FourthName_ {} // violation, name 'FourthName_'
-                              // must match pattern '^[A-Z][a-zA-Z0-9]*$'
+public interface FirstName {} // OK
+protected class SecondName {} // OK
+enum Third_Name {} // violation, name 'Third_Name' must match pattern '^[A-Z][a-zA-Z0-9]*$'
+private class FourthName_ {} // violation, name 'FourthName_'
+                            // must match pattern '^[A-Z][a-zA-Z0-9]*$'
         </source>
         <p>
           An example of how to configure the check for names that begin with a lower case letter,
@@ -3040,11 +3040,11 @@ class MyClass {
         </source>
         <p>Code Example:</p>
         <source>
- public interface firstName {} // OK
- public class SecondName {} // violation, name 'SecondName'
-                            // must match pattern '^[a-z](_?[a-zA-Z0-9]+)*$'
- protected class ThirdName {} // OK
- private class FourthName {} // OK
+public interface firstName {} // OK
+public class SecondName {} // violation, name 'SecondName'
+                          // must match pattern '^[a-z](_?[a-zA-Z0-9]+)*$'
+protected class ThirdName {} // OK
+private class FourthName {} // OK
         </source>
         <p>
           The following configuration element ensures that
@@ -3061,9 +3061,9 @@ class MyClass {
         </source>
         <p>Code Example:</p>
         <source>
- public interface I_firstName {} // OK
- interface SecondName {} // violation, name 'SecondName'
-                         // must match pattern '^I_[a-zA-Z0-9]*$'
+public interface I_firstName {} // OK
+interface SecondName {} // violation, name 'SecondName'
+                       // must match pattern '^I_[a-zA-Z0-9]*$'
         </source>
 
       </subsection>

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -2572,7 +2572,7 @@ class MyClass {
         </p>
 
         <source>
- &lt;module name="PatternVariableName"/&gt;
+&lt;module name="PatternVariableName"/&gt;
         </source>
         <p>Code Example:</p>
         <source>

--- a/src/xdocs/config_sizes.xml
+++ b/src/xdocs/config_sizes.xml
@@ -1287,15 +1287,15 @@ public void needsLotsOfParameters(int a,
           Java code example:
         </p>
         <source>
- public record MyRecord1(int x, int y) { // ok, 2 components
-     ...
- }
+public record MyRecord1(int x, int y) { // ok, 2 components
+   ...
+}
 
- record MyRecord2(int x, int y, String str,
-                           Node node, Order order, Data data
-                           String location, Date date, Image image) { // violation, 9 components
-     ...
- }
+record MyRecord2(int x, int y, String str,
+                         Node node, Order order, Data data
+                         String location, Date date, Image image) { // violation, 9 components
+   ...
+}
 
         </source>
         <p>
@@ -1311,14 +1311,14 @@ public void needsLotsOfParameters(int a,
           Java code example:
         </p>
         <source>
- public record MyRecord1(int x, int y, String str) { // ok, 3 components
-     ...
- }
+public record MyRecord1(int x, int y, String str) { // ok, 3 components
+   ...
+}
 
- public record MyRecord2(int x, int y, String str,
-                           Node node, Order order, Data data) { // violation, 6 components
-     ...
- }
+public record MyRecord2(int x, int y, String str,
+                         Node node, Order order, Data data) { // violation, 6 components
+   ...
+}
 
         </source>
         <p>
@@ -1339,13 +1339,13 @@ public void needsLotsOfParameters(int a,
           Java code example:
         </p>
         <source>
- public record MyRecord1(int x, int y, String str) { // ok, public record definition allowed 10
-     ...
- }
+public record MyRecord1(int x, int y, String str) { // ok, public record definition allowed 10
+   ...
+}
 
- private record MyRecord2(int x, int y, String str, Node node) { // violation
-     ...                                // private record definition allowed 3 components
- }
+private record MyRecord2(int x, int y, String str, Node node) { // violation
+   ...                                // private record definition allowed 3 components
+}
 
         </source>
       </subsection>

--- a/src/xdocs/config_sizes.xml
+++ b/src/xdocs/config_sizes.xml
@@ -365,7 +365,7 @@
           To configure the check to accept lambda bodies with up to 10 lines:
         </p>
         <source>
-          &lt;module name="LambdaBodyLength"/&gt;
+&lt;module name="LambdaBodyLength"/&gt;
         </source>
         <p>
         Example:
@@ -413,9 +413,9 @@ class Test {
           To configure the check to accept lambda bodies with max 5 lines:
         </p>
         <source>
-          &lt;module name="LambdaBodyLength"&gt;
-            &lt;property name="max" value="5"/&gt;
-          &lt;/module&gt;
+&lt;module name="LambdaBodyLength"&gt;
+  &lt;property name="max" value="5"/&gt;
+&lt;/module&gt;
         </source>
         <p>
           Example:


### PR DESCRIPTION
Fix indentations
![image](https://user-images.githubusercontent.com/8901354/98002676-dc4f1100-1dfe-11eb-80fd-70499349dae3.png)

![image](https://user-images.githubusercontent.com/8901354/98002707-e4a74c00-1dfe-11eb-9c5b-137bb64c8f03.png)

