### PR TITLE
 Issue #4358: add requiredJavadocPhrase to DesignForExtensionCheck

### DIFF
--- a/config/checkstyle_non_main_files_suppressions.xml
+++ b/config/checkstyle_non_main_files_suppressions.xml
@@ -92,6 +92,9 @@
   <suppress id="lineLength"
          files="src[\\/]test[\\/]resources-noncompilable[\\/].*[\\/]customimportorder"/>
 
+  <!-- until https://github.com/checkstyle/checkstyle/issues/9204 -->
+  <suppress id="lineLength" files="config_design\.xml" lines="163"/>
+
   <!-- apply check numberOfTestCasesInXpath only for files in suppressionxpathfilter directory -->
   <suppress id="numberOfTestCasesInXpath"
          files="src[\\/]it[\\/]java[\\/]com[\\/].*" />

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -7,6 +7,8 @@
 <suppressions>
   <!-- can't split long messages between lines -->
   <suppress id="lineLengthXml" files="google_checks\.xml" lines="56,126"/>
+  <!-- until https://github.com/checkstyle/checkstyle/issues/9204 -->
+  <suppress id="lineLengthXml" files="config_design\.xml" lines="163"/>
   <!-- don't validate generated files -->
   <suppress id="lineLengthXml" files="releasenotes\.xml"/>
   <suppress id="lineLengthXml" files="[\\/]meta[\\/]"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
@@ -184,7 +184,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * &lt;/module&gt;
  * </pre>
  * <pre>
