### PR TITLE
minor: test PR for new projects file and removal of jxr

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -926,6 +926,7 @@ Niederhauser
 nikitasavinov
 nio
 nlow
+nmancus
 NMTOKEN
 noarch
 noarg

--- a/.ci/no-exception-test.sh
+++ b/.ci/no-exception-test.sh
@@ -13,7 +13,7 @@ guava-with-google-checks)
   echo CS_version: $CS_POM_VERSION
   mkdir -p .ci-temp/
   cd .ci-temp/
-  git clone https://github.com/checkstyle/contribution
+  git clone -b cleanup-projects https://github.com/nmancus1/contribution.git
   cd contribution/checkstyle-tester
   sed -i.'' 's/^guava/#guava/' projects-to-test-on.properties
   sed -i.'' 's/#guava|/guava|/' projects-to-test-on.properties
@@ -36,7 +36,7 @@ guava-with-sun-checks)
   echo CS_version: $CS_POM_VERSION
   mkdir -p .ci-temp/
   cd .ci-temp/
-  git clone https://github.com/checkstyle/contribution
+  git clone -b cleanup-projects https://github.com/nmancus1/contribution.git
   cd contribution/checkstyle-tester
   sed -i.'' 's/^guava/#guava/' projects-to-test-on.properties
   sed -i.'' 's/#guava|/guava|/' projects-to-test-on.properties
@@ -59,7 +59,7 @@ openjdk14-with-checks-nonjavadoc-error)
   echo CS_version: $CS_POM_VERSION
   mkdir -p .ci-temp/
   cd .ci-temp/
-  git clone https://github.com/checkstyle/contribution
+  git clone -b cleanup-projects https://github.com/nmancus1/contribution.git
   cd ..
   sed -i.'' 's/value=\"error\"/value=\"ignore\"/' \
         .ci-temp/contribution/checkstyle-tester/checks-nonjavadoc-error.xml

--- a/.ci/shippable.sh
+++ b/.ci/shippable.sh
@@ -36,7 +36,7 @@ no-exception-openjdk7-openjdk8)
                       --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo 'CS_POM_VERSION='${CS_POM_VERSION}
   build_checkstyle
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from "-b cleanup-projects https://github.com/nmancus1/contribution.git"
   cd .ci-temp/contribution/checkstyle-tester
   sed -i'' 's/^guava/#guava/' projects-for-circle.properties
   sed -i'' 's/#openjdk7/openjdk7/' projects-for-circle.properties
@@ -52,7 +52,7 @@ no-exception-openjdk9-lucene-and-others)
                       --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo 'CS_POM_VERSION='${CS_POM_VERSION}
   build_checkstyle
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from "-b cleanup-projects https://github.com/nmancus1/contribution.git"
   cd .ci-temp/contribution/checkstyle-tester
   sed -i'' 's/^guava/#guava/' projects-for-circle.properties
   # till hg is installed
@@ -72,7 +72,7 @@ no-exception-cassandra-storm-tapestry)
                       --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo 'CS_POM_VERSION='${CS_POM_VERSION}
   build_checkstyle
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from "-b cleanup-projects https://github.com/nmancus1/contribution.git"
   cd .ci-temp/contribution/checkstyle-tester
   sed -i'' 's/^guava/#guava/' projects-for-circle.properties
   sed -i'' 's/#tapestry-5/tapestry-5/' projects-for-circle.properties
@@ -89,7 +89,7 @@ no-exception-hadoop-apache-groovy-scouter)
                       --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo 'CS_POM_VERSION='${CS_POM_VERSION}
   build_checkstyle
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from "-b cleanup-projects https://github.com/nmancus1/contribution.git"
   cd .ci-temp/contribution/checkstyle-tester
   sed -i'' 's/^guava/#guava/' projects-for-circle.properties
   sed -i'' 's/#apache-commons/apache-commons/' projects-for-circle.properties
@@ -107,7 +107,7 @@ no-exception-only-javadoc)
                       --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo 'CS_POM_VERSION='${CS_POM_VERSION}
   build_checkstyle
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from "-b cleanup-projects https://github.com/nmancus1/contribution.git"
   cd .ci-temp/contribution/checkstyle-tester
   sed -i.'' 's/^guava/#guava/' projects-to-test-on.properties
   sed -i.'' 's/#spring-framework/spring-framework/' projects-to-test-on.properties

--- a/.ci/wercker.sh
+++ b/.ci/wercker.sh
@@ -183,7 +183,7 @@ no-error-contribution)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from "-b cleanup-projects https://github.com/nmancus1/contribution.git"
   cd .ci-temp/contribution
   cd patch-diff-report-tool
   mvn -e verify -DskipTests -Dcheckstyle.version=${CS_POM_VERSION} \
