### PR TITLE
Issue #8873: RequireThis: Incorrectly triggers for record fields in compact constructor

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -458,7 +458,8 @@ public class RequireThisCheck extends AbstractCheck {
             default:
                 if (checkFields) {
                     final AbstractFrame frame = getFieldWithoutThis(ast, parentType);
-                    if (frame != null) {
+                    final boolean canUseThis = !isInCompactConstructor(ast);
+                    if (frame != null && canUseThis) {
                         logViolation(MSG_VARIABLE, ast, frame);
                     }
                 }
@@ -508,6 +509,25 @@ public class RequireThisCheck extends AbstractCheck {
             }
         }
         return frame;
+    }
+
+    /**
+     * Return whether ast is in a COMPACT_CTOR_DEF.
+     *
+     * @param ast The token to check
+     * @return true if ast is in a COMPACT_CTOR_DEF, false otherwise
+     */
+    private static boolean isInCompactConstructor(DetailAST ast) {
+        boolean isInCompactCtor = false;
+        DetailAST parent = ast.getParent();
+        while (parent != null) {
+            if (parent.getType() == TokenTypes.COMPACT_CTOR_DEF) {
+                isInCompactCtor = true;
+                break;
+            }
+            parent = parent.getParent();
+        }
+        return isInCompactCtor;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
@@ -424,6 +424,16 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testRecordCompactCtors() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(RequireThisCheck.class);
+        checkConfig.addAttribute("validateOnlyOverlapping", "false");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verify(checkConfig,
+                getNonCompilablePath("InputRequireThisRecordCompactCtors.java"),
+                expected);
+    }
+
+    @Test
     public void testRecordsAsTopLevel() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(RequireThisCheck.class);
         checkConfig.addAttribute("checkFields", "true");
@@ -432,10 +442,6 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
             "14:9: " + getCheckMessage(MSG_METHOD, "method1", ""),
             "15:9: " + getCheckMessage(MSG_METHOD, "method2", ""),
             "16:9: " + getCheckMessage(MSG_METHOD, "method3", ""),
-            "17:17: " + getCheckMessage(MSG_VARIABLE, "x", ""),
-            "17:21: " + getCheckMessage(MSG_VARIABLE, "y", ""),
-            "18:28: " + getCheckMessage(MSG_VARIABLE, "y", ""),
-            "18:32: " + getCheckMessage(MSG_VARIABLE, "x", ""),
             "23:9: " + getCheckMessage(MSG_METHOD, "method1", ""),
             "27:21: " + getCheckMessage(MSG_VARIABLE, "x", ""),
             "35:17: " + getCheckMessage(MSG_VARIABLE, "y", ""),

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisRecordAsTopLevel.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisRecordAsTopLevel.java
@@ -14,8 +14,8 @@ public record InputRequireThisRecordAsTopLevel(int x, int y) {
         method1(); // violation
         method2(42); // violation
         method3(); // violation
-        int z = x + y + 2; // violation x2
-        System.out.println(y + x); // violation x2
+        int z = x + y + 2; // ok, 'this' cannot be used in COMPACT_CTOR_DEF
+        System.out.println(y + x); // ok, 'this' cannot be used in COMPACT_CTOR_DEF
     }
 
     InputRequireThisRecordAsTopLevel(int x) {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisRecordCompactCtors.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisRecordCompactCtors.java
@@ -1,0 +1,17 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.coding.requirethis;
+import java.util.Map;
+
+/* Config:
+ * validateOnlyOverlapping = false
+ *
+ */
+public record InputRequireThisRecordCompactCtors(String name, Map<String, String> items){
+    // 'this' cannot be used in compact constructor
+    public InputRequireThisRecordCompactCtors {
+        if (name == null) { // ok
+            name = "<unknown>"; // ok
+        }
+        items = Map.copyOf(items); // ok
+    }
+}


### PR DESCRIPTION
Fix #8873 
This PR disables `requireThis` in COMPACT_CTOR_DEF, since `this` cannot be used in COMPACT_CTOR_DEF in Java 15 as mentioned [here](https://github.com/checkstyle/checkstyle/issues/8873#issuecomment-720129384).

As mentioned [here](https://github.com/checkstyle/checkstyle/issues/8873#issuecomment-723726379), not printing error message when `ast` is in `COMPACT_CTOR_DEF` solves the problem in #8873

Also, 4 violations in `testRecordsAsTopLevel()` are no longer violations, so I removed them.

Diff Regression config: https://gist.githubusercontent.com/anhminhtran235/bf0e177285c39256dd7e3217d8dae9e1/raw/55ff82d4be5a21d610e83da86dba7835eea2560d/config.xml
Diff Regression projects: https://gist.githubusercontent.com/anhminhtran235/2da94f96d35ab9471624c5b6c4421c66/raw/82b014453ca421085199b4635f6a13c26a62941d/projects-to-test-on.properties