- * public class A extends B {
+ * public class A {
  *   &#64;Override
  *   public int foo() {
  *     return 2;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
@@ -159,6 +161,12 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * Type is {@code java.lang.String[]}.
  * Default value is {@code After, AfterClass, Before, BeforeClass, Test}.
  * </li>
+ * <li>
+ * Property {@code requiredJavadocPhrase} - Specify the comment text pattern which qualifies a
+ * method as designed for extension. Supports multi-line regex.
+ * Type is {@code java.util.regex.Pattern}.
+ * Default value is {@code ".*"}.
+ * </li>
  * </ul>
  * <p>
  * To configure the check:
@@ -208,6 +216,58 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * }
  * </pre>
  * <p>
+ * To configure the check to allow methods which contain a specified comment text
+ * pattern in their javadoc to be designed for extension.
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;DesignForExtension&quot;&gt;
+ *   &lt;property name=&quot;requiredJavadocPhrase&quot;
+ *     value=&quot;This implementation&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <pre>
+ * public class A {
+ *   /&#42;&#42;
+ *   &#42; This implementation ...
+ *   &#42;/
+ *   public int foo() {return 2;} // ok, required javadoc phrase in comment
+ *
+ *   /&#42;&#42;
+ *   &#42; Do not extend ...
+ *   &#42;/
+ *   public int foo2() {return 8;} // violation, required javadoc phrase not in comment
+ *
+ *   public int foo3() {return 3;} // violation, required javadoc phrase not in comment
+ * }
+ * </pre>
+ * <p>
+ * To configure the check to allow methods which contain a specified comment text
+ * pattern in their javadoc which can span multiple lines
+ * to be designed for extension.
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;DesignForExtension&quot;&gt;
+ *   &lt;property name=&quot;requiredJavadocPhrase&quot;
+ *     value=&quot;This[\s\S]*implementation&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <pre>
+ * public class A {
+ *   /&#42;&#42;
+ *   &#42; This
+ *   &#42; implementation ...
+ *   &#42;/
+ *   public int foo() {return 2;} // ok, required javadoc phrase in comment
+ *
+ *   /&#42;&#42;
+ *   &#42; Do not extend ...
+ *   &#42;/
+ *   public int foo2() {return 8;} // violation, required javadoc phrase not in comment
+ *
+ *   public int foo3() {return 3;} // violation, required javadoc phrase not in comment
+ * }
+ * </pre>
+ * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
  * </p>
  * <p>
@@ -237,12 +297,28 @@ public class DesignForExtensionCheck extends AbstractCheck {
         "BeforeClass", "AfterClass", }).collect(Collectors.toSet());
 
     /**
+     * Specify the comment text pattern which qualifies a method as designed for extension.
+     * Supports multi-line regex.
+     */
+    private Pattern requiredJavadocPhrase = Pattern.compile(".*");
+
+    /**
      * Setter to specify annotations which allow the check to skip the method from validation.
      *
      * @param ignoredAnnotations method annotations.
      */
     public void setIgnoredAnnotations(String... ignoredAnnotations) {
         this.ignoredAnnotations = Arrays.stream(ignoredAnnotations).collect(Collectors.toSet());
+    }
+
+    /**
+     * Setter to specify the comment text pattern which qualifies a
+     * method as designed for extension. Supports multi-line regex.
+     *
+     * @param requiredJavadocPhrase method annotations.
+     */
+    public void setRequiredJavadocPhrase(Pattern requiredJavadocPhrase) {
+        this.requiredJavadocPhrase = requiredJavadocPhrase;
     }
 
     @Override
@@ -291,7 +367,7 @@ public class DesignForExtensionCheck extends AbstractCheck {
      * @param methodDef method definition token.
      * @return true if a method has a javadoc comment.
      */
-    private static boolean hasJavadocComment(DetailAST methodDef) {
+    private boolean hasJavadocComment(DetailAST methodDef) {
         return hasJavadocCommentOnToken(methodDef, TokenTypes.MODIFIERS)
                 || hasJavadocCommentOnToken(methodDef, TokenTypes.TYPE);
     }
@@ -303,7 +379,7 @@ public class DesignForExtensionCheck extends AbstractCheck {
      * @param tokenType token type.
      * @return true if a token has a javadoc comment.
      */
-    private static boolean hasJavadocCommentOnToken(DetailAST methodDef, int tokenType) {
+    private boolean hasJavadocCommentOnToken(DetailAST methodDef, int tokenType) {
         final DetailAST token = methodDef.findFirstToken(tokenType);
         return branchContainsJavadocComment(token);
     }
@@ -314,13 +390,13 @@ public class DesignForExtensionCheck extends AbstractCheck {
      * @param token tree token.
      * @return true if a javadoc comment exists under the token.
      */
-    private static boolean branchContainsJavadocComment(DetailAST token) {
+    private boolean branchContainsJavadocComment(DetailAST token) {
         boolean result = false;
         DetailAST curNode = token;
         while (curNode != null) {
             if (curNode.getType() == TokenTypes.BLOCK_COMMENT_BEGIN
                     && JavadocUtil.isJavadocComment(curNode)) {
-                result = true;
+                result = hasValidJavadocComment(curNode);
                 break;
             }
 
@@ -337,6 +413,23 @@ public class DesignForExtensionCheck extends AbstractCheck {
         }
 
         return result;
+    }
+
+    /**
+     * Checks whether a javadoc contains the specified comment pattern that denotes
+     * a method as designed for extension.
+     *
+     * @param detailAST the ast we are checking for possible extension
+     * @return true if the javadoc of this ast contains the required comment pattern
+     */
+    private boolean hasValidJavadocComment(DetailAST detailAST) {
+        final String javadocString =
+            JavadocUtil.getBlockCommentContent(detailAST);
+
+        final Matcher requiredJavadocPhraseMatcher =
+            requiredJavadocPhrase.matcher(javadocString);
+
+        return requiredJavadocPhraseMatcher.find();
     }
 
     /**

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/design/DesignForExtensionCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/design/DesignForExtensionCheck.xml
@@ -128,6 +128,12 @@
                <description>Specify annotations which allow the check to
  skip the method from validation.</description>
             </property>
+            <property default-value=".*"
+                      name="requiredJavadocPhrase"
+                      type="java.util.regex.Pattern">
+               <description>Specify the comment text pattern which qualifies a
+ method as designed for extension. Supports multi-line regex.</description>
+            </property>
          </properties>
          <message-keys>
             <message-key key="design.forExtension"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheckTest.java
@@ -138,4 +138,29 @@ public class DesignForExtensionCheckTest
             getNonCompilablePath("InputDesignForExtensionRecords.java"), expected);
     }
 
+    @Test
+    public void testRequiredJavadocPhrase() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(DesignForExtensionCheck.class);
+        checkConfig.addAttribute("requiredJavadocPhrase", "This implementation");
+        final String className = "InputDesignForExtensionRequiredJavadocPhrase";
+        final String[] expected = {
+            "37:5: " + getCheckMessage(MSG_KEY, className, "foo5"),
+            "44:5: " + getCheckMessage(MSG_KEY, className, "foo8"),
+            "47:5: " + getCheckMessage(MSG_KEY, className, "foo9"),
+            "63:5: " + getCheckMessage(MSG_KEY, className, "foo12"),
+        };
+        verify(checkConfig, getPath("InputDesignForExtensionRequiredJavadocPhrase.java"), expected);
+    }
+
+    @Test
+    public void testRequiredJavadocPhraseMultiLine() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(DesignForExtensionCheck.class);
+        checkConfig.addAttribute("requiredJavadocPhrase", "This[\\s\\S]*implementation");
+        final String className = "InputDesignForExtensionRequiredJavadocPhraseMultiLine";
+        final String[] expected = {
+            "19:5: " + getCheckMessage(MSG_KEY, className, "foo2"),
+        };
+        verify(checkConfig, getPath("InputDesignForExtensionRequiredJavadocPhraseMultiLine.java"),
+            expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionRequiredJavadocPhrase.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionRequiredJavadocPhrase.java
@@ -1,0 +1,66 @@
+package com.puppycrawl.tools.checkstyle.checks.design.designforextension;
+
+/* Config:
+ * requiredJavadocPhrase = "This implementation"
+ *
+ */
+public class InputDesignForExtensionRequiredJavadocPhrase {
+
+    /**
+     * This implementation is for <p> some html code
+     * </p>.
+     *
+     * @param a
+     * @param b
+     * @return sum
+     */
+    public int foo1(int a, int b) {return a + b;}  // ok, required comment pattern in javadoc
+
+    /**
+     * This implementation is required for ...
+     *
+     * @param a
+     * @param b
+     * @return sum
+     */
+    public int foo2(int a, int b) {return a + b;}  // ok, required comment pattern in javadoc
+
+    /** This implementation is for ... */
+    public int foo3(int a, int b) {return a + b;}  // ok, required comment pattern in javadoc
+
+    /**
+     * This implementation ...
+     */
+    public int foo4(int a, int b) {return a + b;}  // ok, required comment pattern in javadoc
+
+    /** This method can safely be overridden. */
+    public int foo5(int a, int b) {return a + b;} // violation
+
+    public final int foo6(int a) {return a - 2;} // ok, final
+
+    protected final int foo7(int a) {return a - 2;} // ok, final
+
+    /** */
+    public int foo8(int a) {return a - 2;} // violation
+
+    // This implementation
+    public int foo9(int a, int b) {return a + b;} // violation, not javadoc
+
+    @Deprecated
+    protected final int foo10(int a) {return a - 2;} // ok, deprecated
+
+    /**
+     * This implementation is for <p> some html code
+     * </p>.
+     *
+     * @param a
+     * @param b
+     * @return sum
+     */
+    public int foo11(int a, int b) {return a + b;} // ok, required comment pattern in javadoc
+
+    /**This method can safely be overridden. */
+    public int foo12(int a, int b) {  // violation
+        return a + b;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionRequiredJavadocPhraseMultiLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionRequiredJavadocPhraseMultiLine.java
@@ -1,0 +1,22 @@
+package com.puppycrawl.tools.checkstyle.checks.design.designforextension;
+
+/* Config:
+ * requiredJavadocPhrase = "This[\s\S]*implementation"
+ *
+ */
+public class InputDesignForExtensionRequiredJavadocPhraseMultiLine {
+    /**
+     * This
+     * implementation ..
+     */
+    public int foo1(int a, int b) {
+        return a * b;
+    }
+
+    /**
+     * This method can safely be overridden.
+     */
+    public int foo2(int a, int b) {  // violation
+        return a + b;
+    }
+}

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -191,7 +191,7 @@ public abstract class Plant {
         </source>
 
         <source>
-public class A extends B {
+public class A {
   @Override
   public int foo() {
     return 2;

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -157,6 +157,15 @@ public abstract class Plant {
               <td><code>After, AfterClass, Before, BeforeClass, Test</code></td>
               <td>7.2</td>
             </tr>
+            <tr>
+              <td>requiredJavadocPhrase</td>
+              <td>
+                Specify the comment text pattern which qualifies a method as designed for extension. Supports multi-line regex.
+              </td>
+              <td><a href="property_types.html#pattern">Pattern</a></td>
+              <td><code>&quot;.*&quot;</code></td>
+              <td>8.40</td>
+            </tr>
           </table>
         </div>
       </subsection>
@@ -211,6 +220,57 @@ public class FooTest {
   }
 
   public int foo4() {return 4;} // violation
+}
+        </source>
+        <p>
+          To configure the check to allow methods which contain a specified comment text
+          pattern in their javadoc to be designed for extension.
+        </p>
+        <source>
+&lt;module name=&quot;DesignForExtension&quot;&gt;
+  &lt;property name=&quot;requiredJavadocPhrase&quot; value=&quot;This implementation&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <source>
+public class A {
+      /&#42;&#42;
+       &#42; This implementation ...
+       &#42;/
+      public int foo() {return 2;} // ok, required javadoc phrase in comment
+
+      /&#42;&#42;
+       &#42; Do not extend ...
+       &#42;/
+      public int foo2() {return 8;} // violation, required javadoc phrase not in comment
+
+  public int foo3() {return 3;} // violation, required javadoc phrase not in comment
+}
+        </source>
+        <p>
+          To configure the check to allow methods which contain a specified comment text
+          pattern in their javadoc which can span multiple lines
+          to be designed for extension.
+        </p>
+        <source>
+&lt;module name=&quot;DesignForExtension&quot;&gt;
+  &lt;property name=&quot;requiredJavadocPhrase&quot;
+          value=&quot;This[\s\S]*implementation&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <source>
+public class A {
+    /&#42;&#42;
+     &#42; This
+     &#42; implementation ...
+     &#42;/
+    public int foo() {return 2;} // ok, required javadoc phrase in comment
+
+    /&#42;&#42;
+     &#42; Do not extend ...
+     &#42;/
+    public int foo2() {return 8;} // violation, required javadoc phrase not in comment
+
+    public int foo3() {return 3;} // violation, required javadoc phrase not in comment
 }
         </source>
       </subsection>


### PR DESCRIPTION
Issue #4358: add requiredJavadocPhrase to DesignForExtensionCheck

I have simplified the logic quite a bit from the previous PR. The responsibility of implementing the `requiredJavadocPhrase` pattern (regex) should be on the user; we should not need to modify the text of the javadoc comment. We are only checking for a match anywhere within the javadoc, not an exact match of the entire contents of the javadoc.

Note that this new property's default value is to match anything; that is, the check will still have the original behavior unless the phrase is changed.  I am making a patch config with the recommended `This implementation`... to make sure this works as intended.  I can run this a few times if we need to.

Link to site: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/issue-4358-design_2021220527/index.html

Link to exact check documentation:  https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/issue-4358-design_2021220527/config_design.html#DesignForExtension

Diff report 1 (Different patch and base): https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/issue-4358-design_2020075745/reports/diff/index.html

Diff report 2 (same config): https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/issue-4358-design_2020134410/reports/diff/index.html

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/ac4228829bdf88c2e20aa77f4c358112/raw/91218ae045625ddb04df95cd03077a1402b624c0/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/121b5d90a82a6fff8831c3842cfd8fed/raw/248c3e4c1d8ae7d9081812a15c0c7921bc417efc/DesignForExtensionBase.xml

~patch config:~ https://gist.githubusercontent.com/nmancus1/63a638e7dd6f9c4d3d3ff1006dafe716/raw/70c2b0ef5111ba9de0ec2b619c05171cee59ece7/DesignForExtensionPatch.xml