### PR TITLE
Issue #9756: IllegalIdentifierName doesn't check single lambda parameter

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/IllegalIdentifierNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/IllegalIdentifierNameCheck.java
@@ -68,7 +68,9 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_DEF">
  * RECORD_DEF</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_COMPONENT_DEF">
- * RECORD_COMPONENT_DEF</a>.
+ * RECORD_COMPONENT_DEF</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
+ * LAMBDA</a>.
  * </li>
  * </ul>
  * <p>
@@ -167,6 +169,7 @@ public class IllegalIdentifierNameCheck extends AbstractNameCheck {
             TokenTypes.PATTERN_VARIABLE_DEF,
             TokenTypes.RECORD_DEF,
             TokenTypes.RECORD_COMPONENT_DEF,
+            TokenTypes.LAMBDA,
         };
     }
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/naming/IllegalIdentifierNameCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/naming/IllegalIdentifierNameCheck.xml
@@ -19,7 +19,7 @@
                       type="java.util.regex.Pattern">
                <description>Specifies valid identifiers.</description>
             </property>
-            <property default-value="CLASS_DEF,INTERFACE_DEF,ENUM_DEF,ANNOTATION_DEF,ANNOTATION_FIELD_DEF,PARAMETER_DEF,VARIABLE_DEF,METHOD_DEF,ENUM_CONSTANT_DEF,PATTERN_VARIABLE_DEF,RECORD_DEF,RECORD_COMPONENT_DEF"
+            <property default-value="CLASS_DEF,INTERFACE_DEF,ENUM_DEF,ANNOTATION_DEF,ANNOTATION_FIELD_DEF,PARAMETER_DEF,VARIABLE_DEF,METHOD_DEF,ENUM_CONSTANT_DEF,PATTERN_VARIABLE_DEF,RECORD_DEF,RECORD_COMPONENT_DEF,LAMBDA"
                       name="tokens"
                       type="java.lang.String[]"
                       validation-type="tokenSet">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/IllegalIdentifierNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/IllegalIdentifierNameCheckTest.java
@@ -53,6 +53,7 @@ public class IllegalIdentifierNameCheckTest extends AbstractModuleTestSupport {
             TokenTypes.PATTERN_VARIABLE_DEF,
             TokenTypes.RECORD_DEF,
             TokenTypes.RECORD_COMPONENT_DEF,
+            TokenTypes.LAMBDA,
         };
 
         assertArrayEquals(expected, illegalIdentifierNameCheck.getAcceptableTokens(),
@@ -146,5 +147,22 @@ public class IllegalIdentifierNameCheckTest extends AbstractModuleTestSupport {
             };
         verify(checkConfig,
             getNonCompilablePath("InputIllegalIdentifierNameUnderscore.java"), expected);
+    }
+
+    @Test
+    public void testIllegalIdentifierNameLambda() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(IllegalIdentifierNameCheck.class);
+        final String format = "(?i)^(?!(record|yield|var|permits|sealed|_)$).+$";
+
+        final String[] expected = {
+            "11:39: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
+            "12:40: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
+            "24:9: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
+            "27:9: " + getCheckMessage(MSG_INVALID_PATTERN, "yield", format),
+            "34:47: " + getCheckMessage(MSG_INVALID_PATTERN, "var", format),
+        };
+        verify(checkConfig,
+            getNonCompilablePath("InputIllegalIdentifierNameLambda.java"), expected);
     }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierNameLambda.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/naming/illegalidentifiername/InputIllegalIdentifierNameLambda.java
@@ -1,0 +1,39 @@
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.naming.illegalidentifiername;
+
+import java.util.function.Function;
+/* Config:
+ * format = "(?i)^(?!(record|yield|var|permits|sealed|_)$).+$"
+ */
+public class InputIllegalIdentifierNameLambda {
+
+    public static void main(String... args) {
+        Function<String, String> f1 = var -> var; // violation
+        Function<String, String> f2 = (var) -> var; // violation
+        Function<String, String> f3 = myLambdaParam -> myLambdaParam; // ok
+    }
+
+    enum Day {
+        MON,
+        TUE,
+        WED,
+        THU,
+        FRI,
+        SAT,
+        SUN,
+        var, // violation
+    }
+
+    int yield(Day day) { // violation
+        return switch (day) {
+            case MON, TUE -> Math.addExact(0, 1);
+            case WED -> Math.addExact(1, 1);
+            case THU, SAT, FRI, SUN -> 0;
+            case var -> 23; // ok, caught above in initialization
+            default -> {
+                Function<String, String> f4 = var -> var; // violation
+                yield Math.addExact(2, 1); // ok, yield statement
+            }
+        };
+    }
+}

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -1054,6 +1054,10 @@ class MyClass {
                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_COMPONENT_DEF">
                   RECORD_COMPONENT_DEF
                 </a>
+                ,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
+                  LAMBDA
+                </a>
                 .
               </td>
               <td>
@@ -1103,6 +1107,10 @@ class MyClass {
                 ,
                 <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RECORD_COMPONENT_DEF">
                   RECORD_COMPONENT_DEF
+                </a>
+                ,
+                <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAMBDA">
+                  LAMBDA
                 </a>
                 .
               </td>


### PR DESCRIPTION
Issue #9756: IllegalIdentifierName doesn't check single no-parentheses lambda parameter


Diff Regression config: https://gist.githubusercontent.com/nmancus1/2267f758c41c127dfee6c6c73c655b0c/raw/c1a31b23cd28a0a476b094790fbf034c26757e01/base.xml

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/a89d2614131e8c0a44f3b31cb6775598/raw/c9476797246225ab23ce707662e1e6b9ce2caa4e/gistfile1.txt