### PR TITLE
#Issue #9310: test inputs should be compilable with javac11

### DIFF
--- a/.ci/eclipse-compiler-javac.sh
+++ b/.ci/eclipse-compiler-javac.sh
@@ -7,6 +7,8 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
+JAVA_RELEASE=${2:-1.8}
+
 ECJ_JAR="ecj-4.17.jar"
 ECJ_MAVEN_VERSION="R-4.17-202009021800"
 ECJ_PATH=~/.m2/repository/$ECJ_MAVEN_VERSION/$ECJ_JAR
@@ -23,10 +25,10 @@ mkdir -p target/classes target/test-classes target/eclipse
 RESULT_FILE=target/eclipse/report.txt
 
 echo "Executing eclipse compiler, output is redirected to $RESULT_FILE..."
-echo "java -jar $ECJ_PATH -target 1.8 -source 1.8 -cp $1  ..."
+echo "java -jar $ECJ_PATH -target ${JAVA_RELEASE} -source ${JAVA_RELEASE} -cp $1  ..."
 
 set +e
-java -jar $ECJ_PATH -target 1.8 -source 1.8 -encoding UTF-8 -cp $1 \
+java -jar $ECJ_PATH -target ${JAVA_RELEASE} -source ${JAVA_RELEASE} -encoding UTF-8 -cp $1 \
         -d target/eclipse-compile \
         -properties config/org.eclipse.jdt.core.prefs \
         -enableJavadoc \
@@ -46,7 +48,7 @@ if [[ $EXIT_CODE != 0 ]]; then
 else
     # check compilation of resources, all WARN and INFO are ignored
     set +e
-    java -jar $ECJ_PATH -target 1.8 -source 1.8 -cp $1 \
+    java -jar $ECJ_PATH -target ${JAVA_RELEASE} -source ${JAVA_RELEASE} -cp $1 \
             -d target/eclipse-compile \
             -nowarn \
             src/main/java \

--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -627,6 +627,7 @@ javaparser
 javarevisited
 javascript
 javase
+javassist
 javastrangefolder
 javax
 Jax

--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -87,6 +87,16 @@ eclipse-static-analysis)
   mvn -e clean compile exec:exec -Peclipse-compiler
   ;;
 
+eclipse-static-analysis-java11)
+  # Ensure that project sources can be compiled by eclipse with Java11 language features.
+  mvn -e clean compile exec:exec -Peclipse-compiler -D java.version=11
+  ;;
+
+java11-verify)
+  # Ensure that project sources can be compiled by jdk with Java11 language features.
+  mvn -e clean verify -D java.version=11
+  ;;
+
 nondex)
   # Below we exclude test that fails due to picocli library usage
   mvn -e --fail-never clean nondex:nondex -DargLine='-Xms1024m -Xmx2048m' \

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -49,6 +49,8 @@ blocks:
                 - .ci/validation.sh all-sevntu-checks
                 - .ci/validation.sh check-missing-pitests
                 - .ci/validation.sh eclipse-static-analysis
+                - .ci/validation.sh eclipse-static-analysis-java11
+                - .ci/validation.sh java11-verify
                 - mvn -e clean install -Pno-validations
                     && .ci/no-exception-test.sh guava-with-google-checks
                 - mvn -e clean install -Pno-validations

--- a/pom.xml
+++ b/pom.xml
@@ -332,6 +332,13 @@
     </dependency>
     <!-- till https://github.com/checkstyle/checkstyle/issues/7368 -->
     <dependency>
+      <groupId>org.javassist</groupId>
+      <artifactId>javassist</artifactId>
+      <version>3.27.0-GA</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- till https://github.com/checkstyle/checkstyle/issues/7368 -->
+    <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
       <version>${powermock.version}</version>
@@ -1184,7 +1191,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>1.8</version>
+                  <version>${java.version}</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
                   <version>3.0.1</version>
@@ -3288,6 +3295,7 @@
               <classpathScope>test</classpathScope>
               <arguments>
                 <classpath />
+                <argument>${java.version}</argument>
               </arguments>
             </configuration>
           </plugin>

--- a/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/packageannotation/SuppressionXpathRegressionPackageAnnotationOne.java
+++ b/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/packageannotation/SuppressionXpathRegressionPackageAnnotationOne.java
@@ -1,4 +1,4 @@
-//non-compiled with javac: non-compilable, compiling on jdk before 8
+//non-compiled with javac: compiling on jdk before 8
 //more details at https://github.com/checkstyle/checkstyle/issues/7846
 @Deprecated
 package com.puppycrawl.tools.checkstyle.checks.annotation.packageannotation; // warn

