### PR TITLE
Issue #9578: add example of AST for TokenTypes.STRING_LITERAL

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -2708,7 +2708,21 @@ public final class TokenTypes {
     /**
      * A string literal.  This is a sequence of (possibly escaped)
      * characters enclosed in double quotes.
+     * <p>For Example:</p>
+     * <pre>String str = "StringLiteral";</pre>
      *
+     * <p>Parse as:</p>
+     * <pre>
+     *   --VARIABLE_DEF -&gt; VARIABLE_DEF
+     *    |--MODIFIERS -&gt; MODIFIERS
+     *    |--TYPE -&gt; TYPE
+     *    |   `--IDENT -&gt; String
+     *    |--IDENT -&gt; str
+     *    |--ASSIGN -&gt; =
+     *    |   `--EXPR -&gt; EXPR
+     *    |       `--STRING_LITERAL -&gt; "StringLiteral"
+     *    `--SEMI -&gt; ;
+     * </pre>
      * @see <a
      * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.5">Java
      * Language Specification, &sect;3.10.5</a>


### PR DESCRIPTION
Closes: #9578
![image](https://user-images.githubusercontent.com/56120837/111308395-a3625b00-8680-11eb-84ca-abefbd86f289.png)
```
**Test.java**
λ cat Test.java
public class Test {
        String str = "StringLiteral";
}

**AST**
λ java -jar checkstyle-8.41-all.jar -t Test.java
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> Test [1:13]
`--OBJBLOCK -> OBJBLOCK [1:18]
    |--LCURLY -> { [1:18]
    |--VARIABLE_DEF -> VARIABLE_DEF [2:1]
    |   |--MODIFIERS -> MODIFIERS [2:1]
    |   |--TYPE -> TYPE [2:1]
    |   |   `--IDENT -> String [2:1]
    |   |--IDENT -> str [2:8]
    |   |--ASSIGN -> = [2:12]
    |   |   `--EXPR -> EXPR [2:14]
    |   |       `--STRING_LITERAL -> "StringLiteral" [2:14]
    |   `--SEMI -> ; [2:29]
    `--RCURLY -> } [3:0]

# Printing the code that we care
λ java -jar checkstyle-8.41-all.jar -t Test.java | grep "2:"
    |--VARIABLE_DEF -> VARIABLE_DEF [2:1]
    |   |--MODIFIERS -> MODIFIERS [2:1]
    |   |--TYPE -> TYPE [2:1]
    |   |   `--IDENT -> String [2:1]
    |   |--IDENT -> str [2:8]
    |   |--ASSIGN -> = [2:12]
    |   |   `--EXPR -> EXPR [2:14]
    |   |       `--STRING_LITERAL -> "StringLiteral" [2:14]
    |   `--SEMI -> ; [2:29]

```

**Expected update for Javadoc**
```
 --VARIABLE_DEF -> VARIABLE_DEF
    |--MODIFIERS -> MODIFIERS
    |--TYPE -> TYPE
    |   `--IDENT -> String
    |--IDENT -> str
    |--ASSIGN -> =
    |   `--EXPR -> EXPR
    |       `--STRING_LITERAL -> "StringLiteral"
    `--SEMI -> ;
```