### PR TITLE
Issue #8905: Add basic SARIF support

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -91,6 +91,7 @@ avoidstarimport
 avoidstaticimport
 aws
 awt
+azurewebsites
 backend
 backport
 Backquote
@@ -491,6 +492,7 @@ gradlew
 Grenner
 grep
 grepped
+groupon
 grp
 Gsp
 GString
@@ -535,6 +537,7 @@ icu
 identifiernames
 Idref
 idx
+ietf
 Igno
 IGNORETHIS
 igorminar
@@ -1066,6 +1069,7 @@ Rethrown
 returncount
 reviewdog
 revwalk
+rfc
 rfe
 rga
 Rgb
@@ -1093,6 +1097,8 @@ rw
 rx
 sabaka
 Sameline
+sariflogger
+sarifweb
 Savinov
 saxonica
 sbe
@@ -1297,7 +1303,7 @@ utf
 UUID
 UWF
 uxxxx
-Validator
+validator
 VALUEEEE
 vararg
 variabledeclarationusagedistance

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -184,6 +184,9 @@
       <!-- Annotations like '@SuppressWarnings' don't need to be checked, it is better to keep their
              strings connected to the annotation instead of separating. -->
       <property name="skipAnnotations" value="true"/>
+      <!-- Keeping the duplicated strings maintains readability -->
+      <property name="violationSuppressXPath"
+                value="//ClassOrInterfaceDeclaration[@SimpleName='SarifLogger']"/>
     </properties>
   </rule>
   <rule ref="category/java/errorprone.xml/EmptyCatchBlock">
@@ -266,9 +269,9 @@
              are big and should not be split without a good reason.
            The methods visitToken/leaveToken are a big SWITCH block with a number of IF blocks.
              If we split the block to several methods it will damage the readability.
-           XMLLogger.encode, FallThroughCheck.isTerminated, ElementNode.iterateAxis,
-             NoWhitespaceAfterCheck.getArrayDeclaratorPreviousElement are also huge switches,
-             they has to be monolithic.
+           XMLLogger.encode, SarifLogger.escape, FallThroughCheck.isTerminated,
+             ElementNode.iterateAxis, NoWhitespaceAfterCheck.getArrayDeclaratorPreviousElement
+             are also huge switches, they has to be monolithic.
            SuppressFilterElement is a single constructor and can't be split easily -->
       <property name="violationSuppressXPath"
                 value="//ClassOrInterfaceDeclaration[@SimpleName='Main'
@@ -276,6 +279,7 @@
         or @SimpleName='VariableDeclarationUsageDistanceCheck'
         or @SimpleName='HandlerFactory']
       | //ClassOrInterfaceDeclaration[@SimpleName='XMLLogger']//MethodDeclaration[@Name='encode']
+      | //ClassOrInterfaceDeclaration[@SimpleName='SarifLogger']//MethodDeclaration[@Name='escape']
       | //ClassOrInterfaceDeclaration[@SimpleName='LeftCurlyCheck'
         or @SimpleName='FinalLocalVariableCheck'
         or @SimpleName='NPathComplexityCheck']

--- a/config/sevntu_suppressions.xml
+++ b/config/sevntu_suppressions.xml
@@ -8,7 +8,7 @@
 
   <!-- Fixing these cases will decrease code readability -->
   <suppress checks="MultipleStringLiteralsExtended"
-             files="JavadocStyleCheck\.java|XMLLogger\.java"/>
+             files="JavadocStyleCheck\.java|XMLLogger\.java|SarifLogger\.java"/>
   <suppress checks="MultipleStringLiteralsExtended"
              files=".*[\\/]src[\\/](test|it)[\\/]"/>
   <!-- ParseTreeBuilder is generated, to keep ease of generation violations are suppressed -->

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -57,7 +57,7 @@
               |AbbreviationAsWordInNameCheckTest\.java)"/>
 
   <!-- Fixing these cases will decrease code readability -->
-  <suppress checks="MultipleStringLiterals" files="JavadocStyleCheck\.java|XMLLogger\.java"/>
+  <suppress checks="MultipleStringLiterals" files="JavadocStyleCheck\.java|XMLLogger\.java|SarifLogger\.java"/>
 
   <!-- There are a lot of setters/getters in the Check.
      A small number of methods is left for Check's logic -->

--- a/pom.xml
+++ b/pom.xml
@@ -1588,6 +1588,31 @@
         <artifactId>nondex-maven-plugin</artifactId>
         <version>1.1.2</version>
       </plugin>
