### PR TITLE
Issue #9562: updated example of AST for TokenTypes.RECORD_DEF

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -4051,21 +4051,23 @@ public final class TokenTypes {
      *
      * <p>For example:</p>
      * <pre>
-     * public record myRecord () {}
+     * public record MyRecord () {
+     *
+     * }
      * </pre>
      * <p>parses as:</p>
      * <pre>
-     * RECORD_DEF
-     * |--MODIFIERS
-     * |   `--LITERAL_PUBLIC (public)
-     * |--LITERAL_RECORD (record)
-     * |--IDENT (myRecord)
-     * |--LPAREN (()
-     * |--RECORD_COMPONENTS
-     * |--RPAREN ())
-     * `--OBJBLOCK
-     *     |--LCURLY ({)
-     *      `--RCURLY (})
+     * RECORD_DEF -&gt; RECORD_DEF
+     * |--MODIFIERS -&gt; MODIFIERS
+     * |   `--LITERAL_PUBLIC -&gt; public
+     * |--LITERAL_RECORD -&gt; record
+     * |--IDENT -&gt; MyRecord
+     * |--LPAREN -&gt; (
+     * |--RECORD_COMPONENTS -&gt; RECORD_COMPONENTS
+     * |--RPAREN -&gt; )
+     * `--OBJBLOCK -&gt; OBJBLOCK
+     *     |--LCURLY -&gt; {
+     *     `--RCURLY -&gt; }
      * </pre>
      *
      * @since 8.35


### PR DESCRIPTION
fixes #9562 

<img width="620" alt="Screenshot 2021-03-23 at 1 17 35 PM" src="https://user-images.githubusercontent.com/65589791/112111568-5f200f00-8bda-11eb-85c0-e62c5750a1a8.png">

Source used to generate AST : 
```
public record MyRecord() {
    
}
```

Generated AST :
```
RECORD_DEF -> RECORD_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_RECORD -> record [1:7]
|--IDENT -> MyRecord [1:14]
|--LPAREN -> ( [1:22]
|--RECORD_COMPONENTS -> RECORD_COMPONENTS [1:23]
|--RPAREN -> ) [1:23]
`--OBJBLOCK -> OBJBLOCK [1:25]
    |--LCURLY -> { [1:25]
    `--RCURLY -> } [3:0]
```

Expected Update for Javadoc:

```
RECORD_DEF -> RECORD_DEF 
|--MODIFIERS -> MODIFIERS 
|   `--LITERAL_PUBLIC -> public 
|--LITERAL_RECORD -> record 
|--IDENT -> MyRecord 
|--LPAREN -> ( 
|--RECORD_COMPONENTS -> RECORD_COMPONENTS
|--RPAREN -> ) 
`--OBJBLOCK -> OBJBLOCK
    |--LCURLY -> { 
    `--RCURLY -> }
```