### PR TITLE
Add one more closed to do issue pattern and fix violations

### DIFF
--- a/.ci/idea_inspection.sh
+++ b/.ci/idea_inspection.sh
@@ -28,7 +28,7 @@ if [[ -z $IDEA_PATH ]]; then
     fi
 fi
 
-#Execute compilation of Checkstyle to generate all source files
+# Execute compilation of Checkstyle to generate all source files
 mvn -e clean compile
 
 mkdir -p $RESULTS_DIR

--- a/.ci/run-link-check-plugin.sh
+++ b/.ci/run-link-check-plugin.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-#This script is used at https://app.codeship.com/projects/124310
-#Run "firefox target/site/linkcheck.html" after completion to review html report
+# This script is used at https://app.codeship.com/projects/124310
+# Run "firefox target/site/linkcheck.html" after completion to review html report
 
 set -e
 pwd

--- a/.ci/sonar-wrapper.sh
+++ b/.ci/sonar-wrapper.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-#This file is for manual execution only
+# This file is for manual execution only
 
 set -e
 
@@ -13,6 +13,6 @@ sleep "60"
 
 ./.ci/sonar.sh
 
-#kill container
+# kill container
 docker stop sonar
 docker rm sonar

--- a/.ci/sonar.sh
+++ b/.ci/sonar.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-#set checkstyle sonar profile
+# set checkstyle sonar profile
 curl -X POST -u admin:admin \
     -F 'backup=@config/default_sonar_profile.xml' -v http://localhost:9000/api/profiles/restore
 
-#execute inspection
+# execute inspection
 mvn -e sonar:sonar -P sonar -Dsonar.language=java -Dsonar.profile=checkstyle-profile
 
 # Uncomment following to get HTML report.
@@ -12,8 +12,8 @@ mvn -e sonar:sonar -P sonar -Dsonar.language=java -Dsonar.profile=checkstyle-pro
 #        -Dsonar.language=java -Dsonar.profile=checkstyle-profile
 
 
-#get and parse response from sonar
-#give some time to sonar for report processing
+# get and parse response from sonar
+# give some time to sonar for report processing
 sleep "60"
 curl -u admin:admin \
    -v http://localhost:9000/api/issues/search?componentRoots=com.puppycrawl.tools:checkstyle \
@@ -21,7 +21,7 @@ curl -u admin:admin \
 
 OUTPUT="$(cat response.json | jq '.total')"
 
-#print number of found issues
+# print number of found issues
 if [ ! "$OUTPUT" -eq "0" ]; then
     jq '.' response.json
     echo "Found issues - $OUTPUT"

--- a/config/checkstyle_non_main_files_checks.xml
+++ b/config/checkstyle_non_main_files_checks.xml
@@ -63,8 +63,14 @@
   </module>
   <module name="RegexpSingleline">
     <property name="id" value="commentStartSpaceYml"/>
-    <property name="format" value=" #[^ !]"/>
-    <property name="fileExtensions" value="sh, yml, yaml"/>
+    <property name="format" value=" #[^ ]"/>
+    <property name="fileExtensions" value="yml, yaml"/>
+    <property name="message" value="space is required after comment start"/>
+  </module>
+  <module name="RegexpSingleline">
+    <property name="id" value="commentStartSpaceSh"/>
+    <property name="format" value="^#[^ !#]"/>
+    <property name="fileExtensions" value="sh"/>
     <property name="message" value="space is required after comment start"/>
   </module>
 </module>

--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -2752,12 +2752,11 @@
   </inspection_tool>
   <inspection_tool class="JUnitDatapoint" enabled="true" level="ERROR" enabled_by_default="true"/>
   <inspection_tool class="JUnitRule" enabled="true" level="ERROR" enabled_by_default="true"/>
