### PR TITLE
Issue #7605: Update doc for SingleLineJavadoc

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
@@ -61,15 +61,161 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <pre>
  * &lt;module name=&quot;SingleLineJavadoc&quot;/&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * &#47;** &#64;see Math *&#47; // violation, javadoc should be multiline
+ * public int foo() {
+ *   return 42;
+ * }
+ *
+ * &#47;**
+ *  * &#64;return 42
+ *  *&#47;  // ok
+ * public int bar() {
+ *   return 42;
+ * }
+ *
+ * &#47;** {&#64;link #equals(Object)} *&#47; // ok
+ * public int baz() {
+ *   return 42;
+ * }
+ *
+ * &#47;**
+ *  * &lt;p&gt;the answer to the ultimate question
+ *  *&#47; // ok
+ * public int magic() {
+ *   return 42;
+ * }
+ *
+ * &#47;**
+ *  * &lt;p&gt;the answer to the ultimate question&lt;/p&gt;
+ *  *&#47; // ok
+ * public int foobar() {
+ *   return 42;
+ * }
+ * </pre>
  * <p>
- * To configure the check with a list of ignored block tags
- * and make inline tags not ignored:
+ * To configure the check with a list of ignored block tags:
  * </p>
  * <pre>
  * &lt;module name=&quot;SingleLineJavadoc&quot;&gt;
  *   &lt;property name=&quot;ignoredTags&quot; value=&quot;&#64;inheritDoc, &#64;see&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * &#47;** &#64;see Math *&#47; // ok
+ * public int foo() {
+ *   return 42;
+ * }
+ *
+ * &#47;**
+ *  * &#64;return 42
+ *  *&#47;  // ok
+ * public int bar() {
+ *   return 42;
+ * }
+ *
+ * &#47;** {&#64;link #equals(Object)} *&#47; // ok
+ * public int baz() {
+ *   return 42;
+ * }
+ *
+ * &#47;**
+ *  * &lt;p&gt;the answer to the ultimate question
+ *  *&#47; // ok
+ * public int magic() {
+ *   return 42;
+ * }
+ *
+ * &#47;**
+ *  * &lt;p&gt;the answer to the ultimate question&lt;/p&gt;
+ *  *&#47; // ok
+ * public int foobar() {
+ *   return 42;
+ * }
+ * </pre>
+ * <p>
+ * To configure the check to not ignore inline tags:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;SingleLineJavadoc&quot;&gt;
  *   &lt;property name=&quot;ignoreInlineTags&quot; value=&quot;false&quot;/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * &#47;** &#64;see Math *&#47; // violation, javadoc should be multiline
