### PR TITLE
Issue #9488: updated example of AST for TokenTypes.LITERAL_PRIVATE

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1448,6 +1448,21 @@ public final class TokenTypes {
     /**
      * The {@code private} keyword.
      *
+     * <p>For example:</p>
+     * <pre>
+     * private int x;
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * VARIABLE_DEF -&gt; VARIABLE_DEF
+     *  |--MODIFIERS -&gt; MODIFIERS
+     *  |   `--LITERAL_PRIVATE -&gt; private
+     *  |--TYPE -&gt; TYPE
+     *  |   `--LITERAL_INT -&gt; int
+     *  |--IDENT -&gt; x
+     *  `--SEMI -&gt; ;
+     * </pre>
+     *
      * @see #MODIFIERS
      **/
     public static final int LITERAL_PRIVATE =


### PR DESCRIPTION
fixes #9488 : 

<img width="630" alt="Screenshot 2021-03-28 at 5 03 57 PM" src="https://user-images.githubusercontent.com/65589791/112750754-04c2ec00-8fe8-11eb-9547-3a006312051d.png">

Source used to generate AST:
```
public class MyClass {
    private int x;
}
```

Generated AST:
```
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> MyClass [1:13]
`--OBJBLOCK -> OBJBLOCK [1:21]
    |--LCURLY -> { [1:21]
    |--VARIABLE_DEF -> VARIABLE_DEF [2:4]
    |   |--MODIFIERS -> MODIFIERS [2:4]
    |   |   `--LITERAL_PRIVATE -> private [2:4]
    |   |--TYPE -> TYPE [2:12]
    |   |   `--LITERAL_INT -> int [2:12]
    |   |--IDENT -> x [2:16]
    |   `--SEMI -> ; [2:17]
    `--RCURLY -> } [3:0]
```

Expected Update for JavaDoc:
```
VARIABLE_DEF -> VARIABLE_DEF
 |--MODIFIERS -> MODIFIERS
 |   `--LITERAL_PRIVATE -> private
 |--TYPE -> TYPE
 |   `--LITERAL_INT -> int
 |--IDENT -> x
 `--SEMI -> ;
```