### PR TITLE
Issue #7688: Adds examples to doc for RedundantImport

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1350,7 +1350,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.2</version>
         <configuration>
-          <argLine>-Dfile.encoding=UTF-8</argLine>
+          <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
           <systemPropertyVariables>
             <jacoco-agent.destfile>${project.build.directory}/jacoco.exec</jacoco-agent.destfile>
           </systemPropertyVariables>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
@@ -48,6 +48,15 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * &lt;module name="RedundantImport"/&gt;
  * </pre>
  * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * import java.util.*; // OK
+ * import java.io.*; // OK
+ * import java.util.Scanner; // violation, Scanner class included in java.util package
+ * import java.io.File; // violation, File class included in java.io package
+ * </pre>
+ * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
  * </p>
  * <p>

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -2317,6 +2317,15 @@ public class SomeClass { }
         <source>
 &lt;module name=&quot;RedundantImport&quot;/&gt;
         </source>
+        <p>
+          Example:
+        </p>
+        <source>
+import java.util.*; // OK
+import java.io.*; // OK
+import java.util.Scanner; // violation, Scanner class included in java.util package
+import java.io.File; // violation, File class included in java.io package
+        </source>
       </subsection>
 
       <subsection name="Example of Usage" id="RedundantImport_Example_of_Usage">


### PR DESCRIPTION
Issue #7688: Adds examples to the doc for RedundantImport.
Before making the changes:
![before](https://user-images.githubusercontent.com/64313783/111067210-38325080-84e9-11eb-8dce-438603446b7f.jpg)
After making the changes:
![after](https://user-images.githubusercontent.com/64313783/111067218-42ece580-84e9-11eb-974a-2b0155cf58bc.jpg)

