### PR TITLE
Issue #9483: updated example of AST for TokenTypes.LITERAL_INTERFACE

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1535,6 +1535,27 @@ public final class TokenTypes {
      * The {@code interface} keyword. This token appears in
      * interface definition.
      *
+     * <p>For example:</p>
+     *
+     * <pre>
+     * public interface MyInterface {
+     *
+     * }
+     * </pre>
+     *
+     * <p>parses as:</p>
+     *
+     * <pre>
+     * INTERFACE_DEF -&gt; INTERFACE_DEF
+     * |--MODIFIERS -&gt; MODIFIERS
+     * |   `--LITERAL_PUBLIC -&gt; public
+     * |--LITERAL_INTERFACE -&gt; interface
+     * |--IDENT -&gt; MyInterface
+     * `--OBJBLOCK -&gt; OBJBLOCK
+     *     |--LCURLY -&gt; {
+     *     `--RCURLY -&gt; }
+     * </pre>
+     *
      * @see #INTERFACE_DEF
      **/
     public static final int LITERAL_INTERFACE =


### PR DESCRIPTION
fixes #9483 :

<img width="630" alt="Screenshot 2021-03-28 at 10 55 04 AM" src="https://user-images.githubusercontent.com/65589791/112743374-61a4af00-8fb4-11eb-8ff6-e23720d5faa2.png">

Source used to generate AST:

```
public interface MyInterface {
    
}
```

Generated AST:

```
INTERFACE_DEF -> INTERFACE_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_INTERFACE -> interface [1:7]
|--IDENT -> MyInterface [1:17]
`--OBJBLOCK -> OBJBLOCK [1:29]
    |--LCURLY -> { [1:29]
    `--RCURLY -> } [3:0]
```

Expected update for JavaDoc:

```
INTERFACE_DEF -> INTERFACE_DEF
|--MODIFIERS -> MODIFIERS
|   `--LITERAL_PUBLIC -> public
|--LITERAL_INTERFACE -> interface
|--IDENT -> MyInterface
`--OBJBLOCK -> OBJBLOCK
    |--LCURLY -> {
    `--RCURLY -> }
```