### PR TITLE
Issue #9399: Updated the example of AST for TokenTypes.BLOCK_COMMENT_BEGIN

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -3973,12 +3973,16 @@ public final class TokenTypes {
 
     /**
      * Beginning of block comment: '/*'.
-     *
+     * <p>For example:</p>
      * <pre>
-     * +--BLOCK_COMMENT_BEGIN
-     *         |
-     *         +--COMMENT_CONTENT
-     *         +--BLOCK_COMMENT_END
+     * /&#42; Comment content
+     * &#42;/
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * --BLOCK_COMMENT_BEGIN -&gt; /&#42;
+     *    |--COMMENT_CONTENT -&gt;  Comment content\r\n
+     *    `--BLOCK_COMMENT_END -&gt; &#42;/
      * </pre>
      */
     public static final int BLOCK_COMMENT_BEGIN =


### PR DESCRIPTION
Closes: #9399 
![CheckStyle_PR_photo](https://user-images.githubusercontent.com/62554685/112132277-6d792580-8bf0-11eb-8705-0cdef9d84540.png)


```
$ cat Test.java

public class Test {
    void block_comment_begin(){
        /* Comment content
        */
    }
}
```
AST in CLI for the above Java file:-
```
$ java -jar checkstyle-8.41-all.jar -T Test.java
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> Test [1:13]
`--OBJBLOCK -> OBJBLOCK [1:18]
    |--LCURLY -> { [1:18]
    |--METHOD_DEF -> METHOD_DEF [2:4]
    |   |--MODIFIERS -> MODIFIERS [2:4]
    |   |--TYPE -> TYPE [2:4]
    |   |   `--LITERAL_VOID -> void [2:4]
    |   |--IDENT -> block_comment_begin [2:9]
    |   |--LPAREN -> ( [2:28]
    |   |--PARAMETERS -> PARAMETERS [2:29]
    |   |--RPAREN -> ) [2:29]
    |   `--SLIST -> { [2:30]
    |       |--BLOCK_COMMENT_BEGIN -> /* [3:8]
    |       |   |--COMMENT_CONTENT ->  Comment content\r\n          [3:10]
    |       |   `--BLOCK_COMMENT_END -> */ [4:9]
    |       `--RCURLY -> } [5:4]
    `--RCURLY -> } [6:0]
```
```
# printing lines we are concerned with:-
$ java -jar checkstyle-8.41-all.jar -T Test.java | grep "3:\|4:"

|       |--BLOCK_COMMENT_BEGIN -> /* [3:8]
|       |   |--COMMENT_CONTENT ->  Comment content\r\n          [3:10]
|       |   `--BLOCK_COMMENT_END -> */ [4:9]
```
expected update for javadoc is:-
```
--BLOCK_COMMENT_BEGIN -&gt; /*
   |--COMMENT_CONTENT -&gt;  Comment content\r\n
   `--BLOCK_COMMENT_END -&gt; */
```
Hence, updated the code accordingly.
