### PR TITLE
Issue #7877: Removed redundant conditional

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -64,7 +64,6 @@ pitest-imports)
   mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;
   declare -a ignoredItems=(
   "ImportControlLoader.java.html:<td class='covered'><pre><span  class='survived'>        else if (ALLOW_ELEMENT_NAME.equals(qName) || &#34;disallow&#34;.equals(qName)) {</span></pre></td></tr>"
-  "ImportOrderCheck.java.html:<td class='covered'><pre><span  class='survived'>        return !beforeFirstImport &#38;&#38; line - lastImportLine &#62; 1;</span></pre></td></tr>"
   "PkgImportControl.java.html:<td class='covered'><pre><span  class='survived'>        if (alreadyRegex) {</span></pre></td></tr>"
   "PkgImportControl.java.html:<td class='covered'><pre><span  class='survived'>        if (regex || parent.regex) {</span></pre></td></tr>"
   "PkgImportControl.java.html:<td class='covered'><pre><span  class='survived'>        if (regex) {</span></pre></td></tr>"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -875,7 +875,7 @@ public class ImportOrderCheck
      * @return true if there is separator before current import which isn't the first import.
      */
     private boolean isSeparatorBeforeImport(int line) {
-        return !beforeFirstImport && line - lastImportLine > 1;
+        return line - lastImportLine > 1;
     }
 
     /**


### PR DESCRIPTION
Fixes #7877 

**Pitest Report before fix:** https://bossever.github.io/issue7877/pit-reports/202102122217/com.puppycrawl.tools.checkstyle.checks.imports/ImportOrderCheck.java.html#org.pitest.mutationtest.report.html.SourceFile@476dda8b_878

[Hardcoded mutation on line 878](https://github.com/bossever/checkstyle/commit/7e0c2b518fe06f41175f1106d1d3bb1e9b00ca32): `removed conditional - replaced equality check with true → SURVIVED`

**Pitest Report after fix:** https://bossever.github.io/issue7877/pit-reports/202102182308/com.puppycrawl.tools.checkstyle.checks.imports/index.html

### Rationale behind removing `!beforeFirstImport`
I tried coming up with test cases where the mutation could be killed, but came to the conclusion that there exists no such test case, please read comment on issue - https://github.com/checkstyle/checkstyle/issues/7877#issuecomment-781327096.
As @nmancus1 has pointed out in issue conversation, I suppose this condition can be safely removed if no test cases were found, and `mvn clean verify` is passing. 
Please let me know if I have missed anything, or if there is another way to fix this issue.
_____________________________________________________________________________

Diff Regression config: https://gist.githubusercontent.com/bossever/ff126a13b0f1422daa5626db6fcdc384/raw/96d1898cdc28233c7a7fef6b3f855b939b2cf694/config.xml

Diff Regression projects: https://gist.githubusercontent.com/bossever/ff126a13b0f1422daa5626db6fcdc384/raw/6e8f8cbf0eb40baaf072ec9a3fe93883614709a9/projects-to-test-on.properties
 
Report label: Diff Regression Report after fix