### PR TITLE
Issue #9115: try to downlaod artifacts one more time in circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,17 @@ jobs:
             else
               echo "build is skipped ..."
             fi
+      - run:
+          name: download all maven dependencies and groovy (second try)
+          command: |
+            RUN_JOB=`cat .ci-temp/run_job`
+            echo "RUN_JOB="$RUN_JOB
+            if [[ $RUN_JOB == 1 ]]; then
+              mvn -e -Ppitest-metrics dependency:go-offline
+            else
+              echo "build is skipped ..."
+            fi
+          when: on_fail
       - persist_to_workspace:
           root: /home/circleci/
           paths:


### PR DESCRIPTION
Issue #9115

https://app.circleci.com/pipelines/github/checkstyle/checkstyle/4862/workflows/900f96cd-378f-4209-b45b-89fd48fe6d30/jobs/74172

![image](https://user-images.githubusercontent.com/812984/107893937-bef00f80-6ee2-11eb-97b0-ec96940181c5.png)

it is not easy to reproduce connection failure, but I think we can trust their documentation, in worse case we will reopen issue.