### PR TITLE
Issue #9566: update example of AST for TokenTypes.RPAREN

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -2049,6 +2049,25 @@ public final class TokenTypes {
     /**
      * A right parenthesis ({@code )}).
      *
+     * <p>For example:</p>
+     * <pre>
+     * void check() {
+     * }
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * METHOD_DEF -&gt; METHOD_DEF
+     *  |--MODIFIERS -&gt; MODIFIERS
+     *  |--TYPE -&gt; TYPE
+     *  |   `--LITERAL_VOID -&gt; void
+     *  |--IDENT -&gt; check
+     *  |--LPAREN -&gt; (
+     *  |--PARAMETERS -&gt; PARAMETERS
+     *  |--RPAREN -&gt; )
+     *  `--SLIST -&gt; {
+     *      `--RCURLY -&gt; }
+     * </pre>
+     *
      * @see #LITERAL_FOR
      * @see #LITERAL_NEW
      * @see #METHOD_CALL


### PR DESCRIPTION
Closes #9566 

<!--![image](https://user-images.githubusercontent.com/55190574/114202428-cb3d9980-9974-11eb-9306-479009cc8964.png)-->
![image](https://user-images.githubusercontent.com/55190574/115195093-f742e280-a10b-11eb-8da6-38755226f9ca.png)
**Rparen.java**
```
public class Rparen{
    void check(){
        //A right parenthesis is used in check(")"
    }
}
```
**Cmd console:**
```
E:\GSoC>javac Rparen.java
E:\GSoC>java -jar checkstyle-8.41-all.jar -t Rparen.java
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> Rparen [1:13]
`--OBJBLOCK -> OBJBLOCK [1:19]
    |--LCURLY -> { [1:19]
    |--METHOD_DEF -> METHOD_DEF [2:4]
    |   |--MODIFIERS -> MODIFIERS [2:4]
    |   |--TYPE -> TYPE [2:4]
    |   |   `--LITERAL_VOID -> void [2:4]
    |   |--IDENT -> check [2:9]
    |   |--LPAREN -> ( [2:14]
    |   |--PARAMETERS -> PARAMETERS [2:15]
    |   |--RPAREN -> ) [2:15]
    |   `--SLIST -> { [2:16]
    |       `--RCURLY -> } [4:4]
    `--RCURLY -> } [5:0]
```
**Expected update for javodoc**
```
METHOD_DEF -&gt; METHOD_DEF
 |--MODIFIERS -&gt; MODIFIERS
 |--TYPE -&gt; TYPE
 |   `--LITERAL_VOID -&gt; void
 |--IDENT -&gt; check
 |--LPAREN -&gt; (
 |--PARAMETERS -&gt; PARAMETERS
 |--RPAREN -&gt; )
 `--SLIST -&gt; {
     `--RCURLY -&gt; }
```