### PR TITLE
Issue #9371: Add example of AST for TokenTypes.ABSTRACT

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1054,6 +1054,25 @@ public final class TokenTypes {
     /**
      * The {@code abstract} keyword.
      *
+     * <p>For example:</p>
+     * <pre>
+     *  public abstract class MyClass
+     *  {
+     *  }
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * --CLASS_DEF
+     *    |--MODIFIERS
+     *    |   |--LITERAL_PUBLIC (public)
+     *    |   `--ABSTRACT (abstract)
+     *    |--LITERAL_CLASS (class)
+     *    |--IDENT (MyClass)
+     *    `--OBJBLOCK
+     *        |--LCURLY ({)
+     *        `--RCURLY (})
+     * </pre>
+     *
      * @see #MODIFIERS
      **/
     public static final int ABSTRACT = GeneratedJavaTokenTypes.ABSTRACT;


### PR DESCRIPTION
Closes: #9371 

Created an example AST for TokenTypes.ABSTRACT:
```
public abstract class MyClass
{
}
```
Please see the screenshot for the detail:
![image](https://user-images.githubusercontent.com/25534730/110981004-82260580-8334-11eb-942c-30c5f06e6f5f.png)



