### PR TITLE
Issue #9504: updated example of AST for TokenTypes.LITERAL_VOID

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1265,6 +1265,19 @@ public final class TokenTypes {
     /**
      * The {@code void} keyword.
      *
+     * <p>For example:</p>
+     * <pre>
+     * {@code void literal_void(){}}
+     * </pre>
+     * <p>'void' parses as:</p>
+     * <pre>
+     * METHOD_DEF -&gt; METHOD_DEF
+     *  |--MODIFIERS -&gt; MODIFIERS
+     *  |--TYPE -&gt; TYPE
+     *  |   `--LITERAL_VOID -&gt; void
+     *  |--IDENT -&gt; literal_void
+     * </pre>
+     *
      * @see #TYPE
      **/
     public static final int LITERAL_VOID =


### PR DESCRIPTION
Closes #9504 
![CheckStyle_void_PR_photo](https://user-images.githubusercontent.com/62554685/112758855-62424300-8fbe-11eb-962b-9b25d979a986.png)


```
$ cat Test.java

public class Test{
    void literal_void(){}
}
```
AST in CLI for the above Java file:-

```
$ java -jar checkstyle-8.41-all.jar -T Test.java
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> Test [1:13]
`--OBJBLOCK -> OBJBLOCK [1:17]
    |--LCURLY -> { [1:17]
    |--METHOD_DEF -> METHOD_DEF [2:4]
    |   |--MODIFIERS -> MODIFIERS [2:4]
    |   |--TYPE -> TYPE [2:4]
    |   |   `--LITERAL_VOID -> void [2:4]
    |   |--IDENT -> literal_void [2:9]
    |   |--LPAREN -> ( [2:21]
    |   |--PARAMETERS -> PARAMETERS [2:22]
    |   |--RPAREN -> ) [2:22]
    |   `--SLIST -> { [2:23]
    |       `--RCURLY -> } [2:24]
    `--RCURLY -> } [3:0]
```

```
# printing lines we are concerned with:-
$ java -jar checkstyle-8.41-all.jar -T Test.java | grep "2:4\|2:9"

|--METHOD_DEF -> METHOD_DEF [2:4]
|   |--MODIFIERS -> MODIFIERS [2:4]
|   |--TYPE -> TYPE [2:4]
|   |   `--LITERAL_VOID -> void [2:4]
|   |--IDENT -> literal_void [2:9]
```

expected update for javadoc is:-
```
METHOD_DEF -> METHOD_DEF
 |--MODIFIERS -> MODIFIERS
 |--TYPE -> TYPE
 |   `--LITERAL_VOID -> void
 |--IDENT -> literal_void
```