### PR TITLE
Issue #9280: replace `Scope` with `AccessModifierOption` in JavadocVariableCheck

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -168,7 +168,9 @@ no-error-xwiki)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo version:$CS_POM_VERSION
   mvn -e --no-transfer-progress clean install -Pno-validations
-  checkout_from "https://github.com/xwiki/xwiki-commons.git"
+  # until https://github.com/xwiki/xwiki-commons/pull/143 is merged
+  # checkout_from "-b checkstyle_9280 https://github.com/checkstyle/xwiki-commons.git"
+  checkout_from "-b updated_checkstyle_9280 https://github.com/martin-mfg/xwiki-commons.git"
   cd .ci-temp/xwiki-commons
   # Build custom Checkstyle rules
   mvn -e --no-transfer-progress -f \

--- a/.ci/wercker.sh
+++ b/.ci/wercker.sh
@@ -200,16 +200,19 @@ no-error-spring-integration)
   ;;
 
 no-error-spring-cloud-gcp)
-  set -e
-  CS_POM_VERSION="$(getCheckstylePomVersion)"
-  echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/googlecloudplatform/spring-cloud-gcp
-  cd .ci-temp/spring-cloud-gcp
-  mvn -e --no-transfer-progress checkstyle:check@checkstyle-validation \
-   -Dmaven-checkstyle-plugin.version=3.1.1 \
-   -Dpuppycrawl-tools-checkstyle.version=${CS_POM_VERSION}
-  cd ..
-  removeFolderWithProtectedFiles spring-cloud-gcp
+  # disabled until https://github.com/spring-io/spring-javaformat/pull/274 is merged, because of
+  # a breaking change (https://github.com/checkstyle/checkstyle/pull/9277) in checkstyle.
+
+  #set -e
+  # CS_POM_VERSION="$(getCheckstylePomVersion)"
+  # echo CS_version: ${CS_POM_VERSION}
+  # checkout_from https://github.com/googlecloudplatform/spring-cloud-gcp
+  # cd .ci-temp/spring-cloud-gcp
+  # mvn -e --no-transfer-progress checkstyle:check@checkstyle-validation \
+  #  -Dmaven-checkstyle-plugin.version=3.1.1 \
+  #  -Dpuppycrawl-tools-checkstyle.version=${CS_POM_VERSION}
+  # cd ..
+  # removeFolderWithProtectedFiles spring-cloud-gcp
   ;;
 
 no-exception-struts)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
