### PR TITLE
Issue #9545: Added example of AST for TokenTypes.NUM_FLOAT

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -2763,6 +2763,19 @@ public final class TokenTypes {
      * A single precision floating point literal.  This is a floating
      * point number with an {@code F} or {@code f} suffix.
      *
+     * <p>For example:</p>
+     * <pre>
+     * a = 3.14f;
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * |--EXPR -&gt; EXPR
+     * |   `--ASSIGN -&gt; =
+     * |       |--IDENT -&gt; a
+     * |       `--NUM_FLOAT -&gt; 3.14f
+     * |--SEMI -&gt; ;
+     * </pre>
+     *
      * @see <a
      * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.2">Java
      * Language Specification, &sect;3.10.2</a>


### PR DESCRIPTION
Resolves #9545 

![image](https://user-images.githubusercontent.com/52609734/111491247-b4cf6400-8761-11eb-9c19-0a3a11cc9d0d.png)


```

>cat Test.java
public class Test {
    void foo(float a) {
      a = 3.14f;
    }
}

>java -jar checkstyle-8.41-all.jar -t Test.java
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> Test [1:13]
`--OBJBLOCK -> OBJBLOCK [1:18]
    |--LCURLY -> { [1:18]
    |--METHOD_DEF -> METHOD_DEF [2:4]
    |   |--MODIFIERS -> MODIFIERS [2:4]
    |   |--TYPE -> TYPE [2:4]
    |   |   `--LITERAL_VOID -> void [2:4]
    |   |--IDENT -> foo [2:9]
    |   |--LPAREN -> ( [2:12]
    |   |--PARAMETERS -> PARAMETERS [2:13]
    |   |   `--PARAMETER_DEF -> PARAMETER_DEF [2:13]
    |   |       |--MODIFIERS -> MODIFIERS [2:13]
    |   |       |--TYPE -> TYPE [2:13]
    |   |       |   `--LITERAL_FLOAT -> float [2:13]
    |   |       `--IDENT -> a [2:19]
    |   |--RPAREN -> ) [2:20]
    |   `--SLIST -> { [2:22]
    |       |--EXPR -> EXPR [3:8]
    |       |   `--ASSIGN -> = [3:8]
    |       |       |--IDENT -> a [3:6]
    |       |       `--NUM_FLOAT -> 3.14f [3:10]
    |       |--SEMI -> ; [3:15]
    |       `--RCURLY -> } [4:4]
    `--RCURLY -> } [5:0]

```