### PR TITLE
Issue #5148: Add MissingJavadocType to google_checks.xml

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -1433,6 +1433,7 @@ webtoolkit
 Wellformedness
 wercker
 wget
+wherejavadocrequired
 wheretobreak
 whi
 Whitebox

--- a/.ci/travis/travis.sh
+++ b/.ci/travis/travis.sh
@@ -165,8 +165,8 @@ assembly-run-all-jar)
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo version:$CS_POM_VERSION
   mkdir -p .ci-temp
-  FOLDER=src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule333orderingandspacing
-  FILE=InputCustomImportOrderNoImports.java
+  FOLDER=src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired
+  FILE=InputMissingJavadocTypeCheckNoViolations.java
   java -jar target/checkstyle-$CS_POM_VERSION-all.jar -c /google_checks.xml \
         $FOLDER/$FILE > .ci-temp/output.log
   fail=0

--- a/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/MissingJavadocTypeTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/MissingJavadocTypeTest.java
@@ -1,0 +1,73 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2020 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.google.checkstyle.test.chapter7javadoc.rule73wherejavadocrequired;
+
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck.MSG_JAVADOC_MISSING;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocTypeCheck;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+
+public class MissingJavadocTypeTest extends AbstractGoogleModuleTestSupport {
+
+    @Override
+    protected String getPackageLocation() {
+        return "com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired";
+    }
+
+    @Test
+    public void testJavadocType() throws Exception {
+
+        final String[] expected = {
+            "3:1: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "5:5: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "9:5: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "13:5: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "14:9: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "17:5: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "21:5: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "25:5: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "29:5: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+            "33:5: " + getCheckMessage(MissingJavadocTypeCheck.class, MSG_JAVADOC_MISSING),
+        };
+
+        final Configuration checkConfig = getModuleConfig("MissingJavadocType");
+        final String filePath = getPath("InputMissingJavadocTypeCheck.java");
+
+        final Integer[] warnList = getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
+    }
+
+    @Test
+    public void testJavadocTypeNoViolations() throws Exception {
+
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        final Configuration checkConfig = getModuleConfig("MissingJavadocType");
+        final String filePath = getPath("InputMissingJavadocTypeCheckNoViolations.java");
+
+        final Integer[] warnList = getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
+    }
+
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputMissingJavadocTypeCheck.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputMissingJavadocTypeCheck.java
@@ -1,0 +1,45 @@
+package com.google.checkstyle.test.chapter7javadoc.rule73wherejavadocrequired;
+
+public class InputMissingJavadocTypeCheck { //warn
+
+    public class Inner { // warn
+
+    }
+
+    public enum MyEnum { // warn
+
+    }
+
+    public interface MyInterface {  // warn
+        class MyInterfaceClass {}  // warn
+    }
+
+    public @interface MyAnnotation { // warn
+
+    }
+
+    protected class InnerProtected { // warn
+
+    }
+
+    protected enum MyEnumProtected { // warn
+
+    }
+
+    protected interface MyInterfaceProtected {  // warn
+
+    }
+
+    protected @interface MyAnnotationProtected { //warn
+
+    }
+
+    public void myMethod() {
+        class MyMethodClass {} // ok
+    }
+
+}
+
+class AdditionalClass { // OK, not public
+
+}

--- a/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputMissingJavadocTypeCheckNoViolations.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/InputMissingJavadocTypeCheckNoViolations.java
@@ -1,0 +1,105 @@
+package com.google.checkstyle.test.chapter7javadoc.rule73wherejavadocrequired;
+
+/**
+ * This is a Javadoc comment.
+ */
+public class InputMissingJavadocTypeCheckNoViolations { // OK
+  private int myInt; // OK
+  int myOtherInt; // OK
+
+  /**
+   * This is a Javadoc comment.
+   */
+  public class InnerPublic implements MyInterfacePublic { // OK
+
+  }
+
+  /**
+   * This is a Javadoc comment.
+   */
+  public enum MyEnumPublic { // OK
+
+  }
+
+  /**
+   * This is a Javadoc comment.
+   */
+  public interface MyInterfacePublic {  // OK
+
+    /**
+     * This is a Javadoc comment.
+     */
+    class MyInterfaceClass {}  // OK
+  }
+
+  /**
+   * This is a Javadoc comment.
+   */
+  public @interface MyAnnotationPublic { // OK
+
+  }
+
+  /**
+   * This is a Javadoc comment.
+   */
+  protected class InnerProtected { // OK
+
+  }
+
+  /**
+   * This is a Javadoc comment.
+   */
+  protected enum MyEnumProtected { // OK
+
+  }
+
+  /**
+   * This is a Javadoc comment.
+   */
+  protected interface MyInterfaceProtected {  // OK
+
+  }
+
+  /**
+   * This is a Javadoc comment.
+   */
+  protected @interface MyAnnotationProtected { // OK
+
+  }
+
+  class Inner { // OK
+
+  }
+
+  enum MyEnum { // OK
+
+  }
+
+  interface MyInterface {  // OK
+
+  }
+
+  @interface MyAnnotation { // OK
+
+  }
+
+  private class InnerPrivate { // OK
+
+  }
+
+  private enum MyEnumPrivate { // OK
+
+  }
+
+  private interface MyInterfacePrivate {  // OK
+
+  }
+
+  private @interface MyAnnotationPrivate { // OK
+
+  }
+
+  public void myMethod() {
+    class MyMethodClass {} // OK
+  }
+}

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -328,6 +328,13 @@
       <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,
                                    COMPACT_CTOR_DEF"/>
     </module>
+    <module name="MissingJavadocType">
+      <property name="scope" value="protected"/>
+      <property name="tokens"
+                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+                      RECORD_DEF, ANNOTATION_DEF"/>
+      <property name="excludeScope" value="nothing"/>
+    </module>
     <module name="MethodName">
       <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
       <message key="name.invalidPattern"

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainViolationsForGoogle.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainViolationsForGoogle.java
@@ -1,5 +1,8 @@
 package com.puppycrawl.tools.checkstyle.main;
 
+/**
+ * A javadoc comment for the class.
+ */
 public class InputMainViolationsForGoogle {
   private String m_field; // violation
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainViolationsForGoogleSuppressions.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainViolationsForGoogleSuppressions.xml
@@ -6,11 +6,11 @@
   <suppress
          files="InputMainViolationsForGoogle.java"
          checks="MemberNameCheck"
-         lines="4"
+         lines="7"
   />
   <suppress
          files="InputMainViolationsForGoogle.java"
          checks="MethodNameCheck"
-         lines="6"
+         lines="9"
   />
 </suppressions>

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -2817,6 +2817,10 @@ class DatabaseConfiguration {}
       <subsection name="Example of Usage" id="MissingJavadocType_Example_of_Usage">
         <ul>
           <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingJavadocType">
+            Google Style</a>
+          </li>
+          <li>
             <a href="https://github.com/search?q=path%3Aconfig+filename%3Acheckstyle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingJavadocType">
             Checkstyle Style</a>
           </li>

--- a/src/xdocs/google_style.xml
+++ b/src/xdocs/google_style.xml
@@ -2147,6 +2147,12 @@
                         src="images/ok_green.png"
                         alt="" />
                   </span>
+                  <a href="config_javadoc.html#MissingJavadocType">MissingJavadocType</a>
+                  <span class="wrapper inline">
+                    <img
+                        src="images/ok_green.png"
+                        alt="" />
+                  </span>
                   <a href="config_javadoc.html#MissingJavadocMethod">MissingJavadocMethod</a>
                   <span class="wrapper inline">
                     <img
@@ -2156,6 +2162,10 @@
                   <a href="config_javadoc.html#JavadocMethod">JavadocMethod</a>
                 </td>
                 <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingJavadocType">
+                    config</a><br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule73wherejavadocrequired/MissingJavadocTypeTest.java">
+                    test</a>
                   <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Agoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingJavadocMethod">
                     config</a><br/>
                   <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/google/checkstyle/test/chapter7javadoc/rule731selfexplanatory/MissingJavadocMethodTest.java">


### PR DESCRIPTION
Issue #5148: Add MissingJavadocType to google_checks.xml

ATTENTION quotes from style guide:

> From https://google.github.io/styleguide/javaguide.html#s1.1-terminology:
"The term class is used inclusively to mean an "ordinary" class, enum class, interface or annotation type (`@interface`)."

> From https://google.github.io/styleguide/javaguide.html#s7.3-javadoc-where-required:
"At the minimum, Javadoc is present for every public class, and every public or protected member of such a class, with a few exceptions noted below."

This PR is a continuation of https://github.com/checkstyle/checkstyle/pull/8105.

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/32ddbff9e69986ac2fcbbeff7def2f80/raw/8480445657f1d215e683dbb6b14c1577bbd44e6b/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/f0a81b257e7f37f23ea4abc2b17ece6f/raw/a5231cef69f0ae909ae0274c2f189b74899c6be8/base.xml

Diff Regression patch config: https://gist.githubusercontent.com/nmancus1/a84775a4bc42a6a3a60899f355d3cf15/raw/76e1c9c783c7160f58c7475ebdded06ceec81f93/patch.xml