### PR TITLE
Issue #7618: Update doc for EmptyForIteratorPad

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheck.java
@@ -51,12 +51,37 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * &lt;module name=&quot;EmptyForIteratorPad&quot;/&gt;
  * </pre>
  * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * for (Iterator it = map.entrySet().iterator();  it.hasNext(););  // ok
+ * for (Iterator it = map.entrySet().iterator();  it.hasNext(); ); // violation since whitespace
+ *                                                                 //after semicolon
+ *
+ * for (Iterator foo = very.long.line.iterator();
+ *       foo.hasNext();
+ *      ); // ok
+ * </pre>
+ * <p>
  * To configure the check to require white space at an empty for iterator:
  * </p>
  * <pre>
  * &lt;module name=&quot;EmptyForIteratorPad&quot;&gt;
  *   &lt;property name=&quot;option&quot; value=&quot;space&quot;/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * for (Iterator it = map.entrySet().iterator();  it.hasNext();); // violation as there is no
+ *                                                                // whitespace after semicolon
+ *
+ * for (Iterator it = map.entrySet().iterator();  it.hasNext(); ); // ok
+ *
+ * for (Iterator foo = very.long.line.iterator();
+ *       foo.hasNext();
+ *      ); // violation as there  is no whitespace after semicolon
  * </pre>
  * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -155,7 +155,18 @@ for (Iterator foo = very.long.line.iterator();
         <source>
 &lt;module name=&quot;EmptyForIteratorPad&quot;/&gt;
         </source>
+        <p>
+          Example:
+        </p>
+        <source>
+for (Iterator it = map.entrySet().iterator();  it.hasNext(););  // ok
+for (Iterator it = map.entrySet().iterator();  it.hasNext(); ); // violation since whitespace
+                                                                //after semicolon
 
+for (Iterator foo = very.long.line.iterator();
+     foo.hasNext();
+     ); // ok
+        </source>
         <p>
           To configure the check to require white space at an empty for
           iterator:
@@ -164,6 +175,19 @@ for (Iterator foo = very.long.line.iterator();
 &lt;module name=&quot;EmptyForIteratorPad&quot;&gt;
   &lt;property name=&quot;option&quot; value=&quot;space&quot;/&gt;
 &lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+for (Iterator it = map.entrySet().iterator();  it.hasNext();); // violation as there is no
+                                                               // whitespace after semicolon
+
+for (Iterator it = map.entrySet().iterator();  it.hasNext(); ); // ok
+
+for (Iterator foo = very.long.line.iterator();
+     foo.hasNext();
+     ); // violation as there  is no whitespace after semicolon
         </source>
       </subsection>
 


### PR DESCRIPTION
Closes: #7618

![image](https://user-images.githubusercontent.com/42171790/110675709-36227600-81f9-11eb-9824-58c6e909f2e8.png)

`$ cat config.xml
`
```
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <module name="EmptyForIteratorPad"/>
  </module>
</module>
```

`$ cat Hello.java`

```
import java.util.*;

class Hello
{
      public static void main(String args[])
      {
            HashMap<Integer,Integer> mp=new HahMap<Integer,Integer>();
            for (Iterator foo =mp.entrySet().iterator();  foo.hasNext(); ); // violation since whitespace
            //after semicolon

            for (Iterator foo =mp.entrySet().iterator();  foo.hasNext();); // ok                                     
      }
}
```

`$ java -jar checkstyle-8.39-all.jar -c config.xml Hello.java
`
```
Starting audit...
[ERROR] E:\New folder\Java Dev\src\com\company\Hello.java:8:74: ';' is followed by whitespace. [EmptyForIteratorPad]
Audit done.
Checkstyle ends with 1 errors.

```
![image](https://user-images.githubusercontent.com/42171790/110676363-e09a9900-81f9-11eb-9dc1-18618a0733a5.png)

`$ cat config.xml`

```
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <module name="EmptyForIteratorPad">
      <property name="option" value="space"/>
    </module>

  </module>
</module>

```


`$ cat Hello.java`

```
import java.util.*;

class Hello
{
      public static void main(String args[])
      {
            HashMap<Integer,Integer> mp=new HahMap<Integer,Integer>();
            for (Iterator foo =mp.entrySet().iterator();  foo.hasNext(); ); // ok

            for (Iterator foo =mp.entrySet().iterator();  foo.hasNext();); // violation as there  is
            // no whitespace after semicolon

      }
}
```

`$ java -jar checkstyle-8.39-all.jar -c config.xml Hello.java
`
```
Starting audit...
[ERROR] E:\New folder\Java Dev\src\com\company\Hello.java:10:73: ';' is not followed by whitespace. [EmptyForIteratorPad]
Audit done.
Checkstyle ends with 1 errors.
```