@@ -257,7 +257,7 @@ no-exception-struts)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from "-b cleanup-projects https://github.com/nmancus1/contribution.git"
   cd .ci-temp/contribution/checkstyle-tester
   sed -i'' 's/^guava/#guava/' projects-for-wercker.properties
   sed -i'' 's/#apache-struts/apache-struts/' projects-for-wercker.properties
@@ -272,7 +272,7 @@ no-exception-checkstyle-sevntu)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from "-b cleanup-projects https://github.com/nmancus1/contribution.git"
   cd .ci-temp/contribution/checkstyle-tester
   sed -i'' 's/^guava/#guava/' projects-for-wercker.properties
   sed -i'' 's/#local-checkstyle/local-checkstyle/' projects-for-wercker.properties
@@ -288,7 +288,7 @@ no-exception-checkstyle-sevntu-javadoc)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from "-b cleanup-projects https://github.com/nmancus1/contribution.git"
   cd .ci-temp/contribution/checkstyle-tester
   sed -i'' 's/^guava/#guava/' projects-for-wercker.properties
   sed -i'' 's/#local-checkstyle/local-checkstyle/' projects-for-wercker.properties
@@ -303,7 +303,7 @@ no-exception-guava)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from "-b cleanup-projects https://github.com/nmancus1/contribution.git"
   cd .ci-temp/contribution/checkstyle-tester
   sed -i'' 's/^guava/#guava/' projects-for-wercker.properties
   sed -i'' 's/#guava/guava/' projects-for-wercker.properties
@@ -317,7 +317,7 @@ no-exception-hibernate-orm)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from "-b cleanup-projects https://github.com/nmancus1/contribution.git"
   cd .ci-temp/contribution/checkstyle-tester
   sed -i.'' 's/^guava/#guava/' projects-to-test-on.properties
   sed -i.'' 's/#hibernate-orm/hibernate-orm/' projects-to-test-on.properties
@@ -331,7 +331,7 @@ no-exception-spotbugs)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from "-b cleanup-projects https://github.com/nmancus1/contribution.git"
   cd .ci-temp/contribution/checkstyle-tester
   sed -i.'' 's/^guava/#guava/' projects-to-test-on.properties
   sed -i.'' 's/#spotbugs/spotbugs/' projects-to-test-on.properties
@@ -345,7 +345,7 @@ no-exception-spoon)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from "-b cleanup-projects https://github.com/nmancus1/contribution.git"
   cd .ci-temp/contribution/checkstyle-tester
   sed -i.'' 's/^guava/#guava/' projects-to-test-on.properties
   sed -i.'' 's/#spoon/spoon/' projects-to-test-on.properties
@@ -359,7 +359,7 @@ no-exception-spring-framework)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from "-b cleanup-projects https://github.com/nmancus1/contribution.git"
   cd .ci-temp/contribution/checkstyle-tester
   sed -i.'' 's/^guava/#guava/' projects-to-test-on.properties
   sed -i.'' 's/#spring-framework/spring-framework/' projects-to-test-on.properties
@@ -373,7 +373,7 @@ no-exception-hbase)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from "-b cleanup-projects https://github.com/nmancus1/contribution.git"
   cd .ci-temp/contribution/checkstyle-tester
   sed -i.'' 's/^guava/#guava/' projects-to-test-on.properties
   sed -i.'' 's/#Hbase/Hbase/' projects-to-test-on.properties
@@ -387,7 +387,7 @@ no-exception-Pmd-elasticsearch-lombok-ast)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from "-b cleanup-projects https://github.com/nmancus1/contribution.git"
   cd .ci-temp/contribution/checkstyle-tester
   sed -i.'' 's/^guava/#guava/' projects-to-test-on.properties
   sed -i.'' 's/#pmd/pmd/' projects-to-test-on.properties
@@ -403,7 +403,7 @@ no-exception-alot-of-projects)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from "-b cleanup-projects https://github.com/nmancus1/contribution.git"
   cd .ci-temp/contribution/checkstyle-tester
   sed -i.'' 's/^guava/#guava/' projects-to-test-on.properties
   sed -i.'' 's/#RxJava/RxJava/' projects-to-test-on.properties
@@ -425,7 +425,7 @@ no-warning-imports-guava)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from "-b cleanup-projects https://github.com/nmancus1/contribution.git"
   cd .ci-temp/contribution/checkstyle-tester
   groovy ./launch.groovy --listOfProjects $PROJECTS --config $CONFIG \
       --checkstyleVersion ${CS_POM_VERSION}
