### PR TITLE
Issue #8933: add handling of empty string in IllegalTypeCheck property

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -19,12 +19,13 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
@@ -113,7 +114,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * This property does not affect method calls nor method references.
  * Type is {@code java.lang.String[]}.
  * Validation type is {@code tokenTypesSet}.
- * Default value is {@code no tokens}.
+ * Default value is {@code ""}.
  * </li>
  * <li>
  * Property {@code tokens} - tokens to check
@@ -348,7 +349,7 @@ public final class IllegalTypeCheck extends AbstractCheck {
      * Control whether to check only methods and fields with any of the specified modifiers.
      * This property does not affect method calls nor method references.
      */
-    private List<Integer> memberModifiers;
+    private List<Integer> memberModifiers = Collections.emptyList();
 
     /** Specify RegExp for illegal abstract class names. */
     private Pattern illegalAbstractClassNameFormat = Pattern.compile("^(.*[.])?Abstract.*$");
@@ -462,7 +463,7 @@ public final class IllegalTypeCheck extends AbstractCheck {
      */
     private boolean isVerifiable(DetailAST methodOrVariableDef) {
         boolean result = true;
-        if (memberModifiers != null) {
+        if (!memberModifiers.isEmpty()) {
             final DetailAST modifiersAst = methodOrVariableDef
                     .findFirstToken(TokenTypes.MODIFIERS);
             result = isContainVerifiableType(modifiersAst);
@@ -823,11 +824,11 @@ public final class IllegalTypeCheck extends AbstractCheck {
      * @param modifiers String contains modifiers.
      */
     public void setMemberModifiers(String modifiers) {
-        final List<Integer> modifiersList = new ArrayList<>();
-        for (String modifier : modifiers.split(",")) {
-            modifiersList.add(TokenUtil.getTokenId(modifier.trim()));
-        }
-        memberModifiers = modifiersList;
+        memberModifiers = Stream.of(modifiers.split(","))
+            .map(String::trim)
+            .filter(token -> !token.isEmpty())
+            .map(TokenUtil::getTokenId)
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/IllegalTypeCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/IllegalTypeCheck.xml
@@ -74,7 +74,7 @@
                <description>Specify RegExp for illegal abstract class
  names.</description>
             </property>
-            <property default-value="no tokens"
+            <property default-value=""
                       name="memberModifiers"
                       type="java.lang.String[]"
                       validation-type="tokenTypesSet">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
@@ -77,6 +77,21 @@ public class IllegalTypeCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testDefaultsEmptyStringMemberModifiers() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IllegalTypeCheck.class);
+        checkConfig.addAttribute("memberModifiers", "");
+
+        final String[] expected = {
+            "17:13: " + getCheckMessage(MSG_KEY, "java.util.TreeSet"),
+            "18:13: " + getCheckMessage(MSG_KEY, "TreeSet"),
+            "43:14: " + getCheckMessage(MSG_KEY, "HashMap"),
+            "45:5: " + getCheckMessage(MSG_KEY, "HashMap"),
+        };
+
+        verify(checkConfig, getPath("InputIllegalType.java"), expected);
+    }
+
+    @Test
     public void testIgnoreMethodNames() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IllegalTypeCheck.class);
         checkConfig.addAttribute("ignoredMethodNames", "table2");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -1136,10 +1136,7 @@ public class XdocsPagesTest {
                 if (isPropertyTokenType(sectionName, propertyName)) {
                     boolean first = true;
 
-                    if (value == null) {
-                        result = "no tokens";
-                    }
-                    else if (value instanceof BitSet) {
+                    if (value instanceof BitSet) {
                         final BitSet list = (BitSet) value;
                         final StringBuilder sb = new StringBuilder(20);
 

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -2895,7 +2895,7 @@ public void myTest() {
               <td>subset of tokens
                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html">TokenTypes</a>
               </td>
-              <td><code>no tokens</code></td>
+              <td><code>{}</code></td>
               <td>6.3</td>
             </tr>
             <tr>


### PR DESCRIPTION
Closes #8933 
Default value is changed from null to empty list, setter is corrected to filter empty strings.

It seems that regression is not required.
