### PR TITLE
Issue #9469: Update example of AST for TokenTypes.LITERAL_CLASS

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1891,6 +1891,17 @@ public final class TokenTypes {
      *     `--RCURLY -&gt; }
      * </pre>
      *
+     * <p>For example:</p>
+     * <pre> int.class
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * EXPR -&gt; EXPR
+     *  `--DOT -&gt; .
+     *      |--LITERAL_INT -&gt; int
+     *      `--LITERAL_CLASS -&gt; class
+     * </pre>
+     *
      * @see #DOT
      * @see #IDENT
      * @see #CLASS_DEF


### PR DESCRIPTION
Closes #9469
Added comment lines to [TokenTypes.java](https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java)
![image](https://user-images.githubusercontent.com/55190574/112365048-32b0e380-8cfd-11eb-9cfc-b64d143a463e.png)
```
E:\GSoC>java -jar checkstyle-8.41-all.jar -t Test.java
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> Test [1:13]
`--OBJBLOCK -> OBJBLOCK [1:17]
    |--LCURLY -> { [1:17]
    |--METHOD_DEF -> METHOD_DEF [2:4]
    |   |--MODIFIERS -> MODIFIERS [2:4]
    |   |--TYPE -> TYPE [2:4]
    |   |   `--LITERAL_VOID -> void [2:4]
    |   |--IDENT -> check [2:9]
    |   |--LPAREN -> ( [2:14]
    |   |--PARAMETERS -> PARAMETERS [2:15]
    |   |--RPAREN -> ) [2:15]
    |   `--SLIST -> { [2:16]
    |       |--VARIABLE_DEF -> VARIABLE_DEF [3:8]
    |       |   |--MODIFIERS -> MODIFIERS [3:8]
    |       |   |--TYPE -> TYPE [3:8]
    |       |   |   |--IDENT -> Class [3:8]
    |       |   |   `--TYPE_ARGUMENTS -> TYPE_ARGUMENTS [3:13]
    |       |   |       |--GENERIC_START -> < [3:13]
    |       |   |       |--TYPE_ARGUMENT -> TYPE_ARGUMENT [3:14]
    |       |   |       |   `--IDENT -> Integer [3:14]
    |       |   |       `--GENERIC_END -> > [3:21]
    |       |   |--IDENT -> a [3:23]
    |       |   `--ASSIGN -> = [3:25]
    |       |       `--EXPR -> EXPR [3:30]
    |       |           `--DOT -> . [3:30]
    |       |               |--LITERAL_INT -> int [3:27]
    |       |               `--LITERAL_CLASS -> class [3:31]
    |       |--SEMI -> ; [3:36]
    |       `--RCURLY -> } [4:4]
    `--RCURLY -> } [5:0]
```
Expected update for javodoc is:
```
|`--EXPR -> EXPR
|    `--DOT -> .
|        |--LITERAL_INT -> int
|        `--LITERAL_CLASS -> class
```