### PR TITLE
Issue #9560: updated example of AST for TokenTypes.RECORD_COMPONENT_DEF

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -4119,33 +4119,35 @@ public final class TokenTypes {
      *
      * <p>For example:</p>
      * <pre>
-     * public record myRecord (Comp x, Comp... comps) { }
+     * public record MyRecord(Comp x, Comp... comps) {
+     *
+     * }
      * </pre>
      * <p>parses as:</p>
      * <pre>
-     * RECORD_DEF
-     * |--MODIFIERS
-     * |   `--LITERAL_PUBLIC (public)
-     * |--LITERAL_RECORD (record)
-     * |--IDENT (myRecord)
-     * |--LPAREN (()
-     * |--RECORD_COMPONENTS
-     * |   |--RECORD_COMPONENT_DEF
-     * |   |   |--ANNOTATIONS
-     * |   |   |--TYPE
-     * |   |   |   `--IDENT (Comp)
-     * |   |   `--IDENT (x)
-     * |   |--COMMA (,)
-     * |   `--RECORD_COMPONENT_DEF
-     * |       |--ANNOTATIONS
-     * |       |--TYPE
-     * |       |   `--IDENT (Comp)
-     * |       |--ELLIPSIS (...)
-     * |       `--IDENT (comps)
-     * |--RPAREN ())
-     * `--OBJBLOCK
-     *      |--LCURLY ({)
-     *       `--RCURLY (})
+     * RECORD_DEF -&gt; RECORD_DEF
+     * |--MODIFIERS -&gt; MODIFIERS
+     * |   `--LITERAL_PUBLIC -&gt; public
+     * |--LITERAL_RECORD -&gt; record
+     * |--IDENT -&gt; MyRecord
+     * |--LPAREN -&gt; (
+     * |--RECORD_COMPONENTS -&gt; RECORD_COMPONENTS
+     * |   |--RECORD_COMPONENT_DEF -&gt; RECORD_COMPONENT_DEF
+     * |   |   |--ANNOTATIONS -&gt; ANNOTATIONS
+     * |   |   |--TYPE -&gt; TYPE
+     * |   |   |   `--IDENT -&gt; Comp
+     * |   |   `--IDENT -&gt; x
+     * |   |--COMMA -&gt; ,
+     * |   `--RECORD_COMPONENT_DEF -&gt; RECORD_COMPONENT_DEF
+     * |       |--ANNOTATIONS -&gt; ANNOTATIONS
+     * |       |--TYPE -&gt; TYPE
+     * |       |   `--IDENT -&gt; Comp
+     * |       |--ELLIPSIS -&gt; ...
+     * |       `--IDENT -&gt; comps
+     * |--RPAREN -&gt; )
+     * `--OBJBLOCK -&gt; OBJBLOCK
+     *     |--LCURLY -&gt; {
+     *     `--RCURLY -&gt; }
      * </pre>
      *
      * @since 8.36


### PR DESCRIPTION
fixes #9560 : 

<img width="620" alt="Screenshot 2021-03-23 at 1 34 21 PM" src="https://user-images.githubusercontent.com/65589791/112113366-bc1cc480-8bdc-11eb-9112-f37cb688039b.png">

Source used to generate AST:
```
public record MyRecord(Comp x, Comp... comps) {

}
```

Generated AST:
```
RECORD_DEF -> RECORD_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_RECORD -> record [1:7]
|--IDENT -> MyRecord [1:14]
|--LPAREN -> ( [1:22]
|--RECORD_COMPONENTS -> RECORD_COMPONENTS [1:23]
|   |--RECORD_COMPONENT_DEF -> RECORD_COMPONENT_DEF [1:23]
|   |   |--ANNOTATIONS -> ANNOTATIONS [1:23]
|   |   |--TYPE -> TYPE [1:23]
|   |   |   `--IDENT -> Comp [1:23]
|   |   `--IDENT -> x [1:28]
|   |--COMMA -> , [1:29]
|   `--RECORD_COMPONENT_DEF -> RECORD_COMPONENT_DEF [1:31]
|       |--ANNOTATIONS -> ANNOTATIONS [1:31]
|       |--TYPE -> TYPE [1:31]
|       |   `--IDENT -> Comp [1:31]
|       |--ELLIPSIS -> ... [1:35]
|       `--IDENT -> comps [1:39]
|--RPAREN -> ) [1:44]
`--OBJBLOCK -> OBJBLOCK [1:46]
    |--LCURLY -> { [1:46]
    `--RCURLY -> } [3:0]
```

Expected Update for Javadoc:
```
RECORD_DEF -> RECORD_DEF
|--MODIFIERS -> MODIFIERS
|   `--LITERAL_PUBLIC -> public
|--LITERAL_RECORD -> record
|--IDENT -> MyRecord
|--LPAREN -> (
|--RECORD_COMPONENTS -> RECORD_COMPONENTS
|   |--RECORD_COMPONENT_DEF -> RECORD_COMPONENT_DEF
|   |   |--ANNOTATIONS -> ANNOTATIONS
|   |   |--TYPE -> TYPE
|   |   |   `--IDENT -> Comp
|   |   `--IDENT -> x
|   |--COMMA -> ,
|   `--RECORD_COMPONENT_DEF -> RECORD_COMPONENT_DEF
|       |--ANNOTATIONS -> ANNOTATIONS
|       |--TYPE -> TYPE
|       |   `--IDENT -> Comp
|       |--ELLIPSIS -> ...
|       `--IDENT -> comps
|--RPAREN -> )
`--OBJBLOCK -> OBJBLOCK
    |--LCURLY -> {
    `--RCURLY -> }
```