### PR TITLE
Issue #6893: Generate Xpath Suppresion on escape xml symbols

### DIFF
--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -110,4 +110,7 @@
   <suppress id="noIndentationConfigExamples"
     files="[\\/]src[\\/]xdocs[\\/]beginning_development.xml"/>
 
+  <!-- Usage of unicode characters to assert the functioning of Xpath on escape character.  -->
+  <suppress id="RegexpSinglelineJava" files="[\\/]XpathQueryGeneratorTest.java"/>
+
 </suppressions>

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMatchXpathTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMatchXpathTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenCheck;
 import com.puppycrawl.tools.checkstyle.checks.coding.MatchXpathCheck;
 
 public class XpathRegressionMatchXpathTest extends AbstractXpathTestSupport {
@@ -86,5 +87,331 @@ public class XpathRegressionMatchXpathTest extends AbstractXpathTestSupport {
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
+    }
+
+    @Test
+    public void testEncodedQuoteString() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionMatchXpathEncodedQuoteString.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(IllegalTokenCheck.class);
+        moduleConfig.addAttribute("tokens", "STRING_LITERAL");
+
+        final String[] expectedViolation = {
+            "4:24: " + getCheckMessage(IllegalTokenCheck.class, IllegalTokenCheck.MSG_KEY,
+                    "\"\\\"testOne\\\"\""),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncodedQuoteString']]/"
+                    + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='quoteChar']]/ASSIGN/EXPR"
+                    + "[./STRING_LITERAL[@text='\\&quot;testOne\\&quot;']]",
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncodedQuoteString']]/"
+                    + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='quoteChar']]/ASSIGN/EXPR"
+                    + "/STRING_LITERAL[@text='\\&quot;testOne\\&quot;']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testEncodedLessString() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionMatchXpathEncodedLessString.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(IllegalTokenCheck.class);
+        moduleConfig.addAttribute("tokens", "STRING_LITERAL");
+
+        final String[] expectedViolation = {
+            "4:23: " + getCheckMessage(IllegalTokenCheck.class, IllegalTokenCheck.MSG_KEY,
+                    "\"<testTwo\""),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncodedLessString']]/"
+                    + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='lessChar']]/ASSIGN/EXPR"
+                    + "[./STRING_LITERAL[@text='&lt;testTwo']]",
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncodedLessString']]/"
+                    + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='lessChar']]/ASSIGN/EXPR/"
+                    + "STRING_LITERAL[@text='&lt;testTwo']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testEncodedNewLineString() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionMatchXpathEncodedNewLineString.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(IllegalTokenCheck.class);
+        moduleConfig.addAttribute("tokens", "STRING_LITERAL");
+
+        final String[] expectedViolation = {
+            "4:26: " + getCheckMessage(IllegalTokenCheck.class, IllegalTokenCheck.MSG_KEY,
+                    "\"testFive\\n\""),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncodedNewLineString']]/"
+                    + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='newLineChar']]/ASSIGN/EXPR"
+                    + "[./STRING_LITERAL[@text='testFive\\n']]",
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncodedNewLineString']]/"
+                    + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='newLineChar']]/ASSIGN/EXPR"
+                    + "/STRING_LITERAL[@text='testFive\\n']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testGreaterString() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionMatchXpathEncodedGreaterString.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(IllegalTokenCheck.class);
+        moduleConfig.addAttribute("tokens", "STRING_LITERAL");
+
+        final String[] expectedViolation = {
+            "4:26: " + getCheckMessage(IllegalTokenCheck.class, IllegalTokenCheck.MSG_KEY,
+                    "\">testFour\""),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncodedGreaterString']]/"
+                    + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='greaterChar']]/ASSIGN/EXPR"
+                    + "[./STRING_LITERAL[@text='&gt;testFour']]",
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncodedGreaterString']]/"
+                    + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='greaterChar']]/ASSIGN/EXPR"
+                    + "/STRING_LITERAL[@text='&gt;testFour']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testEncodedAmpString() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionMatchXpathEncodedAmpString.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(IllegalTokenCheck.class);
+        moduleConfig.addAttribute("tokens", "STRING_LITERAL");
+
+        final String[] expectedViolation = {
+            "4:28: " + getCheckMessage(IllegalTokenCheck.class, IllegalTokenCheck.MSG_KEY,
+                    "\"&testThree\""),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncodedAmpString']]/"
+                    + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='ampersandChar']]/ASSIGN/EXPR"
+                    + "[./STRING_LITERAL[@text='&amp;testThree']]",
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncodedAmpString']]/"
+                    + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='ampersandChar']]/ASSIGN/EXPR"
+                    + "/STRING_LITERAL[@text='&amp;testThree']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testEncodedAposString() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionMatchXpathEncodedAposString.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(IllegalTokenCheck.class);
+        moduleConfig.addAttribute("tokens", "STRING_LITERAL");
+
+        final String[] expectedViolation = {
+            "4:23: " + getCheckMessage(IllegalTokenCheck.class, IllegalTokenCheck.MSG_KEY,
+                    "\"'SingleQuoteOnBothSide'\""),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncodedAposString']]/"
+                    + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='aposChar']]/ASSIGN/EXPR"
+                    + "[./STRING_LITERAL[@text='&apos;&apos;SingleQuoteOnBothSide&apos;&apos;']]",
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncodedAposString']]/"
+                    + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='aposChar']]/ASSIGN/EXPR"
+                    + "/STRING_LITERAL[@text='&apos;&apos;SingleQuoteOnBothSide&apos;&apos;']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testEncodedCarriageString() throws Exception {
+        final File fileToProcess =
+            new File(getPath("SuppressionXpathRegressionMatchXpathEncodedCarriageString.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(IllegalTokenCheck.class);
+        moduleConfig.addAttribute("tokens", "STRING_LITERAL");
+
+        final String[] expectedViolation = {
+            "4:27: " + getCheckMessage(IllegalTokenCheck.class, IllegalTokenCheck.MSG_KEY,
+                    "\"carriageCharAtEnd\\r\""),
+        };
+
+        final List<String> expectedXpathQueries = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncodedCarriage"
+                        + "String']]/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='carriageChar']]/ASSIGN"
+                        + "/EXPR[./STRING_LITERAL[@text='carriageCharAtEnd\\r']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncodedCarriage"
+                        + "String']]/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='carriageChar']]/ASSIGN"
+                        + "/EXPR/STRING_LITERAL[@text='carriageCharAtEnd\\r']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolation,
+                expectedXpathQueries);
+    }
+
+    @Test
+    public void testEncodedAmpersandChars() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionMatchXpathEncodedAmpChar.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(IllegalTokenCheck.class);
+        moduleConfig.addAttribute("tokens", "CHAR_LITERAL");
+
+        final String[] expectedViolationForAmpersand = {
+            "4:20: " + getCheckMessage(IllegalTokenCheck.class, IllegalTokenCheck.MSG_KEY,
+                    "'&'"),
+        };
+
+        final List<String> expectedXpathQueriesForAmpersand = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncodedAmpChar']]/"
+                        + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='ampChar']]/ASSIGN/EXPR"
+                        + "[./CHAR_LITERAL[@text='&apos;&apos;&amp;&apos;&apos;']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncodedAmpChar']]/"
+                        + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='ampChar']]/ASSIGN/EXPR"
+                        + "/CHAR_LITERAL[@text='&apos;&apos;&amp;&apos;&apos;']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolationForAmpersand,
+                expectedXpathQueriesForAmpersand);
+    }
+
+    @Test
+    public void testEncodedQuoteChar() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionMatchXpathEncodedQuotChar.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(IllegalTokenCheck.class);
+        moduleConfig.addAttribute("tokens", "CHAR_LITERAL");
+
+        final String[] expectedViolationsForQuote = {
+            "4:21: " + getCheckMessage(IllegalTokenCheck.class, IllegalTokenCheck.MSG_KEY,
+                    "'\\\"'"),
+        };
+
+        final List<String> expectedXpathQueriesForQuote = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncodedQuotChar']]/"
+                        + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='quotChar']]/ASSIGN/EXPR"
+                        + "[./CHAR_LITERAL[@text='&apos;&apos;\\&quot;&apos;&apos;']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncodedQuotChar']]/"
+                        + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='quotChar']]/ASSIGN/EXPR/"
+                        + "CHAR_LITERAL[@text='&apos;&apos;\\&quot;&apos;&apos;']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolationsForQuote,
+                expectedXpathQueriesForQuote);
+    }
+
+    @Test
+    public void testEncodedLessChar() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionMatchXpathEncodedLessChar.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(IllegalTokenCheck.class);
+        moduleConfig.addAttribute("tokens", "CHAR_LITERAL");
+
+        final String[] expectedViolationsForLess = {
+            "4:21: " + getCheckMessage(IllegalTokenCheck.class, IllegalTokenCheck.MSG_KEY,
+                    "'<'"),
+        };
+
+        final List<String> expectedXpathQueriesForLess = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncodedLessChar']]/"
+                        + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='lessChar']]/ASSIGN/EXPR"
+                        + "[./CHAR_LITERAL[@text='&apos;&apos;&lt;&apos;&apos;']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncodedLessChar']]/"
+                        + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='lessChar']]/ASSIGN/EXPR/"
+                        + "CHAR_LITERAL[@text='&apos;&apos;&lt;&apos;&apos;']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolationsForLess,
+                expectedXpathQueriesForLess);
+    }
+
+    @Test
+    public void testEncodedAposChar() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionMatchXpathEncodedAposChar.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(IllegalTokenCheck.class);
+        moduleConfig.addAttribute("tokens", "CHAR_LITERAL");
+
+        final String[] expectedViolationsForApos = {
+            "4:21: " + getCheckMessage(IllegalTokenCheck.class, IllegalTokenCheck.MSG_KEY,
+                    "'\\''"),
+        };
+
+        final List<String> expectedXpathQueriesForApos = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncodedAposChar']]/"
+                        + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='aposChar']]/ASSIGN/EXPR"
+                        + "[./CHAR_LITERAL[@text='&apos;&apos;\\&apos;&apos;&apos;&apos;']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncodedAposChar']]/"
+                        + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='aposChar']]/ASSIGN/EXPR/"
+                        + "CHAR_LITERAL[@text='&apos;&apos;\\&apos;&apos;&apos;&apos;']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolationsForApos,
+                expectedXpathQueriesForApos);
+    }
+
+    @Test
+    public void testEncodedGreaterChar() throws Exception {
+        final File fileToProcess =
+                new File(getPath("SuppressionXpathRegressionMatchXpathEncodedGreaterChar.java"));
+
+        final DefaultConfiguration moduleConfig =
+                createModuleConfig(IllegalTokenCheck.class);
+        moduleConfig.addAttribute("tokens", "CHAR_LITERAL");
+
+        final String[] expectedViolationsForGreater = {
+            "4:24: " + getCheckMessage(IllegalTokenCheck.class, IllegalTokenCheck.MSG_KEY,
+                    "'>'"),
+        };
+
+        final List<String> expectedXpathQueriesForGreater = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncoded"
+                        + "GreaterChar']]/"
+                        + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='greaterChar']]/ASSIGN/EXPR"
+                        + "[./CHAR_LITERAL[@text='&apos;&apos;&gt;&apos;&apos;']]",
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionMatchXpathEncoded"
+                        + "GreaterChar']]/"
+                        + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='greaterChar']]/ASSIGN/EXPR/"
+                        + "CHAR_LITERAL[@text='&apos;&apos;&gt;&apos;&apos;']"
+        );
+
+        runVerifications(moduleConfig, fileToProcess, expectedViolationsForGreater,
+                expectedXpathQueriesForGreater);
     }
 }

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedAmpChar.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedAmpChar.java
@@ -1,0 +1,5 @@
+package org.checkstyle.suppressionxpathfilter.matchxpath;
+
+public class SuppressionXpathRegressionMatchXpathEncodedAmpChar {
+    char ampChar = '&'; // warning
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedAmpString.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedAmpString.java
@@ -1,0 +1,5 @@
+package org.checkstyle.suppressionxpathfilter.matchxpath;
+
+public class SuppressionXpathRegressionMatchXpathEncodedAmpString {
+    String ampersandChar = "&testThree"; // warning
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedAposChar.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedAposChar.java
@@ -1,0 +1,5 @@
+package org.checkstyle.suppressionxpathfilter.matchxpath;
+
+public class SuppressionXpathRegressionMatchXpathEncodedAposChar {
+    char aposChar = '\''; // warning
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedAposString.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedAposString.java
@@ -1,0 +1,5 @@
+package org.checkstyle.suppressionxpathfilter.matchxpath;
+
+public class SuppressionXpathRegressionMatchXpathEncodedAposString {
+    String aposChar = "'SingleQuoteOnBothSide'"; // warning
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedCarriageString.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedCarriageString.java
@@ -1,0 +1,5 @@
+package org.checkstyle.suppressionxpathfilter.matchxpath;
+
+public class SuppressionXpathRegressionMatchXpathEncodedCarriageString {
+    String carriageChar = "carriageCharAtEnd\r"; // warning
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedGreaterChar.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedGreaterChar.java
@@ -1,0 +1,5 @@
+package org.checkstyle.suppressionxpathfilter.matchxpath;
+
+public class SuppressionXpathRegressionMatchXpathEncodedGreaterChar {
+    char greaterChar = '>'; // warning
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedGreaterString.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedGreaterString.java
@@ -1,0 +1,5 @@
+package org.checkstyle.suppressionxpathfilter.matchxpath;
+
+public class SuppressionXpathRegressionMatchXpathEncodedGreaterString {
+    String greaterChar = ">testFour"; // warning
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedLessChar.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedLessChar.java
@@ -1,0 +1,5 @@
+package org.checkstyle.suppressionxpathfilter.matchxpath;
+
+public class SuppressionXpathRegressionMatchXpathEncodedLessChar {
+    char lessChar = '<'; // warning
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedLessString.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedLessString.java
@@ -1,0 +1,5 @@
+package org.checkstyle.suppressionxpathfilter.matchxpath;
+
+public class SuppressionXpathRegressionMatchXpathEncodedLessString {
+    String lessChar = "<testTwo"; // warning
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedNewLineString.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedNewLineString.java
@@ -1,0 +1,5 @@
+package org.checkstyle.suppressionxpathfilter.matchxpath;
+
+public class SuppressionXpathRegressionMatchXpathEncodedNewLineString {
+    String newLineChar = "testFive\n"; // warning
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedQuotChar.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedQuotChar.java
@@ -1,0 +1,5 @@
+package org.checkstyle.suppressionxpathfilter.matchxpath;
+
+public class SuppressionXpathRegressionMatchXpathEncodedQuotChar {
+    char quotChar = '\"'; // warning
+}

--- a/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedQuoteString.java
+++ b/src/it/resources/org/checkstyle/suppressionxpathfilter/matchxpath/SuppressionXpathRegressionMatchXpathEncodedQuoteString.java
@@ -1,0 +1,5 @@
+package org.checkstyle.suppressionxpathfilter.matchxpath;
+
+public class SuppressionXpathRegressionMatchXpathEncodedQuoteString {
+    String quoteChar = "\"testOne\""; // warning
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilterTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Set;
 
@@ -179,4 +180,70 @@ public class SuppressionXpathFilterTest extends AbstractModuleTestSupport {
         return suppressionXpathFilter;
     }
 
+    @Test
+    public void testFalseEncodeString() throws Exception {
+        final boolean optional = false;
+        final SuppressionXpathFilter filter = createSuppressionXpathFilter(
+                getPath("InputSuppressionXpathFilterEscapeString.xml"), optional);
+        final File file = new File(getPath("InputSuppressionXpathFilterEscapeString.java"));
+
+        assertFalse(filter.accept(createTreeWalkerAudit(8, 23, TokenTypes.STRING_LITERAL, file)),
+                "TreeWalker audit event should be rejected");
+
+        assertFalse(filter.accept(createTreeWalkerAudit(10, 22, TokenTypes.STRING_LITERAL, file)),
+                "TreeWalker audit event should be rejected");
+
+        assertFalse(filter.accept(createTreeWalkerAudit(12, 27, TokenTypes.STRING_LITERAL, file)),
+                "TreeWalker audit event should be rejected");
+
+        assertFalse(filter.accept(createTreeWalkerAudit(14, 25, TokenTypes.STRING_LITERAL, file)),
+                "TreeWalker audit event should be rejected");
+
+        assertFalse(filter.accept(createTreeWalkerAudit(16, 25, TokenTypes.STRING_LITERAL, file)),
+                "TreeWalker audit event should be rejected");
+
+        assertFalse(filter.accept(createTreeWalkerAudit(18, 25, TokenTypes.STRING_LITERAL, file)),
+                "TreeWalker audit event should be rejected");
+
+        assertFalse(filter.accept(createTreeWalkerAudit(20, 22, TokenTypes.STRING_LITERAL, file)),
+                "TreeWalker audit event should be rejected");
+
+        assertFalse(filter.accept(createTreeWalkerAudit(22, 28, TokenTypes.STRING_LITERAL, file)),
+                "TreeWalker audit event should be rejected");
+
+        assertFalse(filter.accept(createTreeWalkerAudit(24, 28, TokenTypes.STRING_LITERAL, file)),
+                "TreeWalker audit event should be rejected");
+    }
+
+    @Test
+    public void testFalseEncodeChar() throws Exception {
+        final boolean optional = false;
+        final SuppressionXpathFilter filter = createSuppressionXpathFilter(
+                getPath("InputSuppressionXpathFilterEscapeChar.xml"), optional);
+        final File file = new File(getPath("InputSuppressionXpathFilterEscapeChar.java"));
+
+        assertFalse(filter.accept(createTreeWalkerAudit(8, 13, TokenTypes.CHAR_LITERAL, file)),
+                "TreeWalker audit event should be rejected");
+
+        assertFalse(filter.accept(createTreeWalkerAudit(10, 13, TokenTypes.CHAR_LITERAL, file)),
+                "TreeWalker audit event should be rejected");
+
+        assertFalse(filter.accept(createTreeWalkerAudit(12, 13, TokenTypes.CHAR_LITERAL, file)),
+                "TreeWalker audit event should be rejected");
+
+        assertFalse(filter.accept(createTreeWalkerAudit(14, 13, TokenTypes.CHAR_LITERAL, file)),
+                "TreeWalker audit event should be rejected");
+
+        assertFalse(filter.accept(createTreeWalkerAudit(16, 13, TokenTypes.CHAR_LITERAL, file)),
+                "TreeWalker audit event should be rejected");
+    }
+
+    private static TreeWalkerAuditEvent createTreeWalkerAudit(int lineNo, int columnNo,
+                                                              int tokenTypes, File file)
+            throws IOException, CheckstyleException {
+        final LocalizedMessage message = new LocalizedMessage(lineNo, columnNo, tokenTypes, "", "",
+                null, null, "777", SuppressionXpathFilterTest.class, null);
+        return new TreeWalkerAuditEvent(null, "Test.java", message,
+                JavaParser.parseFile(file, JavaParser.Options.WITHOUT_COMMENTS));
+    }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGeneratorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGeneratorTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.JavaParser;
 import com.puppycrawl.tools.checkstyle.TreeWalkerAuditEvent;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -40,7 +40,7 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
-public class XpathQueryGeneratorTest extends AbstractPathTestSupport {
+public class XpathQueryGeneratorTest extends AbstractModuleTestSupport {
 
     private static final int DEFAULT_TAB_WIDTH = 4;
 
@@ -350,7 +350,8 @@ public class XpathQueryGeneratorTest extends AbstractPathTestSupport {
 
     @Test
     public void testTabWidthBeforeMethodDef() throws Exception {
-        final File testFile = new File(getPath("InputXpathQueryGeneratorTabWidth.java"));
+        final File testFile = new File(getPath(
+                "InputXpathQueryGeneratorTabWidth.java"));
         final FileText testFileText = new FileText(testFile,
                 StandardCharsets.UTF_8.name());
         final DetailAST detailAst =
@@ -373,7 +374,8 @@ public class XpathQueryGeneratorTest extends AbstractPathTestSupport {
 
     @Test
     public void testTabWidthAfterVoidLiteral() throws Exception {
-        final File testFile = new File(getPath("InputXpathQueryGeneratorTabWidth.java"));
+        final File testFile = new File(getPath(
+                "InputXpathQueryGeneratorTabWidth.java"));
         final FileText testFileText = new FileText(testFile,
                 StandardCharsets.UTF_8.name());
         final DetailAST detailAst =
@@ -458,4 +460,71 @@ public class XpathQueryGeneratorTest extends AbstractPathTestSupport {
         assertEquals(expected, actual, "Generated queries do not match expected ones");
     }
 
+    @Test
+    public void testEscapeCharacters() throws Exception {
+        final File testFile = new File(getPath("InputXpathQueryGeneratorEscapeCharacters.java"));
+        final FileText testFileText = new FileText(testFile,
+                StandardCharsets.UTF_8.name());
+        final DetailAST detailAst =
+                JavaParser.parseFile(testFile, JavaParser.Options.WITHOUT_COMMENTS);
+        final int tabWidth = 8;
+
+        final int lineNumberOne = 4;
+        final int columnNumberOne = 22;
+        final XpathQueryGenerator queryGeneratorOne = new XpathQueryGenerator(detailAst,
+                lineNumberOne, columnNumberOne, testFileText, tabWidth);
+        final List<String> actualTestOne = queryGeneratorOne.generate();
+        final List<String> expectedTestOne = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='InputXpathQueryGeneratorEscapeCharacters']]/"
+                        + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='testOne']]/ASSIGN/EXPR[./"
+                        + "STRING_LITERAL[@text='&lt;&gt;&apos;&apos;\\&quot;&amp;abc;&amp;lt;"
+                        + "\\u0080\\n']]",
+                "/CLASS_DEF[./IDENT[@text='InputXpathQueryGeneratorEscapeCharacters']]/"
+                        + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='testOne']]/ASSIGN/EXPR/"
+                        + "STRING_LITERAL[@text='&lt;&gt;&apos;&apos;\\&quot;&amp;abc;&amp;lt;"
+                        + "\\u0080\\n']"
+        );
+        assertEquals(expectedTestOne, actualTestOne,
+                "Generated queries do not match expected ones");
+
+        final int lineNumberTwo = 6;
+        final int columnNumberTwo = 22;
+        final XpathQueryGenerator queryGeneratorTwo = new XpathQueryGenerator(detailAst,
+                lineNumberTwo, columnNumberTwo, testFileText, tabWidth);
+        final List<String> actualTestTwo = queryGeneratorTwo.generate();
+        final List<String> expectedTestTwo = Arrays.asList(
+                "/CLASS_DEF[./IDENT[@text='InputXpathQueryGeneratorEscapeCharacters']]/"
+                        + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='testTwo']]/ASSIGN/EXPR[./"
+                        + "STRING_LITERAL[@text='&amp;#0;&amp;#X0\\u0001\\r']]",
+                "/CLASS_DEF[./IDENT[@text='InputXpathQueryGeneratorEscapeCharacters']]/"
+                        + "OBJBLOCK/VARIABLE_DEF[./IDENT[@text='testTwo']]/ASSIGN/EXPR/"
+                        + "STRING_LITERAL[@text='&amp;#0;&amp;#X0\\u0001\\r']"
+        );
+        assertEquals(expectedTestTwo, actualTestTwo,
+                "Generated queries do not match expected ones");
+    }
+
+    @Test
+    public void testTextBlocks() throws Exception {
+        final File testFile = new File(getNonCompilablePath(
+                "InputXpathQueryGeneratorTextBlock.java"));
+        final FileText testFileText = new FileText(testFile,
+                StandardCharsets.UTF_8.name());
+        final DetailAST detailAst =
+                JavaParser.parseFile(testFile, JavaParser.Options.WITHOUT_COMMENTS);
+        final int tabWidth = 8;
+
+        final int lineNumberOne = 6;
+        final int columnNumberOne = 25;
+        final XpathQueryGenerator queryGeneratorOne = new XpathQueryGenerator(detailAst,
+                lineNumberOne, columnNumberOne, testFileText, tabWidth);
+        final List<String> actualTestOne = queryGeneratorOne.generate();
+        final List<String> expectedTestOne = Collections.singletonList(
+            "/CLASS_DEF[./IDENT[@text='InputXpathQueryGeneratorTextBlock']]/OBJBLOCK/"
+                    + "VARIABLE_DEF[./IDENT[@text='testOne']]/ASSIGN/EXPR/"
+                    + "TEXT_BLOCK_LITERAL_BEGIN/TEXT_BLOCK_CONTENT"
+            );
+        assertEquals(expectedTestOne, actualTestOne,
+                "Generated queries do not match expected ones");
+    }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/xpath/xpathquerygenerator/InputXpathQueryGeneratorTextBlock.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/xpath/xpathquerygenerator/InputXpathQueryGeneratorTextBlock.java
@@ -1,0 +1,11 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.xpath.xpathquerygenerator;
+
+public class InputXpathQueryGeneratorTextBlock {
+
+    String testOne = """
+        &1line
+        >2line
+        <3line
+        """;
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathfilter/InputSuppressionXpathFilterEscapeChar.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathfilter/InputSuppressionXpathFilterEscapeChar.java
@@ -1,0 +1,17 @@
+package com.puppycrawl.tools.checkstyle.filters.suppressionxpathfilter;
+
+/*
+ * Config: Default.
+ */
+public class InputSuppressionXpathFilterEscapeChar {
+
+    char a = '&'; // violation
+
+    char b = '\"'; // violation
+
+    char c = '\''; // violation
+
+    char d = '<'; // violation
+
+    char e = '>'; // violation
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathfilter/InputSuppressionXpathFilterEscapeChar.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathfilter/InputSuppressionXpathFilterEscapeChar.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Checkstyle//DTD SuppressionXpathFilter Experimental Configuration 1.2//EN"
+        "https://checkstyle.org/dtds/suppressions_1_2_xpath_experimental.dtd">
+<suppressions>
+    <suppress-xpath
+            files="Test.java"
+            id="777"
+            query="/CLASS_DEF[./IDENT[@text='InputSuppressionXpathFilterEscapeChar']]/OBJBLOCK/
+                    VARIABLE_DEF[./IDENT[@text='a']]/ASSIGN/EXPR/CHAR_LITERAL
+                        [@text='&apos;&apos;&amp;&apos;&apos;']"/>
+    <suppress-xpath
+            files="Test.java"
+            id="777"
+            query="/CLASS_DEF[./IDENT[@text='InputSuppressionXpathFilterEscapeChar']]/OBJBLOCK/
+                   VARIABLE_DEF[./IDENT[@text='b']]/ASSIGN/EXPR/CHAR_LITERAL
+                       [@text='&apos;&apos;\&quot;&apos;&apos;']"/>
+    <suppress-xpath
+            files="Test.java"
+            id="777"
+            query="/CLASS_DEF[./IDENT[@text='InputSuppressionXpathFilterEscapeChar']]/OBJBLOCK/
+                    VARIABLE_DEF[./IDENT[@text='c']]/ASSIGN/EXPR/CHAR_LITERAL
+                        [@text='&apos;&apos;\&apos;&apos;&apos;&apos;']"/>
+    <suppress-xpath
+            files="Test.java"
+            id="777"
+            query="/CLASS_DEF[./IDENT[@text='InputSuppressionXpathFilterEscapeChar']]/OBJBLOCK/
+                    VARIABLE_DEF[./IDENT[@text='d']]/ASSIGN/EXPR/CHAR_LITERAL
+                        [@text='&apos;&apos;&lt;&apos;&apos;']"/>
+    <suppress-xpath
+            files="Test.java"
+            id="777"
+            query="/CLASS_DEF[./IDENT[@text='InputSuppressionXpathFilterEscapeChar']]/OBJBLOCK/
+                    VARIABLE_DEF[./IDENT[@text='e']]/ASSIGN/EXPR/CHAR_LITERAL
+                        [@text='&apos;&apos;&gt;&apos;&apos;']"/>
+</suppressions>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathfilter/InputSuppressionXpathFilterEscapeString.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathfilter/InputSuppressionXpathFilterEscapeString.java
@@ -1,0 +1,25 @@
+package com.puppycrawl.tools.checkstyle.filters.suppressionxpathfilter;
+
+/*
+ * Config: Default.
+ */
+public class InputSuppressionXpathFilterEscapeString {
+
+    String quoteChar = "\"escaped\""; // violation
+
+    String lessChar = "<escaped"; // violation
+
+    String ampersandChar = "&escaped"; // violation
+
+    String greaterChar = ">escaped"; // violation
+
+    String newLineChar = "escaped\n"; // violation
+
+    String specialChar = "escaped\r"; // violation
+
+    String aposChar = "'escaped'"; // violation
+
+    String unicodeCharOne = "语言处理Char"; // violation
+
+    String unicodeCharTwo = "ǯChar"; // violation
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathfilter/InputSuppressionXpathFilterEscapeString.xml
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppressionxpathfilter/InputSuppressionXpathFilterEscapeString.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suppressions PUBLIC
+        "-//Checkstyle//DTD SuppressionXpathFilter Experimental Configuration 1.2//EN"
+        "https://checkstyle.org/dtds/suppressions_1_2_xpath_experimental.dtd">
+<suppressions>
+    <suppress-xpath
+            files="Test"
+            id="777"
+            query="/CLASS_DEF[./IDENT[@text='InputSuppressionXpathFilterEscapeString']]/
+                    OBJBLOCK/VARIABLE_DEF[./IDENT[@text='quoteChar']]/ASSIGN/
+                        EXPR/STRING_LITERAL[@text='\&quot;escaped\&quot;']"/>
+    <suppress-xpath
+            files="Test"
+            id="777"
+            query="/CLASS_DEF[./IDENT[@text='InputSuppressionXpathFilterEscapeString']]/
+                    OBJBLOCK/VARIABLE_DEF[./IDENT[@text='lessChar']]/ASSIGN/
+                        EXPR/STRING_LITERAL[@text='&lt;escaped']"/>
+    <suppress-xpath
+            files="Test"
+            id="777"
+            query="/CLASS_DEF[./IDENT[@text='InputSuppressionXpathFilterEscapeString']]/
+                    OBJBLOCK/VARIABLE_DEF[./IDENT[@text='ampersandChar']]/ASSIGN/
+                        EXPR/STRING_LITERAL[@text='&amp;escaped']"/>
+    <suppress-xpath
+            files="Test"
+            id="777"
+            query="/CLASS_DEF[./IDENT[@text='InputSuppressionXpathFilterEscapeString']]/
+                    OBJBLOCK/VARIABLE_DEF[./IDENT[@text='greaterChar']]/ASSIGN/
+                        EXPR/STRING_LITERAL[@text='&gt;escaped']"/>
+    <suppress-xpath
+            files="Test"
+            id="777"
+            query="/CLASS_DEF[./IDENT[@text='InputSuppressionXpathFilterEscapeString']]/
+                    OBJBLOCK/VARIABLE_DEF[./IDENT[@text='newLineChar']]/ASSIGN/
+                        EXPR/STRING_LITERAL[@text='escaped\n']"/>
+    <suppress-xpath
+            files="Test"
+            id="777"
+            query="/CLASS_DEF[./IDENT[@text='InputSuppressionXpathFilterEscapeString']]/
+                    OBJBLOCK/VARIABLE_DEF[./IDENT[@text='specialChar']]/ASSIGN/
+                        EXPR/STRING_LITERAL[@text='escaped\r']"/>
+    <suppress-xpath
+            files="Test"
+            id="777"
+            query="/CLASS_DEF[./IDENT[@text='InputSuppressionXpathFilterEscapeString']]/
+                    OBJBLOCK/VARIABLE_DEF[./IDENT[@text='aposChar']]/ASSIGN/
+                        EXPR/STRING_LITERAL[@text='&apos;&apos;escaped&apos;&apos;']"/>
+    <suppress-xpath
+            files="Test"
+            id="777"
+            query="/CLASS_DEF[./IDENT[@text='InputSuppressionXpathFilterEscapeString']]/
+                    OBJBLOCK/VARIABLE_DEF[./IDENT[@text='unicodeCharOne']]/ASSIGN/
+                        EXPR/STRING_LITERAL[@text='语言处理Char']"/>
+    <suppress-xpath
+            files="Test"
+            id="777"
+            query="/CLASS_DEF[./IDENT[@text='InputSuppressionXpathFilterEscapeString']]/
+                    OBJBLOCK/VARIABLE_DEF[./IDENT[@text='unicodeCharTwo']]/ASSIGN/
+                        EXPR/STRING_LITERAL[@text='ǯChar']"/>
+</suppressions>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/xpathquerygenerator/InputXpathQueryGeneratorEscapeCharacters.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/xpathquerygenerator/InputXpathQueryGeneratorEscapeCharacters.java
@@ -1,0 +1,7 @@
+package com.puppycrawl.tools.checkstyle.xpath.xpathquerygenerator;
+
+public class InputXpathQueryGeneratorEscapeCharacters {
+    String testOne = "<>'\"&abc;&lt;\u0080\n";
+
+    String testTwo = "&#0;&#X0\u0001\r";
+}


### PR DESCRIPTION
## Generate Xpath Suppresion on escape xml symbols

Closes: #6893  

#### Test File
```
$ cat Test.java
class A {

  String quoteChar = "\"escaped\"" +
  "2";

  String lessChar = "<escaped" +
  "3";

  String ampersandChar = "&escaped" +
  "4";

  String greaterChar = ">escaped" +
  "5";

  String newLineChar = "escaped\n" +
  "6";

  String specialChar = "escaped\r" +
  "6";

  String aposChar = "'escaped'" +
  "7";
}
```

#### Configuration File
```
<?xml version="1.0" encoding="utf-8"?>
<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="OperatorWrapCheck"/>
    </module>
</module>
```

#### Result of checkstyle with above config file
```
$ java -jar java -jar checkstyle-8.41-SNAPSHOT-all.jar -c .\config.xml .\Test.java
Starting audit...
[ERROR] H:\CheckstyleCheck\.\Test.java:3:36: '+' should be on a new line. [OperatorWrap]
[ERROR] H:\CheckstyleCheck\.\Test.java:6:32: '+' should be on a new line. [OperatorWrap]
[ERROR] H:\CheckstyleCheck\.\Test.java:9:37: '+' should be on a new line. [OperatorWrap]
[ERROR] H:\CheckstyleCheck\.\Test.java:12:35: '+' should be on a new line. [OperatorWrap]
[ERROR] H:\CheckstyleCheck\.\Test.java:15:36: '+' should be on a new line. [OperatorWrap]
[ERROR] H:\CheckstyleCheck\.\Test.java:18:36: '+' should be on a new line. [OperatorWrap]
[ERROR] H:\CheckstyleCheck\.\Test.java:21:33: '+' should be on a new line. [OperatorWrap]
Audit done.
Checkstyle ends with 7 errors.
```

#### Suppressions generated by checkstyle after doing changes with this config
```
$ java -jar checkstyle-8.41-SNAPSHOT-all.jar -g -c .\config.xml .\Test.java            
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE suppressions PUBLIC
    "-//Checkstyle//DTD SuppressionXpathFilter Experimental Configuration 1.2//EN"
    "https://checkstyle.org/dtds/suppressions_1_2_xpath_experimental.dtd">
<suppressions>
<suppress-xpath
       files="Test.java"
       checks="OperatorWrapCheck"
       query="/CLASS_DEF[./IDENT[@text='A']]/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='quoteChar']]/ASSIGN/EXPR/PLUS[./STRING_LITERAL[@text='\&quot;escaped\&quot;']]"/>
<suppress-xpath
       files="Test.java"
       checks="OperatorWrapCheck"
       query="/CLASS_DEF[./IDENT[@text='A']]/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='lessChar']]/ASSIGN/EXPR/PLUS[./STRING_LITERAL[@text='&lt;escaped']]"/>
<suppress-xpath
       files="Test.java"
       checks="OperatorWrapCheck"
       query="/CLASS_DEF[./IDENT[@text='A']]/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='ampersandChar']]/ASSIGN/EXPR/PLUS[./STRING_LITERAL[@text='&amp;escaped']]"/>
<suppress-xpath
       files="Test.java"
       checks="OperatorWrapCheck"
       query="/CLASS_DEF[./IDENT[@text='A']]/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='greaterChar']]/ASSIGN/EXPR/PLUS[./STRING_LITERAL[@text='&gt;escaped']]"/>
<suppress-xpath
       files="Test.java"
       checks="OperatorWrapCheck"
       query="/CLASS_DEF[./IDENT[@text='A']]/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='newLineChar']]/ASSIGN/EXPR/PLUS[./STRING_LITERAL[@text='escaped\n']]"/>
<suppress-xpath
       files="Test.java"
       checks="OperatorWrapCheck"
       query="/CLASS_DEF[./IDENT[@text='A']]/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='specialChar']]/ASSIGN/EXPR/PLUS[./STRING_LITERAL[@text='escaped\r']]"/>
<suppress-xpath
       files="Test.java"
       checks="OperatorWrapCheck"
       query="/CLASS_DEF[./IDENT[@text='A']]/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='aposChar']]/ASSIGN/EXPR/PLUS[./STRING_LITERAL[@text='&apos;&apos;escaped&apos;&apos;']]"/>
</suppressions>
Checkstyle ends with 7 errors.
```
#### Result of checkstyle after attaching suppressions to config
``` 
$ java -jar checkstyle-8.41-SNAPSHOT-all.jar -c .\suppscon.xml .\Test.java
Starting audit...
Audit done.
```

### Results with  previous 8.40 build

#### Generated Suppressions 
```
$ java -jar H:\checkstyle-8.40-all.jar -g -c .\config.xml .\Test.java
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE suppressions PUBLIC
    "-//Checkstyle//DTD SuppressionXpathFilter Experimental Configuration 1.2//EN"
    "https://checkstyle.org/dtds/suppressions_1_2_xpath_experimental.dtd">
<suppressions>
<suppress-xpath
       files="Test.java"
       checks="OperatorWrapCheck"
       query="/CLASS_DEF[./IDENT[@text='A']]/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='quoteChar']]/ASSIGN/EXPR/PLUS[./STRING_LITERAL[@text='\"escaped\"']]"/>
<suppress-xpath
       files="Test.java"
       checks="OperatorWrapCheck"
       query="/CLASS_DEF[./IDENT[@text='A']]/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='lessChar']]/ASSIGN/EXPR/PLUS[./STRING_LITERAL[@text='<escaped']]"/>
<suppress-xpath
       files="Test.java"
       checks="OperatorWrapCheck"
       query="/CLASS_DEF[./IDENT[@text='A']]/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='ampersandChar']]/ASSIGN/EXPR/PLUS[./STRING_LITERAL[@text='&escaped']]"/>
<suppress-xpath
       files="Test.java"
       checks="OperatorWrapCheck"
       query="/CLASS_DEF[./IDENT[@text='A']]/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='greaterChar']]/ASSIGN/EXPR/PLUS[./STRING_LITERAL[@text='>escaped']]"/>
<suppress-xpath
       files="Test.java"
       checks="OperatorWrapCheck"
       query="/CLASS_DEF[./IDENT[@text='A']]/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='newLineChar']]/ASSIGN/EXPR/PLUS[./STRING_LITERAL[@text='escaped\n']]"/>
<suppress-xpath
       files="Test.java"
       checks="OperatorWrapCheck"
       query="/CLASS_DEF[./IDENT[@text='A']]/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='specialChar']]/ASSIGN/EXPR/PLUS[./STRING_LITERAL[@text='escaped\r']]"/>
<suppress-xpath
       files="Test.java"
       checks="OperatorWrapCheck"
       query="/CLASS_DEF[./IDENT[@text='A']]/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='aposChar']]/ASSIGN/EXPR/PLUS[./STRING_LITERAL[@text=''escaped'']]"/>
</suppressions>
Checkstyle ends with 7 errors.
```
#### On using these supprressions
```
$ java -jar H:\checkstyle-8.39-all.jar -c .\suppscon.xml .\Test.java
com.puppycrawl.tools.checkstyle.api.CheckstyleException: cannot initialize module TreeWalker - cannot initialize module SuppressionXpathFilter - Unable to parse supp.xml - Element type "suppress-xpath" must be followed by either attribute specifications, ">" or "/>".
        at com.puppycrawl.tools.checkstyle.Checker.setupChild(Checker.java:482)
        at com.puppycrawl.tools.checkstyle.api.AutomaticBean.configure(AutomaticBean.java:201)
        at com.puppycrawl.tools.checkstyle.Main.runCheckstyle(Main.java:404)
        at com.puppycrawl.tools.checkstyle.Main.runCli(Main.java:331)
        at com.puppycrawl.tools.checkstyle.Main.execute(Main.java:190)
        at com.puppycrawl.tools.checkstyle.Main.main(Main.java:125)
Caused by: com.puppycrawl.tools.checkstyle.api.CheckstyleException: cannot initialize module SuppressionXpathFilter - Unable to parse supp.xml - Element type "suppress-xpath" must be followed by either attribute specifications, ">" or "/>".
        at com.puppycrawl.tools.checkstyle.TreeWalker.setupChild(TreeWalker.java:125)
        at com.puppycrawl.tools.checkstyle.api.AutomaticBean.configure(AutomaticBean.java:201)
        at com.puppycrawl.tools.checkstyle.Checker.setupChild(Checker.java:477)
        ... 5 more
Caused by: com.puppycrawl.tools.checkstyle.api.CheckstyleException: Unable to parse supp.xml - Element type "suppress-xpath" must be followed by either attribute specifications, ">" or "/>".
        at com.puppycrawl.tools.checkstyle.filters.SuppressionsLoader.getSuppressionLoader(SuppressionsLoader.java:292)
        at com.puppycrawl.tools.checkstyle.filters.SuppressionsLoader.loadXpathSuppressions(SuppressionsLoader.java:267)
        at com.puppycrawl.tools.checkstyle.filters.SuppressionsLoader.loadXpathSuppressions(SuppressionsLoader.java:253)
        at com.puppycrawl.tools.checkstyle.filters.SuppressionXpathFilter.finishLocalSetup(SuppressionXpathFilter.java:591)
        at com.puppycrawl.tools.checkstyle.api.AutomaticBean.configure(AutomaticBean.java:197)
        at com.puppycrawl.tools.checkstyle.TreeWalker.setupChild(TreeWalker.java:120)
        ... 7 more
Caused by: org.xml.sax.SAXParseException; systemId: file:/H:/CheckstyleCheck/supp.xml; lineNumber: 9; columnNumber: 139; Element type "suppress-xpath" must be followed by either attribute specifications, ">" or "/>".
        at java.xml/com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.createSAXParseException(ErrorHandlerWrapper.java:204)
        at java.xml/com.sun.org.apache.xerces.internal.util.ErrorHandlerWrapper.fatalError(ErrorHandlerWrapper.java:178)
        at java.xml/com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(XMLErrorReporter.java:400)
        at java.xml/com.sun.org.apache.xerces.internal.impl.XMLErrorReporter.reportError(XMLErrorReporter.java:327)
        at java.xml/com.sun.org.apache.xerces.internal.impl.XMLScanner.reportFatalError(XMLScanner.java:1471)
        at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.seekCloseOfStartTag(XMLDocumentFragmentScannerImpl.java:1442)
        at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanStartElement(XMLDocumentFragmentScannerImpl.java:1371)
        at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl$FragmentContentDriver.next(XMLDocumentFragmentScannerImpl.java:2725)
        at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl.next(XMLDocumentScannerImpl.java:605)
        at java.xml/com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanDocument(XMLDocumentFragmentScannerImpl.java:541)
        at java.xml/com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:888)
        at java.xml/com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:824)
        at java.xml/com.sun.org.apache.xerces.internal.parsers.XMLParser.parse(XMLParser.java:141)
        at java.xml/com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.parse(AbstractSAXParser.java:1224)
        at java.xml/com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl$JAXPSAXParser.parse(SAXParserImpl.java:635)
        at com.puppycrawl.tools.checkstyle.XmlLoader.parseInputSource(XmlLoader.java:86)
        at com.puppycrawl.tools.checkstyle.filters.SuppressionsLoader.getSuppressionLoader(SuppressionsLoader.java:283)
        ... 12 more
Checkstyle ends with 1 errors.
```
 