### PR TITLE
infra: add checkout_from support to no-exception-test.sh

### DIFF
--- a/.ci/no-exception-test.sh
+++ b/.ci/no-exception-test.sh
@@ -5,16 +5,30 @@ removeFolderWithProtectedFiles() {
   find $1 -delete
 }
 
+function checkout_from {
+  CLONE_URL=$1
+  PROJECT=$(echo "$CLONE_URL" | sed -nE 's/.*\/(.*).git/\1/p')
+  mkdir -p .ci-temp
+  cd .ci-temp
+  if [ -d "$PROJECT" ]; then
+    echo "Target project $PROJECT is already cloned, latest changes will be fetched"
+    cd $PROJECT
+    git fetch
+    cd ../
+  else
+    for i in 1 2 3 4 5; do git clone $CLONE_URL && break || sleep 15; done
+  fi
+  cd ../
+}
+
 case $1 in
 
 guava-with-google-checks)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo CS_version: $CS_POM_VERSION
-  mkdir -p .ci-temp/
-  cd .ci-temp/
-  git clone https://github.com/checkstyle/contribution
-  cd contribution/checkstyle-tester
+  checkout_from https://github.com/checkstyle/contribution
+  cd .ci-temp/contribution/checkstyle-tester
   sed -i.'' 's/^guava/#guava/' projects-to-test-on.properties
   sed -i.'' 's/#guava|/guava|/' projects-to-test-on.properties
   cd ../../../
@@ -34,10 +48,8 @@ guava-with-sun-checks)
   CS_POM_VERSION=$(mvn -e -q -Dexec.executable='echo' -Dexec.args='${project.version}' \
                      --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   echo CS_version: $CS_POM_VERSION
-  mkdir -p .ci-temp/
-  cd .ci-temp/
-  git clone https://github.com/checkstyle/contribution
-  cd contribution/checkstyle-tester
+  checkout_from https://github.com/checkstyle/contribution
+  cd .ci-temp/contribution/checkstyle-tester
   sed -i.'' 's/^guava/#guava/' projects-to-test-on.properties
   sed -i.'' 's/#guava|/guava|/' projects-to-test-on.properties
   cd ../../../
@@ -56,10 +68,7 @@ guava-with-sun-checks)
 openjdk14-with-checks-nonjavadoc-error)
   LOCAL_GIT_REPO=$(pwd)
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
-  mkdir -p .ci-temp/
-  cd .ci-temp/
-  git clone https://github.com/checkstyle/contribution
-  cd ..
+  checkout_from https://github.com/checkstyle/contribution
   sed -i.'' 's/value=\"error\"/value=\"ignore\"/' \
         .ci-temp/contribution/checkstyle-tester/checks-nonjavadoc-error.xml
   cd .ci-temp/contribution/checkstyle-tester


### PR DESCRIPTION
infra: add checkout_from support to no-exception-test.sh

As mentioned at https://github.com/checkstyle/checkstyle/pull/9278/files#r576851236, I have separated the addition of the `checkout_from` bash function from the changes at #9278.