--- a/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/packageannotation/SuppressionXpathRegressionPackageAnnotationTwo.java
+++ b/src/it/resources-noncompilable/org/checkstyle/suppressionxpathfilter/packageannotation/SuppressionXpathRegressionPackageAnnotationTwo.java
@@ -1,4 +1,4 @@
-//non-compiled with javac: non-compilable, compiling on jdk before 8
+//non-compiled with javac: compiling on jdk before 8
 //more details at https://github.com/checkstyle/checkstyle/issues/7846
 @Deprecated @Generated("foo")
 package com.puppycrawl.tools.checkstyle.checks.annotation.packageannotation.two; // warn

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheckTest.java
@@ -54,7 +54,7 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
             "23:1: " + getCheckMessage(MSG_KEY, "java.io.File.listRoots"),
             "27:1: " + getCheckMessage(MSG_KEY, "java.io.File.createTempFile"),
         };
-        verify(checkConfig, getNonCompilablePath("InputIllegalImportDefault.java"), expected);
+        verify(checkConfig, getPath("InputIllegalImportDefault.java"), expected);
     }
 
     @Test
@@ -63,10 +63,10 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig =
             createModuleConfig(IllegalImportCheck.class);
         final String[] expected = {
-            "15:1: " + getCheckMessage(MSG_KEY, "sun.applet.*"),
-            "28:1: " + getCheckMessage(MSG_KEY, "sun.*"),
+            "15:1: " + getCheckMessage(MSG_KEY, "sun.misc.*"),
+            "28:1: " + getCheckMessage(MSG_KEY, "sun.reflect.*"),
         };
-        verify(checkConfig, getNonCompilablePath("InputIllegalImportDefault.java"), expected);
+        verify(checkConfig, getPath("InputIllegalImportDefault.java"), expected);
     }
 
     @Test
@@ -87,10 +87,10 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("illegalClasses", "java.sql.Connection");
         final String[] expected = {
             "11:1: " + getCheckMessage(MSG_KEY, "java.sql.Connection"),
-            "15:1: " + getCheckMessage(MSG_KEY, "sun.applet.*"),
-            "28:1: " + getCheckMessage(MSG_KEY, "sun.*"),
+            "15:1: " + getCheckMessage(MSG_KEY, "sun.misc.*"),
+            "28:1: " + getCheckMessage(MSG_KEY, "sun.reflect.*"),
         };
-        verify(checkConfig, getNonCompilablePath("InputIllegalImportDefault.java"), expected);
+        verify(checkConfig, getPath("InputIllegalImportDefault.java"), expected);
     }
 
     @Test
@@ -101,10 +101,10 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
         checkConfig.addAttribute("illegalClasses", "java.io.*");
         final String[] expected = {
             "9:1: " + getCheckMessage(MSG_KEY, "java.io.*"),
-            "15:1: " + getCheckMessage(MSG_KEY, "sun.applet.*"),
-            "28:1: " + getCheckMessage(MSG_KEY, "sun.*"),
+            "15:1: " + getCheckMessage(MSG_KEY, "sun.misc.*"),
+            "28:1: " + getCheckMessage(MSG_KEY, "sun.reflect.*"),
         };
-        verify(checkConfig, getNonCompilablePath("InputIllegalImportDefault.java"), expected);
+        verify(checkConfig, getPath("InputIllegalImportDefault.java"), expected);
     }
 
     @Test
@@ -123,7 +123,7 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
             "35:1: " + getCheckMessage(MSG_KEY, "java.util.Calendar"),
             "36:1: " + getCheckMessage(MSG_KEY, "java.util.BitSet"),
         };
-        verify(checkConfig, getNonCompilablePath("InputIllegalImportDefault.java"), expected);
+        verify(checkConfig, getPath("InputIllegalImportDefault.java"), expected);
     }
 
     @Test
@@ -139,7 +139,7 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
             "13:1: " + getCheckMessage(MSG_KEY, "java.util.List"),
             "17:1: " + getCheckMessage(MSG_KEY, "java.util.Arrays"),
         };
-        verify(checkConfig, getNonCompilablePath("InputIllegalImportDefault.java"), expected);
+        verify(checkConfig, getPath("InputIllegalImportDefault.java"), expected);
     }
 
     @Test
@@ -164,7 +164,7 @@ public class IllegalImportCheckTest extends AbstractModuleTestSupport {
             "35:1: " + getCheckMessage(MSG_KEY, "java.util.Calendar"),
             "36:1: " + getCheckMessage(MSG_KEY, "java.util.BitSet"),
         };
-        verify(checkConfig, getNonCompilablePath("InputIllegalImportDefault.java"), expected);
+        verify(checkConfig, getPath("InputIllegalImportDefault.java"), expected);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -357,7 +357,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
 
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig,
-            getNonCompilablePath("InputJavadocTypeAllowedAnnotations.java"),
+            getPath("InputJavadocTypeAllowedAnnotations.java"),
             expected);
     }
 
@@ -371,7 +371,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
 
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig,
-                getNonCompilablePath("InputJavadocTypeAllowedAnnotations.java"),
+                getPath("InputJavadocTypeAllowedAnnotations.java"),
                 expected);
     }
 