+
+      <plugin>
+        <groupId>com.groupon.maven.plugin.json</groupId>
+        <artifactId>json-schema-validator</artifactId>
+        <version>1.2.0</version>
+        <executions>
+          <execution>
+            <phase>verify</phase>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <validations>
+            <validation>
+              <directory>${basedir}/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger</directory>
+              <jsonSchema>https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json</jsonSchema>
+              <includes>
+                <include>**/*.sarif</include>
+              </includes>
+            </validation>
+          </validations>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 
@@ -2821,6 +2846,7 @@
                 <param>com.puppycrawl.tools.checkstyle.DefaultLogger*</param>
                 <param>com.puppycrawl.tools.checkstyle.Definitions*</param>
                 <param>com.puppycrawl.tools.checkstyle.XMLLogger*</param>
+                <param>com.puppycrawl.tools.checkstyle.SarifLogger*</param>
                 <param>com.puppycrawl.tools.checkstyle.PackageObjectFactory*</param>
                 <param>com.puppycrawl.tools.checkstyle.PropertiesExpander*</param>
                 <param>com.puppycrawl.tools.checkstyle.PropertyCacheFile*</param>
@@ -2843,6 +2869,7 @@
                 <param>com.puppycrawl.tools.checkstyle.DefaultLoggerTest</param>
                 <param>com.puppycrawl.tools.checkstyle.DefinitionsTest</param>
                 <param>com.puppycrawl.tools.checkstyle.XMLLoggerTest</param>
+                <param>com.puppycrawl.tools.checkstyle.SarifLoggerTest</param>
                 <param>com.puppycrawl.tools.checkstyle.PackageObjectFactoryTest</param>
                 <param>com.puppycrawl.tools.checkstyle.PropertiesExpanderTest</param>
                 <param>com.puppycrawl.tools.checkstyle.PropertyCacheFileTest</param>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -542,6 +542,8 @@ public final class Main {
     enum OutputFormat {
         /** XML output format. */
         XML,
+        /** SARIF output format. */
+        SARIF,
         /** Plain output format. */
         PLAIN;
 
