### PR TITLE
Issue #7602: add code examples for JavadocVariable

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
@@ -67,12 +67,43 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * &lt;module name="JavadocVariable"/&gt;
  * </pre>
  * <p>
+ * By default, this setting will report a violation if
+ * there is no javadoc for any scope member.
+ * </p>
+ * <pre>
+ * public class Test {
+ *   private int a; // violation, missing javadoc for private member
+ *
+ *   &#47;**
+ *    * Some description here
+ *    *&#47;
+ *   private int b; // OK
+ *   protected int c; // violation, missing javadoc for protected member
+ *   public int d; // violation, missing javadoc for public member
+ *   &#47;*package*&#47; int e; // violation, missing javadoc for package member
+ * }
+ * </pre>
+ * <p>
  * To configure the check for {@code public} scope:
  * </p>
  * <pre>
  * &lt;module name="JavadocVariable"&gt;
  *   &lt;property name="scope" value="public"/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>This setting will report a violation if there is no javadoc for {@code public} member.</p>
+ * <pre>
+ * public class Test {
+ *   private int a; // OK
+ *
+ *   &#47;**
+ *    * Some description here
+ *    *&#47;
+ *   private int b; // OK
+ *   protected int c; // OK
+ *   public int d; // violation, missing javadoc for public member
+ *   &#47;*package*&#47; int e; // OK
+ * }
  * </pre>
  * <p>
  * To configure the check for members which are in {@code private},
@@ -85,12 +116,48 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * &lt;/module&gt;
  * </pre>
  * <p>
+ * This setting will report a violation if there is no javadoc for {@code private}
+ * member and ignores {@code protected} member.
+ * </p>
+ * <pre>
+ * public class Test {
+ *   private int a; // violation, missing javadoc for private member
+ *
+ *   &#47;**
+ *    * Some description here
+ *    *&#47;
+ *   private int b; // OK
+ *   protected int c; // OK
+ *   public int d; // OK
+ *   &#47;*package*&#47; int e; // violation, missing javadoc for package member
+ * }
+ * </pre>
+ * <p>
  * To ignore absence of Javadoc comments for variables with names {@code log} or {@code logger}:
  * </p>
  * <pre>
  * &lt;module name="JavadocVariable"&gt;
  *   &lt;property name="ignoreNamePattern" value="log|logger"/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * This setting will report a violation if there is no javadoc for any scope
+ * member and ignores members with name {@code log} or {@code logger}.
+ * </p>
+ * <pre>
+ * public class Test {
+ *   private int a; // violation, missing javadoc for private member
+ *
+ *   &#47;**
+ *    * Some description here
+ *    *&#47;
+ *   private int b; // OK
+ *   protected int c; // violation, missing javadoc for protected member
+ *   public int d; // violation, missing javadoc for public member
+ *   &#47;*package*&#47; int e; // violation, missing javadoc for package member
+ *   private int log; // OK
+ *   private int logger; // OK
+ * }
  * </pre>
  * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -2335,6 +2335,23 @@ class DatabaseConfiguration {}
         <source>
 &lt;module name="JavadocVariable"/&gt;
         </source>
+        <p>
+          By default, this setting will report a violation if
+          there is no javadoc for any scope member.
+        </p>
+        <source>
+public class Test {
+private int a; // violation, missing javadoc for private member
+
+/**
+ * Some description here
+ */
+private int b; // OK
+protected int c; // violation, missing javadoc for protected member
+public int d; // violation, missing javadoc for public member
+/*package*/ int e; // violation, missing javadoc for package member
+}
+        </source>
 
         <p>
           To configure the check for <code>public</code>
@@ -2345,6 +2362,23 @@ class DatabaseConfiguration {}
 &lt;module name="JavadocVariable"&gt;
   &lt;property name="scope" value="public"/&gt;
 &lt;/module&gt;
+        </source>
+        <p>
+          This setting will report a violation if there
+          is no javadoc for <code>public</code> member.
+        </p>
+        <source>
+public class Test {
+private int a; // OK
+
+/**
+ * Some description here
+ */
+private int b; // OK
+protected int c; // OK
+public int d; // violation, missing javadoc for public member
+/*package*/ int e; // OK
+}
         </source>
 
         <p>
@@ -2358,7 +2392,24 @@ class DatabaseConfiguration {}
   &lt;property name="excludeScope" value="protected"/&gt;
 &lt;/module&gt;
         </source>
+        <p>
+          This setting will report a violation if there is no
+          javadoc for <code>private</code> member and
+          ignores <code>protected</code> member.
+        </p>
+        <source>
+public class Test {
+private int a; // violation, missing javadoc for private member
 
+/**
+ * Some description here
+ */
+private int b; // OK
+protected int c; // OK
+public int d; // OK
+/*package*/ int e; // violation, missing javadoc for package member
+}
+        </source>
         <p>
           To ignore absence of Javadoc comments for variables with names <code>log</code> or
           <code>logger</code>:
@@ -2368,6 +2419,26 @@ class DatabaseConfiguration {}
 &lt;module name="JavadocVariable"&gt;
   &lt;property name="ignoreNamePattern" value="log|logger"/&gt;
 &lt;/module&gt;
+        </source>
+        <p>
+          This setting will report a violation if there is no
+          javadoc for any scope member and ignores members with
+          name <code>log</code> or <code>logger</code>.
+        </p>
+        <source>
+public class Test {
+private int a; // violation, missing javadoc for private member
+
+/**
+ * Some description here
+ */
+private int b; // OK
+protected int c; // violation, missing javadoc for protected member
+public int d; // violation, missing javadoc for public member
+/*package*/ int e; // violation, missing javadoc for package member
+private int log; // OK
+private int logger; // OK
+}
         </source>
       </subsection>
 