@@ -379,11 +379,11 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
     public void testAllowedAnnotationsAllowed() throws Exception {
         final DefaultConfiguration checkConfig =
             createModuleConfig(JavadocTypeCheck.class);
-        checkConfig.addAttribute("allowedAnnotations", "Generated, ThisIsOk");
+        checkConfig.addAttribute("allowedAnnotations", "SuppressWarnings, ThisIsOk");
 
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig,
-            getNonCompilablePath("InputJavadocTypeAllowedAnnotations.java"),
+            getPath("InputJavadocTypeAllowedAnnotations.java"),
             expected);
     }
 
@@ -395,7 +395,7 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
 
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig,
-            getNonCompilablePath("InputJavadocTypeAllowedAnnotations.java"),
+            getPath("InputJavadocTypeAllowedAnnotations.java"),
             expected);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/IllegalIdentifierNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/IllegalIdentifierNameCheckTest.java
@@ -142,8 +142,9 @@ public class IllegalIdentifierNameCheckTest extends AbstractModuleTestSupport {
         final String format = "(?i)^(?!(record|yield|var|permits|sealed|_)$).+$";
 
         final String[] expected = {
-            "11:12: " + getCheckMessage(MSG_INVALID_PATTERN, "_", format),
+            "12:12: " + getCheckMessage(MSG_INVALID_PATTERN, "_", format),
             };
-        verify(checkConfig, getPath("InputIllegalIdentifierNameUnderscore.java"), expected);
+        verify(checkConfig,
+            getNonCompilablePath("InputIllegalIdentifierNameUnderscore.java"), expected);
     }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/annotation/packageannotation/InputPackageAnnotation2.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/annotation/packageannotation/InputPackageAnnotation2.java
@@ -1,4 +1,4 @@
-//non-compiled with javac: non-compilable, compiling on jdk before 8
+//non-compiled with javac: compiling on jdk before 8
 //more details at https://github.com/checkstyle/checkstyle/issues/7846
 @Deprecated
 package com.puppycrawl.tools.checkstyle.checks.annotation.packageannotation;

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/illegalinstantiation/InputIllegalInstantiationLang.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/illegalinstantiation/InputIllegalInstantiationLang.java
@@ -1,4 +1,4 @@
-// non-compiled jdk8: different package is intentional for test
+//non-compiled with javac: compiling on jdk before 9
 package java.lang;
 
 class InputIllegalInstantiationLang {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierNameUnderscore.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierNameUnderscore.java
@@ -1,3 +1,4 @@
+//non-compiled with javac: compiling on jdk before 9
 package com.puppycrawl.tools.checkstyle.checks.naming.illegalidentifiername;
 
 /* Config:

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/illegalimport/InputIllegalImportDefault.java
@@ -1,10 +1,10 @@
-//non-compiled with jdk10: contains dropped packages
+
 
 
 
 package com.puppycrawl.tools.checkstyle.checks.imports.illegalimport;
 
-import com.puppycrawl.tools.checkstyle.checks.imports.*;
+import com.puppycrawl.tools.checkstyle.checks.imports.illegalimport.*;
 
 import java.io.*;
 import java.lang.*;
@@ -12,7 +12,7 @@ import java.sql.Connection;
 import java.util.List;
 import java.util.List;
 import java.lang.ArithmeticException;
-import sun.applet.*;
+import sun.misc.*;
 import java.util.Enumeration;
 import java.util.Arrays;
 
@@ -25,7 +25,7 @@ import static java.io.File.listRoots;
 import static javax.swing.WindowConstants.*;
 import static javax.swing.WindowConstants.*;
 import static java.io.File.createTempFile;
-import sun.*;
+import sun.reflect.*;
 
 import java.awt.Component;
 import java.awt.Graphics2D;
@@ -97,5 +97,6 @@ class InputIllegalImportDefault
      * @throws TestClass7 when broken
      * @deprecated in 1 for removal in 2. Use {@link TestClass8}
      */
+    @Deprecated
     public void aMethodWithManyLinks() {}
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeAllowedAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeAllowedAnnotations.java
@@ -1,7 +1,7 @@
-//non-compiled with jkd11: contains dropped packages
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
 
-import javax.annotation.Generated;
+
+import java.lang.SuppressWarnings;
 
 @ThisIsOk
 class InputJavadocTypeAllowedAnnotations {
@@ -11,7 +11,7 @@ class InputJavadocTypeAllowedAnnotations {
 class InputJavadocTypeAllowedAnnotationsFQN {
 }
 
-@Generated(value = "some code generator")
+@SuppressWarnings(value = "some code generator")
 class InputJavadocTypeAllowedAnnotationByDefault {
 }
 


### PR DESCRIPTION
Fixes #9310

The import `sun.*` replaced with `sun.reflect.*`, `sun.applet.*` replaced with `sun.misc.*`, 

The annotation `javax.annotation.Generated` replaced with `java.lang.SuppressWarnings`.

Two new build configs for semaphore CI with `java.version=11`: one for OpenJdk11 javac, another for Eclipse compiler.