### PR TITLE
Issue #9596: updates example of AST for TokenTypes.WILDCARD_TYPE

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -3382,6 +3382,35 @@ public final class TokenTypes {
      * This node has one child - the type that is being used for
      * the bounding.
      *
+     * <p>For example:</p>
+     *
+     * <pre>
+     *     Unknown Type
+     * </pre>
+     *
+     * <p>parses as:</p>
+     *
+     * <pre>
+     * +--VARIABLE_DEF
+     *     |
+     *     +--MODIFIERS
+     *         |
+     *         +--LITERAL_PUBLIC (public)
+     *     +--TYPE
+     *         |
+     *         +--IDENT (Collection)
+     *             |
+     *             +--TYPE_UPPER_BOUNDS
+     *                 |
+     *                 +--GENERIC_START (&lt;)
+     *                 +--TYPE_UPPER_BOUND
+     *                     |
+     *                     +--WILDCARD_TYPE (?)
+     *                 +--GENERIC_END (&gt;)
+     *     +--IDENT (a)
+     *     +--SEMI (;)
+     * </pre>
+     *
      * @see <a href="https://www.jcp.org/en/jsr/detail?id=14">
      * JSR14</a>
      * @see #TYPE_PARAMETER


### PR DESCRIPTION
Issue #9596: updates example of AST for TokenTypes.WILDCARD_TYPE
Before:
![a](https://user-images.githubusercontent.com/64313783/111485620-c82c0080-875c-11eb-9a34-1648449df44c.jpg)
After:
![B](https://user-images.githubusercontent.com/64313783/111485637-cbbf8780-875c-11eb-8dcb-2cbfcef8c5b7.jpg)
