### PR TITLE
Issue #7686: Update doc for CustomImportOrder

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -169,6 +169,183 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </li>
  * </ul>
  * <p>
+ *     To configure the check :
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;CustomImportOrder&quot;/&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * package com.company;
+ * import org.apache.commons.io.FileUtils; // OK
+ * import static java.util.*; // OK
+ * import java.time.*; // OK
+ * import static java.io.*; // OK
+ * import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // OK
+ * import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
+ * </pre>
+ * <p>
+ * To configure the check so that it checks in the order
+ * (static imports,standard java packages,third party package):
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;CustomImportOrder&quot;&gt;
+ *   &lt;property name=&quot;customImportOrderRules&quot;
+ *     value=&quot;STATIC###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * package com.company;
+ *
+ * import static java.util.*; // OK
+ *
+ * import java.time.*; // OK
+ * import javax.net.*; // OK
+ * import static java.io.*; // violation as static imports should be in top
+ *
+ * import org.apache.commons.io.FileUtils; // OK
+ * import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // OK
+ * import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
+ * </pre>
+ * <p>
+ * To configure the check such that only java packages are included in standard java packages
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;CustomImportOrder&quot;&gt;
+ *   &lt;property name=&quot;customImportOrderRules&quot;
+ *     value=&quot;STATIC###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE&quot;/&gt;
+ *   &lt;property name=&quot;standardPackageRegExp&quot; value=&quot;^java\.&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * package com.company;
+ *
+ * import static java.util.*; // OK
+ * import static java.io.*; // OK
+ *
+ * import java.time.*; // OK
+ * import javax.net.*; // violation as it is not included in standard java package group.
+ *
+ * import org.apache.commons.io.FileUtils; // violation
+ * import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // OK
+ * import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
+ * </pre>
+ * <p>
+ * To configure the check to include only "com" packages as third party group imports:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;CustomImportOrder&quot;&gt;
+ *   &lt;property name=&quot;customImportOrderRules&quot;
+ *     value=&quot;STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE&quot;/&gt;
+ *   &lt;property name=&quot;thirdPartyPackageRegExp&quot; value=&quot;^com\.&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * package com.company;
+ *
+ * import static java.util.*; // OK
+ * import static java.io.*; // OK
+ *
+ * import java.time.*; // OK
+ * import javax.net.*; // OK
+ *
+ * import org.apache.commons.io.FileUtils; // violation(should be in end)
+ * import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // violation
+ * import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
+ * </pre>
+ * <p>
+ * To configure the check to force some packages in special import group:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;CustomImportOrder&quot;&gt;
+ *   &lt;property name=&quot;customImportOrderRules&quot;
+ *     value=&quot;STATIC###SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE&quot;/&gt;
+ *   &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;^org\.&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * package com.company;
+ *
+ * import static java.util.*; // OK
+ * import static java.io.*; // OK
+ *
+ * import org.json.JSONObject; // OK
+ *
+ * import java.time.*; // OK
+ * import javax.net.*; // OK
+ *
+ * import org.apache.commons.io.FileUtils; // violation
+ * </pre>
+ * <p>
+ * To configure the check such that empty line separator between two groups is enabled:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;CustomImportOrder&quot;&gt;
+ *   &lt;property name=&quot;customImportOrderRules&quot;
+ *     value=&quot;STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE&quot;/&gt;
+ *   &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;^org\.&quot;/&gt;
+ *   &lt;property name=&quot;thirdPartyPackageRegExp&quot; value=&quot;^com\.&quot;/&gt;
+ *   &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;true&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * package com.company;
+ *
+ * import static java.util.*; // OK
+ * import static java.io.*; // OK
+ *
+ * import java.time.*; // OK
+ * import javax.net.*; // OK
+ * import org.apache.commons.io.FileUtils; // violation
+ * import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // violation
+ * import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
+ * </pre>
+ * <p>
+ * To configure the check such that import groups are forced to be sorted alphabetically:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;CustomImportOrder&quot;&gt;
+ *   &lt;property name=&quot;customImportOrderRules&quot;
+ *     value=&quot;STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE&quot;/&gt;
+ *   &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;^org\.&quot;/&gt;
+ *   &lt;property name=&quot;thirdPartyPackageRegExp&quot; value=&quot;^com\.&quot;/&gt;
+ *   &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;false&quot;/&gt;
+ *   &lt;property name=&quot;sortImportsInGroupAlphabetically&quot; value=&quot;true&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * package com.company;
+ *
+ * import static java.util.*; // OK
+ * import static java.io.*; // Violation since it should come before"java.util"
+ *
+ * import java.time.*; // OK
+ * import javax.net.*; // OK
+ * import org.apache.commons.io.FileUtils; // OK
+ * import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // OK
+ * import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
+ * </pre>
+ * <p>
  * To configure the check so that it matches default Eclipse formatter configuration
  * (tested on Kepler and Luna releases):
  * </p>
