### PR TITLE
Issue #9219: Removed redundant "Unsupported cases" section from…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -39,56 +39,6 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * Checks the distance between declaration of variable and its first usage.
  * Note : Variable declaration/initialization statements are not counted while calculating length.
  * </p>
- * <p>
- * ATTENTION! (Unsupported cases)
- * </p>
- * <p>
- * Case #1:
- * </p>
- * <pre>
- * {
- *   int c;
- *   int a = 3;
- *   int b = 2;
- *   {
- *     a = a + b;
- *     c = b;
- *   }
- * }
- * </pre>
- * <p>
- * Distance for variable 'a' = 1;
- * Distance for variable 'b' = 1;
- * Distance for variable 'c' = 2.
- * </p>
- * <p>
- * As distance by default is 1 the check doesn't raise warning for variables 'a'
- * and 'b' to move them into the block.
- * </p>
- * <p>
- * Case #2:
- * </p>
- * <pre>
- * int sum = 0;
- * for (int i = 0; i &lt; 20; i++) {
- *   a++;
- *   b--;
- *   sum++;
- *   if (sum &gt; 10) {
- *     res = true;
- *   }
- * }
- * </pre>
- * <p>
- * Distance for variable 'sum' = 3.
- * </p>
- * <p>
- * As the distance is more than the default (=1), the check raises warning for variable
- * 'sum' to move it into the 'for(...)' block. But there is situation when
- * variable 'sum' hasn't to be 0 within each iteration. So, to avoid such
- * warnings you can use the Suppression Filter, provided by Checkstyle, for the
- * whole class.
- * </p>
  * <ul>
  * <li>
  * Property {@code allowedDistance} - Specify distance between declaration

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/VariableDeclarationUsageDistanceCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/VariableDeclarationUsageDistanceCheck.xml
@@ -7,56 +7,6 @@
          <description>&lt;p&gt;
  Checks the distance between declaration of variable and its first usage.
  Note : Variable declaration/initialization statements are not counted while calculating length.
