### PR TITLE
Extend closed issues job to check issues in other repos

### DIFF
--- a/.ci/no_old_refs.sh
+++ b/.ci/no_old_refs.sh
@@ -2,27 +2,28 @@
 # Attention, there is no "-x" to avoid problems on Travis
 set -e
 
-MENTIONED_IDS=/tmp/mentioned_ids
-CLOSED_ISSUES=/tmp/failed
-API_ISSUE_LINK_PREFIX="https://api.github.com/repos/checkstyle/checkstyle/issues"
-ISSUE_LINK_PREFIX="https://github.com/checkstyle/checkstyle/issues"
+MENTIONED_ISSUES=/tmp/mentioned_issues
+CLOSED_ISSUES=/tmp/failed_issues
+API_GITHUB_PREFIX="https://api.github.com/repos"
+GITHUB_HOST="https://github.com"
 
 # collect issues where full link is used
-grep -Pohr "(after|[Tt]il[l]?) $ISSUE_LINK_PREFIX/\d{1,5}" . \
-  | sed -e 's/.*issues\///' >> $MENTIONED_IDS
+grep -Pohr "(after|[Tt]il[l]?) $GITHUB_HOST/[\w.-]+/[\w.-]+/issues/\d{1,5}" . \
+  | sed -e 's/.*github.com\///' >> $MENTIONED_ISSUES
 
-# collect issues where only hash sign is used
-grep -Pohr "[Tt]il[l]? #\d{1,5}" . | sed -e 's/.*#//' >> $MENTIONED_IDS
+# collect checkstyle issues where only hash sign is used
+grep -Pohr "[Tt]il[l]? #\d{1,5}" . \
+  | sed -e 's/.*#/checkstyle\/checkstyle\/issues\//' >> $MENTIONED_ISSUES
 
-for issue_id in $(sort -u $MENTIONED_IDS); do
-  STATE=$(curl -s -H "Authorization: token $READ_ONLY_TOKEN" "$API_ISSUE_LINK_PREFIX/$issue_id" \
+for issue in $(sort -u $MENTIONED_ISSUES); do
+  STATE=$(curl -s -H "Authorization: token $READ_ONLY_TOKEN" "$API_GITHUB_PREFIX/$issue" \
    | jq '.state' | xargs)
   if [[ "$STATE" == "closed" ]]; then
-    echo "$ISSUE_LINK_PREFIX/$issue_id" >> $CLOSED_ISSUES
+    echo "$GITHUB_HOST/$issue" >> $CLOSED_ISSUES
   fi
 done
 
-rm -f $MENTIONED_IDS
+rm -f $MENTIONED_ISSUES
 
 if [ -f "$CLOSED_ISSUES" ]; then
     echo "Following issues are mentioned in code to do something after they are closed:"

--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -10,49 +10,49 @@
     <Bug pattern="EQ_DOESNT_OVERRIDE_EQUALS" />
   </Match>
   <Match>
-    <!-- till https://github.com/spotbugs/spotbugs/issues/259 -->
+    <!-- till https://github.com/spotbugs/spotbugs/issues/1338 fails on java11+ -->
     <Class name="com.puppycrawl.tools.checkstyle.Main" />
     <Method name="loadProperties" />
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
   </Match>
   <Match>
-    <!-- till https://github.com/spotbugs/spotbugs/issues/259 -->
+    <!-- till https://github.com/spotbugs/spotbugs/issues/1338 fails on java11+ -->
     <Class name="com.puppycrawl.tools.checkstyle.PropertyCacheFile" />
     <Method name="load" />
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
   </Match>
   <Match>
-    <!-- till https://github.com/spotbugs/spotbugs/issues/259 -->
+    <!-- till https://github.com/spotbugs/spotbugs/issues/1338 fails on java11+ -->
     <Class name="com.puppycrawl.tools.checkstyle.PropertyCacheFile" />
     <Method name="persist" />
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
   </Match>
   <Match>
-    <!-- till https://github.com/spotbugs/spotbugs/issues/259 -->
+    <!-- till https://github.com/spotbugs/spotbugs/issues/1338 fails on java11+ -->
     <Class name="com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask" />
     <Method name="createOverridingProperties" />
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
   </Match>
   <Match>
-    <!-- till https://github.com/spotbugs/spotbugs/issues/259 -->
+    <!-- till https://github.com/spotbugs/spotbugs/issues/1338 fails on java11+ -->
     <Class name="com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck" />
     <Method name="processFiltered" />
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
   </Match>
   <Match>
-    <!-- till https://github.com/spotbugs/spotbugs/issues/259 -->
+    <!-- till https://github.com/spotbugs/spotbugs/issues/1338 fails on java11+ -->
     <Class name="com.puppycrawl.tools.checkstyle.checks.TranslationCheck" />
     <Method name="getTranslationKeys" />
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
   </Match>
   <Match>
-    <!-- till https://github.com/spotbugs/spotbugs/issues/259 -->
+    <!-- till https://github.com/spotbugs/spotbugs/issues/1338 fails on java11+ -->
     <Class name="com.puppycrawl.tools.checkstyle.checks.UniquePropertiesCheck" />
     <Method name="processFiltered" />
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
   </Match>
   <Match>
-    <!-- till https://github.com/spotbugs/spotbugs/issues/259 -->
+    <!-- till https://github.com/spotbugs/spotbugs/issues/1338 fails on java11+ -->
     <Class name="com.puppycrawl.tools.checkstyle.meta.MetadataGeneratorUtil" />
     <Method name="dumpMetadata" />
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />

--- a/pom.xml
+++ b/pom.xml
@@ -3080,15 +3080,6 @@
                 <mutator>TRUE_RETURNS</mutator>
                 <mutator>VOID_METHOD_CALLS</mutator>
               </mutators>
-              <avoidCallsTo>
-                <!-- Till https://github.com/hcoles/pitest/issues/766
-                 Pitest complains about redundant call to close() method.
-                 This is unavoidable, since this method is called deep inside
-                 try-with-resources statement. As a workaround, we can exclude
-                 all methods of these classes from mutation. -->
-                <avoidCallsTo>java.io.BufferedReader</avoidCallsTo>
-                <avoidCallsTo>java.io.Reader</avoidCallsTo>
-              </avoidCallsTo>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.api.*</param>
               </targetClasses>


### PR DESCRIPTION
Related to #9256 

1. Job is changed to detect closed issues in other repos as well
2. Violations are fixed (spotbugs and pitest)