### PR TITLE
Issue #9217: Sonar Dashboard link doesn't work

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1676,15 +1676,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.sonar-plugins</groupId>
-        <artifactId>maven-report</artifactId>
-        <version>0.1</version>
-        <configuration>
-          <sonarHostURL>https://sonarcloud.io</sonarHostURL>
-        </configuration>
-      </plugin>
-
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
         <version>${maven.pmd.plugin.version}</version>


### PR DESCRIPTION
Closes: #9217 

$cat log pom.xml 
```
<plugin>
      <groupId>nl.demon.shadowland.maven.plugins</groupId>
      <artifactId>sonarqube-maven-report</artifactId>
      <version>0.2.2</version>
</plugin>
```
Before change URL - `https://sonarcloud.io/project/index/com.puppycrawl.tools:checkstyle`
Current URL - `https://sonarcloud.io/dashboard?id=com.puppycrawl.tools%3Acheckstyle`
Desired URL - `https://sonarcloud.io/dashboard?id=org.checkstyle%3Acheckstyle`   

I am not able to change `com.puppycrawl.tools` with `org.checkstyle`. Kindly comment on how to solve this.   