### PR TITLE
doc: improve issue templates

### DIFF
--- a/src/xdocs/report_issue.xml
+++ b/src/xdocs/report_issue.xml
@@ -90,7 +90,7 @@ private static final int SOMETHING = 1;
 </module>
 
 /var/tmp $ RUN_LOCALE="-Duser.language=en -Duser.country=US"
-/var/tmp $ java $RUN_LOCALE -jar checkstyle-6.XX-all.jar -c config.xml Test.java
+/var/tmp $ java $RUN_LOCALE -jar checkstyle-X.XX-all.jar -c config.xml Test.java
 Starting audit...
 Audit done.
 
@@ -128,7 +128,7 @@ class Test {
 }
 
 D:\>set RUN_LOCALE="-Duser.language=en -Duser.country=US"
-D:\>java %RUN_LOCALE% -jar checkstyle-8.XX-all.jar -c config.xml Test.java
+D:\>java %RUN_LOCALE% -jar checkstyle-X.XX-all.jar -c config.xml Test.java
 Starting audit...
 [ERROR] D:\Test.java:3: 'try' child has incorrect indentation level 8,
 expected level should be 12. [Indentation]


### PR DESCRIPTION
1. Added `-n` flag to `cat` commands. This flag adds line numbers to file content, which very useful for detecting issues, especially when file is long. For example https://github.com/checkstyle/checkstyle/issues/8546
Unfortunately, I couldn't find similar thing for windows (sigh).
2. Jar version is changed to X.XX to be consistent across patterns.
