### PR TITLE
Issue #9359: Match content of textblock by xpath

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,3 +14,4 @@
 # Test resources that need specific eol
 /src/test/resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/InputNewlineAtEndOfFileCrlf.java eol=crlf
 /src/test/resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/InputNewlineAtEndOfFileCr.java -text
+src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/xpath/xpathquerygenerator/InputXpathQueryGeneratorTextBlockCrlf.java eol=crlf

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/XpathUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/XpathUtil.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -104,8 +105,19 @@ public final class XpathUtil {
     private static final Set<Integer> TOKEN_TYPES_WITH_TEXT_ATTRIBUTE =
         Stream.of(
             TokenTypes.IDENT, TokenTypes.STRING_LITERAL, TokenTypes.CHAR_LITERAL,
-            TokenTypes.NUM_LONG, TokenTypes.NUM_INT, TokenTypes.NUM_DOUBLE, TokenTypes.NUM_FLOAT)
+            TokenTypes.NUM_LONG, TokenTypes.NUM_INT, TokenTypes.NUM_DOUBLE, TokenTypes.NUM_FLOAT,
+            TokenTypes.TEXT_BLOCK_CONTENT)
         .collect(Collectors.toSet());
+
+    /**
+     * This regexp is used to convert new line to newline tag.
+     */
+    private static final Pattern NEWLINE_TO_TAG = Pattern.compile("[\n]");
+
+    /**
+     * This regexp is used to convert carriage return to carriage-return tag.
+     */
+    private static final Pattern CARRIAGE_RETURN_TO_TAG = Pattern.compile("[\r]");
 
     /** Delimiter to separate xpath results. */
     private static final String DELIMITER = "---------" + System.lineSeparator();
