### PR TITLE
Issue #7602: add code examples for JavadocVariable

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGenerator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGenerator.java
@@ -57,7 +57,8 @@ public final class JavadocPropertiesGenerator {
      * The end of the sentence is determined by the symbol "period", "exclamation mark" or
      * "question mark", followed by a space or the end of the text.
      */
-    private static final Pattern END_OF_SENTENCE_PATTERN = Pattern.compile("(.*?[.?!])(\\s|$)");
+    private static final Pattern END_OF_SENTENCE_PATTERN = Pattern.compile(
+        "(([^.?!]|[.?!](?!\\s|$))*+[.?!])(\\s|$)");
 
     /** Max width of the usage help message for this command. */
     private static final int USAGE_HELP_WIDTH = 100;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
@@ -131,14 +131,14 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * <p>Example</p>
  * <pre>
  * public class Test {
- *      public int publicVariable_1;    // violation, missing javadoc for public variable
+ *      private int privateVariable1;    // violation, missing javadoc for private variable
  *
  *      &#47;**
  *      * Some description here.
  *      *&#47;
- *      public int publicVariable_2;    // OK
- *      public int log;   // OK
- *      public int logger;    // OK
+ *      private int publicVariable2;    // OK
+ *      private int log;   // OK
+ *      private int logger;    // OK
  * }
  * </pre>
  * <p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
@@ -66,6 +66,17 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * <pre>
  * &lt;module name="JavadocVariable"/&gt;
  * </pre>
+ * <p>Example</p>
+ * <pre>
+ * public class Test {
+ *      private int privateVariable1; // violation, missing javadoc for private variable
+ *
+ *      &#47;**
+ *      *  Some description here.
+ *      *&#47;
+ *      private int privateVariable2;   // OK
+ * }
+ * </pre>
  * <p>
  * To configure the check for {@code public} scope:
  * </p>
@@ -73,6 +84,18 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * &lt;module name="JavadocVariable"&gt;
  *   &lt;property name="scope" value="public"/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>Example</p>
+ * <pre>
+ * public class Test {
+ *      public int publicVariable1;    // violation, missing javadoc for public variable
+ *
+ *      &#47;**
+ *      * Some description here.
+ *      *&#47;
+ *      public int publicVariable2;  // OK
+ *      private int privateVariable;    // OK
+ * }
  * </pre>
  * <p>
  * To configure the check for members which are in {@code private},
@@ -84,6 +107,19 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  *   &lt;property name="excludeScope" value="protected"/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>Example</p>
+ * <pre>
+ * public class Test {
+ *      private int privateVariable1;    // violation, missing javadoc for private variable
+ *
+ *      &#47;**
+ *      * Some description here.
+ *      *&#47;
+ *      private int privateVariable2;    // OK
+ *      protected int protectedVariable; // OK
+ *      public int publicVariable;  // OK
+ * }
+ * </pre>
  * <p>
  * To ignore absence of Javadoc comments for variables with names {@code log} or {@code logger}:
  * </p>
@@ -91,6 +127,19 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * &lt;module name="JavadocVariable"&gt;
  *   &lt;property name="ignoreNamePattern" value="log|logger"/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>Example</p>
+ * <pre>
+ * public class Test {
+ *      public int publicVariable_1;    // violation, missing javadoc for public variable
+ *
+ *      &#47;**
+ *      * Some description here.
+ *      *&#47;
+ *      public int publicVariable_2;    // OK
+ *      public int log;   // OK
+ *      public int logger;    // OK
+ * }
  * </pre>
  * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -2335,6 +2335,17 @@ class DatabaseConfiguration {}
         <source>
 &lt;module name="JavadocVariable"/&gt;
         </source>
+        <p>Example</p>
+        <source>
+public class Test {
+private int privateVariable1; // violation, missing javadoc for private variable
+
+/**
+*  Some description here.
+*/
+private int privateVariable2;   // OK
+}
+        </source>
 
         <p>
           To configure the check for <code>public</code>
@@ -2345,6 +2356,18 @@ class DatabaseConfiguration {}
 &lt;module name="JavadocVariable"&gt;
   &lt;property name="scope" value="public"/&gt;
 &lt;/module&gt;
+        </source>
+        <p>Example</p>
+        <source>
+public class Test {
+public int publicVariable1;    // violation, missing javadoc for public variable
+
+/**
+* Some description here.
+*/
+public int publicVariable2;  // OK
+private int privateVariable;    // OK
+}
         </source>
 
         <p>
@@ -2358,6 +2381,19 @@ class DatabaseConfiguration {}
   &lt;property name="excludeScope" value="protected"/&gt;
 &lt;/module&gt;
         </source>
+        <p>Example</p>
+        <source>
+public class Test {
+private int privateVariable1;    // violation, missing javadoc for private variable
+
+/**
+* Some description here.
+*/
+private int privateVariable2;    // OK
+protected int protectedVariable; // OK
+public int publicVariable;  // OK
+}
+        </source>
 
         <p>
           To ignore absence of Javadoc comments for variables with names <code>log</code> or
@@ -2368,6 +2404,19 @@ class DatabaseConfiguration {}
 &lt;module name="JavadocVariable"&gt;
   &lt;property name="ignoreNamePattern" value="log|logger"/&gt;
 &lt;/module&gt;
+        </source>
+        <p>Example</p>
+        <source>
+public class Test {
+public int publicVariable_1;    // violation, missing javadoc for public variable
+
+/**
+* Some description here.
+*/
+public int publicVariable_2;    // OK
+public int log;   // OK
+public int logger;    // OK
+}
         </source>
       </subsection>
 

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -2408,14 +2408,14 @@ public int publicVariable;  // OK
         <p>Example</p>
         <source>
 public class Test {
-public int publicVariable_1;    // violation, missing javadoc for public variable
+private int publicVariable1;    // violation, missing javadoc for private variable
 
 /**
 * Some description here.
 */
-public int publicVariable_2;    // OK
-public int log;   // OK
-public int logger;    // OK
+private int publicVariable2;    // OK
+private int log;   // OK
+private int logger;    // OK
 }
         </source>
       </subsection>


### PR DESCRIPTION
Issue #7602: add code examples for JavadocVariable

Before:
![image](https://user-images.githubusercontent.com/56120837/111109021-f0aad380-857f-11eb-9497-9b1d31823ca9.png)

After:
![image](https://user-images.githubusercontent.com/56120837/111109103-17690a00-8580-11eb-9946-814868e7240e.png)
![image](https://user-images.githubusercontent.com/56120837/111109148-2d76ca80-8580-11eb-8d73-259839cae4d3.png)
