### PR TITLE
Issue #9489: add example of AST for TokenTypes.LITERAL_PROTECTED

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1449,6 +1449,21 @@ public final class TokenTypes {
     /**
      * The {@code protected} keyword.
      *
+     * <p>For example:</p>
+     * <pre>
+     * protected int x;
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * VARIABLE_DEF -&gt; VARIABLE_DEF
+     *  |--MODIFIERS -&gt; MODIFIERS
+     *  |   `--LITERAL_PROTECTED -&gt; protected
+     *  |--TYPE -&gt; TYPE
+     *  |   `--LITERAL_INT -&gt; int
+     *  |--IDENT -&gt; x
+     *  `--SEMI -&gt; ;
+     * </pre>
+     *
      * @see #MODIFIERS
      **/
     public static final int LITERAL_PROTECTED =


### PR DESCRIPTION
Issue: #9489 
![LITERAL_PROTECTED photo](https://user-images.githubusercontent.com/49342895/112834037-20e08f00-90b5-11eb-9115-8a8198969cae.PNG)

Source used to generate AST:
```
public class MyClass{
    protected int x;
}
```
Generated AST:

```
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> MyClass [1:13]
`--OBJBLOCK -> OBJBLOCK [1:20]
    |--LCURLY -> { [1:20]
    |--VARIABLE_DEF -> VARIABLE_DEF [2:2]
    |   |--MODIFIERS -> MODIFIERS [2:2]
    |   |   `--LITERAL_PROTECTED -> protected [2:2]
    |   |--TYPE -> TYPE [2:12]
    |   |   `--LITERAL_INT -> int [2:12]
    |   |--IDENT -> x [2:16]
    |   `--SEMI -> ; [2:17]
    `--RCURLY -> } [3:0]

```
Expected Update for JavaDoc:

```
VARIABLE_DEF -> VARIABLE_DEF
 |--MODIFIERS -> MODIFIERS
 |   `--LITERAL_PROTECTED -> protected
 |--TYPE -> TYPE
 |   `--LITERAL_INT -> int
 |--IDENT -> x
 `--SEMI -> ;
```