-  <!-- suppressed till #5949 when we migrate to 2018.1.4 where such rule have new name -->
-  <inspection_tool class="JUnitTestClassNamingConvention" enabled="false" level="ERROR"
+  <inspection_tool class="JUnitTestClassNamingConvention" enabled="true" level="ERROR"
                    enabled_by_default="true">
     <option name="m_regex" value="[A-Z][A-Za-z\d]*Test"/>
     <option name="m_minLength" value="8"/>
-    <option name="m_maxLength" value="64"/>
+    <option name="m_maxLength" value="65"/>
   </inspection_tool>
   <!-- we need to stay on junit -->
   <inspection_tool class="JUnitTestNG" enabled="false" level="ERROR" enabled_by_default="false"/>
@@ -4419,10 +4418,6 @@
         <option value="CheckedExceptionClass"/>
         <option value="StaticVariableMayNotBeInitialized"/>
         <option value="StaticVariableUsedBeforeInitialization"/>
-        <!-- till #4734 -->
-        <option value="NonFinalFieldReferenceInEquals"/>
-        <!-- till #4734 -->
-        <option value="NonFinalFieldReferencedInHashCode"/>
         <!-- violations in DetailAST will be addressed further -->
         <option value="FieldNotUsedInToString"/>
         <!-- WeakerAccess reports 'can be protected' that we can not change -->
@@ -4438,7 +4433,7 @@
         <option value="unused"/>
         <!-- we use it for testing purposes -->
         <option value="UseOfPropertiesAsHashtable"/>
-        <!-- till #4861, #4862, #4863, #4864, #4866 -->
+        <!-- till #4862, #4864 -->
         <option value="ThisEscapedInObjectConstruction"/>
         <!-- it will makes code too complicated in some cases -->
         <option value="MultipleReturnPointsPerMethod"/>
@@ -4446,10 +4441,6 @@
         <option value="AnnotationClass"/>
         <!-- Suppression is only for TokenTypes class -->
         <option value="ClassWithTooManyDependents"/>
-        <!-- till #4870, used in MT check markers -->
-        <option value="ClassIndependentOfModule"/>
-        <!-- till #4870, used in MT check markers -->
-        <option value="unused"/>
         <!-- XDocs UT is very long and complex -->
         <option value="OverlyComplexBooleanExpression"/>
         <option value="ReuseOfLocalVariable"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/CheckstyleAntTaskPowerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/CheckstyleAntTaskPowerTest.java
@@ -28,16 +28,13 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -45,6 +42,9 @@ import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
 import com.puppycrawl.tools.checkstyle.Definitions;
 import com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask;
 import com.puppycrawl.tools.checkstyle.api.LocalizedMessage;
+import com.puppycrawl.tools.checkstyle.internal.powermock.testmodules.CheckstyleAntTaskLogStub;
+import com.puppycrawl.tools.checkstyle.internal.powermock.testmodules.CheckstyleAntTaskStub;
+import com.puppycrawl.tools.checkstyle.internal.powermock.testmodules.MessageLevelPair;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(CheckstyleAntTask.class)
@@ -123,78 +123,4 @@ public class CheckstyleAntTaskPowerTest extends AbstractPathTestSupport {
                     ex.getMessage().startsWith("Unable to process files:"));
         }
     }
