### PR TITLE
Issue #9568: update example of AST for TokenTypes.SINGLE_LINE_COMMENT

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -4022,6 +4022,16 @@ public final class TokenTypes {
      *         |
      *         +--COMMENT_CONTENT
      * </pre>
+     *
+     * <p>For example:</p>
+     * <pre>
+     * // Comment content
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * SINGLE_LINE_COMMENT -&gt; //
+     *  `--COMMENT_CONTENT -&gt;  Comment Content\n
+     * </pre>
      */
     public static final int SINGLE_LINE_COMMENT =
             GeneratedJavaTokenTypes.SINGLE_LINE_COMMENT;


### PR DESCRIPTION
Closes #9568
![image](https://user-images.githubusercontent.com/43009893/112738696-fc2dcf80-8f6d-11eb-88ce-398f8f8cb93d.png)

Code used for Generating example: 
```
mahmoud:~/Desktop/checkstyle$ more Test.java 
// Comment Content
public class A {

}
```
```
mahmoud:~/Desktop/checkstyle$ java -jar checkstyle-8.41-all.jar -T Test.java 
CLASS_DEF -> CLASS_DEF [2:0]
|--MODIFIERS -> MODIFIERS [2:0]
|   |--SINGLE_LINE_COMMENT -> // [1:0]
|   |   `--COMMENT_CONTENT ->  Comment Content\n [1:2]
|   `--LITERAL_PUBLIC -> public [2:0]
|--LITERAL_CLASS -> class [2:7]
|--IDENT -> A [2:13]
`--OBJBLOCK -> OBJBLOCK [2:15]
    |--LCURLY -> { [2:15]
    `--RCURLY -> } [4:0]
```
Expected update for JavaDoc is:
```
SINGLE_LINE_COMMENT -> //
 `--COMMENT_CONTENT ->  Comment Content\n
```
