### PR TITLE
infra: move all launch.groovy usages in CI to diff.groovy

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -1376,6 +1376,7 @@ xffffffffffffffff
 xg
 Xhenseval
 XHTML
+xm
 xml
 XMLHTTP
 xmllogger
@@ -1383,7 +1384,6 @@ xmlmetareader
 xmlns
 xmlp
 xmlstarlet
-Xms
 Xmx
 xpath
 xpathfilegenerator

--- a/.ci/no-exception-test.sh
+++ b/.ci/no-exception-test.sh
@@ -18,8 +18,10 @@ guava-with-google-checks)
   sed -i.'' 's/warning/ignore/' .ci-temp/google_checks.xml
   cd .ci-temp/contribution/checkstyle-tester
   export MAVEN_OPTS="-Xmx2048m"
-  groovy ./launch.groovy --listOfProjects projects-to-test-on.properties \
-      --config ../../google_checks.xml --checkstyleVersion $CS_POM_VERSION
+  groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
+      --patchConfig ../../google_checks.xml \
+      --mode single -xm "-Dcheckstyle.failsOnError=false \
+      -Dcheckstyle.version=${CS_POM_VERSION}" -p master -r ../../..
   cd ../..
   removeFolderWithProtectedFiles contribution
   rm google_checks.*
@@ -38,8 +40,10 @@ guava-with-sun-checks)
   sed -i.'' 's/value=\"error\"/value=\"ignore\"/' .ci-temp/sun_checks.xml
   cd .ci-temp/contribution/checkstyle-tester
   export MAVEN_OPTS="-Xmx2048m"
-  groovy ./launch.groovy --listOfProjects projects-to-test-on.properties \
-      --config ../../sun_checks.xml --checkstyleVersion $CS_POM_VERSION
+  groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
+      --patchConfig ../../sun_checks.xml \
+      --mode single -xm "-Dcheckstyle.failsOnError=false \
+      -Dcheckstyle.version=${CS_POM_VERSION}"  -p master -r ../../..
   cd ../..
   removeFolderWithProtectedFiles contribution
   rm sun_checks.*
@@ -59,7 +63,7 @@ openjdk14-with-checks-nonjavadoc-error)
       --mode single \
       --patchConfig checks-nonjavadoc-error.xml \
       --localGitRepo  "$LOCAL_GIT_REPO" \
-      --patchBranch "$BRANCH"
+      --patchBranch "$BRANCH" -xm "-Dcheckstyle.failsOnError=false"
 
   cd ../../
   removeFolderWithProtectedFiles contribution

--- a/.ci/shippable.sh
+++ b/.ci/shippable.sh
@@ -17,13 +17,14 @@ no-exception-openjdk7-openjdk8)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo 'CS_POM_VERSION='${CS_POM_VERSION}
   build_checkstyle
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from https://github.com/checkstyle/contribution
   cd .ci-temp/contribution/checkstyle-tester
   sed -i'' 's/^guava/#guava/' projects-for-circle.properties
   sed -i'' 's/#openjdk7/openjdk7/' projects-for-circle.properties
   sed -i'' 's/#openjdk8/openjdk8/' projects-for-circle.properties
-  groovy launch.groovy --listOfProjects projects-for-circle.properties \
-    --config checks-nonjavadoc-error.xml --checkstyleVersion ${CS_POM_VERSION}
+  groovy diff.groovy --listOfProjects projects-for-circle.properties \
+    --config checks-nonjavadoc-error.xml --checkstyleVersion ${CS_POM_VERSION} \
+    --allowExcludes -xm "-Dcheckstyle.failsOnError=false"
   cd ../..
   removeFolderWithProtectedFiles .ci-temp/contribution
   ;;
@@ -32,7 +33,7 @@ no-exception-openjdk9-lucene-and-others)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo 'CS_POM_VERSION='${CS_POM_VERSION}
   build_checkstyle
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from https://github.com/checkstyle/contribution
   cd .ci-temp/contribution/checkstyle-tester
   sed -i'' 's/^guava/#guava/' projects-for-circle.properties
   # till hg is installed
