### PR TITLE
Issue #9590: updated example of AST for TokenTypes.TYPE_PARAMETERS

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -3615,39 +3615,30 @@ public final class TokenTypes {
      * <p>For example:</p>
      *
      * <pre>
-     *     public class Blah&lt;A, B&gt;
-     *     {
-     *     }
+     * public class MyClass&lt;A, B&gt; {
+     *
+     * }
      * </pre>
      *
      * <p>parses as:</p>
      *
      * <pre>
-     * +--CLASS_DEF ({)
-     *     |
-     *     +--MODIFIERS
-     *         |
-     *         +--LITERAL_PUBLIC (public)
-     *     +--LITERAL_CLASS (class)
-     *     +--IDENT (Blah)
-     *     +--TYPE_PARAMETERS
-     *         |
-     *         +--GENERIC_START (&lt;)
-     *         +--TYPE_PARAMETER
-     *             |
-     *             +--IDENT (A)
-     *         +--COMMA (,)
-     *         +--TYPE_PARAMETER
-     *             |
-     *             +--IDENT (B)
-     *         +--GENERIC_END (&gt;)
-     *     +--OBJBLOCK
-     *         |
-     *         +--LCURLY ({)
-     *     +--NUM_INT (1)
-     *     +--COMMA (,)
-     *     +--NUM_INT (2)
-     *     +--RCURLY (})
+     * CLASS_DEF -&gt; CLASS_DEF
+     * |--MODIFIERS -&gt; MODIFIERS
+     * |   `--LITERAL_PUBLIC -&gt; public
+     * |--LITERAL_CLASS -&gt; class
+     * |--IDENT -&gt; MyClass
+     * |--TYPE_PARAMETERS -&gt; TYPE_PARAMETERS
+     * |   |--GENERIC_START -&gt; &lt;
+     * |   |--TYPE_PARAMETER -&gt; TYPE_PARAMETER
+     * |   |   `--IDENT -&gt; A
+     * |   |--COMMA -&gt; ,
+     * |   |--TYPE_PARAMETER -&gt; TYPE_PARAMETER
+     * |   |   `--IDENT -&gt; B
+     * |   `--GENERIC_END -&gt; &gt;
+     * `--OBJBLOCK -&gt; OBJBLOCK
+     *     |--LCURLY -&gt; {
+     *     `--RCURLY -&gt; }
      * </pre>
      *
      * @see <a href="https://www.jcp.org/en/jsr/detail?id=14">


### PR DESCRIPTION
fixes #9590 :

<img width="909" alt="Screenshot 2021-03-23 at 2 13 22 AM" src="https://user-images.githubusercontent.com/65589791/112057345-2acb3500-8b7f-11eb-9119-2f52403d6475.png">

Source used to generate AST:
```
public class MyClass<A, B> {
    
}
```

```
anmolsharma@Anmols-MacBook-Pro GSOC % java -jar checkstyle-8.41-all.jar -t MyClass.java
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> MyClass [1:13]
|--TYPE_PARAMETERS -> TYPE_PARAMETERS [1:20]
|   |--GENERIC_START -> < [1:20]
|   |--TYPE_PARAMETER -> TYPE_PARAMETER [1:21]
|   |   `--IDENT -> A [1:21]
|   |--COMMA -> , [1:22]
|   |--TYPE_PARAMETER -> TYPE_PARAMETER [1:24]
|   |   `--IDENT -> B [1:24]
|   `--GENERIC_END -> > [1:25]
`--OBJBLOCK -> OBJBLOCK [1:27]
    |--LCURLY -> { [1:27]
    `--RCURLY -> } [3:0]
```

Expected Update for Javadoc:
```
CLASS_DEF -> CLASS_DEF
|--MODIFIERS -> MODIFIERS
|   `--LITERAL_PUBLIC -> public
|--LITERAL_CLASS -> class
|--IDENT -> MyClass
|--TYPE_PARAMETERS -> TYPE_PARAMETERS
|   |--GENERIC_START -> <
|   |--TYPE_PARAMETER -> TYPE_PARAMETER
|   |   `--IDENT -> A
|   |--COMMA -> ,
|   |--TYPE_PARAMETER -> TYPE_PARAMETER
|   |   `--IDENT -> B
|   `--GENERIC_END -> >
`--OBJBLOCK -> OBJBLOCK
    |--LCURLY -> {
    `--RCURLY -> }
```