### PR TITLE
Issue #9086: ForceStrictCondition should not affect individual array elements

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -6,6 +6,7 @@ aarch
 abbreviationaswordinname
 abcun
 abego
+Abhishek
 abstractcheck
 abstractclassname
 abstractfileset
@@ -768,6 +769,7 @@ keygen
 konstantinos
 Kordas
 Kotlin
+kumar
 kused
 lambdabodylength
 lambdaparametername

--- a/.ci/wercker.sh
+++ b/.ci/wercker.sh
@@ -61,10 +61,10 @@ no-error-pgjdbc)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/pgjdbc/pgjdbc.git
+  checkout_from https://github.com/Abhishek-kumar09/pgjdbc.git
   cd .ci-temp/pgjdbc
   # pgjdbc easily damage build, we should use stable versions
-  git checkout "7d64d""d""c2460e""e1a7c8d715308431cd3a3a3a0856"
+  git checkout "f41cc39001fe""bd824242a""fa5cb474fa0a52c1081"
   ./gradlew --no-parallel --no-daemon checkstyleAll \
             -PenableMavenLocal -Pcheckstyle.version=${CS_POM_VERSION}
   cd ../

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AnnotationArrayInitHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AnnotationArrayInitHandler.java
@@ -93,27 +93,18 @@ public class AnnotationArrayInitHandler extends BlockParentHandler {
 
     @Override
     protected IndentLevel getChildrenExpectedIndent() {
+        IndentLevel expectedIndent =
+            new IndentLevel(getIndent(), getArrayInitIndentation(), getLineWrappingIndentation());
 
-        final int offset = Math.min(getArrayInitIndentation(), getLineWrappingIndentation());
-        IndentLevel expectedIndent = new IndentLevel(getIndent(), offset);
+        final int firstLine = getFirstLine(getListChild());
+        final int lcurlyPos = expandedTabsColumnNo(getLeftCurly());
+        final int firstChildPos =
+            getNextFirstNonBlankOnLineAfter(firstLine, lcurlyPos);
 
-        // If force strict condition is true,
-        // then the child should have discrete indentation values.
-        if (getIndentCheck().isForceStrictCondition()) {
-            expectedIndent = new IndentLevel(getIndent(),
-                        getArrayInitIndentation(), getLineWrappingIndentation());
-
-            final int firstLine = getFirstLine(getListChild());
-            final int lcurlyPos = expandedTabsColumnNo(getLeftCurly());
-            final int firstChildPos =
-                getNextFirstNonBlankOnLineAfter(firstLine, lcurlyPos);
-
-            if (firstChildPos != NOT_EXIST) {
-                expectedIndent = IndentLevel.addAcceptable(expectedIndent, firstChildPos, lcurlyPos
+        if (firstChildPos != NOT_EXIST) {
+            expectedIndent = IndentLevel.addAcceptable(expectedIndent, firstChildPos, lcurlyPos
                     + getLineWrappingIndentation());
-            }
         }
-
         return expectedIndent;
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
@@ -254,18 +254,10 @@ public class BlockParentHandler extends AbstractExpressionHandler {
         else {
             // NOTE: switch statements usually don't have curlies
             if (!hasCurlies() || !TokenUtil.areOnSameLine(getLeftCurly(), getRightCurly())) {
-                // Note: For Annotation Array Init only:
-                // If its a annotation array init block with strict cond being false then,
-                // we want flexible child indents with any indentLevel above minimum requirement
-                // All the other block elements will follow strict discrete indentation levels.
-                final boolean doesAnnotationArrayInitFollowsStrictCond =
-                    !TokenUtil.isOfType(listChild, TokenTypes.ANNOTATION_ARRAY_INIT)
-                        || getIndentCheck().isForceStrictCondition();
-
                 checkChildren(listChild,
                         getCheckedChildren(),
                         getChildrenExpectedIndent(),
-                        doesAnnotationArrayInitFollowsStrictCond,
+                        true,
                         canChildrenBeNested());
             }
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -312,9 +312,12 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("tabWidth", "4");
         checkConfig.addAttribute("throwsIndent", "4");
         final String[] expected = {
-            "40:1: " + getCheckMessage(MSG_CHILD_ERROR, "annotation array initialization", 0, 4),
-            "41:1: " + getCheckMessage(MSG_CHILD_ERROR, "annotation array initialization", 0, 4),
-            "50:7: " + getCheckMessage(MSG_CHILD_ERROR, "annotation array initialization", 6, 8),
+            "40:1: " + getCheckMessage(MSG_CHILD_ERROR_MULTI,
+                    "annotation array initialization", 0, "4, 23, 25"),
+            "41:1: " + getCheckMessage(MSG_CHILD_ERROR_MULTI,
+                    "annotation array initialization", 0, "4, 23, 25"),
+            "50:7: " + getCheckMessage(MSG_CHILD_ERROR_MULTI,
+                    "annotation array initialization", 6, "8, 27, 29"),
         };
         verifyWarns(checkConfig, getPath("InputIndentationDifficultAnnotations.java"), expected);
     }
@@ -526,15 +529,20 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("tabWidth", "8");
         checkConfig.addAttribute("throwsIndent", "4");
         final String[] expected = {
-            "17:1: " + getCheckMessage(MSG_CHILD_ERROR, "annotation array initialization", 0, 4),
+
+            "17:1: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "annotation array initialization", 0,
+                "4, 6, 34, 36"),
+            "22:14: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "annotation array initialization",
+                    13, "4, 6, 34, 36"),
             "23:3: " + getCheckMessage(MSG_ERROR_MULTI,
                     "annotation array initialization rcurly", 2, "0, 4"),
-            "35:7: " + getCheckMessage(MSG_CHILD_ERROR, "annotation array initialization", 6, 8),
+            "35:7: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "annotation array initialization", 6,
+                "8, 10, 31, 33"),
             "36:3: " + getCheckMessage(MSG_ERROR_MULTI,
                     "annotation array initialization rcurly", 2, "4, 8"),
 
-            "52:6: " + getCheckMessage(MSG_CHILD_ERROR,
-                    "annotation array initialization", 5, 6),
+            "52:6: " + getCheckMessage(MSG_CHILD_ERROR_MULTI,
+                    "annotation array initialization", 5, "6, 8, 10"),
             "54:6: " + getCheckMessage(MSG_ERROR_MULTI,
                     "annotation array initialization rcurly", 5, "2, 6"),
         };
@@ -555,10 +563,17 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("tabWidth", "8");
         checkConfig.addAttribute("throwsIndent", "4");
         final String[] expected = {
+
+            "17:5: " + getCheckMessage(MSG_CHILD_ERROR_MULTI,
+                "annotation array initialization", 4, "0, 33, 35"),
+            "30:9: " + getCheckMessage(MSG_CHILD_ERROR_MULTI,
+                "annotation array initialization", 8, "4, 29, 31"),
             "32:3: " + getCheckMessage(MSG_ERROR,
                 "annotation array initialization rcurly", 2, 4),
             "47:7: " + getCheckMessage(MSG_ERROR,
                 "annotation array initialization lcurly", 6, 2),
+            "49:5: " + getCheckMessage(MSG_CHILD_ERROR_MULTI,
+                "annotation array initialization", 4, "2, 6, 8"),
         };
         final String fileName = getPath("InputIndentationAnnArrInit2.java");
         verifyWarns(checkConfig, fileName, expected);
@@ -573,7 +588,8 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("basicOffset", "4");
         checkConfig.addAttribute("braceAdjustment", "0");
         checkConfig.addAttribute("caseIndent", "4");
-        checkConfig.addAttribute("forceStrictCondition", "true");
+
+        checkConfig.addAttribute("forceStrictCondition", "false");
         checkConfig.addAttribute("lineWrappingIndentation", "9");
         checkConfig.addAttribute("tabWidth", "4");
         checkConfig.addAttribute("throwsIndent", "4");
@@ -599,7 +615,11 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("tabWidth", "4");
         checkConfig.addAttribute("throwsIndent", "4");
         final String fileName = getPath("InputIndentationZeroArrayInit.java");
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        final String[] expected = {
+            "22:12: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "annotation array initialization",
+                    11, "8, 12, 35, 37"),
+        };
         verifyWarns(checkConfig, fileName, expected);
     }
 
