### PR TITLE
Issue #9553: updated example of AST for TokenTypes.PLUS

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -2442,6 +2442,21 @@ public final class TokenTypes {
     /**
      * The {@code +} (addition) operator.
      *
+     * <p>For example:</p>
+     * <pre>
+     *     a = b + c;
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * |--EXPR -&gt; EXPR
+     * |   `--ASSIGN -&gt; =
+     * |   |--IDENT -&gt; a
+     * |   `--PLUS -&gt; +
+     * |   |--IDENT -&gt; b
+     * |   `--IDENT -&gt; c
+     * |--SEMI -> ;
+     * </pre>
+     *
      * @see <a
      * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.18">Java
      * Language Specification, &sect;15.18</a>


### PR DESCRIPTION
## closes issue #9553: updated example of AST for TokenTypes.PLUS

<img width="975" alt="Screenshot 2021-03-16 at 6 46 04 PM" src="https://user-images.githubusercontent.com/65589791/111316002-e6c0c780-8688-11eb-845a-508912091ebf.png">

```
anmolsharma@Anmols-MacBook-Pro GSOC % java -jar checkstyle-8.41-all.jar -t MyClass.java | grep "4:"
    |       |--EXPR -> EXPR [4:10]
    |       |   `--ASSIGN -> = [4:10]
    |       |       |--IDENT -> a [4:8]
    |       |       `--PLUS -> + [4:14]
    |       |           |--IDENT -> b [4:12]
    |       |           `--IDENT -> c [4:16]
    |       |--SEMI -> ; [4:17]
```

expected update for javodoc is:

```
|--EXPR -> EXPR
|   `--ASSIGN -> =
|       |--IDENT -> a
|       `--PLUS -> +
|           |--IDENT -> b
|           `--IDENT -> c
|--SEMI -> ;
```


