### PR TITLE
Issue #9173: Checkstyle should support property chaining

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -188,6 +188,7 @@ Cfml
 Cfoo
 cfz
 cgi
+chainedpropertyutil
 charset
 CHDBACBF
 CHDBEFIF

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -49,6 +49,7 @@ import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.api.RootModule;
+import com.puppycrawl.tools.checkstyle.utils.ChainedPropertyUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import com.puppycrawl.tools.checkstyle.utils.XpathUtil;
 import picocli.CommandLine;
@@ -437,7 +438,7 @@ public final class Main {
             throw new CheckstyleException(loadPropertiesExceptionMessage.getMessage(), ex);
         }
 
-        return properties;
+        return ChainedPropertyUtil.getResolvedProperties(properties);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/ChainedPropertyUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/ChainedPropertyUtil.java
@@ -1,0 +1,133 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2021 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.utils;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+
+/**
+ * Resolves chained properties from a user-defined property file.
+ */
+public final class ChainedPropertyUtil {
+
+    /**
+     * Used to report undefined property in exception message.
+     */
+    public static final String UNDEFINED_PROPERTY_MESSAGE = "Undefined property: ";
+
+    /**
+     * Property variable expression pattern, matches property variables such as {@code ${basedir}}.
+     */
+    private static final Pattern PROPERTY_VARIABLE_PATTERN = Pattern.compile("\\$\\{([^\\s}]+)}");
+
+    /**
+     * Prevent instantiation.
+     */
+    private ChainedPropertyUtil() {
+    }
+
+    /**
+     * Accepts user defined properties and returns new properties
+     * with all chained properties resolved.
+     *
+     * @param properties the underlying properties to use
+     *                   for property resolution.
+     * @return resolved properties
+     * @throws CheckstyleException when chained property is not defined
+     */
+    public static Properties getResolvedProperties(Properties properties)
+            throws CheckstyleException {
+        final Set<String> unresolvedPropertyNames =
+            new HashSet<>(properties.stringPropertyNames());
+        Iterator<String> unresolvedPropertyIterator = unresolvedPropertyNames.iterator();
+        final Map<Object, Object> comparisonProperties = new Properties();
+
+        while (unresolvedPropertyIterator.hasNext()) {
+            final String propertyName = unresolvedPropertyIterator.next();
+            String propertyValue = properties.getProperty(propertyName);
+            final Matcher matcher = PROPERTY_VARIABLE_PATTERN.matcher(propertyValue);
+
+            while (matcher.find()) {
+                final String propertyVariableExpression = matcher.group();
+                final String unresolvedPropertyName =
+                    getPropertyNameFromExpression(propertyVariableExpression);
+
+                final String resolvedPropertyValue =
+                    properties.getProperty(unresolvedPropertyName);
+
+                if (resolvedPropertyValue != null) {
+                    propertyValue = propertyValue.replace(propertyVariableExpression,
+                        resolvedPropertyValue);
+                    properties.setProperty(propertyName, propertyValue);
+                }
+            }
+
+            if (allChainedPropertiesAreResolved(propertyValue)) {
+                unresolvedPropertyIterator.remove();
+            }
+
+            if (!unresolvedPropertyIterator.hasNext()) {
+
+                if (comparisonProperties.equals(properties)) {
+                    // At this point, we will have not resolved any properties in two iterations,
+                    // so unresolvable properties exist.
+                    throw new CheckstyleException(UNDEFINED_PROPERTY_MESSAGE
+                        + unresolvedPropertyNames);
+                }
+                comparisonProperties.putAll(properties);
+                unresolvedPropertyIterator = unresolvedPropertyNames.iterator();
+            }
+
+        }
+        return properties;
+    }
+
+    /**
+     * Gets an unresolved property name from a property variable expression
+     * by stripping the preceding '${' and trailing '}'.
+     *
+     * @param variableExpression the full property variable expression
+     * @return property name
+     */
+    private static String getPropertyNameFromExpression(String variableExpression) {
+        final int propertyStartIndex = variableExpression.lastIndexOf('{') + 1;
+        final int propertyEndIndex = variableExpression.lastIndexOf('}');
+        return variableExpression.substring(propertyStartIndex, propertyEndIndex);
+    }
+
+    /**
+     * Checks if all chained properties have been resolved. Essentially,
+     * this means that there exist no matches for PROPERTY_VARIABLE_PATTERN in the
+     * property value string.
+     *
+     * @param propertyValue the property value to check
+     * @return true if all chained properties are resolved
+     */
+    private static boolean allChainedPropertiesAreResolved(String propertyValue) {
+        return !PROPERTY_VARIABLE_PATTERN.matcher(propertyValue).find();
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/ChainedPropertyUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/ChainedPropertyUtilTest.java
@@ -1,0 +1,142 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2021 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.utils;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.PropertiesExpander;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+
+public class ChainedPropertyUtilTest extends AbstractModuleTestSupport {
+
+    @Override
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/utils/chainedpropertyutil";
+    }
+
+    @Test
+    public void testIsProperUtilsClass() throws ReflectiveOperationException {
+        assertWithMessage("Constructor is not private.")
+            .that(isUtilsClassHasPrivateConstructor(ChainedPropertyUtil.class, true))
+            .isTrue();
+    }
+
+    @Test
+    public void testPropertyChaining() throws Exception {
+        final File propertiesFile =
+            new File(getPath("InputChainedPropertyUtil.properties"));
+        final Properties properties = loadProperties(propertiesFile);
+        final Properties resolvedProperties =
+            ChainedPropertyUtil.getResolvedProperties(properties);
+        final PropertiesExpander expander = new PropertiesExpander(resolvedProperties);
+        final String message = "Unexpected property resolution.";
+
+        assertWithMessage(message)
+            .that(expander.resolve("basedir"))
+            .isEqualTo("/home");
+        assertWithMessage(message)
+            .that(expander.resolve("checkstyle.dir"))
+            .isEqualTo("/home/checkstyle");
+        assertWithMessage(message)
+            .that(expander.resolve("config.dir"))
+            .isEqualTo("/home/checkstyle/configs");
+        assertWithMessage(message)
+            .that(expander.resolve("checkstyle.suppressions.file"))
+            .isEqualTo("/home/checkstyle/configs/suppressions.xml");
+        assertWithMessage(message)
+            .that(expander.resolve("checkstyle.dir"))
+            .isEqualTo("/home/checkstyle");
+        assertWithMessage(message)
+            .that(expander.resolve("str"))
+            .isEqualTo("value");
+    }
+
+    @Test
+    public void testPropertyChainingPropertyNotFound() throws Exception {
+        final File propertiesFile =
+            new File(getPath("InputChainedPropertyUtilUndefinedProperty.properties"));
+        final Properties properties = loadProperties(propertiesFile);
+        final String expected =
+            ChainedPropertyUtil.UNDEFINED_PROPERTY_MESSAGE + "[property.not.found]";
+        final String message = "Undefined property reference expected.";
+
+        final CheckstyleException exception =
+            assertThrows(CheckstyleException.class,
+                () -> ChainedPropertyUtil.getResolvedProperties(properties));
+
+        assertWithMessage(message)
+            .that(exception)
+            .hasMessageThat()
+            .isEqualTo(expected);
+    }
+
+    @Test
+    public void testPropertyChainingRecursiveUnresolvable() throws Exception {
+        final File propertiesFile =
+            new File(getPath("InputChainedPropertyUtilRecursiveUnresolvable.properties"));
+        final Properties properties = loadProperties(propertiesFile);
+        final String expected = ChainedPropertyUtil.UNDEFINED_PROPERTY_MESSAGE;
+        final String message = "Undefined property reference expected.";
+
+        final CheckstyleException exception =
+            assertThrows(CheckstyleException.class,
+                () -> ChainedPropertyUtil.getResolvedProperties(properties));
+
+        assertWithMessage(message)
+            .that(exception)
+            .hasMessageThat()
+            .contains(expected);
+    }
+
+    /**
+     * Loads properties from a file. We could load properties inline
+     * with StringReader, but that would preserve the order of the
+     * properties. Since properties are not loaded/ stored in
+     * sequential order, it is important to maintain this
+     * random property order for testing.
+     *
+     * @param file the properties file
+     * @return the properties in file
+     * @throws CheckstyleException when cannot load properties file
+     */
+    private static Properties loadProperties(File file) throws CheckstyleException {
+        final Properties properties = new Properties();
+
+        try (InputStream stream = Files.newInputStream(file.toPath())) {
+            properties.load(stream);
+        }
+        catch (final IOException ex) {
+            throw new CheckstyleException(ex.getMessage(), ex);
+        }
+
+        return properties;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainPropertyChaining.properties
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainPropertyChaining.properties
@@ -1,0 +1,2 @@
+mycheckstyle.severity=${severity}
+severity=warning

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainPropertyChainingUndefinedProperty.properties
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/main/InputMainPropertyChainingUndefinedProperty.properties
@@ -1,0 +1,2 @@
+mycheckstyle.severity=${undefined.property}
+severity=warning

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/chainedpropertyutil/InputChainedPropertyUtil.properties
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/chainedpropertyutil/InputChainedPropertyUtil.properties
@@ -1,0 +1,11 @@
+basedir=/home
+checkstyle.dir=${basedir}/checkstyle
+checkstyle.dir.nochaining=/checkstyle
+config.dir=${checkstyle.dir}/configs
+config.nochaining=/config
+checkstyle.suppressions.file=${config.dir}/suppressions.xml
+checkstyle.file.other=${basedir}${checkstyle.dir.nochaining}${config.nochaining}/suppressions.xml
+dollar=$
+unescaped=value
+str=${dollar}{unescaped}
+

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/chainedpropertyutil/InputChainedPropertyUtilRecursiveUnresolvable.properties
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/chainedpropertyutil/InputChainedPropertyUtilRecursiveUnresolvable.properties
@@ -1,0 +1,2 @@
+Mycheckstyle.severity=${severity}
+severity=${Mycheckstyle.severity}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/chainedpropertyutil/InputChainedPropertyUtilUndefinedProperty.properties
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/chainedpropertyutil/InputChainedPropertyUtilUndefinedProperty.properties
@@ -1,0 +1,8 @@
+basedir=/home
+checkstyle.dir=${basedir}/checkstyle
+checkstyle.dir.nochaining=/checkstyle
+config.dir=${checkstyle.dir}/configs
+config.nochaining=/config
+checkstyle.suppressions.file=${config.dir}/suppressions.xml
+checkstyle.file.other=${basedir}${checkstyle.dir.nochaining}${config.nochaining}/suppressions.xml
+property.not.found=${some.other.prop}

--- a/src/xdocs/config_system_properties.xml
+++ b/src/xdocs/config_system_properties.xml
@@ -74,5 +74,31 @@
       </p>
     </section>
 
+    <section name="Property chaining support">
+      <p>
+        Checkstyle supports property expansion within property definitions, also
+        known as property chaining. This feature allows you to define properties
+        using other properties. For example:
+        <source>
+checkstyle.dir=/home/user/checkstyle
+config.dir=configs
+checkstyle.suppressions.file=${checkstyle.dir}/${config.dir}/suppressions.xml
+        </source>
+        You can then use
+        <code>${checkstyle.suppressions.file}</code> in your checkstyle configuration,
+        which will resolve to
+        <code>/home/user/checkstyle/configs/suppressions.xml</code>.
+      </p>
+      <subsection name="Notes" id="Property_chaining_support_Notes">
+        <p>
+          Note that property variable expression must be of the form
+          <code>${expression}</code>.
+        </p>
+        <p>
+          It is not necessary to define chained properties sequentially.
+        </p>
+      </subsection>
+    </section>
+
   </body>
 </document>


### PR DESCRIPTION
Issue #9173: Checkstyle should support property expansion within property definitions (property chaining)

Link to documentation: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/issue-9173_2021201706/config_system_properties.html