### PR TITLE
Fix escaped char pattern in AvoidEscapedUnicodeCharactersCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -174,7 +174,7 @@ public class AvoidEscapedUnicodeCharactersCheck
     public static final String MSG_KEY = "forbid.escaped.unicode.char";
 
     /** Regular expression for Unicode chars. */
-    private static final Pattern UNICODE_REGEXP = Pattern.compile("\\\\u[a-fA-F0-9]{4}");
+    private static final Pattern UNICODE_REGEXP = Pattern.compile("\\\\u+[a-fA-F0-9]{4}");
 
     /**
      * Regular expression Unicode control characters.
@@ -182,7 +182,7 @@ public class AvoidEscapedUnicodeCharactersCheck
      * @see <a href="https://en.wiktionary.org/wiki/Appendix:Control_characters">
      *     Appendix:Control characters</a>
      */
-    private static final Pattern UNICODE_CONTROL = Pattern.compile("\\\\[uU]"
+    private static final Pattern UNICODE_CONTROL = Pattern.compile("\\\\u+"
             + "(00[0-1][0-9A-Fa-f]"
             + "|00[8-9][0-9A-Fa-f]"
             + "|00[aA][dD]"
@@ -200,7 +200,8 @@ public class AvoidEscapedUnicodeCharactersCheck
      * See "EscapeSequence" at
      * https://docs.oracle.com/javase/specs/jls/se15/html/jls-3.html#jls-3.10.7
      */
-    private static final Pattern ALL_ESCAPED_CHARS = Pattern.compile("^((\\\\u)[a-fA-F0-9]{4}"
+    private static final Pattern ALL_ESCAPED_CHARS = Pattern.compile("^("
+            + UNICODE_REGEXP.pattern()
             + "|\""
             + "|'"
             + "|\\\\"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
@@ -219,6 +219,8 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
             "113:55: " + getCheckMessage(MSG_KEY),
             "114:46: " + getCheckMessage(MSG_KEY),
             "115:55: " + getCheckMessage(MSG_KEY),
+            "116:48: " + getCheckMessage(MSG_KEY),
+            "117:57: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputAvoidEscapedUnicodeCharacters.java"), expected);
     }
@@ -271,6 +273,8 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
             "113:55: " + getCheckMessage(MSG_KEY),
             "114:46: " + getCheckMessage(MSG_KEY),
             "115:55: " + getCheckMessage(MSG_KEY),
+            "116:48: " + getCheckMessage(MSG_KEY),
+            "117:57: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputAvoidEscapedUnicodeCharacters.java"), expected);
     }
@@ -308,6 +312,7 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
             "110:46: " + getCheckMessage(MSG_KEY),
             "112:46: " + getCheckMessage(MSG_KEY),
             "114:46: " + getCheckMessage(MSG_KEY),
+            "116:48: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputAvoidEscapedUnicodeCharacters.java"), expected);
     }
@@ -342,6 +347,8 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
             "113:55: " + getCheckMessage(MSG_KEY),
             "114:46: " + getCheckMessage(MSG_KEY),
             "115:55: " + getCheckMessage(MSG_KEY),
+            "116:48: " + getCheckMessage(MSG_KEY),
+            "117:57: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputAvoidEscapedUnicodeCharacters.java"), expected);
     }
@@ -382,6 +389,8 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
             "113:55: " + getCheckMessage(MSG_KEY),
             "114:46: " + getCheckMessage(MSG_KEY),
             "115:55: " + getCheckMessage(MSG_KEY),
+            "116:48: " + getCheckMessage(MSG_KEY),
+            "117:57: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputAvoidEscapedUnicodeCharacters.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharacters.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharacters.java
@@ -113,4 +113,6 @@ public class InputAvoidEscapedUnicodeCharacters {
         private String sumilarToEscapedCommentedByN = "n\u1234"; // comment
         private String sumilarToEscapedByT = "t\u1234";
         private String sumilarToEscapedCommentedByT = "t\u1234"; // comment
+        private String validEscapeWithManyUs = "t\uuuuuuuuu1234";
+        private String validEscapeWithManyUsCommented = "t\uuuuuuuuu1234"; // comment
 }


### PR DESCRIPTION
AvoidEscapedUnicodeCharactersCheck pattern for escaped chars is a bit incorrect.
According to [JLS](https://docs.oracle.com/javase/specs/jls/se15/html/jls-3.html#jls-3.3) char 'u' can be repeated many times, and it is still valid escape.

Note: pattern for whitespace escapes was not updated - it is causing sonar violation that require big refactoring of regex and tests.

Diff Regression config: https://gist.githubusercontent.com/strkkk/31749e0743553a606f69fdfc6670d780/raw/2031b8f52d40c522c5cd8c343ff2c8af476082d7/confg.xml
Diff Regression projects: https://gist.githubusercontent.com/strkkk/29c0f3a0ce06a681afdf8d3c417a4b30/raw/f2771cee1ba63f0236377c2b55b77a2fb1fe45e0/small_projects
Report label: only jdk9