### PR TITLE
Issue #9271: Remove detailAstImp from Rcurly

### DIFF
--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -14,9 +14,6 @@
   <!-- guava causes issues with other libraries since not everyone is on the same version -->
   <disallow pkg="com\.google.*" regex="true"/>
 
-  <!-- until https://github.com/checkstyle/checkstyle/issues/9271 -->
-  <allow class="com.puppycrawl.tools.checkstyle.DetailAstImpl"/>
-
   <allow pkg="com.puppycrawl.tools.checkstyle.api"/>
   <allow pkg="com.puppycrawl.tools.checkstyle.checks"/>
   <allow pkg="java.io"/>
@@ -60,6 +57,7 @@
   </file>
   <file name="ParserUtil">
     <allow class="antlr.Token"/>
+    <allow class="com.puppycrawl.tools.checkstyle.DetailAstImpl"/>
   </file>
 
   <subpackage name="utils">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
@@ -646,6 +646,48 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testRightCurlyDoubleBrace() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
+        checkConfig.addAttribute("option", RightCurlyOption.ALONE.toString());
+        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR,"
+                + "LITERAL_WHILE, STATIC_INIT,"
+                + "INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,"
+                + "COMPACT_CTOR_DEF");
+        final String[] expected = {
+            "12:1: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 1),
+            "12:2: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 2),
+        };
+        verify(checkConfig,
+                getPath("InputRightCurlyDoubleBrace.java"), expected);
+    }
+
+    @Test
+    public void testRightCurlyEmptyOnSingleLine() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
+        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR,"
+                + "LITERAL_WHILE, STATIC_INIT,"
+                + "INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,"
+                + "COMPACT_CTOR_DEF");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verify(checkConfig,
+                getPath("InputRightCurlyEmptyOnSingleLine.java"), expected);
+    }
+
+    @Test
+    public void testRightCurlyEndOfFile() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
+        checkConfig.addAttribute("option", RightCurlyOption.SAME.toString());
+        checkConfig.addAttribute("tokens", "CLASS_DEF, METHOD_DEF, CTOR_DEF,"
+                + "LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT");
+        final String[] expected = {
+            "15:2: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 2),
+            "15:3: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 3),
+        };
+        verify(checkConfig,
+                getPath("InputRightCurlyEndOfFile.java"), expected);
+    }
+
+    @Test
     public void testRightCurlyRecordsAndCompactCtors() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(RightCurlyCheck.class);
         checkConfig.addAttribute("option", RightCurlyOption.SAME.toString());
@@ -663,5 +705,4 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         verify(checkConfig,
             getNonCompilablePath("InputRightCurlyRecordsAndCompactCtors.java"), expected);
     }
-
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyDoubleBrace.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyDoubleBrace.java
@@ -1,0 +1,12 @@
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+/* Config:
+ * option = alone
+ * tokens = {CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
+ *           INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
+ *           COMPACT_CTOR_DEF}
+ *
+ */
+class InputRightCurlyDoubleBrace {{
+
+}} // violation

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyEmptyOnSingleLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyEmptyOnSingleLine.java
@@ -1,0 +1,9 @@
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+/* Config:
+ * tokens = {CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
+ *           INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
+ *           COMPACT_CTOR_DEF}
+ *
+ */
+public class InputRightCurlyEmptyOnSingleLine {} // ok

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyEndOfFile.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyEndOfFile.java
@@ -1,0 +1,15 @@
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+/* Config:
+ * option = alone
+ * tokens = {CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
+ *           INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
+ *           COMPACT_CTOR_DEF}
+ *
+ */
+public class InputRightCurlyEndOfFile
+{
+    public static void main(String[] arg)
+    {
+
+ }} // violation


### PR DESCRIPTION
Closes: #9271 

Continutation of #9288

Interestingly according to GitHub  [renaming](https://github.com/github/renaming/) the PR should automatically get targeted on renaming branch. But didn't happen with this one. It might be targeting PR on this branch and not from this branch. 

Sorry for that. Fixed points as pointed in #9288 in recent commit.

Diff Regression config: https://raw.githubusercontent.com/AkMo3/akmo3.github.io/Issue9217/Issue9271/config-Issue9271-20210224194247.xml
Diff Regression projects: https://raw.githubusercontent.com/AkMo3/akmo3.github.io/Issue9217/Issue9271/projects-to-test-on.properties