- &lt;/p&gt;
- &lt;p&gt;
- ATTENTION! (Unsupported cases)
- &lt;/p&gt;
- &lt;p&gt;
- Case #1:
- &lt;/p&gt;
- &lt;pre&gt;
- {
-   int c;
-   int a = 3;
-   int b = 2;
-   {
-     a = a + b;
-     c = b;
-   }
- }
- &lt;/pre&gt;
- &lt;p&gt;
- Distance for variable 'a' = 1;
- Distance for variable 'b' = 1;
- Distance for variable 'c' = 2.
- &lt;/p&gt;
- &lt;p&gt;
- As distance by default is 1 the check doesn't raise warning for variables 'a'
- and 'b' to move them into the block.
- &lt;/p&gt;
- &lt;p&gt;
- Case #2:
- &lt;/p&gt;
- &lt;pre&gt;
- int sum = 0;
- for (int i = 0; i &amp;lt; 20; i++) {
-   a++;
-   b--;
-   sum++;
-   if (sum &amp;gt; 10) {
-     res = true;
-   }
- }
- &lt;/pre&gt;
- &lt;p&gt;
- Distance for variable 'sum' = 3.
- &lt;/p&gt;
- &lt;p&gt;
- As the distance is more than the default (=1), the check raises warning for variable
- 'sum' to move it into the 'for(...)' block. But there is situation when
- variable 'sum' hasn't to be 0 within each iteration. So, to avoid such
- warnings you can use the Suppression Filter, provided by Checkstyle, for the
- whole class.
  &lt;/p&gt;</description>
          <properties>
             <property default-value="3" name="allowedDistance" type="int">

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -7516,59 +7516,6 @@ public class Test {
         </source>
       </subsection>
 
-      <subsection name="Notes" id="VariableDeclarationUsageDistance_Notes">
-        <p>
-          ATTENTION! (Unsupported cases)
-        </p>
-        <p>
-          Case #1:
-        </p>
-        <source>
-{
-  int c;
-  int a = 3;
-  int b = 2;
-  {
-    a = a + b;
-    c = b;
-  }
-}
-        </source>
-        <p>
-         Distance for variable 'a' = 1;
-         Distance for variable 'b' = 1;
-         Distance for variable 'c' = 2.
-        </p>
-        <p>
-          As distance by default is 1 the check doesn't raise warning for
-          variables 'a' and 'b' to move them into the block.
-        </p>
-        <p>
-          Case #2:
-        </p>
-        <source>
-int sum = 0;
-for (int i = 0; i &lt; 20; i++) {
-  a++;
-  b--;
-  sum++;
-  if (sum > 10) {
-    res = true;
-  }
-}
-        </source>
-        <p>
-          Distance for variable 'sum' = 3.
-        </p>
-        <p>
-          As the distance is more than the default (=1), the check
-          raises warning for variable 'sum' to move it into the 'for(...)' block.
-          But there is situation when variable 'sum' hasn't to be 0 within each iteration.
-          So, to avoid such warnings you can use the Suppression Filter, provided by
-          Checkstyle, for the whole class.
-        </p>
-      </subsection>
-
       <subsection name="Example of Usage" id="VariableDeclarationUsageDistance_Example_of_Usage">
         <ul>
           <li>


### PR DESCRIPTION
…VariableDeclarationUsageDistance check documentation

Solves #9219 

### Case 1: ###
`$ cat Test.java`
```java
public class Test {

    public void foo() {
        int c;          // OK, distance = 2
        int a = 3;      // OK, distance = 1
        int b = 2;      // OK, distance = 1
        {
          a = a + b;
          c = b;
        }
    }
} 
```
`$ cat check.xml`
```xml
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">		
  <module name="TreeWalker">
    <module name="VariableDeclarationUsageDistance">
      <property name="validateBetweenScopes" value="true"/>
    </module>
  </module>
</module>
```

`$ java com.puppycrawl.tools.checkstyle.Main -c`
```
Starting audit...
Audit done.
```

As expected, the check does not raise violation because maximum allowed distance = 3.

### Case 2: ###
`$ cat Test.java`
```java
public class Test {
    boolean res;

    public void foo() {
        int sum = 0;            // OK, distance = 3
        
        for (int i = 0; i < 20; i++) {
            a++;
            b--;
            sum++;
            
            if (sum > 10) {
              res = true;
            }
        }
    }
}
```
`$ cat check.xml`
```xml
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">		
  <module name="TreeWalker">
    <module name="VariableDeclarationUsageDistance">
      <property name="validateBetweenScopes" value="true"/>
    </module>
  </module>
</module>
```

`$ java com.puppycrawl.tools.checkstyle.Main -c`
```
Starting audit...
Audit done.
```

As expected, the check does not raise violation because max allowed distance = 3, and in the example also, distance between usage and declaration for `sum` = 3. 

Also, the check does not suggest to move `sum` into the `for(...)` block, even if distance>3.

`$ cat Test.java`
```java
public class Test {
    boolean res;

    public void foo() {
        int sum = 0;            // violation, distance = 4
        
        for (int i = 0; i < 20; i++) {
            System.out.println("Extra statement");
            a++;
            b--;
            sum++;
            
            if (sum > 10) {
              res = true;
            }
        }
    }
}
```

`$ java com.puppycrawl.tools.checkstyle.Main -c`
```
Starting audit...
[ERROR] /home/ayushman/Desktop/CheckstyleExperiments/VariableDeclarationUsageDistance/Test.java:32:9:
Distance between variable 'sum' declaration and its first usage is 4, but allowed 3.
Consider making that variable final if you still need to store its value in advance
(before method calls that might have side effects on the original value). [VariableDeclarationUsageDistance]
Audit done.
Checkstyle ends with 1 errors.
```