@@ -210,6 +387,22 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * &lt;/module&gt;
  * </pre>
  * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * package com.company;
+ *
+ * import static java.util.*; // OK
+ * import static java.io.*; // Violation since it should come before"java.util"
+ *
+ * import java.time.*; // OK
+ * import javax.net.*; // OK
+ * import org.apache.commons.io.FileUtils; // Violation should be separated by space
+ *
+ * import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // OK
+ * import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
+ * </pre>
+ * <p>
  * To configure the check so that it matches default Eclipse formatter configuration
  * (tested on Mars release):
  * </p>
@@ -237,6 +430,23 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *   &lt;property name=&quot;sortImportsInGroupAlphabetically&quot; value=&quot;true&quot;/&gt;
  *   &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * package com.company;
+ *
+ * import static java.io.*; // OK
+ * import static java.util.*; // OK
+ *
+ * import java.time.*; // OK
+ * import javax.net.*; // OK
+ *
+ * import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // Violation
+ * import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // Violation
+ *
+ * import org.apache.commons.io.FileUtils;
  * </pre>
  * <p>
  * To configure the check so that it matches default IntelliJ IDEA formatter configuration
@@ -271,6 +481,25 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * &lt;/module&gt;
  * </pre>
  * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * package com.company;
+ *
+ * import static java.io.*; // OK
+ * import static java.util.*; // OK
+ *
+ * import java.time.*; // violation should be in standard package group
+ *                    // below special import
+ *
+ * import javax.net.*; // Violation should be in special import group
+ *
+ * import org.apache.commons.io.FileUtils; // Violation should be in
+ *                                        // THIRD PARTY PACKAGE GROUP
+ * import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // Violation
+ * import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // Violation
+ * </pre>
+ * <p>
  * To configure the check so that it matches default NetBeans formatter configuration
  * (tested on v8):
  * </p>
@@ -286,6 +515,21 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * &lt;module name=&quot;CustomImportOrder&quot;/&gt;
  * </pre>
  * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * package com.company;
+ *
+ * import static java.io.*; // OK
+ * import static java.util.*; // OK
+ * import java.time.*; // OK
+ * import javax.net.*; // OK
+ * import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // OK
+ * import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
+ *
+ * import org.apache.commons.io.FileUtils; // should not be separated by line
+ * </pre>
+ * <p>
  * To set RegExps for THIRD_PARTY_PACKAGE and STANDARD_JAVA_PACKAGE groups use
  * thirdPartyPackageRegExp and standardPackageRegExp options.
  * </p>
@@ -298,6 +542,21 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * &lt;/module&gt;
  * </pre>
  * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * package com.company;
+ *
+ * import static java.io.*; // OK
+ * import static java.util.*; // OK
+ * import java.time.*; // violation
+ * import javax.net.*; // violation
+ *
+ * import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // OK
+ * import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
+ * import org.apache.commons.io.FileUtils; // OK
+ * </pre>
+ * <p>
  * Also, this check can be configured to force empty line separator between
  * import groups. For example.
  * </p>
@@ -305,6 +564,20 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * &lt;module name=&quot;CustomImportOrder&quot;&gt;
  *   &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;true&quot;/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * package com.company;
+ *
+ * import static java.io.*; // OK
+ * import static java.util.*; // OK
+ * import java.time.*; // OK
+ * import javax.net.*; // OK
+ * import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // OK
+ * import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
+ * import org.apache.commons.io.FileUtils; // OK
  * </pre>
  * <p>
  * It is possible to enforce

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -486,6 +486,183 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
       </subsection>
 
       <subsection name="Examples" id="CustomImportOrder_Examples">
