### PR TITLE
Issue #7297: Fix EmptyLineSeparator skips single line comments under …

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -414,7 +414,7 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
             checkCommentInModifiers(ast);
         }
         DetailAST nextToken = ast.getNextSibling();
-        while (isComment(nextToken)) {
+        while (nextToken != null && TokenUtil.isCommentType(nextToken.getType())) {
             nextToken = nextToken.getNextSibling();
         }
         if (nextToken != null) {
@@ -630,9 +630,44 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
                 log(ast, MSG_SHOULD_BE_SEPARATED, ast.getText());
             }
         }
-        if (!hasEmptyLineAfter(ast)) {
+        if (isLineEmptyAfterPackage(ast)) {
+            final DetailAST elementAst = getViolationAstForPackage(ast);
+            log(elementAst, MSG_SHOULD_BE_SEPARATED, elementAst.getText());
+        }
+        else if (!hasEmptyLineAfter(ast)) {
             log(nextToken, MSG_SHOULD_BE_SEPARATED, nextToken.getText());
         }
+    }
+
+    /**
+     * Checks if there is another element at next line of package declaration.
+     *
+     * @param ast Package ast.
+     * @return true, if there is an element.
+     */
+    private static boolean isLineEmptyAfterPackage(DetailAST ast) {
+        DetailAST nextElement = ast.getNextSibling();
+        final int lastChildLineNo = ast.getLastChild().getLineNo();
+        while (nextElement.getLineNo() < lastChildLineNo + 1
+                && nextElement.getNextSibling() != null) {
+            nextElement = nextElement.getNextSibling();
+        }
+        return nextElement.getLineNo() == lastChildLineNo + 1;
+    }
+
+    /**
+     * Gets the Ast on which violation is to be given for package declaration.
+     *
+     * @param ast Package ast.
+     * @return Violation ast.
+     */
+    private static DetailAST getViolationAstForPackage(DetailAST ast) {
+        DetailAST nextElement = ast.getNextSibling();
+        final int lastChildLineNo = ast.getLastChild().getLineNo();
+        while (nextElement.getLineNo() < lastChildLineNo + 1) {
+            nextElement = nextElement.getNextSibling();
+        }
+        return nextElement;
     }
 
     /**
@@ -770,7 +805,7 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
             lastToken = token.getLastChild();
         }
         DetailAST nextToken = token.getNextSibling();
-        if (isComment(nextToken)) {
+        if (TokenUtil.isCommentType(nextToken.getType())) {
             nextToken = nextToken.getNextSibling();
         }
         // Start of the next token
@@ -790,7 +825,7 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
         return Optional.ofNullable(packageDef.getNextSibling())
             .map(sibling -> sibling.findFirstToken(TokenTypes.MODIFIERS))
             .map(DetailAST::getFirstChild)
-            .filter(EmptyLineSeparatorCheck::isComment)
+            .filter(token -> TokenUtil.isCommentType(token.getType()))
             .filter(comment -> comment.getLineNo() == packageDef.getLineNo() + 1);
     }
 
@@ -865,17 +900,6 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
             result = true;
         }
         return result;
-    }
-
-    /**
-     * Check if token is a comment.
-     *
-     * @param ast ast node
-     * @return true, if given ast is comment.
-     */
-    private static boolean isComment(DetailAST ast) {
-        return TokenUtil.isOfType(ast,
-            TokenTypes.SINGLE_LINE_COMMENT, TokenTypes.BLOCK_COMMENT_BEGIN);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -180,6 +180,62 @@ public class EmptyLineSeparatorCheckTest
     }
 
     @Test