@@ -41,8 +42,9 @@ no-exception-openjdk9-lucene-and-others)
   sed -i'' 's/#protonpack/protonpack/' projects-for-circle.properties
   sed -i'' 's/#jOOL/jOOL/' projects-for-circle.properties
   sed -i'' 's/#lucene-solr/lucene-solr/' projects-for-circle.properties
-  groovy launch.groovy --listOfProjects projects-for-circle.properties \
-    --config checks-nonjavadoc-error.xml --checkstyleVersion ${CS_POM_VERSION}
+  groovy diff.groovy --listOfProjects projects-for-circle.properties \
+    --config checks-nonjavadoc-error.xml --checkstyleVersion ${CS_POM_VERSION} \
+    --allowExcludes -xm "-Dcheckstyle.failsOnError=false"
   cd ../..
   removeFolderWithProtectedFiles contribution
   ;;
@@ -51,14 +53,15 @@ no-exception-cassandra-storm-tapestry)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo 'CS_POM_VERSION='${CS_POM_VERSION}
   build_checkstyle
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from https://github.com/checkstyle/contribution
   cd .ci-temp/contribution/checkstyle-tester
   sed -i'' 's/^guava/#guava/' projects-for-circle.properties
   sed -i'' 's/#tapestry-5/tapestry-5/' projects-for-circle.properties
   sed -i'' 's/#storm/storm/' projects-for-circle.properties
   sed -i'' 's/#cassandra/cassandra/' projects-for-circle.properties
-  groovy launch.groovy --listOfProjects projects-for-circle.properties \
-    --config checks-nonjavadoc-error.xml --checkstyleVersion ${CS_POM_VERSION}
+  groovy diff.groovy --listOfProjects projects-for-circle.properties \
+    --config checks-nonjavadoc-error.xml --checkstyleVersion ${CS_POM_VERSION} \
+    --allowExcludes -xm "-Dcheckstyle.failsOnError=false"
   cd ../..
   removeFolderWithProtectedFiles contribution
   ;;
@@ -67,15 +70,16 @@ no-exception-hadoop-apache-groovy-scouter)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo 'CS_POM_VERSION='${CS_POM_VERSION}
   build_checkstyle
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from https://github.com/checkstyle/contribution
   cd .ci-temp/contribution/checkstyle-tester
   sed -i'' 's/^guava/#guava/' projects-for-circle.properties
   sed -i'' 's/#apache-commons/apache-commons/' projects-for-circle.properties
   sed -i'' 's/#hadoop/hadoop/' projects-for-circle.properties
   sed -i'' 's/#groovy/groovy/' projects-for-circle.properties
   sed -i'' 's/#scouter/scouter/' projects-for-circle.properties
-  groovy launch.groovy --listOfProjects projects-for-circle.properties \
-    --config checks-nonjavadoc-error.xml --checkstyleVersion ${CS_POM_VERSION}
+  groovy diff.groovy --listOfProjects projects-for-circle.properties \
+    --config checks-nonjavadoc-error.xml --checkstyleVersion ${CS_POM_VERSION} \
+    --allowExcludes -xm "-Dcheckstyle.failsOnError=false"
   cd ../..
   removeFolderWithProtectedFiles contribution
   ;;
@@ -84,7 +88,7 @@ no-exception-only-javadoc)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo 'CS_POM_VERSION='${CS_POM_VERSION}
   build_checkstyle
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from https://github.com/checkstyle/contribution
   cd .ci-temp/contribution/checkstyle-tester
   sed -i.'' 's/^guava/#guava/' projects-to-test-on.properties
   sed -i.'' 's/#spring-framework/spring-framework/' projects-to-test-on.properties
@@ -92,8 +96,9 @@ no-exception-only-javadoc)
   sed -i.'' 's/#spotbugs/spotbugs/' projects-to-test-on.properties
   sed -i.'' 's/#pmd/pmd/' projects-to-test-on.properties
   sed -i.'' 's/#apache-ant/apache-ant/' projects-to-test-on.properties
-  groovy launch.groovy --listOfProjects projects-to-test-on.properties \
-    --config checks-only-javadoc-error.xml --checkstyleVersion ${CS_POM_VERSION}
+  groovy diff.groovy --listOfProjects projects-to-test-on.properties \
+    --config checks-only-javadoc-error.xml --checkstyleVersion ${CS_POM_VERSION} \
+    --allowExcludes -xm "-Dcheckstyle.failsOnError=false"
   cd ../..
   removeFolderWithProtectedFiles contribution
   ;;

