### PR TITLE
Issue #7417: change scope to access modifier in JavadocMethodCheck

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -852,6 +852,7 @@ Niederhauser
 nikitasavinov
 nio
 nlow
+nmancus
 NMTOKEN
 noarch
 noarg

--- a/.ci/travis/travis.sh
+++ b/.ci/travis/travis.sh
@@ -266,7 +266,7 @@ no-error-xwiki)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo version:$CS_POM_VERSION
   mvn -e --no-transfer-progress clean install -Pno-validations
-  checkout_from https://github.com/xwiki/xwiki-commons.git
+  checkout_from "-b checkstyle_7417 https://github.com/nmancus1/xwiki-commons.git"
   cd .ci-temp/xwiki-commons
   # Build custom Checkstyle rules
   mvn -e --no-transfer-progress -f \

--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -111,12 +111,21 @@ nondex)
 no-error-pmd)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo "CS_version: ${CS_POM_VERSION}"
-  mkdir -p .ci-temp/
-  cd .ci-temp/
+  checkout_from "-b checkstyle-7417 https://github.com/nmancus1/build-tools.git"
+  cd .ci-temp/build-tools/
+  PMD_POM_VERSION=$(mvn -e --no-transfer-progress -q -Dexec.executable='echo' \
+    -Dexec.args='${project.version}' \
+     --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
+  mvn -e --no-transfer-progress install
+  cd ..
   git clone https://github.com/pmd/pmd.git
   cd pmd
-  mvn -e --no-transfer-progress install checkstyle:check -Dcheckstyle.version=${CS_POM_VERSION}
+  # Using specific commit so that build-tools dependencies match
+  git checkout 342dc1d03aaa1082e42f7496d6869d15859af321
+  mvn -e --no-transfer-progress install checkstyle:check -Dcheckstyle.version=${CS_POM_VERSION} \
+    -Dpmd.build-tools.version=${PMD_POM_VERSION}
   cd ..
+  removeFolderWithProtectedFiles build-tools
   removeFolderWithProtectedFiles pmd
   ;;
 

--- a/.ci/wercker.sh
+++ b/.ci/wercker.sh
@@ -88,8 +88,9 @@ no-error-apex-core)
 no-error-equalsverifier)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo CS_version: ${CS_POM_VERSION}
-  checkout_from https://github.com/jqno/equalsverifier.git
+  checkout_from https://github.com/checkstyle/equalsverifier.git
   cd .ci-temp/equalsverifier
+  git checkout checkstyle_7417
   mvn -e --no-transfer-progress compile checkstyle:check -Dcheckstyle.version=${CS_POM_VERSION}
   cd ../
   removeFolderWithProtectedFiles equalsverifier

--- a/pom.xml
+++ b/pom.xml
@@ -3217,6 +3217,9 @@
                 <param>
                   com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheckTest
                 </param>
+                <param>
+                  com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheckTest
+                </param>
               </targetTests>
               <excludedTestClasses>
                 <param>*.Input*</param>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
