### PR TITLE
minor: move run link check job to github action and fixed violations

### DIFF
--- a/.ci/run-link-check-plugin.sh
+++ b/.ci/run-link-check-plugin.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-# This script is used at https://app.codeship.com/projects/124310
 # Run "firefox target/site/linkcheck.html" after completion to review html report
 
 set -e
@@ -8,7 +7,7 @@ pwd
 uname -a
 mvn --version
 curl -I https://sourceforge.net/projects/checkstyle/
-mvn -e clean site -Dcheckstyle.ant.skip=true -DskipTests -DskipITs \
+mvn -e --no-transfer-progress clean site -Dcheckstyle.ant.skip=true -DskipTests -DskipITs \
    -Dpmd.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -Dcheckstyle.skip=true
 echo "------------ grep of linkcheck.html--BEGIN"
 # "grep ... | cat" is required command is running in "set -e" mode and

--- a/.github/workflows/run_link_check.yml
+++ b/.github/workflows/run_link_check.yml
@@ -1,0 +1,28 @@
+#####################################################################################
+# Github Action to run link checks.
+#
+# Workflow starts when:
+# 1) push on master branch
+#
+#####################################################################################
+name: "Check no broken links"
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  check_issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download checkstyle
+        uses: actions/checkout@v2
+        with:
+          repository: checkstyle/checkstyle
+          ref: master
+          path: checkstyle
+
+      - name: Check links
+        run: |
+          cd checkstyle
+          ./.ci/run-link-check-plugin.sh

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ or set of validation rules (best practices).
 [![][sonar img]][sonar]
 
 [![][closed issues img]][closed issues]
+[![][link check img]][link check]
 
 Members chat: [![][gitter_mem img]][gitter_mem]
 Contributors chat: [![][gitter_con img]][gitter_con]
@@ -188,3 +189,6 @@ are in the file named "LICENSE.apache20" in this directory.
 
 [closed issues]:https://github.com/checkstyle/checkstyle/actions/workflows/no_old_refs.yml
 [closed issues img]:https://github.com/checkstyle/checkstyle/actions/workflows/no_old_refs.yml/badge.svg
+
+[link check]:https://github.com/checkstyle/checkstyle/actions/workflows/run_link_check.yml
+[link check img]:https://github.com/checkstyle/checkstyle/actions/workflows/run_link_check.yml/badge.svg

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -8,4 +8,3 @@
     # -  command: ./.ci/travis/travis.sh site
     # -  command: ./.ci/travis/travis.sh nondex
     -  command: ls -la
-    -  command: .ci/run-link-check-plugin.sh

--- a/config/checkstyle_non_main_files_suppressions.xml
+++ b/config/checkstyle_non_main_files_suppressions.xml
@@ -131,9 +131,6 @@
   <!-- Until https://github.com/checkstyle/checkstyle/issues/9351 -->
   <suppress id="properMavenCommand" files=".*[\\/]pitest.sh"/>
   <suppress id="properMavenCommand" files=".circleci[\\/]config.yml"/>
-  <!-- Until codeship will update base image to one with proper maven version (3.6.1 or higher) -->
-  <!-- https://docs.cloudbees.com/docs/cloudbees-codeship/latest/general-about/vm-and-infrastructure#_build_machines -->
-  <suppress id="properMavenCommand" files=".*[\\/]run-link-check-plugin.sh"/>
 
   <!-- Empty files that are used as input for UT -->
   <suppress id="noEmptyFile"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
@@ -46,14 +46,14 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </li>
  * <li>
  * Property {@code ignoredTags} - Specify
- * <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
+ * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
  * block tags</a> which are ignored by the check.
  * Type is {@code java.lang.String[]}.
  * Default value is {@code ""}.
  * </li>
  * <li>
  * Property {@code ignoreInlineTags} - Control whether
- * <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
+ * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
  * inline tags</a> must be ignored.
  * Type is {@code boolean}.
  * Default value is {@code true}.
