### PR TITLE
minor: fix link to javadoc.html

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
@@ -46,14 +46,14 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </li>
  * <li>
  * Property {@code ignoredTags} - Specify
- * <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
+ * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
  * block tags</a> which are ignored by the check.
  * Type is {@code java.lang.String[]}.
  * Default value is {@code ""}.
  * </li>
  * <li>
  * Property {@code ignoreInlineTags} - Control whether
- * <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
+ * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
  * inline tags</a> must be ignored.
  * Type is {@code boolean}.
  * Default value is {@code true}.
@@ -255,21 +255,21 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
 
     /**
      * Specify
-     * <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
+     * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
      * block tags</a> which are ignored by the check.
      */
     private List<String> ignoredTags = new ArrayList<>();
 
     /**
      * Control whether
-     * <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
+     * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
      * inline tags</a> must be ignored.
      */
     private boolean ignoreInlineTags = true;
 
     /**
      * Setter to specify
-     * <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
+     * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
      * block tags</a> which are ignored by the check.
      *
      * @param tags to be ignored by check.
@@ -280,7 +280,7 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
 
     /**
      * Setter to control whether
-     * <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
+     * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
      * inline tags</a> must be ignored.
      *
      * @param ignoreInlineTags whether inline tags must be ignored.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/SingleLineJavadocCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/SingleLineJavadocCheck.xml
@@ -18,12 +18,12 @@
             </property>
             <property default-value="" name="ignoredTags" type="java.lang.String[]">
                <description>Specify
- &lt;a href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF"&gt;
+ &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF"&gt;
  block tags&lt;/a&gt; which are ignored by the check.</description>
             </property>
             <property default-value="true" name="ignoreInlineTags" type="boolean">
                <description>Control whether
- &lt;a href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF"&gt;
+ &lt;a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF"&gt;
  inline tags&lt;/a&gt; must be ignored.</description>
             </property>
          </properties>

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -3314,7 +3314,7 @@ public boolean testMethod(int firstParam) {
               <td>ignoredTags</td>
               <td>
                 Specify
-                <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
+                <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
                 block tags</a> which are ignored by the check.
               </td>
               <td><a href="property_types.html#String.5B.5D">String[]</a></td>
@@ -3325,7 +3325,7 @@ public boolean testMethod(int firstParam) {
               <td>ignoreInlineTags</td>
               <td>
                 Control whether
-                <a href="http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
+                <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
                 inline tags</a> must be ignored.
               </td>
               <td><a href="property_types.html#boolean">boolean</a></td>


### PR DESCRIPTION
Detected at https://app.codeship.com/projects/124310/builds/00aa1aa8-ac0b-4d8a-b35e-547a70968fc9?line=638e41b1-85c9-431a-8c32-22e85320cda2&step=parallel_.ci%2Frun-link-check-plugin.sh

```bash
$ curl -v "http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF"
* Connected to docs.oracle.com (2a02:26f0:e2:494::af5) port 80 (#0)
> GET /javase/8/docs/technotes/tools/windows/javadoc.html HTTP/1.1
> Host: docs.oracle.com
> 
< HTTP/1.1 301 Moved Permanently
< Server: AkamaiGHost
< Content-Length: 0
< Location: https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html
```