### PR DESCRIPTION
Closes: #7602

### Example - 1
![image](https://user-images.githubusercontent.com/56120837/111896319-cc973880-8a3e-11eb-84ca-b2d6526a1079.png)

**Successfully Compiled**
![image](https://user-images.githubusercontent.com/56120837/111575955-825f4e80-87d5-11eb-9901-d7b86a17e26c.png)

`λ cat config.xml`
```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
        <module name="TreeWalker">
                <module name="JavadocVariable"/>
        </module>
</module>
```

`λ cat Test.java`
```
public class Test {
        private int a; // violation, missing javadoc for private member

        /**
         * Some description here
         */
        private int b; // OK
        protected int c; // violation, missing javadoc for protected member
        public int d; // violation, missing javadoc for public member
        /*package*/ int e; // violation, missing javadoc for package member
}
```
`λ set RUN_LOCALE="-Duser.language=en -Duser.country=US"`
`λ java %RUN_LOCALE% -jar checkstyle-8.41-all.jar -c config.xml Test.java`
```
Starting audit...
[ERROR] E:\GitHub\Test.java:2:9: Missing a Javadoc comment. [JavadocVariable]
[ERROR] E:\GitHub\Test.java:8:9: Missing a Javadoc comment. [JavadocVariable]
[ERROR] E:\GitHub\Test.java:9:9: Missing a Javadoc comment. [JavadocVariable]
[ERROR] E:\GitHub\Test.java:10:21: Missing a Javadoc comment. [JavadocVariable]
Audit done.
Checkstyle ends with 4 errors.
```

### Example-2
![image](https://user-images.githubusercontent.com/56120837/111896415-82628700-8a3f-11eb-9a0c-aeacf3cf85dd.png)

**Successfully compiled**
![image](https://user-images.githubusercontent.com/56120837/111576263-29dc8100-87d6-11eb-92e6-00454f870459.png)

`λ cat config.xml`
```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
        <module name="TreeWalker">
                <module name="JavadocVariable">
                        <property name="scope" value="public"/>
                </module>
        </module>
</module>
```
`λ cat Test.java`
```
public class Test {
        private int a; // OK

        /**
         * Some description here
         */
        private int b; // OK
        protected int c; // OK
        public int d; // violation, missing javadoc for public member
        /*package*/ int e; // OK
}
```
`λ java %RUN_LOCALE% -jar checkstyle-8.41-all.jar -c config.xml Test.java`
```
Starting audit...
[ERROR] E:\GitHub\Test.java:9:9: Missing a Javadoc comment. [JavadocVariable]
Audit done.
Checkstyle ends with 1 errors.
```

### Example-3
![image](https://user-images.githubusercontent.com/56120837/111896538-601d3900-8a40-11eb-8175-c9f2b09d92f3.png)

**Successfully compiled**
![image](https://user-images.githubusercontent.com/56120837/111576892-5b098100-87d7-11eb-98c2-9c34bdae6c13.png)

`λ cat config.xml`
```
<?xml version="1.0"?>                                                        
<!DOCTYPE module PUBLIC                                                      
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"                
        "https://checkstyle.org/dtds/configuration_1_3.dtd">                 
<module name="Checker">                                                      
        <module name="TreeWalker">                                           
                <module name="JavadocVariable">                              
                        <property name="scope" value="private"/>             
                        <property name="excludeScope" value="protected"/>    
                </module>                                                    
        </module>                                                            
</module>
```
`λ cat Test.java`
```
public class Test {
        private int a; // violation, missing javadoc for private member

        /**
         * Some description here
         */
        private int b; // OK
        protected int c; // OK
        public int d; // OK
        /*package*/ int e; // violation, missing javadoc for package member
}
```
`λ java %RUN_LOCALE% -jar checkstyle-8.41-all.jar -c config.xml Test.java`
```
Starting audit...
[ERROR] E:\GitHub\Test.java:2:9: Missing a Javadoc comment. [JavadocVariable]
[ERROR] E:\GitHub\Test.java:10:21: Missing a Javadoc comment. [JavadocVariable]
Audit done.
Checkstyle ends with 2 errors.
```

### Example-4
![image](https://user-images.githubusercontent.com/56120837/111896561-93f85e80-8a40-11eb-8aa1-0d1394a9b13e.png)

**Successfully compiled**
![image](https://user-images.githubusercontent.com/56120837/111577583-9193cb80-87d8-11eb-99f7-1381497d579a.png)

`λ cat config.xml`
```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
        <module name="TreeWalker">
                <module name="JavadocVariable">
                        <property name="ignoreNamePattern" value="log|logger"/>
                </module>
        </module>
</module>
```

`λ cat Test.java`
```
public class Test {
        private int a; // violation, missing javadoc for private member

        /**
         * Some description here
         */
        private int b; // OK
        protected int c; // violation, missing javadoc for protected member
        public int d; // violation, missing javadoc for public member
        /*package*/ int e; // violation, missing javadoc for package member
        private int log; // OK
        private int logger; // OK
}
```
`λ java %RUN_LOCALE% -jar checkstyle-8.41-all.jar -c config.xml Test.java`
```
Starting audit...
[ERROR] E:\GitHub\Test.java:2:9: Missing a Javadoc comment. [JavadocVariable]
[ERROR] E:\GitHub\Test.java:8:9: Missing a Javadoc comment. [JavadocVariable]
[ERROR] E:\GitHub\Test.java:9:9: Missing a Javadoc comment. [JavadocVariable]
[ERROR] E:\GitHub\Test.java:10:21: Missing a Javadoc comment. [JavadocVariable]
Audit done.
Checkstyle ends with 4 errors.
```