### PR TITLE
minor: exclude librepay.com from linkcheck plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1840,6 +1840,8 @@
             <excludedLink>https://oss.sonatype.org/service/local/staging/deploy/maven2/</excludedLink>
             <!-- site is too unstable, it might improve in future -->
             <excludedLink>https://freedomsponsors.org/*</excludedLink>
+            <!-- site works fine in browser but for plugin always return 500  -->
+            <excludedLink>https://liberapay.com/checkstyle/</excludedLink>
           </excludedLinks>
         </configuration>
       </plugin>


### PR DESCRIPTION
https://app.codeship.com/projects/124310/builds/30087815-da4a-4e15-8c18-0cf73ba3a00b?line=ee94ae31-1aef-48bf-8482-e20f3e2c4b34&step=parallel_.ci%2Frun-link-check-plugin.sh

```
2020-12-27 00:02:03
 system ------------ grep of linkcheck.html--BEGIN
2020-12-27 00:02:03
 system <td><i><a class="externalLink" href="https://liberapay.com/checkstyle/">
https://liberapay.com/checkstyle/</a>
: 503 Service Temporarily Unavailable</i></td></tr></table></td></tr>
2020-12-27 00:02:03
 system ------------ grep of linkcheck.html--END
```

it is very stable failure for several builds and restart does not help