### PR TITLE
Issue #7624: Adds examples to doc for NoWhiteSpaceAfter

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
@@ -89,6 +89,15 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <pre>
  * &lt;module name=&quot;NoWhitespaceAfter&quot;/&gt;
  * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * int[] array; // OK
+ * int [] array; // violation, whitespace between int and opening bracket [
+ * array[2]; // OK
+ * array[ 2 ]; // violation, whitespace between opening bracket [ and dimension of array
+ * </pre>
  * <p>To configure the check to forbid linebreaks after a DOT token:
  * </p>
  * <pre>
@@ -96,6 +105,18 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *   &lt;property name=&quot;tokens&quot; value=&quot;DOT&quot;/&gt;
  *   &lt;property name=&quot;allowLineBreaks&quot; value=&quot;false&quot;/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * public class A { // initializing a class
+ * int create(); // method in class
+ * }
+ * A obj = new A(); // instantiating object of class A
+ * A.create(); // OK
+ * A.
+ * create(); // violation, dot operator at line break
  * </pre>
  * <p>
  * If the annotation is between the type and the array, the check will skip validation for spaces:

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -1371,6 +1371,15 @@ import static java.math.BigInteger.ZERO;
         <source>
 &lt;module name=&quot;NoWhitespaceAfter&quot;/&gt;
         </source>
+        <p>
+          Example:
+        </p>
+        <source>
+int[] array; // OK
+int [] array; // violation, whitespace between int and opening bracket [
+array[2]; // OK
+array[ 2 ]; // violation, whitespace between opening bracket [ and dimension of array
+        </source>
 
         <p>
           To configure the check to forbid linebreaks after a DOT token:
@@ -1380,6 +1389,18 @@ import static java.math.BigInteger.ZERO;
   &lt;property name=&quot;tokens&quot; value=&quot;DOT&quot;/&gt;
   &lt;property name=&quot;allowLineBreaks&quot; value=&quot;false&quot;/&gt;
 &lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+public class A { // initializing a class
+int create(); // method in class
+}
+A obj = new A(); // instantiating object of class A
+A.create(); // OK
+A.
+create(); // violation, dot operator at line break
         </source>
         <p>
          If the annotation is between the type and the array, the check will skip validation for


### PR DESCRIPTION
Issue #7624: Adds examples to doc for NoWhiteSpaceAfter
Before:
![1](https://user-images.githubusercontent.com/64313783/111079631-c675f900-8520-11eb-9c59-16b5b825d9ea.jpg)
After:
![2](https://user-images.githubusercontent.com/64313783/111079636-c970e980-8520-11eb-8e2f-2e6b2128afd4.jpg)