@@ -1090,68 +1110,6 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
                 "8, 31, 33"),
             "53:5: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "array initialization",
                     4, "8, 31, 33"),
-            "58:7: " + getCheckMessage(MSG_CHILD_ERROR, "array initialization", 6, 8),
-            "63:3: " + getCheckMessage(MSG_ERROR, "member def type", 2, 4),
-            "65:7: " + getCheckMessage(MSG_ERROR, "member def type", 6, 4),
-            "66:3: " + getCheckMessage(MSG_ERROR_MULTI, "array initialization rcurly", 2, "6, 10"),
-            "69:7: " + getCheckMessage(MSG_CHILD_ERROR, "array initialization", 6, 8),
-            "76:11: " + getCheckMessage(MSG_CHILD_ERROR, "array initialization", 10, 12),
-            "89:9: " + getCheckMessage(MSG_ERROR, "1", 8, 12),
-            "100:11: " + getCheckMessage(MSG_CHILD_ERROR, "array initialization", 10, 12),
-            "101:15: " + getCheckMessage(MSG_CHILD_ERROR, "array initialization", 14, 12),
-            "104:11: " + getCheckMessage(MSG_CHILD_ERROR, "array initialization", 10, 12),
-            "105:15: " + getCheckMessage(MSG_CHILD_ERROR, "array initialization", 14, 12),
-            "106:7: " + getCheckMessage(MSG_ERROR_MULTI, "array initialization rcurly", 6, "8, 12"),
-            "109:7: " + getCheckMessage(MSG_ERROR_MULTI, "array initialization lcurly", 6, "8, 12"),
-            "110:15: " + getCheckMessage(MSG_CHILD_ERROR, "array initialization", 14, 12),
-            "111:11: " + getCheckMessage(MSG_CHILD_ERROR, "array initialization", 10, 12),
-            "112:7: " + getCheckMessage(MSG_ERROR_MULTI, "array initialization rcurly", 6, "8, 12"),
-            // following are tests for annotation array initialisation
-            "120:13: " + getCheckMessage(MSG_CHILD_ERROR, "annotation array initialization",
-                    12, 16),
-            "128:15: " + getCheckMessage(MSG_CHILD_ERROR, "annotation array initialization",
-                    14, 16),
-            "129:9: " + getCheckMessage(MSG_ERROR_MULTI, "annotation array initialization rcurly",
-                8, "12, 16"),
-            "131:13: " + getCheckMessage(MSG_CHILD_ERROR, "annotation array initialization",
-                    12, 16),
-        };
-
-        // Test input for this test case is not checked due to issue #693.
-        verify(checkConfig, fileName, expected);
-    }
-
-    @Test
-    public void testInvalidArrayInitWithTrueStrictCondition()
-            throws Exception {
-        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
-
-        checkConfig.addAttribute("arrayInitIndent", "4");
-        checkConfig.addAttribute("basicOffset", "4");
-        checkConfig.addAttribute("braceAdjustment", "0");
-        checkConfig.addAttribute("caseIndent", "4");
-        checkConfig.addAttribute("forceStrictCondition", "true");
-        checkConfig.addAttribute("lineWrappingIndentation", "4");
-        checkConfig.addAttribute("tabWidth", "4");
-        checkConfig.addAttribute("throwsIndent", "4");
-        final String fileName = getPath("InputIndentationInvalidArrayInitIndent.java");
-        final String[] expected = {
-            "21:3: " + getCheckMessage(MSG_ERROR, "member def type", 2, 4),
-            "22:7: " + getCheckMessage(MSG_ERROR, "member def type", 6, 4),
-            "24:3: " + getCheckMessage(MSG_ERROR, "member def type", 2, 4),
-            "28:7: " + getCheckMessage(MSG_ERROR, "member def type", 6, 4),
-            "29:9: " + getCheckMessage(MSG_CHILD_ERROR, "array initialization", 8, 10),
-            "30:5: " + getCheckMessage(MSG_ERROR_MULTI, "array initialization rcurly", 4, "6, 10"),
-            "33:10: " + getCheckMessage(MSG_CHILD_ERROR, "array initialization", 9, 8),
-            "34:8: " + getCheckMessage(MSG_CHILD_ERROR, "array initialization", 7, 8),
-            "35:10: " + getCheckMessage(MSG_CHILD_ERROR, "array initialization", 9, 8),
-            "40:3: " + getCheckMessage(MSG_ERROR_MULTI, "array initialization lcurly", 2, "4, 8"),
-            "44:7: " + getCheckMessage(MSG_ERROR_MULTI, "array initialization rcurly", 6, "4, 8"),
-            "48:3: " + getCheckMessage(MSG_ERROR_MULTI, "array initialization lcurly", 2, "4, 8"),
-            "52:21: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "array initialization", 20,
-                "8, 31, 33"),
-            "53:5: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "array initialization",
-                4, "8, 31, 33"),
             "58:7: " + getCheckMessage(MSG_CHILD_ERROR, "array initialization", 6, 8),
             "63:3: " + getCheckMessage(MSG_ERROR, "member def type", 2, 4),
             "65:7: " + getCheckMessage(MSG_ERROR, "member def type", 6, 4),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationAnnArrInit.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationAnnArrInit.java
