### PR TITLE
Issue #9544: Added example of AST for TokenTypes.NUM_DOUBLE

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -2787,6 +2787,19 @@ public final class TokenTypes {
      * point number with an optional {@code D} or {@code d}
      * suffix.
      *
+     * <p>For example:</p>
+     * <pre>
+     * a = 3.14d;
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * |--EXPR -&gt; EXPR
+     * |   `--ASSIGN -&gt; =
+     * |       |--IDENT -&gt; a
+     * |       `--NUM_DOUBLE -&gt; 3.14d
+     * |--SEMI -&gt; ;
+     * </pre>
+     *
      * @see <a
      * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.2">Java
      * Language Specification, &sect;3.10.2</a>


### PR DESCRIPTION
Resolves #9544 

![image](https://user-images.githubusercontent.com/52609734/111486054-2822a700-875d-11eb-9f51-770e117a9220.png)


```
>cat Test.java
public class Test {
    void foo(double a) {
      a = 3.14d;
    }
}

>java -jar checkstyle-8.41-all.jar -t Test.java
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> Test [1:13]
`--OBJBLOCK -> OBJBLOCK [1:18]
    |--LCURLY -> { [1:18]
    |--METHOD_DEF -> METHOD_DEF [2:4]
    |   |--MODIFIERS -> MODIFIERS [2:4]
    |   |--TYPE -> TYPE [2:4]
    |   |   `--LITERAL_VOID -> void [2:4]
    |   |--IDENT -> foo [2:9]
    |   |--LPAREN -> ( [2:12]
    |   |--PARAMETERS -> PARAMETERS [2:13]
    |   |   `--PARAMETER_DEF -> PARAMETER_DEF [2:13]
    |   |       |--MODIFIERS -> MODIFIERS [2:13]
    |   |       |--TYPE -> TYPE [2:13]
    |   |       |   `--LITERAL_DOUBLE -> double [2:13]
    |   |       `--IDENT -> a [2:20]
    |   |--RPAREN -> ) [2:21]
    |   `--SLIST -> { [2:23]
    |       |--EXPR -> EXPR [3:8]
    |       |   `--ASSIGN -> = [3:8]
    |       |       |--IDENT -> a [3:6]
    |       |       `--NUM_DOUBLE -> 3.14d [3:10]
    |       |--SEMI -> ; [3:15]
    |       `--RCURLY -> } [4:4]
    `--RCURLY -> } [5:0]


```