### PR TITLE
Mark sonar violation 'Regular expressions should not overflow the stack' as false positive over AvoidEscapedUnicodeCharactersCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -177,7 +177,11 @@ public class AvoidEscapedUnicodeCharactersCheck
             + "|[fF]{3}[9a-bA-B]"
             + "|[fF][eE][fF]{2})");
 
-    /** Regular expression for all escaped chars. */
+    /**
+     * Regular expression for all escaped chars.
+     * See "EscapeSequence" at
+     * https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.6
+     */
     private static final Pattern ALL_ESCAPED_CHARS = Pattern.compile("^((\\\\u)[a-fA-F0-9]{4}"
             + "|\""
             + "|'"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
@@ -209,6 +209,16 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
             "94:46: " + getCheckMessage(MSG_KEY),
             "98:38: " + getCheckMessage(MSG_KEY),
             "104:38: " + getCheckMessage(MSG_KEY),
+            "106:46: " + getCheckMessage(MSG_KEY),
+            "107:55: " + getCheckMessage(MSG_KEY),
+            "108:46: " + getCheckMessage(MSG_KEY),
+            "109:55: " + getCheckMessage(MSG_KEY),
+            "110:46: " + getCheckMessage(MSG_KEY),
+            "111:55: " + getCheckMessage(MSG_KEY),
+            "112:46: " + getCheckMessage(MSG_KEY),
+            "113:55: " + getCheckMessage(MSG_KEY),
+            "114:46: " + getCheckMessage(MSG_KEY),
+            "115:55: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputAvoidEscapedUnicodeCharacters.java"), expected);
     }
@@ -251,6 +261,16 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
             "94:46: " + getCheckMessage(MSG_KEY),
             "98:38: " + getCheckMessage(MSG_KEY),
             "104:38: " + getCheckMessage(MSG_KEY),
+            "106:46: " + getCheckMessage(MSG_KEY),
+            "107:55: " + getCheckMessage(MSG_KEY),
+            "108:46: " + getCheckMessage(MSG_KEY),
+            "109:55: " + getCheckMessage(MSG_KEY),
+            "110:46: " + getCheckMessage(MSG_KEY),
+            "111:55: " + getCheckMessage(MSG_KEY),
+            "112:46: " + getCheckMessage(MSG_KEY),
+            "113:55: " + getCheckMessage(MSG_KEY),
+            "114:46: " + getCheckMessage(MSG_KEY),
+            "115:55: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputAvoidEscapedUnicodeCharacters.java"), expected);
     }
@@ -283,6 +303,11 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
             "92:45: " + getCheckMessage(MSG_KEY),
             "98:38: " + getCheckMessage(MSG_KEY),
             "104:38: " + getCheckMessage(MSG_KEY),
+            "106:46: " + getCheckMessage(MSG_KEY),
+            "108:46: " + getCheckMessage(MSG_KEY),
+            "110:46: " + getCheckMessage(MSG_KEY),
+            "112:46: " + getCheckMessage(MSG_KEY),
+            "114:46: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputAvoidEscapedUnicodeCharacters.java"), expected);
     }
@@ -307,6 +332,16 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
             "88:38: " + getCheckMessage(MSG_KEY),
             "89:38: " + getCheckMessage(MSG_KEY),
             "98:38: " + getCheckMessage(MSG_KEY),
+            "106:46: " + getCheckMessage(MSG_KEY),
+            "107:55: " + getCheckMessage(MSG_KEY),
+            "108:46: " + getCheckMessage(MSG_KEY),
+            "109:55: " + getCheckMessage(MSG_KEY),
+            "110:46: " + getCheckMessage(MSG_KEY),
+            "111:55: " + getCheckMessage(MSG_KEY),
+            "112:46: " + getCheckMessage(MSG_KEY),
+            "113:55: " + getCheckMessage(MSG_KEY),
+            "114:46: " + getCheckMessage(MSG_KEY),
+            "115:55: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputAvoidEscapedUnicodeCharacters.java"), expected);
     }
@@ -337,6 +372,16 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
             "94:46: " + getCheckMessage(MSG_KEY),
             "98:38: " + getCheckMessage(MSG_KEY),
             "104:38: " + getCheckMessage(MSG_KEY),
+            "106:46: " + getCheckMessage(MSG_KEY),
+            "107:55: " + getCheckMessage(MSG_KEY),
+            "108:46: " + getCheckMessage(MSG_KEY),
+            "109:55: " + getCheckMessage(MSG_KEY),
+            "110:46: " + getCheckMessage(MSG_KEY),
+            "111:55: " + getCheckMessage(MSG_KEY),
+            "112:46: " + getCheckMessage(MSG_KEY),
+            "113:55: " + getCheckMessage(MSG_KEY),
+            "114:46: " + getCheckMessage(MSG_KEY),
+            "115:55: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputAvoidEscapedUnicodeCharacters.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharacters.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharacters.java
@@ -102,4 +102,15 @@ public class InputAvoidEscapedUnicodeCharacters {
         private String notAUnicodeEscaped2 = "\\\\u1234";
 
         private String onlyEscaped = "\\\u1234";
+
+        private String sumilarToEscapedByB = "b\u1234";
+        private String sumilarToEscapedCommentedByB = "b\u1234"; // comment
+        private String sumilarToEscapedByF = "f\u1234";
+        private String sumilarToEscapedCommentedByF = "f\u1234"; // comment
+        private String sumilarToEscapedByR = "r\u1234";
+        private String sumilarToEscapedCommentedByR = "r\u1234"; // comment
+        private String sumilarToEscapedByN = "n\u1234";
+        private String sumilarToEscapedCommentedByN = "n\u1234"; // comment
+        private String sumilarToEscapedByT = "t\u1234";
+        private String sumilarToEscapedCommentedByT = "t\u1234"; // comment
 }


### PR DESCRIPTION
https://sonarcloud.io/project/issues?id=org.checkstyle%3Acheckstyle&issues=AXZvXAtca-Kxo9081VHK&open=AXZvXAtca-Kxo9081VHK

![image](https://user-images.githubusercontent.com/812984/103140636-c3940680-469d-11eb-82f3-31691c36929c.png)

it is very questionable fix as all other regexp expressions are prone to the same problem, so fixing only one of them will not resolve problem. But we reduce reabability of code for sure, not that much but still. It might be good to keep all regexp in same format to keep code consistent in view.

-----

I marked as "wontfix" similar case https://sonarcloud.io/project/issues?id=org.checkstyle%3Acheckstyle&issues=AXZvXApaa-Kxo9081VHJ&open=AXZvXApaa-Kxo9081VHJ
```
context of this match is always small (names of identifiers or method names or class names).
Additional points:
- is that such change might change default values of some modules.
- we sometime print regexp to user to let him know mismatch, 
     but not all users aware of "possessive quantifier". So we try to be more user friendly there.
```