--- a/.ci/wercker.sh
+++ b/.ci/wercker.sh
@@ -216,12 +216,14 @@ no-error-spring-cloud-gcp)
 no-exception-struts)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from https://github.com/checkstyle/contribution
   cd .ci-temp/contribution/checkstyle-tester
   sed -i'' 's/^guava/#guava/' projects-for-wercker.properties
   sed -i'' 's/#apache-struts/apache-struts/' projects-for-wercker.properties
-  groovy ./launch.groovy --listOfProjects projects-for-wercker.properties \
-      --config checks-nonjavadoc-error.xml --checkstyleVersion ${CS_POM_VERSION}
+  groovy ./diff.groovy --listOfProjects projects-for-wercker.properties \
+      --patchConfig checks-nonjavadoc-error.xml  -p master -r ../../..  \
+      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
+      -Dcheckstyle.version=${CS_POM_VERSION}"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -230,13 +232,15 @@ no-exception-checkstyle-sevntu)
   set -e
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from https://github.com/checkstyle/contribution
   cd .ci-temp/contribution/checkstyle-tester
   sed -i'' 's/^guava/#guava/' projects-for-wercker.properties
   sed -i'' 's/#local-checkstyle/local-checkstyle/' projects-for-wercker.properties
   sed -i'' 's/#sevntu-checkstyle/sevntu-checkstyle/' projects-for-wercker.properties
-  groovy ./launch.groovy --listOfProjects projects-for-wercker.properties \
-      --config checks-nonjavadoc-error.xml --checkstyleVersion ${CS_POM_VERSION}
+  groovy ./diff.groovy --listOfProjects projects-for-wercker.properties \
+      --patchConfig checks-nonjavadoc-error.xml  -p master -r ../../..  \
+      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
+      -Dcheckstyle.version=${CS_POM_VERSION}"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -245,13 +249,15 @@ no-exception-checkstyle-sevntu-javadoc)
   set -e
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from https://github.com/checkstyle/contribution
   cd .ci-temp/contribution/checkstyle-tester
   sed -i'' 's/^guava/#guava/' projects-for-wercker.properties
   sed -i'' 's/#local-checkstyle/local-checkstyle/' projects-for-wercker.properties
   sed -i'' 's/#sevntu-checkstyle/sevntu-checkstyle/' projects-for-wercker.properties
-  groovy ./launch.groovy --listOfProjects projects-for-wercker.properties \
-      --config checks-only-javadoc-error.xml --checkstyleVersion ${CS_POM_VERSION}
+  groovy ./diff.groovy --listOfProjects projects-for-wercker.properties \
+      --patchConfig checks-only-javadoc-error.xml  -p master -r ../../..  \
+      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
+      -Dcheckstyle.version=${CS_POM_VERSION}"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -259,12 +265,14 @@ no-exception-checkstyle-sevntu-javadoc)
 no-exception-guava)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from https://github.com/checkstyle/contribution
   cd .ci-temp/contribution/checkstyle-tester
   sed -i'' 's/^guava/#guava/' projects-for-wercker.properties
   sed -i'' 's/#guava/guava/' projects-for-wercker.properties
-  groovy ./launch.groovy --listOfProjects projects-for-wercker.properties \
-      --config checks-nonjavadoc-error.xml --checkstyleVersion ${CS_POM_VERSION}
+  groovy ./diff.groovy --listOfProjects projects-for-wercker.properties \
+      --patchConfig checks-nonjavadoc-error.xml  -p master -r ../../..  \
+      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
+      -Dcheckstyle.version=${CS_POM_VERSION}"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -272,12 +280,14 @@ no-exception-guava)
 no-exception-hibernate-orm)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from https://github.com/checkstyle/contribution
   cd .ci-temp/contribution/checkstyle-tester
   sed -i.'' 's/^guava/#guava/' projects-to-test-on.properties
   sed -i.'' 's/#hibernate-orm/hibernate-orm/' projects-to-test-on.properties
