### PR TITLE
infra: use pgjdbc original fork as the repo for wercker checks

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -6,7 +6,6 @@ aarch
 abbreviationaswordinname
 abcun
 abego
-Abhishek
 abstractcheck
 abstractclassname
 abstractfileset
@@ -769,7 +768,6 @@ keygen
 konstantinos
 Kordas
 Kotlin
-kumar
 kused
 lambdabodylength
 lambdaparametername

--- a/.ci/wercker.sh
+++ b/.ci/wercker.sh
@@ -61,10 +61,10 @@ no-error-pgjdbc)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/pgjdbc.git
+  checkout_from https://github.com/pgjdbc/pgjdbc.git
   cd .ci-temp/pgjdbc
   # pgjdbc easily damage build, we should use stable versions
-  git checkout checkstyle-fixes
+  git checkout "bad34f1c2985225b8809eb1c3fee5c5684d363a7"
   ./gradlew --no-parallel --no-daemon checkstyleAll \
             -PenableMavenLocal -Pcheckstyle.version=${CS_POM_VERSION}
   cd ../


### PR DESCRIPTION
Use pgjdbc original fork as the wercker repo for no-error-pgjdbc