### PR TITLE
Issue #7572: update doc for MissingDeprecated

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
@@ -85,15 +85,63 @@ import com.puppycrawl.tools.checkstyle.utils.AnnotationUtil;
  * &lt;module name=&quot;MissingDeprecated&quot;/&gt;
  * </pre>
  * <p>
- * Examples of validating source code:
+ * Example:
  * </p>
  * <pre>
  * &#64;Deprecated
- * public static final int MY_CONST = 123456; // no violation
+ * public static final int MY_CONST = 13; // ok
  *
  * &#47;** This javadoc is missing deprecated tag. *&#47;
  * &#64;Deprecated
  * public static final int COUNTER = 10; // violation
+ *
+ * &#47;**
+ *  * &#64;deprecated
+ *  * &lt;p&gt;&lt;/p&gt;
+ *  *&#47;
+ * &#64;Deprecated
+ * public static final int NUM = 123456; // ok
+ *
+ * &#47;**
+ *  * &#64;deprecated
+ *  * &lt;p&gt;
+ *  *&#47;
+ * &#64;Deprecated
+ * public static final int CONST = 12; // ok
+ * </pre>
+ * <p>
+ * To configure the check such that it prints violation
+ * messages if tight HTML rules are not obeyed
+ * </p>
+ * <pre>
+ * &lt;module name="MissingDeprecated"&gt;
+ *   &lt;property name="violateExecutionOnNonTightHtml" value="true"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * &#64;Deprecated
+ * public static final int MY_CONST = 13; // ok
+ *
+ * &#47;** This javadoc is missing deprecated tag. *&#47;
+ * &#64;Deprecated
+ * public static final int COUNTER = 10; // violation
+ *
+ * &#47;**
+ *  * &#64;deprecated
+ *  * &lt;p&gt;&lt;/p&gt;
+ *  *&#47;
+ * &#64;Deprecated
+ * public static final int NUM = 123456; // ok
+ *
+ * &#47;**
+ *  * &#64;deprecated
+ *  * &lt;p&gt;
+ *  *&#47;
+ * &#64;Deprecated
+ * public static final int CONST = 12; // violation, tight HTML rules not obeyed
  * </pre>
  * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -771,14 +771,62 @@ class TestTwo {
         <source>
 &lt;module name=&quot;MissingDeprecated&quot;/&gt;
         </source>
-        <p>Examples of validating source code:</p>
+        <p>Example:</p>
         <source>
 @Deprecated
-public static final int MY_CONST = 123456; // no violation
+public static final int MY_CONST = 13; // ok
 
 /** This javadoc is missing deprecated tag. */
 @Deprecated
 public static final int COUNTER = 10; // violation
+
+/**
+ * @deprecated
+ * &lt;p&gt;&lt;/p&gt;
+ */
+@Deprecated
+public static final int NUM = 123456; // ok
+
+/**
+ * @deprecated
+ *  &lt;p&gt;
+ */
+@Deprecated
+public static final int CONST = 12; // ok
+        </source>
+        <p>
+          To configure the check such that it prints violation
+          messages if tight HTML rules are not obeyed
+        </p>
+        <source>
+&lt;module name="MissingDeprecated"&gt;
+  &lt;property name="violateExecutionOnNonTightHtml" value="true"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+@Deprecated
+public static final int MY_CONST = 13; // ok
+
+/** This javadoc is missing deprecated tag. */
+@Deprecated
+public static final int COUNTER = 10; // violation
+
+/**
+ * @deprecated
+ * &lt;p&gt;&lt;/p&gt;
+ */
+@Deprecated
+public static final int NUM = 123456; // ok
+
+/**
+ * @deprecated
+ * &lt;p&gt;
+ */
+@Deprecated
+public static final int CONST = 12; // violation, tight HTML rules not obeyed
         </source>
       </subsection>
 


### PR DESCRIPTION
Closes : #7572

![image](https://user-images.githubusercontent.com/42171790/111506809-0848ae80-8770-11eb-9850-e02abfedd22c.png)

`$ cat config.xml`

```
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
   <module name="TreeWalker">
      <module name="MissingDeprecated"/>
   </module>
</module>


```

`$ cat Demo.java`

```
class Demo{

@Deprecated
public static final int MY_CONST=13; // ok

/** This javadoc is missing deprecated tag. */
@Deprecated
public static final int COUNTER = 10; // violation

/** @deprecated
 * <p></p>
 */
@Deprecated
public static final int NUM = 123456; // ok


/**
 * @deprecated
 *  <p>
 */
    @Deprecated
    public static final int CONST=12; // ok
    public static void main(String args[]) {

    }


```


`$ java -jar checkstyle-8.39-all.jar -c config.xml Demo.java`

```
Starting audit...
[ERROR] E:\New folder\Java Dev\src\com\company\Demo.java:7: Must include both @java.lang.Deprecated annotation and @deprecated Javadoc tag with description. [MissingDeprecated]
Audit done.
Checkstyle ends with 1 errors.

```

![image](https://user-images.githubusercontent.com/42171790/111507278-81480600-8770-11eb-87f0-b74a7be07091.png)


`$ cat config.xml`


```
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
   <module name="TreeWalker">
      <module name="MissingDeprecated">
         <property name="violateExecutionOnNonTightHtml" value="true"/>
      </module>
   </module>
</module>

```

`$ cat Demo.java`

```
class Demo{

@Deprecated
public static final int MY_CONST=13; // ok

/** This javadoc is missing deprecated tag. */
@Deprecated
public static final int COUNTER = 10; // violation

/** @deprecated
 * <p></p>
 */
@Deprecated
public static final int NUM = 123456; // ok


/**
 * @deprecated
 *  <p>
 */
    @Deprecated
    public static final int CONST=12; // violation
    public static void main(String args[]) {

    }
}

```

`$ java -jar checkstyle-8.39-all.jar -c config.xml Demo.java`

```
Starting audit...
[ERROR] E:\New folder\Java Dev\src\com\company\Demo.java:7: Must include both @java.lang.Deprecated annotation and @deprecated Javadoc tag with description. [MissingDeprecated]
[ERROR] E:\New folder\Java Dev\src\com\company\Demo.java:19: javadoc.unclosedHtml [MissingDeprecated]
Audit done.
Checkstyle ends with 2 errors.
```