@@ -255,21 +255,21 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
 
     /**
      * Specify
-     * <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
+     * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
      * block tags</a> which are ignored by the check.
      */
     private List<String> ignoredTags = new ArrayList<>();
 
     /**
      * Control whether
-     * <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
+     * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
      * inline tags</a> must be ignored.
      */
     private boolean ignoreInlineTags = true;
 
     /**
      * Setter to specify
-     * <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
+     * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
      * block tags</a> which are ignored by the check.
      *
      * @param tags to be ignored by check.
@@ -280,7 +280,7 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
 
     /**
      * Setter to control whether
-     * <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
+     * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
      * inline tags</a> must be ignored.
      *
      * @param ignoreInlineTags whether inline tags must be ignored.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/SingleLineJavadocCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/SingleLineJavadocCheck.xml
@@ -18,12 +18,12 @@
             </property>
             <property default-value="" name="ignoredTags" type="java.lang.String[]">
                <description>Specify
- &lt;a href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF"&gt;
+ &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF"&gt;
  block tags&lt;/a&gt; which are ignored by the check.</description>
             </property>
             <property default-value="true" name="ignoreInlineTags" type="boolean">
                <description>Control whether
- &lt;a href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF"&gt;
+ &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF"&gt;
  inline tags&lt;/a&gt; must be ignored.</description>
             </property>
          </properties>

--- a/src/site/resources/styleguides/google-java-style-20180523/javaguide.html
+++ b/src/site/resources/styleguides/google-java-style-20180523/javaguide.html
@@ -83,7 +83,7 @@ anywhere in a source file. This implies that:</p>
 <h4 id="s2.3.2-special-escape-sequences">2.3.2 Special escape sequences</h4>
 
 <p>For any character that has a
-<a href="http://docs.oracle.com/javase/tutorial/java/data/characters.html">
+<a href="https://docs.oracle.com/javase/tutorial/java/data/characters.html">
   special escape sequence</a>
 (<code class="prettyprint lang-java">\b</code>,
 <code class="prettyprint lang-java">\t</code>,

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -3314,7 +3314,7 @@ public boolean testMethod(int firstParam) {
               <td>ignoredTags</td>
               <td>
                 Specify
-                <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
+                <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
                 block tags</a> which are ignored by the check.
               </td>
               <td><a href="property_types.html#String.5B.5D">String[]</a></td>
@@ -3325,7 +3325,7 @@ public boolean testMethod(int firstParam) {
               <td>ignoreInlineTags</td>
               <td>
                 Control whether
-                <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
+                <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
                 inline tags</a> must be ignored.
               </td>
               <td><a href="property_types.html#boolean">boolean</a></td>

--- a/src/xdocs/index.xml.vm
+++ b/src/xdocs/index.xml.vm
@@ -321,7 +321,7 @@
               <td/>
             </tr>
             <tr>
-              <td><a href="https://netbeans.org/">NetBeans</a></td>
+              <td><a href="https://netbeans.apache.org/">NetBeans</a></td>
               <td>Petr Hejl</td>
               <td>
                 <a href="https://www.sickboy.cz/checkstyle/">Checkstyle Beans</a>
@@ -332,7 +332,7 @@
               </td>
             </tr>
             <tr>
-              <td><a href="https://netbeans.org/">NetBeans</a></td>
+              <td><a href="https://netbeans.apache.org/">NetBeans</a></td>
               <td/>
               <td>
                 <a href="http://sqe-team.github.io">Software Quality Environment (SQE)</a>


### PR DESCRIPTION
Move run link job to github actions and fix violations

```
 ------------ grep of linkcheck.html--BEGIN
<td><i><a class="externalLink" href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF</a>: 301 Moved Permanently</i></td></tr></table></td></tr>
<td><i><a class="externalLink" href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF</a>: 301 Moved Permanently</i></td></tr></table></td></tr>
<td><i><a class="externalLink" href="https://docs.oracle.com/javase/8/docs/api/java/awt/Window.AccessibleAWTWindow.html?is-external=true">https://docs.oracle.com/javase/8/docs/api/java/awt/Window.AccessibleAWTWindow.html?is-external=true</a>: java.net.SocketTimeoutException : Read timed out</i></td></tr></table></td></tr>
<td><i><a class="externalLink" href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF</a>: 301 Moved Permanently</i></td></tr></table></td></tr>
<td><i><a class="externalLink" href="https://netbeans.org/">https://netbeans.org/</a>: 301 Moved Permanently</i></td></tr></table></td></tr>
------------ grep of linkcheck.html--END
```