### PR TITLE
Issue #7635: Update doc for DeclarationOrder

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
@@ -89,36 +89,89 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * <pre>
  * &lt;module name=&quot;DeclarationOrder&quot;/&gt;
  * </pre>
- * <p>
- * With default options:
- * </p>
+ * <p>Example:</p>
  * <pre>
- * class K {
- *   int a;
- *   void m(){}
- *   K(){}  &lt;-- &quot;Constructor definition in wrong order&quot;
- *   int b; &lt;-- &quot;Instance variable definition in wrong order&quot;
+ * public class Test {
+ *
+ *   public int a;
+ *   protected int b;
+ *   public int c;            // violation, variable access definition in wrong order
+ *
+ *   Test() {
+ *     this.a = 0;
+ *   }
+ *
+ *   public void foo() {
+ *     // This method does nothing
+ *   }
+ *
+ *   Test(int a) {            // violation, constructor definition in wrong order
+ *     this.a = a;
+ *   }
+ *
+ *   private String name;     // violation, instance variable declaration in wrong order
  * }
  * </pre>
  * <p>
- * With <b>ignoreConstructors</b> option:
+ * To configure the check to ignore validation of constructors:
  * </p>
  * <pre>
- * class K {
- *   int a;
- *   void m(){}
- *   K(){}
- *   int b; &lt;-- &quot;Instance variable definition in wrong order&quot;
+ * &lt;module name=&quot;DeclarationOrder&quot;&gt;
+ *   &lt;property name=&quot;ignoreConstructors&quot; value=&quot;true&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public class Test {
+ *
+ *   public int a;
+ *   protected int b;
+ *   public int c;            // violation, variable access definition in wrong order
+ *
+ *   Test() {
+ *     this.a = 0;
+ *   }
+ *
+ *   public void foo() {
+ *     // This method does nothing
+ *   }
+ *
+ *   Test(int a) {            // OK, validation of constructors ignored
+ *     this.a = a;
+ *   }
+ *
+ *   private String name;     // violation, instance variable declaration in wrong order
  * }
  * </pre>
  * <p>
- * With <b>ignoreConstructors</b> option and without a method definition in a source class:
+ * To configure the check to ignore modifiers:
  * </p>
  * <pre>
- * class K {
- *   int a;
- *   K(){}
- *   int b; &lt;-- &quot;Instance variable definition in wrong order&quot;
+ * &lt;module name=&quot;DeclarationOrder&quot;&gt;
+ *   &lt;property name=&quot;ignoreModifiers&quot; value=&quot;true&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public class Test {
+ *
+ *   public int a;
+ *   protected int b;
+ *   public int c;            // OK, access modifiers not considered while validating
+ *
+ *   Test() {
+ *     this.a = 0;
+ *   }
+ *
+ *   public void foo() {
+ *     // This method does nothing
+ *   }
+ *
+ *   Test(int a) {            // violation, constructor definition in wrong order
+ *     this.a = a;
+ *   }
+ *
+ *   private String name;     // violation, instance variable declaration in wrong order
  * }
  * </pre>
  * <p>

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -724,37 +724,89 @@ public class A {
         <source>
 &lt;module name=&quot;DeclarationOrder&quot;/&gt;
         </source>
+        <p>Example:</p>
+        <source>
+public class Test {
 
-        <p>
-          With default options:
-        </p>
-        <source>
-class K {
-  int a;
-  void m(){}
-  K(){}  &lt;-- "Constructor definition in wrong order"
-  int b; &lt;-- "Instance variable definition in wrong order"
+  public int a;
+  protected int b;
+  public int c;            // violation, variable access definition in wrong order
+
+  Test() {
+    this.a = 0;
+  }
+
+  public void foo() {
+    // This method does nothing
+  }
+
+  Test(int a) {            // violation, constructor definition in wrong order
+    this.a = a;
+  }
+
+  private String name;     // violation, instance variable declaration in wrong order
 }
         </source>
         <p>
-          With <b>ignoreConstructors</b> option:
+          To configure the check to ignore validation of constructors:
         </p>
         <source>
-class K {
-  int a;
-  void m(){}
-  K(){}
-  int b; &lt;-- "Instance variable definition in wrong order"
+&lt;module name=&quot;DeclarationOrder&quot;&gt;
+  &lt;property name=&quot;ignoreConstructors&quot; value=&quot;true&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+
+  public int a;
+  protected int b;
+  public int c;            // violation, variable access definition in wrong order
+
+  Test() {
+    this.a = 0;
+  }
+
+  public void foo() {
+    // This method does nothing
+  }
+
+  Test(int a) {            // OK, validation of constructors ignored
+    this.a = a;
+  }
+
+  private String name;     // violation, instance variable declaration in wrong order
 }
         </source>
         <p>
-          With <b>ignoreConstructors</b> option and without a method definition in a source class:
+          To configure the check to ignore modifiers:
         </p>
         <source>
-class K {
-  int a;
-  K(){}
-  int b; &lt;-- "Instance variable definition in wrong order"
+&lt;module name=&quot;DeclarationOrder&quot;&gt;
+  &lt;property name=&quot;ignoreModifiers&quot; value=&quot;true&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+
+  public int a;
+  protected int b;
+  public int c;            // OK, access modifiers not considered while validating
+
+  Test() {
+    this.a = 0;
+  }
+
+  public void foo() {
+    // This method does nothing
+  }
+
+  Test(int a) {            // violation, constructor definition in wrong order
+    this.a = a;
+  }
+
+  private String name;     // violation, instance variable declaration in wrong order
 }
         </source>
       </subsection>


### PR DESCRIPTION
Resolves #7635.
Website after update - 
![image](https://user-images.githubusercontent.com/58329164/107004451-4f787280-67b4-11eb-9a18-abf5c5e541a6.png)
![image](https://user-images.githubusercontent.com/58329164/107004563-7cc52080-67b4-11eb-877b-0809dfb5db56.png)
![image](https://user-images.githubusercontent.com/58329164/107004502-63bc6f80-67b4-11eb-95e9-73b1ec6cd5cc.png)

### Default config - ###
`$ cat conifg.xml`
```xml
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">		
  <module name="TreeWalker">
    <module name="DeclarationOrder"/>
  </module>
</module>
```

`$ cat Test.java`
```java
public class Test {

  public int a;
  protected int b;
  public int c;            // violation, variable access definition in wrong order

  Test() {
    this.a = 0;
    this.b = 0;
    this.c = 0;
    this.name = "";
  }

  public void foo() {
    // This method does nothing
  }

  Test(int a, int b, int c, String name) {   // violation, constructor definition in wrong order
    this.a = a;
    this.b = b;
    this.c = c;
    this.name = name;
  }

  private String name;     // violation, instance variable declaration in wrong order
}
```

`$ java com.puppycrawl.tools.checkstyle.Main -c config.xml Test.java`
```
Starting audit...
[ERROR] /home/ayushman/Desktop/Checkstyle Experiments/DeclarationOrder/Test.java:5:3: Variable access definition in wrong order. [DeclarationOrder]
[ERROR] /home/ayushman/Desktop/Checkstyle Experiments/DeclarationOrder/Test.java:18:3: Constructor definition in wrong order. [DeclarationOrder]
[ERROR] /home/ayushman/Desktop/Checkstyle Experiments/DeclarationOrder/Test.java:25:3: Instance variable definition in wrong order. [DeclarationOrder]
Audit done.
Checkstyle ends with 3 errors.
```

### Config which ignores validation of constructors - ###
`$ cat conifg.xml`
```xml
<module name="DeclarationOrder">
  <property name="ignoreConstructors" value="true"/>
</module>
```

`$ cat Test.java`
```java
public class Test {

  public int a;
  protected int b;
  public int c;            // violation, variable access definition in wrong order

  Test() {
    this.a = 0;
    this.b = 0;
    this.c = 0;
    this.name = "";
  }

  public void foo() {
    // This method does nothing
  }

  Test(int a, int b, int c, String name) {   // OK, validation of constructors ignored
    this.a = a;
    this.b = b;
    this.c = c;
    this.name = name;
  }

  private String name;     // violation, instance variable declaration in wrong order
}
```

`$ java com.puppycrawl.tools.checkstyle.Main -c config.xml Test.java`
```
Starting audit...
[ERROR] /home/ayushman/Desktop/Checkstyle Experiments/DeclarationOrder/Test.java:5:3: Variable access definition in wrong order. [DeclarationOrder]
[ERROR] /home/ayushman/Desktop/Checkstyle Experiments/DeclarationOrder/Test.java:25:3: Instance variable definition in wrong order. [DeclarationOrder]
Audit done.
Checkstyle ends with 2 errors.
```

### Config which ignores access modifiers while validating - ###
`$ cat config.xml`
```xml
<module name="DeclarationOrder">
  <property name="ignoreModifiers" value="true"/>
</module>
```

`$ cat Test,java`
```java
ublic class Test {

  public int a;
  protected int b;
  public int c;            // OK, access modifiers not considered while validating

  Test() {
    this.a = 0;
    this.b = 0;
    this.c = 0;
    this.name = "";
  }

  public void foo() {
    // This method does nothing
  }

  Test(int a, int b, int c, String name) {   // violation, constructor definition in wrong order
    this.a = a;
    this.b = b;
    this.c = c;
    this.name = name;
  }

  private String name;     // violation, instance variable declaration in wrong order
}
```

`$ java com.puppycrawl.tools.checkstyle.Main -c config.xml Test.java`
```
Starting audit...
[ERROR] /home/ayushman/Desktop/Checkstyle Experiments/DeclarationOrder/Test.java:18:3: Constructor definition in wrong order. [DeclarationOrder]
[ERROR] /home/ayushman/Desktop/Checkstyle Experiments/DeclarationOrder/Test.java:25:3: Instance variable definition in wrong order. [DeclarationOrder]
Audit done.
Checkstyle ends with 2 errors.
```