-  groovy ./launch.groovy --listOfProjects projects-for-wercker.properties \
-      --config checks-nonjavadoc-error.xml --checkstyleVersion ${CS_POM_VERSION}
+  groovy ./diff.groovy --listOfProjects projects-for-wercker.properties \
+      --patchConfig checks-nonjavadoc-error.xml  -p master -r ../../..  \
+       --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
+      -Dcheckstyle.version=${CS_POM_VERSION}"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -285,12 +295,14 @@ no-exception-hibernate-orm)
 no-exception-spotbugs)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from https://github.com/checkstyle/contribution
   cd .ci-temp/contribution/checkstyle-tester
   sed -i.'' 's/^guava/#guava/' projects-to-test-on.properties
   sed -i.'' 's/#spotbugs/spotbugs/' projects-to-test-on.properties
-  groovy ./launch.groovy --listOfProjects projects-to-test-on.properties \
-      --config checks-nonjavadoc-error.xml --checkstyleVersion ${CS_POM_VERSION}
+  groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
+      --patchConfig checks-nonjavadoc-error.xml  -p master -r ../../..  \
+      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
+      -Dcheckstyle.version=${CS_POM_VERSION}"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -298,12 +310,14 @@ no-exception-spotbugs)
 no-exception-spoon)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from https://github.com/checkstyle/contribution
   cd .ci-temp/contribution/checkstyle-tester
   sed -i.'' 's/^guava/#guava/' projects-to-test-on.properties
   sed -i.'' 's/#spoon/spoon/' projects-to-test-on.properties
-  groovy ./launch.groovy --listOfProjects projects-for-wercker.properties \
-      --config checks-nonjavadoc-error.xml --checkstyleVersion ${CS_POM_VERSION}
+  groovy ./diff.groovy --listOfProjects projects-for-wercker.properties \
+      --patchConfig checks-nonjavadoc-error.xml  -p master -r ../../..  \
+      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
+      -Dcheckstyle.version=${CS_POM_VERSION}"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -311,12 +325,14 @@ no-exception-spoon)
 no-exception-spring-framework)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from https://github.com/checkstyle/contribution
   cd .ci-temp/contribution/checkstyle-tester
   sed -i.'' 's/^guava/#guava/' projects-to-test-on.properties
   sed -i.'' 's/#spring-framework/spring-framework/' projects-to-test-on.properties
-  groovy ./launch.groovy --listOfProjects projects-to-test-on.properties \
-      --config checks-nonjavadoc-error.xml --checkstyleVersion ${CS_POM_VERSION}
+  groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
+      --patchConfig checks-nonjavadoc-error.xml  -p master -r ../../..  \
+       --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
+      -Dcheckstyle.version=${CS_POM_VERSION}"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -324,12 +340,14 @@ no-exception-spring-framework)
 no-exception-hbase)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from https://github.com/checkstyle/contribution
   cd .ci-temp/contribution/checkstyle-tester
   sed -i.'' 's/^guava/#guava/' projects-to-test-on.properties
   sed -i.'' 's/#Hbase/Hbase/' projects-to-test-on.properties
-  groovy ./launch.groovy --listOfProjects projects-to-test-on.properties \
-      --config checks-nonjavadoc-error.xml --checkstyleVersion ${CS_POM_VERSION}
+  groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
+      --patchConfig checks-nonjavadoc-error.xml  -p master -r ../../..  \
+      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
+      -Dcheckstyle.version=${CS_POM_VERSION}"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -337,14 +355,16 @@ no-exception-hbase)
 no-exception-Pmd-elasticsearch-lombok-ast)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from https://github.com/checkstyle/contribution
   cd .ci-temp/contribution/checkstyle-tester
   sed -i.'' 's/^guava/#guava/' projects-to-test-on.properties
   sed -i.'' 's/#pmd/pmd/' projects-to-test-on.properties
   sed -i.'' 's/#elasticsearch/elasticsearch/' projects-to-test-on.properties
   sed -i.'' 's/#lombok-ast/lombok-ast/' projects-to-test-on.properties
