### PR TITLE
Issue #270: LineWrappingHandler keeps same indentation level for syntactically parallel elements if forceStrictCondition is true

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -132,6 +132,7 @@ pitest-indentation)
   "IndentationCheck.java.html:<td class='covered'><pre><span  class='survived'>        handlerFactory.clearCreatedHandlers();</span></pre></td></tr>"
   "IndentationCheck.java.html:<td class='covered'><pre><span  class='survived'>        handlers.clear();</span></pre></td></tr>"
   "IndentationCheck.java.html:<td class='covered'><pre><span  class='survived'>        primordialHandler.checkIndentation();</span></pre></td></tr>"
+  "LineWrappingHandler.java.html:<td class='covered'><pre><span  class='survived'>            if (additionalOffset &#62;= previousOffset) {</span></pre></td></tr>"
   "MethodDefHandler.java.html:<td class='covered'><pre><span  class='survived'>            if (node.getLineNo() &#60; lineStart) {</span></pre></td></tr>"
   "NewHandler.java.html:<td class='covered'><pre><span  class='survived'>        return false;</span></pre></td></tr>"
   "SwitchHandler.java.html:<td class='covered'><pre><span  class='survived'>        checkExpressionSubtree(</span></pre></td></tr>"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -812,7 +812,7 @@ public final class Main {
             }
             // ensure there is no conflicting options
             else if (printAst || printAstWithComments || printJavadocTree || printTreeWithJavadoc
-                || xpath != null) {
+                    || xpath != null) {
                 if (suppressionLineColumnNumber != null || configurationFile != null
                         || propertiesFile != null || outputPath != null
                         || parseResult.hasMatchedOption(OUTPUT_FORMAT_OPTION)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -372,10 +372,10 @@ public class AvoidEscapedUnicodeCharactersCheck
             CheckUtil.stripIndentAndInitialNewLineFromTextBlock(ast.getText());
 
         if (hasUnicodeChar(literal) && !(allowByTailComment && hasTrailComment(ast)
-                || isAllCharactersEscaped(literal)
-                || allowEscapesForControlCharacters
+                    || isAllCharactersEscaped(literal)
+                    || allowEscapesForControlCharacters
                         && isOnlyUnicodeValidChars(literal, UNICODE_CONTROL)
-                || allowNonPrintableEscapes
+                    || allowNonPrintableEscapes
                         && isOnlyUnicodeValidChars(literal, NON_PRINTABLE_CHARS))) {
             log(ast, MSG_KEY);
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -485,8 +485,8 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
                 TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR);
 
         if (valuePairCount == 1
-            && ANNOTATION_ELEMENT_SINGLE_NAME.equals(
-                valuePair.getFirstChild().getText())) {
+                && ANNOTATION_ELEMENT_SINGLE_NAME.equals(
+                    valuePair.getFirstChild().getText())) {
             log(annotation, MSG_KEY_ANNOTATION_INCORRECT_STYLE,
                 ElementStyleOption.COMPACT);
         }
@@ -503,7 +503,7 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
 
         // in compact style with one value
         if (arrayInit != null
-            && arrayInit.getChildCount(TokenTypes.EXPR) == 1) {
+                && arrayInit.getChildCount(TokenTypes.EXPR) == 1) {
             log(annotation, MSG_KEY_ANNOTATION_INCORRECT_STYLE,
                 ElementStyleOption.COMPACT_NO_ARRAY);
         }
@@ -514,7 +514,7 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
                 final DetailAST nestedArrayInit =
                     ast.findFirstToken(TokenTypes.ANNOTATION_ARRAY_INIT);
                 if (nestedArrayInit != null
-                    && nestedArrayInit.getChildCount(TokenTypes.EXPR) == 1) {
+                        && nestedArrayInit.getChildCount(TokenTypes.EXPR) == 1) {
                     log(annotation, MSG_KEY_ANNOTATION_INCORRECT_STYLE,
                         ElementStyleOption.COMPACT_NO_ARRAY);
                 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
@@ -240,16 +240,16 @@ public final class MissingOverrideCheck extends AbstractCheck {
                 final DetailAST defOrNew = ast.getParent().getParent();
 
                 if (defOrNew.findFirstToken(TokenTypes.EXTENDS_CLAUSE) != null
-                    || defOrNew.findFirstToken(TokenTypes.IMPLEMENTS_CLAUSE) != null
-                    || defOrNew.getType() == TokenTypes.LITERAL_NEW) {
+                        || defOrNew.findFirstToken(TokenTypes.IMPLEMENTS_CLAUSE) != null
+                        || defOrNew.getType() == TokenTypes.LITERAL_NEW) {
                     check = false;
                 }
             }
 
             if (check
-                && containsTag
-                && !AnnotationUtil.containsAnnotation(ast, OVERRIDE)
-                && !AnnotationUtil.containsAnnotation(ast, FQ_OVERRIDE)) {
+                    && containsTag
+                    && !AnnotationUtil.containsAnnotation(ast, OVERRIDE)
+                    && !AnnotationUtil.containsAnnotation(ast, FQ_OVERRIDE)) {
                 log(ast, MSG_KEY_ANNOTATION_MISSING_OVERRIDE);
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
@@ -342,7 +342,7 @@ public class EmptyBlockCheck
         final DetailAST leftCurly;
         final DetailAST slistAST = ast.findFirstToken(TokenTypes.SLIST);
         if ((ast.getType() == TokenTypes.LITERAL_CASE
-                || ast.getType() == TokenTypes.LITERAL_DEFAULT)
+                    || ast.getType() == TokenTypes.LITERAL_DEFAULT)
                 && ast.getNextSibling() != null
                 && ast.getNextSibling().getFirstChild() != null
                 && ast.getNextSibling().getFirstChild().getType() == TokenTypes.SLIST) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheck.java
@@ -373,7 +373,7 @@ public class EmptyCatchBlockCheck extends AbstractCheck {
         DetailAST catchBlockStmt = slistToken.getFirstChild();
         while (catchBlockStmt.getType() != TokenTypes.RCURLY) {
             if (catchBlockStmt.getType() != TokenTypes.SINGLE_LINE_COMMENT
-                 && catchBlockStmt.getType() != TokenTypes.BLOCK_COMMENT_BEGIN) {
+                    && catchBlockStmt.getType() != TokenTypes.BLOCK_COMMENT_BEGIN) {
                 result = false;
                 break;
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
@@ -403,8 +403,8 @@ public class NeedBracesCheck extends AbstractCheck {
             result = parent.getLastChild().getType() != TokenTypes.SLIST;
         }
         else if (nextSibling != null
-            && nextSibling.getType() == TokenTypes.SLIST
-            && nextSibling.getFirstChild().getType() != TokenTypes.SLIST) {
+                && nextSibling.getType() == TokenTypes.SLIST
+                && nextSibling.getFirstChild().getType() != TokenTypes.SLIST) {
             result = true;
         }
         return result;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
@@ -99,10 +99,10 @@ public abstract class AbstractSuperCheck
         boolean superCall = false;
 
         if (literalSuperAst.getType() == TokenTypes.LITERAL_SUPER
-            && !isSameNameMethod(literalSuperAst)) {
+                && !isSameNameMethod(literalSuperAst)) {
             final DetailAST parent = literalSuperAst.getParent();
             if (parent.getType() == TokenTypes.METHOD_REF
-                || !hasArguments(parent)) {
+                    || !hasArguments(parent)) {
                 superCall = isSuperCallInOverridingMethod(parent);
             }
         }
@@ -151,7 +151,7 @@ public abstract class AbstractSuperCheck
         DetailAST sibling = ast.getNextSibling();
         // ignore type parameters
         if (sibling != null
-            && sibling.getType() == TokenTypes.TYPE_ARGUMENTS) {
+                && sibling.getType() == TokenTypes.TYPE_ARGUMENTS) {
             sibling = sibling.getNextSibling();
         }
         return sibling == null || !getMethodName().equals(sibling.getText());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidDoubleBraceInitializationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidDoubleBraceInitializationCheck.java
@@ -147,7 +147,7 @@ public class AvoidDoubleBraceInitializationCheck extends AbstractCheck {
     @Override
     public void visitToken(DetailAST ast) {
         if (ast.getParent().getType() == TokenTypes.LITERAL_NEW
-            && hasOnlyInitialization(ast)) {
+                && hasOnlyInitialization(ast)) {
             log(ast, MSG_KEY);
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
@@ -288,7 +288,7 @@ public class DeclarationOrderCheck extends AbstractCheck {
                 break;
             case TokenTypes.MODIFIERS:
                 if (parentType == TokenTypes.VARIABLE_DEF
-                    && ast.getParent().getParent().getType() == TokenTypes.OBJBLOCK) {
+                        && ast.getParent().getParent().getType() == TokenTypes.OBJBLOCK) {
                     processModifiers(ast);
                 }
                 break;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DefaultComesLastCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DefaultComesLastCheck.java
@@ -192,8 +192,8 @@ public class DefaultComesLastCheck extends AbstractCheck {
                 log(ast, MSG_KEY_SKIP_IF_LAST_AND_SHARED_WITH_CASE);
             }
             else if (ast.getPreviousSibling() == null
-                && Objects.nonNull(findNextSibling(defaultGroupAST,
-                                                   TokenTypes.CASE_GROUP))) {
+                    && Objects.nonNull(findNextSibling(defaultGroupAST,
+                                                       TokenTypes.CASE_GROUP))) {
                 log(ast, MSG_KEY);
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
@@ -253,7 +253,7 @@ public class FallThroughCheck extends AbstractCheck {
             final DetailAST slist = ast.findFirstToken(TokenTypes.SLIST);
 
             if (slist != null && !isTerminated(slist, true, true)
-                && !hasFallThroughComment(ast, nextGroup)) {
+                    && !hasFallThroughComment(ast, nextGroup)) {
                 if (isLastGroup) {
                     log(ast, MSG_FALL_THROUGH_LAST);
                 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -273,8 +273,8 @@ public class FinalLocalVariableCheck extends AbstractCheck {
             case TokenTypes.SLIST:
                 currentScopeAssignedVariables.push(new ArrayDeque<>());
                 if (ast.getParent().getType() != TokenTypes.CASE_GROUP
-                    || ast.getParent().getParent().findFirstToken(TokenTypes.CASE_GROUP)
-                    == ast.getParent()) {
+                        || ast.getParent().getParent().findFirstToken(TokenTypes.CASE_GROUP)
+                        == ast.getParent()) {
                     storePrevScopeUninitializedVariableData();
                     scopeStack.push(new ScopeData());
                 }
@@ -316,8 +316,8 @@ public class FinalLocalVariableCheck extends AbstractCheck {
             case TokenTypes.EXPR:
                 // Switch labeled expression has no slist
                 if (ast.getParent().getType() == TokenTypes.SWITCH_RULE
-                    && ast.getParent().getParent().findFirstToken(TokenTypes.SWITCH_RULE)
-                        == ast.getParent()) {
+                        && ast.getParent().getParent().findFirstToken(TokenTypes.SWITCH_RULE)
+                            == ast.getParent()) {
                     storePrevScopeUninitializedVariableData();
                 }
                 break;
@@ -350,7 +350,7 @@ public class FinalLocalVariableCheck extends AbstractCheck {
                 prevScopeUninitializedVariableData = prevScopeUninitializedVariables.peek();
                 boolean containsBreak = false;
                 if (ast.getParent().getType() != TokenTypes.CASE_GROUP
-                    || findLastChildWhichContainsSpecifiedToken(ast.getParent().getParent(),
+                        || findLastChildWhichContainsSpecifiedToken(ast.getParent().getParent(),
                             TokenTypes.CASE_GROUP, TokenTypes.SLIST) == ast.getParent()) {
                     containsBreak = scopeStack.peek().containsBreak;
                     scope = scopeStack.pop().scope;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -428,7 +428,7 @@ public class HiddenFieldCheck
                 && firstChild.getType() == TokenTypes.IDENT) {
             final String untypedLambdaParameterName = firstChild.getText();
             if (frame.containsStaticField(untypedLambdaParameterName)
-                || isInstanceField(firstChild, untypedLambdaParameterName)) {
+                    || isInstanceField(firstChild, untypedLambdaParameterName)) {
                 log(firstChild, MSG_KEY, untypedLambdaParameterName);
             }
         }
@@ -501,9 +501,9 @@ public class HiddenFieldCheck
     @Override
     public void leaveToken(DetailAST ast) {
         if (ast.getType() == TokenTypes.CLASS_DEF
-            || ast.getType() == TokenTypes.ENUM_DEF
-            || ast.getType() == TokenTypes.ENUM_CONSTANT_DEF
-            || ast.getType() == TokenTypes.RECORD_DEF) {
+                || ast.getType() == TokenTypes.ENUM_DEF
+                || ast.getType() == TokenTypes.ENUM_CONSTANT_DEF
+                || ast.getType() == TokenTypes.RECORD_DEF) {
             // pop
             frame = frame.getParent();
         }
@@ -518,10 +518,10 @@ public class HiddenFieldCheck
      */
     private void processVariable(DetailAST ast) {
         if (!ScopeUtil.isInInterfaceOrAnnotationBlock(ast)
-            && !CheckUtil.isReceiverParameter(ast)
-            && (ScopeUtil.isLocalVariableDef(ast)
-                || ast.getType() == TokenTypes.PARAMETER_DEF
-                || ast.getType() == TokenTypes.PATTERN_VARIABLE_DEF)) {
+                && !CheckUtil.isReceiverParameter(ast)
+                && (ScopeUtil.isLocalVariableDef(ast)
+                    || ast.getType() == TokenTypes.PARAMETER_DEF
+                    || ast.getType() == TokenTypes.PATTERN_VARIABLE_DEF)) {
             // local variable or parameter. Does it shadow a field?
             final DetailAST nameAST = ast.findFirstToken(TokenTypes.IDENT);
             final String name = nameAST.getText();
@@ -618,8 +618,8 @@ public class HiddenFieldCheck
             final DetailAST parametersAST = ast.getParent();
             final DetailAST methodAST = parametersAST.getParent();
             if (parametersAST.getChildCount() == 1
-                && methodAST.getType() == TokenTypes.METHOD_DEF
-                && isSetterMethod(methodAST, name)) {
+                    && methodAST.getType() == TokenTypes.METHOD_DEF
+                    && isSetterMethod(methodAST, name)) {
                 isIgnoredSetterParam = true;
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -448,8 +448,8 @@ public class IllegalInstantiationCheck
         boolean isStandardClass = false;
         // class from java.lang
         if (illegal.length() - JAVA_LANG.length() == className.length()
-            && illegal.endsWith(className)
-            && illegal.startsWith(JAVA_LANG)) {
+                && illegal.endsWith(className)
+                && illegal.startsWith(JAVA_LANG)) {
             // java.lang needs no import, but a class without import might
             // also come from the same file or be in the same package.
             // E.g. if a class defines an inner class "Boolean",

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
@@ -330,7 +330,7 @@ public final class ModifiedControlVariableCheck extends AbstractCheck {
         final DetailAST identAST = ast.getFirstChild();
 
         if (identAST != null && identAST.getType() == TokenTypes.IDENT
-            && currentVariables.contains(identAST.getText())) {
+                && currentVariables.contains(identAST.getText())) {
             log(ast, MSG_KEY, identAST.getText());
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleVariableDeclarationsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleVariableDeclarationsCheck.java
@@ -119,7 +119,7 @@ public class MultipleVariableDeclarationsCheck extends AbstractCheck {
             final boolean isCommaSeparated = nextNode.getType() == TokenTypes.COMMA;
 
             if (isCommaSeparated
-                || nextNode.getType() == TokenTypes.SEMI) {
+                    || nextNode.getType() == TokenTypes.SEMI) {
                 nextNode = nextNode.getNextSibling();
             }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
@@ -318,7 +318,7 @@ public final class OneStatementPerLineCheck extends AbstractCheck {
                 lastVariableResourceStatementEnd = currentStatement.getLineNo();
             }
             if (nextNode.findFirstToken(TokenTypes.ASSIGN) != null
-                && nextNode.getLineNo() == lastVariableResourceStatementEnd) {
+                    && nextNode.getLineNo() == lastVariableResourceStatementEnd) {
                 log(currentStatement, MSG_KEY);
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheck.java
@@ -230,8 +230,8 @@ public final class ParameterAssignmentCheck extends AbstractCheck {
         final DetailAST identAST = ast.getFirstChild();
 
         if (identAST != null
-            && identAST.getType() == TokenTypes.IDENT
-            && parameterNames.contains(identAST.getText())) {
+                && identAST.getType() == TokenTypes.IDENT
+                && parameterNames.contains(identAST.getText())) {
             log(ast, MSG_KEY, identAST.getText());
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -1044,7 +1044,7 @@ public class RequireThisCheck extends AbstractCheck {
             }
             while (vertex != null) {
                 if (tokenType == vertex.getType()
-                    && vertex.getLineNo() <= endLineNumber) {
+                        && vertex.getLineNo() <= endLineNumber) {
                     result.add(vertex);
                 }
                 if (vertex.getNextSibling() != null) {
@@ -1340,7 +1340,7 @@ public class RequireThisCheck extends AbstractCheck {
             final AbstractFrame frame;
 
             if (!lookForMethod
-                && containsFieldOrVariable(nameToFind)) {
+                    && containsFieldOrVariable(nameToFind)) {
                 frame = this;
             }
             else {
@@ -1565,7 +1565,7 @@ public class RequireThisCheck extends AbstractCheck {
             AbstractFrame frame = null;
 
             if (lookForMethod && containsMethod(nameToFind)
-                || containsFieldOrVariable(nameToFind)) {
+                    || containsFieldOrVariable(nameToFind)) {
                 frame = this;
             }
             else if (getParent() != null) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheck.java
@@ -159,7 +159,7 @@ public class SimplifyBooleanReturnCheck
             final DetailAST thenStatement = condition.getNextSibling().getNextSibling();
 
             if (canReturnOnlyBooleanLiteral(thenStatement)
-                && canReturnOnlyBooleanLiteral(elseStatement)) {
+                    && canReturnOnlyBooleanLiteral(elseStatement)) {
                 log(ast, MSG_KEY);
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
@@ -456,7 +456,7 @@ public class UnnecessaryParenthesesCheck extends AbstractCheck {
             log(ast, MSG_LAMBDA, ast.getText());
         }
         else if (type != TokenTypes.ASSIGN
-            || parent.getType() != TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR) {
+                || parent.getType() != TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR) {
             final boolean surrounded = isSurrounded(ast);
             // An identifier surrounded by parentheses.
             if (surrounded && type == TokenTypes.IDENT) {
@@ -501,7 +501,7 @@ public class UnnecessaryParenthesesCheck extends AbstractCheck {
 
         // shouldn't process assign in annotation pairs
         if (type != TokenTypes.ASSIGN
-            || parent.getType() != TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR) {
+                || parent.getType() != TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR) {
             if (type == TokenTypes.EXPR) {
                 checkExpression(ast);
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonInTryWithResourcesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonInTryWithResourcesCheck.java
@@ -138,8 +138,8 @@ public final class UnnecessarySemicolonInTryWithResourcesCheck extends AbstractC
         final DetailAST closingParen = ast.getLastChild();
         final DetailAST tokenBeforeCloseParen = closingParen.getPreviousSibling();
         if (tokenBeforeCloseParen.getType() == TokenTypes.SEMI
-            && (!allowWhenNoBraceAfterSemicolon
-                || TokenUtil.areOnSameLine(closingParen, tokenBeforeCloseParen))) {
+                && (!allowWhenNoBraceAfterSemicolon
+                    || TokenUtil.areOnSameLine(closingParen, tokenBeforeCloseParen))) {
             log(tokenBeforeCloseParen, MSG_SEMI);
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
@@ -203,12 +203,12 @@ public class FinalClassCheck
         if (ast.getType() == TokenTypes.CLASS_DEF) {
             final ClassDesc desc = classes.pop();
             if (desc.isWithPrivateCtor()
-                && !(desc.isDeclaredAsAbstract()
-                    || desc.isWithAnonymousInnerClass())
-                && !desc.isDeclaredAsFinal()
-                && !desc.isWithNonPrivateCtor()
-                && !desc.isWithNestedSubclass()
-                && !ScopeUtil.isInInterfaceOrAnnotationBlock(ast)) {
+                    && !(desc.isDeclaredAsAbstract()
+                        || desc.isWithAnonymousInnerClass())
+                    && !desc.isDeclaredAsFinal()
+                    && !desc.isWithNonPrivateCtor()
+                    && !desc.isWithNestedSubclass()
+                    && !ScopeUtil.isInInterfaceOrAnnotationBlock(ast)) {
                 final String qualifiedName = desc.getQualifiedName();
                 final String className = getClassNameFromQualifiedName(qualifiedName);
                 log(ast, MSG_KEY, className);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/HideUtilityClassConstructorCheck.java
@@ -280,7 +280,7 @@ public class HideUtilityClassConstructorCheck extends AbstractCheck {
                     final DetailAST modifiers =
                         child.findFirstToken(TokenTypes.MODIFIERS);
                     if (modifiers.findFirstToken(TokenTypes.LITERAL_PRIVATE) == null
-                        && modifiers.findFirstToken(TokenTypes.LITERAL_PROTECTED) == null) {
+                            && modifiers.findFirstToken(TokenTypes.LITERAL_PROTECTED) == null) {
                         // treat package visible as public
                         // for the purpose of this Check
                         hasPublicCtor = true;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/InnerTypeLastCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/InnerTypeLastCheck.java
@@ -130,7 +130,7 @@ public class InnerTypeLastCheck extends AbstractCheck {
             DetailAST nextSibling = ast.getNextSibling();
             while (nextSibling != null) {
                 if (!ScopeUtil.isInCodeBlock(ast)
-                    && CLASS_MEMBER_TOKENS.contains(nextSibling.getType())) {
+                        && CLASS_MEMBER_TOKENS.contains(nextSibling.getType())) {
                     log(nextSibling, MSG_KEY);
                 }
                 nextSibling = nextSibling.getNextSibling();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -815,8 +815,8 @@ public class ImportOrderCheck
 
         if (groupIdx > lastGroup) {
             if (!beforeFirstImport
-                && ast.getLineNo() - lastImportLine < 2
-                && needSeparator(isStatic)) {
+                    && ast.getLineNo() - lastImportLine < 2
+                    && needSeparator(isStatic)) {
                 log(ast, MSG_SEPARATION, name);
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -139,12 +139,22 @@ public abstract class AbstractExpressionHandler {
         else {
             typeStr = " " + subtypeName;
         }
+        indentCheck.indentationLog(ast, getIndentErrorMessage(expectedIndent),
+            typeName + typeStr, actualIndent, expectedIndent);
+    }
+
+    /**
+     * Returns expected indentation error message.
+     *
+     * @param expectedIndent One or more accepted indentation levels.
+     * @return Singular error message for one indentation level, plural error message else.
+     */
+    public static String getIndentErrorMessage(IndentLevel expectedIndent) {
         String messageKey = IndentationCheck.MSG_ERROR;
         if (expectedIndent.isMultiLevel()) {
             messageKey = IndentationCheck.MSG_ERROR_MULTI;
         }
-        indentCheck.indentationLog(ast, messageKey,
-            typeName + typeStr, actualIndent, expectedIndent);
+        return messageKey;
     }
 
     /**
@@ -288,7 +298,7 @@ public abstract class AbstractExpressionHandler {
 
             IndentLevel theLevel = indentLevel;
             if (firstLineMatches
-                || firstLine > mainAst.getLineNo() && shouldIncreaseIndent()) {
+                    || firstLine > mainAst.getLineNo() && shouldIncreaseIndent()) {
                 theLevel = new IndentLevel(indentLevel, getBasicOffset());
             }
 
@@ -440,8 +450,8 @@ public abstract class AbstractExpressionHandler {
         DetailAST realStart = ast;
 
         if (tree.getLineNo() < realStart.getLineNo()
-            || tree.getLineNo() == realStart.getLineNo()
-            && tree.getColumnNo() < realStart.getColumnNo()
+                || tree.getLineNo() == realStart.getLineNo()
+                && tree.getColumnNo() < realStart.getColumnNo()
         ) {
             realStart = tree;
         }
@@ -509,7 +519,7 @@ public abstract class AbstractExpressionHandler {
              modifier != null;
              modifier = modifier.getNextSibling()) {
             if (isOnStartOfLine(modifier)
-                && !getIndent().isAcceptable(expandedTabsColumnNo(modifier))) {
+                    && !getIndent().isAcceptable(expandedTabsColumnNo(modifier))) {
                 logError(modifier, "modifier",
                     expandedTabsColumnNo(modifier));
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AnnotationArrayInitHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AnnotationArrayInitHandler.java
@@ -93,8 +93,11 @@ public class AnnotationArrayInitHandler extends BlockParentHandler {
 
     @Override
     protected IndentLevel getChildrenExpectedIndent() {
+        final int additionalIndent = getBasicOffset()
+            * LineWrappingHandler.expressionStartsBetween(getParent().getMainAst(), getMainAst());
         IndentLevel expectedIndent =
-            new IndentLevel(getIndent(), getArrayInitIndentation(), getLineWrappingIndentation());
+            new IndentLevel(getIndent(), getArrayInitIndentation(), getLineWrappingIndentation(),
+                    additionalIndent + getArrayInitIndentation());
 
         final int firstLine = getFirstLine(getListChild());
         final int lcurlyPos = expandedTabsColumnNo(getLeftCurly());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java
@@ -156,7 +156,7 @@ public class BlockParentHandler extends AbstractExpressionHandler {
         final DetailAST lcurly = getLeftCurly();
         IndentLevel expIndentLevel = new IndentLevel(getIndent(), getBraceAdjustment());
         if (!isOnStartOfLine(lcurly)
-            || lcurly.getParent().getType() == TokenTypes.INSTANCE_INIT) {
+                || lcurly.getParent().getType() == TokenTypes.INSTANCE_INIT) {
             expIndentLevel = new IndentLevel(getIndent(), 0);
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LambdaHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LambdaHandler.java
@@ -97,7 +97,7 @@ public class LambdaHandler extends AbstractExpressionHandler {
         final boolean isSwitchRuleLambda = firstChild == null;
 
         if (!isSwitchRuleLambda
-            && getLineStart(firstChild) == expandedTabsColumnNo(firstChild)) {
+                && getLineStart(firstChild) == expandedTabsColumnNo(firstChild)) {
             final int firstChildColumnNo = expandedTabsColumnNo(firstChild);
             final IndentLevel level = getIndent();
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
@@ -163,12 +163,158 @@ public class LineWrappingHandler {
                 continue;
             }
             if (currentType == TokenTypes.RPAREN) {
-                logWarningMessage(node, firstNodeIndent);
+                logWarningMessage(node, new IndentLevel(firstNodeIndent));
             }
             else if (!TokenUtil.isOfType(currentType, IGNORED_LIST)) {
-                logWarningMessage(node, currentIndent);
+                final int[] offsets =
+                    additionalOffsets(firstNode, node, currentIndent);
+                logWarningMessage(node, new IndentLevel(
+                        new IndentLevel(currentIndent), offsets));
             }
         }
+    }
+
+    /**
+     * Returns possible offsets in addition to baseIndent for {@code node}.
+     *
+     * @param firstNode Node on the highest line.
+     * @param node Node to examine.
+     * @param baseIndent Current indentation level.
+     * @return Indentation offsets.
+     */
+    private int[] additionalOffsets(final DetailAST firstNode, DetailAST node, int baseIndent) {
+        int[] result = {0};
+        if (indentCheck.isForceStrictCondition()) {
+            final int additionalOffset = expressionStartsBetween(firstNode, node)
+                * indentCheck.getLineWrappingIndentation();
+            final int previousOffset = getPreviousElementIndentation(node) - baseIndent;
+            if (additionalOffset >= previousOffset) {
+                result = new int[] {additionalOffset};
+            }
+            else {
+                result = new int[] {additionalOffset, previousOffset};
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns indentation level of previous element.
+     *
+     * @param node Node to start examining.
+     * @return Indentation level of previous element or zero.
+     */
+    private static int getPreviousElementIndentation(DetailAST node) {
+        int result = 0;
+        if (node != null) {
+            if (node.getType() == TokenTypes.PARAMETERS) {
+                result = node.getPreviousSibling().getColumnNo() + 1;
+            }
+            else if (node.getType() == TokenTypes.ELIST) {
+                if (node.getPreviousSibling() != null
+                        && node.getPreviousSibling().getType() == TokenTypes.LPAREN) {
+                    result = node.getPreviousSibling().getColumnNo() + 1;
+                }
+                else if (node.getParent().getType() == TokenTypes.METHOD_CALL) {
+                    result = node.getParent().getColumnNo() + 1;
+                }
+                else {
+                    result = 0;
+                }
+            }
+            else if (node.getType() == TokenTypes.ARRAY_INIT) {
+                result = node.getColumnNo() + 1;
+            }
+            else {
+                result = getPreviousElementIndentation(node.getParent());
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Counts the beginnings of expressions in previous lines between {@code firstNode} and
+     * {@code node}.
+     *
+     * @param firstNode Node on the highest line.
+     * @param node Node to start examining.
+     * @return Number of expression starts (negative, if there are more expression ends than starts
+     *            between {@code firstNode} and {@code node}.
+     */
+    public static int expressionStartsBetween(final DetailAST firstNode, DetailAST node) {
+        final int result;
+        if (node == firstNode) {
+            result = 0;
+        }
+        else if (node.getType() == TokenTypes.LPAREN
+                || node.getType() == TokenTypes.GENERIC_START) {
+            // lparen / generic_start is in own line -> skip
+            result = expressionStartsBetween(firstNode, node.getParent());
+        }
+        else {
+            result = numberOfSingleLparenPreviousSiblings(node)
+                + expressionStartsBetween(firstNode, node.getParent());
+        }
+        return result;
+    }
+
+    /**
+     * Counts the number of previous siblings starting new expressions.
+     *
+     * @param node Node to start examining.
+     * @return Number of previous siblings starting new expressions.
+     */
+    private static int numberOfSingleLparenPreviousSiblings(DetailAST node) {
+        int previousSiblings = 0;
+        if (node.getPreviousSibling() == null) {
+            previousSiblings = firstNodeIsLparen(node);
+        }
+        else if (shouldExamineNodeType(node)) {
+            if (node.getType() == TokenTypes.LPAREN) {
+                previousSiblings =
+                        numberOfSingleLparenPreviousSiblings(node.getPreviousSibling()) + 1;
+            }
+            else if (node.getType() == TokenTypes.RPAREN) {
+                previousSiblings =
+                        numberOfSingleLparenPreviousSiblings(node.getPreviousSibling()) - 1;
+            }
+            else {
+                previousSiblings = numberOfSingleLparenPreviousSiblings(node.getPreviousSibling());
+            }
+        }
+        else if (node.getType() == TokenTypes.ELIST
+                && node.getParent().getType() == TokenTypes.METHOD_CALL
+                && node.getLineNo() != node.getParent().getLineNo()) {
+            previousSiblings = 1;
+        }
+        return previousSiblings;
+    }
+
+    /**
+     * Decides if node should be examined in
+     * {@link #numberOfSingleLparenPreviousSiblings(DetailAST)}.
+     *
+     * @param node Actual node.
+     * @return true, if node should be examined.
+     */
+    private static boolean shouldExamineNodeType(DetailAST node) {
+        return node.getType() != TokenTypes.FOR_INIT && node.getType() != TokenTypes.ELIST
+            && (node.getType() != TokenTypes.PARAMETERS
+                    || node.getParent().getType() == TokenTypes.LAMBDA);
+    }
+
+    /**
+     * Checks if node is lparen or generic_start.
+     *
+     * @param node Node to examine.
+     * @return 1 if node is lparen or generic_start, otherwise 0.
+     */
+    private static int firstNodeIsLparen(DetailAST node) {
+        int previousSiblings = 0;
+        if (node.getType() == TokenTypes.LPAREN || node.getType() == TokenTypes.GENERIC_START) {
+            previousSiblings = 1;
+        }
+        return previousSiblings;
     }
 
     /**
@@ -259,7 +405,7 @@ public class LineWrappingHandler {
             final DetailAST firstTokenOnLine = result.get(curNode.getLineNo());
 
             if (firstTokenOnLine == null
-                || expandedTabsColumnNo(firstTokenOnLine) >= expandedTabsColumnNo(curNode)) {
+                    || expandedTabsColumnNo(firstTokenOnLine) >= expandedTabsColumnNo(curNode)) {
                 result.put(curNode.getLineNo(), curNode);
             }
             curNode = getNextCurNode(curNode);
@@ -314,14 +460,14 @@ public class LineWrappingHandler {
                     && isEndOfScope(lastAnnotationNode, node);
             if (!isArrayInitPresentInAncestors
                     && (isCurrentNodeCloseAnnotationAloneInLine
-                    || node.getType() == TokenTypes.AT
-                    && (parentNode.getParent().getType() == TokenTypes.MODIFIERS
-                        || parentNode.getParent().getType() == TokenTypes.ANNOTATIONS)
-                    || TokenUtil.areOnSameLine(node, atNode))) {
-                logWarningMessage(node, firstNodeIndent);
+                        || node.getType() == TokenTypes.AT
+                        && (parentNode.getParent().getType() == TokenTypes.MODIFIERS
+                            || parentNode.getParent().getType() == TokenTypes.ANNOTATIONS)
+                        || TokenUtil.areOnSameLine(node, atNode))) {
+                logWarningMessage(node, new IndentLevel(firstNodeIndent));
             }
             else if (!isArrayInitPresentInAncestors) {
-                logWarningMessage(node, currentIndent);
+                logWarningMessage(node, new IndentLevel(currentIndent));
             }
             itr.remove();
         }
@@ -423,21 +569,22 @@ public class LineWrappingHandler {
      * @param currentIndent
      *            correct indentation.
      */
-    private void logWarningMessage(DetailAST currentNode, int currentIndent) {
+    private void logWarningMessage(DetailAST currentNode, IndentLevel currentIndent) {
         if (indentCheck.isForceStrictCondition()) {
-            if (expandedTabsColumnNo(currentNode) != currentIndent) {
+            if (!currentIndent.isAcceptable(expandedTabsColumnNo(currentNode))) {
                 indentCheck.indentationLog(currentNode,
-                        IndentationCheck.MSG_ERROR, currentNode.getText(),
+                        AbstractExpressionHandler.getIndentErrorMessage(currentIndent),
+                        currentNode.getText(),
                         expandedTabsColumnNo(currentNode), currentIndent);
             }
         }
         else {
-            if (expandedTabsColumnNo(currentNode) < currentIndent) {
+            if (currentIndent.isGreaterThan(expandedTabsColumnNo(currentNode))) {
                 indentCheck.indentationLog(currentNode,
-                        IndentationCheck.MSG_ERROR, currentNode.getText(),
+                        AbstractExpressionHandler.getIndentErrorMessage(currentIndent),
+                        currentNode.getText(),
                         expandedTabsColumnNo(currentNode), currentIndent);
             }
         }
     }
-
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MemberDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MemberDefHandler.java
@@ -67,7 +67,7 @@ public class MemberDefHandler extends AbstractExpressionHandler {
     protected void checkModifiers() {
         final DetailAST modifier = getMainAst().findFirstToken(TokenTypes.MODIFIERS);
         if (isOnStartOfLine(modifier)
-            && !getIndent().isAcceptable(expandedTabsColumnNo(modifier))) {
+                && !getIndent().isAcceptable(expandedTabsColumnNo(modifier))) {
             logError(modifier, "modifier", expandedTabsColumnNo(modifier));
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodCallHandler.java
@@ -124,7 +124,7 @@ public class MethodCallHandler extends AbstractExpressionHandler {
         final DetailAST target1 = dot1.getFirstChild();
 
         if (dot1.getType() == TokenTypes.DOT
-            && target1.getType() == TokenTypes.METHOD_CALL) {
+                && target1.getType() == TokenTypes.METHOD_CALL) {
             result = true;
         }
         return result;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java
@@ -51,7 +51,7 @@ public class MethodDefHandler extends BlockParentHandler {
     protected void checkModifiers() {
         final DetailAST modifier = getMainAst().findFirstToken(TokenTypes.MODIFIERS);
         if (isOnStartOfLine(modifier)
-            && !getIndent().isAcceptable(expandedTabsColumnNo(modifier))) {
+                && !getIndent().isAcceptable(expandedTabsColumnNo(modifier))) {
             logError(modifier, "modifier", expandedTabsColumnNo(modifier));
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/NewHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/NewHandler.java
@@ -55,7 +55,7 @@ public class NewHandler extends AbstractExpressionHandler {
 
             final boolean forceStrictCondition = getIndentCheck().isForceStrictCondition();
             if (forceStrictCondition && !level.isAcceptable(columnNo)
-                || !forceStrictCondition && level.isGreaterThan(columnNo)) {
+                    || !forceStrictCondition && level.isGreaterThan(columnNo)) {
                 logError(mainAst, "", columnNo, level);
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SlistHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SlistHandler.java
@@ -82,9 +82,9 @@ public class SlistHandler extends BlockParentHandler {
         final IndentLevel result;
         // if our parent is a block handler we want to be transparent
         if (getParent() instanceof BlockParentHandler
-                && !(getParent() instanceof SlistHandler)
-            || child instanceof SlistHandler
-                && getParent() instanceof CaseHandler) {
+                    && !(getParent() instanceof SlistHandler)
+                || child instanceof SlistHandler
+                    && getParent() instanceof CaseHandler) {
             result = getParent().getSuggestedChildIndent(child);
         }
         else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/TryHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/TryHandler.java
@@ -63,8 +63,8 @@ public class TryHandler extends BlockParentHandler {
     public IndentLevel getSuggestedChildIndent(AbstractExpressionHandler child) {
         final IndentLevel result;
         if (child instanceof CatchHandler
-            || child instanceof FinallyHandler
-            || child instanceof NewHandler
+                || child instanceof FinallyHandler
+                || child instanceof NewHandler
                 && isTryBlocksResourceSpecification(child)) {
             result = getIndent();
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -487,9 +487,9 @@ public class JavadocMethodCheck extends AbstractCheck {
     @Override
     public final void leaveToken(DetailAST ast) {
         if (ast.getType() == TokenTypes.CLASS_DEF
-            || ast.getType() == TokenTypes.INTERFACE_DEF
-            || ast.getType() == TokenTypes.ENUM_DEF
-            || ast.getType() == TokenTypes.RECORD_DEF) {
+                || ast.getType() == TokenTypes.INTERFACE_DEF
+                || ast.getType() == TokenTypes.ENUM_DEF
+                || ast.getType() == TokenTypes.RECORD_DEF) {
             // perhaps it was inner class
             final int dotIdx = currentClassName.lastIndexOf('$');
             currentClassName = currentClassName.substring(0, dotIdx);
@@ -688,7 +688,7 @@ public class JavadocMethodCheck extends AbstractCheck {
         final List<JavadocTag> tags = new ArrayList<>();
         final String lFin = multilineCont.group(1);
         if (!lFin.equals(NEXT_TAG)
-            && !lFin.equals(END_JAVADOC)) {
+                && !lFin.equals(END_JAVADOC)) {
             final String param1 = noargMultilineStart.group(1);
             final int col = noargMultilineStart.start(1) - 1;
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
@@ -283,10 +283,10 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
         DetailNode previousNode = JavadocUtil.getPreviousSibling(paragraphTag);
         while (previousNode != null) {
             if (previousNode.getType() == JavadocTokenTypes.TEXT
-                    && !CommonUtil.isBlank(previousNode.getText())
-                || previousNode.getType() != JavadocTokenTypes.LEADING_ASTERISK
-                    && previousNode.getType() != JavadocTokenTypes.NEWLINE
-                    && previousNode.getType() != JavadocTokenTypes.TEXT) {
+                        && !CommonUtil.isBlank(previousNode.getText())
+                    || previousNode.getType() != JavadocTokenTypes.LEADING_ASTERISK
+                        && previousNode.getType() != JavadocTokenTypes.NEWLINE
+                        && previousNode.getType() != JavadocTokenTypes.TEXT) {
                 result = false;
                 break;
             }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -495,9 +495,9 @@ public class JavadocStyleCheck
         final String commentText = getCommentText(comment.getText());
 
         if (!commentText.isEmpty()
-            && !endOfSentenceFormat.matcher(commentText).find()
-            && !(commentText.startsWith("{@inheritDoc}")
-            && JavadocTagInfo.INHERIT_DOC.isValidOn(ast))) {
+                && !endOfSentenceFormat.matcher(commentText).find()
+                && !(commentText.startsWith("{@inheritDoc}")
+                    && JavadocTagInfo.INHERIT_DOC.isValidOn(ast))) {
             log(comment.getStartLineNo(), MSG_NO_PERIOD);
         }
     }
@@ -657,8 +657,8 @@ public class JavadocStyleCheck
         final List<String> typeParameters = CheckUtil.getTypeParameterNames(ast);
         for (final HtmlTag htmlTag : htmlStack) {
             if (!isSingleTag(htmlTag)
-                && !htmlTag.getId().equals(lastFound)
-                && !typeParameters.contains(htmlTag.getId())) {
+                    && !htmlTag.getId().equals(lastFound)
+                    && !typeParameters.contains(htmlTag.getId())) {
                 log(htmlTag.getLineNo(), htmlTag.getPosition(),
                         MSG_UNCLOSED_HTML, htmlTag.getText());
                 lastFound = htmlTag.getId();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java
@@ -270,8 +270,8 @@ class TagParser {
                            || currentLine.charAt(column) == '*')) {
                     column++;
                     if (column < currentLine.length()
-                        && currentLine.charAt(column - 1) == '*'
-                        && currentLine.charAt(column) == '/') {
+                            && currentLine.charAt(column - 1) == '*'
+                            && currentLine.charAt(column) == '/') {
                         // this is end of comment
                         column = currentLine.length();
                     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
@@ -309,8 +309,8 @@ public class JavaNCSSCheck extends AbstractCheck {
         final int tokenType = ast.getType();
 
         if (tokenType == TokenTypes.CLASS_DEF
-            || tokenType == TokenTypes.RECORD_DEF
-            || isMethodOrCtorOrInitDefinition(tokenType)) {
+                || tokenType == TokenTypes.RECORD_DEF
+                || isMethodOrCtorOrInitDefinition(tokenType)) {
             // add a counter for this class/method
             counters.push(new Counter());
         }
@@ -444,7 +444,7 @@ public class JavaNCSSCheck extends AbstractCheck {
         final int parentType = ast.getParent().getType();
 
         if (parentType == TokenTypes.SLIST
-            || parentType == TokenTypes.OBJBLOCK) {
+                || parentType == TokenTypes.OBJBLOCK) {
             final DetailAST prevSibling = ast.getPreviousSibling();
 
             // is countable if no previous sibling is found or

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
@@ -317,11 +317,11 @@ public class RedundantModifierCheck
 
             final int type = modifier.getType();
             if (type == TokenTypes.LITERAL_PUBLIC
-                || type == TokenTypes.LITERAL_STATIC
+                    || type == TokenTypes.LITERAL_STATIC
                         && ast.getType() != TokenTypes.METHOD_DEF
-                || type == TokenTypes.ABSTRACT
+                    || type == TokenTypes.ABSTRACT
                         && ast.getType() != TokenTypes.CLASS_DEF
-                || type == TokenTypes.FINAL
+                    || type == TokenTypes.FINAL
                         && ast.getType() != TokenTypes.CLASS_DEF) {
                 log(modifier, MSG_KEY, modifier.getText());
                 break;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ConstantNameCheck.java
@@ -174,7 +174,7 @@ public class ConstantNameCheck
             // which are used for Serialization. Cannot enforce rules on it. :-)
             final DetailAST nameAST = ast.findFirstToken(TokenTypes.IDENT);
             if (!"serialVersionUID".equals(nameAST.getText())
-                && !"serialPersistentFields".equals(nameAST.getText())) {
+                    && !"serialPersistentFields".equals(nameAST.getText())) {
                 returnValue = true;
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheck.java
@@ -240,7 +240,7 @@ public class MethodNameCheck
     @Override
     public void visitToken(DetailAST ast) {
         if (!AnnotationUtil.containsAnnotation(ast, OVERRIDE)
-            && !AnnotationUtil.containsAnnotation(ast, CANONICAL_OVERRIDE)) {
+                && !AnnotationUtil.containsAnnotation(ast, CANONICAL_OVERRIDE)) {
             // Will check the name against the format.
             super.visitToken(ast);
         }
@@ -260,7 +260,7 @@ public class MethodNameCheck
             // Such a rare case, will not have the logic to handle parsing
             // down the tree looking for the first ident.
             if (classIdent != null
-                && method.getText().equals(classIdent.getText())) {
+                    && method.getText().equals(classIdent.getText())) {
                 log(method, MSG_KEY, method.getText());
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
@@ -147,7 +147,7 @@ public class LineLengthCheck extends AbstractFileSetCheck {
                 line, line.codePointCount(0, line.length()), getTabWidth());
 
             if (realLength > max && !IGNORE_PATTERN.matcher(line).find()
-                && !ignorePattern.matcher(line).find()) {
+                    && !ignorePattern.matcher(line).find()) {
                 log(i + 1, MSG_KEY, max, realLength);
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/AbstractParenPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/AbstractParenPadCheck.java
@@ -89,7 +89,7 @@ public abstract class AbstractParenPadCheck
         final int after = ast.getColumnNo() + 1;
         if (after < line.length()) {
             if (option == PadOption.NOSPACE
-                && Character.isWhitespace(line.charAt(after))) {
+                    && Character.isWhitespace(line.charAt(after))) {
                 log(ast, MSG_WS_FOLLOWED, OPEN_PARENTHESIS);
             }
             else if (option == PadOption.SPACE
@@ -110,13 +110,13 @@ public abstract class AbstractParenPadCheck
         if (before >= 0) {
             final String line = getLines()[ast.getLineNo() - 1];
             if (option == PadOption.NOSPACE
-                && Character.isWhitespace(line.charAt(before))
-                && !CommonUtil.hasWhitespaceBefore(before, line)) {
+                    && Character.isWhitespace(line.charAt(before))
+                    && !CommonUtil.hasWhitespaceBefore(before, line)) {
                 log(ast, MSG_WS_PRECEDED, CLOSE_PARENTHESIS);
             }
             else if (option == PadOption.SPACE
-                && !Character.isWhitespace(line.charAt(before))
-                && line.charAt(before) != OPEN_PARENTHESIS) {
+                    && !Character.isWhitespace(line.charAt(before))
+                    && line.charAt(before) != OPEN_PARENTHESIS) {
                 log(ast, MSG_WS_NOT_PRECEDED, CLOSE_PARENTHESIS);
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheck.java
@@ -133,7 +133,7 @@ public class EmptyForInitializerPadCheck
             // don't check if semi at beginning of line
             if (!CommonUtil.hasWhitespaceBefore(before, line)) {
                 if (option == PadOption.NOSPACE
-                    && Character.isWhitespace(line.charAt(before))) {
+                        && Character.isWhitespace(line.charAt(before))) {
                     log(ast, MSG_PRECEDED, SEMICOLON);
                 }
                 else if (option == PadOption.SPACE

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheck.java
@@ -157,7 +157,7 @@ public class EmptyForIteratorPadCheck
             // don't check if at end of line
             if (after < line.length()) {
                 if (option == PadOption.NOSPACE
-                    && Character.isWhitespace(line.charAt(after))) {
+                        && Character.isWhitespace(line.charAt(after))) {
                     log(ast, MSG_WS_FOLLOWED, SEMICOLON);
                 }
                 else if (option == PadOption.SPACE

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -631,7 +631,7 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
     private boolean hasMultipleLinesBefore(DetailAST ast) {
         boolean result = false;
         if ((ast.getType() != TokenTypes.VARIABLE_DEF
-            || isTypeField(ast))
+                    || isTypeField(ast))
                 && hasNotAllowedTwoEmptyLinesBefore(ast)) {
             result = true;
         }
@@ -703,7 +703,7 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
      */
     private void processImport(DetailAST ast, DetailAST nextToken) {
         if (!TokenUtil.isOfType(nextToken, TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT)
-            && !hasEmptyLineAfter(ast)) {
+                && !hasEmptyLineAfter(ast)) {
             log(nextToken, MSG_SHOULD_BE_SEPARATED, nextToken.getText());
         }
     }
@@ -753,8 +753,8 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
     private void checkComments(DetailAST token) {
         if (!allowMultipleEmptyLines) {
             if (TokenUtil.isOfType(token,
-                TokenTypes.PACKAGE_DEF, TokenTypes.IMPORT,
-                TokenTypes.STATIC_IMPORT, TokenTypes.STATIC_INIT)) {
+                    TokenTypes.PACKAGE_DEF, TokenTypes.IMPORT,
+                    TokenTypes.STATIC_IMPORT, TokenTypes.STATIC_INIT)) {
                 DetailAST previousNode = token.getPreviousSibling();
                 while (isCommentInBeginningOfLine(previousNode)) {
                     if (hasEmptyLineBefore(previousNode) && isPrePreviousLineEmpty(previousNode)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java
@@ -230,7 +230,7 @@ public class GenericWhitespaceCheck extends AbstractCheck {
         //
         final int indexOfAmp = line.indexOf('&', after);
         if (indexOfAmp >= 1
-            && containsWhitespaceBetween(after, indexOfAmp, line)) {
+                && containsWhitespaceBetween(after, indexOfAmp, line)) {
             if (indexOfAmp - after == 0) {
                 log(ast, MSG_WS_NOT_PRECEDED, "&");
             }
@@ -328,7 +328,7 @@ public class GenericWhitespaceCheck extends AbstractCheck {
             }
             // Whitespace not required
             else if (Character.isWhitespace(line.charAt(before))
-                && !containsWhitespaceBefore(before, line)) {
+                    && !containsWhitespaceBefore(before, line)) {
                 log(ast, MSG_WS_PRECEDED, OPEN_ANGLE_BRACKET);
             }
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheck.java
@@ -219,7 +219,7 @@ public class MethodParamPadCheck
             else {
                 final int before = parenAST.getColumnNo() - 1;
                 if (option == PadOption.NOSPACE
-                    && Character.isWhitespace(line.charAt(before))) {
+                        && Character.isWhitespace(line.charAt(before))) {
                     log(parenAST, MSG_WS_PRECEDED, parenAST.getText());
                 }
                 else if (option == PadOption.SPACE

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
@@ -457,9 +457,9 @@ public class NoWhitespaceAfterCheck extends AbstractCheck {
             final int instanceOfSize = 13;
             // +2 because ast has `[]` after the ident
             if (ident.getColumnNo() >= ast.getColumnNo() + 2
-                // +13 because ident (at most 1 character) is followed by
-                // ' instanceof ' (12 characters)
-                || lastTypeNode.getColumnNo() >= ident.getColumnNo() + instanceOfSize) {
+                    // +13 because ident (at most 1 character) is followed by
+                    // ' instanceof ' (12 characters)
+                    || lastTypeNode.getColumnNo() >= ident.getColumnNo() + instanceOfSize) {
                 previousElement = lastTypeNode;
             }
             else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -509,8 +509,8 @@ public class SuppressionCommentFilter
         Tag result = null;
         for (Tag tag : tags) {
             if (tag.getLine() > event.getLine()
-                || tag.getLine() == event.getLine()
-                    && tag.getColumn() > event.getColumn()) {
+                    || tag.getLine() == event.getLine()
+                        && tag.getColumn() > event.getColumn()) {
                 break;
             }
             if (tag.isMatch(event)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java
@@ -377,7 +377,7 @@ public class JavadocMetadataScraper extends AbstractJavadocCheck {
             for (DetailNode child : detailNode.getChildren()) {
                 if (child.getParent().equals(node)
                         && (child.getIndex() < childLeftLimit
-                        || child.getIndex() > childRightLimit)) {
+                            || child.getIndex() > childRightLimit)) {
                     continue;
                 }
                 if (!visited.contains(child)) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtil.java
@@ -145,7 +145,7 @@ public final class AnnotationUtil {
         final DetailAST annotationHolder;
 
         if (ast.getType() == TokenTypes.ENUM_CONSTANT_DEF
-            || ast.getType() == TokenTypes.PACKAGE_DEF) {
+                || ast.getType() == TokenTypes.PACKAGE_DEF) {
             annotationHolder = ast.findFirstToken(TokenTypes.ANNOTATIONS);
         }
         else {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
@@ -183,8 +183,8 @@ public final class ScopeUtil {
                 returnValue = true;
             }
             else if (TokenUtil.isOfType(token, TokenTypes.INTERFACE_DEF,
-                TokenTypes.ANNOTATION_DEF, TokenTypes.CLASS_DEF,
-                TokenTypes.LITERAL_NEW)) {
+                    TokenTypes.ANNOTATION_DEF, TokenTypes.CLASS_DEF,
+                    TokenTypes.LITERAL_NEW)) {
                 break;
             }
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -222,6 +222,27 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testStrictCondition2() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addAttribute("arrayInitIndent", "4");
+        checkConfig.addAttribute("basicOffset", "4");
+        checkConfig.addAttribute("braceAdjustment", "4");
+        checkConfig.addAttribute("caseIndent", "4");
+        checkConfig.addAttribute("forceStrictCondition", "true");
+        checkConfig.addAttribute("lineWrappingIndentation", "4");
+        checkConfig.addAttribute("tabWidth", "4");
+        checkConfig.addAttribute("throwsIndent", "4");
+        final String[] expected = {
+            "31:9: " + getCheckMessage(MSG_ERROR, "method def rcurly", 8, 4),
+            "35:17: " + getCheckMessage(MSG_ERROR, "||", 16, 20),
+            "36:17: " + getCheckMessage(MSG_ERROR, "||", 16, 20),
+            "59:23: " + getCheckMessage(MSG_ERROR_MULTI, "\"test\"", 22, "20, 32"),
+            "111:15: " + getCheckMessage(MSG_ERROR_MULTI, "\"test\"", 14, "16, 49"),
+        };
+        verifyWarns(checkConfig, getPath("InputIndentationStrictCondition2.java"), expected);
+    }
+
+    @Test
     public void forbidOldStyle() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
         checkConfig.addAttribute("arrayInitIndent", "4");
@@ -233,8 +254,8 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("tabWidth", "4");
         checkConfig.addAttribute("throwsIndent", "8");
         final String[] expected = {
-            "20:30: " + getCheckMessage(MSG_ERROR, "int", 29, 12),
-            "21:30: " + getCheckMessage(MSG_ERROR, "int", 29, 12),
+            "20:30: " + getCheckMessage(MSG_ERROR_MULTI, "int", 29, "12, 40"),
+            "21:30: " + getCheckMessage(MSG_ERROR_MULTI, "int", 29, "12, 40"),
         };
         verifyWarns(checkConfig, getPath("InputIndentationMethodCStyle.java"), expected);
     }
@@ -313,11 +334,11 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("throwsIndent", "4");
         final String[] expected = {
             "40:1: " + getCheckMessage(MSG_CHILD_ERROR_MULTI,
-                    "annotation array initialization", 0, "4, 23, 25"),
+                    "annotation array initialization", 0, "4, 8, 23, 25"),
             "41:1: " + getCheckMessage(MSG_CHILD_ERROR_MULTI,
-                    "annotation array initialization", 0, "4, 23, 25"),
+                    "annotation array initialization", 0, "4, 8, 23, 25"),
             "50:7: " + getCheckMessage(MSG_CHILD_ERROR_MULTI,
-                    "annotation array initialization", 6, "8, 27, 29"),
+                    "annotation array initialization", 6, "8, 12, 27, 29"),
         };
         verifyWarns(checkConfig, getPath("InputIndentationDifficultAnnotations.java"), expected);
     }
@@ -531,9 +552,9 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
 
             "17:1: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "annotation array initialization", 0,
-                "4, 6, 34, 36"),
+                "4, 6, 8, 34, 36"),
             "22:14: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "annotation array initialization",
-                    13, "4, 6, 34, 36"),
+                    13, "4, 6, 8, 34, 36"),
             "23:3: " + getCheckMessage(MSG_ERROR_MULTI,
                     "annotation array initialization rcurly", 2, "0, 4"),
             "35:7: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "annotation array initialization", 6,
@@ -565,15 +586,13 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
 
             "17:5: " + getCheckMessage(MSG_CHILD_ERROR_MULTI,
-                "annotation array initialization", 4, "0, 33, 35"),
+                "annotation array initialization", 4, "0, 2, 33, 35"),
             "30:9: " + getCheckMessage(MSG_CHILD_ERROR_MULTI,
                 "annotation array initialization", 8, "4, 29, 31"),
             "32:3: " + getCheckMessage(MSG_ERROR,
                 "annotation array initialization rcurly", 2, 4),
             "47:7: " + getCheckMessage(MSG_ERROR,
                 "annotation array initialization lcurly", 6, 2),
-            "49:5: " + getCheckMessage(MSG_CHILD_ERROR_MULTI,
-                "annotation array initialization", 4, "2, 6, 8"),
         };
         final String fileName = getPath("InputIndentationAnnArrInit2.java");
         verifyWarns(checkConfig, fileName, expected);
@@ -596,7 +615,7 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         final String fileName = getPath("InputIndentationOddLineWrappingAndArrayInit.java");
         final String[] expected = {
             "25:17: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "annotation array initialization",
-                    16, "11, 17, 47, 54"),
+                    16, "11, 15, 17, 47, 54"),
         };
         verifyWarns(checkConfig, fileName, expected);
     }
@@ -1225,14 +1244,14 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
             // following are tests for annotation array initialisation
             "120:13: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "annotation array initialization",
                 12, "16, 46, 48"),
-            "124:15: " + getCheckMessage(MSG_CHILD_ERROR, "annotation array initialization",
-                14, 12),
+            "124:15: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "annotation array initialization",
+                14, "12, 16"),
             "128:15: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "annotation array initialization",
-                14, "16, 28, 30"),
+                14, "16, 20, 28, 30"),
             "129:9: " + getCheckMessage(MSG_ERROR_MULTI, "annotation array initialization rcurly",
                 8, "12, 16"),
-            "131:13: " + getCheckMessage(MSG_CHILD_ERROR, "annotation array initialization",
-                12, 16),
+            "131:13: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "annotation array initialization",
+                12, "16, 20"),
         };
 
         // Test input for this test case is not checked due to issue #693.
@@ -1299,7 +1318,7 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
             "66:3: " + getCheckMessage(MSG_ERROR_MULTI, "array initialization rcurly", 2, "6, 10"),
             "69:7: " + getCheckMessage(MSG_CHILD_ERROR, "array initialization", 6, 8),
             "76:11: " + getCheckMessage(MSG_CHILD_ERROR, "array initialization", 10, 12),
-            "89:9: " + getCheckMessage(MSG_ERROR, "1", 8, 12),
+            "89:9: " + getCheckMessage(MSG_ERROR_MULTI, "1", 8, "12, 25"),
             "100:11: " + getCheckMessage(MSG_CHILD_ERROR, "array initialization", 10, 12),
             "101:15: " + getCheckMessage(MSG_CHILD_ERROR, "array initialization", 14, 12),
             "104:11: " + getCheckMessage(MSG_CHILD_ERROR, "array initialization", 10, 12),
@@ -1312,14 +1331,14 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
             // following are tests for annotation array initialisation
             "120:13: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "annotation array initialization",
                 12, "16, 46, 48"),
-            "124:15: " + getCheckMessage(MSG_CHILD_ERROR, "annotation array initialization",
-                14, 12),
+            "124:15: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "annotation array initialization",
+                14, "12, 16"),
             "128:15: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "annotation array initialization",
-                14, "16, 28, 30"),
+                14, "16, 20, 28, 30"),
             "129:9: " + getCheckMessage(MSG_ERROR_MULTI, "annotation array initialization rcurly",
                 8, "12, 16"),
-            "131:13: " + getCheckMessage(MSG_CHILD_ERROR, "annotation array initialization",
-                12, 16),
+            "131:13: " + getCheckMessage(MSG_CHILD_ERROR_MULTI, "annotation array initialization",
+                12, "16, 20"),
         };
 
         // Test input for this test case is not checked due to issue #693.
@@ -2333,10 +2352,9 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("forceStrictCondition", "true");
         checkConfig.addAttribute("lineWrappingIndentation", "4");
         final String[] expected = {
-            "23:17: " + getCheckMessage(MSG_ERROR, "(", 16, 12),
-            "24:17: " + getCheckMessage(MSG_ERROR, "->", 16, 12),
-            "26:27: " + getCheckMessage(MSG_ERROR, "\"SECOND_ARG\"", 26, 12),
-            "27:26: " + getCheckMessage(MSG_ERROR, "(", 25, 12),
+            "23:17: " + getCheckMessage(MSG_ERROR_MULTI, "(", 16, "12, 26"),
+            "24:17: " + getCheckMessage(MSG_ERROR_MULTI, "->", 16, "12, 26"),
+            "27:26: " + getCheckMessage(MSG_ERROR_MULTI, "(", 25, "12, 26"),
             "30:17: " + getCheckMessage(MSG_ERROR, "(", 16, 12),
             "31:21: " + getCheckMessage(MSG_ERROR, "if", 20, 16),
             "32:25: " + getCheckMessage(MSG_CHILD_ERROR, "if", 24, 20),
@@ -2525,8 +2543,8 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
             "84:20: " + getCheckMessage(MSG_ERROR, "writ", 19, 12),
             "91:20: " + getCheckMessage(MSG_ERROR, "writ", 19, 16),
             "98:22: " + getCheckMessage(MSG_ERROR, "writ", 21, 16),
-            "113:18: " + getCheckMessage(MSG_ERROR, "zipFileName", 17, 16),
-            "120:16: " + getCheckMessage(MSG_ERROR, "zipFileName", 15, 16),
+            "113:18: " + getCheckMessage(MSG_ERROR_MULTI, "zipFileName", 17, "16, 37"),
+            "120:16: " + getCheckMessage(MSG_ERROR_MULTI, "zipFileName", 15, "16, 37"),
             "130:8: " + getCheckMessage(MSG_ERROR, "try", 7, 8),
             "135:16: " + getCheckMessage(MSG_CHILD_ERROR, "try", 15, 12),
             "141:12: " + getCheckMessage(MSG_ERROR, "try resource", 11, 12),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -370,7 +370,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
         final String result;
         if (!isSpecialAllTokensType
                 && (propertyName.endsWith("token") || propertyName.endsWith(
-                "tokens"))) {
+                    "tokens"))) {
             result = " Default value is: ";
         }
         else {
@@ -397,8 +397,8 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
                                                 boolean isPropertyTokenType) {
         String defaultValueText = getNodeText(defaultValueNode);
         if ("{@code {}}".equals(defaultValueText)
-            || "{@code all files}".equals(defaultValueText)
-            || isPropertyTokenType && "{@code empty}".equals(defaultValueText)) {
+                || "{@code all files}".equals(defaultValueText)
+                || isPropertyTokenType && "{@code empty}".equals(defaultValueText)) {
             defaultValueText = "{@code \"\"}";
         }
         return defaultValueText;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -366,9 +366,9 @@ public class XdocsPagesTest {
                         .replace("...", "").trim();
 
                 if (unserializedSource.length() > 1 && (unserializedSource.charAt(0) != '<'
-                        || unserializedSource.charAt(unserializedSource.length() - 1) != '>'
-                        // no dtd testing yet
-                        || unserializedSource.contains("<!"))) {
+                            || unserializedSource.charAt(unserializedSource.length() - 1) != '>'
+                            // no dtd testing yet
+                            || unserializedSource.contains("<!"))) {
                     continue;
                 }
 
@@ -971,16 +971,16 @@ public class XdocsPagesTest {
         String result = null;
         final String checkProperty = sectionName + ":" + propertyName;
         if (("SuppressionCommentFilter".equals(sectionName)
-                || "SuppressWithNearbyCommentFilter".equals(sectionName)
-                || "SuppressWithPlainTextCommentFilter".equals(sectionName))
-                    && ("checkFormat".equals(propertyName)
-                        || "messageFormat".equals(propertyName)
-                        || "idFormat".equals(propertyName)
-                        || "influenceFormat".equals(propertyName))
+                    || "SuppressWithNearbyCommentFilter".equals(sectionName)
+                    || "SuppressWithPlainTextCommentFilter".equals(sectionName))
+                && ("checkFormat".equals(propertyName)
+                    || "messageFormat".equals(propertyName)
+                    || "idFormat".equals(propertyName)
+                    || "influenceFormat".equals(propertyName))
                 || ("RegexpMultiline".equals(sectionName)
                     || "RegexpSingleline".equals(sectionName)
                     || "RegexpSinglelineJava".equals(sectionName))
-                    && "format".equals(propertyName)) {
+                && "format".equals(propertyName)) {
             // dynamic custom expression
             result = "Regular Expression";
         }
@@ -1027,10 +1027,10 @@ public class XdocsPagesTest {
         }
         else if (fieldClass == Pattern.class) {
             if ("SuppressionSingleFilter:checks".equals(checkProperty)
-                || "SuppressionXpathSingleFilter:files".equals(checkProperty)
-                || "SuppressionXpathSingleFilter:checks".equals(checkProperty)
-                || "SuppressionXpathSingleFilter:message".equals(checkProperty)
-                || "IllegalTokenText:format".equals(checkProperty)) {
+                    || "SuppressionXpathSingleFilter:files".equals(checkProperty)
+                    || "SuppressionXpathSingleFilter:checks".equals(checkProperty)
+                    || "SuppressionXpathSingleFilter:message".equals(checkProperty)
+                    || "IllegalTokenText:format".equals(checkProperty)) {
                 result = "Regular Expression";
             }
             else {
@@ -1039,9 +1039,9 @@ public class XdocsPagesTest {
         }
         else if (fieldClass == Pattern[].class) {
             if ("ImportOrder:groups".equals(checkProperty)
-                || "ImportOrder:staticGroups".equals(checkProperty)
-                || "ClassDataAbstractionCoupling:excludeClassesRegexps".equals(checkProperty)
-                || "ClassFanOutComplexity:excludeClassesRegexps".equals(checkProperty)) {
+                    || "ImportOrder:staticGroups".equals(checkProperty)
+                    || "ClassDataAbstractionCoupling:excludeClassesRegexps".equals(checkProperty)
+                    || "ClassFanOutComplexity:excludeClassesRegexps".equals(checkProperty)) {
                 result = "Regular Expressions";
             }
             else {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationAnnArrInit.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationAnnArrInit.java
@@ -14,12 +14,12 @@ package com.puppycrawl.tools.checkstyle.checks.indentation.indentation; //indent
 
 @InputIndentationAnnArrInit.Foo({ @InputIndentationAnnArrInit.Bar, //indent:0 exp:0
     @InputIndentationAnnArrInit.Bar, //indent:4 exp:4
-@InputIndentationAnnArrInit.Bar, //indent:0 exp:4,6,34,36 warn
+@InputIndentationAnnArrInit.Bar, //indent:0 exp:4,6,8,34,36 warn
 }) //indent:0 exp:0
 
 @InputIndentationAnnArrInit.Baz({ //indent:0 exp:0
     "Hello", //indent:4 exp:4
-             "Checkstyle", //indent:13 exp:4,6,34,36 warn
+             "Checkstyle", //indent:13 exp:4,6,8,34,36 warn
   }) //indent:2 exp:0,4 warn
 
 class InputIndentationAnnArrInit { //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationAnnArrInit2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationAnnArrInit2.java
@@ -14,7 +14,7 @@
 package com.puppycrawl.tools.checkstyle.checks.indentation.indentation; //indent:0 exp:0
 
 @InputIndentationAnnArrInit2.Foo({ //indent:0 exp:0
-    @InputIndentationAnnArrInit2.Bar, //indent:4 exp:0,33,35 warn
+    @InputIndentationAnnArrInit2.Bar, //indent:4 exp:0,2,33,35 warn
 @InputIndentationAnnArrInit2.Bar, //indent:0 exp:0
 }) //indent:0 exp:0
 
@@ -46,7 +46,7 @@ interface SomeInterface2 { //indent:0 exp:0
   @SomeAnnotation(values =  //indent:2 exp:2
       { //indent:6 exp:2 warn
   Info.A, //indent:2 exp:2
-    Info.B //indent:4 exp:2,6,8 warn
+    Info.B //indent:4 exp:2,4,6,8
   } //indent:2 exp:2
   ) //indent:2 exp:2
   void works(); //indent:2 exp:2

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationDifficultAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationDifficultAnnotations.java
@@ -37,8 +37,8 @@ public class InputIndentationDifficultAnnotations { //indent:0 exp:0
 } //indent:0 exp:0
 
 @DifficultAnnotation({ //indent:0 exp:0
-@MyType(value = Boolean.class, name = "boolean"), //indent:0 exp:4,23,25 warn
-@MyType(value = String.class, name = "string") }) //indent:0 exp:4,23,25 warn
+@MyType(value = Boolean.class, name = "boolean"), //indent:0 exp:4,8,23,25 warn
+@MyType(value = String.class, name = "string") }) //indent:0 exp:4,8,23,25 warn
 class IncorrectClass { //indent:0 exp:0
 
     @DifficultAnnotation({ //indent:4 exp:4
@@ -47,7 +47,7 @@ class IncorrectClass { //indent:0 exp:0
     String foo = "foo"; //indent:4 exp:4
 
     @DifficultAnnotation({ //indent:4 exp:4
-      @MyType(value = Boolean.class, name = "boolean"), //indent:6 exp:8,27,29 warn
+      @MyType(value = Boolean.class, name = "boolean"), //indent:6 exp:8,12,27,29 warn
         @MyType(value = String.class, name = "string") }) //indent:8 exp:8
     void foo() { //indent:4 exp:4
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationLambda7.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationLambda7.java
@@ -20,11 +20,11 @@ import java.util.function.Supplier; //indent:0 exp:0
 public class InputIndentationLambda7 { //indent:0 exp:0
     public static void someFunction(SomeUtilClass util) { //indent:4 exp:4
         util.myLambdaUtil("FIRST_ARG", //indent:8 exp:8
-                (string) //indent:16 exp:12 warn
-                -> //indent:16 exp:12 warn
+                (string) //indent:16 exp:12,26 warn
+                -> //indent:16 exp:12,26 warn
             System.out.println(string.trim()), //indent:12 exp:12
-                          "SECOND_ARG", //indent:26 exp:12 warn
-                         () -> "WHAT WHAT!"); //indent:25 exp:12 warn
+                          "SECOND_ARG", //indent:26 exp:26
+                         () -> "WHAT WHAT!"); //indent:25 exp:12,26 warn
 
         Function<String, String> someFunction1 = //indent:8 exp:8
                 (string) -> { //indent:16 exp:12 warn

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationMethodCStyle.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationMethodCStyle.java
@@ -17,8 +17,8 @@ package com.puppycrawl.tools.checkstyle.checks.indentation.indentation; //indent
  */                                                                           //indent:1 exp:1
 public class InputIndentationMethodCStyle { //indent:0 exp:0
     public InputIndentationMethodCStyle(int appleCount, //indent:4 exp:4
-                             int bananaCount, //indent:29 exp:12 warn
-                             int pearsCount) { //indent:29 exp:12 warn
+                             int bananaCount, //indent:29 exp:12,40 warn
+                             int pearsCount) { //indent:29 exp:12,40 warn
     } //indent:4 exp:4
 
     public InputIndentationMethodCStyle(String appleCount, //indent:4 exp:4

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationOddLineWrappingAndArrayInit.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationOddLineWrappingAndArrayInit.java
@@ -22,7 +22,7 @@ public class InputIndentationOddLineWrappingAndArrayInit { //indent:0 exp:0
             String A = "a"; //indent:12 exp:12
         } //indent:8 exp:8
         @MyInterface.SomeAnnotation(values = { //indent:8 exp:8
-                MyInterface.Info.A, //indent:16 exp:11,17,47,54 warn
+                MyInterface.Info.A, //indent:16 exp:11,15,17,47,54 warn
         } //indent:8 exp:8
         ) //indent:8 exp:8
         void works(); //indent:8 exp:8

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationStrictCondition2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationStrictCondition2.java
@@ -1,0 +1,130 @@
+/* Config:                                                                  //indent:0 exp:0
+ * This test-input is intended to be checked using following configuration: //indent:1 exp:1
+ *                                                                          //indent:1 exp:1
+ * arrayInitIndent = 4                                                      //indent:1 exp:1
+ * basicOffset = 4                                                          //indent:1 exp:1
+ * braceAdjustment = 4                                                      //indent:1 exp:1
+ * caseIndent = 4                                                           //indent:1 exp:1
+ * forceStrictCondition = true                                              //indent:1 exp:1
+ * lineWrappingIndentation = 4                                              //indent:1 exp:1
+ * tabWidth = 4                                                             //indent:1 exp:1
+ * throwsIndent = 4                                                         //indent:1 exp:1
+ */                                                                         //indent:1 exp:1
+
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation; //indent:0 exp:0
+
+import java.io.Serializable; //indent:0 exp:0
+import java.lang.Comparable; //indent:0 exp:0
+import java.lang.StringBuilder; //indent:0 exp:0
+import java.lang.Thread; //indent:0 exp:0
+import java.util.Collection; //indent:0 exp:0
+import java.util.Map; //indent:0 exp:0
+
+public class InputIndentationStrictCondition2 { //indent:0 exp:0
+    void method(Thread foo) { //indent:4 exp:4
+        method( //indent:8 exp:8
+            new Thread() { //indent:12 exp:12
+                public void run() { //indent:16 exp:16
+                } //indent:16 exp:16
+            } //indent:12 exp:12
+        ); //indent:8 exp:8
+        } //indent:8 exp:4 warn
+
+    void method2(boolean test) { //indent:4 exp:4
+        if ((test //indent:8 exp:8
+                || 1 < 2 //indent:16 exp:20 warn
+                || 3 < 4) //indent:16 exp:20 warn
+                && 5 == 6 //indent:16 exp:16
+                && 7 == 8) { //indent:16 exp:16
+            System.getProperty("blah");  //indent:12 exp:12
+        } //indent:8 exp:8
+
+        if (1 < 2 //indent:8 exp:8
+                && ( //indent:16 exp:16
+                    test //indent:20 exp:20
+                    && 3 < 4) //indent:20 exp:20
+                || (5 < 6)) { //indent:16 exp:16
+            throw new RuntimeException(); //indent:12 exp:12
+        } //indent:8 exp:8
+
+        if (//indent:8 exp:8
+                test //indent:16 exp:16
+                && 3 < 4 //indent:16 exp:16
+                || (5 < 6)) { //indent:16 exp:16
+            throw new RuntimeException(); //indent:12 exp:12
+        } //indent:8 exp:8
+
+        if (1 < 2 //indent:8 exp:8
+                && getSomething( //indent:16 exp:16
+                      "test") < 0) { //indent:22 exp:20,32 warn
+            throw new RuntimeException(); //indent:12 exp:12
+        } //indent:8 exp:8
+
+        if ( //indent:8 exp:8
+                test //indent:16 exp:16
+            ) { //indent:12 exp:12
+            throw new RuntimeException(); //indent:12 exp:12
+        } //indent:8 exp:8
+    } //indent:4 exp:4
+
+    private //indent:4 exp:4
+        < //indent:8 exp:8
+            T extends Object //indent:12 exp:12
+            & Comparable<? super T> //indent:12 exp:12
+            & StrictCondition<? super Comparable<? super Number>, //indent:12 exp:12
+                ? extends Map<Long, //indent:16 exp:16
+                    Comparable<? super T>>, //indent:20 exp:20
+                ? super int[]> //indent:16 exp:16
+            & Serializable> T max(Collection<? extends T> coll){ //indent:12 exp:12
+        return null;  //indent:8 exp:8
+    } //indent:4 exp:4
+
+    private int getSomething(String str) { //indent:4 exp:4
+        return new StringBuilder(str).lastIndexOf( //indent:8 exp:8
+                new StringBuilder("file") //indent:16 exp:16
+                    .insert(0, String.valueOf(new String("str"))) //indent:20 exp:20
+                    .replace( //indent:20 exp:20
+                        0, //indent:24 exp:24
+                        1, //indent:24 exp:24
+                        new StringBuilder("otherFile").toString() //indent:24 exp:24
+                    ).toString(), //indent:20 exp:20
+                new StringBuilder("resource") //indent:16 exp:16
+                    .insert(0, String.valueOf(new String("foo"))) //indent:20 exp:20
+                    .replace(2, 3, new StringBuilder("bar").toString()) //indent:20 exp:20
+                    .toString().length() //indent:20 exp:20
+        ); //indent:8 exp:8
+    } //indent:4 exp:4
+
+    private void method3(String param1, //indent:4 exp:4
+        String param2, //indent:8 exp:8
+        String param3) { //indent:8 exp:8
+        for (int i = 0; i < 100; //indent:8 exp:8
+            i++) { //indent:12 exp:12
+            System.getenv(param1); //indent:12 exp:12
+    	} //indent:8 exp:8
+        if (!param1.equals(param2)) { //indent:8 exp:8
+            method3(param3, param3, //indent:12 exp:12
+                param1 + param2); //indent:16 exp:16
+        } //indent:8 exp:8
+
+        final int loooooooongName = getSomething( //indent:8 exp:8
+              "test"); //indent:14 exp:16,49 warn
+        final int loooooooongName2 = getSomething( //indent:8 exp:8
+                                                  "test"); //indent:50 exp:50
+    } //indent:4 exp:4
+
+    @InputIndentationStrictCondition2Annotation(value = {"true", //indent:4 exp:4
+            "false"}, //indent:12 exp:12
+        value2 = "blub") //indent:8 exp:8
+    private void method4(String param1, //indent:4 exp:4
+                         String param2) { //indent:25 exp:25
+    	throw new RuntimeException(); //indent:8 exp:8
+    } //indent:4 exp:4
+} //indent:0 exp:0
+
+interface StrictCondition<A, B, C> {} //indent:0 exp:0
+
+@interface InputIndentationStrictCondition2Annotation { //indent:0 exp:0
+    String[] value(); //indent:4 exp:4
+    String value2(); //indent:4 exp:4
+} //indent:0 exp:0

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTryWithResourcesStrict.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationTryWithResourcesStrict.java
@@ -110,14 +110,14 @@ newBufferedWriter(filePath, charset); //indent:0 exp:12 warn
         try ( //indent:8 exp:8
             BufferedWriter writer = Files.newBufferedWriter(filePath, charset); //indent:12 exp:12
             ZipFile zf = new ZipFile( //indent:12 exp:12
-                 zipFileName) //indent:17 exp:16 warn
+                 zipFileName) //indent:17 exp:16,37 warn
             ) { //indent:12 exp:8,12
             zf.getName(); //indent:12 exp:12
         } //indent:8 exp:8
         try ( //indent:8 exp:8
             BufferedWriter writer = Files.newBufferedWriter(filePath, charset); //indent:12 exp:12
             ZipFile zf = new ZipFile( //indent:12 exp:12
-               zipFileName) //indent:15 exp:16 warn
+               zipFileName) //indent:15 exp:16,37 warn
             ) { //indent:12 exp:8,12
             zf.getName(); //indent:12 exp:12
         } //indent:8 exp:8


### PR DESCRIPTION
Resolves #270

Only active if forceStrictCondition is true

Diff Regression projects: https://gist.githubusercontent.com/plan3d/ca91d8262d18c4c84f6b62fa1cb4bebc/raw/55f3df0043861c1c5c0eaf2ee7868b2b211d8771/projects-to-test-on.properties
Diff Regression config: https://gist.githubusercontent.com/plan3d/ca91d8262d18c4c84f6b62fa1cb4bebc/raw/0b5868a05497728b1ab705790eb3c411cb846b10/my_check_strict.xml