### PR TITLE
Issue #9177: add label for diff report from PR description

### DIFF
--- a/.github/workflows/diff_report.yml
+++ b/.github/workflows/diff_report.yml
@@ -96,15 +96,15 @@ jobs:
        run: |
         wget -q "${{needs.parse_body.outputs.projects_link}}" -O project.properties
 
-        if [ ! -z  "${{needs.parse_body.outputs.new_module_config_link}}" ]; then
+        if [ -n "${{needs.parse_body.outputs.new_module_config_link}}" ]; then
           wget -q "${{needs.parse_body.outputs.new_module_config_link}}" -O new_module_config.xml
         fi
 
-        if [ ! -z  "${{needs.parse_body.outputs.config_link}}" ]; then
+        if [ -n "${{needs.parse_body.outputs.config_link}}" ]; then
           wget -q "${{needs.parse_body.outputs.config_link}}" -O diff_config.xml
         fi
 
-        if [ ! -z  "${{needs.parse_body.outputs.patch_config_link}}" ]; then
+        if [ -n "${{needs.parse_body.outputs.patch_config_link}}" ]; then
           wget -q "${{needs.parse_body.outputs.patch_config_link}}" -O patch_config.xml
         fi
         
@@ -203,7 +203,7 @@ jobs:
 
       - name: Get message
         run: |
-         if [ -z  "${{needs.make_report.outputs.message}}" ]; then
+         if [ -z "${{needs.make_report.outputs.message}}" ]; then
            JOBS_LINK="https://github.com/checkstyle/checkstyle/actions/runs/${{github.run_id}}"
            API_LINK="https://api.github.com/repos/checkstyle/checkstyle/actions/runs/"
            API_LINK="${API_LINK}${{github.run_id}}/jobs"

--- a/.github/workflows/diff_report.yml
+++ b/.github/workflows/diff_report.yml
@@ -31,6 +31,7 @@ jobs:
       config_link: ${{ steps.parse.outputs.config_link }}
       new_module_config_link: ${{ steps.parse.outputs.new_module_config_link }}
       patch_config_link: ${{ steps.parse.outputs.patch_config_link }}
+      report_label: ${{ steps.parse.outputs.report_label }}
       user: ${{ steps.branch.outputs.user }}
       branch: ${{ steps.branch.outputs.ref }}
       
@@ -69,7 +70,11 @@ jobs:
         grep "^Diff Regression patch config:" text | cat > temp
         sed 's/Diff Regression patch config: //' temp > patch_config_link
         echo ::set-output name=patch_config_link::$(cat patch_config_link)
-        
+
+        grep "^Report label:" text | cat > temp
+        sed 's/Report label: //' temp > report_label
+        echo ::set-output name=report_label::$(cat report_label)
+
      - name: Set branch and username
        id: branch
        run: |
@@ -180,8 +185,11 @@ jobs:
         DIFF="./contribution/checkstyle-tester/reports/diff"
         LINK="https://${{env.AWS_BUCKET_NAME}}.s3.${{env.AWS_REGION}}.amazonaws.com"
         aws s3 cp $DIFF s3://${{env.AWS_BUCKET_NAME}}/$FOLDER/reports/diff/ --recursive
-        echo $LINK/$FOLDER/reports/diff/index.html > message
-        
+        if [ -n "${{needs.parse_body.outputs.report_label}}" ]; then
+          echo "${{needs.parse_body.outputs.report_label}}: " > message
+        fi
+        echo $LINK/$FOLDER/reports/diff/index.html >> message
+
      - name: Set output
        id: out
        run: echo ::set-output name=message::$(cat message)   


### PR DESCRIPTION
Closes #9177 

Adds label to report message, it is parsed from PR description line "Report label: "
If there is no such line, no label added to report.
Example PR https://github.com/strkkk/checkstyle/pull/16

PR with updated documentation https://github.com/checkstyle/contribution/pull/540

![image](https://user-images.githubusercontent.com/8901354/105199082-6762bc00-5b4f-11eb-8807-ac7e84522c92.png)

Results in
![image](https://user-images.githubusercontent.com/8901354/105199134-75b0d800-5b4f-11eb-867a-8d67206deea4.png)
