### PR TITLE
Issue #9456: updated example of AST for TokenTypes.INTERFACE_DEF

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -432,27 +432,22 @@ public final class TokenTypes {
      * <p>For example:</p>
      *
      * <pre>
-     *   public interface MyInterface
-     *   {
-     *   }
+     * public interface MyInterface {
      *
+     * }
      * </pre>
      *
      * <p>parses as:</p>
      *
      * <pre>
-     * +--INTERFACE_DEF
-     *     |
-     *     +--MODIFIERS
-     *         |
-     *         +--LITERAL_PUBLIC (public)
-     *     +--LITERAL_INTERFACE (interface)
-     *     +--IDENT (MyInterface)
-     *     +--EXTENDS_CLAUSE
-     *     +--OBJBLOCK
-     *         |
-     *         +--LCURLY ({)
-     *         +--RCURLY (})
+     * INTERFACE_DEF -&gt; INTERFACE_DEF
+     * |--MODIFIERS -&gt; MODIFIERS
+     * |   `--LITERAL_PUBLIC -&gt; public
+     * |--LITERAL_INTERFACE -&gt; interface
+     * |--IDENT -&gt; MyInterface
+     * `--OBJBLOCK -&gt; OBJBLOCK
+     *     |--LCURLY -&gt; {
+     *     `--RCURLY -&gt; }
      * </pre>
      *
      * @see <a


### PR DESCRIPTION
fixes #9456: 

<img width="630" alt="Screenshot 2021-03-28 at 10 08 11 AM" src="https://user-images.githubusercontent.com/65589791/112742616-abd66200-8fad-11eb-92cb-e0f016097465.png">

Source used to generate AST:

```
public interface MyInterface {
    
}
```

Generated AST:

```
INTERFACE_DEF -> INTERFACE_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_INTERFACE -> interface [1:7]
|--IDENT -> MyInterface [1:17]
`--OBJBLOCK -> OBJBLOCK [1:29]
    |--LCURLY -> { [1:29]
    `--RCURLY -> } [3:0]
```

Expected update for JavaDoc:

```
INTERFACE_DEF -> INTERFACE_DEF
|--MODIFIERS -> MODIFIERS
|   `--LITERAL_PUBLIC -> public
|--LITERAL_INTERFACE -> interface
|--IDENT -> MyInterface
`--OBJBLOCK -> OBJBLOCK
    |--LCURLY -> {
    `--RCURLY -> }
```