### PR TITLE
minor: add link to google config to release page

### DIFF
--- a/src/site/resources/js/google-style-links.js
+++ b/src/site/resources/js/google-style-links.js
@@ -1,0 +1,21 @@
+/*jslint browser: true*/
+/*global window */
+(function () {
+    "use strict";
+    window.addEventListener("load", function () {
+        var headers = document.getElementsByTagName("h2");
+        [].forEach.call(headers, function (header) {
+            var csVersion = header.childNodes[0].name.replace("Release_", "");
+            var link = `https:\/\/raw.githubusercontent.com/checkstyle/checkstyle/checkstyle-${csVersion}/src/main/resources/google_checks.xml`
+            var p = document.createElement("p");
+
+            var a = document.createElement("a");
+            a.setAttribute("href", link);
+            a.innerText = "Google config";
+            p.appendChild(a)
+            header.parentNode.insertBefore(p, header.nextSibling.nextSibling );
+        });
+
+    });
+}());
+

--- a/src/xdocs/releasenotes.xml
+++ b/src/xdocs/releasenotes.xml
@@ -6,6 +6,7 @@
 
   <head>
     <title>Release Notes</title>
+    <script type="text/javascript" src="js/google-style-links.js"/>
   </head>
 
   <body>


### PR DESCRIPTION
Reason: it is not easy for users to get google config for some checkstyle version. You need to either dig into jar file, or find it in checkstyle repo for particular release.

This enhancement will add Google config link for each release, so users will have a convinient way to get config for specific version.