### PR TITLE
Issue #9547: Added example of AST for TokenTypes.NUM_LONG

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -2775,6 +2775,19 @@ public final class TokenTypes {
      * literals, but they have an {@code L} or {@code l}
      * (ell) suffix.
      *
+     * <p>For example:</p>
+     * <pre>
+     * a = 3l;
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * |--EXPR -&gt; EXPR
+     * |   `--ASSIGN -&gt; =
+     * |       |--IDENT -&gt; a
+     * |       `--NUM_LONG -&gt; 3l
+     * |--SEMI -&gt; ;
+     * </pre>
+     *
      * @see <a
      * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.1">Java
      * Language Specification, &sect;3.10.1</a>


### PR DESCRIPTION
Resolves #9547 

![image](https://user-images.githubusercontent.com/52609734/111493220-5efbbb80-8763-11eb-8129-823ad2681a08.png)


```
C:\Users\Shashwat>cat Test.java
public class Test {
    void foo(long a) {
      a = 3l;
    }
}

C:\Users\Shashwat>java -jar checkstyle-8.41-all.jar -t Test.java
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> Test [1:13]
`--OBJBLOCK -> OBJBLOCK [1:18]
    |--LCURLY -> { [1:18]
    |--METHOD_DEF -> METHOD_DEF [2:4]
    |   |--MODIFIERS -> MODIFIERS [2:4]
    |   |--TYPE -> TYPE [2:4]
    |   |   `--LITERAL_VOID -> void [2:4]
    |   |--IDENT -> foo [2:9]
    |   |--LPAREN -> ( [2:12]
    |   |--PARAMETERS -> PARAMETERS [2:13]
    |   |   `--PARAMETER_DEF -> PARAMETER_DEF [2:13]
    |   |       |--MODIFIERS -> MODIFIERS [2:13]
    |   |       |--TYPE -> TYPE [2:13]
    |   |       |   `--LITERAL_LONG -> long [2:13]
    |   |       `--IDENT -> a [2:18]
    |   |--RPAREN -> ) [2:19]
    |   `--SLIST -> { [2:21]
    |       |--EXPR -> EXPR [3:8]
    |       |   `--ASSIGN -> = [3:8]
    |       |       |--IDENT -> a [3:6]
    |       |       `--NUM_LONG -> 3l [3:10]
    |       |--SEMI -> ; [3:12]
    |       `--RCURLY -> } [4:4]
    `--RCURLY -> } [5:0]
```
