### PR TITLE
Issue #9477: updated example of AST for TokenTypes.LITERAL_FLOAT

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1325,6 +1325,21 @@ public final class TokenTypes {
     /**
      * The {@code float} keyword.
      *
+     * <p>For example:</p>
+     * <pre>
+     * public float x;
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * VARIABLE_DEF -&gt; VARIABLE_DEF
+     *  |--MODIFIERS -&gt; MODIFIERS
+     *  |   `--LITERAL_PUBLIC -&gt; public
+     *  |--TYPE -&gt; TYPE
+     *  |   `--LITERAL_FLOAT -&gt; float
+     *  |--IDENT -&gt; x
+     *  `--SEMI -&gt; ;
+     * </pre>
+     *
      * @see #TYPE
      **/
     public static final int LITERAL_FLOAT =


### PR DESCRIPTION
fixes #9477 : 

<img width="630" alt="Screenshot 2021-03-29 at 2 02 10 PM" src="https://user-images.githubusercontent.com/65589791/112809503-b2d99f00-9097-11eb-8b2b-b8164d575aa8.png">


Source used to generate AST:
```
public class MyClass {
    public float x;
}
```

Generated AST:
```
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> MyClass [1:13]
`--OBJBLOCK -> OBJBLOCK [1:21]
    |--LCURLY -> { [1:21]
    |--VARIABLE_DEF -> VARIABLE_DEF [2:4]
    |   |--MODIFIERS -> MODIFIERS [2:4]
    |   |   `--LITERAL_PUBLIC -> public [2:4]
    |   |--TYPE -> TYPE [2:11]
    |   |   `--LITERAL_FLOAT -> float [2:11]
    |   |--IDENT -> x [2:15]
    |   `--SEMI -> ; [2:16]
    `--RCURLY -> } [3:0]
```

Expected update for JavaDoc:
```
VARIABLE_DEF -> VARIABLE_DEF
 |--MODIFIERS -> MODIFIERS
 |  `--LITERAL_PUBLIC -> public
 |--TYPE -> TYPE
 |  `--LITERAL_FLOAT -> float
 |--IDENT -> x
 `--SEMI -> ;
```