### PR TITLE
Issue #7595: Update doc for UniqueProperties

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
@@ -55,9 +55,39 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
  * To configure the check:
  * </p>
  * <pre>
+ * &lt;module name=&quot;UniqueProperties&quot;/&gt;
+ * </pre>
+ * <p>
+ * Example: in foo.properties file
+ * </p>
+ * <pre>
+ * key.one=44
+ * key.two=32 // OK
+ * key.one=54 // violation
+ * </pre>
+ * <p>
+ * To configure the check to scan custom file extensions:
+ * </p>
+ * <pre>
  * &lt;module name=&quot;UniqueProperties&quot;&gt;
- *   &lt;property name=&quot;fileExtensions&quot; value=&quot;properties&quot; /&gt;
+ *  &lt;property name=&quot;fileExtensions&quot; value=&quot;customProperties&quot;/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example: in foo.customProperties file
+ * </p>
+ * <pre>
+ * key.one=44
+ * key.two=32 // OK
+ * key.one=54 // violation
+ * </pre>
+ * <p>
+ * Example: in foo.properties file
+ * </p>
+ * <pre>
+ * key.one=44
+ * key.two=32 // OK
+ * key.one=54 // OK, file is not checked
  * </pre>
  * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.Checker}

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -2490,9 +2490,39 @@ public record MyRecord1 {
           To configure the check:
         </p>
         <source>
+&lt;module name=&quot;UniqueProperties&quot;/&gt;
+        </source>
+        <p>
+          Example: in foo.properties file
+        </p>
+        <source>
+key.one=44
+key.two=32 // OK
+key.one=54 // violation
+        </source>
+        <p>
+          To configure the check to scan custom file extensions:
+        </p>
+        <source>
 &lt;module name=&quot;UniqueProperties&quot;&gt;
-  &lt;property name=&quot;fileExtensions&quot; value=&quot;properties&quot; /&gt;
+  &lt;property name=&quot;fileExtensions&quot; value=&quot;customProperties"/&gt;
 &lt;/module&gt;
+        </source>
+        <p>
+          Example: in foo.customProperties file
+        </p>
+        <source>
+key.one=44
+key.two=32 // OK
+key.one=54 // violation
+        </source>
+        <p>
+          Example: in foo.properties file
+        </p>
+        <source>
+key.one=44
+key.two=32 // OK
+key.one=54 // OK, file is not checked
         </source>
       </subsection>
 


### PR DESCRIPTION
I have added examples for the UniqueProperties Check, Closes #7595 . Request the admins to verify and point out any changes if required.

## Was Before
![Screenshot from 2021-02-12 15-03-19](https://user-images.githubusercontent.com/52334437/107766036-d8fde680-6d58-11eb-9583-bc0f962c6f85.png)

## Is Now
![Screenshot from 2021-02-12 17-21-26](https://user-images.githubusercontent.com/52334437/107766294-3f830480-6d59-11eb-96f1-841d07133c88.png)
![Screenshot from 2021-02-12 17-21-41](https://user-images.githubusercontent.com/52334437/107766302-427df500-6d59-11eb-9d25-6b103cfc5170.png)
![Screenshot from 2021-02-12 17-21-45](https://user-images.githubusercontent.com/52334437/107766305-4447b880-6d59-11eb-93af-dab01e30107d.png)

#### To configure the check:
`$ cat cnf.xml `
```
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
	<module name="UniqueProperties"/>
</module>
```
`$ cat app.properties`
```
key.one=44
key.two=32 
key.one=54
```
`$ java -jar checkstyle-8.40-all.jar -c cnf.xml app.properties`
```
Starting audit...
[ERROR] /home/divesh/Desktop/app.properties:1: Duplicated property 'key.one' (2 occurrence(s)). [UniqueProperties]
Audit done.
Checkstyle ends with 1 errors.
```

#### To configure the check to scan custom file extensions:
`$ cat cnf.xml `
```
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
	<module name="UniqueProperties">
  		<property name="fileExtensions" value="customproperties"/>
	</module>
</module>
```
`$ cat app.customproperties`
```
key.one=44
key.two=32 
key.one=54 
```
`$ java -jar checkstyle-8.40-all.jar -c cnf.xml app.customproperties`
```
Starting audit...
[ERROR] /home/divesh/Desktop/app.customproperties:1: Duplicated property 'key.one' (2 occurrence(s)). [UniqueProperties]
Audit done.
Checkstyle ends with 1 errors.
```
`$ cat app.properties`
```
key.one=44
key.two=32 
key.one=54 
```
`$ java -jar checkstyle-8.40-all.jar -c cnf.xml app.properties`
```
Starting audit...
Audit done.
```
#### To configure the check to scan custom file extensions and properties file:
`$ cat cnf.xml `
```
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
	<module name="UniqueProperties">
  		<property name="fileExtensions" value="properties, customproperties"/>
	</module>
</module>
```
`$ cat app.customproperties`
```
key.one=44
key.two=32 
key.one=54 
```
`$ java -jar checkstyle-8.40-all.jar -c cnf.xml app.customproperties`
```
Starting audit...
[ERROR] /home/divesh/Desktop/app.customproperties:1: Duplicated property 'key.one' (2 occurrence(s)). [UniqueProperties]
Audit done.
Checkstyle ends with 1 errors.
```
`$ cat app.properties`
```
key.one=44
key.two=32 
key.one=54 
```
`$ java -jar checkstyle-8.40-all.jar -c cnf.xml app.properties`
```
Starting audit...
[ERROR] /home/divesh/Desktop/app.properties:1: Duplicated property 'key.one' (2 occurrence(s)). [UniqueProperties]
Audit done.
Checkstyle ends with 1 errors.
```






