### PR TITLE
Issue #9143:AvoidEscapedUnicodeCharacters does not identify line ending characters in multiline text blocks

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -208,6 +208,7 @@ public class AvoidEscapedUnicodeCharactersCheck
             + "|\\\\b"
             + "|\\\\f"
             + "|\\\\n"
+            + "|\\R"
             + "|\\\\r"
             + "|\\\\s"
             + "|\\\\t"

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersEscapedS.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharactersEscapedS.java
@@ -31,4 +31,8 @@ public class InputAvoidEscapedUnicodeCharactersEscapedS {
             l\u03bc\n
             """; // violation on line 30
     String value10 = "\n       \u03bc\s";
+    String value11 = """
+        \u03bc\
+        \s\u03bc\
+        """;
 }


### PR DESCRIPTION
Resolves #9143


Diff Regression config: https://gist.githubusercontent.com/shashwatj07/62612965266474738d91ed8a1eda53fd/raw/06c9dc513f0fa2e8086aa1e1d76abd7491458a53/config1.xml
Diff Regression projects: https://gist.githubusercontent.com/shashwatj07/b3de11a5c370e5f6092e31776b9c3b91/raw/8f42d25090f9d1b10c9b5d56ba39b482ac0aa91f/projects.properties