### PR TITLE
Issue #9021: fix josm validation

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -651,6 +651,7 @@ itsallcode
 ivanov
 ivanovjr
 IVersion
+ivysettings
 iws
 Izmailov
 jacoco

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -53,9 +53,8 @@ blocks:
                     && .ci/no-exception-test.sh guava-with-google-checks
                 - mvn -e clean install -Pno-validations
                     && .ci/no-exception-test.sh guava-with-sun-checks
-                # disabled until 9021
-                # - mvn -e clean install -Pno-validations
-                #    && .ci/validation.sh no-violation-test-josm
+                - mvn -e clean package -Passembly
+                    && .ci/validation.sh no-violation-test-josm
           commands:
             - sem-version java 11
             - echo "eval of CMD is starting";


### PR DESCRIPTION
Issue #9021

`validation.sh` installs `SNAPSHOT` version of the Checkstyle to the maven cache. But JOSM uses ANT, so it can't find the right jar file. To solve this problem, the `ivysettings.xml` file is patched to use the Checkstyle bundle from the `target` directory.

Before patching:
```xml
<?xml version="1.0" encoding="utf-8"?>
<!-- License: GPL. For details, see LICENSE file. -->
<ivysettings>
  <settings defaultResolver="josm-nexus"/>
  <resolvers>
    <ibiblio name="josm-nexus" m2compatible="true" root="https://josm.openstreetmap.de/nexus/content/repositories/public/"/>
    <ibiblio name="jcenter" m2compatible="true" root="https://jcenter.bintray.com/"/>
  </resolvers>
  <modules>
    <module organisation="ch.poole" name="OpeningHoursParser" resolver="jcenter"/>
  </modules>
</ivysettings>
```
after patching
```xml
<?xml version="1.0" encoding="utf-8"?>
<!-- License: GPL. For details, see LICENSE file. -->
<ivysettings>
  <settings defaultResolver="josm-nexus"/>
  <resolvers>
    <ibiblio name="josm-nexus" m2compatible="true" root="https://josm.openstreetmap.de/nexus/content/repositories/public/"/>
    <ibiblio name="jcenter" m2compatible="true" root="https://jcenter.bintray.com/"/>
    <filesystem name="local-checkstyle">
      <artifact pattern="${base.dir}/../../target/[artifact]-[revision]-all.[ext]"/>
    </filesystem>
  </resolvers>
  <modules>
    <module organisation="ch.poole" name="OpeningHoursParser" resolver="jcenter"/>
    <module organisation="com.puppycrawl.tools" name="checkstyle" resolver="local-checkstyle"/>
  </modules>
</ivysettings>
```

Here we add a new file system resolver, as well as telling ANT to resolve `com.puppycrawl.tools/checkstyle` artifact with this resolver.