### PR TITLE
Issue #7202: Add Support for Summary Javadoc tag

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
@@ -23,9 +23,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
@@ -87,6 +89,31 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
  * }
  * </pre>
  * <p>
+ * Example of non permitted empty javadoc for Inline Summary Javadoc.
+ * </p>
+ * <pre>
+ * public class Test extends Exception {
+ *   &#47;**
+ *    * {&#64;summary  }
+ *    *&#47;
+ *   public String InvalidFunctionOne(){ // violation
+ *     return "";
+ *   }
+ *
+ *   &#47;**
+ *    * {&#64;summary &lt;p&gt; &lt;p/&gt;}
+ *    *&#47;
+ *   public String InvalidFunctionTwo(){ // violation
+ *     return "";
+ *   }
+ *
+ *   &#47;**
+ *    * {&#64;summary &lt;p&gt;This is summary for validFunctionThree.&lt;p/&gt;}
+ *    *&#47;
+ *   public void validFunctionThree(){} // ok
+ * }
+ * </pre>
+ * <p>
  * To ensure that summary do not contain phrase like "This method returns",
  * use following config:
  * </p>
@@ -109,15 +136,49 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
  * </p>
  * <pre>
  * public class TestClass {
- *   &#47;**
+ *  &#47;**
  *   * This is invalid java doc.
  *   *&#47;
  *   void invalidJavaDocMethod() {
  *   }
- *   &#47;**
+ *  &#47;**
  *   * This is valid java doc。
  *   *&#47;
  *   void validJavaDocMethod() {
+ *   }
+ * }
+ * </pre>
+ * <p>
+ * Example of period property for inline summary javadoc.
+ * </p>
+ * <pre>
+ * public class TestClass {
+ *  &#47;**
+ *   * {&#64;summary This is invalid java doc.}
+ *   *&#47;
+ *   public void invalidJavaDocMethod() { // violation
+ *   }
+ *  &#47;**
+ *   * {&#64;summary This is valid java doc。}
+ *   *&#47;
+ *   public void validJavaDocMethod() { // ok
+ *   }
+ * }
+ * </pre>
+ * <p>
+ * Example of inline summary javadoc with HTML tags.
+ * </p>
+ * <pre>
+ * public class Test {
+ *  &#47;**
+ *   * {&#64;summary First sentence is normally the summary.
+ *   * Use of html tags:
+ *   * &lt;ul&gt;
+ *   * &lt;li&gt;Item one.&lt;/li&gt;
+ *   * &lt;li&gt;Item two.&lt;/li&gt;
+ *   * &lt;/ul&gt;}
+ *   *&#47;
+ *   public void validInlineJavadoc() { // ok
  *   }
  * }
  * </pre>
@@ -146,6 +207,9 @@ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
  * <li>
  * {@code summary.javaDoc.missing}
  * </li>
+ * <li>
+ * {@code summary.javaDoc.missing.period}
+ * </li>
  * </ul>
  *
  * @since 6.0
@@ -164,30 +228,56 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
      * file.
      */
     public static final String MSG_SUMMARY_JAVADOC = "summary.javaDoc";
+
     /**
      * A key is pointing to the warning message text in "messages.properties"
      * file.
      */
     public static final String MSG_SUMMARY_JAVADOC_MISSING = "summary.javaDoc.missing";
+
+    /**
+     * A key is pointing to the warning message text in "messages.properties" file.
+     */
+    public static final String MSG_SUMMARY_MISSING_PERIOD = "summary.javaDoc.missing.period";
+
     /**
      * This regexp is used to convert multiline javadoc to single line without stars.
      */
     private static final Pattern JAVADOC_MULTILINE_TO_SINGLELINE_PATTERN =
             Pattern.compile("\n[ ]+(\\*)|^[ ]+(\\*)");
 
+    /**
+     * This regexp is used to remove html tags, whitespace, and asterisks from a string.
+     */
+    private static final Pattern HTML_ELEMENTS =
+            Pattern.compile("<[^>]*>");
+
+    /**
+     * This regexp is used to extract the content of a summary javadoc tag.
+     */
+    private static final Pattern SUMMARY_PATTERN = Pattern.compile("\\{@summary ([\\S\\s]+)}");
     /** Period literal. */
     private static final String PERIOD = ".";
 
+    /** Summary tag text. */
+    private static final String SUMMARY_TEXT = "@summary";
+
     /** Set of allowed Tokens tags in summary java doc. */
     private static final Set<Integer> ALLOWED_TYPES = Collections.unmodifiableSet(
-            new HashSet<>(Arrays.asList(JavadocTokenTypes.TEXT,
-                    JavadocTokenTypes.WS))
+            new HashSet<>(Arrays.asList(
+                    JavadocTokenTypes.WS,
+                    JavadocTokenTypes.DESCRIPTION,
+                    JavadocTokenTypes.TEXT))
     );
 
-    /** Specify the regexp for forbidden summary fragments. */
+    /**
+     * Specify the regexp for forbidden summary fragments.
+     */
     private Pattern forbiddenSummaryFragments = CommonUtil.createPattern("^$");
 
-    /** Specify the period symbol at the end of first javadoc sentence. */
+    /**
+     * Specify the period symbol at the end of first javadoc sentence.
+     */
     private String period = PERIOD;
 
     /**
@@ -222,7 +312,10 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
 
     @Override
     public void visitJavadocToken(DetailNode ast) {
-        if (!startsWithInheritDoc(ast)) {
+        if (containsSummaryTag(ast)) {
+            validateSummaryTag(ast);
+        }
+        else if (!startsWithInheritDoc(ast)) {
             final String summaryDoc = getSummarySentence(ast);
             if (summaryDoc.isEmpty()) {
                 log(ast.getLineNumber(), MSG_SUMMARY_JAVADOC_MISSING);
@@ -242,9 +335,195 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
     }
 
     /**
+     * Checks if summary tag present.
+     *
+     * @param javadoc javadoc root node.
+     * @return {@code true} if first sentence contains @summary tag.
+     */
+    private static boolean containsSummaryTag(DetailNode javadoc) {
+        final DetailNode node = getFirstInlineTag(javadoc);
+        return node != null && isSummaryTag(node);
+    }
+
+    /**
+     * Finds and returns the first inline tag node from a javadoc root node.
+     *
+     * @param javadoc javadoc root node.
+     * @return first inline tag node or null if no node is found.
+     */
+    private static DetailNode getFirstInlineTag(DetailNode javadoc) {
+        DetailNode node = null;
+        final DetailNode[] children = javadoc.getChildren();
+        for (DetailNode child: children) {
+            // If present as a children of javadoc
+            if (child.getType() == JavadocTokenTypes.JAVADOC_INLINE_TAG) {
+                node = child;
+            }
+            // If nested inside html tag
+            else if (child.getType() == JavadocTokenTypes.HTML_ELEMENT) {
+                node = getInlineTagNodeWithinHtmlElement(child);
+            }
+
+            if (node != null) {
+                break;
+            }
+        }
+        return node;
+    }
+
+    /**
+     * Returns an inline javadoc tag node that is within a html tag.
+     *
+     * @param ast html tag node.
+     * @return inline summary javadoc tag node or null if no node is found.
+     */
+    private static DetailNode getInlineTagNodeWithinHtmlElement(DetailNode ast) {
+        DetailNode node = ast;
+        DetailNode result = null;
+        // node can never be null as this method is called when there is a HTML_ELEMENT
+        if (node.getType() == JavadocTokenTypes.JAVADOC_INLINE_TAG) {
+            result = node;
+        }
+        else if (node.getType() == JavadocTokenTypes.HTML_TAG) {
+            // HTML_TAG always has more than 2 children.
+            node = node.getChildren()[1];
+            result = getInlineTagNodeWithinHtmlElement(node);
+        }
+        else if (node.getType() == JavadocTokenTypes.HTML_ELEMENT
+                // Condition for SINGLETON html element which cannot contain summary node
+                && node.getChildren()[0].getChildren().length > 1) {
+            // Html elements have one tested tag before actual content inside it
+            node = node.getChildren()[0].getChildren()[1];
+            result = getInlineTagNodeWithinHtmlElement(node);
+        }
+        return result;
+    }
+
+    /**
+     * Checks if the first tag inside ast is summary tag.
+     *
+     * @param javadoc root node.
+     * @return {@code true} if first tag is summary tag.
+     */
+    private static boolean isSummaryTag(DetailNode javadoc) {
+        final DetailNode[] child = javadoc.getChildren();
+
+        // Checking size of ast is not required, since ast contains
+        // children of Inline Tag, as at least 2 children will be present which are
+        // RCURLY and LCURLY.
+        return child[1].getType() == JavadocTokenTypes.CUSTOM_NAME
+                && SUMMARY_TEXT.equals(child[1].getText());
+    }
+
+    /**
+     * Checks the inline summary (if present) for {@code period} at end and forbidden fragments.
+     *
+     * @param ast javadoc root node.
+     */
+    private void validateSummaryTag(DetailNode ast) {
+        final String inlineSummary = getInlineSummary();
+        final String summaryVisible = getVisibleContent(inlineSummary);
+        if (summaryVisible.isEmpty()) {
+            log(ast.getLineNumber(), MSG_SUMMARY_JAVADOC_MISSING);
+        }
+        else if (!period.isEmpty()) {
+            if (isPeriodAtEnd(summaryVisible, period)) {
+                log(ast.getLineNumber(), MSG_SUMMARY_MISSING_PERIOD);
+            }
+            else if (containsForbiddenFragment(inlineSummary)) {
+                log(ast.getLineNumber(), MSG_SUMMARY_JAVADOC);
+            }
+        }
+    }
+
+    /**
+     * Gets entire content of summary tag.
+     *
+     * @return summary sentence of javadoc root node.
+     */
+    private String getInlineSummary() {
+        final DetailAST blockCommentAst = getBlockCommentAst();
+        final String javadocText = blockCommentAst.getFirstChild().getText();
+        final Matcher matcher = SUMMARY_PATTERN.matcher(javadocText);
+        String comment = "";
+        if (matcher.find()) {
+            comment = matcher.group(1);
+        }
+        comment = JAVADOC_MULTILINE_TO_SINGLELINE_PATTERN.matcher(comment)
+                .replaceAll("");
+        return comment;
+    }
+
+    /**
+     * Gets the string that is visible to user in javadoc.
+     *
+     * @param summary entire content of summary javadoc.
+     * @return string that is visible to user in javadoc.
+     */
+    private static String getVisibleContent(String summary) {
+        final String visibleSummary = HTML_ELEMENTS.matcher(summary).replaceAll("");
+        return visibleSummary.trim();
+    }
+
+    /**
+     * Checks if the string ends with period.
+     *
+     * @param sentence string to check for period at end.
+     * @param period string to check within sentence.
+     * @return {@code true} if sentence ends with period.
+     */
+    private static boolean isPeriodAtEnd(String sentence, String period) {
+        final String summarySentence = sentence.trim();
+        return summarySentence.lastIndexOf(period) != summarySentence.length() - 1;
+    }
+
+    /**
+     * Tests if first sentence contains forbidden summary fragment.
+     *
+     * @param firstSentence string with first sentence.
+     * @return {@code true} if first sentence contains forbidden summary fragment.
+     */
+    private boolean containsForbiddenFragment(String firstSentence) {
+        final String javadocText = JAVADOC_MULTILINE_TO_SINGLELINE_PATTERN
+                .matcher(firstSentence).replaceAll(" ").trim();
+        return forbiddenSummaryFragments.matcher(trimExcessWhitespaces(javadocText)).find();
+    }
+
+    /**
+     * Trims the given {@code text} of duplicate whitespaces.
+     *
+     * @param text the text to transform.
+     * @return the finalized form of the text.
+     */
+    private static String trimExcessWhitespaces(String text) {
+        final StringBuilder result = new StringBuilder(256);
+        boolean previousWhitespace = true;
+
+        for (char letter : text.toCharArray()) {
+            final char print;
+            if (Character.isWhitespace(letter)) {
+                if (previousWhitespace) {
+                    continue;
+                }
+
+                previousWhitespace = true;
+                print = ' ';
+            }
+            else {
+                previousWhitespace = false;
+                print = letter;
+            }
+
+            result.append(print);
+        }
+
+        return result.toString();
+    }
+
+    /**
      * Checks if the node starts with an {&#64;inheritDoc}.
      *
-     * @param root The root node to examine.
+     * @param root the root node to examine.
      * @return {@code true} if the javadoc starts with an {&#64;inheritDoc}.
      */
     private static boolean startsWithInheritDoc(DetailNode root) {
@@ -267,10 +546,10 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
     }
 
     /**
-     * Checks if period is at the end of sentence.
+     * Finds and returns summary sentence.
      *
-     * @param ast Javadoc root node.
-     * @return violation string
+     * @param ast javadoc root node.
+     * @return violation string.
      */
     private static String getSummarySentence(DetailNode ast) {
         boolean flag = true;
@@ -295,7 +574,7 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
     }
 
     /**
-     * Concatenates string within text of html tags.
+     * Get concatenated string within text of html tags.
      *
      * @param result javadoc string
      * @param detailNode javadoc tag node
@@ -338,49 +617,6 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
 
             result.append(text);
         }
-        return result.toString();
-    }
-
-    /**
-     * Tests if first sentence contains forbidden summary fragment.
-     *
-     * @param firstSentence String with first sentence.
-     * @return true, if first sentence contains forbidden summary fragment.
-     */
-    private boolean containsForbiddenFragment(String firstSentence) {
-        final String javadocText = JAVADOC_MULTILINE_TO_SINGLELINE_PATTERN
-                .matcher(firstSentence).replaceAll(" ").trim();
-        return forbiddenSummaryFragments.matcher(trimExcessWhitespaces(javadocText)).find();
-    }
-
-    /**
-     * Trims the given {@code text} of duplicate whitespaces.
-     *
-     * @param text The text to transform.
-     * @return The finalized form of the text.
-     */
-    private static String trimExcessWhitespaces(String text) {
-        final StringBuilder result = new StringBuilder(100);
-        boolean previousWhitespace = true;
-
-        for (char letter : text.toCharArray()) {
-            final char print;
-            if (Character.isWhitespace(letter)) {
-                if (previousWhitespace) {
-                    continue;
-                }
-
-                previousWhitespace = true;
-                print = ' ';
-            }
-            else {
-                previousWhitespace = false;
-                print = letter;
-            }
-
-            result.append(print);
-        }
-
         return result.toString();
     }
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages.properties
@@ -36,6 +36,7 @@ singleline.javadoc=Single-line Javadoc comment should be multi-line.
 summary.first.sentence=First sentence of Javadoc is missing an ending period.
 summary.javaDoc=Forbidden summary fragment.
 summary.javaDoc.missing=Summary javadoc is missing.
+summary.javaDoc.missing.period=Summary of Javadoc is missing an ending period.
 tag.continuation.indent=Line continuation have incorrect indentation level, expected level should be {0}.
 type.missingTag=Type Javadoc comment is missing {0} tag.
 type.tagFormat=Type Javadoc tag {0} must match pattern ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_de.properties
@@ -36,6 +36,7 @@ singleline.javadoc=Einzeiliger Javadoc-Kommentar sollte auf mehrere Zeilen verte
 summary.first.sentence=Nach dem ersten Satz des Javadoc-Kommentars fehlt ein Punkt.
 summary.javaDoc=Verbotener Ausdruck im ersten Javadoc-Satz.
 summary.javaDoc.missing=Javadoc-Zusammenfassung fehlt.
+summary.javaDoc.missing.period=Zusammenfassung von Javadoc fehlt eine Endperiode.
 tag.continuation.indent=Fortsetzung der Zeile hat falsche Einrückungstiefe (erwartet: {0}).
 type.missingTag=Im Javadoc des Typs fehlt das Tag {0}.
 type.tagFormat=Das Tag {0} im Javadoc des Typs muss dem Muster ''{1}'' entsprechen.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_es.properties
@@ -36,6 +36,7 @@ singleline.javadoc=Una sola línea Javadoc comentario debe ser de varias líneas
 summary.first.sentence=Primera frase de Javadoc falta un período final.
 summary.javaDoc=Resumen fragmento Prohibida.
 summary.javaDoc.missing=Resumen javadoc falta.
+summary.javaDoc.missing.period=Al resumen de Javadoc le falta un período de finalización.
 tag.continuation.indent=Línea continuación tiene nivel de sangría incorrecta, nivel esperado debería ser {0}
 type.missingTag=Al comentario Javadoc le falta una etiqueta {0}.
 type.tagFormat=El comentario Javadoc {0} debe coincidir con el patrón ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fi.properties
@@ -36,6 +36,7 @@ singleline.javadoc=Yksilinjainen Javadoc kommentti pitäisi olla multi-line.
 summary.first.sentence=Javadocin ensimmäinen lause puuttuu päättymisajasta.
 summary.javaDoc=Kielletty yhteenveto fragmentti.
 summary.javaDoc.missing=Yhteenveto javadoc puuttuu.
+summary.javaDoc.missing.period=Javadoc-yhteenvedosta puuttuu loppuvaihe.
 tag.continuation.indent=Jatkorivin on väärä sisennystason, odotettu taso olisi {0} .
 type.missingTag=Javadoc-kommentista puuttuu {0}-tagi.
 type.tagFormat=Javadoc-tagin {0} pitää olla mallin ''{1}'' mukainen.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_fr.properties
@@ -36,6 +36,7 @@ singleline.javadoc=Le commentaire Javadoc doit être sur plusieurs lignes.
 summary.first.sentence=La première phrase de la Javadoc doit se terminer avec un point.
 summary.javaDoc=Résumé Javadoc interdit.
 summary.javaDoc.missing=Le résumé Javadoc est manquant.
+summary.javaDoc.missing.period=Le résumé de Javadoc n'a pas de période de fin.
 tag.continuation.indent=La continuation de la ligne a un niveau d''indentation incorrect, le niveau attendu doit être {0}.
 type.missingTag=Dans le commentaire Javadoc de la classe, il manque une balise {0}.
 type.tagFormat=La balise Javadoc {0} doit correspondre au motif ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_ja.properties
@@ -36,6 +36,7 @@ singleline.javadoc=単一行のJavadocコメントは、複数行にする必要
 summary.first.sentence=Javadocの最初の文に末尾のピリオドがありません。
 summary.javaDoc=禁止された文言が概要に含まれています。
 summary.javaDoc.missing=要約javadocがありません。
+summary.javaDoc.missing.period=Javadocの要約に終了期間がありません。
 tag.continuation.indent=行継続のインデントのレベルが間違っています。期待されるレベルは {0} です。
 type.missingTag=クラスの Javadoc コメントに {0} タグがありません。
 type.tagFormat=クラスの Javadoc タグ {0} はパターン ''{1}'' に合致しなければなりません。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_pt.properties
@@ -36,6 +36,7 @@ singleline.javadoc=O comentário Javadoc de uma só linha deveria ser de múltip
 summary.first.sentence=A primeira frase do Javadoc está com o ponto final faltando.
 summary.javaDoc=Fragmento de resumo de Javadoc proibido.
 summary.javaDoc.missing=O resumo do Javadoc está ausente.
+summary.javaDoc.missing.period=O resumo do Javadoc está sem um ponto final.
 tag.continuation.indent=Continuação de linha têm um nível de identação incorreto. O nível esperado era {0}.
 type.missingTag=O comentário Javadoc do tipo está com uma tag {0} faltando.
 type.tagFormat=O formato da tag Javadoc {0} deveria condizer com o padrão ''{1}''

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_tr.properties
@@ -36,6 +36,7 @@ singleline.javadoc=Tek satır Javadoc comment multi-line olmalıdır.
 summary.first.sentence=Javadoc'un ilk cümlesi biten bir süre eksik.
 summary.javaDoc=Yasak özeti fragmanı.
 summary.javaDoc.missing=Özet javadoc eksik.
+summary.javaDoc.missing.period=Javadoc'un özetinde bir bitiş dönemi eksik.
 tag.continuation.indent=Çizgi devamı yanlış girinti düzeyine sahip, beklenen seviyede olmalıdır {0}
 type.missingTag=Tür için yazılan Javadoc açıklamasında {0} etiketi eksik.
 type.tagFormat=Tür için yazılan {0} Javadoc etiketi şu kalıpta olmalı: ''{1}''.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/messages_zh.properties
@@ -36,6 +36,7 @@ singleline.javadoc=该Javadoc注释应为多行的。
 summary.first.sentence=Javadoc的第一句缺少一个结束时期。
 summary.javaDoc=禁止出现的首行内容。
 summary.javaDoc.missing=缺少摘要javadoc。
+summary.javaDoc.missing.period=Javadoc的摘要缺少结束时间。
 tag.continuation.indent=Javadoc 缩进级别错误，应为 {0} 个缩进符。
 type.missingTag=缺少 {0} 标签。
 type.tagFormat=标签 {0} 必须匹配： ''{1}'' 。

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/SummaryJavadocCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/SummaryJavadocCheck.xml
@@ -35,6 +35,7 @@
             <message-key key="summary.first.sentence"/>
             <message-key key="summary.javaDoc"/>
             <message-key key="summary.javaDoc.missing"/>
+            <message-key key="summary.javaDoc.missing.period"/>
          </message-keys>
       </check>
    </module>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck.MSG_SUMMARY_FIRST_SENTENCE;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck.MSG_SUMMARY_JAVADOC;
 import static com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck.MSG_SUMMARY_JAVADOC_MISSING;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck.MSG_SUMMARY_MISSING_PERIOD;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 import org.junit.jupiter.api.Test;
@@ -57,6 +58,14 @@ public class SummaryJavadocCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testInlineCorrect() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(SummaryJavadocCheck.class);
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verify(checkConfig, getPath("InputSummaryJavadocInlineCorrect.java"), expected);
+    }
+
+    @Test
     public void testIncorrect() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(SummaryJavadocCheck.class);
         checkConfig.addAttribute("forbiddenSummaryFragments",
@@ -82,12 +91,34 @@ public class SummaryJavadocCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testInlineForbidden() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(SummaryJavadocCheck.class);
+        checkConfig.addAttribute("forbiddenSummaryFragments",
+                "@return the *|This method returns");
+        final String[] expected = {
+            "24: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+            "30: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+            "36: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+            "42: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
+            "47: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "52: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+            "62: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
+            "84: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
+            "97: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+            "112: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "118: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+        };
+        verify(checkConfig, getPath("InputSummaryJavadocInlineForbidden.java"), expected);
+    }
+
+    @Test
     public void testPeriod() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(SummaryJavadocCheck.class);
         checkConfig.addAttribute("period", "_");
         final String[] expected = {
             "5: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
             "10: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
+            "28: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
         };
 
         verify(checkConfig, getPath("InputSummaryJavadocPeriod.java"), expected);
@@ -126,6 +157,30 @@ public class SummaryJavadocCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testInlineDefaultConfiguration() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(SummaryJavadocCheck.class);
+        createChecker(checkConfig);
+        final String[] expected = {
+            "13: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+            "18: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+            "23: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "33: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+            "38: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+            "51: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "56: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+            "113: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+            "118: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
+            "123: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "134: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+            "152: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "157: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "177: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+        };
+
+        verify(checkConfig, getPath("InputSummaryJavadocInlineDefault.java"), expected);
+    }
+
+    @Test
     public void testPeriodAtEnd() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(SummaryJavadocCheck.class);
         checkConfig.addAttribute("period", ".");
@@ -138,6 +193,18 @@ public class SummaryJavadocCheckTest extends AbstractModuleTestSupport {
         };
 
         verify(checkConfig, getPath("InputSummaryJavadocPeriodAtEnd.java"), expected);
+    }
+
+    @Test
+    public void testHtmlFormatSummary() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(SummaryJavadocCheck.class);
+        final String[] expected = {
+            "13: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
+            "28: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "33: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+        };
+
+        verify(checkConfig, getPath("InputSummaryJavadocHtmlFormat.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocHtmlFormat.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocHtmlFormat.java
@@ -1,0 +1,51 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
+
+/**
+ * Config: default.
+ */
+public class InputSummaryJavadocHtmlFormat {
+
+    /**
+     * <p><b>{@summary Normal Javadoc.}</b></p>
+     */
+    private void foo1() {} // ok
+
+    /**
+     * <p><b><i>{@summary Normal Javadoc}</i></b></p>
+     */
+    private void foo2() {} // violation
+
+    /**
+     * <p>{@summary Normal Javadoc {@author my code}.}</p>
+     */
+    private void foo3() {} // ok
+
+    /**
+     * {@summary <p> .</p>}
+     */
+    private void foo4() {} // ok
+
+    /**
+     * <p>{@code Code.}</p>
+     */
+    private void foo6() {} // violation
+
+    /**
+     * <p>{@summary}</p>
+     */
+    private void foo11() {} // violation
+
+    /**
+     * <b><p>{@summary Normal Javadoc.}</p></b>
+     */
+    private void foo13() {} // ok
+
+    /**
+     * <i><b><p>{@summary Normal Javadoc.}</p></b></i>
+     */
+    private void foo14() {} // ok
+
+    /** <b>{@summary Normal single line Javadoc.}</b> */
+    private void foo16() {} // ok
+}
+

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineCorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineCorrect.java
@@ -1,0 +1,216 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
+
+/*
+ * Config: default
+ */
+class InputSummaryJavadocInlineCorrect {
+
+    /**
+     * {@summary Simple JavaDoc. }
+     */
+    private void foo1() {} // ok
+
+    /**
+     * {@summary {@code ABC} Javadoc.}
+     */
+    private void foo2() {} // ok
+
+    /**
+     * {@summary {@code ABC} Javadoc {@code some defination}.}
+     */
+    private void foo3() {} // ok
+
+    /**
+     * {@summary , *. }
+     */
+    private void foo4() {} // ok
+
+    /**
+     * {@summary first sentence is normally the summary.
+     * Use of html tags:
+     * <ul>
+     * <li>Item one.</li>
+     * <li>Item two.</li>
+     * </ul>}
+     */
+    private void validInlineJavadocWithList() // ok
+    {
+    }
+
+    /**
+     * {@summary first sentence is normally the summary.
+     * Use of html tags:
+     * {@code SomeCodeHere.}
+     * <ul>
+     * <li>Item one.</li>
+     * <li>Item two.</li>
+     * </ul>}
+     */
+    private void validInlineJavadocList() // ok
+    {
+    }
+
+    /**
+     * {@summary first does have period.
+     * Use of html tags:
+     * {@code makes tree parse properly}
+     * <p>
+     * This is a paragraph.
+     * </p>}
+     */
+    private void validInlineJavadocTwo() // ok
+    {
+    }
+
+    /**
+     * {@summary first sentence is normally the summary.
+     * Use of html tags:
+     * <h1> This is heading.</h1>
+     * <p> This is a paragraph.</p>}
+     */
+    private void validInlineJavadocWithParagraph() // ok
+    {
+    }
+
+    /**
+     * {@summary first sentence is normally the summary.
+     * Use of html tags:
+     * <ul>
+     * <a href="NOEHRE">Item one.</a>
+     * <a href="SOMEWEHRE">Item two.</a>
+     * </ul>}
+     */
+    private void validInlineJavadoc() // ok
+    {
+    }
+
+    /**
+     * {@summary first sentence is normally the summary.}
+     *
+     * @param a some parameter.
+     * @return This method returns input back.
+     */
+    public int validInlineJavadocReturn(int a) // ok
+    {
+        return a;
+    }
+
+    /**
+     * {@summary this is first sentence with period.
+     * But here should also be period.
+     * }
+     */
+    private void voidValidJavadoc() {} // ok
+
+    /**
+     * Sentence starts as a plain text sentence
+     * {@summary ... but ends in the summary tag.}
+     */
+    public class TestClass {}
+
+    private static class InputSummaryJavadocInlineParagraphCheck {
+        /**
+         * {@summary foo.}
+         */
+        private static final byte NUL = 0; // ok
+
+        /**
+         * {@summary Some java@doc.
+         * This method returns.}
+         */
+        private static final byte NUL_2 = 0; // ok
+
+        /**
+         * {@summary Returns the customer ID.
+         *  This method returns. }
+         */
+        private int getId() {return 666;} // ok
+
+        /**
+         * {@summary This is valid.
+         * <a href="mailto:vlad@htmlbook.ru"/>.}
+         */
+        private void foo2() {} // ok
+
+        /**
+         * {@summary As of JDK 1.1,
+         * replaced by {@link #setBounds(int,int,int,int)}. This method returns.}
+         */
+        private void foo3() {} // ok
+
+        /**
+         * {@summary This is description. }
+         * @throws Exception if a problem occurs.
+         */
+        private void foo4() throws Exception {} // ok
+
+        /**
+         * {@summary An especially short (int... A) bit of Javadoc. This
+         * method returns.}
+         */
+        void foo6() {} // ok
+    }
+
+    InputSummaryJavadocInlineParagraphCheck iden =
+        new InputSummaryJavadocInlineParagraphCheck() { // ok
+        /**
+         * {@summary JAXB 1.0 only default validation event handler.}
+         */
+        private static final byte NUL = 0; // ok
+
+        /**
+         * {@summary Returns the current state.
+         * This method returns.}
+         */
+        private boolean emulated(String s) {return false;} // ok
+
+        /**
+         * {@summary As of JDK 1.1, replaced by {@link #setBounds(int,int,int,int)}.}
+         */
+        private void foo3() {} // ok
+
+        /**
+         * {@summary This is valid.}
+         * @throws Exception if a problem occurs.
+         */
+        private void foo4() throws Exception {} // ok
+
+        /** {@summary An especially short bit of Javadoc.} */
+        void foo5() {} // ok
+
+        /**
+         * {@summary An especially short bit of Javadoc.}
+         */
+        void foo6() {} // ok
+
+        /**
+         * {@summary This code is <p>right</p>. }
+         */
+        private void foo7(){} // ok
+
+        /**
+         * {@summary Some Javadoc. This method returns some javadoc.}
+         */
+        private boolean emulated() {return false;} // ok
+
+        /**
+         * {@summary Some Javadoc. This method returns some javadoc. Some Javadoc.}
+         */
+        private boolean emulated1() {return false;} // ok
+
+        /**
+         * {@summary This is valid.}
+         * @return Some Javadoc the customer ID. // ok
+         */
+        private int geId() {return 666;} // ok
+
+        /**
+         * {@summary This is valid.}
+         * @return Sentence one. Sentence two. // ok
+         */
+        private String twoSentences() {return "Sentence one. Sentence two.";} // ok
+
+        /** {@summary Stop instances being created.} **/ // ok
+        private String twoSentences1() {return "Sentence one. Sentence two.";} // ok
+    }; // ok
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineDefault.java
@@ -1,0 +1,189 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
+
+/**
+ * Config: default.
+ */
+class InputSummaryJavadocInlineDefault {
+
+    /**
+     * {@summary A simple correct Javadoc.}
+     */
+    void foo1() {} // ok
+
+    /**
+     * {@summary This code is wrong }
+     */
+    void foo5(){} // violation
+
+    /**
+     * {@summary This code {@see Javadoc} is wrong }
+     */
+    void foo6(){} // violation
+
+    /**
+     * {@sometag This code {@see Javadoc} is wrong }
+     */
+    void foo7(){} // violation
+
+    /**
+     * {@summary <p>This code is right.</p>}
+     */
+    void foo8(){} // ok
+
+    /**
+     * {@summary As of , replaced by {@link #setBounds(int,int,int,int)}}
+     */
+    void foo11() {} // violation
+
+    /**
+     * {@summary {@throws Exception if a problem occurs}}
+     */
+    void foo12() throws Exception {} // violation
+
+    /** {@summary An especially short bit of Javadoc.} */
+    void foo13() {} // ok
+
+    /**
+     * {@summary Some Javadoc.}
+     */
+    public static final byte NUL = 0; // ok
+
+    /**
+     * {@summary <a href="mailto:vlad@htmlbook.ru"/>}
+     */
+    class InnerInputCorrectJavaDocParagraphCheck { // violation
+
+        /**
+         * {@summary foooo@foooo}
+         */
+        public static final byte NUL = 0; // violation
+
+        /**
+         * {@summary Some java@doc.}
+         */
+        public static final byte NUL_2 = 0; // ok
+
+        /**
+         * {@summary This method
+         * returns some javadoc. Some javadoc.}
+         */
+        boolean emulated() {return false;} // ok
+
+        /**
+         * {@summary @return the
+         * customer ID some javadoc.}
+         */
+        int geId() {return 666;} // ok
+
+        /**
+         * {@summary from {@link #setBounds(int,int,int,int)}.}
+         */
+        void foo3() {} // ok
+
+        /** {@summary  An especially short bit of Javadoc.} */
+        void foo5() {} // ok
+
+        /**
+         * {@summary An especially short bit of Javadoc.}
+         */
+        void foo6() {} // ok
+    }
+
+    /**
+     * {@summary A {@code InnerInputCorrectJavaDocParagraphCheck} is a simple code.}
+     */
+    InputSummaryJavadocInlineDefault.InnerInputCorrectJavaDocParagraphCheck anon =
+            new InputSummaryJavadocInlineDefault.InnerInputCorrectJavaDocParagraphCheck() {
+
+        /**
+         * Some Javadoc.
+         */
+        public static final byte NUL = 0; // ok
+
+        /**
+         * Some Javadoc.
+         */
+        void emulated(String s) {} // ok
+
+        /**
+         * from {@link #setBounds(int,int,int,int)}.
+         */
+        void foo3() {} // ok
+
+        /**
+         * {@summary {}@throws Exception if a problem occurs}
+         */
+        void foo4() throws Exception {} // violation
+
+        /**
+         * mm{@inheritDoc}
+         */
+        void foo7() {} // violation
+
+        /**
+         * {@link #setBounds(int,int,int,int)}
+         */
+        void foo8() {} // violation
+
+        /**
+         * {@summary {@code see} .}
+         */
+        void foo10() {} // ok
+    };
+
+    /**
+     * {@summary M m m m {@inheritDoc}}
+     */
+    void foo14() {} // violation
+
+    /**{@summary @summary .} */
+    int foo15() {return 0;} // ok
+
+    /**
+     * {@summary @author Akash Mondal.}
+     */
+    void foo16(){} // ok
+
+    /**
+     * {@summary {@input Javadoc}.}
+     */
+    void foo17(){} // ok
+
+    /**
+     * {@summary}
+     */
+    void foo22() {} // violation
+
+    /** */
+    String[] foo9() {return null;} // violation
+
+    /**
+     * {@summary Javadoc {@code code} correct.}
+     */
+    void foo23(){} // ok
+
+    /**
+     * {@summary first doesn't have period
+     * Use of html tags:
+     * <ul>
+     * <li>Item one.</li>
+     * <li>Period here.</li>
+     * </ul>}
+     */
+    private void invalidInlineJavadocTwo() // ok
+    {
+    }
+
+    /**
+     * {@summary first sentence is normally the summary.
+     * Use of html tags:
+     * {@code SomeCodeHere.}
+     * <ul>
+     * <li>Item one.</li>
+     * <li>No period here</li>
+     * </ul>}
+     */
+    private void invalidInlineJavadocList() // violation
+    {
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineForbidden.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineForbidden.java
@@ -1,0 +1,134 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
+
+/*
+ * Config:
+ * This test-input is intended to be checked using following configuration:
+ *
+ * Attributes = forbiddenSummaryFragments
+ * value = "^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"
+ */
+public class InputSummaryJavadocInlineForbidden {
+
+    /**
+     * {@summary A simple correct Javadoc.}
+     */
+    void foo1() { // ok
+    }
+
+    /**
+     * {@summary This code {@input Javadoc} is right.}
+     */
+    void foo3() { // ok
+    }
+
+    /**
+     * {@summary This code is wrong }
+     */
+    void foo5() { // violation
+    }
+
+    /**
+     * {@summary This code {@see Javadoc} is wrong }
+     */
+    void foo6() { // violation
+    }
+
+    /**
+     * {@summary As of , replaced by {@link #setBounds(int, int, int, int)}}
+     */
+    void foo11() { // violation
+    }
+
+    /**
+     * {@summary This method returns something.}
+     */
+    public static final byte NUL = 0; // violation
+
+    /**
+     * {@summary <a href="mailto:vlad@htmlbook.ru"/>}
+     */
+    class InnerInputCorrectJavaDocParagraphCheck { // violation
+
+        /**
+         * {@summary foooo@foooo}
+         */
+        public static final byte NUL = 0; // violation
+
+        /**
+         * {@summary Some java@doc.}
+         */
+        public static final byte NUL_2 = 0; // ok
+
+        /**
+         * {@summary @return the
+         * customer ID some javadoc.}
+         */
+        int geId() { // violation
+            return 666;
+        }
+
+        /**
+         * {@summary As of JDK 1.1, replaced by {@link #setBounds(int, int, int, int)}.}
+         */
+        void foo3() {
+        } // ok
+
+    }
+
+    /**
+     * {@summary A {@code InnerInputCorrectJavaDocParagraphCheck} is a simple code.}
+     */
+    InputSummaryJavadocInlineForbidden.InnerInputCorrectJavaDocParagraphCheck anon =
+            new InputSummaryJavadocInlineForbidden.InnerInputCorrectJavaDocParagraphCheck() {
+
+                /**
+                 * mm{@inheritDoc}
+                 */
+                void foo7() { // violation
+                }
+
+                /**
+                 * {@summary {@code see}.}
+                 */
+                void foo10() { // ok
+                }
+            };
+
+    /**
+     * {@summary first sentence is normally the summary.
+     * Use of html tags:
+     * {@throws error}
+     * <ul>
+     * <li>Item one.</li>
+     * <li>Item two.</li>
+     * </ul>
+     * <p> This is the paragraph.</p>
+     * <h1> This is a heading </h1>}
+     */
+    public void validInlineJavadoc() // violation
+    {
+    }
+
+    /**
+     * {@summary <p> </p>}
+     */
+    void foo12() { // violation
+    }
+
+    /**
+     * Sentence starts as a plain text sentence
+     * {@summary ... but ends in the summary tag}
+     */
+    public class TestClass {} // violation
+
+    /**
+     * {@summary first sentence is normally the summary.}
+     *
+     * @param a some parameter.
+     * @return This method returns a, this statement is allowed in return.
+     */
+    public int validInlineJavadocReturn(int a) // ok
+    {
+        return a;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocNoPeriod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocNoPeriod.java
@@ -14,4 +14,9 @@ public class InputSummaryJavadocNoPeriod
 
     /** An especially short bit of Javadoc */
     void foo5() {}
+
+    /**
+     * {@summary No Period in end}
+     */
+    void foo6(){}
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocPeriod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocPeriod.java
@@ -19,4 +19,14 @@ public class InputSummaryJavadocPeriod
      * An especially short bit of Javadoc_
      */
     void foo6() {}
+
+    /**
+     * {@summary An especially short bit of Javadoc_}
+     */
+    void foo7(){}
+
+    /**
+     * {@summary An especially short bit of Javadoc}
+     */
+    void foo8() {}
 }

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -3693,6 +3693,31 @@ public class Test extends Exception {
 }
         </source>
         <p>
+              Example of non permitted empty javadoc for Inline Summary Javadoc.
+        </p>
+        <source>
+public class Test extends Exception {
+  /**
+   * {@summary  }
+   */
+  public String InvalidFunctionOne(){ // violation
+    return "";
+  }
+
+  /**
+   * {@summary &lt;p&gt; &lt;p/&gt;}
+   */
+  public String InvalidFunctionTwo(){ // violation
+    return "";
+  }
+
+  /**
+   * {@summary &lt;p&gt;This is summary for validFunctionThree.&lt;p/&gt;}
+   */
+  public void validFunctionThree(){} // ok
+}
+        </source>
+        <p>
           To ensure that summary do not contain phrase like "This method returns", use
           following config:
         </p>
@@ -3716,15 +3741,49 @@ public class Test extends Exception {
 
         <source>
 public class TestClass {
-  /**
+ /**
   * This is invalid java doc.
   */
   void invalidJavaDocMethod() {
   }
-  /**
+ /**
   * This is valid java doc。
   */
   void validJavaDocMethod() {
+  }
+}
+        </source>
+        <p>
+          Example of period property for inline summary javadoc.
+        </p>
+        <source>
+public class TestClass {
+ /**
+  * {@summary This is invalid java doc.}
+  */
+  public void invalidJavaDocMethod() { // violation
+  }
+ /**
+  * {@summary This is valid java doc。}
+  */
+  public void validJavaDocMethod() { // ok
+  }
+}
+        </source>
+        <p>
+          Example of inline summary javadoc with HTML tags.
+        </p>
+        <source>
+public class Test {
+ /**
+  * {@summary First sentence is normally the summary.
+  * Use of html tags:
+  * &lt;ul&gt;
+  * &lt;li&gt;Item one.&lt;/li&gt;
+  * &lt;li&gt;Item two.&lt;/li&gt;
+  * &lt;/ul&gt;}
+  */
+  public void validInlineJavadoc() { // ok
   }
 }
         </source>
@@ -3767,6 +3826,10 @@ public class TestClass {
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22summary.javaDoc.missing%22">
               summary.javaDoc.missing</a>
+          </li>
+          <li>
+            <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc+filename%3Amessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22summary.javaDoc.missing.period%22">
+              summary.javaDoc.missing.period</a>
           </li>
         </ul>
         <p>


### PR DESCRIPTION
Closes : #7202 

Adds support for Inline @summary Javadoc Tag . Added support for summary within HTML format as INLINE_TAG

Diff Regression config: https://raw.githubusercontent.com/AkMo3/akmo3.github.io/master/SummaryJavadoc/SummaryJavadocConfig.xml

Diff Regression projects: https://raw.githubusercontent.com/AkMo3/akmo3.github.io/71feb5493e64467d24bf4bb73545cb1db8c0d4fb/Issue9010/projects-to-test-on.properties

Report: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/767e05a_2021020750/reports/diff/index.html Clean report