### PR TITLE
Issue #9037: IndentationCheck throws NPE on line wrapped switch rule

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LambdaHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LambdaHandler.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle.checks.indentation;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 /**
  * Handler for lambda expressions.
@@ -90,12 +89,15 @@ public class LambdaHandler extends AbstractExpressionHandler {
 
     @Override
     public void checkIndentation() {
-        // If the argument list is the first element on the line
-        final DetailAST firstChild = getMainAst().getFirstChild();
-        final DetailAST parent = getMainAst().getParent();
+        final DetailAST mainAst = getMainAst();
+        final DetailAST firstChild = mainAst.getFirstChild();
 
-        if (parent.getType() != TokenTypes.SWITCH_RULE
-                && getLineStart(firstChild) == expandedTabsColumnNo(firstChild)) {
+        // If the "->" has no children, it is a switch
+        // rule lambda (i.e. 'case ONE -> 1;')
+        final boolean isSwitchRuleLambda = firstChild == null;
+
+        if (!isSwitchRuleLambda
+            && getLineStart(firstChild) == expandedTabsColumnNo(firstChild)) {
             final int firstChildColumnNo = expandedTabsColumnNo(firstChild);
             final IndentLevel level = getIndent();
 
@@ -106,15 +108,10 @@ public class LambdaHandler extends AbstractExpressionHandler {
         }
 
         // If the "->" is the first element on the line, assume line wrapping.
-        final int mainAstColumnNo = expandedTabsColumnNo(getMainAst());
-        if (mainAstColumnNo == getLineStart(getMainAst())) {
-            final IndentLevel level =
-                new IndentLevel(getIndent(), getIndentCheck().getLineWrappingIndentation());
-
-            if (isNonAcceptableIndent(mainAstColumnNo, level)) {
-                isLambdaCorrectlyIndented = false;
-                logError(getMainAst(), "", mainAstColumnNo, level);
-            }
+        final int mainAstColumnNo = expandedTabsColumnNo(mainAst);
+        final boolean isLineWrappedLambda = mainAstColumnNo == getLineStart(mainAst);
+        if (isLineWrappedLambda) {
+            checkLineWrappedLambda(isSwitchRuleLambda, mainAstColumnNo);
         }
     }
 
@@ -124,4 +121,36 @@ public class LambdaHandler extends AbstractExpressionHandler {
                && !level.isAcceptable(astColumnNo);
     }
 
+    /**
+     * This method checks a line wrapped lambda, whether it is a lambda
+     * expression or switch rule lambda.
+     *
+     * @param isSwitchRuleLambda if mainAst is a switch rule lambda
+     * @param mainAstColumnNo the column number of the lambda we are checking
+     */
+    private void checkLineWrappedLambda(final boolean isSwitchRuleLambda,
+                                        final int mainAstColumnNo) {
+        final IndentLevel level;
+        final DetailAST mainAst = getMainAst();
+
+        if (isSwitchRuleLambda) {
+            // We check the indentation of the case literal or default literal
+            // on the previous line and use that to determine the correct
+            // indentation for the line wrapped "->"
+            final DetailAST previousSibling = mainAst.getPreviousSibling();
+            final int previousLineStart = getLineStart(previousSibling);
+
+            level = new IndentLevel(new IndentLevel(previousLineStart),
+                    getIndentCheck().getLineWrappingIndentation());
+        }
+        else {
+            level = new IndentLevel(getIndent(),
+                getIndentCheck().getLineWrappingIndentation());
+        }
+
+        if (isNonAcceptableIndent(mainAstColumnNo, level)) {
+            isLambdaCorrectlyIndented = false;
+            logError(mainAst, "", mainAstColumnNo, level);
+        }
+    }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SwitchRuleHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SwitchRuleHandler.java
@@ -33,7 +33,6 @@ public class SwitchRuleHandler extends AbstractExpressionHandler {
     private static final int[] SWITCH_RULE_CHILDREN = {
         TokenTypes.LITERAL_CASE,
         TokenTypes.LITERAL_DEFAULT,
-        TokenTypes.LAMBDA,
     };
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -2397,6 +2397,20 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
             expected);
     }
 
