### PR TITLE
Issue #9137: Create MatchXpath instance to forbid usage of 'expected'

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -399,6 +399,12 @@
       //LITERAL_CATCH//METHOD_CALL[.//IDENT[@text = 'printStackTrace']]/.."/>
       <message key="matchxpath.match" value="Avoid using 'printStackTrace'."/>
     </module>
+    <module name="MatchXpath">
+      <property name="query" value="//METHOD_DEF/MODIFIERS//
+            ANNOTATION[./IDENT[@text='Test']]/ANNOTATION_MEMBER_VALUE_PAIR
+            [./IDENT[@text='expected']]"/>
+      <message key="matchxpath.match" value="Avoid using 'expected' attribute in Test annotation."/>
+    </module>
     <module name="MissingCtor">
       <!--
         we will not use that fanatic validation, extra code is not good


### PR DESCRIPTION
Issue #9137: Create MatchXpath instance to forbid usage of 'expected' element in Test annotation

```
➜  src cat config.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">

<module name="Checker">
    <property name="charset" value="UTF-8"/>

    <module name="TreeWalker">
        <module name="MatchXpath">
            <property name="query" value="//CLASS_DEF//OBJBLOCK//METHOD_DEF//MODIFIERS//
            ANNOTATION[.//IDENT[@text='Test']]//ANNOTATION_MEMBER_VALUE_PAIR
            [.//IDENT[@text='expected']]"/>
            <message key="matchxpath.match" value="Avoid using ''expected'' in Test annotation."/>
        </module>
    </module>
</module>

➜  src cat XPathExpectedMatcher.java 
import org.junit.Test;

public class XPathExpectedMatcher {
    @Test(expected = IllegalArgumentException.class) // violation
    public void getNameWithNullValue() {
        MyObj obj = new MyObj();
        obj.setName(null);
    }
}

class MyObj{
    public void setName(String name) {
    }
}

➜  src javac -classpath /home/nick/.m2/repository/junit/junit/4.12/junit-4.12.jar XPathExpectedMatcher.java 

➜  src java -jar checkstyle-8.40-SNAPSHOT-all.jar -c config.xml XPathExpectedMatcher.java
Starting audit...
[ERROR] XPathExpectedMatcher.java:4:11: Avoid using 'expected' in Test annotation. [MatchXpath]
Audit done.
Checkstyle ends with 1 errors.

```