-import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
 
 /**
  * <p>
@@ -230,38 +229,16 @@ public class ParameterNameCheck extends AbstractNameCheck {
     @Override
     protected boolean mustCheckName(DetailAST ast) {
         boolean checkName = true;
+        final DetailAST parent = ast.getParent();
         if (ignoreOverridden && isOverriddenMethod(ast)
-                || ast.getParent().getType() == TokenTypes.LITERAL_CATCH
-                || ast.getParent().getParent().getType() == TokenTypes.LAMBDA
+                || parent.getType() == TokenTypes.LITERAL_CATCH
+                || parent.getParent().getType() == TokenTypes.LAMBDA
                 || CheckUtil.isReceiverParameter(ast)
-                || !matchAccessModifiers(getAccessModifier(ast))) {
+                || !matchAccessModifiers(
+                        CheckUtil.getAccessModifierFromModifiersToken(parent.getParent()))) {
             checkName = false;
         }
         return checkName;
-    }
-
-    /**
-     * Returns the access modifier of the method/constructor at the specified AST. If
-     * the method is in an interface or annotation block, the access modifier is assumed
-     * to be public.
-     *
-     * @param ast the token of the method/constructor.
-     * @return the access modifier of the method/constructor.
-     */
-    private static AccessModifierOption getAccessModifier(final DetailAST ast) {
-        final AccessModifierOption accessModifier;
-
-        if (ScopeUtil.isInInterfaceOrAnnotationBlock(ast)) {
-            accessModifier = AccessModifierOption.PUBLIC;
-        }
-        else {
-            final DetailAST params = ast.getParent();
-            final DetailAST meth = params.getParent();
-            final DetailAST modsToken = meth.findFirstToken(TokenTypes.MODIFIERS);
-            accessModifier = CheckUtil.getAccessModifierFromModifiersToken(modsToken);
-        }
-
-        return accessModifier;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/RecordComponentNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/RecordComponentNumberCheck.java
@@ -198,10 +198,8 @@ public class RecordComponentNumberCheck extends AbstractCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
-        final DetailAST modifiers =
-            ast.findFirstToken(TokenTypes.MODIFIERS);
         final AccessModifierOption accessModifier =
-            CheckUtil.getAccessModifierFromModifiersToken(modifiers);
+            CheckUtil.getAccessModifierFromModifiersToken(ast);
 
         if (matchAccessModifiers(accessModifier)) {
             final DetailAST recordComponents =

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocMethodCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocMethodCheck.xml
@@ -6,9 +6,6 @@
              parent="com.puppycrawl.tools.checkstyle.TreeWalker">
          <description>&lt;p&gt;
  Checks the Javadoc of a method or constructor.
- The scope to verify is specified using the {@code Scope} class and defaults
- to {@code Scope.PRIVATE}. To verify another scope, set property scope to
- a different &lt;a href="https://checkstyle.org/property_types.html#Scope"&gt;scope&lt;/a&gt;.
  &lt;/p&gt;
  &lt;p&gt;
  Violates parameters and type parameters for which no param tags are present can
@@ -73,14 +70,11 @@
             <property default-value="false" name="validateThrows" type="boolean">
                <description>Control whether to validate {@code throws} tags.</description>
             </property>
-            <property default-value="private"
-                      name="scope"
-                      type="com.puppycrawl.tools.checkstyle.api.Scope">
-               <description>Specify the visibility scope where Javadoc comments are checked.</description>
-            </property>
-            <property name="excludeScope" type="com.puppycrawl.tools.checkstyle.api.Scope">
-               <description>Specify the visibility scope where Javadoc comments
- are not checked.</description>
+            <property default-value="public, protected, package, private"
+                      name="accessModifiers"
+                      type="com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption[]">
+               <description>Specify the access modifiers where Javadoc comments are
+ checked.</description>
             </property>
             <property default-value="false" name="allowMissingParamTags" type="boolean">
                <description>Control whether to ignore violations

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -321,7 +321,7 @@
                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
     </module>
     <module name="JavadocMethod">
-      <property name="scope" value="public"/>
+      <property name="accessModifiers" value="public"/>
       <property name="allowMissingParamTags" value="true"/>
       <property name="allowMissingReturnTag" value="true"/>
       <property name="allowedAnnotations" value="Override, Test"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
@@ -194,17 +193,16 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testNoJavadoc() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(JavadocMethodCheck.class);
-        checkConfig.addAttribute("scope", Scope.NOTHING.getName());
-        final String[] expected = {
-        };
-        verify(checkConfig, getPath("InputJavadocMethodNoScopeJavadoc.java"), expected);
+        checkConfig.addAttribute("accessModifiers", "");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputJavadocMethodPublicOnly.java"), expected);
     }
 
     // pre 1.4 relaxed mode is roughly equivalent with check=protected
     @Test
     public void testRelaxedJavadoc() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(JavadocMethodCheck.class);
-        checkConfig.addAttribute("scope", Scope.PROTECTED.getName());
+        checkConfig.addAttribute("accessModifiers", "public, protected");
         final String[] expected = {
             "79:41: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aA"),
             "84:37: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "aA"),
@@ -215,7 +213,7 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testScopeInnerInterfacesPublic() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(JavadocMethodCheck.class);
-        checkConfig.addAttribute("scope", Scope.PUBLIC.getName());
+        checkConfig.addAttribute("accessModifiers", "public");
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputJavadocMethodScopeInnerInterfaces.java"), expected);
     }
