### PR TITLE
Issue #9357: FinalClass now exempts private-only constructor classes that also have nested subclasses

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
@@ -46,7 +46,12 @@ public class FinalClassCheckTest
     @Test
     public void testGetRequiredTokens() {
         final FinalClassCheck checkObj = new FinalClassCheck();
-        final int[] expected = {TokenTypes.CLASS_DEF, TokenTypes.CTOR_DEF, TokenTypes.PACKAGE_DEF};
+        final int[] expected =
+            {TokenTypes.CLASS_DEF,
+             TokenTypes.CTOR_DEF,
+             TokenTypes.PACKAGE_DEF,
+             TokenTypes.LITERAL_NEW,
+            };
         assertArrayEquals(expected, checkObj.getRequiredTokens(),
                 "Default required tokens are invalid");
     }
@@ -56,9 +61,11 @@ public class FinalClassCheckTest
         final DefaultConfiguration checkConfig =
             createModuleConfig(FinalClassCheck.class);
         final String[] expected = {
-            "7:1: " + getCheckMessage(MSG_KEY, "InputFinalClass"),
-            "15:4: " + getCheckMessage(MSG_KEY, "test4"),
-            "113:5: " + getCheckMessage(MSG_KEY, "someinnerClass"),
+            "9:1: " + getCheckMessage(MSG_KEY, "InputFinalClass"),
+            "17:4: " + getCheckMessage(MSG_KEY, "test4"),
+            "115:5: " + getCheckMessage(MSG_KEY, "someinnerClass"),
+            "149:1: " + getCheckMessage(MSG_KEY, "TestNewKeyword"),
+            "182:5: " + getCheckMessage(MSG_KEY, "NestedClass"),
         };
         verify(checkConfig, getPath("InputFinalClass.java"), expected);
     }
@@ -120,7 +127,12 @@ public class FinalClassCheckTest
     @Test
     public void testGetAcceptableTokens() {
         final FinalClassCheck obj = new FinalClassCheck();
-        final int[] expected = {TokenTypes.CLASS_DEF, TokenTypes.CTOR_DEF, TokenTypes.PACKAGE_DEF};
+        final int[] expected =
+            {TokenTypes.CLASS_DEF,
+             TokenTypes.CTOR_DEF,
+             TokenTypes.PACKAGE_DEF,
+             TokenTypes.LITERAL_NEW,
+            };
         assertArrayEquals(expected, obj.getAcceptableTokens(),
                 "Default acceptable tokens are invalid");
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClass.java
@@ -4,6 +4,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 package com.puppycrawl.tools.checkstyle.checks.design.finalclass;
 
+import java.util.ArrayList;
+
 public class InputFinalClass
 {
     private InputFinalClass() {}
@@ -127,3 +129,74 @@ interface TestInterface {
         private SomeClass() {}
     }
 }
+
+class TestAnonymousInnerClasses { // ok
+    public static final TestAnonymousInnerClasses ONE = new TestAnonymousInnerClasses() {
+        @Override
+        public int value() {
+            return 1;
+        }
+    };
+
+    private TestAnonymousInnerClasses() {
+    }
+
+    public int value() {
+        return 0;
+    }
+}
+
+class TestNewKeyword { // violation, class should be declared final.
+
+    private TestNewKeyword(String s) {
+        String a = "hello" + s;
+    }
+
+    public int count() {
+        return 1;
+    }
+    public static final TestNewKeyword ONE = new TestNewKeyword("world");
+    public static final test6 TWO = new test6() {
+    };
+
+    public static void main(String[] args) {
+        ArrayList<String> foo = new ArrayList<>();
+        foo.add("world");
+        foo.forEach(TestNewKeyword::new);
+    }
+}
+
+interface TestNewKeywordInsideInterface { // ok
+    ArrayList<String> foo = new ArrayList<>();
+}
+
+// abstract classes cannot be final
+abstract class TestPrivateCtorInAbstractClasses { // ok
+    private TestPrivateCtorInAbstractClasses() {
+    }
+}
+
+class TestAnonymousInnerClassInsideNestedClass { // ok
+    private TestAnonymousInnerClassInsideNestedClass() { }
+
+    static class NestedClass { // violation, class should be declared final
+
+        public final static TestAnonymousInnerClassInsideNestedClass ONE
+                = new TestAnonymousInnerClassInsideNestedClass() {
+        };
+
+        private NestedClass() {}
+    }
+    static class NestedClass2 { // ok
+
+        private NestedClass2() {}
+
+        public static final test6  ONE = new test6() {
+
+            public final NestedClass2 ONE = new NestedClass2() {
+
+            };
+        };
+    }
+}
+

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -371,6 +371,15 @@ public @interface Test {
     private MyClass() { }
   }
 }
+
+class TestAnonymousInnerClasses { // OK, class has an anonymous inner class.
+    public static final TestAnonymousInnerClasses ONE = new TestAnonymousInnerClasses() {
+
+    };
+
+    private TestAnonymousInnerClasses() {
+    }
+}
         </source>
       </subsection>
 


### PR DESCRIPTION
Resolves #9357: FinalClass now exempts private-only constructor classes that also have nested subclasses
Note:- This will still give a violation if used inside the default package. Its fix is simple but writing an input class without package name is not permitted by checkstlye even if you write in the non-compilable resources folder. Code coverage will not be met without that.
Diff Regression projects: https://gist.githubusercontent.com/Vyom-Yadav/91807e6244cff60698d9e33e32ba2d51/raw/85355576c05c80e8b08752a62ba3a4076909d266/projects-to-test-on.properties
Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/be2b54fe328d0024818fe8aa52def42eca798c34/my_checks.xml