+    public void testCommentAfterPackageWithImports() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(EmptyLineSeparatorCheck.class);
+        final String[] expected = {
+            "2:1: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "//"),
+        };
+        verify(checkConfig,
+                getPath("InputEmptyLineSeparatorSingleLineCommentAfterPackage.java"),
+                expected);
+    }
+
+    @Test
+    public void testJavadocCommentAfterPackageWithImports() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(EmptyLineSeparatorCheck.class);
+        final String[] expected = {
+            "2:1: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "/*"),
+        };
+        verify(checkConfig,
+                getPath("InputEmptyLineSeparatorJavadocCommentAfterPackage.java"),
+                expected);
+    }
+
+    @Test
+    public void testPackageImportsClassInSingleLine() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(EmptyLineSeparatorCheck.class);
+        final String[] expected = {
+            "1:79: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "import"),
+            "1:101: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "CLASS_DEF"),
+        };
+        verify(checkConfig,
+                getPath("InputEmptyLineSeparatorPackageImportClassInOneLine.java"),
+                expected);
+    }
+
+    @Test
+    public void testEmptyLineAfterPackageForPackageAst() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(EmptyLineSeparatorCheck.class);
+        checkConfig.addAttribute("tokens", "PACKAGE_DEF");
+        final String[] expected = {
+            "2:1: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "/*"),
+        };
+        verify(checkConfig,
+                getPath("InputEmptyLineSeparatorEmptyLineAfterPackageForPackageAst.java"),
+                expected);
+    }
+
+    @Test
+    public void testEmptyLineAfterPackageForImportAst() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(EmptyLineSeparatorCheck.class);
+        checkConfig.addAttribute("tokens", "IMPORT");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verify(checkConfig,
+                getPath("InputEmptyLineSeparatorEmptyLineAfterPackageForImportAst.java"),
+                expected);
+    }
+
+    @Test
     public void testClassDefinitionAndCommentNotSeparatedFromPackage() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(EmptyLineSeparatorCheck.class);
         final String[] expected = {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorEmptyLineAfterPackageForImportAst.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorEmptyLineAfterPackageForImportAst.java
@@ -1,0 +1,14 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator; // ok
+/**
+ * ok, no violation.
+ *
+ */
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Config:
+ * tokens - IMPORT
+ */
+public class InputEmptyLineSeparatorEmptyLineAfterPackageForImportAst {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorEmptyLineAfterPackageForPackageAst.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorEmptyLineAfterPackageForPackageAst.java
@@ -1,0 +1,14 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
+/** // violation
+ * violation expected at line above.
+ *
+ */
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Config:
+ * tokens - PACKAGE_DEF
+ */
+public class InputEmptyLineSeparatorEmptyLineAfterPackageForPackageAst {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorJavadocCommentAfterPackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorJavadocCommentAfterPackage.java
@@ -1,0 +1,13 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
+/**
+ * Some javadoc here.
+ */
+// violation
+
+import java.util.Map;
+
+/**
+ * Config: default.
+ */
+public class InputEmptyLineSeparatorJavadocCommentAfterPackage {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorPackageImportClassInOneLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorPackageImportClassInOneLine.java
@@ -1,0 +1,1 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator; import java.util.Map; public class  /** Config: default */ InputEmptyLineSeparatorPackageImportClassInOneLine {} // violation

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorSingleLineCommentAfterPackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorSingleLineCommentAfterPackage.java
@@ -1,0 +1,11 @@
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator; // trailing comment is allowed.
+// violation
+// violation at line above
+
+import java.util.Map;
+
+/**
+ * Config: default
+ */
+public class InputEmptyLineSeparatorSingleLineCommentAfterPackage {
+}


### PR DESCRIPTION
Closes #7297 

```
$ cat Test.java 
package test;
// violation is expected

import java.lang;

class Test {}

$ cat config.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">

<module name="Checker">
    <property name="charset" value="UTF-8"/>
    <module name="TreeWalker">
        <module name="EmptyLineSeparatorCheck">
		<property name="tokens" value="PACKAGE_DEF,IMPORT"/>
    </module>
    </module>
</module>       
                                                                                                                                                      
$ java -jar checkstyle-8.42-SNAPSHOT-all.jar -c config.xml Test.java 
Starting audit...
[ERROR] /home/akmo/GitHub/Test/NewLineSeperator/Test.java:2:1: '//' should be separated from previous statement. [EmptyLineSeparator]
Audit done.
Checkstyle ends with 1 errors.

```

Diff Regression config: https://raw.githubusercontent.com/AkMo3/akmo3.github.io/master/Issue7297/config-FIX_EMPTY_LINE_AFTER_PACKAGE-20210323145757.xml
Diff Regression projects: https://raw.githubusercontent.com/AkMo3/akmo3.github.io/master/Issue9010/projects-to-test-on.properties