-
-    /**
-     * Non meaningful javadoc just to contain "noinspection" tag.
-     * Till https://youtrack.jetbrains.com/issue/IDEA-187210
-     *
-     * @noinspection JUnitTestCaseWithNoTests
-     */
-    private static class CheckstyleAntTaskStub extends CheckstyleAntTask {
-
-        @Override
-        protected List<File> scanFileSets() {
-            final File mock = PowerMockito.mock(File.class);
-            // Assume that I/O error is happened when we try to invoke 'lastModified()' method.
-            final Exception expectedError = new RuntimeException("");
-            when(mock.lastModified()).thenThrow(expectedError);
-            final List<File> list = new ArrayList<>();
-            list.add(mock);
-            return list;
-        }
-
-    }
-
-    /**
-     * Non meaningful javadoc just to contain "noinspection" tag.
-     * Till https://youtrack.jetbrains.com/issue/IDEA-187210
-     *
-     * @noinspection JUnitTestCaseWithNoTests
-     */
-    private static class CheckstyleAntTaskLogStub extends CheckstyleAntTask {
-
-        private final List<MessageLevelPair> loggedMessages = new ArrayList<>();
-
-        @Override
-        public void log(String msg, int msgLevel) {
-            loggedMessages.add(new MessageLevelPair(msg, msgLevel));
-        }
-
-        @Override
-        public void log(String msg, Throwable t, int msgLevel) {
-            loggedMessages.add(new MessageLevelPair(msg, msgLevel));
-        }
-
-        public List<MessageLevelPair> getLoggedMessages() {
-            return Collections.unmodifiableList(loggedMessages);
-        }
-
-    }
-
-    /**
-     * Non meaningful javadoc just to contain "noinspection" tag.
-     * Till https://youtrack.jetbrains.com/issue/IDEA-187210
-     *
-     * @noinspection JUnitTestCaseWithNoTests
-     */
-    private static final class MessageLevelPair {
-
-        private final String msg;
-        private final int level;
-
-        /* package */ MessageLevelPair(String msg, int level) {
-            this.msg = msg;
-            this.level = level;
-        }
-
-        public String getMsg() {
-            return msg;
-        }
-
-        public int getLevel() {
-            return level;
-        }
-
-    }
-
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/testmodules/CheckstyleAntTaskLogStub.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/testmodules/CheckstyleAntTaskLogStub.java
@@ -1,0 +1,46 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2021 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.internal.powermock.testmodules;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask;
+
+public final class CheckstyleAntTaskLogStub extends CheckstyleAntTask {
+
+    private final List<MessageLevelPair> loggedMessages = new ArrayList<>();
+
+    @Override
+    public void log(String msg, int msgLevel) {
+        loggedMessages.add(new MessageLevelPair(msg, msgLevel));
+    }
+
+    @Override
+    public void log(String msg, Throwable t, int msgLevel) {
+        loggedMessages.add(new MessageLevelPair(msg, msgLevel));
+    }
+
+    public List<MessageLevelPair> getLoggedMessages() {
+        return Collections.unmodifiableList(loggedMessages);
+    }
+
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/testmodules/CheckstyleAntTaskStub.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/testmodules/CheckstyleAntTaskStub.java
@@ -1,0 +1,45 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2021 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.internal.powermock.testmodules;
+
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.powermock.api.mockito.PowerMockito;
+
+import com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask;
+
+public class CheckstyleAntTaskStub extends CheckstyleAntTask {
+
+    @Override
+    protected List<File> scanFileSets() {
+        final File mock = PowerMockito.mock(File.class);
+        // Assume that I/O error is happened when we try to invoke 'lastModified()' method.
+        final Exception expectedError = new RuntimeException("");
+        when(mock.lastModified()).thenThrow(expectedError);
+        final List<File> list = new ArrayList<>();
+        list.add(mock);
+        return list;
+    }
+
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/testmodules/MessageLevelPair.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/testmodules/MessageLevelPair.java
@@ -1,0 +1,39 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2021 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.internal.powermock.testmodules;
+
+public final class MessageLevelPair {
+
+    private final String msg;
+    private final int level;
+
+    public MessageLevelPair(String msg, int level) {
+        this.msg = msg;
+        this.level = level;
+    }
+
+    public String getMsg() {
+        return msg;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+}


### PR DESCRIPTION
Related to #9256 

I found one more pattern for to do issues, it is like `till #<issue number>`

1. This pattern is added to job for checking source code
2. Violations fixed for closed items
3. Second commit - found bug in checkstyle check for checking whitespaces after comments in sh files. Added a new check for it and fixed violations. May be new PR is needed for this change?