### PR TITLE
Issue #9204: Change metadata generator to fail on invalid properties

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -116,6 +116,14 @@
     <property name="maximum" value="0"/>
     <property name="message" value="Trailing whitespace is not allowed"/>
   </module>
+  <!-- This is needed for correct metadata generation -->
+  <module name="RegexpSingleline">
+    <property name="id" value="propertyTypeOnNewLine"/>
+    <property name="format" value="^ \* .+(Type|Default value|Validation type) is \{@code "/>
+    <property name="minimum" value="0"/>
+    <property name="maximum" value="0"/>
+    <property name="message" value="Property attribute should be on new javadoc line"/>
+  </module>
   <module name="RegexpSingleline">
     <property name="id" value="commentFirstSentenceSingleline"/>
     <property name="format" value="/\*\* +\p{javaLowerCase}"/>

--- a/config/checkstyle_non_main_files_suppressions.xml
+++ b/config/checkstyle_non_main_files_suppressions.xml
@@ -92,9 +92,6 @@
   <suppress id="lineLength"
          files="src[\\/]test[\\/]resources-noncompilable[\\/].*[\\/]customimportorder"/>
 
-  <!-- until https://github.com/checkstyle/checkstyle/issues/9204 -->
-  <suppress id="lineLength" files="config_design\.xml" lines="163"/>
-
   <!-- apply check numberOfTestCasesInXpath only for files in suppressionxpathfilter directory -->
   <suppress id="numberOfTestCasesInXpath"
          files="src[\\/]it[\\/]java[\\/]com[\\/].*" />

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -7,8 +7,6 @@
 <suppressions>
   <!-- can't split long messages between lines -->
   <suppress id="lineLengthXml" files="google_checks\.xml" lines="56,126"/>
-  <!-- until https://github.com/checkstyle/checkstyle/issues/9204 -->
-  <suppress id="lineLengthXml" files="config_design\.xml" lines="163"/>
   <!-- don't validate generated files -->
   <suppress id="lineLengthXml" files="releasenotes\.xml"/>
   <suppress id="lineLengthXml" files="[\\/]meta[\\/]"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMissingLeadingAsteriskCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMissingLeadingAsteriskCheck.java
@@ -41,7 +41,8 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * Property {@code violateExecutionOnNonTightHtml} - Control when to print violations if the
  * Javadoc being examined by this check violates the tight html rules defined at
  * <a href="https://checkstyle.org/writingjavadocchecks.html#Tight-HTML_rules">Tight-HTML Rules</a>.
- * Type is {@code boolean}. Default value is {@code false}.
+ * Type is {@code boolean}.
+ * Default value is {@code false}.
  * </li>
  * </ul>
  * <p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java
@@ -26,6 +26,7 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -57,14 +58,14 @@ public class JavadocMetadataScraper extends AbstractJavadocCheck {
     private static final Pattern PROPERTY_TAG = Pattern.compile("\\s*Property\\s*");
 
     /** Regular expression for property type location in class-level javadocs. */
-    private static final Pattern TYPE_TAG = Pattern.compile("\\s.*Type is\\s.*");
+    private static final Pattern TYPE_TAG = Pattern.compile("^ Type is\\s.*");
 
     /** Regular expression for property validation type location in class-level javadocs. */
     private static final Pattern VALIDATION_TYPE_TAG =
             Pattern.compile("\\s.*Validation type is\\s.*");
 
     /** Regular expression for property default value location in class-level javadocs. */
-    private static final Pattern DEFAULT_VALUE_TAG = Pattern.compile("\\s*Default value is:*.*");
+    private static final Pattern DEFAULT_VALUE_TAG = Pattern.compile("^ Default value is:*.*");
 
     /** Regular expression for check example location in class-level javadocs. */
     private static final Pattern EXAMPLES_TAG =
@@ -103,6 +104,17 @@ public class JavadocMetadataScraper extends AbstractJavadocCheck {
                     "the charset property of the parent <a href=https://checkstyle.org/"
                         + "config.html#Checker>Checker</a> module"
     )));
+
+    /**
+     * Format for exception message for missing type for check property.
+     */
+    private static final String PROP_TYPE_MISSING = "Type for property '%s' is missing";
+
+    /**
+     * Format for exception message for missing default value for check property.
+     */
+    private static final String PROP_DEFAULT_VALUE_MISSING =
+        "Default value for property '%s' is missing";
 
     /** ModuleDetails instance for each module AST traversal. */
     private ModuleDetails moduleDetails;