@@ -14,12 +14,12 @@ package com.puppycrawl.tools.checkstyle.checks.indentation.indentation; //indent
 
 @InputIndentationAnnArrInit.Foo({ @InputIndentationAnnArrInit.Bar, //indent:0 exp:0
     @InputIndentationAnnArrInit.Bar, //indent:4 exp:4
-@InputIndentationAnnArrInit.Bar, //indent:0 exp:>=4 warn
+@InputIndentationAnnArrInit.Bar, //indent:0 exp:4,6,34,36 warn
 }) //indent:0 exp:0
 
 @InputIndentationAnnArrInit.Baz({ //indent:0 exp:0
     "Hello", //indent:4 exp:4
-             "Checkstyle", //indent:13 exp:13
+             "Checkstyle", //indent:13 exp:4,6,34,36 warn
   }) //indent:2 exp:0,4 warn
 
 class InputIndentationAnnArrInit { //indent:0 exp:0
@@ -32,7 +32,7 @@ class InputIndentationAnnArrInit { //indent:0 exp:0
   @interface Baz { //indent:2 exp:2
     String[] value() default { //indent:4 exp:4
         "Hello", //indent:8 exp:8
-      "Checkstyle" //indent:6 exp:>=8 warn
+      "Checkstyle" //indent:6 exp:8,10,31,33 warn
   }; //indent:2 exp:4,8 warn
   } //indent:2 exp:2
 
@@ -49,7 +49,7 @@ interface SomeInterface { //indent:0 exp:0
 
   @SomeAnnotation(values =  //indent:2 exp:2
       { //indent:6 exp:6
-     Info.A, //indent:5 exp:>=6 warn
+     Info.A, //indent:5 exp:6,8,10 warn
       Info.B //indent:6 exp:6
      } //indent:5 exp:2,6 warn
   ) //indent:2 exp:2

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationAnnArrInit2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationAnnArrInit2.java
@@ -14,7 +14,7 @@
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation; //indent:0 exp:0
 
 @InputIndentationAnnArrInit2.Foo({ //indent:0 exp:0
-    @InputIndentationAnnArrInit2.Bar, //indent:4 exp:>=0
+    @InputIndentationAnnArrInit2.Bar, //indent:4 exp:0,33,35 warn
 @InputIndentationAnnArrInit2.Bar, //indent:0 exp:0
 }) //indent:0 exp:0
 
@@ -27,7 +27,7 @@ class InputIndentationAnnArrInit2 { //indent:0 exp:0
 
   @interface Baz { //indent:2 exp:2
     String[] value() default { //indent:4 exp:4
-        "Hello", //indent:8 exp:>=4
+        "Hello", //indent:8 exp:4,29,31 warn
     "Checkstyle" //indent:4 exp:4
   }; //indent:2 exp:4 warn
   } //indent:2 exp:2
@@ -46,7 +46,7 @@ interface SomeInterface2 { //indent:0 exp:0
   @SomeAnnotation(values =  //indent:2 exp:2
       { //indent:6 exp:2 warn
   Info.A, //indent:2 exp:2
-    Info.B //indent:4 exp:>=2
+    Info.B //indent:4 exp:2,6,8 warn
   } //indent:2 exp:2
   ) //indent:2 exp:2
   void works(); //indent:2 exp:2

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationDifficultAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationDifficultAnnotations.java
@@ -37,8 +37,8 @@ public class InputIndentationDifficultAnnotations { //indent:0 exp:0
 } //indent:0 exp:0
 
 @DifficultAnnotation({ //indent:0 exp:0
-@MyType(value = Boolean.class, name = "boolean"), //indent:0 exp:>=4 warn
-@MyType(value = String.class, name = "string") }) //indent:0 exp:>=4 warn
+@MyType(value = Boolean.class, name = "boolean"), //indent:0 exp:4,23,25 warn
+@MyType(value = String.class, name = "string") }) //indent:0 exp:4,23,25 warn
 class IncorrectClass { //indent:0 exp:0
 
     @DifficultAnnotation({ //indent:4 exp:4
@@ -47,7 +47,7 @@ class IncorrectClass { //indent:0 exp:0
     String foo = "foo"; //indent:4 exp:4
 
     @DifficultAnnotation({ //indent:4 exp:4
-      @MyType(value = Boolean.class, name = "boolean"), //indent:6 exp:>=8 warn
+      @MyType(value = Boolean.class, name = "boolean"), //indent:6 exp:8,27,29 warn
         @MyType(value = String.class, name = "string") }) //indent:8 exp:8
     void foo() { //indent:4 exp:4
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationZeroArrayInit.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationZeroArrayInit.java
@@ -19,7 +19,7 @@ public class InputIndentationZeroArrayInit { //indent:0 exp:0
     interface MyInterface { //indent:4 exp:4
         @interface SomeAnnotation { String[] values(); } //indent:8 exp:8
         @SomeAnnotation(values = { //indent:8 exp:8
-           "Hello"//indent:11 exp:11
+           "Hello"//indent:11 exp:8,12,35,37 warn
         }) //indent:8 exp:8
         void works(); //indent:8 exp:8
     } //indent:4 exp:4


### PR DESCRIPTION
Fixes #9086 
 Reverted to code point where we were not following forceStrictCondition for annotation array-elements.
Reverted to commit: https://github.com/Abhishek-kumar09/checkstyle/commit/543f240b13c90f7eec991824eb82ff1622d4e301 from Issue #5951 .

Diff Regression projects: https://gist.githubusercontent.com/Abhishek-kumar09/717190a7e2e06f4747b9c622692d4b99/raw/93fe7739cbdc52d7d17273a12d2b92328812c504/projects-to-test-on.properties
Diff Regression config: https://gist.githubusercontent.com/Abhishek-kumar09/57961e5808a1495433051701ff921494/raw/e7a3d51cabe1f918782b547a40763a9152743691/gconfig.xml