+ * public int foo() {
+ *   return 42;
+ * }
+ *
+ * &#47;**
+ *  * &#64;return 42
+ *  *&#47;  // ok
+ * public int bar() {
+ *   return 42;
+ * }
+ *
+ * &#47;** {&#64;link #equals(Object)} *&#47; // violation, javadoc should be multiline
+ * public int baz() {
+ *   return 42;
+ * }
+ *
+ * &#47;**
+ *  * &lt;p&gt;the answer to the ultimate question
+ *  *&#47; // ok
+ * public int magic() {
+ *   return 42;
+ * }
+ *
+ * &#47;**
+ *  * &lt;p&gt;the answer to the ultimate question&lt;/p&gt;
+ *  *&#47; // ok
+ * public int foobar() {
+ *   return 42;
+ * }
+ * </pre>
+ * <p>
+ * To configure the check to report violations for Tight-HTML Rules:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;SingleLineJavadoc&quot;&gt;
+ *   &lt;property name=&quot;violateExecutionOnNonTightHtml&quot; value=&quot;true&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * &#47;** &#64;see Math *&#47; // violation, javadoc should be multiline
+ * public int foo() {
+ *   return 42;
+ * }
+ *
+ * &#47;**
+ *  * &#64;return 42
+ *  *&#47;  // ok
+ * public int bar() {
+ *   return 42;
+ * }
+ *
+ * &#47;** {&#64;link #equals(Object)} *&#47; // ok
+ * public int baz() {
+ *   return 42;
+ * }
+ *
+ * &#47;**
+ *  * &lt;p&gt;the answer to the ultimate question
+ *  *&#47; // violation, unclosed HTML tag found: p
+ * public int magic() {
+ *   return 42;
+ * }
+ *
+ * &#47;**
+ *  * &lt;p&gt;the answer to the ultimate question&lt;/p&gt;
+ *  *&#47; // ok
+ * public int foobar() {
+ *   return 42;
+ * }
  * </pre>
  * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -3336,14 +3336,168 @@ public boolean testMethod(int firstParam) {
 &lt;module name=&quot;SingleLineJavadoc&quot;/&gt;
         </source>
         <p>
-          To configure the check with a list of ignored block tags and make
-          inline tags not ignored:
+          Example:
+        </p>
+        <source>
+/** @see Math */ // violation, javadoc should be multiline
+public int foo() {
+  return 42;
+}
+
+/**
+ * @return 42
+ */  // ok
+public int bar() {
+  return 42;
+}
+
+/** {@link #equals(Object)} */ // ok
+public int baz() {
+  return 42;
+}
+
+/**
+ * &lt;p&gt;the answer to the ultimate question
+ */ // ok
+public int magic() {
+  return 42;
+}
+
+/**
+ * &lt;p&gt;the answer to the ultimate question&lt;/p&gt;
+ */ // ok
+public int foobar() {
+  return 42;
+}
+        </source>
+        <p>
+          To configure the check with a list of ignored block tags:
         </p>
         <source>
 &lt;module name=&quot;SingleLineJavadoc&quot;&gt;
   &lt;property name=&quot;ignoredTags&quot; value=&quot;&#64;inheritDoc, &#64;see&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+/** @see Math */ // ok
+public int foo() {
+    return 42;
+}
+
+/**
+ * @return 42
+ */  // ok
+public int bar() {
+  return 42;
+}
+
+/** {@link #equals(Object)} */ // ok
+public int baz() {
+  return 42;
+}
+
+/**
+ * &lt;p&gt;the answer to the ultimate question
+ */ // ok
+public int magic() {
+  return 42;
+}
+
+/**
+ * &lt;p&gt;the answer to the ultimate question&lt;/p&gt;
+ */ // ok
+public int foobar() {
+  return 42;
+}
+        </source>
+        <p>
+          To configure the check to not ignore inline tags:
+        </p>
+        <source>
+&lt;module name=&quot;SingleLineJavadoc&quot;&gt;
   &lt;property name=&quot;ignoreInlineTags&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+/** @see Math */ // violation, javadoc should be multiline
+public int foo() {
+  return 42;
+}
+
+/**
+ * @return 42
+ */  // ok
+public int bar() {
+  return 42;
+}
+
+/** {@link #equals(Object)} */ // violation, javadoc should be multiline
+public int baz() {
+  return 42;
+}
+
+/**
+ * &lt;p&gt;the answer to the ultimate question
+ */ // ok
+public int magic() {
+  return 42;
+}
+
+/**
+ * &lt;p&gt;the answer to the ultimate question&lt;/p&gt;
+ */ // ok
+public int foobar() {
+  return 42;
+}
+        </source>
+        <p>
+          To configure the check to report violations for Tight-HTML Rules:
+        </p>
+        <source>
+&lt;module name=&quot;SingleLineJavadoc&quot;&gt;
+  &lt;property name=&quot;violateExecutionOnNonTightHtml&quot; value=&quot;true&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+/** @see Math */ // violation, javadoc should be multiline
+public int foo() {
+  return 42;
+}
+
+/**
+ * @return 42
+ */  // ok
+public int bar() {
+  return 42;
+}
+
+/** {@link #equals(Object)} */ // ok
+public int baz() {
+  return 42;
+}
+
+/**
+ * &lt;p&gt;the answer to the ultimate question
+ */ // violation, unclosed HTML tag found: p
+public int magic() {
+  return 42;
+}
+
+/**
+ * &lt;p&gt;the answer to the ultimate question&lt;/p&gt;
+ */ // ok
+public int foobar() {
+  return 42;
+}
         </source>
       </subsection>
 


### PR DESCRIPTION
Fixes #7605

![Screenshot from 2021-02-07 18-17-00](https://user-images.githubusercontent.com/70439255/107150208-c3687580-6982-11eb-9707-1dd6d2f0d47c.png)
![Screenshot from 2021-02-07 18-17-09](https://user-images.githubusercontent.com/70439255/107150212-c6fbfc80-6982-11eb-9414-4c6533ee1b0e.png)

**config_1.xml**
```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
      <module name="SingleLineJavadoc"/>
  </module>
</module>
```

**Test_1_Invalid.java**
```
class Test_1_Invalid
{
    /** @return 42 */ // violation, javadoc should be multiline
    public int foo() {
        return 42;
    }
}
```

```
java -jar ~/Downloads/checkstyle-8.40-all.jar -c config_1.xml Test_1_Invalid.java
Starting audit...
[ERROR] /home/lucifer/IdeaProjects/testing/src/Test_1_Invalid.java:3: Single-line Javadoc comment should be multi-line. [SingleLineJavadoc]
Audit done.
Checkstyle ends with 1 errors.
```

**Test_1_Valid.java**
```
public class Test_1_Valid
{
    /**
     * @return 42
     */  // ok
    public int bar() {
        return 42;
    }
}
```
```
java -jar ~/Downloads/checkstyle-8.40-all.jar -c config_1.xml Test_1_Valid.java
Starting audit...
Audit done.
```

**config_2.xml**
```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="SingleLineJavadoc">
      <property name="ignoredTags" value="@inheritDoc, @see"/>
      <property name="ignoreInlineTags" value="false"/>
    </module>
  </module>
</module>
```

**Test_2_Invalid.java**
```
public class Test_2_Invalid
{

    /** {@link #equals(Object)} */ // violation, javadoc should be multiline
    public int bar() {
        return 42;
    }
}
```
```
java -jar ~/Downloads/checkstyle-8.40-all.jar -c config_2.xml Test_2_Invalid.java
Starting audit...
[ERROR] /home/lucifer/IdeaProjects/testing/src/Test_2_Invalid.java:4: Single-line Javadoc comment should be multi-line. [SingleLineJavadoc]
Audit done.
Checkstyle ends with 1 errors.
```

**Test_2_Valid.java**
```
public class Test_2_Valid
{
    /** @see #foo()  */ // ok
    public int foo() {
        return 42;
    }
}
```
```
java -jar ~/Downloads/checkstyle-8.40-all.jar -c config_2.xml Test_2_Valid.java
Starting audit...
Audit done.
```

**config_3.xml**
```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="SingleLineJavadoc">
      <property name="violateExecutionOnNonTightHtml" value="true"/>
    </module>
  </module>
</module>
```

**Test_3_Invalid.java**
```
public class Test_3_Invalid
{
    /**
     * <p>the answer to the ultimate question
     */ // violation, html tag needs closing
    public int foo() {
        return 42;
    }
}
```
```
java -jar ~/Downloads/checkstyle-8.40-all.jar -c config_3.xml Test_3_Invalid.java
Starting audit...
[ERROR] /home/lucifer/IdeaProjects/testing/src/Test_3_Invalid.java:4: Unclosed HTML tag found: p [SingleLineJavadoc]
Audit done.
Checkstyle ends with 1 errors.
```

**Test_3_Valid.java**
```
public class Test_3_Valid
{
    /**
     * <p>the answer to the ultimate question</p>
     */ // ok
    public int bar() {
        return 42;
    }
}
```
```
java -jar ~/Downloads/checkstyle-8.40-all.jar -c config_3.xml Test_3_Valid.java
Starting audit...
Audit done.
```