### PR TITLE
Issue #9484: updated example of AST for TokenTypes.LITERAL_LONG

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1332,6 +1332,21 @@ public final class TokenTypes {
     /**
      * The {@code long} keyword.
      *
+     * <p>For example:</p>
+     * <pre>
+     * public long x;
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * VARIABLE_DEF -&gt; VARIABLE_DEF
+     *  |--MODIFIERS -&gt; MODIFIERS
+     *  |   `--LITERAL_PUBLIC -&gt; public
+     *  |--TYPE -&gt; TYPE
+     *  |   `--LITERAL_LONG -&gt; long
+     *  |--IDENT -&gt; x
+     *  `--SEMI -&gt; ;
+     * </pre>
+     *
      * @see #TYPE
      **/
     public static final int LITERAL_LONG =


### PR DESCRIPTION
fixes #9484 : 

<img width="630" alt="Screenshot 2021-03-29 at 1 30 12 AM" src="https://user-images.githubusercontent.com/65589791/112766679-68710780-9030-11eb-9b5a-2ef48d4f0c08.png">

Source used to generate AST:
```
public class MyClass {
    public long x;
}
```

Generated AST:
```
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> MyClass [1:13]
`--OBJBLOCK -> OBJBLOCK [1:21]
    |--LCURLY -> { [1:21]
    |--VARIABLE_DEF -> VARIABLE_DEF [2:4]
    |   |--MODIFIERS -> MODIFIERS [2:4]
    |   |   `--LITERAL_PUBLIC -> public [2:4]
    |   |--TYPE -> TYPE [2:11]
    |   |   `--LITERAL_LONG -> long [2:11]
    |   |--IDENT -> x [2:16]
    |   `--SEMI -> ; [2:17]
    `--RCURLY -> } [3:0]
```

Expected update for JavaDoc:
```
VARIABLE_DEF -> VARIABLE_DEF
--MODIFIERS -> MODIFIERS
   `--LITERAL_PUBLIC -> public
--TYPE -> TYPE
   `--LITERAL_LONG -> long
--IDENT -> x
`--SEMI -> ;
```