### PR TITLE
minor: add maven flag to omit download progress

### DIFF
--- a/.ci/wercker.sh
+++ b/.ci/wercker.sh
@@ -38,7 +38,7 @@ sonarqube)
   fi
   if [[ -z $SONAR_TOKEN ]]; then echo "SONAR_TOKEN is not set"; sleep 5s; exit 1; fi
   export MAVEN_OPTS='-Xmx2000m'
-  mvn -e -Pno-validations clean package sonar:sonar $SONAR_PR_VARIABLES \
+  mvn -e -Pno-validations --no-transfer-progress clean package sonar:sonar $SONAR_PR_VARIABLES \
        -Dsonar.host.url=https://sonarcloud.io \
        -Dsonar.login=$SONAR_TOKEN \
        -Dsonar.projectKey=org.checkstyle:checkstyle \

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           cd checkstyle
           bash
-          mvn -e clean site -Pno-validations
+          mvn -e --no-transfer-progress clean site -Pno-validations
 
       - name: Copy site to AWS S3 Bucket
         run: |


### PR DESCRIPTION
Reason: long list of downloads makes in difficult to find useful information, e.g. for sonar: https://app.wercker.com/checkstyle/checkstyle/runs/build/60311065237ec900083b7685?step=60311852476e90000847aad5
and site generation.

`ntp` flag (stands for "no-transfer-progress") suppresses all entries like
```
Downloading from central: ...
Downloaded from central: ...
```

May be there are other places where it can be useful?