### PR TITLE
Issue #7656: Update doc for RequireThis

### DIFF
--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -5830,55 +5830,112 @@ public class AnnotationLocationCheck extends AbstractCheck {
         <source>
 &lt;module name=&quot;RequireThis&quot;/&gt;
         </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+  private int a;
+  private int b;
+  private int c;
 
+  public Test(int a) {
+    // overlapping by constructor argument
+    this.a = a;       // OK, this keyword used
+    b = 0;            // OK, no overlap
+    foo(5);           // OK
+  }
+
+  public void foo(int c) {
+    // overlapping by method argument
+    c = c;            // violation, reference to instance variable "c" requires "this"
+  }
+}
+        </source>
         <p>
-          To configure to check the <code>this</code> qualifier for fields only:
+          To configure the check for fields only:
         </p>
         <source>
 &lt;module name="RequireThis"&gt;
   &lt;property name=&quot;checkMethods&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
         </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+  private int a;
+  private int b;
+  private int c;
 
+  public Test(int a) {
+    // overlapping by constructor argument
+    this.a = a;       // OK, this keyword used
+    b = 0;            // OK, no overlap
+    foo(5);           // OK, no validation for methods
+  }
+
+  public void foo(int c) {
+    // overlapping by method argument
+    c = c;            // violation, reference to instance variable "c" requires "this"
+  }
+}
+        </source>
         <p>
-          Examples of how the check works if validateOnlyOverlapping option is set to true:
+            To configure the check for methods only:
         </p>
         <source>