@@ -157,6 +169,8 @@ public final class XpathUtil {
         if (ast.getType() == TokenTypes.STRING_LITERAL) {
             text = text.substring(1, text.length() - 1);
         }
+        text = CARRIAGE_RETURN_TO_TAG.matcher(text).replaceAll("\\\\r");
+        text = NEWLINE_TO_TAG.matcher(text).replaceAll("\\\\n");
         return text;
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGeneratorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGeneratorTest.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.xpath;
 
+import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -514,17 +515,70 @@ public class XpathQueryGeneratorTest extends AbstractModuleTestSupport {
                 JavaParser.parseFile(testFile, JavaParser.Options.WITHOUT_COMMENTS);
         final int tabWidth = 8;
 
-        final int lineNumberOne = 6;
-        final int columnNumberOne = 25;
-        final XpathQueryGenerator queryGeneratorOne = new XpathQueryGenerator(detailAst,
-                lineNumberOne, columnNumberOne, testFileText, tabWidth);
-        final List<String> actualTestOne = queryGeneratorOne.generate();
-        final List<String> expectedTestOne = Collections.singletonList(
+        final int lineNumber = 6;
+        final int columnNumber = 25;
+        final XpathQueryGenerator queryGenerator = new XpathQueryGenerator(detailAst,
+                lineNumber, columnNumber, testFileText, tabWidth);
+        final List<String> actual = queryGenerator.generate();
+        final List<String> expected = Collections.singletonList(
             "/CLASS_DEF[./IDENT[@text='InputXpathQueryGeneratorTextBlock']]/OBJBLOCK/"
                     + "VARIABLE_DEF[./IDENT[@text='testOne']]/ASSIGN/EXPR/"
-                    + "TEXT_BLOCK_LITERAL_BEGIN/TEXT_BLOCK_CONTENT"
+                    + "TEXT_BLOCK_LITERAL_BEGIN/TEXT_BLOCK_CONTENT[@text='\\n        "
+                    + "&amp;1line\\n        &gt;2line\\n        &lt;3line\\n        ']"
             );
-        assertEquals(expectedTestOne, actualTestOne,
-                "Generated queries do not match expected ones");
+        assertWithMessage("Generated queries do not match expected ones")
+                .that(expected).isEqualTo(actual);
     }
+
+    @Test
+    public void testTextBlocksWithNewLine() throws Exception {
+        final File testFile = new File(getNonCompilablePath(
+                "InputXpathQueryGeneratorTextBlockNewLine.java"));
+        final FileText testFileText = new FileText(testFile,
+                StandardCharsets.UTF_8.name());
+        final DetailAST detailAst =
+                JavaParser.parseFile(testFile, JavaParser.Options.WITHOUT_COMMENTS);
+        final int tabWidth = 8;
+
+        final int lineNumber = 6;
+        final int columnNumber = 25;
+        final XpathQueryGenerator queryGenerator = new XpathQueryGenerator(detailAst,
+                lineNumber, columnNumber, testFileText, tabWidth);
+        final List<String> actual = queryGenerator.generate();
+        final List<String> expected = Collections.singletonList(
+                "/CLASS_DEF[./IDENT[@text='InputXpathQueryGeneratorTextBlockNewLine']]/OBJBLOCK/"
+                        + "VARIABLE_DEF[./IDENT[@text='testOne']]/ASSIGN/EXPR/"
+                        + "TEXT_BLOCK_LITERAL_BEGIN/TEXT_BLOCK_CONTENT[@text='\\n        "
+                        + "&amp;1line\\n\\n        &gt;2line\\n        &lt;3line\\n        ']"
+        );
+        assertWithMessage("Generated queries do not match expected ones")
+                .that(expected).isEqualTo(actual);
+    }
+
+    @Test
+    public void testTextBlocksWithNewCrlf() throws Exception {
+        final File testFile = new File(getNonCompilablePath(
+                "InputXpathQueryGeneratorTextBlockCrlf.java"));
+        final FileText testFileText = new FileText(testFile,
+                StandardCharsets.UTF_8.name());
+        final DetailAST detailAst =
+                JavaParser.parseFile(testFile, JavaParser.Options.WITHOUT_COMMENTS);
+        final int tabWidth = 8;
+
+        final int lineNumber = 6;
+        final int columnNumber = 25;
+        final XpathQueryGenerator queryGenerator = new XpathQueryGenerator(detailAst,
+                lineNumber, columnNumber, testFileText, tabWidth);
+        final List<String> actual = queryGenerator.generate();
+        final List<String> expected = Collections.singletonList(
+                "/CLASS_DEF[./IDENT[@text='InputXpathQueryGeneratorTextBlockCrlf']]/OBJBLOCK/"
+                        + "VARIABLE_DEF[./IDENT[@text='testOne']]/ASSIGN/EXPR/"
+                        + "TEXT_BLOCK_LITERAL_BEGIN/TEXT_BLOCK_CONTENT[@text='\\r\\n        "
+                        + "&amp;1line\\r\\n\\r\\n        &gt;2line\\r\\n        &lt;3line\\r\\n"
+                        + "        ']"
+        );
+        assertWithMessage("Generated queries do not match expected ones")
+                .that(expected).isEqualTo(actual);
+    }
+
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/xpath/xpathmapper/InputXpathMapperTextBlock.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/xpath/xpathmapper/InputXpathMapperTextBlock.java
@@ -1,0 +1,11 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.xpath.xpathmapper;
+
+public class InputXpathMapperTextBlock {
+
+    String testOne = """
+        &1line
+        >2line
+        <3line
+        """;
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/xpath/xpathquerygenerator/InputXpathQueryGeneratorTextBlockCrlf.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/xpath/xpathquerygenerator/InputXpathQueryGeneratorTextBlockCrlf.java
@@ -1,0 +1,12 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.xpath.xpathquerygenerator;
+
+public class InputXpathQueryGeneratorTextBlockCrlf {
+
+    String testOne = """
+        &1line
+
+        >2line
+        <3line
+        """;
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/xpath/xpathquerygenerator/InputXpathQueryGeneratorTextBlockNewLine.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/xpath/xpathquerygenerator/InputXpathQueryGeneratorTextBlockNewLine.java
@@ -1,0 +1,12 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.xpath.xpathquerygenerator;
+
+public class InputXpathQueryGeneratorTextBlockNewLine {
+
+    String testOne = """
+        &1line
+
+        >2line
+        <3line
+        """;
+}


### PR DESCRIPTION
Closes #9359 

```
$ cat InputXpathQueryGeneratorTextBlock.java 
//non-compiled with javac: Compilable with Java14
package com.puppycrawl.tools.checkstyle.xpath.xpathquerygenerator;

public class InputXpathQueryGeneratorTextBlock {

    String testOne = """
        &1line
        >2line
        <3line
        """;
}

$ cat config.xml                            
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
    "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="IllegalToken">
      <property name="tokens" value="STRING_LITERAL"/>
      <property name="tokens" value="TEXT_BLOCK_CONTENT"/>
    </module>
  </module>
</module>

$ java -jar checkstyle-8.42-SNAPSHOT-all.jar -c config.xml InputXpathQueryGeneratorTextBlock.java 
Starting audit...
[ERROR] /home/akmo/GitHub/Test/InputXpathQueryGeneratorTextBlock.java:6:25: Using '
        &1line
        >2line
        <3line
        ' is not allowed. [IllegalToken]
Audit done.
Checkstyle ends with 1 errors.

$ java -jar checkstyle-8.42-SNAPSHOT-all.jar -g -c config.xml InputXpathQueryGeneratorTextBlock.java
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE suppressions PUBLIC
    "-//Checkstyle//DTD SuppressionXpathFilter Experimental Configuration 1.2//EN"
    "https://checkstyle.org/dtds/suppressions_1_2_xpath_experimental.dtd">
<suppressions>
<suppress-xpath
       files="InputXpathQueryGeneratorTextBlock.java"
       checks="IllegalTokenCheck"
       query="/CLASS_DEF[./IDENT[@text='InputXpathQueryGeneratorTextBlock']]/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='testOne']]/ASSIGN/EXPR/TEXT_BLOCK_LITERAL_BEGIN/TEXT_BLOCK_CONTENT[@text='\n        &amp;1line\n        &gt;2line\n        &lt;3line\n        ']"/>
</suppressions>
Checkstyle ends with 1 errors.

$ java -jar checkstyle-8.42-SNAPSHOT-all.jar -g -o supp.xml -c config.xml InputXpathQueryGeneratorTextBlock.java 
Checkstyle ends with 1 errors.

$ java -jar checkstyle-8.42-SNAPSHOT-all.jar -c supcon.xml InputXpathQueryGeneratorTextBlock.java               
Starting audit...
Audit done.