@@ -449,7 +449,7 @@ no-warning-imports-java-design-patterns)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from "-b cleanup-projects https://github.com/nmancus1/contribution.git"
   cd .ci-temp/contribution/checkstyle-tester
   groovy ./launch.groovy --listOfProjects $PROJECTS --config $CONFIG \
       --checkstyleVersion ${CS_POM_VERSION}

--- a/.github/workflows/diff_report.yml
+++ b/.github/workflows/diff_report.yml
@@ -123,8 +123,8 @@ jobs:
      - name: Download contribution
        uses: actions/checkout@v2
        with:
-        repository: checkstyle/contribution
-        ref: master
+        repository: nmancus1/contribution
+        ref: cleanup-projects
         path: contribution
 
      - name: Prepare environment


### PR DESCRIPTION
Related to https://github.com/checkstyle/contribution/pull/527

No need for review on this PR; I have opened it to check that the removal of the maven jxr plugin from `checkstyle-tester` won't cause any problems with checkstyle CI.  In order to determine where to test the changes in  https://github.com/checkstyle/contribution/pull/527, I did:
```
➜  checkstyle git:(remove-jxr) grep -R 'launch.groovy\|diff.groovy'
.github/workflows/diff_report.yml:           groovy diff.groovy -r $REPO -p $REF -pc new_module_config.xml -m single\
.github/workflows/diff_report.yml:           groovy diff.groovy -r $REPO -b $BASE_BRANCH -p $REF -bc diff_config.xml\
.github/workflows/diff_report.yml:           groovy diff.groovy -r $REPO -b $BASE_BRANCH -p $REF -c diff_config.xml\
.ci/no-exception-test.sh:  groovy ./launch.groovy --listOfProjects projects-to-test-on.properties \
.ci/no-exception-test.sh:  groovy ./launch.groovy --listOfProjects projects-to-test-on.properties \
.ci/no-exception-test.sh:  groovy ./launch.groovy --listOfProjects ../../../.ci/openjdk-projects-to-test-on.config \
.ci/wercker.sh:  groovy ./launch.groovy --listOfProjects projects-for-wercker.properties \
.ci/wercker.sh:  groovy ./launch.groovy --listOfProjects projects-for-wercker.properties \
.ci/wercker.sh:  groovy ./launch.groovy --listOfProjects projects-for-wercker.properties \
.ci/wercker.sh:  groovy ./launch.groovy --listOfProjects projects-for-wercker.properties \
.ci/wercker.sh:  groovy ./launch.groovy --listOfProjects projects-for-wercker.properties \
.ci/wercker.sh:  groovy ./launch.groovy --listOfProjects projects-to-test-on.properties \
.ci/wercker.sh:  groovy ./launch.groovy --listOfProjects projects-for-wercker.properties \
.ci/wercker.sh:  groovy ./launch.groovy --listOfProjects projects-to-test-on.properties \
.ci/wercker.sh:  groovy ./launch.groovy --listOfProjects projects-to-test-on.properties \
.ci/wercker.sh:  groovy ./launch.groovy --listOfProjects projects-to-test-on.properties \
.ci/wercker.sh:  groovy ./launch.groovy --listOfProjects projects-to-test-on.properties \
.ci/wercker.sh:  groovy ./launch.groovy --listOfProjects $PROJECTS --config $CONFIG \
.ci/wercker.sh:  groovy ./launch.groovy --listOfProjects $PROJECTS --config $CONFIG \
.ci/shippable.sh:  groovy launch.groovy --listOfProjects projects-for-circle.properties \
.ci/shippable.sh:  groovy launch.groovy --listOfProjects projects-for-circle.properties \
.ci/shippable.sh:  groovy launch.groovy --listOfProjects projects-for-circle.properties \
.ci/shippable.sh:  groovy launch.groovy --listOfProjects projects-for-circle.properties \
.ci/shippable.sh:  groovy launch.groovy --listOfProjects projects-to-test-on.properties \
➜  checkstyle git:(remove-jxr) 

```
@rnveach Is there anything else we should look at to verify that it is safe to remove the JXR plugin from `checkstyle-tester`?

Note that I have used the github mirror for openjdk(in the projects file) that has failed to run in the past due to the JXR plugin, to show that this mirror will parse now that JXR is removed.

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/97cf95e0aed0c5789d5e0fc23ef82ff3/raw/1d4d102d59e7cfbc0a4d770fc55de3e04fee3b4d/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/f5579d1ad36c5ebe441738ad9bf71d4a/raw/74a7356c0a6fc322b11013055046333136f0f3ae/NoWhitespaceBefore.xml