### PR TITLE
doc: udpate BeforeExecutionExclusionFileFilter to show example of negative lookahead

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -807,6 +807,7 @@ localhost
 localvariablename
 Loggable
 lombok
+lookaround
 Loughran
 lparen
 lpb

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filefilters/BeforeExecutionExclusionFileFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filefilters/BeforeExecutionExclusionFileFilter.java
@@ -62,6 +62,18 @@ import com.puppycrawl.tools.checkstyle.api.BeforeExecutionFileFilter;
  * &lt;/module&gt;
  * </pre>
  * <p>
+ * To configure the filter to run only on required files for example that ends with "Remote"
+ * or end with "Client" in names or named as "Remote.java" or "Client.java"
+ * use <a href="https://www.regular-expressions.info/lookaround.html">negative lookahead</a>:
+ * </p>
+ *
+ * <pre>
+ * &lt;module name=&quot;BeforeExecutionExclusionFileFilter&quot;&gt;
+ *   &lt;property name=&quot;fileNamePattern&quot;
+ *  value=&quot;^(?!.*(Remote\.java|Client\.java|[\\/]Remote\.java|[\\/]Client\.java)).*$&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.Checker}
  * </p>
  *

--- a/src/xdocs/config_filefilters.xml
+++ b/src/xdocs/config_filefilters.xml
@@ -68,6 +68,17 @@
   &lt;property name=&quot;fileNamePattern&quot; value=&quot;module\-info\.java$&quot;/&gt;
 &lt;/module&gt;
         </source>
+        <p>
+          To configure the filter to run only on required files for example that ends with "Remote"
+          or end with "Client" in names or named as "Remote.java" or "Client.java"
+          use <a href="https://www.regular-expressions.info/lookaround.html">negative lookahead</a>:
+        </p>
+        <source>
+&lt;module name=&quot;BeforeExecutionExclusionFileFilter&quot;&gt;
+  &lt;property name=&quot;fileNamePattern&quot;
+    value=&quot;^(?!.*(Remote\.java|Client\.java|[\\/]Remote\.java|[\\/]Client\.java)).*$&quot;/&gt;
+&lt;/module&gt;
+        </source>
       </subsection>
       <subsection name="Example of Usage" id="BeforeExecutionExclusionFileFilter_Example_of_Usage">
         <ul>


### PR DESCRIPTION
based on discussion from https://github.com/checkstyle/checkstyle/issues/3523#issuecomment-765615028