### PR TITLE
Issue #9533: update AtclauseOrderCheckTest to use unique Input file in each test method

### DIFF
--- a/config/checkstyle_input_suppressions.xml
+++ b/config/checkstyle_input_suppressions.xml
@@ -2965,10 +2965,6 @@
   <suppress id="StyleValidationCommentInInputs"
             files="javadoc[\\/]abstractjavadoc[\\/]InputAbstractJavadocWrongSingletonTagInJavadoc.java"/>
   <suppress id="StyleValidationCommentInInputs"
-            files="javadoc[\\/]atclauseorder[\\/]InputAtclauseOrderCorrect.java"/>
-  <suppress id="StyleValidationCommentInInputs"
-            files="javadoc[\\/]atclauseorder[\\/]InputAtclauseOrderIncorrect.java"/>
-  <suppress id="StyleValidationCommentInInputs"
             files="javadocdetailnodeparser[\\/]InputJavadocDetailNodeParser.java"/>
   <suppress id="StyleValidationCommentInInputs"
             files="javadoc[\\/]invalidjavadocposition[\\/]InputInvalidJavadocPosition.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckTest.java
@@ -120,9 +120,9 @@ public class AtclauseOrderCheckTest extends AbstractModuleTestSupport {
         final String tagOrder = "[@since, @version, @param, @return, @throws, @exception,"
                 + " @deprecated, @see, @serial, @serialField, @serialData, @author]";
         final String[] expected = {
-            "113: " + getCheckMessage(MSG_KEY, tagOrder),
+            "119: " + getCheckMessage(MSG_KEY, tagOrder),
         };
-        verify(checkConfig, getPath("InputAtclauseOrderIncorrect.java"), expected);
+        verify(checkConfig, getPath("InputAtclauseOrderIncorrectCustom.java"), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckTest.java
@@ -114,8 +114,8 @@ public class AtclauseOrderCheckTest extends AbstractModuleTestSupport {
     public void testIncorrectCustom() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(AtclauseOrderCheck.class);
         checkConfig.addAttribute("target", "CLASS_DEF");
-        checkConfig.addAttribute("tagOrder", " @since,  @version, @param,@return,@throws, "
-                + "@exception,@deprecated, @see,@serial,   @serialField,  @serialData,@author");
+        checkConfig.addAttribute("tagOrder", "@since, @version, @param, @return, @throws, "
+                + "@exception, @deprecated, @see, @serial, @serialField, @serialData,@author");
 
         final String tagOrder = "[@since, @version, @param, @return, @throws, @exception,"
                 + " @deprecated, @see, @serial, @serialField, @serialData, @author]";

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderCorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderCorrect.java
@@ -9,7 +9,7 @@ import java.io.Serializable;
  * @version 1.0
  * @see Some javadoc.
  * @since Some javadoc.
- * @deprecated Some javadoc.
+ * @deprecated Some javadoc. // ok
  */
 class InputAtclauseOrderCorrect implements Serializable
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrect.java
@@ -6,10 +6,10 @@ import java.io.Serializable;
  * Some javadoc.
  *
  * @since Some javadoc.
- * @version 1.0 //warn //warn
+ * @version 1.0 // violation
  * @deprecated Some javadoc.
- * @see Some javadoc. //warn
- * @author max //warn
+ * @see Some javadoc. // violation
+ * @author max // violation
  */
 class InputAtclauseOrderIncorrect implements Serializable
 {
@@ -37,7 +37,7 @@ class InputAtclauseOrderIncorrect implements Serializable
      * @return Some text.
      * @serialData Some javadoc.
      * @deprecated Some text.
-     * @throws Exception Some text. //warn
+     * @throws Exception Some text. // violation
      */
     String method(String aString) throws Exception
     {
@@ -47,9 +47,9 @@ class InputAtclauseOrderIncorrect implements Serializable
     /**
      * Some text.
      * @serialData Some javadoc.
-     * @return Some text. //warn
-     * @param aString Some text. //warn
-     * @throws Exception Some text.
+     * @return Some text. // violation
+     * @param aString Some text. // violation
+     * @throws Exception Some text. // violation
      */
     String method1(String aString) throws Exception
     {
@@ -59,14 +59,14 @@ class InputAtclauseOrderIncorrect implements Serializable
     /**
      * Some text.
      * @throws Exception Some text.
-     * @param aString Some text. //warn
+     * @param aString Some text. // violation
      */
     void method2(String aString) throws Exception {}
 
     /**
      * Some text.
      * @deprecated Some text.
-     * @throws Exception Some text. //warn
+     * @throws Exception Some text. // violation
      */
     void method3() throws Exception {}
 
@@ -83,8 +83,8 @@ class InputAtclauseOrderIncorrect implements Serializable
     /**
      * Some text.
      * @deprecated Some text.
-     * @return Some text. //warn
-     * @param aString Some text. //warn
+     * @return Some text. // violation
+     * @param aString Some text. // violation
      */
     String method5(String aString)
     {
@@ -96,9 +96,9 @@ class InputAtclauseOrderIncorrect implements Serializable
      * @param aString Some text.
      * @return Some text.
      * @serialData Some javadoc.
-     * @param aInt Some text. //warn
-     * @throws Exception Some text.
-     * @param aBoolean Some text. //warn
+     * @param aInt Some text. // violation
+     * @throws Exception Some text. // violation
+     * @param aBoolean Some text. // violation
      * @deprecated Some text.
      */
     String method6(String aString, int aInt, boolean aBoolean) throws Exception
@@ -112,7 +112,7 @@ class InputAtclauseOrderIncorrect implements Serializable
      * @version 1.0
      * @since Some javadoc.
      * @serialData Some javadoc.
-     * @author max //warn
+     * @author max // violation
      */
     class InnerClassWithAnnotations
     {
@@ -120,8 +120,8 @@ class InputAtclauseOrderIncorrect implements Serializable
          * Some text.
          * @return Some text.
          * @deprecated Some text.
-         * @param aString Some text. //warn
-         * @throws Exception Some text.
+         * @param aString Some text. // violation
+         * @throws Exception Some text. // violation
          */
         String method(String aString) throws Exception
         {
@@ -131,8 +131,8 @@ class InputAtclauseOrderIncorrect implements Serializable
         /**
          * Some text.
          * @throws Exception Some text.
-         * @return Some text. //warn
-         * @param aString Some text. //warn
+         * @return Some text. // violation
+         * @param aString Some text. // violation
          */
         String method1(String aString) throws Exception
         {
@@ -142,15 +142,15 @@ class InputAtclauseOrderIncorrect implements Serializable
         /**
          * Some text.
          * @serialData Some javadoc.
-         * @param aString Some text. //warn
-         * @throws Exception Some text.
+         * @param aString Some text. // violation
+         * @throws Exception Some text. // violation
          */
         void method2(String aString) throws Exception {}
 
         /**
          * Some text.
          * @deprecated Some text.
-         * @throws Exception Some text. //warn
+         * @throws Exception Some text. // violation
          */
         void method3() throws Exception {}
 
@@ -158,7 +158,7 @@ class InputAtclauseOrderIncorrect implements Serializable
          * Some text.
          * @throws Exception Some text.
          * @serialData Some javadoc.
-         * @return Some text. //warn
+         * @return Some text. // violation
          */
         String method4() throws Exception
         {
@@ -169,7 +169,7 @@ class InputAtclauseOrderIncorrect implements Serializable
          * Some text.
          * @param aString Some text.
          * @deprecated Some text.
-         * @return Some text. //warn
+         * @return Some text. // violation
          */
         String method5(String aString)
         {
@@ -180,9 +180,9 @@ class InputAtclauseOrderIncorrect implements Serializable
          * Some text.
          * @param aString Some text.
          * @return Some text.
-         * @param aInt Some text. //warn
+         * @param aInt Some text. // violation
          * @throws Exception Some text.
-         * @param aBoolean Some text. //warn
+         * @param aBoolean Some text. // violation
          * @deprecated Some text.
          */
         String method6(String aString, int aInt, boolean aBoolean) throws Exception
@@ -196,10 +196,10 @@ class InputAtclauseOrderIncorrect implements Serializable
         /**
          * Some text.
          * @throws Exception Some text.
-         * @param aString Some text. //warn
+         * @param aString Some text. // violation
          * @serialData Some javadoc.
          * @deprecated Some text.
-         * @return Some text. //warn
+         * @return Some text. // violation
          */
         String method(String aString) throws Exception
         {
@@ -210,7 +210,7 @@ class InputAtclauseOrderIncorrect implements Serializable
          * Some text.
          * @param aString Some text.
          * @throws Exception Some text.
-         * @return Some text. //warn
+         * @return Some text. // violation
          */
         String method1(String aString) throws Exception
         {
@@ -220,21 +220,21 @@ class InputAtclauseOrderIncorrect implements Serializable
         /**
          * Some text.
          * @throws Exception Some text.
-         * @param aString Some text. //warn
+         * @param aString Some text. // violation
          */
         void method2(String aString) throws Exception {}
 
         /**
          * Some text.
          * @deprecated Some text.
-         * @throws Exception Some text. //warn
+         * @throws Exception Some text. // violation
          */
         void method3() throws Exception {}
 
         /**
          * Some text.
          * @throws Exception Some text.
-         * @return Some text. //warn
+         * @return Some text. // violation
          */
         String method4() throws Exception
         {
@@ -244,8 +244,8 @@ class InputAtclauseOrderIncorrect implements Serializable
         /**
          * Some text.
          * @deprecated Some text.
-         * @return Some text. //warn
-         * @param aString Some text. //warn
+         * @return Some text. // violation
+         * @param aString Some text. // violation
          */
         String method5(String aString)
         {
@@ -256,9 +256,9 @@ class InputAtclauseOrderIncorrect implements Serializable
          * Some text.
          * @param aString Some text.
          * @return Some text.
-         * @param aInt Some text. //warn
+         * @param aInt Some text. // violation
          * @throws Exception Some text.
-         * @param aBoolean Some text. //warn
+         * @param aBoolean Some text. // violation
          * @deprecated Some text.
          */
         String method6(String aString, int aInt, boolean aBoolean) throws Exception
@@ -272,10 +272,10 @@ class InputAtclauseOrderIncorrect implements Serializable
  * Some javadoc.
  *
  * @since Some javadoc.
- * @version 1.0 //warn //warn
+ * @version 1.0 // violation
  * @deprecated Some javadoc.
- * @see Some javadoc. //warn
- * @author max //warn
+ * @see Some javadoc. // violation
+ * @author max // violation
  */
 enum Foo4 {}
 
@@ -285,7 +285,7 @@ enum Foo4 {}
  * @version 1.0
  * @since Some javadoc.
  * @serialData Some javadoc.
- * @author max //warn
+ * @author max // violation
  */
 interface FooIn {
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrectCustom.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderIncorrectCustom.java
@@ -1,0 +1,301 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
+/** Javadoc for import */
+import java.io.Serializable;
+
+/* Config:
+ * target = "CLASS_DEF"
+ * tagOrder = "@since, @version, @param, @return, @throws, @exception, @deprecated, @see,
+ *          @serial, @serialField, @serialData,@author"
+ */
+
+/**
+ * Some javadoc.
+ *
+ * @since Some javadoc.
+ * @version 1.0
+ * @deprecated Some javadoc.
+ * @see Some javadoc.
+ * @author max
+ */
+class InputAtclauseOrderIncorrectCustom implements Serializable
+{
+        /**
+     * The client's first name.
+     * @serial
+     */
+    private String fFirstName;
+
+    /**
+     * The client's first name.
+     * @serial
+     */
+    private String sSecondName;
+
+    /**
+     * The client's first name.
+     * @serialField
+     */
+    private String tThirdName;
+
+    /**
+     * Some text.
+     * @param aString Some text.
+     * @return Some text.
+     * @serialData Some javadoc.
+     * @deprecated Some text.
+     * @throws Exception Some text.
+     */
+    String method(String aString) throws Exception
+    {
+        return "null";
+    }
+
+    /**
+     * Some text.
+     * @serialData Some javadoc.
+     * @return Some text.
+     * @param aString Some text.
+     * @throws Exception Some text.
+     */
+    String method1(String aString) throws Exception
+    {
+        return "null";
+    }
+
+    /**
+     * Some text.
+     * @throws Exception Some text.
+     * @param aString Some text.
+     */
+    void method2(String aString) throws Exception {}
+
+    /**
+     * Some text.
+     * @deprecated Some text.
+     * @throws Exception Some text.
+     */
+    void method3() throws Exception {}
+
+    /**
+     * Some text.
+     * @return Some text.
+     * @throws Exception Some text.
+     */
+    String method4() throws Exception
+    {
+        return "null";
+    }
+
+    /**
+     * Some text.
+     * @deprecated Some text.
+     * @return Some text.
+     * @param aString Some text.
+     */
+    String method5(String aString)
+    {
+        return "null";
+    }
+
+    /**
+     * Some text.
+     * @param aString Some text.
+     * @return Some text.
+     * @serialData Some javadoc.
+     * @param aInt Some text.
+     * @throws Exception Some text.
+     * @param aBoolean Some text.
+     * @deprecated Some text.
+     */
+    String method6(String aString, int aInt, boolean aBoolean) throws Exception
+    {
+        return "null";
+    }
+
+    /**
+     * Some javadoc.
+     *
+     * @version 1.0
+     * @since Some javadoc. // violation
+     * @serialData Some javadoc.
+     * @author max
+     */
+    class InnerClassWithAnnotations
+    {
+        /**
+         * Some text.
+         * @return Some text.
+         * @deprecated Some text.
+         * @param aString Some text.
+         * @throws Exception Some text.
+         */
+        String method(String aString) throws Exception
+        {
+            return "null";
+        }
+
+        /**
+         * Some text.
+         * @throws Exception Some text.
+         * @return Some text.
+         * @param aString Some text.
+         */
+        String method1(String aString) throws Exception
+        {
+            return "null";
+        }
+
+        /**
+         * Some text.
+         * @serialData Some javadoc.
+         * @param aString Some text.
+         * @throws Exception Some text.
+         */
+        void method2(String aString) throws Exception {}
+
+        /**
+         * Some text.
+         * @deprecated Some text.
+         * @throws Exception Some text.
+         */
+        void method3() throws Exception {}
+
+        /**
+         * Some text.
+         * @throws Exception Some text.
+         * @serialData Some javadoc.
+         * @return Some text.
+         */
+        String method4() throws Exception
+        {
+            return "null";
+        }
+
+        /**
+         * Some text.
+         * @param aString Some text.
+         * @deprecated Some text.
+         * @return Some text.
+         */
+        String method5(String aString)
+        {
+            return "null";
+        }
+
+        /**
+         * Some text.
+         * @param aString Some text.
+         * @return Some text.
+         * @param aInt Some text.
+         * @throws Exception Some text.
+         * @param aBoolean Some text.
+         * @deprecated Some text.
+         */
+        String method6(String aString, int aInt, boolean aBoolean) throws Exception
+        {
+            return "null";
+        }
+    }
+
+    InnerClassWithAnnotations anon = new InnerClassWithAnnotations()
+    {
+        /**
+         * Some text.
+         * @throws Exception Some text.
+         * @param aString Some text.
+         * @serialData Some javadoc.
+         * @deprecated Some text.
+         * @return Some text.
+         */
+        String method(String aString) throws Exception
+        {
+            return "null";
+        }
+
+        /**
+         * Some text.
+         * @param aString Some text.
+         * @throws Exception Some text.
+         * @return Some text.
+         */
+        String method1(String aString) throws Exception
+        {
+            return "null";
+        }
+
+        /**
+         * Some text.
+         * @throws Exception Some text.
+         * @param aString Some text.
+         */
+        void method2(String aString) throws Exception {}
+
+        /**
+         * Some text.
+         * @deprecated Some text.
+         * @throws Exception Some text.
+         */
+        void method3() throws Exception {}
+
+        /**
+         * Some text.
+         * @throws Exception Some text.
+         * @return Some text.
+         */
+        String method4() throws Exception
+        {
+            return "null";
+        }
+
+        /**
+         * Some text.
+         * @deprecated Some text.
+         * @return Some text.
+         * @param aString Some text.
+         */
+        String method5(String aString)
+        {
+            return "null";
+        }
+
+        /**
+         * Some text.
+         * @param aString Some text.
+         * @return Some text.
+         * @param aInt Some text.
+         * @throws Exception Some text.
+         * @param aBoolean Some text.
+         * @deprecated Some text.
+         */
+        String method6(String aString, int aInt, boolean aBoolean) throws Exception
+        {
+            return "null";
+        }
+    };
+}
+
+/**
+ * Some javadoc.
+ *
+ * @since Some javadoc.
+ * @version 1.0
+ * @deprecated Some javadoc.
+ * @see Some javadoc.
+ * @author max
+ */
+enum Foo6 {}
+
+/**
+ * Some javadoc.
+ *
+ * @version 1.0
+ * @since Some javadoc.
+ * @serialData Some javadoc.
+ * @author max
+ */
+interface FooInterface {
+    /**
+     * @value tag without specified order by default
+     */
+    int CONSTANT = 0;
+}


### PR DESCRIPTION
Issue #9533: update AtclauseOrderCheckTest to use unique Input file in each test method

Added a few minor commits to update existing input files and removed corresponding suppression (https://github.com/checkstyle/checkstyle/pull/9613/commits/a92ea914b23e8825d3aba5c49f03baa6f3e70e2f) and to reformat (fix whitespace) in existing UT properties(https://github.com/checkstyle/checkstyle/pull/9613/commits/3ada3145503bee04a4a788e2b85b9643a4b829f6).

Note that warn/violation comments in https://github.com/checkstyle/checkstyle/pull/9613/commits/3ada3145503bee04a4a788e2b85b9643a4b829f6 changed location to match the existing UT, as they were not consistent.