### PR TITLE
minor: Fix github issue template not working

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,3 @@
-# Bug report template
-
 ---
 name: Bug report
 about: Create a report to help us improve
@@ -8,6 +6,7 @@ labels: ''
 assignees: ''
 
 ---
+
 I have read check documentation: https://checkstyle.org/config_xxxxxx.html#NameOfAffectedCheck
 I have downloaded the latest checkstyle from: https://checkstyle.org/cmdline.html#Download_and_Run
 I have executed the cli and showed it below, as cli describes the problem better than 1,000 words

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,3 @@
-# Feature request template
-
 ---
 name: Feature request
 about: Suggest an idea for this project


### PR DESCRIPTION
Fixes #9285: The template is read from the first line, since the first line doesn't matchup with the github extensible template, it is failing to create an issue template. 