### PR TITLE
minor: fix anchors for generated pages

### DIFF
--- a/src/site/resources/js/anchors.js
+++ b/src/site/resources/js/anchors.js
@@ -31,7 +31,12 @@
 
         var anchorsSubSection = document.getElementsByTagName("h3");
         [].forEach.call(anchorsSubSection, function (anchorItem) {
-            var name = anchorItem.parentNode.previousElementSibling.name;
+            var name;
+            if (anchorItem.parentNode.id) {
+                name = anchorItem.parentNode.id;
+            } else {
+                name = anchorItem.childNodes[0].name;
+            }
             var link = "" + url + "#" + name + "";
 
             var a = document.createElement("a");


### PR DESCRIPTION
Found during https://github.com/checkstyle/checkstyle/pull/9183

In generated pages, e.g. for project summary, anchors for subsection are broken. For example https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/fix_button_2021113707/summary.html

![image](https://user-images.githubusercontent.com/812984/104815563-26268100-57ca-11eb-96f7-570a70268843.png)