+        <p>
+          To configure the check :
+        </p>
+        <source>
+&lt;module name=&quot;CustomImportOrder&quot;/&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+package com.company;
+import org.apache.commons.io.FileUtils; // OK
+import static java.util.*; // OK
+import java.time.*; // OK
+import static java.io.*; // OK
+import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // OK
+import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
+        </source>
+        <p>
+          To configure the check so that it checks in the order
+          (static imports,standard java packages,third party package):
+        </p>
+        <source>
+&lt;module name=&quot;CustomImportOrder&quot;&gt;
+  &lt;property name=&quot;customImportOrderRules&quot;
+    value=&quot;STATIC###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+package com.company;
+
+import static java.util.*; // OK
+
+import java.time.*; // OK
+import javax.net.*; // OK
+import static java.io.*; // violation as static imports should be in top
+
+import org.apache.commons.io.FileUtils; // OK
+import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // OK
+import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
+        </source>
+        <p>
+          To configure the check such that only java packages are included in standard java packages
+        </p>
+        <source>
+&lt;module name=&quot;CustomImportOrder&quot;&gt;
+  &lt;property name=&quot;customImportOrderRules&quot;
+    value=&quot;STATIC###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE&quot;/&gt;
+  &lt;property name=&quot;standardPackageRegExp&quot; value=&quot;^java\.&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+        Example:
+        </p>
+        <source>
+package com.company;
+
+import static java.util.*; // OK
+import static java.io.*; // OK
+
+import java.time.*; // OK
+import javax.net.*; // violation as it is not included in standard java package group.
+
+import org.apache.commons.io.FileUtils; // violation
+import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // OK
+import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
+        </source>
+        <p>
+          To configure the check to include only "com" packages as third party group imports:
+        </p>
+        <source>
+&lt;module name=&quot;CustomImportOrder&quot;&gt;
+  &lt;property name=&quot;customImportOrderRules&quot;
+    value=&quot;STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE&quot;/&gt;
+  &lt;property name=&quot;thirdPartyPackageRegExp&quot; value=&quot;^com\.&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+package com.company;
+
+import static java.util.*; // OK
+import static java.io.*; // OK
+
+import java.time.*; // OK
+import javax.net.*; // OK
+
+import org.apache.commons.io.FileUtils; // violation(should be in end)
+import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // violation
+import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
+        </source>
+        <p>
+          To configure the check to force some packages in special import group:
+        </p>
+        <source>
+&lt;module name=&quot;CustomImportOrder&quot;&gt;
+  &lt;property name=&quot;customImportOrderRules&quot;
+    value=&quot;STATIC###SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE&quot;/&gt;
+  &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;^org\.&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+        Example:
+        </p>
+        <source>
+package com.company;
+
+import static java.util.*; // OK
+import static java.io.*; // OK
+
+import org.json.JSONObject; // OK
+
+import java.time.*; // OK
+import javax.net.*; // OK
+
+import org.apache.commons.io.FileUtils; // violation
+        </source>
+        <p>
+          To configure the check such that empty line separator between two groups is enabled:
+        </p>
+        <source>
+&lt;module name=&quot;CustomImportOrder&quot;&gt;
+  &lt;property name=&quot;customImportOrderRules&quot;
+    value=&quot;STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE&quot;/&gt;
+  &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;^org\.&quot;/&gt;
+  &lt;property name=&quot;thirdPartyPackageRegExp&quot; value=&quot;^com\.&quot;/&gt;
+  &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;true&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+package com.company;
+
+import static java.util.*; // OK
+import static java.io.*; // OK
+
+import java.time.*; // OK
+import javax.net.*; // OK
+import org.apache.commons.io.FileUtils; // violation
+import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // violation
+import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
+        </source>
+        <p>
+          To configure the check such that import groups are forced to be sorted alphabetically:
+        </p>
+        <source>
+&lt;module name=&quot;CustomImportOrder&quot;&gt;
+  &lt;property name=&quot;customImportOrderRules&quot;
+    value=&quot;STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE&quot;/&gt;
+  &lt;property name=&quot;specialImportsRegExp&quot; value=&quot;^org\.&quot;/&gt;
+  &lt;property name=&quot;thirdPartyPackageRegExp&quot; value=&quot;^com\.&quot;/&gt;
+  &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;false&quot;/&gt;
+  &lt;property name=&quot;sortImportsInGroupAlphabetically&quot; value=&quot;true&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+package com.company;
+
+import static java.util.*; // OK
+import static java.io.*; // Violation since it should come before"java.util"
+
+import java.time.*; // OK
+import javax.net.*; // OK
+import org.apache.commons.io.FileUtils; // OK
+import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // OK
+import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
+        </source>
         <p>To configure the check so that it matches default Eclipse formatter configuration
            (tested on Kepler and Luna releases):</p>
         <ul>
