### PR TITLE
Issue #7688: Adds examples to doc for RedundantImport

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
@@ -48,6 +48,15 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * &lt;module name="RedundantImport"/&gt;
  * </pre>
  * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * import java.util.*; // OK
+ * import java.io.*; // OK
+ * import java.util.Scanner; // violation, Scanner class included in java.util package
+ * import java.io.File; // violation, File class included in java.io package
+ * </pre>
+ * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
  * </p>
  * <p>

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -2317,6 +2317,15 @@ public class SomeClass { }
         <source>
 &lt;module name=&quot;RedundantImport&quot;/&gt;
         </source>
+        <p>
+          Example:
+        </p>
+        <source>
+import java.util.*; // OK
+import java.io.*; // OK
+import java.util.Scanner; // violation, Scanner class included in java.util package
+import java.io.File; // violation, File class included in java.io package
+        </source>
       </subsection>
 
       <subsection name="Example of Usage" id="RedundantImport_Example_of_Usage">


### PR DESCRIPTION
Issue #7688: Adds examples to doc for RedundantImport
Before:
![before](https://user-images.githubusercontent.com/64313783/111075221-ed2a3480-850c-11eb-9c02-6be86a682879.jpg)
After:
![after](https://user-images.githubusercontent.com/64313783/111075226-f1eee880-850c-11eb-819e-0519fbcba69a.jpg)
