### PR TITLE
Issue #9577: add code example of AST for TokenTypes.STRICTFP

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1048,6 +1048,22 @@ public final class TokenTypes {
     /**
      * The {@code strictfp} keyword.
      *
+     * <p>For example:</p>
+     * <pre>public strictfp class Test {}</pre>
+     *
+     * <p>parses as:</p>
+     * <pre>
+     * CLASS_DEF -&gt; CLASS_DEF
+     * |--MODIFIERS -&gt; MODIFIERS
+     * |   |--LITERAL_PUBLIC -&gt; public
+     * |   `--STRICTFP -&gt; strictfp
+     * |--LITERAL_CLASS -&gt; class
+     * |--IDENT -&gt; Test
+     * `--OBJBLOCK -&gt; OBJBLOCK
+     *     |--LCURLY -&gt; {
+     *     `--RCURLY -&gt; }
+     * </pre>
+     *
      * @see #MODIFIERS
      **/
     public static final int STRICTFP = GeneratedJavaTokenTypes.STRICTFP;


### PR DESCRIPTION
Closes: #9577 
![image](https://user-images.githubusercontent.com/56120837/111423704-b162bb00-8716-11eb-8abb-decadf6b6a6b.png)

```
**Test.java**
λ cat Test.java
public strictfp class Test {}

**AST**
λ java -jar checkstyle-8.41-all.jar -t Test.java
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   |--LITERAL_PUBLIC -> public [1:0]
|   `--STRICTFP -> strictfp [1:7]
|--LITERAL_CLASS -> class [1:16]
|--IDENT -> Test [1:22]
`--OBJBLOCK -> OBJBLOCK [1:27]
    |--LCURLY -> { [1:27]
    `--RCURLY -> } [1:28]
```

### Expected update for javadoc

```
CLASS_DEF -> CLASS_DEF
|--MODIFIERS -> MODIFIERS
|   |--LITERAL_PUBLIC -> public
|   `--STRICTFP -> strictfp
|--LITERAL_CLASS -> class
|--IDENT -> Test
`--OBJBLOCK -> OBJBLOCK
    |--LCURLY -> {
    `--RCURLY -> }
```