### PR TITLE
Correct NoEnumTrailingCheck and UnnessaryEnumSemicolonCheck to handle empty enums

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoEnumTrailingCommaCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NoEnumTrailingCommaCheck.java
@@ -23,6 +23,7 @@ import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
  * <p>
@@ -123,17 +124,16 @@ public class NoEnumTrailingCommaCheck extends AbstractCheck {
 
     @Override
     public int[] getRequiredTokens() {
-        return new int[] {TokenTypes.ENUM_CONSTANT_DEF};
+        return new int[] {TokenTypes.ENUM_DEF};
     }
 
     @Override
     public void visitToken(DetailAST detailAST) {
-        final DetailAST nextSibling = detailAST.getNextSibling();
-        if (nextSibling.getType() == TokenTypes.COMMA) {
-            final DetailAST nextToNextSibling = nextSibling.getNextSibling();
-            if (nextToNextSibling.getType() != TokenTypes.ENUM_CONSTANT_DEF) {
-                log(nextSibling, MSG_KEY);
-            }
-        }
+        final DetailAST enumBlock = detailAST.findFirstToken(TokenTypes.OBJBLOCK);
+        TokenUtil.findFirstTokenByPredicate(enumBlock,
+            node -> TokenUtil.isOfType(node, TokenTypes.SEMI, TokenTypes.RCURLY))
+            .map(DetailAST::getPreviousSibling)
+            .filter(token -> token.getType() == TokenTypes.COMMA)
+            .ifPresent(comma -> log(comma, MSG_KEY));
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NoEnumTrailingCommaCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/NoEnumTrailingCommaCheckTest.java
@@ -59,6 +59,8 @@ public class NoEnumTrailingCommaCheckTest extends AbstractModuleTestSupport {
             "180:21: " + getCheckMessage(MSG_KEY),
             "200:10: " + getCheckMessage(MSG_KEY),
             "244:55: " + getCheckMessage(MSG_KEY),
+            "249:9: " + getCheckMessage(MSG_KEY),
+            "252:9: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputNoEnumTrailingComma.java"), expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonInEnumerationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonInEnumerationCheckTest.java
@@ -56,6 +56,7 @@ public class UnnecessarySemicolonInEnumerationCheckTest extends AbstractModuleTe
             "46:9: " + getCheckMessage(MSG_SEMI),
             "51:33: " + getCheckMessage(MSG_SEMI),
             "55:9: " + getCheckMessage(MSG_SEMI),
+            "58:10: " + getCheckMessage(MSG_SEMI),
         };
 
         verify(checkConfig, getPath("InputUnnecessarySemicolonInEnumeration.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/noenumtrailingcomma/InputNoEnumTrailingComma.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/noenumtrailingcomma/InputNoEnumTrailingComma.java
@@ -244,4 +244,11 @@ public class InputNoEnumTrailingComma {
         A,B(){ public String toString() { return "";}},; //violation
         interface SomeInterface {}
     }
+
+    enum Foo45 {
+        , // violation
+    }
+    enum Foo46 {
+        ,; // violation
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicoloninenumeration/InputUnnecessarySemicolonInEnumeration.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessarysemicoloninenumeration/InputUnnecessarySemicolonInEnumeration.java
@@ -55,10 +55,16 @@ public class InputUnnecessarySemicolonInEnumeration{
         ; // violation
     }
     enum NoEnums2 {
+        ,; // violation
+    }
+    enum NoEnums3 {
         ;
         {}
     }
     enum EmptyEnum {
+    }
+    enum EmptyEnum2 {
+        ,
     }
     enum Normal {
         A,B;


### PR DESCRIPTION
Fixes for #8653

NoEnumTrailingCheck is rewritten to handle empty enums with only comma as well (there was no violation before since it inspected ENUM_CONSTANT_DEF token instead of ENUM_DEF).
UnnessaryEnumSemicolonCheck test inputs were extended with enum with only comma.

