### PR TITLE
Issue #9116: add dependencies cache for maven in github actions

### DIFF
--- a/.github/workflows/diff_report.yml
+++ b/.github/workflows/diff_report.yml
@@ -117,7 +117,13 @@ jobs:
          git remote add upstream $MAIN_REPO_GIT_URL
          git fetch upstream
          cd ../
-     
+
+     - name: Setup local maven cache
+       uses: actions/cache@v2
+       with:
+         path: ~/.m2/repository
+         key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}
+
      # fetch-depth default: 1
      # Don't need history for all branches and tags here.
      - name: Download contribution

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -66,6 +66,12 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Setup local maven cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}
+
       - name: Generate site
         run: |
           cd checkstyle


### PR DESCRIPTION
Closes #9116 

Cache added for diff report generation and site generation.
Tests on local fork shows that site generation took 2,5 minutes vs 4 without cache, report took 4 minutes with cache vs 6,5 minutes without it (1 project, 1 check)