### PR TITLE
infra: update drone to have readonly token for verify-no-exception-configs valiation

### DIFF
--- a/.ci/travis/travis.sh
+++ b/.ci/travis/travis.sh
@@ -287,8 +287,8 @@ verify-no-exception-configs)
   fail=0
   if [[ $DIFF_TEXT != "" ]]; then
     echo "Diff is detected."
-    if [[ $TRAVIS_PULL_REQUEST =~ ^([0-9]+)$ ]]; then
-      LINK_PR=https://api.github.com/repos/checkstyle/checkstyle/pulls/$TRAVIS_PULL_REQUEST
+    if [[ $DRONE_PULL_REQUEST =~ ^([0-9]+)$ ]]; then
+      LINK_PR=https://api.github.com/repos/checkstyle/checkstyle/pulls/$DRONE_PULL_REQUEST
       REGEXP="https://github.com/checkstyle/contribution/pull/"
       PR_DESC=$(curl -s -H "Authorization: token $READ_ONLY_TOKEN" $LINK_PR \
                   | jq '.body' | grep $REGEXP | cat )


### PR DESCRIPTION
token defined at https://cloud.drone.io/checkstyle/checkstyle/settings

pr number is from https://docs.drone.io/pipeline/environment/reference/drone-pull-request/