### PR TITLE
Issue #9143:AvoidEscapedUnicodeCharacters does not identify line ending characters in multiline text blocks

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -208,6 +208,7 @@ public class AvoidEscapedUnicodeCharactersCheck
             + "|\\\\b"
             + "|\\\\f"
             + "|\\\\n"
+            + "|\\n"
             + "|\\\\r"
             + "|\\\\s"
             + "|\\\\t"

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersEscapedS.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersEscapedS.java
@@ -31,4 +31,8 @@ public class InputAvoidEscapedUnicodeCharactersEscapedS {
             l\u03bc\n
             """; // violation on line 30
     String value10 = "\n       \u03bc\s";
+    String value11 = """
+        \u03bc\
+        \s\u03bc\
+        """;
 }


### PR DESCRIPTION
Issue #9143: AvoidEscapedUnicodeCharacters does not identify line ending characters in multiline text blocks

Diff Regression config: https://gist.githubusercontent.com/nmancus1/5518fdcdbcf0bcfa973b5f55dab057ec/raw/1abc863bce57cc97a5e89224c5f1138cb4330027/config.xml