### PR TITLE
Improve metadata code and coverage

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -1495,6 +1495,7 @@ xml
 xmlcatalog
 XMLHTTP
 xmllogger
+xmlmetareader
 xmlns
 xmlp
 xmlstarlet

--- a/config/sevntu_suppressions.xml
+++ b/config/sevntu_suppressions.xml
@@ -36,4 +36,8 @@
   so static Loggers are okay there. -->
   <suppress checks="AvoidModifiersForTypesCheck"
              files="Main\.java|MainTest\.java"/>
+
+  <!-- No need for constructor with cause -->
+  <suppress checks="CauseParameterInException" files=".*MetadataGenerationException\.java"/>
+
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -892,7 +892,9 @@
                     <exclude>com.puppycrawl.tools.checkstyle.gui.TreeTableCellRenderer*</exclude>
                     <exclude>com.puppycrawl.tools.checkstyle.gui.TreeTableModelAdapter*</exclude>
                     <!-- Metadata Generator related classes -->
-                    <exclude>com.puppycrawl.tools.checkstyle.meta.*</exclude>
+                    <exclude>com.puppycrawl.tools.checkstyle.meta.ModuleDetails*</exclude>
+                    <exclude>com.puppycrawl.tools.checkstyle.meta.JavadocMetadataScraper*</exclude>
+                    <exclude>com.puppycrawl.tools.checkstyle.meta.XmlMeta*</exclude>
                   </excludes>
                   <limits>
                     <limit>
@@ -1079,7 +1081,7 @@
                     <limit>
                       <counter>BRANCH</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.87</minimum>
+                      <minimum>0.95</minimum>
                     </limit>
                   </limits>
                 </rule>
@@ -1114,12 +1116,12 @@
                     <limit>
                       <counter>LINE</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.00</minimum>
+                      <minimum>0.74</minimum>
                     </limit>
                     <limit>
                       <counter>BRANCH</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.00</minimum>
+                      <minimum>0.71</minimum>
                     </limit>
                   </limits>
                 </rule>
@@ -1135,26 +1137,6 @@
                       <counter>LINE</counter>
                       <value>COVEREDRATIO</value>
                       <minimum>0.76</minimum>
-                    </limit>
-                  </limits>
-                </rule>
-                <rule>
-                  <element>CLASS</element>
-                  <includes>
-                    <include>
-                      com.puppycrawl.tools.checkstyle.meta.MetadataGeneratorUtil
-                    </include>
-                  </includes>
-                  <limits>
-                    <limit>
-                      <counter>LINE</counter>
-                      <value>COVEREDRATIO</value>
-                      <minimum>0.87</minimum>
-                    </limit>
-                    <limit>
-                      <counter>BRANCH</counter>
-                      <value>COVEREDRATIO</value>
-                      <minimum>0.90</minimum>
                     </limit>
                   </limits>
                 </rule>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/meta/MetadataGenerationException.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/meta/MetadataGenerationException.java
@@ -36,14 +36,4 @@ public class MetadataGenerationException extends RuntimeException {
         super(message);
     }
 