@@ -511,7 +688,22 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
   &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
         </source>
+        <p>
+          Example:
+        </p>
+        <source>
+package com.company;
 
+import static java.util.*; // OK
+import static java.io.*; // Violation since it should come before"java.util"
+
+import java.time.*; // OK
+import javax.net.*; // OK
+import org.apache.commons.io.FileUtils; // Violation should be separated by space
+
+import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // OK
+import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
+        </source>
         <p>To configure the check so that it matches default Eclipse formatter configuration
            (tested on Mars release):</p>
         <ul>
@@ -531,7 +723,23 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
   &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
         </source>
+        <p>
+          Example:
+        </p>
+        <source>
+package com.company;
 
+import static java.io.*; // OK
+import static java.util.*; // OK
+
+import java.time.*; // OK
+import javax.net.*; // OK
+
+import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // Violation
+import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // Violation
+
+import org.apache.commons.io.FileUtils;
+        </source>
         <p>To configure the check so that it matches default IntelliJ IDEA formatter configuration
            (tested on v14):</p>
         <ul>
@@ -558,7 +766,25 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
   &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
         </source>
+        <p>
+          Example:
+        </p>
+        <source>
+package com.company;
 
+import static java.io.*; // OK
+import static java.util.*; // OK
+
+import java.time.*; // violation should be in standard package group
+                   // below special import
+
+import javax.net.*; // Violation should be in special import group
+
+import org.apache.commons.io.FileUtils; // Violation should be in
+                                       // THIRD PARTY PACKAGE GROUP
+import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // Violation
+import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // Violation
+        </source>
         <p>To configure the check so that it matches default NetBeans formatter configuration
            (tested on v8):</p>
         <ul>
@@ -570,7 +796,21 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
         <source>
 &lt;module name=&quot;CustomImportOrder&quot;/&gt;
         </source>
+        <p>
+          Example:
+        </p>
+        <source>
+package com.company;
 
+import static java.io.*; // OK
+import static java.util.*; // OK
+import java.time.*; // OK
+import javax.net.*; // OK
+import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // OK
+import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
+
+import org.apache.commons.io.FileUtils; // should not be separated by line
+        </source>
         <p>
           To set RegExps for THIRD_PARTY_PACKAGE and STANDARD_JAVA_PACKAGE groups use
           thirdPartyPackageRegExp and standardPackageRegExp options.
@@ -584,6 +824,21 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
 &lt;/module&gt;
         </source>
         <p>
+          Example:
+        </p>
+        <source>
+package com.company;
+
+import static java.io.*; // OK
+import static java.util.*; // OK
+import java.time.*; // violation
+import javax.net.*; // violation
+
+import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // OK
+import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
+import org.apache.commons.io.FileUtils; // OK
+        </source>
+        <p>
           Also, this check can be configured to force empty line separator between
           import groups. For example.
         </p>
@@ -591,6 +846,20 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
 &lt;module name=&quot;CustomImportOrder&quot;&gt;
   &lt;property name=&quot;separateLineBetweenGroups&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+package com.company;
+
+import static java.io.*; // OK
+import static java.util.*; // OK
+import java.time.*; // OK
+import javax.net.*; // OK
+import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; // OK
+import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; // OK
+import org.apache.commons.io.FileUtils; // OK
         </source>
         <p>
           It is possible to enforce <a href="https://en.wikipedia.org/wiki/ASCII#Order">


### PR DESCRIPTION
Closes: #7686

### Added Examples for each property of CustomImportOrder

