### PR TITLE
Issue #5779: fixing no violation on parenthesis in if statement betwe…

### DIFF
--- a/.ci/wercker.sh
+++ b/.ci/wercker.sh
@@ -67,7 +67,7 @@ no-error-orekit)
   # no CI is enforced in project, so to make our build stable we should
   # checkout to latest release/development (annotated tag or hash) or sha that have fix we need
   # git checkout $(git describe --abbrev=0 --tags)
-  git checkout "54f5f2eb410ec42e5410ec8e5c415ff9182d3235"
+  git checkout "76760bf""bf""b847e227490cd5d3662f""ca087f1a324"
   mvn -e --no-transfer-progress compile checkstyle:check \
     -Dorekit.checkstyle.version=${CS_POM_VERSION}
   cd ..

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
@@ -448,7 +448,7 @@ public class UnnecessaryParenthesesCheck extends AbstractCheck {
                 log(ast, MSG_IDENT, ast.getText());
             }
             // A literal (numeric or string) surrounded by parentheses.
-            else if (surrounded && isInTokenList(type, LITERALS)) {
+            else if (surrounded && TokenUtil.isOfType(type, LITERALS)) {
                 parentToSkip = ast.getParent();
                 if (type == TokenTypes.STRING_LITERAL) {
                     log(ast, MSG_STRING,
@@ -468,7 +468,7 @@ public class UnnecessaryParenthesesCheck extends AbstractCheck {
                 }
             }
             // The rhs of an assignment surrounded by parentheses.
-            else if (isInTokenList(type, ASSIGNMENTS)) {
+            else if (TokenUtil.isOfType(type, ASSIGNMENTS)) {
                 assignDepth++;
                 final DetailAST last = ast.getLastChild();
                 if (last.getType() == TokenTypes.RPAREN) {
@@ -489,7 +489,7 @@ public class UnnecessaryParenthesesCheck extends AbstractCheck {
             if (type == TokenTypes.EXPR) {
                 checkExpression(ast);
             }
-            else if (isInTokenList(type, ASSIGNMENTS)) {
+            else if (TokenUtil.isOfType(type, ASSIGNMENTS)) {
                 assignDepth--;
             }
             else if (checkAroundOperators(ast)) {
@@ -591,26 +591,6 @@ public class UnnecessaryParenthesesCheck extends AbstractCheck {
             }
         }
         return result;
-    }
-
-    /**
-     * Check if the given token type can be found in an array of token types.
-     *
-     * @param type the token type.
-     * @param tokens an array of token types to search.
-     * @return {@code true} if {@code type} was found in {@code
-     *         tokens}.
-     */
-    private static boolean isInTokenList(int type, int... tokens) {
-        // NOTE: Given the small size of the two arrays searched, I'm not sure
-        //       it's worth bothering with doing a binary search or using a
-        //       HashMap to do the searches.
-
-        boolean found = false;
-        for (int i = 0; i < tokens.length && !found; i++) {
-            found = tokens[i] == type;
-        }
-        return found;
     }
 
     /**

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/UnnecessaryParenthesesCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/UnnecessaryParenthesesCheck.xml
@@ -9,11 +9,16 @@
  The check will flag the following with warnings:
  &lt;/p&gt;
  &lt;pre&gt;
-     return (x);          // parens around identifier
-     return (x + 1);      // parens around return value
-     int x = (y / 2 + 1); // parens around assignment rhs
-     for (int i = (0); i &amp;lt; 10; i++) {  // parens around literal
-     t -= (z + 1);        // parens around assignment rhs&lt;/pre&gt;
+ return (x);          // parens around identifier
+ return (x + 1);      // parens around return value
+ int x = (y / 2 + 1); // parens around assignment rhs
+ for (int i = (0); i &amp;lt; 10; i++) {  // parens around literal
+ t -= (z + 1);                     // parens around assignment rhs
+ boolean a = (x &amp;gt; 7 &amp;amp;&amp;amp; y &amp;gt; 5)      // parens around expression
+             || z &amp;lt; 9;
+ boolean b = (~a) &amp;gt; -27            // parens around ~a
+             &amp;amp;&amp;amp; (a-- &amp;lt; 30);        // parens around expression
+ &lt;/pre&gt;
  &lt;p&gt;
  The check is not "type aware", that is to say, it can't tell if parentheses
  are unnecessary based on the types in an expression.  It also doesn't know
@@ -28,7 +33,7 @@
  are not needed.
  &lt;/p&gt;</description>
          <properties>
-            <property default-value="EXPR,IDENT,NUM_DOUBLE,NUM_FLOAT,NUM_INT,NUM_LONG,STRING_LITERAL,LITERAL_NULL,LITERAL_FALSE,LITERAL_TRUE,ASSIGN,BAND_ASSIGN,BOR_ASSIGN,BSR_ASSIGN,BXOR_ASSIGN,DIV_ASSIGN,MINUS_ASSIGN,MOD_ASSIGN,PLUS_ASSIGN,SL_ASSIGN,SR_ASSIGN,STAR_ASSIGN,LAMBDA,TEXT_BLOCK_LITERAL_BEGIN"
+            <property default-value="EXPR,IDENT,NUM_DOUBLE,NUM_FLOAT,NUM_INT,NUM_LONG,STRING_LITERAL,LITERAL_NULL,LITERAL_FALSE,LITERAL_TRUE,ASSIGN,BAND_ASSIGN,BOR_ASSIGN,BSR_ASSIGN,BXOR_ASSIGN,DIV_ASSIGN,MINUS_ASSIGN,MOD_ASSIGN,PLUS_ASSIGN,SL_ASSIGN,SR_ASSIGN,STAR_ASSIGN,LAMBDA,TEXT_BLOCK_LITERAL_BEGIN,LAND,LITERAL_INSTANCEOF,GT,LT,GE,LE,EQUAL,NOT_EQUAL,UNARY_MINUS,UNARY_PLUS,INC,DEC,LNOT,BNOT,POST_INC,POST_DEC"
                       name="tokens"
                       type="java.lang.String[]"
                       validation-type="tokenSet">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheckTest.java
@@ -184,4 +184,40 @@ public class UnnecessaryParenthesesCheckTest extends AbstractModuleTestSupport {
         assertNotNull(check.getRequiredTokens(), "Required tokens should not be null");
     }
 
+    @Test
+    public void testIfStatement() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(UnnecessaryParenthesesCheck.class);
+
+        final String[] expected = {
+            "10:20: " + getCheckMessage(MSG_EXPR),
+            "25:13: " + getCheckMessage(MSG_EXPR),
+            "26:20: " + getCheckMessage(MSG_EXPR),
+            "30:13: " + getCheckMessage(MSG_EXPR),
+            "30:14: " + getCheckMessage(MSG_EXPR),
+            "31:20: " + getCheckMessage(MSG_EXPR),
+            "36:20: " + getCheckMessage(MSG_EXPR),
+            "40:13: " + getCheckMessage(MSG_EXPR),
+            "41:20: " + getCheckMessage(MSG_EXPR),
+            "45:13: " + getCheckMessage(MSG_EXPR),
+            "46:17: " + getCheckMessage(MSG_EXPR),
+            "47:28: " + getCheckMessage(MSG_EXPR),
+            "52:13: " + getCheckMessage(MSG_EXPR),
+            "57:14: " + getCheckMessage(MSG_EXPR),
+            "58:24: " + getCheckMessage(MSG_EXPR),
+            "61:13: " + getCheckMessage(MSG_EXPR),
+            "62:21: " + getCheckMessage(MSG_EXPR),
+            "63:21: " + getCheckMessage(MSG_EXPR),
+            "69:12: " + getCheckMessage(MSG_EXPR),
+            "70:20: " + getCheckMessage(MSG_EXPR),
+            "77:20: " + getCheckMessage(MSG_EXPR),
+            "95:13: " + getCheckMessage(MSG_EXPR),
+            "98:13: " + getCheckMessage(MSG_EXPR),
+            "99:21: " + getCheckMessage(MSG_EXPR),
+            "102:13: " + getCheckMessage(MSG_EXPR),
+        };
+
+        verify(checkConfig, getPath("InputUnnecessaryParenthesesIfStatement.java"), expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesIfStatement.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesIfStatement.java
@@ -1,0 +1,110 @@
+package com.puppycrawl.tools.checkstyle.checks.coding.unnecessaryparentheses;
+
+/* Config: default
+ */
+
+public class InputUnnecessaryParenthesesIfStatement {
+
+    void method(String sectionName) {
+        if ("Content".equals(sectionName) || "Overview".equals(sectionName)
+                || (!"AbbreviationAsWordInName".equals(sectionName) // violation, unnecessary
+                                                                    // parenthesis
+                && !"AbstractClassName".equals(sectionName) // ok
+        )) {
+            System.out.println("sd");
+        }
+    }
+
+    private void method() {
+        int x, y, z;
+        x = 0;
+        y = 0;
+
+        z = (x < y) ? x : y; // ok
+
+        if ((x < y)           // violation, unnecessary parenthesis
+                && (x > z)) { // violation, unnecessary parenthesis
+            return;
+        }
+
+        if (((x < y)           // violation, unnecessary parenthesis
+                && (x > z))) { // violation, unnecessary parenthesis
+            return;
+        }
+
+        if (!(x <= y)          // ok
+                || (x >= z)) { // violation, unnecessary parenthesis
+            return;
+        }
+
+        if ((x == y)           // violation, unnecessary parenthesis
+                || (x != z)) { // violation, unnecessary parenthesis
+            return;
+        }
+
+        if ((                       // violation, unnecessary parenthesis
+                (x == y)            // violation, unnecessary parenthesis
+                        || (x != z) // violation, unnecessary parenthesis
+        )) {
+            return;
+        }
+
+        if ((Integer.valueOf(x) instanceof Integer) // violation, unnecessary parenthesis
+                || Integer.valueOf(y) instanceof Integer) { // ok
+            return;
+        }
+        if (x == ((y<z) ? y : z) &&
+            ((x>y && y>z)                  // violation, unnecessary parenthesis before 'x>y'
+                    || (!(x<z) && y>z))) { // violation, unnecessary parenthesis before '!'
+            return;
+        }
+        if ((x >= 0 && y <= 9)            // violation, unnecessary parenthesis
+                 || (z >= 5 && y <= 5)    // violation, unnecessary parenthesis
+                 || (z >= 3 && x <= 7)) { // violation, unnecessary parenthesis
+            return;
+        }
+        if(x>= 0 && (x<=8 || y<=11) && y>=8) { // ok
+            return;
+        }
+        if((y>=11 && x<=5)            // violation, unnecessary parenthesis
+                || (x<=12 && y>=8)) { // violation, unnecessary parenthesis
+            return;
+        }
+    }
+    private void check() {
+        String sectionName = "Some String";
+        if ("Some content".equals(sectionName) || "Some overview".equals(sectionName) // ok
+                || (!"AbbreviationAsWordInName".equals(sectionName) // violation, unnecessary
+                                                                    // parenthesis
+                && !"AbstractClassName".equals(sectionName) // ok
+        )) {
+            return;
+        }
+
+        if (sectionName instanceof String && "Other Overview".equals(sectionName) // ok
+                && (!"AbbreviationAsWordInName".equals(sectionName) // ok
+                || !"AbstractClassName".equals(sectionName) // ok
+        )) {
+            return;
+        }
+    }
+    private void UnaryAndPostfix() {
+        boolean x = true;
+        boolean y = true;
+        int a = 25;
+        if ((++a) >= 54 && x) { // violation, unnecessary parenthesis around '++a'
+            return;
+        }
+        if ((~a) > -27            // violation, unnecessary parenthesis around '~a'
+                 && (a-- < 30)) { // violation, unnecessary parenthesis
+            return;
+        }
+        if ((-a) != -27 // violation, unnecessary parenthesis around '-a'
+                 && x) {
+            return;
+        }
+    }
+
+
+}
+

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -6842,7 +6842,11 @@ return (x);          // parens around identifier
 return (x + 1);      // parens around return value
 int x = (y / 2 + 1); // parens around assignment rhs
 for (int i = (0); i &lt; 10; i++) {  // parens around literal
-t -= (z + 1);        // parens around assignment rhs
+t -= (z + 1);                     // parens around assignment rhs
+boolean a = (x &gt; 7 &amp;&amp; y &gt; 5)      // parens around expression
+            || z &lt; 9;
+boolean b = (~a) &gt; -27            // parens around ~a
+            &amp;&amp; (a-- &lt; 30);        // parens around expression
         </source>
       </subsection>
 
@@ -6924,6 +6928,38 @@ int x = (a + b) + c;
                   LAMBDA</a>
                 ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TEXT_BLOCK_LITERAL_BEGIN">
                 TEXT_BLOCK_LITERAL_BEGIN</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">
+                LAND</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_INSTANCEOF">
+                LITERAL_INSTANCEOF</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GT">
+                GT</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LT">
+                LT</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GE">
+                GE</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LE">
+                LE</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EQUAL">
+                EQUAL</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NOT_EQUAL">
+                NOT_EQUAL</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_MINUS">
+                UNARY_MINUS</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_PLUS">
+                UNARY_PLUS</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INC">
+                INC</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DEC">
+                DEC</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LNOT">
+                LNOT</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BNOT">
+                BNOT</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#POST_INC">
+                POST_INC</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#POST_DEC">
+                POST_DEC</a>
                   .
               </td>
               <td>
@@ -6975,6 +7011,38 @@ int x = (a + b) + c;
                   LAMBDA</a>
                 ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#TEXT_BLOCK_LITERAL_BEGIN">
                   TEXT_BLOCK_LITERAL_BEGIN</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">
+                  LAND</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_INSTANCEOF">
+                  LITERAL_INSTANCEOF</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GT">
+                  GT</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LT">
+                  LT</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GE">
+                  GE</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LE">
+                  LE</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#EQUAL">
+                  EQUAL</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#NOT_EQUAL">
+                  NOT_EQUAL</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_MINUS">
+                  UNARY_MINUS</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#UNARY_PLUS">
+                  UNARY_PLUS</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#INC">
+                  INC</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#DEC">
+                  DEC</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LNOT">
+                  LNOT</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#BNOT">
+                  BNOT</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#POST_INC">
+                  POST_INC</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#POST_DEC">
+                  POST_DEC</a>
                   .
               </td>
               <td>3.4</td>
@@ -6996,18 +7064,28 @@ int x = (a + b) + c;
         <source>
 public int square(int a, int b){
   int square = (a * b); //violation
-  return (square); //violation
+  return (square);      //violation
 }
 int sumOfSquares = 0;
-for(int i=(0); i&lt;10; i++){ //violation
-  int x = (i + 1); //violation
-  sumOfSquares += (square(x * x)); //violation
+for(int i=(0); i&lt;10; i++){          //violation
+  int x = (i + 1);                  //violation
+  sumOfSquares += (square(x * x));  //violation
 }
 double num = (10.0); //violation
 List&lt;String&gt; list = Arrays.asList(&quot;a1&quot;, &quot;b1&quot;, &quot;c1&quot;);
 myList.stream()
   .filter((s) -&gt; s.startsWith(&quot;c&quot;)) //violation
   .forEach(System.out::println);
+int a = 10, b = 12, c = 15;
+if ((a &gt;= 0 &amp;&amp; b &lt;= 9)            // violation, unnecessary parenthesis
+         || (c &gt;= 5 &amp;&amp; b &lt;= 5)    // violation, unnecessary parenthesis
+         || (c &gt;= 3 &amp;&amp; a &lt;= 7)) { // violation, unnecessary parenthesis
+    return;
+}
+if ((-a) != -27 // violation, unnecessary parenthesis
+         &amp;&amp; b &gt; 5) {
+    return;
+}
         </source>
       </subsection>
 


### PR DESCRIPTION
Continuing #9308 
Resolves #5779: fixing no violation on parenthesis in if statement between || and &&
Diff Regression projects: https://gist.githubusercontent.com/Vyom-Yadav/91807e6244cff60698d9e33e32ba2d51/raw/85355576c05c80e8b08752a62ba3a4076909d266/projects-to-test-on.properties
Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/7a57a856b6657d8606276270a6ca3276d102ef65/my_checks.xml