### PR TITLE
minor: fix TOKEN_TEXT_PATTERN in JavadocMetadataScraper

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java
@@ -78,7 +78,7 @@ public class JavadocMetadataScraper extends AbstractJavadocCheck {
             Pattern.compile("\\s*Violation Message Keys:\\s*");
 
     /** Regular expression for detecting ANTLR tokens(for e.g. CLASS_DEF). */
-    private static final Pattern TOKEN_TEXT_PATTERN = Pattern.compile("([A-Z]+_*+)+[A-Z]+");
+    private static final Pattern TOKEN_TEXT_PATTERN = Pattern.compile("([A-Z]+_)*[A-Z]{2,}");
 
     /** Regular expression for removal of @code{-} present at the beginning of texts. */
     private static final Pattern DESC_CLEAN = Pattern.compile("-\\s");


### PR DESCRIPTION
Resolves #9140 : fix TOKEN_TEXT_PATTERN in JavadocMetadataScraper