### PR TITLE
Issue #9407: Added Example of AST for TokenTypes.CHAR_LITERAL

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -3013,6 +3013,18 @@ public final class TokenTypes {
      * A character literal.  This is a (possibly escaped) character
      * enclosed in single quotes.
      *
+     * <p>For example:</p>
+     * <pre>
+     * return 'a';
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * --LITERAL_RETURN -&gt; return
+     *    |--EXPR -&gt; EXPR
+     *    |   `--CHAR_LITERAL -&gt; 'a'
+     *    `--SEMI -&gt; ;
+     * </pre>
+     *
      * @see <a
      * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.4">Java
      * Language Specification, &sect;3.10.4</a>


### PR DESCRIPTION
Closes: #9407 
![CLIT](https://user-images.githubusercontent.com/36664705/112047599-8abbde80-8b73-11eb-8c27-8440b38865c3.png)


```
$ javac Tester.java

$ cat Tester.java
public class Tester {
	public static char test() {
		return 'a';
	}
}

$ java -jar checkstyle-8.41-all.jar -T Tester.java 
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> Tester [1:13]
`--OBJBLOCK -> OBJBLOCK [1:20]
    |--LCURLY -> { [1:20]
    |--METHOD_DEF -> METHOD_DEF [2:1]
    |   |--MODIFIERS -> MODIFIERS [2:1]
    |   |   |--LITERAL_PUBLIC -> public [2:1]
    |   |   `--LITERAL_STATIC -> static [2:8]
    |   |--TYPE -> TYPE [2:15]
    |   |   `--LITERAL_CHAR -> char [2:15]
    |   |--IDENT -> test [2:20]
    |   |--LPAREN -> ( [2:24]
    |   |--PARAMETERS -> PARAMETERS [2:25]
    |   |--RPAREN -> ) [2:25]
    |   `--SLIST -> { [2:27]
    |       |--LITERAL_RETURN -> return [3:2]
    |       |   |--EXPR -> EXPR [3:9]
    |       |   |   `--CHAR_LITERAL -> 'a' [3:9]
    |       |   `--SEMI -> ; [3:12]
    |       `--RCURLY -> } [4:1]
    `--RCURLY -> } [5:0]

Printing a line for the code we care
    |       |--LITERAL_RETURN -> return [3:2]
    |       |   |--EXPR -> EXPR [3:9]
    |       |   |   `--CHAR_LITERAL -> 'a' [3:9]
    |       |   `--SEMI -> ; [3:12]
```
Expected update for javadoc

```
 --LITERAL_RETURN -> return
    |--EXPR -> EXPR
    |   `--CHAR_LITERAL -> 'a'
    `--SEMI -> ;
 
```