### PR TITLE
Issue #8548: reformulate regex to fix Sonar warning

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGenerator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGenerator.java
@@ -57,7 +57,8 @@ public final class JavadocPropertiesGenerator {
      * The end of the sentence is determined by the symbol "period", "exclamation mark" or
      * "question mark", followed by a space or the end of the text.
      */
-    private static final Pattern END_OF_SENTENCE_PATTERN = Pattern.compile("(.*?[.?!])(\\s|$)");
+    private static final Pattern END_OF_SENTENCE_PATTERN = Pattern.compile(
+        "(([^.?!]|[.?!](?!\\s|$))*+[.?!])(\\s|$)");
 
     /** Max width of the usage help message for this command. */
     private static final int USAGE_HELP_WIDTH = 100;


### PR DESCRIPTION
fix for #8548

Rewrite the regex field `JavadocPropertiesGenerator.END_OF_SENTENCE_PATTERN`, to fix [this SonarQube warning](https://sonarcloud.io/project/issues?id=org.checkstyle%3Acheckstyle&issues=AXN1aAJJvRinlJ3puDUg&open=AXN1aAJJvRinlJ3puDUg).

* `(.*?[.?!])(\s|$)` - the original regex
* `([^.?!]*+[.?!])(\s|$)` - what SonarQube suggested
* `(([^.?!]|[.?!](?!\s|$))*+[.?!])(\s|$)` - what I used in the end

The problem with Sonar's suggestion is that it matches different things than the original pattern. For the input "Get obj.field.", their suggestion matches "field.", while the original pattern and my solution match the whole string.

The regex is a bit complex now. An alternative solution could be to write some Java code for finding the first sentence.

edit: fixed 3rd regex