### PR TITLE
Issue #9490: updated example of AST for TokenTypes.LITERAL_PUBLIC

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1297,6 +1297,21 @@ public final class TokenTypes {
     /**
      * The {@code public} keyword.
      *
+     * <p>For example:</p>
+     * <pre>
+     * public int x;
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * VARIABLE_DEF -&gt; VARIABLE_DEF
+     *  |--MODIFIERS -&gt; MODIFIERS
+     *  |   `--LITERAL_PUBLIC -&gt; public
+     *  |--TYPE -&gt; TYPE
+     *  |   `--LITERAL_INT -&gt; int
+     *  |--IDENT -&gt; x
+     *  `--SEMI -&gt; ;
+     * </pre>
+     *
      * @see #MODIFIERS
      **/
     public static final int LITERAL_PUBLIC =


### PR DESCRIPTION
fixes #9490 :

<img width="620" alt="Screenshot 2021-03-24 at 3 34 18 PM" src="https://user-images.githubusercontent.com/65589791/112292012-ac71ae80-8cb6-11eb-9a36-c11e091e5d55.png">

Source used to generate AST:
```
public class MyClass{
    public int x;
}
```

Generated AST:
```
CLASS_DEF -> CLASS_DEF [22:0]
|--MODIFIERS -> MODIFIERS [22:0]
|   `--LITERAL_PUBLIC -> public [22:0]
|--LITERAL_CLASS -> class [22:7]
|--IDENT -> MyClass [22:13]
`--OBJBLOCK -> OBJBLOCK [22:20]
    |--LCURLY -> { [22:20]
    |--VARIABLE_DEF -> VARIABLE_DEF [23:4]
    |   |--MODIFIERS -> MODIFIERS [23:4]
    |   |   `--LITERAL_PUBLIC -> public [23:4]
    |   |--TYPE -> TYPE [23:11]
    |   |   `--LITERAL_INT -> int [23:11]
    |   |--IDENT -> x [23:15]
    |   `--SEMI -> ; [23:16]
    `--RCURLY -> } [24:0]
```

Expected Update for JavaDoc:
```
VARIABLE_DEF -> VARIABLE_DEF
 |--MODIFIERS -> MODIFIERS
 |   `--LITERAL_PUBLIC -> public
 |--TYPE -> TYPE
 |   `--LITERAL_INT -> int
 |--IDENT -> x
 `--SEMI -> ;
```