### PR TITLE
minor: remove pitest suppression for loadUri

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2308,10 +2308,6 @@
               <targetTests>
                 <param>com.puppycrawl.tools.checkstyle.checks.imports.*</param>
               </targetTests>
-              <excludedMethods>
-                <!-- unkilled in generated code https://github.com/hcoles/pitest/issues/255 -->
-                <param>loadUri</param>
-              </excludedMethods>
               <excludedTestClasses>
                 <param>*.Input*</param>
               </excludedTestClasses>


### PR DESCRIPTION
Remove suppression [fixed](https://github.com/hcoles/pitest/pull/860) in 1.6.3.