### PR TITLE
Issue #9149: workaround for stack overflow in Navigator.next

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1354,7 +1354,9 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.2</version>
         <configuration>
-          <argLine>-Dfile.encoding=UTF-8</argLine>
+          <!-- The default stack size is 1M for x64, 320K for i386.
+               Set explicitly to 1M to avoid stack overflow errors on i386. -->
+          <argLine>-Xss1M -Dfile.encoding=UTF-8</argLine>
           <systemPropertyVariables>
             <jacoco-agent.destfile>${project.build.directory}/jacoco.exec</jacoco-agent.destfile>
           </systemPropertyVariables>


### PR DESCRIPTION
Issue #9149 

No changes in the code. Only test inputs and test environment.

The idea is simple: reduce the stack size for all unit tests to trigger possible stack overflow error on much smaller input files.

As the result, 80% of each `InputXXXXNoStackOverflow.java` can be removed.

Also, explicitly specifying the stack size makes the tests (almost) platform-independent.