### PR TITLE
Issue #9046: use xenial compatible markdownlint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,8 @@ branches:
   only:
     - master
 
-# until https://github.com/checkstyle/checkstyle/issues/9046
-# install:
-#   - gem install mdl
+install:
+  - gem install chef-utils:16.6.14 mdl
 
 jobs:
   fast_finish: true


### PR DESCRIPTION
Issue #9046

One of markdownlint dependencies, chef-utils was recently [released](https://rubygems.org/gems/chef-utils) without support for older ruby versions, such as 2.5.3 that installed with ubuntu 16.04
As markdownlint is not dependent on new features from this release, we can continue to use old chef-utils version.