### PR TITLE
Issue #9323: replace branch name with hash in diff report action

### DIFF
--- a/.github/workflows/diff_report.yml
+++ b/.github/workflows/diff_report.yml
@@ -34,7 +34,8 @@ jobs:
       patch_config_link: ${{ steps.parse.outputs.patch_config_link }}
       report_label: ${{ steps.parse.outputs.report_label }}
       branch: ${{ steps.branch.outputs.ref }}
-      
+      commit_sha: ${{ steps.branch.outputs.commit_sha }}
+
     steps:
      - uses: khan/pull-request-comment-trigger@master
        name: React with rocket on run
@@ -54,7 +55,8 @@ jobs:
         echo "$USER_LOGIN" > user
         wget -q "$PULL_REQUEST_URL" -O info.json
         jq .head.ref info.json > branch
-        
+        jq .head.sha info.json > commit_sha
+
      - name: Parsing content of PR description
        id: parse
        run: |
@@ -82,8 +84,8 @@ jobs:
        id: branch
        run: |
         echo ::set-output name=ref::$(cat branch)
+        echo ::set-output name=commit_sha::$(cat commit_sha | xargs | cut -c 1-7)
 
-     
   make_report:
     runs-on: ubuntu-latest
     needs: parse_body
@@ -189,7 +191,7 @@ jobs:
        run: |
         bash
         TIME=`date +%Y%H%M%S`
-        FOLDER="${{needs.parse_body.outputs.branch}}_$TIME"
+        FOLDER="${{needs.parse_body.outputs.commit_sha}}_$TIME"
         DIFF="./contribution/checkstyle-tester/reports/diff"
         LINK="https://${{env.AWS_BUCKET_NAME}}.s3.${{env.AWS_REGION}}.amazonaws.com"
         aws s3 cp $DIFF s3://${{env.AWS_BUCKET_NAME}}/$FOLDER/reports/diff/ --recursive


### PR DESCRIPTION
Closes #9323 

Branch name is replaced with 7 chars commit sha, which protects link from any special chars that can be in branch name