-  groovy ./launch.groovy --listOfProjects projects-to-test-on.properties \
-      --config checks-nonjavadoc-error.xml --checkstyleVersion ${CS_POM_VERSION}
+  groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
+      --patchConfig checks-nonjavadoc-error.xml  -p master -r ../../..  \
+      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
+      -Dcheckstyle.version=${CS_POM_VERSION}"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -352,7 +372,7 @@ no-exception-Pmd-elasticsearch-lombok-ast)
 no-exception-alot-of-projects)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from https://github.com/checkstyle/contribution
   cd .ci-temp/contribution/checkstyle-tester
   sed -i.'' 's/^guava/#guava/' projects-to-test-on.properties
   sed -i.'' 's/#RxJava/RxJava/' projects-to-test-on.properties
@@ -361,8 +381,10 @@ no-exception-alot-of-projects)
   sed -i.'' 's/#apache-ant/apache-ant/' projects-to-test-on.properties
   sed -i.'' 's/#apache-jsecurity/apache-jsecurity/' projects-to-test-on.properties
   sed -i.'' 's/#android-launcher/android-launcher/' projects-to-test-on.properties
-  groovy ./launch.groovy --listOfProjects projects-to-test-on.properties \
-      --config checks-nonjavadoc-error.xml --checkstyleVersion ${CS_POM_VERSION}
+  groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
+      --patchConfig checks-nonjavadoc-error.xml  -p master -r ../../.. \
+      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
+      -Dcheckstyle.version=${CS_POM_VERSION}"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -373,10 +395,11 @@ no-warning-imports-guava)
   REPORT=reports/guava/site/index.html
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from https://github.com/checkstyle/contribution
   cd .ci-temp/contribution/checkstyle-tester
-  groovy ./launch.groovy --listOfProjects $PROJECTS --config $CONFIG \
-      --checkstyleVersion ${CS_POM_VERSION}
+  groovy ./diff.groovy --listOfProjects $PROJECTS --patchConfig $CONFIG \
+      --allowExcludes -p master -r ../../.. \
+      --mode single -xm "-Dcheckstyle.failsOnError=false -Dcheckstyle.version=${CS_POM_VERSION}"
   RESULT=`grep -A 5 "&#160;Warning</td>" $REPORT | cat`
   cd ../../
   removeFolderWithProtectedFiles contribution
@@ -396,10 +419,11 @@ no-warning-imports-java-design-patterns)
   REPORT=reports/java-design-patterns/site/index.html
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/checkstyle/contribution.git
+  checkout_from https://github.com/checkstyle/contribution
   cd .ci-temp/contribution/checkstyle-tester
-  groovy ./launch.groovy --listOfProjects $PROJECTS --config $CONFIG \
-      --checkstyleVersion ${CS_POM_VERSION}
+  groovy ./diff.groovy --listOfProjects $PROJECTS --patchConfig $CONFIG \
+      --allowExcludes -p master -r ../../..\
+      --mode single -xm "-Dcheckstyle.version=${CS_POM_VERSION}"
   RESULT=`grep -A 5 "&#160;Warning</td>" $REPORT | cat`
   cd ../../
   removeFolderWithProtectedFiles contribution

--- a/.github/workflows/diff_report.yml
+++ b/.github/workflows/diff_report.yml
@@ -176,13 +176,13 @@ jobs:
          BASE_BRANCH="upstream/master"
          if [ -f new_module_config.xml ]; then
            groovy diff.groovy -r $REPO -p $REF -pc new_module_config.xml -m single\
-             -l project.properties
+             -l project.properties -xm "-Dcheckstyle.failsOnError=false"
          elif [ -f patch_config.xml ]; then
            groovy diff.groovy -r $REPO -b $BASE_BRANCH -p $REF -bc diff_config.xml\
-             -pc patch_config.xml -l project.properties
+             -pc patch_config.xml -l project.properties -xm "-Dcheckstyle.failsOnError=false"
          else
            groovy diff.groovy -r $REPO -b $BASE_BRANCH -p $REF -c diff_config.xml\
-             -l project.properties
+             -l project.properties -xm "-Dcheckstyle.failsOnError=false"
          fi
 
      - name: Copy Report to AWS S3 Bucket


### PR DESCRIPTION
infra: move all launch.groovy usages in CI to diff.groovy

Right now this PR is just to test and make sure that all CI works as expected.  See https://github.com/checkstyle/contribution/pull/546 for details.