@@ -551,12 +553,17 @@ public final class Main {
          * @param out the output stream
          * @param options the output stream options
          * @return a new AuditListener for this OutputFormat
+         * @throws IOException if there is any IO exception during logger initialization
          */
-        public AuditListener createListener(OutputStream out,
-                                            AutomaticBean.OutputStreamOptions options) {
+        public AuditListener createListener(
+            OutputStream out,
+            AutomaticBean.OutputStreamOptions options) throws IOException {
             final AuditListener result;
             if (this == XML) {
                 result = new XMLLogger(out, options);
+            }
+            else if (this == SARIF) {
+                result = new SarifLogger(out, options);
             }
             else {
                 result = new DefaultLogger(out, options);
@@ -697,8 +704,8 @@ public final class Main {
          */
         @Option(names = "-f",
                 description = "Specifies the output format. Valid values: "
-                + "${COMPLETION-CANDIDATES} for XMLLogger and DefaultLogger respectively. "
-                + "Defaults to ${DEFAULT-VALUE}.")
+                + "${COMPLETION-CANDIDATES} for XMLLogger, SarifLogger, "
+                + "and DefaultLogger respectively. Defaults to ${DEFAULT-VALUE}.")
         private OutputFormat format = DEFAULT_OUTPUT_FORMAT;
 
         /** Option that controls whether to print the AST of the file. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/SarifLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/SarifLogger.java
@@ -1,0 +1,340 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2021 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import com.puppycrawl.tools.checkstyle.api.AuditEvent;
+import com.puppycrawl.tools.checkstyle.api.AuditListener;
+import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
+import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
+
+/**
+ * Simple SARIF logger.
+ * SARIF stands for the static analysis results interchange format.
+ * Reference: https://sarifweb.azurewebsites.net/
+ */
+public class SarifLogger extends AutomaticBean implements AuditListener {
+
+    /** The length of unicode placeholder. */
+    private static final int UNICODE_LENGTH = 4;
+
+    /** Unicode escaping upper limit. */
+    private static final int UNICODE_ESCAPE_UPPER_LIMIT = 0x1F;
+
+    /** Input stream buffer size. */
+    private static final int BUFFER_SIZE = 1024;
+
+    /** The placeholder for message. */
+    private static final String MESSAGE_PLACEHOLDER = "${message}";
+
+    /** The placeholder for severity level. */
+    private static final String SEVERITY_LEVEL_PLACEHOLDER = "${severityLevel}";
+
+    /** The placeholder for uri. */
+    private static final String URI_PLACEHOLDER = "${uri}";
+
+    /** The placeholder for line. */
+    private static final String LINE_PLACEHOLDER = "${line}";
+
+    /** The placeholder for column. */
+    private static final String COLUMN_PLACEHOLDER = "${column}";
+
+    /** The placeholder for rule id. */
+    private static final String RULE_ID_PLACEHOLDER = "${ruleId}";
+
+    /** The placeholder for version. */
+    private static final String VERSION_PLACEHOLDER = "${version}";
+
+    /** The placeholder for results. */
+    private static final String RESULTS_PLACEHOLDER = "${results}";
+
+    /** Helper writer that allows easy encoding and printing. */
+    private final PrintWriter writer;
+
+    /** Close output stream in auditFinished. */
+    private final boolean closeStream;
+
+    /** The results. */
+    private final List<String> results = new ArrayList<>();
+
+    /** Content for the entire report. */
+    private final String report;
+
+    /** Content for result representing an error with source line and column. */
+    private final String resultLineColumn;
+
+    /** Content for result representing an error with source line only. */
+    private final String resultLineOnly;
+
+    /** Content for result representing an error with filename only and without source location. */
+    private final String resultFileOnly;
+
+    /** Content for result representing an error without filename or location. */
+    private final String resultErrorOnly;
+
+    /**
+     * Creates a new {@code SarifLogger} instance.
+     *
+     * @param outputStream where to log audit events
+     * @param outputStreamOptions if {@code CLOSE} that should be closed in auditFinished()
+     * @throws IllegalArgumentException if outputStreamOptions is null
+     * @throws IOException if there is reading errors.
+     */
+    public SarifLogger(
+        OutputStream outputStream,
+        OutputStreamOptions outputStreamOptions) throws IOException {
+        if (outputStreamOptions == null) {
+            throw new IllegalArgumentException("Parameter outputStreamOptions can not be null");
+        }
+        writer = new PrintWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8));
+        closeStream = outputStreamOptions == OutputStreamOptions.CLOSE;
+        report = readResource("/com/puppycrawl/tools/checkstyle/sarif/SarifReport.template");
+        resultLineColumn =
+            readResource("/com/puppycrawl/tools/checkstyle/sarif/ResultLineColumn.template");
+        resultLineOnly =
+            readResource("/com/puppycrawl/tools/checkstyle/sarif/ResultLineOnly.template");
+        resultFileOnly =
+            readResource("/com/puppycrawl/tools/checkstyle/sarif/ResultFileOnly.template");
+        resultErrorOnly =
+            readResource("/com/puppycrawl/tools/checkstyle/sarif/ResultErrorOnly.template");
+    }
+
+    @Override
+    protected void finishLocalSetup() {
+        // No code by default
+    }
+
+    @Override
+    public void auditStarted(AuditEvent event) {
+        // No code by default
+    }
+
+    /**
+     * {@inheritDoc}
+     * Following idea suppressions are false positives
+     *
+     * @noinspection DynamicRegexReplaceableByCompiledPattern
+     */
+    @Override
+    public void auditFinished(AuditEvent event) {
+        final String version = SarifLogger.class.getPackage().getImplementationVersion();
+        final String rendered = report
+            .replace(VERSION_PLACEHOLDER, String.valueOf(version))
+            .replace(RESULTS_PLACEHOLDER, String.join(",\n", results));
+        writer.print(rendered);
+        if (closeStream) {
+            writer.close();
+        }
+        else {
+            writer.flush();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * Following idea suppressions are false positives
+     *
+     * @noinspection DynamicRegexReplaceableByCompiledPattern
+     */
+    @Override
+    public void addError(AuditEvent event) {
+        if (event.getColumn() > 0) {
+            results.add(resultLineColumn
+                .replace(SEVERITY_LEVEL_PLACEHOLDER, renderSeverityLevel(event.getSeverityLevel()))
+                .replace(URI_PLACEHOLDER, event.getFileName())
+                .replace(COLUMN_PLACEHOLDER, Integer.toString(event.getColumn()))
+                .replace(LINE_PLACEHOLDER, Integer.toString(event.getLine()))
+                .replace(MESSAGE_PLACEHOLDER, escape(event.getMessage()))
+                .replace(RULE_ID_PLACEHOLDER, event.getViolation().getKey())
+            );
+        }
+        else {
+            results.add(resultLineOnly
+                .replace(SEVERITY_LEVEL_PLACEHOLDER, renderSeverityLevel(event.getSeverityLevel()))
+                .replace(URI_PLACEHOLDER, event.getFileName())
+                .replace(LINE_PLACEHOLDER, Integer.toString(event.getLine()))
+                .replace(MESSAGE_PLACEHOLDER, escape(event.getMessage()))
+                .replace(RULE_ID_PLACEHOLDER, event.getViolation().getKey())
+            );
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * Following idea suppressions are false positives
+     *
+     * @noinspection DynamicRegexReplaceableByCompiledPattern
+     */
+    @Override
+    public void addException(AuditEvent event, Throwable throwable) {
+        final StringWriter stringWriter = new StringWriter();
+        final PrintWriter printer = new PrintWriter(stringWriter);
+        throwable.printStackTrace(printer);
+        if (event.getFileName() == null) {
+            results.add(resultErrorOnly
+                .replace(SEVERITY_LEVEL_PLACEHOLDER, renderSeverityLevel(event.getSeverityLevel()))
+                .replace(MESSAGE_PLACEHOLDER, escape(stringWriter.toString()))
+            );
+        }
+        else {
+            results.add(resultFileOnly
+                .replace(SEVERITY_LEVEL_PLACEHOLDER, renderSeverityLevel(event.getSeverityLevel()))
+                .replace(URI_PLACEHOLDER, event.getFileName())
+                .replace(MESSAGE_PLACEHOLDER, escape(stringWriter.toString()))
+            );
+        }
+    }
+
+    @Override
+    public void fileStarted(AuditEvent event) {
+        // No need to implement this method in this class
+    }
+
+    @Override
+    public void fileFinished(AuditEvent event) {
+        // No need to implement this method in this class
+    }
+
+    /**
+     * Render the severity level into SARIF severity level.
+     *
+     * @param severityLevel the Severity level.
+     * @return the rendered severity level in string.
+     */
+    private static String renderSeverityLevel(SeverityLevel severityLevel) {
+        final String renderedSeverityLevel;
+        switch (severityLevel) {
+            case IGNORE:
+                renderedSeverityLevel = "none";
+                break;
+            case INFO:
+                renderedSeverityLevel = "note";
+                break;
+            case WARNING:
+                renderedSeverityLevel = "warning";
+                break;
+            case ERROR:
+            default:
+                renderedSeverityLevel = "error";
+                break;
+        }
+        return renderedSeverityLevel;
+    }
+
+    /**
+     * Escape \b, \f, \n, \r, \t, \", \\ and U+0000 through U+001F.
+     * Reference: https://www.ietf.org/rfc/rfc4627.txt - 2.5. Strings
+     *
+     * @param value the value to escape.
+     * @return the escaped value if necessary.
+     */
+    public static String escape(String value) {
+        final StringBuilder sb = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            final char chr = value.charAt(i);
+            switch (chr) {
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '\b':
+                    sb.append("\\b");
+                    break;
+                case '\f':
+                    sb.append("\\f");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
+                case '/':
+                    sb.append("\\/");
+                    break;
+                default:
+                    if (chr <= UNICODE_ESCAPE_UPPER_LIMIT) {
+                        sb.append(escapeUnicode1F(chr));
+                    }
+                    else {
+                        sb.append(chr);
+                    }
+                    break;
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Escape the character between 0x00 to 0x1F in JSON.
+     *
+     * @param chr the character to be escaped.
+     * @return the escaped string.
+     */
+    private static String escapeUnicode1F(char chr) {
+        final StringBuilder stringBuilder = new StringBuilder(UNICODE_LENGTH + 1);
+        stringBuilder.append("\\u");
+        final String hexString = Integer.toHexString(chr);
+        for (int i = 0; i < UNICODE_LENGTH - hexString.length(); i++) {
+            stringBuilder.append('0');
+        }
+        stringBuilder.append(hexString.toUpperCase(Locale.US));
+        return stringBuilder.toString();
+    }
+
+    /**
+     * Read string from given resource.
+     *
+     * @param name name of the desired resource
+     * @return the string content from the give resource
+     * @throws IOException if there is reading errors
+     */
+    public static String readResource(String name) throws IOException {
+        try (InputStream inputStream = SarifLogger.class.getResourceAsStream(name);
+             ByteArrayOutputStream result = new ByteArrayOutputStream()) {
+            if (inputStream == null) {
+                throw new IOException("Cannot find the resource " + name);
+            }
+            final byte[] buffer = new byte[BUFFER_SIZE];
+            int length = inputStream.read(buffer);
+            while (length != -1) {
+                result.write(buffer, 0, length);
+                length = inputStream.read(buffer);
+            }
+            return result.toString(StandardCharsets.UTF_8.name());
+        }
+    }
+}

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/sarif/ResultErrorOnly.template
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/sarif/ResultErrorOnly.template
@@ -1,0 +1,6 @@
+        {
+          "level": "${severityLevel}",
+          "message": {
+            "text": "${message}"
+          }
+        }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/sarif/ResultFileOnly.template
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/sarif/ResultFileOnly.template
@@ -1,0 +1,15 @@
+        {
+          "level": "${severityLevel}",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "${uri}"
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "${message}"
+          }
+        }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/sarif/ResultLineColumn.template
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/sarif/ResultLineColumn.template
@@ -1,0 +1,20 @@
+        {
+          "level": "${severityLevel}",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "${uri}"
+                },
+                "region": {
+                  "startColumn": ${column},
+                  "startLine": ${line}
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "${message}"
+          },
+          "ruleId": "${ruleId}"
+        }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/sarif/ResultLineOnly.template
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/sarif/ResultLineOnly.template
@@ -1,0 +1,19 @@
+        {
+          "level": "${severityLevel}",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "${uri}"
+                },
+                "region": {
+                  "startLine": ${line}
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "${message}"
+          },
+          "ruleId": "${ruleId}"
+        }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/sarif/SarifReport.template
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/sarif/SarifReport.template
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "downloadUri": "https://github.com/checkstyle/checkstyle/releases/",
+          "fullName": "Checkstyle",
+          "informationUri": "https://checkstyle.org/",
+          "language": "en",
+          "name": "Checkstyle",
+          "organization": "Checkstyle",
+          "rules": [
+          ],
+          "semanticVersion": "${version}",
+          "version": "${version}"
+        }
+      },
+      "results": [
+${results}
+      ]
+    }
+  ]
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -108,9 +108,11 @@ public class MainTest {
                   + "                              allowed.%n"
                   + "  -E, --executeIgnoredModules%n"
                   + "                            Allows ignored modules to be run.%n"
-                  + "  -f=<format>               Specifies the output format. Valid values: xml,"
-                  + " plain for XMLLogger and%n"
-                  + "                              DefaultLogger respectively. Defaults to plain.%n"
+                  + "  -f=<format>               Specifies the output format. Valid values: "
+                  + "xml, sarif, plain for%n"
+                  + "                              XMLLogger, SarifLogger, and "
+                  + "DefaultLogger respectively. Defaults to%n"
+                  + "                              plain.%n"
                   + "  -g, --generate-xpath-suppression%n"
                   + "                            Generates to output a suppression xml to use"
                   + " to suppress all violations%n"
@@ -347,7 +349,7 @@ public class MainTest {
             invokeMain("-c", "/google_checks.xml", "-f", "xmlp", getPath("InputMain.java"));
         });
         assertEquals("", systemOut.getCapturedData(), "Unexpected output log");
-        assertEquals("Invalid value for option '-f': expected one of [XML, PLAIN]"
+        assertEquals("Invalid value for option '-f': expected one of [XML, SARIF, PLAIN]"
                     + " (case-insensitive) but was 'xmlp'" + EOL + SHORT_USAGE,
                 systemErr.getCapturedData(), "Unexpected system error log");
     }
@@ -1544,7 +1546,7 @@ public class MainTest {
     }
 
     @Test
-    public void testXmlOutputFormatCreateListener() {
+    public void testXmlOutputFormatCreateListener() throws IOException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         final AuditListener listener = Main.OutputFormat.XML.createListener(out,
                 AutomaticBean.OutputStreamOptions.CLOSE);
@@ -1552,7 +1554,15 @@ public class MainTest {
     }
 
     @Test
-    public void testPlainOutputFormatCreateListener() {
+    public void testSarifOutputFormatCreateListener() throws IOException {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        final AuditListener listener = Main.OutputFormat.SARIF.createListener(out,
+                AutomaticBean.OutputStreamOptions.CLOSE);
+        assertTrue(listener instanceof SarifLogger, "listener is SarifLogger");
+    }
+
+    @Test
+    public void testPlainOutputFormatCreateListener() throws IOException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         final AuditListener listener = Main.OutputFormat.PLAIN.createListener(out,
                 AutomaticBean.OutputStreamOptions.CLOSE);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
@@ -1,0 +1,296 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2021 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.api.AuditEvent;
+import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
+import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
+import com.puppycrawl.tools.checkstyle.api.Violation;
+import com.puppycrawl.tools.checkstyle.internal.utils.CloseAndFlushTestByteArrayOutputStream;
+
+public class SarifLoggerTest extends AbstractModuleTestSupport {
+
+    /**
+     * Output stream to hold the test results. The IntelliJ IDEA issues the AutoCloseableResource
+     * warning here, so it need to be suppressed. The {@code ByteArrayOutputStream} does not hold
+     * any resources that need to be released.
+     */
+    private final CloseAndFlushTestByteArrayOutputStream outStream =
+        new CloseAndFlushTestByteArrayOutputStream();
+
+    @Override
+    protected String getPackageLocation() {
+        return "com/puppycrawl/tools/checkstyle/sariflogger";
+    }
+
+    @Test
+    public void testEscape() {
+        final String[][] encodings = {
+            {"\"", "\\\""},
+            {"\\", "\\\\"},
+            {"\b", "\\b"},
+            {"\f", "\\f"},
+            {"\n", "\\n"},
+            {"\r", "\\r"},
+            {"\t", "\\t"},
+            {"/", "\\/"},
+            {"\u0010", "\\u0010"},
+            {"\u001E", "\\u001E"},
+            {"\u001F", "\\u001F"},
+            {" ", " "},
+            {"bar1234", "bar1234"},
+        };
+        for (String[] encoding : encodings) {
+            final String encoded = SarifLogger.escape(encoding[0]);
+            assertEquals(encoding[1], encoded, "\"" + encoding[0] + "\"");
+        }
+    }
+
+    @Test
+    public void testAddError() throws IOException {
+        final SarifLogger logger = new SarifLogger(outStream,
+                AutomaticBean.OutputStreamOptions.CLOSE);
+        logger.auditStarted(null);
+        final Violation violation =
+                new Violation(1, 1,
+                        "messages.properties", "ruleId", null, SeverityLevel.ERROR, null,
+                        getClass(), "found an error");
+        final AuditEvent ev = new AuditEvent(this, "Test.java", violation);
+        logger.fileStarted(ev);
+        logger.addError(ev);
+        logger.fileFinished(ev);
+        logger.auditFinished(null);
+        verifyContent(getPath("ExpectedSarifLoggerSingleError.sarif"), outStream);
+    }
+
+    @Test
+    public void testAddErrorWithWarningLevel() throws IOException {
+        final SarifLogger logger = new SarifLogger(outStream,
+                AutomaticBean.OutputStreamOptions.CLOSE);
+        logger.auditStarted(null);
+        final Violation violation =
+                new Violation(1, 1,
+                        "messages.properties", "ruleId", null, SeverityLevel.WARNING, null,
+                        getClass(), "found an error");
+        final AuditEvent ev = new AuditEvent(this, "Test.java", violation);
+        logger.fileStarted(ev);
+        logger.addError(ev);
+        logger.fileFinished(ev);
+        logger.auditFinished(null);
+        verifyContent(getPath("ExpectedSarifLoggerSingleWarning.sarif"), outStream);
+    }
+
+    @Test
+    public void testAddErrors() throws IOException {
+        final SarifLogger logger = new SarifLogger(outStream,
+                AutomaticBean.OutputStreamOptions.CLOSE);
+        logger.auditStarted(null);
+        final Violation violation =
+                new Violation(1, 1,
+                        "messages.properties", "ruleId", null, SeverityLevel.INFO, null,
+                        getClass(), "found an error");
+        final AuditEvent ev = new AuditEvent(this, "Test.java", violation);
+        final Violation violation2 =
+                new Violation(1, 1,
+                        "messages.properties", "ruleId2", null, SeverityLevel.IGNORE, null,
+                        getClass(), "found another error");
+        final AuditEvent ev2 = new AuditEvent(this, "Test.java", violation2);
+        logger.fileStarted(ev);
+        logger.addError(ev);
+        logger.fileFinished(ev);
+        logger.fileStarted(ev2);
+        logger.addError(ev2);
+        logger.fileFinished(ev2);
+        logger.auditFinished(null);
+        verifyContent(getPath("ExpectedSarifLoggerDoubleError.sarif"), outStream);
+    }
+
+    @Test
+    public void testAddException() throws IOException {
+        final SarifLogger logger = new SarifLogger(outStream,
+                AutomaticBean.OutputStreamOptions.CLOSE);
+        logger.auditStarted(null);
+        final Violation message =
+                new Violation(1, 1,
+                        "messages.properties", "null", null, null,
+                        getClass(), "found an error");
+        final AuditEvent ev = new AuditEvent(this, null, message);
+        logger.fileStarted(ev);
+        logger.addException(ev, new TestException("msg", new RuntimeException("msg")));
+        logger.fileFinished(ev);
+        logger.auditFinished(null);
+        verifyContent(getPath("ExpectedSarifLoggerSingleException.sarif"), outStream);
+    }
+
+    @Test
+    public void testAddExceptions() throws IOException {
+        final SarifLogger logger = new SarifLogger(outStream,
+                AutomaticBean.OutputStreamOptions.CLOSE);
+        logger.auditStarted(null);
+        final Violation violation =
+                new Violation(1, 1,
+                        "messages.properties", "null", null, null,
+                        getClass(), "found an error");
+        final AuditEvent ev = new AuditEvent(this, null, violation);
+        final Violation violation2 =
+                new Violation(1, 1,
+                        "messages.properties", "null", null, null,
+                        getClass(), "found an error");
+        final AuditEvent ev2 = new AuditEvent(this, "Test.java", violation2);
+        logger.fileStarted(ev);
+        logger.addException(ev, new TestException("msg", new RuntimeException("msg")));
+        logger.fileFinished(ev);
+        logger.fileStarted(ev2);
+        logger.addException(ev2, new TestException("msg2", new RuntimeException("msg2")));
+        logger.fileFinished(ev);
+        logger.auditFinished(null);
+        verifyContent(getPath("ExpectedSarifLoggerDoubleException.sarif"), outStream);
+    }
+
+    @Test
+    public void testLineOnly() throws IOException {
+        final SarifLogger logger = new SarifLogger(outStream,
+            AutomaticBean.OutputStreamOptions.CLOSE);
+        logger.auditStarted(null);
+        final Violation violation =
+            new Violation(1, 0,
+                "messages.properties", "ruleId", null, null,
+                getClass(), "found an error");
+        final AuditEvent ev = new AuditEvent(this, "Test.java", violation);
+        logger.fileStarted(ev);
+        logger.addError(ev);
+        logger.fileFinished(ev);
+        logger.auditFinished(null);
+        verifyContent(getPath("ExpectedSarifLoggerLineOnly.sarif"), outStream);
+    }
+
+    @Test
+    public void testEmpty() throws IOException {
+        final SarifLogger logger = new SarifLogger(outStream,
+                AutomaticBean.OutputStreamOptions.CLOSE);
+        logger.auditStarted(null);
+        final Violation violation =
+                new Violation(1, 1,
+                        "messages.properties", "null", null, null,
+                        getClass(), "found an error");
+        final AuditEvent ev = new AuditEvent(this, null, violation);
+        logger.fileStarted(ev);
+        logger.fileFinished(ev);
+        logger.auditFinished(null);
+        verifyContent(getPath("ExpectedSarifLoggerEmpty.sarif"), outStream);
+    }
+
+    @Test
+    public void testNullOutputStreamOptions() {
+        try {
+            final SarifLogger logger = new SarifLogger(outStream, null);
+            // assert required to calm down eclipse's 'The allocated object is never used' violation
+            assertNotNull(logger, "Null instance");
+            fail("Exception was expected");
+        }
+        catch (IllegalArgumentException | IOException exception) {
+            assertEquals("Parameter outputStreamOptions can not be null",
+                    exception.getMessage(), "Invalid error message");
+        }
+    }
+
+    @Test
+    public void testCloseStream() throws IOException {
+        final SarifLogger logger = new SarifLogger(outStream,
+                AutomaticBean.OutputStreamOptions.CLOSE);
+        logger.auditStarted(null);
+        logger.auditFinished(null);
+
+        assertEquals(1, outStream.getCloseCount(), "Invalid close count");
+
+        verifyContent(getPath("ExpectedSarifLoggerEmpty.sarif"), outStream);
+    }
+
+    @Test
+    public void testNoCloseStream() throws IOException {
+        final SarifLogger logger = new SarifLogger(outStream,
+                AutomaticBean.OutputStreamOptions.NONE);
+        logger.auditStarted(null);
+        logger.auditFinished(null);
+
+        assertEquals(0, outStream.getCloseCount(), "Invalid close count");
+        assertEquals(1, outStream.getFlushCount(), "Invalid flush count");
+
+        outStream.close();
+        verifyContent(getPath("ExpectedSarifLoggerEmpty.sarif"), outStream);
+    }
+
+    @Test
+    public void testFinishLocalSetup() throws IOException {
+        final SarifLogger logger = new SarifLogger(outStream,
+                AutomaticBean.OutputStreamOptions.CLOSE);
+        logger.finishLocalSetup();
+        logger.auditStarted(null);
+        logger.auditFinished(null);
+        assertNotNull(logger, "instance should not be null");
+    }
+
+    @Test
+    public void testReadResourceWithInvalidName() {
+        try {
+            SarifLogger.readResource("random");
+            fail("Exception expected");
+        }
+        catch (IOException exception) {
+            assertEquals("Cannot find the resource random",
+                exception.getMessage(),
+                "Exception message must match");
+        }
+    }
+
+    private static void verifyContent(
+            String expectedOutputFile,
+            ByteArrayOutputStream actualOutputStream) throws IOException {
+        final String expectedContent = readFile(expectedOutputFile);
+        final String actualContent = toLfLineEnding(new String(actualOutputStream.toByteArray(),
+                StandardCharsets.UTF_8));
+        assertEquals(expectedContent, actualContent, "sarif content should match");
+    }
+
+    private static class TestException extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+
+        /* package */ TestException(String msg, Throwable cause) {
+            super(msg, cause);
+        }
+
+        @Override
+        public void printStackTrace(PrintWriter printWriter) {
+            printWriter.print("stackTrace\nexample");
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerDoubleError.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerDoubleError.sarif
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "downloadUri": "https://github.com/checkstyle/checkstyle/releases/",
+          "fullName": "Checkstyle",
+          "informationUri": "https://checkstyle.org/",
+          "language": "en",
+          "name": "Checkstyle",
+          "organization": "Checkstyle",
+          "rules": [
+          ],
+          "semanticVersion": "null",
+          "version": "null"
+        }
+      },
+      "results": [
+        {
+          "level": "note",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "Test.java"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "found an error"
+          },
+          "ruleId": "ruleId"
+        },
+        {
+          "level": "none",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "Test.java"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "found another error"
+          },
+          "ruleId": "ruleId2"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerDoubleException.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerDoubleException.sarif
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "downloadUri": "https://github.com/checkstyle/checkstyle/releases/",
+          "fullName": "Checkstyle",
+          "informationUri": "https://checkstyle.org/",
+          "language": "en",
+          "name": "Checkstyle",
+          "organization": "Checkstyle",
+          "rules": [
+          ],
+          "semanticVersion": "null",
+          "version": "null"
+        }
+      },
+      "results": [
+        {
+          "level": "error",
+          "message": {
+            "text": "stackTrace\nexample"
+          }
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "Test.java"
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "stackTrace\nexample"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerEmpty.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerEmpty.sarif
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "downloadUri": "https://github.com/checkstyle/checkstyle/releases/",
+          "fullName": "Checkstyle",
+          "informationUri": "https://checkstyle.org/",
+          "language": "en",
+          "name": "Checkstyle",
+          "organization": "Checkstyle",
+          "rules": [
+          ],
+          "semanticVersion": "null",
+          "version": "null"
+        }
+      },
+      "results": [
+
+      ]
+    }
+  ]
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerLineOnly.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerLineOnly.sarif
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "downloadUri": "https://github.com/checkstyle/checkstyle/releases/",
+          "fullName": "Checkstyle",
+          "informationUri": "https://checkstyle.org/",
+          "language": "en",
+          "name": "Checkstyle",
+          "organization": "Checkstyle",
+          "rules": [
+          ],
+          "semanticVersion": "null",
+          "version": "null"
+        }
+      },
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "Test.java"
+                },
+                "region": {
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "found an error"
+          },
+          "ruleId": "ruleId"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerSingleError.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerSingleError.sarif
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "downloadUri": "https://github.com/checkstyle/checkstyle/releases/",
+          "fullName": "Checkstyle",
+          "informationUri": "https://checkstyle.org/",
+          "language": "en",
+          "name": "Checkstyle",
+          "organization": "Checkstyle",
+          "rules": [
+          ],
+          "semanticVersion": "null",
+          "version": "null"
+        }
+      },
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "Test.java"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "found an error"
+          },
+          "ruleId": "ruleId"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerSingleException.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerSingleException.sarif
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "downloadUri": "https://github.com/checkstyle/checkstyle/releases/",
+          "fullName": "Checkstyle",
+          "informationUri": "https://checkstyle.org/",
+          "language": "en",
+          "name": "Checkstyle",
+          "organization": "Checkstyle",
+          "rules": [
+          ],
+          "semanticVersion": "null",
+          "version": "null"
+        }
+      },
+      "results": [
+        {
+          "level": "error",
+          "message": {
+            "text": "stackTrace\nexample"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerSingleWarning.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/sariflogger/ExpectedSarifLoggerSingleWarning.sarif
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "downloadUri": "https://github.com/checkstyle/checkstyle/releases/",
+          "fullName": "Checkstyle",
+          "informationUri": "https://checkstyle.org/",
+          "language": "en",
+          "name": "Checkstyle",
+          "organization": "Checkstyle",
+          "rules": [
+          ],
+          "semanticVersion": "null",
+          "version": "null"
+        }
+      },
+      "results": [
+        {
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "Test.java"
+                },
+                "region": {
+                  "startColumn": 1,
+                  "startLine": 1
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "found an error"
+          },
+          "ruleId": "ruleId"
+        }
+      ]
+    }
+  ]
+}

