### PR TITLE
Issue #9493: updated example of AST for TokenTypes.LITERAL_SHORT

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1296,6 +1296,21 @@ public final class TokenTypes {
     /**
      * The {@code short} keyword.
      *
+     * <p>For example:</p>
+     * <pre>
+     * public short x;
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * VARIABLE_DEF -&gt; VARIABLE_DEF
+     *  |--MODIFIERS -&gt; MODIFIERS
+     *  |   `--LITERAL_PUBLIC -&gt; public
+     *  |--TYPE -&gt; TYPE
+     *  |   `--LITERAL_SHORT -&gt; short
+     *  |--IDENT -&gt; x
+     *  `--SEMI -&gt; ;
+     * </pre>
+     *
      * @see #TYPE
      **/
     public static final int LITERAL_SHORT =


### PR DESCRIPTION
fixes #9493 : 

<img width="630" alt="Screenshot 2021-03-29 at 12 04 09 PM" src="https://user-images.githubusercontent.com/65589791/112796242-566e8380-9087-11eb-8f0a-6e4e7f29f4aa.png">


Source used to generate AST:
```
public class MyClass {
    public short x;
}
```

Generated AST:
```
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> MyClass [1:13]
`--OBJBLOCK -> OBJBLOCK [1:21]
    |--LCURLY -> { [1:21]
    |--VARIABLE_DEF -> VARIABLE_DEF [2:4]
    |   |--MODIFIERS -> MODIFIERS [2:4]
    |   |   `--LITERAL_PUBLIC -> public [2:4]
    |   |--TYPE -> TYPE [2:11]
    |   |   `--LITERAL_SHORT -> short [2:11]
    |   |--IDENT -> x [2:15]
    |   `--SEMI -> ; [2:16]
    `--RCURLY -> } [3:0]
```

Expected update for JavaDoc:
```
VARIABLE_DEF -> VARIABLE_DEF
 |--MODIFIERS -> MODIFIERS
 |  `--LITERAL_PUBLIC -> public
 |--TYPE -> TYPE
 |  `--LITERAL_SHORT -> short
 |--IDENT -> x
 `--SEMI -> ;
```