![image](https://user-images.githubusercontent.com/42171790/106309786-a0eea200-6288-11eb-9713-42884946475d.png)

**Output of the default configuration:-**

`$ cat config.xml`

```
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <property name="tabWidth" value="7"/>
    <module name="CustomImportOrder"/>
  </module>
</module>
```

`$ cat Hello.java`

```
package com.company;
import org.apache.commons.io.fileutils; //OK
import static java.util.*; //OK
import java.time.*; //OK
import static java.io.*; //OK
import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; //OK
import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; //OK
```
```
$ java -jar checkstyle-8.39-all.jar -c config.xml Hello.java
Starting audit...
Audit done.
```

![image](https://user-images.githubusercontent.com/42171790/106310954-6423aa80-628a-11eb-9b1c-aa42d99796bd.png)

Output of it in command line:-

`$ cat config.xml
`
```
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <property name="tabWidth" value="7"/>
    <module name="CustomImportOrder">
      <property name="customImportOrderRules"
                value="STATIC###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE"/>
    </module>
  </module>
</module>

```
`$ cat Hello.java
`
```
package com.company;

import static java.util.*; //OK

import java.time.*; //OK
import javax.net.*; //OK
import static java.io.*; //violation as static imports should be in top

import org.apache.commons.io.fileutils; //OK
import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; //OK
import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; //OK
        
```
`$ java -jar checkstyle-8.39-all.jar -c config.xml Hello.java
`
```

Starting audit...
[ERROR] E:\New folder\Java Dev\src\com\company\Hello.java:7:1: Import statement for 'java.io.*' is in the wrong order. Should be in the 'STATIC' group, expecting group 'THIRD_PARTY_PAC
KAGE' on this line. [CustomImportOrder]
Audit done.
Checkstyle ends with 1 errors.
```
![image](https://user-images.githubusercontent.com/42171790/106312918-6c311980-628d-11eb-8e40-6527859a932c.png)

Output of this in command line:-

`$ cat config.xml`

```
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <property name="tabWidth" value="7"/>
    <module name="CustomImportOrder">
      <property name="customImportOrderRules"
                value="STATIC###STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE"/>
      <property name="standardPackageRegExp" value="^java\."/>
    </module>
  </module>
</module>

```
`$ cat Hello.java`
```
package com.company;

import static java.util.*; //OK
import static java.io.*; //OK

import java.time.*; //OK
import javax.net.*; //violation as it is not included in standard java package group.

import org.apache.commons.io.fileutils; //violation
import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; //OK
import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; //OK
```
        
`$ java -jar checkstyle-8.39-all.jar -c config.xml Hello.java
`
```
Starting audit...
[ERROR] E:\New folder\Java Dev\src\com\company\Hello.java:7:1: 'javax.net.*' should be separated from previous import group by one line. [CustomImportOrder]
[ERROR] E:\New folder\Java Dev\src\com\company\Hello.java:9:1: Extra separation in import group before 'org.apache.commons.io.fileutils' [CustomImportOrder]
Audit done.
Checkstyle ends with 2 errors.
```

![image](https://user-images.githubusercontent.com/42171790/106311747-a3063000-628b-11eb-8951-a8c53f66d084.png)

Output of it in command line:-

`$ cat config.xml`

```
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <property name="tabWidth" value="7"/>
    <module name="CustomImportOrder">
      <property name="customImportOrderRules"
                value="STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE"/>
      <property name="thirdPartyPackageRegExp" value="^com\."/>
    </module>
  </module>
</module>
```

`$ cat Hello.java`

```
package com.company;

import static java.util.*; //OK
import static java.io.*; //OK

import java.time.*; //OK
import javax.net.*; //OK

import org.apache.commons.io.fileutils; //violation(should be in end)
import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; //violation
import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; //OK
```

`$ java -jar checkstyle-8.39-all.jar -c config.xml Hello.java
`
```
Starting audit...
[ERROR] E:\New folder\Java Dev\src\com\company\Hello.java:9:1: Imports without groups should be placed at the end of the import list: 'org.apache.commons.io.fileutils'. [CustomImportOr
der]
[ERROR] E:\New folder\Java Dev\src\com\company\Hello.java:10:1: 'com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck' should be separated from previous import group b
y one line. [CustomImportOrder]
Audit done.
Checkstyle ends with 2 errors.
```

![image](https://user-images.githubusercontent.com/42171790/106313613-7dc6f100-628e-11eb-9920-8a9244bc9321.png)

Output in command line:-

`$ cat config.xml`

```
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <property name="tabWidth" value="7"/>
    <module name="CustomImportOrder">
      <property name="customImportOrderRules"
                value="STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE"/>
      <property name="specialImportsRegExp" value="^org\."/>
      <property name="thirdPartyPackageRegExp" value="^com\."/>
    </module>
  </module>
</module>

```

`$ cat Hello.java`

```
package com.company;

import static java.util.*; //OK
import static java.io.*; //OK

import java.time.*; //OK
import javax.net.*; //OK
import org.apache.commons.io.fileutils; //OK
import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; //violation
import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; //OK
```
` $ java -jar checkstyle-8.39-all.jar -c config.xml Hello.java
`
```
Starting audit...
[ERROR] E:\New folder\Java Dev\src\com\company\Hello.java:8:1: 'org.apache.commons.io.fileutils' should be separated from previous import group by one line. [CustomImportOrder]
[ERROR] E:\New folder\Java Dev\src\com\company\Hello.java:9:1: 'com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck' should be separated from previous import group by
 one line. [CustomImportOrder]
Audit done.
Checkstyle ends with 2 errors.

```

![image](https://user-images.githubusercontent.com/42171790/106314230-6d634600-628f-11eb-8d0c-a29fac8bd315.png)

`$ cat config.xml`

```
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <property name="tabWidth" value="7"/>
    <module name="CustomImportOrder">
      <property name="customImportOrderRules"
                value="STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE"/>
      <property name="specialImportsRegExp" value="^org\."/>
      <property name="thirdPartyPackageRegExp" value="^com\."/>
      <property name="separateLineBetweenGroups" value="false"/>
    </module>
  </module>
</module>

```
`$ cat Hello.java`

```
package com.company;

import static java.util.*; //OK
import static java.io.*; //OK

import java.time.*; //OK
import javax.net.*; //OK
import org.apache.commons.io.fileutils; //OK
import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; //OK
import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; //OK
        
```
`$ java -jar checkstyle-8.39-all.jar -c config.xml Hello.java`
```
Starting audit...
Audit done.
```
![image](https://user-images.githubusercontent.com/42171790/106314633-009c7b80-6290-11eb-9d82-855bad796f6c.png)

`$ cat config.xml
`
```
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <property name="tabWidth" value="7"/>
    <module name="CustomImportOrder">
      <property name="customImportOrderRules"
                value="STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE"/>
      <property name="specialImportsRegExp" value="^org\."/>
      <property name="thirdPartyPackageRegExp" value="^com\."/>
      <property name="separateLineBetweenGroups" value="false"/>
      <property name="sortImportsInGroupAlphabetically" value="true"/>
    </module>
  </module>
</module>

```
`$ cat Hello.java`

```
package com.company;

import static java.util.*; //OK
import static java.io.*; //Violation since it should come before"java.util"

import java.time.*; //OK
import javax.net.*; //OK
import org.apache.commons.io.fileutils; //OK
import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; //OK
import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; //OK

```
`$java -jar checkstyle-8.39-all.jar -c config.xml Hello.java`

```
Starting audit...
[ERROR] E:\New folder\Java Dev\src\com\company\Hello.java:4:1: Wrong lexicographical order for 'java.io.*' import. Should be before 'java.util.*'. [CustomImportOrder]
Audit done.
Checkstyle ends with 1 errors.
```

![image](https://user-images.githubusercontent.com/42171790/106315103-c2ec2280-6290-11eb-88ff-d839f4b72b6c.png)

Output in command line:-

`$  cat config.xml`

```
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <property name="tabWidth" value="7"/>
    <module name="CustomImportOrder">
      <property name="customImportOrderRules"
                value="STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS"/>
      <property name="specialImportsRegExp" value="^org\."/>
      <property name="sortImportsInGroupAlphabetically" value="true"/>
      <property name="separateLineBetweenGroups" value="true"/>
    </module>
  </module>
</module>
```
`$ cat Hello.java`

```
package com.company;

import static java.util.*; //OK
import static java.io.*; //Violation since it should come before"java.util"

import java.time.*; //OK
import javax.net.*; //OK
import org.apache.commons.io.fileutils; //Violation should be separated by space

import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; //OK
import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; //OK
        
```
`$ java -jar checkstyle-8.39-all.jar -c config.xml Hello.java`

```
Starting audit...
[ERROR] E:\New folder\Java Dev\src\com\company\Hello.java:4:1: Wrong lexicographical order for 'java.io.*' import. Should be before 'java.util.*'. [CustomImportOrder]
[ERROR] E:\New folder\Java Dev\src\com\company\Hello.java:8:1: 'org.apache.commons.io.fileutils' should be separated from previous import group by one line. [CustomImportOrder]
Audit done.
Checkstyle ends with 2 errors.
```
![image](https://user-images.githubusercontent.com/42171790/106315524-5aea0c00-6291-11eb-8d7e-a5e441f32baa.png)

`$ cat config.xml
`
```
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <property name="tabWidth" value="7"/>
    <module name="CustomImportOrder">
      <property name="customImportOrderRules"
                value="STATIC###STANDARD_JAVA_PACKAGE###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE"/>
      <property name="specialImportsRegExp" value="^org\."/>
      <property name="thirdPartyPackageRegExp" value="^com\."/>
      <property name="sortImportsInGroupAlphabetically" value="true"/>
      <property name="separateLineBetweenGroups" value="true"/>
    </module>
  </module>
</module>
```
`$ cat Hello.java`

```
package com.company;

import static java.io.*; //OK
import static java.util.*; //OK

import java.time.*; //OK
import javax.net.*; //OK

import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; //Violation
import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; //Violation

import org.apache.commons.io.fileutils;
```
`$ java -jar checkstyle-8.39-all.jar -c config.xml Hello.java`

```
Starting audit...
[ERROR] E:\New folder\Java Dev\src\com\company\Hello.java:9:1: Import statement for 'com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck' is in the wrong order. Shoul
d be in the 'THIRD_PARTY_PACKAGE' group, expecting group 'SPECIAL_IMPORTS' on this line. [CustomImportOrder]
[ERROR] E:\New folder\Java Dev\src\com\company\Hello.java:10:1: Import statement for 'com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck' is in the wrong order. Should be
in the 'THIRD_PARTY_PACKAGE' group, expecting group 'SPECIAL_IMPORTS' on this line. [CustomImportOrder]
Audit done.
Checkstyle ends with 2 errors.
```

![image](https://user-images.githubusercontent.com/42171790/106316025-1ca11c80-6292-11eb-9f57-8bd3fdcb1b27.png)

Output in command line:-

`$ cat config.xml`

```
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <property name="tabWidth" value="7"/>
    <module name="CustomImportOrder">
      <property name="customImportOrderRules"
                value="THIRD_PARTY_PACKAGE###SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE###STATIC"/>
      <property name="specialImportsRegExp" value="^javax\."/>
      <property name="standardPackageRegExp" value="^java\."/>
      <property name="sortImportsInGroupAlphabetically" value="true"/>
      <property name="separateLineBetweenGroups" value="false"/>
    </module>
  </module>
</module>
```
`$ cat Hello.java`

```
package com.company;

import static java.io.*; //OK
import static java.util.*; //OK

import java.time.*; //violation should be in standard package group
                   //below special import

import javax.net.*; //Violation should be in special import group

import org.apache.commons.io.fileutils; //Violation should be in
                                       //THIRD PARTY PACKAGE GROUP
import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; //Violation
import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; //Violation
```
`$ java -jar checkstyle-8.39-all.jar -c config.xml Hello.java
`
```
Starting audit...
[ERROR] E:\New folder\Java Dev\src\com\company\Hello.java:6:1: Import statement for 'java.time.*' is in the wrong order. Should be in the 'STANDARD_JAVA_PACKAGE' group, expecting not a
ssigned imports on this line. [CustomImportOrder]
[ERROR] E:\New folder\Java Dev\src\com\company\Hello.java:9:1: Import statement for 'javax.net.*' is in the wrong order. Should be in the 'SPECIAL_IMPORTS' group, expecting not assigne
d imports on this line. [CustomImportOrder]
[ERROR] E:\New folder\Java Dev\src\com\company\Hello.java:11:1: Import statement for 'org.apache.commons.io.fileutils' is in the wrong order. Should be in the 'THIRD_PARTY_PACKAGE' gro
up, expecting not assigned imports on this line. [CustomImportOrder]
[ERROR] E:\New folder\Java Dev\src\com\company\Hello.java:13:1: Import statement for 'com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck' is in the wrong order. Shou
ld be in the 'THIRD_PARTY_PACKAGE' group, expecting not assigned imports on this line. [CustomImportOrder]
[ERROR] E:\New folder\Java Dev\src\com\company\Hello.java:14:1: Import statement for 'com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck' is in the wrong order. Should be
in the 'THIRD_PARTY_PACKAGE' group, expecting not assigned imports on this line. [CustomImportOrder]
Audit done.
Checkstyle ends with 5 errors.

```

![image](https://user-images.githubusercontent.com/42171790/106316454-c54f7c00-6292-11eb-9c01-e50282bed2c4.png)

`$ cat config.xml
`
```
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <property name="tabWidth" value="7"/>
    <module name="CustomImportOrder"/>
  </module>
</module>
```
`$ cat Hello.java
`
```
package com.company;

import static java.io.*; //OK
import static java.util.*; //OK
import java.time.*; //OK
import javax.net.*; //OK
import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; //OK
import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; //OK

import org.apache.commons.io.fileutils; //should not be separated by line
        
```
`$ java -jar checkstyle-8.39-all.jar -c config.xml Hello.java`

```
Starting audit...
[ERROR] E:\New folder\Java Dev\src\com\company\Hello.java:10:1: Extra separation in import group before 'org.apache.commons.io.fileutils' [CustomImportOrder]
Audit done.
Checkstyle ends with 1 errors.
```

![image](https://user-images.githubusercontent.com/42171790/106316828-5e7e9280-6293-11eb-9a2f-bc5bfc0e829b.png)

Output in command line:-

`$ cat config.xml
`
```
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <property name="tabWidth" value="7"/>
    <module name="CustomImportOrder">
      <property name="customImportOrderRules"
                value="STATIC###SAME_PACKAGE(3)###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
      <property name="thirdPartyPackageRegExp" value="^(com|org)\."/>
      <property name="standardPackageRegExp" value="^(java|javax)\."/>
    </module>
  </module>
</module>
```
`$ cat Hello.java`

```
package com.company;

import static java.io.*; //OK
import static java.util.*; //OK
import java.time.*; //violation
import javax.net.*; //violation

import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; //OK
import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; //OK
import org.apache.commons.io.fileutils; //OK
        
```
`$ java -jar checkstyle-8.39-all.jar -c config.xml Hello.java
`
```
Starting audit...
[ERROR] E:\New folder\Java Dev\src\com\company\Hello.java:5:1: Import statement for 'java.time.*' is in the wrong order. Should be in the 'STANDARD_JAVA_PACKAGE' group, expecting group
 'THIRD_PARTY_PACKAGE' on this line. [CustomImportOrder]
[ERROR] E:\New folder\Java Dev\src\com\company\Hello.java:6:1: Import statement for 'javax.net.*' is in the wrong order. Should be in the 'STANDARD_JAVA_PACKAGE' group, expecting group
 'THIRD_PARTY_PACKAGE' on this line. [CustomImportOrder]
Audit done.
Checkstyle ends with 2 errors.
```

![image](https://user-images.githubusercontent.com/42171790/106317175-ecf31400-6293-11eb-8ddc-639e637465b3.png)

Output in command line:-

`$ cat config.xml
`
```
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <property name="tabWidth" value="7"/>
    <module name="CustomImportOrder">
      <property name="separateLineBetweenGroups" value="true"/>
    </module>
  </module>
</module>
```
`$ cat Hello.java`

```
package com.company;

import static java.io.*; //OK
import static java.util.*; //OK
import java.time.*; //OK
import javax.net.*; //OK
import com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck; //OK
import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck; //OK
import org.apache.commons.io.fileutils; //OK
        
```
`$ java -jar checkstyle-8.39-all.jar -c config.xml Hello.java`

```
Starting audit...
Audit done.

```