+    @Test
+    public void testIndentationSwitchExpressionNewLine() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addAttribute("tabWidth", "4");
+        final String[] expected = {
+            "30:13: " + getCheckMessage(MSG_ERROR, "lambda", 12, 16),
+            "32:13: " + getCheckMessage(MSG_ERROR, "lambda", 12, 16),
+        };
+
+        verifyWarns(checkConfig,
+            getNonCompilablePath("InputIndentationCheckSwitchExpressionNewLine.java"),
+            expected);
+    }
+
     private static final class IndentAudit implements AuditListener {
 
         private final IndentComment[] comments;

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckSwitchExpressionNewLine.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckSwitchExpressionNewLine.java
@@ -1,0 +1,44 @@
+//non-compiled with javac: Compilable with Java15                                   //indent:0 exp:0
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;             //indent:0 exp:0
+                                                                                  //indent:82 exp:82
+/* Config:                                                                          //indent:0 exp:0
+ *                                                                                  //indent:1 exp:1
+ * basicOffset = 4                                                                  //indent:1 exp:1
+ * braceAdjustment = 0                                                              //indent:1 exp:1
+ * caseIndent = 4                                                                   //indent:1 exp:1
+ * throwsIndent = 4                                                                 //indent:1 exp:1
+ * arrayInitIndent = 4                                                              //indent:1 exp:1
+ * lineWrappingIndentation = 4                                                      //indent:1 exp:1
+ * forceStrictCondition = false                                                     //indent:1 exp:1
+ */                                                                                 //indent:1 exp:1
+public class InputIndentationCheckSwitchExpressionNewLine {                         //indent:0 exp:0
+                                                                                  //indent:82 exp:82
+    private B map(A a) {                                                            //indent:4 exp:4
+        return switch (a) {                                                         //indent:8 exp:8
+            case one, two,                                                        //indent:12 exp:12
+                three, four                                                       //indent:16 exp:16
+                -> B.one;                                                         //indent:16 exp:16
+            default                                                               //indent:12 exp:12
+                -> B.two;                                                         //indent:16 exp:16
+        };                                                                          //indent:8 exp:8
+    }                                                                               //indent:4 exp:4
+                                                                                  //indent:82 exp:82
+    private A map(B a) {                                                            //indent:4 exp:4
+        return switch (a) {                                                         //indent:8 exp:8
+            case one, two,                                                        //indent:12 exp:12
+                three, four                                                       //indent:16 exp:16
+            -> A.one;                                                        //indent:12 exp:16 warn
+            default                                                               //indent:12 exp:12
+            -> A.two;                                                        //indent:12 exp:16 warn
+        };                                                                          //indent:8 exp:8
+    }                                                                               //indent:4 exp:4
+                                                                                  //indent:82 exp:82
+    enum A {                                                                        //indent:4 exp:4
+        one, two, three, four, five                                                 //indent:8 exp:8
+    }                                                                               //indent:4 exp:4
+                                                                                  //indent:82 exp:82
+    enum B {                                                                        //indent:4 exp:4
+        one, two, three, four, five                                                 //indent:8 exp:8
+    }                                                                               //indent:4 exp:4
+}                                                                                   //indent:0 exp:0
+                                                                                  //indent:82 exp:82


### PR DESCRIPTION
Issue #9037: IndentationCheck throws NPE on line wrapped switch rule

Note that I have removed `TokenTypes.LAMBDA` from `SWITCH_RULE_CHILDREN[]`; there was already a redundancy between `SwitchRuleHandler` and `LambdaHandler`, so I decided to just let `LambdaHandler` do the work.

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/931b74d45ae7ff3b68f379898f9c816e/raw/c8d3c4f19440789c4eaaa17786ebc98d120dd22c/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/8277e4d4d979cd9745b86048999a20b5/raw/4064b88513abd5ac7f1af27616af47f168d0d1d4/Indentation.xml

