### PR TITLE
Issue #9593: update example of AST for TokenTypes.UNARY_MINUS

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -928,6 +928,28 @@ public final class TokenTypes {
     /**
      * The {@code +} (unary plus) operator.
      *
+     * <p>For example:</p>
+     *
+     *  <pre>
+     *   a=-b;
+     * </pre>
+     *
+     * <p>parses as:</p>
+     *
+     * <pre>
+     *   +--UNARY_MINUS
+     *       |
+     *       +--EXPR
+     *          |
+     *          +--ASSIGN (=)
+     *              |
+     *              +--IDENT (a)
+     *              +--MINUS (-)
+     *                  |
+     *                  +--IDENT (b)
+     *   +--SEMI (;)
+     * </pre>
+     *
      * @see <a
      * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.15.3">Java
      * Language Specification, &sect;15.15.3</a>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -919,15 +919,6 @@ public final class TokenTypes {
     /**
      * The {@code -} (unary minus) operator.
      *
-     * @see <a
-     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.15.4">Java
-     * Language Specification, &sect;15.15.4</a>
-     * @see #EXPR
-     **/
-    public static final int UNARY_MINUS = GeneratedJavaTokenTypes.UNARY_MINUS;
-    /**
-     * The {@code +} (unary plus) operator.
-     *
      * <p>For example:</p>
      *
      *  <pre>
@@ -949,6 +940,15 @@ public final class TokenTypes {
      *                  +--IDENT (b)
      *   +--SEMI (;)
      * </pre>
+     *
+     * @see <a
+     * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.15.4">Java
+     * Language Specification, &sect;15.15.4</a>
+     * @see #EXPR
+     **/
+    public static final int UNARY_MINUS = GeneratedJavaTokenTypes.UNARY_MINUS;
+    /**
+     * The {@code +} (unary plus) operator.
      *
      * @see <a
      * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.15.3">Java


### PR DESCRIPTION
Issue #9593: update example of AST for TokenTypes.UNARY_MINUS
BEFORE:
![be](https://user-images.githubusercontent.com/64313783/111504197-6de76b80-876d-11eb-84eb-618149d56690.jpg)

AFTER:
![af](https://user-images.githubusercontent.com/64313783/111504094-56a87e00-876d-11eb-94f7-90ad1933e1c4.jpg)