@@ -223,24 +221,9 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testScopeAnonInnerPrivate() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(JavadocMethodCheck.class);
-        checkConfig.addAttribute("scope", Scope.PRIVATE.getName());
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("InputJavadocMethodScopeAnonInnerPrivate.java"), expected);
-    }
-
-    @Test
-    public void testScopeAnonInnerAnonInner() throws Exception {
-        final DefaultConfiguration checkConfig = createModuleConfig(JavadocMethodCheck.class);
-        checkConfig.addAttribute("scope", Scope.ANONINNER.getName());
+        checkConfig.addAttribute("accessModifiers", "public, protected, package, private");
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputJavadocMethodScopeAnonInner.java"), expected);
-    }
-
-    @Test
-    public void testScopeAnonInnerWithResolver() throws Exception {
-        final DefaultConfiguration checkConfig = createModuleConfig(JavadocMethodCheck.class);
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        verify(checkConfig, getPath("InputJavadocMethodScopeAnonInnerDefault.java"), expected);
     }
 
     @Test
@@ -258,7 +241,7 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testScopes2() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(JavadocMethodCheck.class);
-        checkConfig.addAttribute("scope", Scope.PROTECTED.getName());
+        checkConfig.addAttribute("accessModifiers", "public, protected");
         final String[] expected = {
             "19: " + getCheckMessage(MSG_UNUSED_TAG_GENERAL),
             "21: " + getCheckMessage(MSG_UNUSED_TAG_GENERAL),
@@ -269,8 +252,7 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testExcludeScope() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(JavadocMethodCheck.class);
-        checkConfig.addAttribute("scope", Scope.PRIVATE.getName());
-        checkConfig.addAttribute("excludeScope", Scope.PROTECTED.getName());
+        checkConfig.addAttribute("accessModifiers", "private, package, public");
         final String[] expected = {
             "20: " + getCheckMessage(MSG_UNUSED_TAG_GENERAL),
             "24: " + getCheckMessage(MSG_UNUSED_TAG_GENERAL),
@@ -287,6 +269,14 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputJavadocMethodMissingJavadocNoMissingTags.java"),
                 expected);
+    }
+
+    @Test
+    public void testSurroundingAccessModifier() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(JavadocMethodCheck.class);
+        checkConfig.addAttribute("accessModifiers", "private");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verify(checkConfig, getPath("InputJavadocMethodSurroundingAccessModifier.java"), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
@@ -154,19 +154,6 @@ public class CheckUtilTest extends AbstractPathTestSupport {
     }
 
     @Test
-    public void testGetAccessModifierFromModifiersTokenWithNullParameter() {
-        try {
-            CheckUtil.getAccessModifierFromModifiersToken(null);
-            fail(IllegalArgumentException.class.getSimpleName() + " was expected.");
-        }
-        catch (IllegalArgumentException exc) {
-            final String expectedExceptionMsg = "expected non-null AST-token with type 'MODIFIERS'";
-            final String actualExceptionMsg = exc.getMessage();
-            assertEquals(expectedExceptionMsg, actualExceptionMsg, "Invalid exception message");
-        }
-    }
-
-    @Test
     public void testCreateFullType() throws Exception {
         final DetailAST typeNode = getNodeFromFile(TokenTypes.TYPE);
 
@@ -270,24 +257,31 @@ public class CheckUtilTest extends AbstractPathTestSupport {
 
     @Test
     public void testGetAccessModifierFromModifiersToken() throws Exception {
+        final DetailAST interfaceDef = getNodeFromFile(TokenTypes.INTERFACE_DEF);
+        final AccessModifierOption modifierInterface = CheckUtil
+                .getAccessModifierFromModifiersToken(interfaceDef
+                        .findFirstToken(TokenTypes.OBJBLOCK)
+                        .findFirstToken(TokenTypes.METHOD_DEF));
+        assertEquals(AccessModifierOption.PUBLIC, modifierInterface, "Invalid access modifier");
+
         final DetailAST privateVariable = getNodeFromFile(TokenTypes.VARIABLE_DEF);
         final AccessModifierOption modifierPrivate =
-                CheckUtil.getAccessModifierFromModifiersToken(privateVariable.getFirstChild());
+                CheckUtil.getAccessModifierFromModifiersToken(privateVariable);
         assertEquals(AccessModifierOption.PRIVATE, modifierPrivate, "Invalid access modifier");
 
         final DetailAST protectedVariable = privateVariable.getNextSibling();
         final AccessModifierOption modifierProtected =
-                CheckUtil.getAccessModifierFromModifiersToken(protectedVariable.getFirstChild());
+                CheckUtil.getAccessModifierFromModifiersToken(protectedVariable);
         assertEquals(AccessModifierOption.PROTECTED, modifierProtected, "Invalid access modifier");
 
         final DetailAST publicVariable = protectedVariable.getNextSibling();
         final AccessModifierOption modifierPublic =
-                CheckUtil.getAccessModifierFromModifiersToken(publicVariable.getFirstChild());
+                CheckUtil.getAccessModifierFromModifiersToken(publicVariable);
         assertEquals(AccessModifierOption.PUBLIC, modifierPublic, "Invalid access modifier");
 
         final DetailAST packageVariable = publicVariable.getNextSibling();
         final AccessModifierOption modifierPackage =
-                CheckUtil.getAccessModifierFromModifiersToken(packageVariable.getFirstChild());
+                CheckUtil.getAccessModifierFromModifiersToken(packageVariable);
         assertEquals(AccessModifierOption.PACKAGE, modifierPackage, "Invalid access modifier");
     }
 
@@ -335,7 +329,8 @@ public class CheckUtilTest extends AbstractPathTestSupport {
     @Test
     public void testIsReceiverParameter() throws Exception {
         final DetailAST objBlock = getNodeFromFile(TokenTypes.OBJBLOCK);
-        final DetailAST methodWithReceiverParameter = objBlock.getLastChild().getPreviousSibling();
+        final DetailAST methodWithReceiverParameter = objBlock.getLastChild().getPreviousSibling()
+                .getPreviousSibling();
         final DetailAST receiverParameter =
                 getNode(methodWithReceiverParameter, TokenTypes.PARAMETER_DEF);
         final DetailAST simpleParameter =

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPublicOnly.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodPublicOnly.java
@@ -117,4 +117,34 @@ public class InputJavadocMethodPublicOnly // ignore - need javadoc
     {
         return super.hashCode();
     }
+
+    public Thread anonymousClassInMethod() {
+        return new Thread() {
+            @Override
+            public void run() {
+                privateMethod(null, null);
+            }
+
+            /**
+             * Javadoc
+             */
+            private String privateMethod(String a, String b) {
+                return null;
+            }
+        };
+    }
+
+    private final Thread anonymousClassInField = new Thread() {
+        @Override
+        public void run() {
+            publicMethod(null, null);
+        }
+
+        /**
+         * Javadoc
+         */
+        public String publicMethod(String a, String b) {
+            return null;
+        }
+    };
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodSurroundingAccessModifier.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodSurroundingAccessModifier.java
@@ -1,0 +1,212 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
+
+/* Config:
+ *
+ * accessModifiers = "private"
+ */
+public class InputJavadocMethodSurroundingAccessModifier //comment test
+{
+    public int i1;
+    protected int i2;
+    int i3;
+    private int i4;
+
+    public void foo1() {
+    }
+
+    protected void foo2() {
+    }
+
+    void foo3() {
+    }
+
+    private void foo4() {
+    }
+
+    /**
+     * @return // ok
+     */
+    public void foo5() {
+    }
+
+    /**
+     * @return // ok
+     */
+    protected void foo6() {
+    }
+
+    /**
+     * @return // ok
+     */
+    void foo7() {
+    }
+
+    /**
+     * @return // ok
+     */
+    private void foo8() {
+    }
+
+    protected class ProtectedInner {
+        public int i1;
+        protected int i2;
+        int i3;
+        private int i4;
+
+        public void foo1() {
+        }
+
+        protected void foo2() {
+        }
+
+        void foo3() {
+        }
+
+        private void foo4() {
+        }
+    }
+
+    class PackageInner {
+        public int i1;
+        protected int i2;
+        int i3;
+        private int i4;
+
+        public void foo1() {
+        }
+
+        protected void foo2() {
+        }
+
+        void foo3() {
+        }
+
+        private void foo4() {
+        }
+    }
+
+    private class PrivateInner {
+        public int i1;
+        protected int i2;
+        int i3;
+        private int i4;
+
+        public void foo1() {
+        }
+
+        protected void foo2() {
+        }
+
+        void foo3() {
+        }
+
+        private void foo4() {
+        }
+    }
+}
+
+class PackageClass2 {
+    public int i1;
+    protected int i2;
+    int i3;
+    private int i4;
+
+    public void foo1() {
+    }
+
+    protected void foo2() {
+    }
+
+    void foo3() {
+    }
+
+    private void foo4() {
+    }
+
+    public class PublicInner {
+        public int i1;
+        protected int i2;
+        int i3;
+        private int i4;
+
+        public void foo1() {
+        }
+
+        protected void foo2() {
+        }
+
+        void foo3() {
+        }
+
+        private void foo4() {
+        }
+    }
+
+    protected class ProtectedInner {
+        public int i1;
+        protected int i2;
+        int i3;
+        private int i4;
+
+        public void foo1() {
+        }
+
+        protected void foo2() {
+        }
+
+        void foo3() {
+        }
+
+        private void foo4() {
+        }
+    }
+
+    class PackageInner {
+        public int i1;
+        protected int i2;
+        int i3;
+        private int i4;
+
+        public void foo1() {
+        }
+
+        protected void foo2() {
+        }
+
+        void foo3() {
+        }
+
+        private void foo4() {
+        }
+    }
+
+    private class PrivateInner {
+        public int i1;
+        protected int i2;
+        int i3;
+        private int i4;
+
+        public void foo1() {
+        }
+
+        protected void foo2() {
+        }
+
+        void foo3() {
+        }
+
+        private void foo4() {
+        }
+    }
+
+    class IgnoredName {
+        // ignore by name
+        private int logger;
+        // no warning, 'serialVersionUID' fields do not require Javadoc
+        private static final long serialVersionUID = 0;
+    }
+
+    /**/
+    void methodWithTwoStarComment() {
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtilTest.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtilTest.java
@@ -67,4 +67,8 @@ public class InputCheckUtilTest<V, C> {
     }
 
     public void testReceiver(InputCheckUtilTest<V, C>this, int variable) {}
+
+    public interface Example {
+        void method();
+    }
 }

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -609,11 +609,7 @@ public void method();
       <p>Since Checkstyle 3.0</p>
       <subsection name="Description" id="JavadocMethod_Description">
         <p>
-          Checks the Javadoc of a method or constructor. The scope
-          to verify is specified using the <code>Scope</code> class and
-          defaults to <code>Scope.PRIVATE</code>. To verify another
-          scope, set property scope to a different
-          <a href="property_types.html#Scope">scope</a>.
+          Checks the Javadoc of a method or constructor.
         </p>
 
         <p>
@@ -711,18 +707,11 @@ public int checkReturnTag(final int aTagIndex,
               <td>6.0</td>
             </tr>
             <tr>
-              <td>scope</td>
-              <td>Specify the visibility scope where Javadoc comments are checked.</td>
-              <td><a href="property_types.html#Scope">Scope</a></td>
-              <td><code>private</code></td>
-              <td>3.0</td>
-            </tr>
-            <tr>
-              <td>excludeScope</td>
-              <td>Specify the visibility scope where Javadoc comments are not checked.</td>
-              <td><a href="property_types.html#Scope">Scope</a></td>
-              <td><code>null</code></td>
-              <td>3.4</td>
+              <td>accessModifiers</td>
+              <td>Specify the access modifiers where Javadoc comments are checked.</td>
+              <td><a href="property_types.html#access_modifiers">AccessModifierOption[]</a></td>
+              <td><code>public, protected, package, private</code></td>
+              <td>8.42</td>
             </tr>
             <tr>
               <td>allowMissingParamTags</td>
@@ -782,25 +771,24 @@ public int checkReturnTag(final int aTagIndex,
         </source>
 
         <p>
-          To configure the check for <code>public</code>
-          scope, ignoring any missing param tags is:
+          To configure the check for only <code>public</code>
+          modifier, ignoring any missing param tags is:
         </p>
 
         <source>
 &lt;module name=&quot;JavadocMethod&quot;&gt;
-  &lt;property name=&quot;scope&quot; value=&quot;public&quot;/&gt;
+  &lt;property name=&quot;accessModifiers&quot; value=&quot;public&quot;/&gt;
   &lt;property name=&quot;allowMissingParamTags&quot; value=&quot;true&quot;/&gt;
 &lt;/module&gt;
         </source>
 
         <p>
-          To configure the check for methods which are in <code>private</code>,
-          but not in <code>protected</code> scope:
+          To configure the check for methods which are in <code>private</code>
+          and <code>package</code>, but not any other modifier:
         </p>
         <source>
 &lt;module name="JavadocMethod"&gt;
-  &lt;property name="scope" value="private"/&gt;
-  &lt;property name="excludeScope" value="protected"/&gt;
+  &lt;property name="accessModifiers" value="private, package"/&gt;
 &lt;/module&gt;
         </source>
 


### PR DESCRIPTION
Issue #7417: change scope to access modifier in JavadocMethodCheck

1. Need regression reports for JavadocMethodCheck, and RecordComponentNumberCheck.

Failing CI:

1. `./.ci/wercker.sh no-error-equalsverifier` - [uses scope property in config](https://app.wercker.com/checkstyle/checkstyle/runs/build/6054d9b9237ec90008473aa6?step=6054dfea476e900008b0f46c)
2.  `./.ci/travis/travis.sh no-error-xwiki` - [uses scope property in config](https://travis-ci.org/github/checkstyle/checkstyle/jobs/763584503)
3.  ` .ci/validation.sh no-error-pmd`  - [uses scope property in config](https://checkstyle.semaphoreci.com/jobs/d8ae46ab-f367-4a12-b17c-a7991ec296d7)

Link to specific check documentation: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/issue-7417_2021172805/config_javadoc.html#JavadocMethod

JavadocMethodCheck patch config: https://gist.githubusercontent.com/nmancus1/7e1d79086bf212cdf7258487f5f032b9/raw/f1a950969add296d39669aa18a9447270fb47db7/patch.xml
JavadocMethodCheck config: https://gist.githubusercontent.com/nmancus1/a0c9b864e1884c69da516e417e786660/raw/08e10a1bf15a7b5b4ecb36416f880116a016c535/base.xml

RecordComponentNumberCheck config: https://gist.githubusercontent.com/nmancus1/9346e53fbbefca5d66ea10c350c82909/raw/7c7dc5836ef0a3b9b89699dd8418258f0bdfdb0b/RecordComponentNumberCheck.xml

ParameterNameCheck config: https://gist.githubusercontent.com/nmancus1/d7df0ce0d2aceff720aef0f2155a132b/raw/a8315ee56b880536744018c11ef82ca5e2139e3d/ParameterNameCheck.xml

----------------------------------
#### REPORTS

ParameterNameCheck (clean): https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/825c42d_2021130103/reports/diff/index.html

RecordComponentNumberCheck(clean): https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/825c42d_2021133159/reports/diff/index.html

JavadocMethodCheck: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/72b0648_2021162030/reports/diff/index.html

New violations in JavadocMethodCheck report are expected. 

----------------------------------

Diff Regression patch config: https://gist.githubusercontent.com/nmancus1/7e1d79086bf212cdf7258487f5f032b9/raw/f1a950969add296d39669aa18a9447270fb47db7/patch.xml
Diff Regression config: https://gist.githubusercontent.com/nmancus1/a0c9b864e1884c69da516e417e786660/raw/08e10a1bf15a7b5b4ecb36416f880116a016c535/base.xml

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/75ce9b2a63774eb82ba10277424e050a/raw/bf9a6c9aa11c143f7f6c4b7b659f7e81b6640067/projects.properties

Report label: JavadocMethodCheck
