### PR TITLE
minor: fix link to redirected target that found by link-check-plugin

### DIFF
--- a/src/xdocs/index.xml.vm
+++ b/src/xdocs/index.xml.vm
@@ -286,7 +286,8 @@
               </td>
               <td>
                 Provides analysis per pull request as GitHub
-                <a href="https://developer.github.com/v3/checks/runs/">Check Run</a>
+                <a href="https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#runs">
+                  Check Run</a>
                 annotations. Supports CheckStyle config files.
               </td>
             </tr>


### PR DESCRIPTION
https://app.codeship.com/projects/124310/builds/595d26c7-9546-4b84-968f-5d6cca11af2b?line=33703021-6716-42d9-92c2-4019201856ad&step=parallel_.ci%2Frun-link-check-plugin.sh

https://wheregoes.com/trace/

https://developer.github.com/v3/checks/runs/
redirect301 Redirect
https://docs.github.com/v3/checks/runs/
🍪
redirect301 Redirect
https://docs.github.com/v3/checks/runs
🍪
redirect301 Redirect
https://docs.github.com/en/free-pro-team@latest/rest/reference/checks#runs
Trace Complete - Total Redirects:3