### PR TITLE
Issue: #9373 Add example of AST for TokenTypes.ASSIGN

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1425,6 +1425,21 @@ public final class TokenTypes {
     /**
      * The {@code =} (assignment) operator.
      *
+     * <p>For example:</p>
+     * <pre>
+     * a = b;
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * +--EXPR
+     *     |
+     *     +--ASSIGN (=)
+     *         |
+     *         +--IDENT (a)
+     *         +--IDENT (b)
+     * +--SEMI (;)
+     * </pre>
+     *
      * @see <a
      * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.26.1">Java
      * Language Specification, &sect;15.26.1</a>


### PR DESCRIPTION
Closes: #9373 
Added The example of AST for TokenTypes.ASSIGN, used the simple assignment example (a = b; ), refer to the image for clarification.
![image](https://user-images.githubusercontent.com/35426911/110784855-33bf2b00-8290-11eb-9007-fec2f9ec4755.png)