-    /**
-     * Creates a new {@code MetadataGenerationException} instance
-     * that was caused by another exception.
-     *
-     * @param message a message that explains this exception
-     * @param cause the Exception that is wrapped by this exception
-     */
-    public MetadataGenerationException(String message, Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java
@@ -40,6 +40,7 @@ import org.xml.sax.SAXException;
 
 /**
  * Class having utilities required to read module details from an XML metadata file of a module.
+ * This class is used by plugins that need load of metadata from XML files.
  */
 public final class XmlMetaReader {
 
@@ -119,27 +120,16 @@ public final class XmlMetaReader {
      */
     public static ModuleDetails read(InputStream moduleMetadataStream, ModuleType moduleType)
             throws ParserConfigurationException, IOException, SAXException {
-        final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        final DocumentBuilder builder = factory.newDocumentBuilder();
-        final Document document = builder.parse(moduleMetadataStream);
-        final Element root = document.getDocumentElement();
-        final Element element = getDirectChildsByTag(root, "module").get(0);
-        Element module = null;
-        final ModuleDetails moduleDetails = new ModuleDetails();
-        if (moduleType == ModuleType.CHECK) {
-            module = getDirectChildsByTag(element, "check").get(0);
-            moduleDetails.setModuleType(ModuleType.CHECK);
-        }
-        else if (moduleType == ModuleType.FILTER) {
-            module = getDirectChildsByTag(element, "filter").get(0);
-            moduleDetails.setModuleType(ModuleType.FILTER);
-        }
-        else if (moduleType == ModuleType.FILEFILTER) {
-            module = getDirectChildsByTag(element, "file-filter").get(0);
-            moduleDetails.setModuleType(ModuleType.FILEFILTER);
-        }
         ModuleDetails result = null;
-        if (module != null) {
+        if (moduleType != null) {
+            final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            final DocumentBuilder builder = factory.newDocumentBuilder();
+            final Document document = builder.parse(moduleMetadataStream);
+            final Element root = document.getDocumentElement();
+            final Element element = getDirectChildsByTag(root, "module").get(0);
+            final ModuleDetails moduleDetails = new ModuleDetails();
+            final Element module = getDirectChildsByTag(element, moduleType.getLabel()).get(0);
+            moduleDetails.setModuleType(moduleType);
             result = createModule(module, moduleDetails);
         }
         return result;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReaderTest.java
@@ -1,0 +1,151 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2021 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.meta;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+
+public class XmlMetaReaderTest extends AbstractPathTestSupport {
+
+    @Override
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/meta/xmlmetareader";
+    }
+
+    @Test
+    public void testReadXmlMetaCheckWithProperties() throws Exception {
+        final String path = getPath("InputXmlMetaReaderCheckWithProps.xml");
+        try (InputStream is = Files.newInputStream(Paths.get(path))) {
+            final ModuleDetails result = XmlMetaReader.read(is, ModuleType.CHECK);
+            checkModuleProps(result, ModuleType.CHECK, "Some description for check",
+                "com.puppycrawl.tools.checkstyle.checks.misc.InputCheck",
+                "com.puppycrawl.tools.checkstyle.TreeWalker");
+            assertThat(result.getName()).isEqualTo("InputCheck");
+            final List<String> violationMessageKeys = result.getViolationMessageKeys();
+            assertThat(violationMessageKeys.size()).isEqualTo(1);
+            assertThat(violationMessageKeys.get(0)).isEqualTo("test.key");
+            final List<ModulePropertyDetails> props = result.getProperties();
+            assertThat(props.size()).isEqualTo(2);
+            final ModulePropertyDetails prop1 = props.get(0);
+            checkProperty(prop1, "propertyOne", "java.lang.String",
+                "propertyOneDefaultValue",
+                "Property wrapped\n            description.");
+            assertThat(prop1.getValidationType()).isNull();
+
+            final ModulePropertyDetails prop2 = props.get(1);
+            checkProperty(prop2, "propertyTwo", "java.lang.String[]",
+                "", "Property two desc");
+            assertThat(prop2.getValidationType()).isEqualTo("tokenTypesSet");
+        }
+    }
+
+    @Test
+    public void testReadXmlMetaCheckNoProperties() throws Exception {
+        final String path = getPath("InputXmlMetaReaderCheckNoProps.xml");
+        try (InputStream is = Files.newInputStream(Paths.get(path))) {
+            final ModuleDetails result = XmlMetaReader.read(is, ModuleType.CHECK);
+            checkModuleProps(result, ModuleType.CHECK,
+                "Some description for check with no properties",
+                "com.puppycrawl.tools.checkstyle.checks.misc.InputCheckNoProps",
+                "com.puppycrawl.tools.checkstyle.TreeWalker");
+            assertThat(result.getName()).isEqualTo("InputCheckNoProps");
+            final List<String> violationMessageKeys = result.getViolationMessageKeys();
+            assertThat(violationMessageKeys.size()).isEqualTo(2);
+            assertThat(violationMessageKeys.get(0)).isEqualTo("test.key1");
+            assertThat(violationMessageKeys.get(1)).isEqualTo("test.key2");
+            assertThat(result.getProperties().isEmpty()).isTrue();
+        }
+    }
+
+    @Test
+    public void testReadXmlMetaFilter() throws Exception {
+        final String path = getPath("InputXmlMetaReaderFilter.xml");
+        try (InputStream is = Files.newInputStream(Paths.get(path))) {
+            final ModuleDetails result = XmlMetaReader.read(is, ModuleType.FILTER);
+            checkModuleProps(result, ModuleType.FILTER, "Description for filter",
+                "com.puppycrawl.tools.checkstyle.filters.SomeFilter",
+                "com.puppycrawl.tools.checkstyle.TreeWalker");
+            assertThat(result.getName()).isEqualTo("SomeFilter");
+            assertThat(result.getViolationMessageKeys().isEmpty()).isTrue();
+            final List<ModulePropertyDetails> props = result.getProperties();
+            assertThat(props.size()).isEqualTo(1);
+            final ModulePropertyDetails prop1 = props.get(0);
+            checkProperty(prop1, "propertyOne", "java.util.regex.Pattern",
+                "propertyDefaultValue", "Property description.");
+            assertThat(prop1.getValidationType()).isNull();
+        }
+    }
+
+    @Test
+    public void testReadXmlMetaFileFilter() throws Exception {
+        final String path = getPath("InputXmlMetaReaderFileFilter.xml");
+        try (InputStream is = Files.newInputStream(Paths.get(path))) {
+            final ModuleDetails result = XmlMetaReader.read(is, ModuleType.FILEFILTER);
+            checkModuleProps(result, ModuleType.FILEFILTER,
+                "File filter description",
+                "com.puppycrawl.tools.checkstyle.filefilters.FileFilter",
+                "com.puppycrawl.tools.checkstyle.Checker");
+            assertThat(result.getName()).isEqualTo("FileFilter");
+            assertThat(result.getViolationMessageKeys().isEmpty()).isTrue();
+            final List<ModulePropertyDetails> props = result.getProperties();
+            assertThat(props.size()).isEqualTo(1);
+            final ModulePropertyDetails prop1 = props.get(0);
+            assertThat(prop1.getName()).isEqualTo("fileNamePattern");
+            assertThat(prop1.getType()).isEqualTo("java.util.regex.Pattern");
+            assertThat(prop1.getDefaultValue()).isNull();
+            assertThat(prop1.getValidationType()).isNull();
+            assertThat(prop1.getDescription())
+                .isEqualTo("Define regular expression to match the file name against.");
+        }
+    }
+
+    @Test
+    public void testReadXmlMetaModuleTypeNull() throws Exception {
+        try (InputStream is = IOUtils.toInputStream("", "UTF-8")) {
+            assertThat(XmlMetaReader.read(is, null)).isNull();
+        }
+    }
+
+    private static void checkModuleProps(ModuleDetails result, ModuleType moduleType,
+                                         String description,
+                                         String fullName, String parent) {
+        assertThat(result.getModuleType()).isEqualTo(moduleType);
+        assertThat(result.getDescription()).isEqualTo(description);
+        assertThat(result.getFullQualifiedName()).isEqualTo(fullName);
+        assertThat(result.getParent()).isEqualTo(parent);
+    }
+
+    private static void checkProperty(ModulePropertyDetails prop, String name,
+                                      String type, String defaultValue, String description) {
+        assertThat(prop.getName()).isEqualTo(name);
+        assertThat(prop.getType()).isEqualTo(type);
+        assertThat(prop.getDefaultValue()).isEqualTo(defaultValue);
+        assertThat(prop.getDescription()).isEqualTo(description);
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/meta/xmlmetareader/InputXmlMetaReaderCheckNoProps.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/meta/xmlmetareader/InputXmlMetaReaderCheckNoProps.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle-metadata>
+  <module>
+    <check fully-qualified-name="com.puppycrawl.tools.checkstyle.checks.misc.InputCheckNoProps"
+           name="InputCheckNoProps"
+           parent="com.puppycrawl.tools.checkstyle.TreeWalker">
+      <description>Some description for check with no properties</description>
+      <message-keys>
+        <message-key key="test.key1"/>
+        <message-key key="test.key2"/>
+      </message-keys>
+    </check>
+  </module>
+</checkstyle-metadata>
+

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/meta/xmlmetareader/InputXmlMetaReaderCheckWithProps.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/meta/xmlmetareader/InputXmlMetaReaderCheckWithProps.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle-metadata>
+  <module>
+    <check fully-qualified-name="com.puppycrawl.tools.checkstyle.checks.misc.InputCheck"
+           name="InputCheck"
+           parent="com.puppycrawl.tools.checkstyle.TreeWalker">
+      <description>Some description for check</description>
+      <properties>
+        <property default-value="propertyOneDefaultValue"
+                  name="propertyOne"
+                  type="java.lang.String">
+          <description>Property wrapped
+            description.</description>
+        </property>
+        <property default-value=""
+                  name="propertyTwo"
+                  type="java.lang.String[]"
+                  validation-type="tokenTypesSet">
+          <description>Property two desc</description>
+        </property>
+      </properties>
+      <message-keys>
+        <message-key key="test.key"/>
+      </message-keys>
+    </check>
+  </module>
+</checkstyle-metadata>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/meta/xmlmetareader/InputXmlMetaReaderFileFilter.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/meta/xmlmetareader/InputXmlMetaReaderFileFilter.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle-metadata>
+  <module>
+    <file-filter fully-qualified-name="com.puppycrawl.tools.checkstyle.filefilters.FileFilter"
+                 name="FileFilter"
+                 parent="com.puppycrawl.tools.checkstyle.Checker">
+      <description>File filter description</description>
+      <properties>
+        <property name="fileNamePattern" type="java.util.regex.Pattern">
+          <description>Define regular expression to match the file name against.</description>
+        </property>
+      </properties>
+    </file-filter>
+  </module>
+</checkstyle-metadata>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/meta/xmlmetareader/InputXmlMetaReaderFilter.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/meta/xmlmetareader/InputXmlMetaReaderFilter.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<checkstyle-metadata>
+  <module>
+    <filter fully-qualified-name="com.puppycrawl.tools.checkstyle.filters.SomeFilter"
+            name="SomeFilter"
+            parent="com.puppycrawl.tools.checkstyle.TreeWalker">
+      <description>Description for filter</description>
+      <properties>
+        <property default-value="propertyDefaultValue"
+                  name="propertyOne"
+                  type="java.util.regex.Pattern">
+          <description>Property description.</description>
+        </property>
+      </properties>
+    </filter>
+  </module>
+</checkstyle-metadata>


### PR DESCRIPTION
Relates to #8771

1. Some unnecessary null checks has been removed
2. Added tests for XmlMetaReader
3. Constructor with cause in MetadataGenerationException is removed + suppression added, since this ctor is not used anywhere and there is no need for it.
4. Coverage data is changed, exclude list is changed to have only specific classes instead of whole meta package