### PR TITLE
Issue #9170: Checkstyle should support "classpath:" protocol

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
@@ -64,6 +64,8 @@ public final class CommonUtil {
     public static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
     /** Copied from org.apache.commons.lang3.ArrayUtils. */
     public static final double[] EMPTY_DOUBLE_ARRAY = new double[0];
+    /** Pseudo URL protocol for loading from the class path. */
+    public static final String CLASSPATH_URL_PROTOCOL = "classpath:";
 
     /** Prefix for the exception when unable to find resource. */
     private static final String UNABLE_TO_FIND_EXCEPTION_PREFIX = "Unable to find: ";
@@ -529,7 +531,8 @@ public final class CommonUtil {
 
     /**
      * Resolves the specified local filename, possibly with 'classpath:'
-     * protocol, to a URI.
+     * protocol, to a URI.  First we attempt to create a new file with
+     * given filename, then attempt to load file from class path.
      *
      * @param filename name of the file
      * @return resolved file URI
@@ -537,12 +540,21 @@ public final class CommonUtil {
      */
     private static URI getFilepathOrClasspathUri(String filename) throws CheckstyleException {
         final URI uri;
-        if (new File(filename).exists()) {
-            final File file = new File(filename);
+        final File file = new File(filename);
+
+        if (file.exists()) {
             uri = file.toURI();
         }
         else {
-            uri = getResourceFromClassPath(filename);
+            final int lastIndexOfClasspathProtocol;
+            if (filename.lastIndexOf(CLASSPATH_URL_PROTOCOL) == 0) {
+                lastIndexOfClasspathProtocol = CLASSPATH_URL_PROTOCOL.length();
+            }
+            else {
+                lastIndexOfClasspathProtocol = 0;
+            }
+            uri = getResourceFromClassPath(filename
+                .substring(lastIndexOfClasspathProtocol));
         }
         return uri;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
@@ -523,7 +523,7 @@ public final class CommonUtil {
             final URL url = new URL(filename);
             uri = url.toURI();
         }
-        catch (final URISyntaxException | MalformedURLException ignored) {
+        catch (URISyntaxException | MalformedURLException ignored) {
             uri = null;
         }
         return uri;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
@@ -494,7 +494,7 @@ public final class CommonUtil {
     /**
      * Resolve the specified filename to a URI.
      *
-     * @param filename name os the file
+     * @param filename name of the file
      * @return resolved header file URI
      * @throws CheckstyleException on failure
      */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
@@ -495,11 +495,27 @@ public final class CommonUtil {
      * Resolve the specified filename to a URI.
      *
      * @param filename name of the file
-     * @return resolved header file URI
+     * @return resolved file URI
      * @throws CheckstyleException on failure
      */
     public static URI getUriByFilename(String filename) throws CheckstyleException {
-        // figure out if this is a File or a URL
+        URI uri = getWebOrFileProtocolUri(filename);
+
+        if (uri == null) {
+            uri = getFilepathOrClasspathUri(filename);
+        }
+
+        return uri;
+    }
+
+    /**
+     * Resolves the specified filename containing 'http', 'https', 'ftp',
+     * and 'file' protocols (or any RFC 2396 compliant URL) to a URI.
+     *
+     * @param filename name of the file
+     * @return resolved file URI or null if URL is malformed or non-existent
+     */
+    public static URI getWebOrFileProtocolUri(String filename) {
         URI uri;
         try {
             final URL url = new URL(filename);
@@ -508,31 +524,55 @@ public final class CommonUtil {
         catch (final URISyntaxException | MalformedURLException ignored) {
             uri = null;
         }
+        return uri;
+    }
 
-        if (uri == null) {
+    /**
+     * Resolves the specified local filename, possibly with 'classpath:'
+     * protocol, to a URI.
+     *
+     * @param filename name of the file
+     * @return resolved file URI
+     * @throws CheckstyleException on failure
+     */
+    private static URI getFilepathOrClasspathUri(String filename) throws CheckstyleException {
+        final URI uri;
+        if (new File(filename).exists()) {
             final File file = new File(filename);
-            if (file.exists()) {
-                uri = file.toURI();
-            }
-            else {
-                // check to see if the file is in the classpath
-                try {
-                    final URL configUrl;
-                    if (filename.charAt(0) == '/') {
-                        configUrl = CommonUtil.class.getResource(filename);
-                    }
-                    else {
-                        configUrl = ClassLoader.getSystemResource(filename);
-                    }
-                    if (configUrl == null) {
-                        throw new CheckstyleException(UNABLE_TO_FIND_EXCEPTION_PREFIX + filename);
-                    }
-                    uri = configUrl.toURI();
-                }
-                catch (final URISyntaxException ex) {
-                    throw new CheckstyleException(UNABLE_TO_FIND_EXCEPTION_PREFIX + filename, ex);
-                }
-            }
+            uri = file.toURI();
+        }
+        else {
+            uri = getResourceFromClassPath(filename);
+        }
+        return uri;
+    }
+
+    /**
+     * Gets a resource from the classpath.
+     *
+     * @param filename name of file
+     * @return URI of file in classpath
+     * @throws CheckstyleException on failure
+     */
+    public static URI getResourceFromClassPath(String filename) throws CheckstyleException {
+        final URL configUrl;
+        if (filename.charAt(0) == '/') {
+            configUrl = CommonUtil.class.getResource(filename);
+        }
+        else {
+            configUrl = ClassLoader.getSystemResource(filename);
+        }
+
+        if (configUrl == null) {
+            throw new CheckstyleException(UNABLE_TO_FIND_EXCEPTION_PREFIX + filename);
+        }
+
+        final URI uri;
+        try {
+            uri = configUrl.toURI();
+        }
+        catch (final URISyntaxException ex) {
+            throw new CheckstyleException(UNABLE_TO_FIND_EXCEPTION_PREFIX + filename, ex);
         }
 
         return uri;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilTest.java
@@ -39,12 +39,16 @@ import java.lang.reflect.Constructor;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Dictionary;
+import java.util.Properties;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
+import com.puppycrawl.tools.checkstyle.PropertiesExpander;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
@@ -474,6 +478,30 @@ public class CommonUtilTest extends AbstractPathTestSupport {
         final String content = IOUtils.toString(uri.toURL(), StandardCharsets.UTF_8);
         assertThat("Content mismatches for: " + uri,
                 content, startsWith("good"));
+    }
+
+    @Test
+    public void testGetUriByFilenameClasspathPrefixLoadConfig() throws Exception {
+        final String filename = CommonUtil.CLASSPATH_URL_PROTOCOL
+            + getPackageLocation() + "/InputCommonUtilTestWithChecks.xml";
+        final URI uri = CommonUtil.getUriByFilename(filename);
+
+        final Properties properties = System.getProperties();
+        final Configuration config = ConfigurationLoader.loadConfiguration(uri.toString(),
+            new PropertiesExpander(properties));
+        assertEquals("Checker", config.getName(), "Unexpected config name!");
+    }
+
+    @Test
+    public void testGetUriByFilenameFindsRelativeResourceOnClasspathPrefix() throws Exception {
+        final String filename = CommonUtil.CLASSPATH_URL_PROTOCOL
+            + getPackageLocation() + "/InputCommonUtilTest_empty_checks.xml";
+        final URI uri = CommonUtil.getUriByFilename(filename);
+
+        final Properties properties = System.getProperties();
+        final Configuration config = ConfigurationLoader.loadConfiguration(uri.toString(),
+            new PropertiesExpander(properties));
+        assertEquals("Checker", config.getName(), "Unexpected config name!");
     }
 
     private static class TestCloseable implements Closeable {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilTest.java
@@ -446,7 +446,11 @@ public class CommonUtilTest extends AbstractPathTestSupport {
         final String filename =
             "/" + getPackageLocation() + "/InputCommonUtilTest_empty_checks.xml";
         final URI uri = CommonUtil.getUriByFilename(filename);
-        assertThat("URI is null for: " + filename, uri, is(not(nullValue())));
+
+        final Properties properties = System.getProperties();
+        final Configuration config = ConfigurationLoader.loadConfiguration(uri.toString(),
+            new PropertiesExpander(properties));
+        assertEquals("Checker", config.getName(), "Unexpected config name!");
     }
 
     @Test
@@ -454,7 +458,11 @@ public class CommonUtilTest extends AbstractPathTestSupport {
         final String filename =
             getPackageLocation() + "/InputCommonUtilTest_empty_checks.xml";
         final URI uri = CommonUtil.getUriByFilename(filename);
-        assertThat("URI is null for: " + filename, uri, is(not(nullValue())));
+
+        final Properties properties = System.getProperties();
+        final Configuration config = ConfigurationLoader.loadConfiguration(uri.toString(),
+            new PropertiesExpander(properties));
+        assertEquals("Checker", config.getName(), "Unexpected config name!");
     }
 
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/commonutil/InputCommonUtilTestWithChecks.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/commonutil/InputCommonUtilTestWithChecks.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+  <property name="charset" value="UTF-8"/>
+
+  <module name="TreeWalker">
+    <module name="IllegalInstantiation">
+      <property name="classes" value="mypackage.lang.Boolean, java.lang.Boolean"/>
+      <property name="tokens" value="CLASS_DEF, LITERAL_NEW, IMPORT, PACKAGE_DEF"/>
+    </module>
+  </module>
+</module>

--- a/src/xdocs/property_types.xml
+++ b/src/xdocs/property_types.xml
@@ -925,9 +925,12 @@
       <p>
         This type represents a URI. The string representation is parsed using a custom
         routine to analyze what type of URI the string is.
-        It can be a URL, regular file, or a resource path. It will try loading the path as
-        a URL first, then as a file that must exist, and then finally as a resource on the
-        classpath.
+        It can be a URL, regular file, a file referenced using 'classpath:' protocol, or
+        a resource path. It will try loading the path as a URL first, then as a file that
+        must exist, and then finally as a resource on the classpath.
+
+        Note that the pseudo URL `classpath:` specifies that the resource
+        should be loaded from the class path, if it is not a local file.
       </p>
     </section>
 


### PR DESCRIPTION
Issue #9170: Checkstyle should support "classpath:" protocol

The logic in my changes maintain the order of searching for resources; the original PR at https://github.com/checkstyle/checkstyle/pull/8789/files forced `getUriByFilename()` to check the classpath first if `classpath:` protocol is specified.  Since I have refactored this method, it will be simple to add this logic in this PR or later if we decide to.

Also, it will now be simple to add support for `file:` protocol, however, `getUrl()` currently supports this.