### PR TITLE
Issue #9133: AvoidEscapedUnicodeCharacters should support '\s' escape symbol

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -348,7 +348,8 @@ public class AvoidEscapedUnicodeCharactersCheck
 
     @Override
     public void visitToken(DetailAST ast) {
-        final String literal = ast.getText();
+        final String literal =
+            CheckUtil.stripIndentAndInitialNewLineFromTextBlock(ast.getText());
 
         if (hasUnicodeChar(literal) && !(allowByTailComment && hasTrailComment(ast)
                 || isAllCharactersEscaped(literal)
@@ -452,8 +453,7 @@ public class AvoidEscapedUnicodeCharactersCheck
      */
     private boolean isAllCharactersEscaped(String literal) {
         return allowIfAllCharactersEscaped
-                && ALL_ESCAPED_CHARS.matcher(literal.substring(1,
-                        literal.length() - 1)).find();
+                && ALL_ESCAPED_CHARS.matcher(literal).find();
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -29,6 +29,7 @@ import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TextBlock;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
@@ -180,7 +181,7 @@ public class AvoidEscapedUnicodeCharactersCheck
     /**
      * Regular expression for all escaped chars.
      * See "EscapeSequence" at
-     * https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.6
+     * https://docs.oracle.com/javase/specs/jls/se15/html/jls-3.html#jls-3.10.7
      */
     private static final Pattern ALL_ESCAPED_CHARS = Pattern.compile("^((\\\\u)[a-fA-F0-9]{4}"
             + "|\""
@@ -190,6 +191,7 @@ public class AvoidEscapedUnicodeCharactersCheck
             + "|\\\\f"
             + "|\\\\n"
             + "|\\\\r"
+            + "|\\\\s"
             + "|\\\\t"
             + ")+$");
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
@@ -429,6 +429,24 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
     }
 
     @Test
+    public void testAvoidEscapedUnicodeCharactersEscapedS() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(AvoidEscapedUnicodeCharactersCheck.class);
+        checkConfig.addAttribute("allowIfAllCharactersEscaped", "true");
+        final String[] expected = {
+            "14:21: " + getCheckMessage(MSG_KEY),
+            "15:22: " + getCheckMessage(MSG_KEY),
+            "24:39: " + getCheckMessage(MSG_KEY),
+            "27:39: " + getCheckMessage(MSG_KEY),
+            "30:39: " + getCheckMessage(MSG_KEY),
+            "33:22: " + getCheckMessage(MSG_KEY),
+        };
+        verify(checkConfig,
+                getNonCompilablePath("InputAvoidEscapedUnicodeCharactersEscapedS.java"),
+                expected);
+    }
+
+    @Test
     public void testGetAcceptableTokens() {
         final AvoidEscapedUnicodeCharactersCheck check = new AvoidEscapedUnicodeCharactersCheck();
         final int[] actual = check.getAcceptableTokens();

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersEscapedS.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersEscapedS.java
@@ -1,0 +1,34 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.avoidescapedunicodecharacters;
+
+/* Config:
+ *
+ * allowEscapesForControlCharacters = false
+ * allowByTailComment = false
+ * allowIfAllCharactersEscaped = true
+ * allowNonPrintableEscapes = false
+ */
+public class InputAvoidEscapedUnicodeCharactersEscapedS {
+    String value1 = "\u03bc\t"; // ok
+    String value2 = "\u03bc\s"; // ok
+    String value3 = "\u03bc\s not all escaped chars"; // violation
+    String value31 = "\u03bc\n not all escaped chars"; // violation
+    String value4 = """
+            \s\s\s\n
+            """; // ok, no unicode chars
+    String value5 = """
+            \u03bc\s"""; // ok, same string as 'value2'
+    String value6 = """
+            \s\s\s\n not all escaped chars
+            """; // ok, no unicode chars
+    String value7 = /* violation */"""
+            \u03bc\s not all escaped chars
+            """; // violation on line 24
+    String value8 = /* violation */"""
+            \u03bc\n not all escaped chars
+            """; // violation on line 27
+    String value9 = /* violation */"""
+            l\u03bc\n
+            """; // violation on line 30
+    String value10 = "\n       \u03bc\s";
+}


### PR DESCRIPTION
Issue #9133: AvoidEscapedUnicodeCharacters should support '\s' escape symbol
and Issue #9159

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/931b74d45ae7ff3b68f379898f9c816e/raw/c8d3c4f19440789c4eaaa17786ebc98d120dd22c/projects-to-test-on.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/895dff8ab31b89ef9623e98391767441/raw/4a83b19384168311d39053b43a06d640b0cdcd55/config.xml

In an effort to make `TEXT_BLOCK_LITERAL` content match that of an identical (after compilation) `STRING_LITERAL` content, I attempted to do the following:
```
        String literal = ast.getText();
        if (ast.getType() == TokenTypes.TEXT_BLOCK_CONTENT) {
            literal = "\"" 
                + CheckUtil.stripIndentAndInitialNewLineFromTextBlock(ast.getText())
                + "\"";
        }

```
However, pitest complained that when the `if` statement condition is mutated to `true`, like so:
```
        String literal = ast.getText();
        if (true) {
            literal = "\""
                + CheckUtil.stripIndentAndInitialNewLineFromTextBlock(ast.getText())
                + "\"";
        }
```
It made no difference in violations. Instead of making some impossible test, I simply removed the `if` statement and the additional quotes, since they do not matter, based on the following:
1. `CheckUtil.stripIndentAndInitialNewLineFromTextBlock()` has no effect on `STRING_LITERAL` content, since `STRING_LITERAL`s have no preceding whitespace and newline.
2. The additional quotes I was adding made no difference(even when allowIfAllCharactersEscaped = true), since they are escaped anyway.


~~note: commit https://github.com/checkstyle/checkstyle/commit/9266613df869595a26a10c43d1771c4687d53d5c is not under review in this PR, I have included it because this PR depends on it. We can merge this PR after  https://github.com/checkstyle/checkstyle/pull/9134 is merged.~~