+import java.util.Arrays;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
@@ -28,6 +29,7 @@ import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.api.TextBlock;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption;
 import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
 
 /**
@@ -36,15 +38,10 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * </p>
  * <ul>
  * <li>
- * Property {@code scope} - Specify the visibility scope where Javadoc comments are checked.
- * Type is {@code com.puppycrawl.tools.checkstyle.api.Scope}.
- * Default value is {@code private}.
- * </li>
- * <li>
- * Property {@code excludeScope} - Specify the visibility scope where Javadoc
- * comments are not checked.
- * Type is {@code com.puppycrawl.tools.checkstyle.api.Scope}.
- * Default value is {@code null}.
+ * Property {@code accessModifiers} - Specify the access modifiers where Javadoc comments are
+ * checked.
+ * Type is {@code com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption[]}.
+ * Default value is {@code public, protected, package, private}.
  * </li>
  * <li>
  * Property {@code ignoreNamePattern} - Specify the regexp to define variable names to ignore.
@@ -67,8 +64,8 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * &lt;module name="JavadocVariable"/&gt;
  * </pre>
  * <p>
- * By default, this setting will report a violation if
- * there is no javadoc for any scope member.
+ * By default, this setting will report a violation
+ * if there is no javadoc for a member with any access modifier.
  * </p>
  * <pre>
  * public class Test {
@@ -84,40 +81,16 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * }
  * </pre>
  * <p>
- * To configure the check for {@code public} scope:
+ * To configure the check for {@code package} and {@code private} variables:
  * </p>
  * <pre>
  * &lt;module name="JavadocVariable"&gt;
- *   &lt;property name="scope" value="public"/&gt;
- * &lt;/module&gt;
- * </pre>
- * <p>This setting will report a violation if there is no javadoc for {@code public} member.</p>
- * <pre>
- * public class Test {
- *   private int a; // OK
- *
- *   &#47;**
- *    * Some description here
- *    *&#47;
- *   private int b; // OK
- *   protected int c; // OK
- *   public int d; // violation, missing javadoc for public member
- *   &#47;*package*&#47; int e; // OK
- * }
- * </pre>
- * <p>
- * To configure the check for members which are in {@code private},
- * but not in {@code protected} scope:
- * </p>
- * <pre>
- * &lt;module name="JavadocVariable"&gt;
- *   &lt;property name="scope" value="private"/&gt;
- *   &lt;property name="excludeScope" value="protected"/&gt;
+ *   &lt;property name="accessModifiers" value="package,private"/&gt;
  * &lt;/module&gt;
  * </pre>
  * <p>
- * This setting will report a violation if there is no javadoc for {@code private}
- * member and ignores {@code protected} member.
+ * This setting will report a violation if there is no javadoc for {@code package}
+ * or {@code private} members.
  * </p>
  * <pre>
  * public class Test {
@@ -141,8 +114,8 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * &lt;/module&gt;
  * </pre>
  * <p>
- * This setting will report a violation if there is no javadoc for any scope
- * member and ignores members with name {@code log} or {@code logger}.
+ * This setting will report a violation if there is no javadoc for a
+ * member with any scope and ignores members with name {@code log} or {@code logger}.
  * </p>
  * <pre>
  * public class Test {
@@ -183,31 +156,25 @@ public class JavadocVariableCheck
      */
     public static final String MSG_JAVADOC_MISSING = "javadoc.missing";
 
-    /** Specify the visibility scope where Javadoc comments are checked. */
-    private Scope scope = Scope.PRIVATE;
-
-    /** Specify the visibility scope where Javadoc comments are not checked. */
-    private Scope excludeScope;
+    /** Specify the access modifiers where Javadoc comments are checked. */
+    private AccessModifierOption[] accessModifiers = {
+        AccessModifierOption.PUBLIC,
+        AccessModifierOption.PROTECTED,
+        AccessModifierOption.PACKAGE,
+        AccessModifierOption.PRIVATE,
+    };
 
     /** Specify the regexp to define variable names to ignore. */
     private Pattern ignoreNamePattern;
 
     /**
-     * Setter to specify the visibility scope where Javadoc comments are checked.
+     * Setter to specify the access modifiers where Javadoc comments are checked.
      *
-     * @param scope a scope.
+     * @param accessModifiers access modifiers of variables which should be checked.
      */
