### PR TITLE
Issue #7452: OBJBLOCK token support in RightCurlyCheck

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -306,6 +306,7 @@
       <property name="tokens" value="ENUM_DEF"/>
       <property name="tokens" value="RECORD_DEF"/>
       <property name="tokens" value="COMPACT_CTOR_DEF"/>
+      <property name="tokens" value="OBJBLOCK"/>
       <property name="option" value="alone"/>
     </module>
     <module name="RightCurly">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -294,6 +294,7 @@ public class RightCurlyCheck extends AbstractCheck {
             TokenTypes.INTERFACE_DEF,
             TokenTypes.RECORD_DEF,
             TokenTypes.COMPACT_CTOR_DEF,
+            TokenTypes.OBJBLOCK,
         };
     }
 

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -94,7 +94,7 @@
       <property name="tokens"
                value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
                     INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
-                    COMPACT_CTOR_DEF"/>
+                    COMPACT_CTOR_DEF, OBJBLOCK"/>
     </module>
     <module name="SuppressionXpathSingleFilter">
       <!-- suppresion is required till https://github.com/checkstyle/checkstyle/issues/7541 -->

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -1117,6 +1117,8 @@ allowedFuture.addCallback(result -> {
                   RECORD_DEF</a>
                 ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
                   COMPACT_CTOR_DEF</a>
+              , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#OBJBLOCK">
+                  OBJBLOCK</a>
                 .
               </td>
               <td>

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -1113,9 +1113,9 @@ allowedFuture.addCallback(result -> {
                   ENUM_DEF</a>
               , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INTERFACE_DEF">
                   INTERFACE_DEF</a>
-                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
+              , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
                   RECORD_DEF</a>
-                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
+              , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
                   COMPACT_CTOR_DEF</a>
               , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#OBJBLOCK">
                   OBJBLOCK</a>


### PR DESCRIPTION
Issue #7452: OBJBLOCK token support in RightCurlyCheck

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/ac4228829bdf88c2e20aa77f4c358112/raw/91218ae045625ddb04df95cd03077a1402b624c0/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/c1727391d09a3cdeac33b24bdf4631ad/raw/be2bf8d22a604a807ecaff62543e7cedddea23c0/rcurlybasenotokens.xml

Diff Regression patch config: https://gist.githubusercontent.com/nmancus1/ffc76fe4b452fd33c9045d2d266ea421/raw/0866080176f56c644b7d229f1aeb50bcfe737404/rcurlyonlyobjblock.xml

Diff report (single config): https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/issue-7452-rcurly_2020173208/reports/diff/index.html

Diff report (default config vs default + `OBJBLOCK` token): https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/issue-7452-rcurly_2020194907/reports/diff/index.html