@@ -261,38 +273,41 @@ public class JavadocMetadataScraper extends AbstractJavadocCheck {
                 JavadocTokenTypes.JAVADOC_INLINE_TAG, 0);
         if (propertyNameNode.isPresent()) {
             final DetailNode propertyNameTag = propertyNameNode.get();
+            final String propertyName = getTextFromTag(propertyNameTag);
 
-            final Optional<DetailNode> propertyTypeNode =
-                    getFirstChildOfMatchingText(nodeLi, TYPE_TAG);
-            if (propertyTypeNode.isPresent()) {
-                final DetailNode propertyType = propertyTypeNode.get();
-                final String propertyDesc = DESC_CLEAN.matcher(
-                        constructSubTreeText(nodeLi, propertyNameTag.getIndex() + 1,
-                                propertyType.getIndex() - 1))
-                        .replaceAll(Matcher.quoteReplacement(""));
+            final DetailNode propertyType = getFirstChildOfMatchingText(nodeLi, TYPE_TAG)
+                .orElseThrow(() -> {
+                    return new MetadataGenerationException(String.format(
+                        Locale.ROOT, PROP_TYPE_MISSING, propertyName)
+                    );
+                });
+            final String propertyDesc = DESC_CLEAN.matcher(
+                    constructSubTreeText(nodeLi, propertyNameTag.getIndex() + 1,
+                            propertyType.getIndex() - 1))
+                    .replaceAll(Matcher.quoteReplacement(""));
 
-                modulePropertyDetails.setDescription(propertyDesc.trim());
+            modulePropertyDetails.setDescription(propertyDesc.trim());
+            modulePropertyDetails.setName(propertyName);
+            modulePropertyDetails.setType(getTagTextFromProperty(nodeLi, propertyType));
+
+            final Optional<DetailNode> validationTypeNodeOpt = getFirstChildOfMatchingText(nodeLi,
+                VALIDATION_TYPE_TAG);
+            if (validationTypeNodeOpt.isPresent()) {
+                final DetailNode validationTypeNode = validationTypeNodeOpt.get();
+                modulePropertyDetails.setValidationType(getTagTextFromProperty(nodeLi,
+                    validationTypeNode));
             }
 
-            modulePropertyDetails.setName(getTextFromTag(propertyNameTag));
-        }
-
-        final Optional<DetailNode> typeNode = getFirstChildOfMatchingText(nodeLi, TYPE_TAG);
-        if (typeNode.isPresent()) {
-            modulePropertyDetails.setType(getTagTextFromProperty(nodeLi, typeNode.get()));
-        }
-
-        final Optional<DetailNode> validationTypeNodeOpt = getFirstChildOfMatchingText(nodeLi,
-                VALIDATION_TYPE_TAG);
-        if (validationTypeNodeOpt.isPresent()) {
-            final DetailNode validationTypeNode = validationTypeNodeOpt.get();
-            modulePropertyDetails.setValidationType(getTagTextFromProperty(nodeLi,
-                    validationTypeNode));
-        }
-
-        final String defaultValue = getPropertyDefaultText(nodeLi);
-        if (!PROPERTIES_TO_NOT_WRITE.contains(defaultValue)) {
-            modulePropertyDetails.setDefaultValue(defaultValue);
+            final String defaultValue = getFirstChildOfMatchingText(nodeLi, DEFAULT_VALUE_TAG)
+                .map(defaultValueNode -> getPropertyDefaultText(nodeLi, defaultValueNode))
+                .orElseThrow(() -> {
+                    return new MetadataGenerationException(String.format(
+                        Locale.ROOT, PROP_DEFAULT_VALUE_MISSING, propertyName)
+                    );
+                });
+            if (!PROPERTIES_TO_NOT_WRITE.contains(defaultValue)) {
+                modulePropertyDetails.setDefaultValue(defaultValue);
+            }
         }
         return modulePropertyDetails;
     }