-    public void setScope(Scope scope) {
-        this.scope = scope;
-    }
-
-    /**
-     * Setter to specify the visibility scope where Javadoc comments are not checked.
-     *
-     * @param excludeScope a scope.
-     */
-    public void setExcludeScope(Scope excludeScope) {
-        this.excludeScope = excludeScope;
+    public void setAccessModifiers(AccessModifierOption... accessModifiers) {
+        this.accessModifiers =
+            Arrays.copyOf(accessModifiers, accessModifiers.length);
     }
 
     /**
@@ -279,12 +246,56 @@ public class JavadocVariableCheck
         if (!ScopeUtil.isInCodeBlock(ast) && !isIgnored(ast)) {
             final Scope customScope = ScopeUtil.getScope(ast);
             final Scope surroundingScope = ScopeUtil.getSurroundingScope(ast);
-            result = customScope.isIn(scope) && surroundingScope.isIn(scope)
-                && (excludeScope == null
-                    || !customScope.isIn(excludeScope)
-                    || !surroundingScope.isIn(excludeScope));
+
+            final Scope effectiveScope;
+            if (surroundingScope.isIn(customScope)) {
+                effectiveScope = customScope;
+            }
+            else {
+                effectiveScope = surroundingScope;
+            }
+            result = matchAccessModifiers(toAccessModifier(effectiveScope));
         }
         return result;
+    }
+
+    /**
+     * Checks whether a variable has the correct access modifier to be checked.
+     *
+     * @param accessModifier the access modifier of the variable.
+     * @return whether the variable matches the expected access modifier.
+     */
+    private boolean matchAccessModifiers(final AccessModifierOption accessModifier) {
+        return Arrays.stream(accessModifiers)
+            .anyMatch(modifier -> modifier == accessModifier);
+    }
+
+    /**
+     * Converts a {@link Scope} to {@link AccessModifierOption}. {@code Scope.NOTHING} and {@code
+     * Scope.ANONINNER} are converted to {@code AccessModifierOption.PUBLIC}.
+     *
+     * @param scope Scope to be converted.
+     * @return the corresponding AccessModifierOption.
+     */
+    private static AccessModifierOption toAccessModifier(Scope scope) {
+        final AccessModifierOption accessModifier;
+        switch (scope) {
+            case PROTECTED:
+                accessModifier = AccessModifierOption.PROTECTED;
+                break;
+            case PACKAGE:
+                accessModifier = AccessModifierOption.PACKAGE;
+                break;
+            case PRIVATE:
+                accessModifier = AccessModifierOption.PRIVATE;
+                break;
+            case NOTHING:
+            case ANONINNER:
+            case PUBLIC:
+            default:
+                accessModifier = AccessModifierOption.PUBLIC;
+        }
+        return accessModifier;
     }
 
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocVariableCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocVariableCheck.xml
@@ -8,14 +8,11 @@
  Checks that a variable has a Javadoc comment. Ignores {@code serialVersionUID} fields.
  &lt;/p&gt;</description>
          <properties>
-            <property default-value="private"
-                      name="scope"
-                      type="com.puppycrawl.tools.checkstyle.api.Scope">
-               <description>Specify the visibility scope where Javadoc comments are checked.</description>
-            </property>
-            <property name="excludeScope" type="com.puppycrawl.tools.checkstyle.api.Scope">
-               <description>Specify the visibility scope where Javadoc
- comments are not checked.</description>
+            <property default-value="public, protected, package, private"
+                      name="accessModifiers"
+                      type="com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption[]">
+               <description>Specify the access modifiers where Javadoc comments are
+ checked.</description>
             </property>
             <property name="ignoreNamePattern" type="java.util.regex.Pattern">
                <description>Specify the regexp to define variable names to ignore.</description>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
@@ -119,7 +119,7 @@ public class JavadocVariableCheckTest
     }
 
     @Test
