### PR TITLE
Issue #9482: updated example of AST for TokenTypes.LITERAL_INT

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1318,6 +1318,21 @@ public final class TokenTypes {
     /**
      * The {@code int} keyword.
      *
+     * <p>For example:</p>
+     * <pre>
+     * public int x;
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * VARIABLE_DEF -&gt; VARIABLE_DEF
+     *  |--MODIFIERS -&gt; MODIFIERS
+     *  |   `--LITERAL_PUBLIC -&gt; public
+     *  |--TYPE -&gt; TYPE
+     *  |   `--LITERAL_INT -&gt; int
+     *  |--IDENT -&gt; x
+     *  `--SEMI -&gt; ;
+     * </pre>
+     *
      * @see #TYPE
      **/
     public static final int LITERAL_INT = GeneratedJavaTokenTypes.LITERAL_int;


### PR DESCRIPTION
fixes #9482 : 

<img width="630" alt="Screenshot 2021-03-29 at 2 04 48 AM" src="https://user-images.githubusercontent.com/65589791/112767246-4e84f400-9033-11eb-8c4d-83839c3776b2.png">

Source used to generate AST:
```
public class MyClass {
    public int x;
}
```

Generated AST:
```
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> MyClass [1:13]
`--OBJBLOCK -> OBJBLOCK [1:21]
    |--LCURLY -> { [1:21]
    |--VARIABLE_DEF -> VARIABLE_DEF [2:4]
    |   |--MODIFIERS -> MODIFIERS [2:4]
    |   |   `--LITERAL_PUBLIC -> public [2:4]
    |   |--TYPE -> TYPE [2:11]
    |   |   `--LITERAL_INT -> int [2:11]
    |   |--IDENT -> x [2:15]
    |   `--SEMI -> ; [2:16]
    `--RCURLY -> } [3:0]
```

Expected update for JavaDoc:
```
VARIABLE_DEF -> VARIABLE_DEF
 |--MODIFIERS -> MODIFIERS
 |  `--LITERAL_PUBLIC -> public
 |--TYPE -> TYPE
 |  `--LITERAL_INT -> int
 |--IDENT -> x
 `--SEMI -> ;
```