### PR TITLE
Issue #9559: update example of AST for TokenTypes.RCURLY

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1672,6 +1672,26 @@ public final class TokenTypes {
     /**
      * A right curly brace (<code>}</code>).
      *
+     * <p>For example:</p>
+     * <pre>
+     * {@code
+     * void foo(){}
+     * }
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * METHOD_DEF -&gt; METHOD_DEF
+     *  |--MODIFIERS -&gt; MODIFIERS
+     *  |--TYPE -&gt; TYPE
+     *  |   `--LITERAL_VOID -&gt; void
+     *  |--IDENT -&gt; foo
+     *  |--LPAREN -&gt; (
+     *  |--PARAMETERS -&gt; PARAMETERS
+     *  |--RPAREN -&gt; )
+     *  `--SLIST -&gt; {
+     *      `--RCURLY -&gt; }
+     * </pre>
+     *
      * @see #OBJBLOCK
      * @see #ARRAY_INIT
      * @see #SLIST


### PR DESCRIPTION
Closes #9559 
![CheckStyle_rcurly_PR_photo](https://user-images.githubusercontent.com/62554685/113503230-83df8500-94fe-11eb-8441-04209d2e05e7.png)






```
$ cat Test.java

public class Test{
    void foo(){} 
} 

```
AST in CLI for the above Java file:-
```
$ java -jar checkstyle-8.41-all.jar -T Test.java
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> Test [1:13]
`--OBJBLOCK -> OBJBLOCK [1:17]
    |--LCURLY -> { [1:17]
    |--METHOD_DEF -> METHOD_DEF [2:4]
    |   |--MODIFIERS -> MODIFIERS [2:4]
    |   |--TYPE -> TYPE [2:4]
    |   |   `--LITERAL_VOID -> void [2:4]
    |   |--IDENT -> foo [2:9]
    |   |--LPAREN -> ( [2:12]
    |   |--PARAMETERS -> PARAMETERS [2:13]
    |   |--RPAREN -> ) [2:13]
    |   `--SLIST -> { [2:14]
    |       `--RCURLY -> } [2:15]
    `--RCURLY -> } [3:0]
```

```
# printing lines we are concerned with:-
$ java -jar checkstyle-8.41-all.jar -T Test.java | grep "2:15"

|--METHOD_DEF -> METHOD_DEF [2:4]
|   |--MODIFIERS -> MODIFIERS [2:4]
|   |--TYPE -> TYPE [2:4]
|   |   `--LITERAL_VOID -> void [2:4]
|   |--IDENT -> foo [2:9]
|   |--LPAREN -> ( [2:12]
|   |--PARAMETERS -> PARAMETERS [2:13]
|   |--RPAREN -> ) [2:13]
|   `--SLIST -> { [2:14]
|       `--RCURLY -> } [2:15]
```
expected update for javadoc :-

```
METHOD_DEF -> METHOD_DEF 
 |--MODIFIERS -> MODIFIERS 
 |--TYPE -> TYPE 
 |   `--LITERAL_VOID -> void 
 |--IDENT -> foo 
 |--LPAREN -> ( 
 |--PARAMETERS -> PARAMETERS 
 |--RPAREN -> ) 
 `--SLIST -> { 
     `--RCURLY -> } 

```
