### PR TITLE
Issue #9549 : updated example of AST for TokenTypes.PACKAGE_DEF

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -393,23 +393,18 @@ public final class TokenTypes {
      * <p>parses as:</p>
      *
      * <pre>
-     * +--PACKAGE_DEF (package)
-     *     |
-     *     +--ANNOTATIONS
-     *     +--DOT (.)
-     *         |
-     *         +--DOT (.)
-     *             |
-     *             +--DOT (.)
-     *                 |
-     *                 +--DOT (.)
-     *                     |
-     *                     +--IDENT (com)
-     *                     +--IDENT (puppycrawl)
-     *                 +--IDENT (tools)
-     *             +--IDENT (checkstyle)
-     *         +--IDENT (api)
-     *     +--SEMI (;)
+     * PACKAGE_DEF -&gt; package
+     * |--ANNOTATIONS -&gt; ANNOTATIONS
+     * |--DOT -&gt; .
+     * |   |--DOT -&gt; .
+     * |   |   |--DOT -&gt; .
+     * |   |   |   |--DOT -&gt; .
+     * |   |   |   |   |--IDENT -&gt; com
+     * |   |   |   |   `--IDENT -&gt; puppycrawl
+     * |   |   |   `--IDENT -&gt; tools
+     * |   |   `--IDENT -&gt; checkstyle
+     * |   `--IDENT -&gt; api
+     * `--SEMI -&gt; ;
      * </pre>
      *
      * @see <a


### PR DESCRIPTION
## Issue #9549 : updated example of AST for TokenTypes.PACKAGE_DEF

closes #9549 
<img width="482" alt="Screenshot 2021-03-16 at 9 02 09 PM" src="https://user-images.githubusercontent.com/65589791/111337146-d9610880-869b-11eb-8b70-556fecb418e4.png">

```
% java -jar checkstyle-8.41-all.jar -t MyClass.java | grep "1:"
PACKAGE_DEF -> package [1:0]
|--ANNOTATIONS -> ANNOTATIONS [1:39]
|--DOT -> . [1:39]
|   |--DOT -> . [1:28]
|   |   |--DOT -> . [1:22]
|   |   |   |--DOT -> . [1:11]
|   |   |   |   |--IDENT -> com [1:8]
|   |   |   |   `--IDENT -> puppycrawl [1:12]
|   |   |   `--IDENT -> tools [1:23]
|   |   `--IDENT -> checkstyle [1:29]
|   `--IDENT -> api [1:40]
`--SEMI -> ; [1:43]
```

expected update for javodoc is:

```
PACKAGE_DEF -> package
|--ANNOTATIONS -> ANNOTATIONS
|--DOT -> .
|   |--DOT -> .
|   |   |--DOT -> .
|   |   |   |--DOT -> .
|   |   |   |   |--IDENT -> com
|   |   |   |   `--IDENT -> puppycrawl
|   |   |   `--IDENT -> tools
|   |   `--IDENT -> checkstyle
|   `--IDENT -> api
`--SEMI -> ;
```