### PR TITLE
swap treewalker token master list to integer from string

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
@@ -198,6 +198,10 @@ public class TokenUtilTest {
                 "Should return true when valid type passed");
         assertTrue(TokenUtil.isCommentType("COMMENT_CONTENT"),
                 "Should return true when valid type passed");
+        assertFalse(TokenUtil.isCommentType(TokenTypes.CLASS_DEF),
+                "Should return false when invalid type passed");
+        assertFalse(TokenUtil.isCommentType("CLASS_DEF"),
+                "Should return false when invalid type passed");
     }
 
     @Test


### PR DESCRIPTION
As identified in https://github.com/checkstyle/checkstyle/pull/9225#issuecomment-774683879 , this swaps the master list we use in `TreeWalker` to store tokens as integers instead of strings.