### PR TITLE
Issue #9105: avoid comments break 'getDistributedPreviousStatement' flow

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
@@ -502,7 +502,13 @@ public class CommentsIndentationCheck extends AbstractCheck {
         if (currentToken.getType() == TokenTypes.SEMI) {
             currentToken = currentToken.getPreviousSibling();
             while (currentToken.getFirstChild() != null) {
-                currentToken = currentToken.getFirstChild();
+                DetailAST child = currentToken.getFirstChild();
+                while (child != null && isComment(child)) {
+                    child = child.getNextSibling();
+                }
+                if (child != null) {
+                    currentToken = child;
+                }
             }
             previousStatement = currentToken;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
@@ -503,12 +503,10 @@ public class CommentsIndentationCheck extends AbstractCheck {
             currentToken = currentToken.getPreviousSibling();
             while (currentToken.getFirstChild() != null) {
                 DetailAST child = currentToken.getFirstChild();
-                while (child != null && isComment(child)) {
+                while (isComment(child)) {
                     child = child.getNextSibling();
                 }
-                if (child != null) {
-                    currentToken = child;
-                }
+                currentToken = child;
             }
             previousStatement = currentToken;
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
@@ -89,6 +89,7 @@ public class CommentsIndentationCheckTest extends AbstractModuleTestSupport {
             "557:1: " + getCheckMessage(MSG_KEY_SINGLE, 555, 0, 8),
             "562:1: " + getCheckMessage(MSG_KEY_SINGLE, 561, 0, 8),
             "577:1: " + getCheckMessage(MSG_KEY_SINGLE, 574, 0, 8),
+            "601:17: " + getCheckMessage(MSG_KEY_SINGLE, 596, 16, 8),
         };
         final String testInputFile = "InputCommentsIndentationCommentIsAtTheEndOfBlock.java";
         verify(checkConfig, getPath(testInputFile), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationCommentIsAtTheEndOfBlock.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationCommentIsAtTheEndOfBlock.java
@@ -380,7 +380,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
             /* violation */
         new Object()
             .toString();
-            // comment
+        // comment
     }
 
     void foo56() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationCommentIsAtTheEndOfBlock.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationCommentIsAtTheEndOfBlock.java
@@ -583,6 +583,24 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
         }
     }
 
+    void foo79() {
+        String
+                // comment
+                .valueOf(new Integer(0))
+                .trim()
+                .length();
+        // comment
+    }
+
+    void foo80() {
+        String
+                // comment
+                .valueOf(new Integer(0))
+                .trim()
+                .length();
+                // violation
+    }
+
     // We almost reached the end of the class here.
 }
 // The END of the class.


### PR DESCRIPTION
Issue: #9105

Skip the comments in `getDistributedPreviousStatement`.
