### PR TITLE
Issue #4219: UnusedImports doesn't recognize imports shadowed by inner types

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
@@ -182,6 +182,8 @@ public class UnusedImportsCheckTest extends AbstractModuleTestSupport {
             TokenTypes.VARIABLE_DEF,
             TokenTypes.RECORD_DEF,
             TokenTypes.COMPACT_CTOR_DEF,
+            TokenTypes.OBJBLOCK,
+            TokenTypes.SLIST,
         };
 
         assertArrayEquals(expected, actual, "Default required tokens are invalid");
@@ -209,6 +211,8 @@ public class UnusedImportsCheckTest extends AbstractModuleTestSupport {
             TokenTypes.VARIABLE_DEF,
             TokenTypes.RECORD_DEF,
             TokenTypes.COMPACT_CTOR_DEF,
+            TokenTypes.OBJBLOCK,
+            TokenTypes.SLIST,
         };
 
         assertArrayEquals(expected, actual, "Default acceptable tokens are invalid");
@@ -273,6 +277,18 @@ public class UnusedImportsCheckTest extends AbstractModuleTestSupport {
         verify(checkConfig,
                 getNonCompilablePath("InputUnusedImportsRecordsAndCompactCtors.java"),
                 expected);
+    }
+
+    @Test
+    public void testShadowedImports() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(UnusedImportsCheck.class);
+        final String[] expected = {
+            "5:8: " + getCheckMessage(MSG_KEY, "java.util.Map"),
+            "6:8: " + getCheckMessage(MSG_KEY, "java.util.Set"),
+            "9:8: " + getCheckMessage(MSG_KEY, "com.puppycrawl.tools.checkstyle.checks.imports."
+                    + "unusedimports.InputUnusedImportsShadowed"),
+        };
+        verify(checkConfig, getPath("InputUnusedImportsShadowed.java"), expected);
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsShadowed.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsShadowed.java
@@ -1,0 +1,89 @@
+package com.puppycrawl.tools.checkstyle.checks.imports.unusedimports;
+
+import java.util.AbstractMap; // ok
+import java.util.List; // ok
+import java.util.Map; // violation
+import java.util.Set; // violation
+import java.util.concurrent.Callable; // ok
+
+import com.puppycrawl.tools.checkstyle.checks.imports.unusedimports.InputUnusedImportsShadowed; // violation
+import com.puppycrawl.tools.checkstyle.checks.imports.unusedimports.InputUnusedImportsShadowed.Deprecated; // ok
+import com.puppycrawl.tools.checkstyle.checks.imports.unusedimports.InputUnusedImportsShadowed.Foo; // ok
+import com.puppycrawl.tools.checkstyle.checks.imports.unusedimports.InputUnusedImportsShadowed.Inner; // ok
+import com.puppycrawl.tools.checkstyle.checks.imports.unusedimports.InputUnusedImportsShadowed.Nested; // ok
+import com.puppycrawl.tools.checkstyle.checks.imports.unusedimports.InputUnusedImportsShadowed.Nested.List.Map.Entry; // ok
+
+/*
+ * Config: default
+*/
+@Deprecated(foo = Foo.class, classes = {Inner.class})
+public class InputUnusedImportsShadowed
+        extends AbstractMap.SimpleEntry
+        implements Comparable<Nested.List.Map.Entry>, Callable<Entry> {
+
+    InputUnusedImportsShadowed() {
+        super(null, null);
+        List x = null; // java.util.List
+    }
+
+    @Override
+    public int compareTo(Nested.List.Map.Entry entry) {
+        return 0;
+    }
+
+    @Override
+    public Entry call() throws Exception {
+        return Entry.IGNORED;
+    }
+
+    static class Nested {
+        List.Map field;
+        public Nested() {
+            List x = null;
+        }
+
+        @Set
+        interface List {
+            Map foo();
+            class Map {
+                enum Entry {
+                    BAR, FOO, IGNORED
+                }
+            }
+        }
+    }
+
+    @interface Set {
+    }
+
+    @interface Deprecated {
+        Class<?> foo();
+        Class<?>[] classes();
+    }
+
+    @interface Inner {
+    }
+
+    enum Foo {
+    }
+
+    interface Callable<V> {
+        V call();
+    }
+
+    interface AbstractMap {
+        class SimpleEntry {
+        }
+    }
+
+    List field; // java.util.List
+
+    void function() {
+        List variable; // java.util.List
+        {
+            class List {
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Issue #4219

Instead of collecting types into the plain list, collect them for the current frame only.
Then remove all locally declared types and pull the rest up to the parent frame.
On the top level there will be plain list, but without any locally declared types.

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/32ddbff9e69986ac2fcbbeff7def2f80/raw/8480445657f1d215e683dbb6b14c1577bbd44e6b/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/pbludov/25180f2628587d294328749677a73c30/raw/2f786c594fd647f3eb42031eded04f1575a3aafd/unused-imports.xml