@@ -398,28 +413,24 @@ public class JavadocMetadataScraper extends AbstractJavadocCheck {
      * Create property default text, which is either normal property value or list of tokens.
      *
      * @param nodeLi list item javadoc node
+     * @param defaultValueNode default value node
      * @return default property text
      */
-    private static String getPropertyDefaultText(DetailNode nodeLi) {
-        String result = "";
-        final Optional<DetailNode> defaultValueNodeOpt = getFirstChildOfMatchingText(nodeLi,
-                DEFAULT_VALUE_TAG);
-        if (defaultValueNodeOpt.isPresent()) {
-            final DetailNode defaultValueNode = defaultValueNodeOpt.get();
-            final Optional<DetailNode> propertyDefaultValueTagNode = getFirstChildOfType(nodeLi,
-                    JavadocTokenTypes.JAVADOC_INLINE_TAG, defaultValueNode.getIndex() + 1);
-            DetailNode propertyDefaultValueTag = null;
-            if (propertyDefaultValueTagNode.isPresent()) {
-                propertyDefaultValueTag = propertyDefaultValueTagNode.get();
-            }
-            if (propertyDefaultValueTag == null) {
-                final String tokenText = constructSubTreeText(nodeLi,
-                        defaultValueNode.getIndex(), nodeLi.getChildren().length);
-                result = cleanDefaultTokensText(tokenText);
-            }
-            else {
-                result = getTextFromTag(propertyDefaultValueTag);
-            }
+    private static String getPropertyDefaultText(DetailNode nodeLi, DetailNode defaultValueNode) {
+        final Optional<DetailNode> propertyDefaultValueTagNode = getFirstChildOfType(nodeLi,
+                JavadocTokenTypes.JAVADOC_INLINE_TAG, defaultValueNode.getIndex() + 1);
+        DetailNode propertyDefaultValueTag = null;
+        if (propertyDefaultValueTagNode.isPresent()) {
+            propertyDefaultValueTag = propertyDefaultValueTagNode.get();
+        }
+        final String result;
+        if (propertyDefaultValueTag == null) {
+            final String tokenText = constructSubTreeText(nodeLi,
+                    defaultValueNode.getIndex(), nodeLi.getChildren().length);
+            result = cleanDefaultTokensText(tokenText);
+        }
+        else {
+            result = getTextFromTag(propertyDefaultValueTag);
         }
         return result;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/meta/MetadataGenerationException.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/meta/MetadataGenerationException.java
@@ -1,0 +1,49 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2021 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.meta;
+
+/**
+ * Exception for metadata generation errors.
+ */
+public class MetadataGenerationException extends RuntimeException {
+
+    /** For serialization that will never happen. */
+    private static final long serialVersionUID = -254525356420746283L;
+
+    /**
+     * Creates a new {@code MetadataGenerationException} instance.
+     *
+     * @param message a {@code String} value
+     */
+    public MetadataGenerationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new {@code MetadataGenerationException} instance
+     * that was caused by another exception.
+     *
+     * @param message a message that explains this exception
+     * @param cause the Exception that is wrapped by this exception
+     */
+    public MetadataGenerationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtil.java
@@ -35,7 +35,6 @@ import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.TreeWalker;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
-import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /** Class which handles all the metadata generation and writing calls. */
 public final class MetadataGeneratorUtil {
@@ -98,16 +97,5 @@ public final class MetadataGeneratorUtil {
         }
 
         checker.process(validFiles);
-    }
-
-    /**
-     * Return all token types present in checkstyle.
-     *
-     * @return list of token type names
-     */
-    public static List<String> fetchAllTokens() {
-        return Arrays.stream(TokenUtil.getAllTokenIds())
-                .mapToObj(TokenUtil::getTokenName)
-                .collect(Collectors.toList());
     }
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocMissingLeadingAsteriskCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocMissingLeadingAsteriskCheck.xml
@@ -14,7 +14,7 @@
  All other lines in a Javadoc should start with {@code *}, including blank lines and code blocks.
  &lt;/p&gt;</description>
          <properties>
-            <property default-value=""
+            <property default-value="false"
                       name="violateExecutionOnNonTightHtml"
                       type="boolean">
                <description>Control when to print violations if the

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/meta/javadocmetadatascraper/invalid_metadata/InputJavadocMetadataScraperPropertyMisplacedDefaultValueCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/meta/javadocmetadatascraper/invalid_metadata/InputJavadocMetadataScraperPropertyMisplacedDefaultValueCheck.java
@@ -1,0 +1,17 @@
+package com.puppycrawl.tools.checkstyle.meta.javadocmetadatascraper.invalid_metadata;
+
+/**
+ * <p>
+ * Description.
+ * </p>
+ * <ul>
+ * <li>
+ * Property {@code misplacedDefaultValue} - Some description.
+ * Type is {@code java.lang.String}. Default value is {@code ""}.
+ * </li>
+ * </ul>
+ *
+ * @since 8.33
+ */
+public class InputJavadocMetadataScraperPropertyMisplacedDefaultValueCheck {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/meta/javadocmetadatascraper/invalid_metadata/InputJavadocMetadataScraperPropertyMisplacedTypeCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/meta/javadocmetadatascraper/invalid_metadata/InputJavadocMetadataScraperPropertyMisplacedTypeCheck.java
@@ -1,0 +1,30 @@
+package com.puppycrawl.tools.checkstyle.meta.javadocmetadatascraper.invalid_metadata;
+
+/**
+ * <p>
+ * Checks whether file contains code. Files which are considered to have no code:
+ * </p>
+ * <ul>
+ * <li>
+ * File with no text
+ * </li>
+ * <li>
+ * File with single line comment(s)
+ * </li>
+ * <li>
+ * File with a multi line comment(s).
+ * </li>
+ * </ul>
+ * <p>
+ * <ul>
+ * <li>
+ * Property {@code misplacedType} - Some long wrapped
+ * description. Type is {@code java.lang.String}.
+ * Default value is {@code ""}.
+ * </li>
+ * </ul>
+ *
+ * @since 8.33
+ */
+public class InputJavadocMetadataScraperPropertyMisplacedTypeCheck {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/meta/javadocmetadatascraper/invalid_metadata/InputJavadocMetadataScraperPropertyMissingDefaultValueCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/meta/javadocmetadatascraper/invalid_metadata/InputJavadocMetadataScraperPropertyMissingDefaultValueCheck.java
@@ -1,0 +1,17 @@
+package com.puppycrawl.tools.checkstyle.meta.javadocmetadatascraper.invalid_metadata;
+
+/**
+ * <p>
+ * Description.
+ * </p>
+ * <ul>
+ * <li>
+ * Property {@code missingDefaultValue} - Some description.
+ * Type is {@code java.lang.String}.
+ * </li>
+ * </ul>
+ *
+ * @since 8.33
+ */
+public class InputJavadocMetadataScraperPropertyMissingDefaultValueCheck {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/meta/javadocmetadatascraper/invalid_metadata/InputJavadocMetadataScraperPropertyMissingTypeCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/meta/javadocmetadatascraper/invalid_metadata/InputJavadocMetadataScraperPropertyMissingTypeCheck.java
@@ -1,0 +1,29 @@
+package com.puppycrawl.tools.checkstyle.meta.javadocmetadatascraper.invalid_metadata;
+
+/**
+ * <p>
+ * Checks whether file contains code. Files which are considered to have no code:
+ * </p>
+ * <ul>
+ * <li>
+ * File with no text
+ * </li>
+ * <li>
+ * File with single line comment(s)
+ * </li>
+ * <li>
+ * File with a multi line comment(s).
+ * </li>
+ * </ul>
+ * <p>
+ * <ul>
+ * <li>
+ * Property {@code missingType} - Some description.
+ * Default value is {@code ""}.
+ * </li>
+ * </ul>
+ *
+ * @since 8.33
+ */
+public class InputJavadocMetadataScraperPropertyMissingTypeCheck {
+}

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -160,7 +160,8 @@ public abstract class Plant {
             <tr>
               <td>requiredJavadocPhrase</td>
               <td>
-                Specify the comment text pattern which qualifies a method as designed for extension. Supports multi-line regex.
+                Specify the comment text pattern which qualifies a method as designed for
+                extension. Supports multi-line regex.
               </td>
               <td><a href="property_types.html#pattern">Pattern</a></td>
               <td><code>&quot;.*&quot;</code></td>


### PR DESCRIPTION
Closes #9204 

1. Metadata tool code is changed to fail in case default value or type is misssing/misplaced
2. Suppression mentioned in issue is fixed.
3. Added check to make sure that properties for metadata generation are on new javadoc line.
4. Fixed one issue with properties that was found after check addition.