-    public void testScopes() throws Exception {
+    public void testAccessModifiersAll() throws Exception {
         final String[] expected = {
             "15:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
@@ -165,7 +165,7 @@ public class JavadocVariableCheckTest
     }
 
     @Test
-    public void testScopes2() throws Exception {
+    public void testAccessModifiersPublicProtected() throws Exception {
         final String[] expected = {
             "15:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
@@ -178,7 +178,7 @@ public class JavadocVariableCheckTest
     }
 
     @Test
-    public void testExcludeScope() throws Exception {
+    public void testAccessModifiersPrivatePackage() throws Exception {
         final String[] expected = {
             "17:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
             "18:5: " + getCheckMessage(MSG_JAVADOC_MISSING),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableInner.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableInner.java
@@ -1,9 +1,9 @@
 /*
 JavadocVariable
-scope = (default)private
-excludeScope = (default)null
+accessModifiers = (default)public, protected, package, private
 ignoreNamePattern = (default)null
 tokens = (default)ENUM_CONSTANT_DEF
+
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableInner2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableInner2.java
@@ -1,9 +1,9 @@
 /*
 JavadocVariable
-scope = public
-excludeScope = (default)null
+accessModifiers = public
 ignoreNamePattern = (default)null
 tokens = (default)ENUM_CONSTANT_DEF
+
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableInterfaceMemberScopeIsPublic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableInterfaceMemberScopeIsPublic.java
@@ -1,9 +1,9 @@
 /*
 JavadocVariable
-scope = public
-excludeScope = (default)null
+accessModifiers = public
 ignoreNamePattern = (default)null
 tokens = ENUM_CONSTANT_DEF, VARIABLE_DEF
+
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc.java
@@ -1,9 +1,9 @@
 /*
 JavadocVariable
-scope = (default)private
-excludeScope = (default)null
+accessModifiers = (default)public, protected, package, private
 ignoreNamePattern = (default)null
 tokens = (default)ENUM_CONSTANT_DEF
+
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc2.java
@@ -1,9 +1,9 @@
 /*
 JavadocVariable
-scope = protected
-excludeScope = (default)null
+accessModifiers = public, protected
 ignoreNamePattern = (default)null
 tokens = (default)ENUM_CONSTANT_DEF
+
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc3.java
@@ -1,9 +1,9 @@
 /*
 JavadocVariable
-scope = (default)private
-excludeScope = protected
+accessModifiers = package, private
 ignoreNamePattern = (default)null
 tokens = (default)ENUM_CONSTANT_DEF
+
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc4.java
@@ -1,9 +1,9 @@
 /*
 JavadocVariable
-scope = (default)private
-excludeScope = (default)null
+accessModifiers = (default)public, protected, package, private
 ignoreNamePattern = log|logger
 tokens = (default)ENUM_CONSTANT_DEF
+
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadoc5.java
@@ -1,9 +1,9 @@
 /*
 JavadocVariable
-scope = (default)private
-excludeScope = (default)null
+accessModifiers = (default)public, protected, package, private
 ignoreNamePattern =
 tokens = (default)ENUM_CONSTANT_DEF
+
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadocNeededInLambda.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableNoJavadocNeededInLambda.java
@@ -1,9 +1,9 @@
 /*
 JavadocVariable
-scope = (default)private
-excludeScope = (default)null
+accessModifiers = (default)public, protected, package, private
 ignoreNamePattern = (default)null
 tokens = (default)ENUM_CONSTANT_DEF
+
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariablePublicOnly.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariablePublicOnly.java
@@ -1,9 +1,9 @@
 /*
 JavadocVariable
-scope = (default)private
-excludeScope = (default)null
+accessModifiers = (default)public, protected, package, private
 ignoreNamePattern = (default)null
 tokens = (default)ENUM_CONSTANT_DEF
+
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariablePublicOnly2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariablePublicOnly2.java
@@ -1,9 +1,9 @@
 /*
 JavadocVariable
-scope = public
-excludeScope = (default)null
+accessModifiers = public
 ignoreNamePattern = (default)null
 tokens = (default)ENUM_CONSTANT_DEF
+
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableTags.java
@@ -1,9 +1,9 @@
 /*
 JavadocVariable
-scope = (default)private
-excludeScope = (default)null
+accessModifiers = (default)public, protected, package, private
 ignoreNamePattern = (default)null
 tokens = (default)ENUM_CONSTANT_DEF
+
 
 
 */

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -2280,18 +2280,13 @@ class DatabaseConfiguration {}
               <th>since</th>
             </tr>
             <tr>
-              <td>scope</td>
-              <td>Specify the visibility scope where Javadoc comments are checked.</td>
-              <td><a href="property_types.html#Scope">Scope</a></td>
-              <td><code>private</code></td>
-              <td>3.0</td>
-            </tr>
-            <tr>
-              <td>excludeScope</td>
-              <td>Specify the visibility scope where Javadoc comments are not checked.</td>
-              <td><a href="property_types.html#Scope">Scope</a></td>
-              <td><code>null</code></td>
-              <td>3.4</td>
+              <td>accessModifiers</td>
+              <td>Specify the access modifiers where Javadoc comments are checked.</td>
+              <td><a href="property_types.html#AccessModifierOption.5B.5D">AccessModifierOption[]
+              </a>
+              </td>
+              <td><code>public, protected, package, private</code></td>
+              <td>8.46</td>
             </tr>
             <tr>
               <td>ignoreNamePattern</td>
@@ -2326,7 +2321,7 @@ class DatabaseConfiguration {}
         </source>
         <p>
           By default, this setting will report a violation if
-          there is no javadoc for any scope member.
+          there is no javadoc for a member with any access modifier.
         </p>
         <source>
 public class Test {
@@ -2343,48 +2338,18 @@ public int d; // violation, missing javadoc for public member
         </source>
 
         <p>
-          To configure the check for <code>public</code>
-          scope:
+          To configure the check for <code>package</code> and <code>private</code>
+          variables:
         </p>
 
         <source>
 &lt;module name="JavadocVariable"&gt;
-  &lt;property name="scope" value="public"/&gt;
-&lt;/module&gt;
-        </source>
-        <p>
-          This setting will report a violation if there
-          is no javadoc for <code>public</code> member.
-        </p>
-        <source>
-public class Test {
-private int a; // OK
-
-/**
- * Some description here
- */
-private int b; // OK
-protected int c; // OK
-public int d; // violation, missing javadoc for public member
-/*package*/ int e; // OK
-}
-        </source>
-
-        <p>
-          To configure the check for members which are in <code>private</code>, but not in
-          <code>protected</code> scope:
-        </p>
-
-        <source>
-&lt;module name="JavadocVariable"&gt;
-  &lt;property name="scope" value="private"/&gt;
-  &lt;property name="excludeScope" value="protected"/&gt;
+  &lt;property name="accessModifiers" value="package,private"/&gt;
 &lt;/module&gt;
         </source>
         <p>
           This setting will report a violation if there is no
-          javadoc for <code>private</code> member and
-          ignores <code>protected</code> member.
+          javadoc for <code>package</code> or <code>private</code> members.
         </p>
         <source>
 public class Test {
@@ -2411,7 +2376,7 @@ public int d; // OK
         </source>
         <p>
           This setting will report a violation if there is no
-          javadoc for any scope member and ignores members with
+          javadoc for a member with any scope and ignores members with
           name <code>log</code> or <code>logger</code>.
         </p>
         <source>


### PR DESCRIPTION
fix for #9280

might be related issue #3183

In `JavadocVariableCheck`, replace `Scope scope` and `Scope excludeScope` by `AccessModifierOption[] accessModifiers`.

Whether the JavadocVariableCheck is applied to a given variable still depends on the variable's modifier *and on the variable's surrounding scope*, like it was before. I.e. to run the check on a `public` field in a `private` class, `accessModifiers` must include `private`, but not necessarily `public`. If it was intended to change this behaviour, let me know.

I intended to make changes similar to those in [f91b1af](https://github.com/checkstyle/checkstyle/commit/f91b1af3d7c130daaeb52fea303b5d8e4c2769bf#diff-f1dcf2d250d8b52ccfbc408a657c47c4c735aef522b9c2f93c7826d93c152541), because of this comment: https://github.com/checkstyle/checkstyle/issues/3183#issuecomment-283539970.

In https://github.com/checkstyle/checkstyle/issues/3675#issue-197441645 it says 
> Looks like scope is counted by more visible and less visible. But should be simply by matching.

I thought this should apply here too.

-------

Similar update was done at https://github.com/checkstyle/checkstyle/pull/9670 and it has interesting problem point in javadoc on inner classes.

-------

ATTENTION: we recently run into edge case with scope property but for another Check - https://github.com/checkstyle/checkstyle/issues/13749 , and I am not sure how accessModifiersOption is going to handle it.