-public static class A {
-  private int field1;
-  private int field2;
+&lt;module name="RequireThis"&gt;
+  &lt;property name=&quot;checkFields&quot; value=&quot;false&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+  private int a;
+  private int b;
+  private int c;
 
-  public A(int field1) {
-    // Overlapping by constructor argument.
-    field1 = field1; // violation: Reference to instance variable "field1" needs "this".
-    field2 = 0;
+  public Test(int a) {
+    // overlapping by constructor argument
+    this.a = a;       // OK, no validation for fields
+    b = 0;            // OK, no validation for fields
+    foo(5);           // OK, no overlap
   }
 
-  void foo3() {
-    String field1 = "values";
-    // Overlapping by local variable.
-    field1 = field1; // violation:  Reference to instance variable "field1" needs "this".
-  }
-}
-
-public static class B {
-  private int field;
-
-  public A(int f) {
-    field = f;
-  }
-
-  String addSuffixToField(String field) {
-    // Overlapping by method argument. Equal to "return field = field + "suffix";"
-    return field += "suffix"; // violation: Reference to instance variable "field" needs "this".
+  public void foo(int c) {
+    // overlapping by method argument
+    c = c;            // OK, no validation for fields
   }
 }
+        </source>
+        <p>
+          Note that method call foo(5) does not raise a violation
+          because methods cannot be overlapped in java.
+        </p>
+        <p>
+            To configure the check to validate for non-overlapping fields and methods:
+        </p>
+        <source>
+&lt;module name="RequireThis"&gt;
+  &lt;property name=&quot;validateOnlyOverlapping&quot; value=&quot;false&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public class Test {
+  private int a;
+  private int b;
+  private int c;
 
-public static record C(int x) {
-    void getTwoX(int x) {
-        // Overlapping by method argument.
-        return x += x; // violation: Reference to instance variable "x" needs "this".
-    }
+  public Test(int a) {
+    // overlapping by constructor argument
+    this.a = a;       // OK, no validation for fields
+    b = 0;            // violation, reference to instance variable "b" requires "this"
+    foo(5);           // violation, method call "foo(5)" requires "this"
+  }
+
+  public void foo(int c) {
+    // overlapping by method argument
+    c = c;            // violation, reference to instance variable "c" requires "this"
+  }
 }
         </source>
         <p>
@@ -5892,10 +5949,12 @@ public static record C(int x) {
 public class C {
   private int scale;
   private int x;
+
   public void foo(int scale) {
-    scale = this.scale; // no violation
+    scale = this.scale;      // no violation
+
     if (scale > 0) {
-      scale = -scale; // no violation
+      scale = -scale;        // no violation
     }
     x *= scale;
   }
@@ -5908,63 +5967,11 @@ public class C {
         <source>
 public class D {
   private String prefix;
+
   public String modifyPrefix(String prefix) {
-    prefix = "^" + prefix + "$" // no violation (modification of parameter)
-    return prefix; // modified method parameter is returned from the method
+    prefix = "^" + prefix + "$";  // no violation, because method parameter is returned
+    return prefix;
   }
-}
-        </source>
-        <p>
-          Examples of how the check works if validateOnlyOverlapping option is set to false:
-        </p>
-        <source>
-public static class A {
-  private int field1;
-  private int field2;
-
-  public A(int field1) {
-    field1 = field1; // violation: Reference to instance variable "field1" needs "this".
-    field2 = 0; // violation: Reference to instance variable "field2" needs "this".
-    String field2;
-    field2 = "0"; // No violation. Local var allowed
-  }
-
-  void foo3() {
-    String field1 = "values";
-    field1 = field1; // violation:  Reference to instance variable "field1" needs "this".
-  }
-}
-
-public static class B {
-  private int field;
-
-  public A(int f) {
-    field = f; // violation:  Reference to instance variable "field" needs "this".
-  }
-
-  String addSuffixToField(String field) {
-    return field += "suffix"; // violation: Reference to instance variable "field" needs "this".
-  }
-}
-
-// If the variable is locally defined, there won't be a violation provided the variable
-// doesn't overlap.
-class C {
-  private String s1 = "foo1";
-  String s2 = "foo2";
-
-  C() {
-    s1 = "bar1"; // Violation. Reference to instance variable 's1' needs "this.".
-    String s2;
-    s2 = "bar2"; // No violation. Local var allowed.
-    s2 += s2; // Violation. Overlapping. Reference to instance variable 's2' needs "this.".
-  }
-}
-
-public static record D(int x) {
-    public D {
-        x = x; // violation: Reference to instance variable "x" needs "this".
-    }
 }
         </source>
       </subsection>


### PR DESCRIPTION
Resolves #7656 
Website after update - 
![image](https://user-images.githubusercontent.com/58329164/107116638-b53f2a00-689a-11eb-803e-b890c22fdddf.png)
![image](https://user-images.githubusercontent.com/58329164/107116656-c2f4af80-689a-11eb-881c-53c09d521470.png)
![image](https://user-images.githubusercontent.com/58329164/107116662-cf790800-689a-11eb-9625-f128f7a5916d.png)

### Default config - ###
`$ cat check_config.xml`
```xml                 
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">		
  <module name="TreeWalker">
    <module name="RequireThis">
    </module>
  </module>
</module>
```

`$ cat Test.java`
```java
public class Test {
  private int a;
  private int b;
  private int c;

  public Test(int a) {
    // overlapping by constructor argument
    this.a = a;       // OK, this keyword used
    b = 0;            // OK, no overlap
    foo(arg);         // OK, no overlap
  }

  public void foo(int c) {
    // overlapping by method argument
    c = c;            // violation, reference to instance variable "c" requires "this"
  }
}
```

`$ java com.puppycrawl.tools.checkstyle.Main -c check_config.xml Test.java`
```
Starting audit...
[ERROR] /home/ayushman/Desktop/Checkstyle Experiments/RequireThis/Test.java:15:5: Reference to instance variable 'c' needs "this.". [RequireThis]
Audit done.
Checkstyle ends with 1 errors.
```

### Config to check only fields - ###
**(with validateOnlyOverlapping set to false)**

`$ cat check_config.xml`
```xml
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">		
  <module name="TreeWalker">
    <module name="RequireThis">
      <property name="checkMethods" value="false"/>
      <property name="validateOnlyOverlapping" value="false"/>
    </module>
  </module>
</module>
```

`$ cat Test.java`
```java
public class Test {
  private int a;
  private int b;
  private int c;

  public Test(int a) {
    // overlapping by constructor argument
    this.a = a;       // OK, this keyword used
    b = 0;            // violation, reference to instance variable "b" requires "this"
    foo(arg);         // OK, no validation for methods
  }

  public void foo(int c) {
    // overlapping by method argument
    c = c;            // violation, reference to instance variable "c" requires "this"
  }
}
```

`$ java com.puppycrawl.tools.checkstyle.Main -c check_config.xml Test.java`
```
Starting audit...
[ERROR] /home/ayushman/Desktop/Checkstyle Experiments/RequireThis/Test.java:9:5: Reference to instance variable 'b' needs "this.". [RequireThis]
[ERROR] /home/ayushman/Desktop/Checkstyle Experiments/RequireThis/Test.java:15:5: Reference to instance variable 'c' needs "this.". [RequireThis]
Audit done.
Checkstyle ends with 2 errors.
```

### Config to check only methods - ###
**(with validateOnlyOverlapping set to false)**

`$ cat check_config.xml`
```xml
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">		
  <module name="TreeWalker">
    <module name="RequireThis">
      <property name="checkFields" value="false"/>
      <property name="validateOnlyOverlapping" value="false"/>
    </module>
  </module>
</module>
```

`$ cat Test.java`
```java
public class Test {
  private int a;
  private int b;
  private int c;

  public Test(int a) {
    // overlapping by constructor argument
    this.a = a;       // OK, no validation for fields
    b = 0;            // OK, no validation for fields
    foo(arg);         // violation, method call to "foo" requires "this"
  }

  public void foo(int c) {
    // overlapping by method argument
    c = c;            // OK, no validation for fields
  }
}
```

`$ java com.puppycrawl.tools.checkstyle.Main -c check_config.xml Test.java`
```
Starting audit...
[ERROR] /home/ayushman/Desktop/Checkstyle Experiments/RequireThis/Test.java:10:5: Method call to 'foo' needs "this.". [RequireThis]
Audit done.
Checkstyle ends with 1 errors.
```