--- a/src/xdocs/cmdline.xml.vm
+++ b/src/xdocs/cmdline.xml.vm
@@ -60,8 +60,9 @@ java -D&lt;property&gt;=&lt;value&gt;  \
         </li>
         <li>
           <code>-f format</code> - Specifies the output
-          format. Valid values: <code>xml</code>, <code>plain</code> for <a
-          href="apidocs/com/puppycrawl/tools/checkstyle/XMLLogger.html">XMLLogger</a>
+          format. Valid values: <code>xml</code>, <code>sarif</code>, <code>plain</code> for <a
+          href="apidocs/com/puppycrawl/tools/checkstyle/XMLLogger.html">XMLLogger</a>,
+          <a href="apidocs/com/puppycrawl/tools/checkstyle/SarifLogger.html">SarifLogger</a>,
           and <a href="apidocs/com/puppycrawl/tools/checkstyle/DefaultLogger
           .html">DefaultLogger</a> respectively.
           Defaults to <code>plain</code>.


### PR DESCRIPTION
Closes: #8905
by providing a basic version of [SARIF](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html)

This PR does not include:
- Fully update the documentation with SARIF support.
- Populating `runs[0].tool.rules` for the actual checkstyle checks that are executed.
- Fully integrated relative path support since the basePath can only be set through `Checker` instead of `Main`.

Given that this PR is already a mammoth, I would prefer the rest to be implemented in follow-up PRs.

## Test
I have validated the output at https://sarifweb.azurewebsites.net/Validation
This [gist](https://gist.github.com/chao2zhang/8ebff385e0c6e1da4ebbb50024d873fe) is a sample SARIF output that I ran with `java -jar target/checkstyle-8.42-SNAPSHOT-all.jar -c src/main/resources/sun_checks.xml -f=sarif -o=a.sarif src/main/java/com/puppycrawl/tools/checkstyle/S*.java`

