### PR TITLE
minor: fix link for LeftCurlyOption in LeftCurly

### DIFF
--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -551,7 +551,7 @@ try {
             <tr>
               <td>option</td>
               <td>Specify the policy on placement of a left curly brace (<code>'{'</code>).</td>
-              <td><a href="property_types.html>SeverityLevel">LeftCurlyOption</a></td>
+              <td><a href="property_types.html#LeftCurlyOption">LeftCurlyOption</a></td>
               <td><code>eol</code></td>
               <td>3.0</td>
             </tr>


### PR DESCRIPTION
https://checkstyle.org/property_types.html%3ESeverityLevel

is result in 404 error

I am not sure why our link validator is not catching this, still open question