### PR TITLE
Issue #8010: CommentsIndentation false positive for comments in multi…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
@@ -332,7 +332,8 @@ public class CommentsIndentationCheck extends AbstractCheck {
             else if (isCommentAtTheEndOfTheCodeBlock(nextStmt)) {
                 handleCommentAtTheEndOfTheCodeBlock(prevStmt, comment, nextStmt);
             }
-            else if (nextStmt != null && !areSameLevelIndented(comment, nextStmt, nextStmt)) {
+            else if (nextStmt != null && !areSameLevelIndented(comment, nextStmt, nextStmt)
+                    && !areInSameMethodCallWithSameIndent(comment)) {
                 log(comment, getMessageKey(comment), nextStmt.getLineNo(),
                     comment.getColumnNo(), nextStmt.getColumnNo());
             }
@@ -1171,6 +1172,42 @@ public class CommentsIndentationCheck extends AbstractCheck {
         final DetailAST nextSibling = blockComment.getNextSibling();
         return !CommonUtil.hasWhitespaceBefore(commentColumnNo, commentLine)
             || nextSibling != null && TokenUtil.areOnSameLine(nextSibling, blockComment);
+    }
+
+    /**
+     * Checks if the comment is inside a method call with same indentation of
+     * first expression. e.g:
+     * <p>
+     * {@code
+     * private final boolean myList = someMethod(
+     *     // Some comment here
+     *     s1,
+     *     s2,
+     *     s3
+     *     // ok
+     * );
+     * }
+     * </p>
+     *
+     * @param comment comment to check.
+     * @return true, if comment is inside inside a method call with same indentation.
+     */
+    private static boolean areInSameMethodCallWithSameIndent(DetailAST comment) {
+        return comment.getParent() != null
+                && comment.getParent().getType() == TokenTypes.METHOD_CALL
+                && comment.getColumnNo()
+                     == getFirstExpressionNodeFromMethodCall(comment.getParent()).getColumnNo();
+    }
+
+    /**
+     * Returns the first EXPR DetailAST child from parent of comment.
+     *
+     * @param methodCall methodCall DetailAst from which node to be extracted.
+     * @return first EXPR DetailAST child from parent of comment.
+     */
+    private static DetailAST getFirstExpressionNodeFromMethodCall(DetailAST methodCall) {
+        // Method call always has ELIST
+        return methodCall.findFirstToken(TokenTypes.ELIST);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
@@ -277,6 +277,29 @@ public class CommentsIndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testCommentsInSameMethodCallWithSameIndent() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(CommentsIndentationCheck.class);
+        final String[] expected = {
+            "19:7: " + getCheckMessage(MSG_KEY_SINGLE, 20, 6, 4),
+            "26:11: " + getCheckMessage(MSG_KEY_SINGLE, 27, 10, 4),
+        };
+        verify(checkConfig,
+                getPath("InputCommentsIndentationWithInMethodCallWithSameIndent.java"),
+                expected);
+    }
+
+    @Test
+    public void testCommentsBlockCommentBeforePackage() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(CommentsIndentationCheck.class);
+        final String[] expected = {
+            "1:1: " + getCheckMessage(MSG_KEY_BLOCK, 4, 0, 1),
+        };
+        verify(checkConfig,
+                getPath("InputCommentsIndentationBlockCommentBeforePackage.java"),
+                expected);
+    }
+
+    @Test
     public void testCommentsAfterRecordsAndCompactCtors() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(CommentsIndentationCheck.class);
         final String[] expected = {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationBlockCommentBeforePackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationBlockCommentBeforePackage.java
@@ -1,0 +1,10 @@
+/* // violation
+ * Some comment here.
+ */
+ package com.puppycrawl.tools.checkstyle.checks.indentation.commentsindentation;
+
+/**
+ * Config: default
+ */
+public class InputCommentsIndentationBlockCommentBeforePackage {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationWithInMethodCallWithSameIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationWithInMethodCallWithSameIndent.java
@@ -1,0 +1,32 @@
+package com.puppycrawl.tools.checkstyle.checks.indentation.commentsindentation;
+
+/**
+ * Config: default
+ */
+public class InputCommentsIndentationWithInMethodCallWithSameIndent {
+    String s1 = "ONE", s2 = "TWO", s3 = "THREE";
+    private final boolean isEqualsOne = equals(
+        // Some comment here
+        s1,
+        s2
+        // ok
+    );
+
+    private final boolean isEqualsTwo = equals(
+        // Some comment here
+        s1,
+        s2
+      // violation
+    );
+
+    private final boolean isEqualsThree = equals(
+        // Some comment here
+        s1,
+        s2
+          // violation
+    );
+
+    private boolean equals(String s1, String s2) {
+        return s1.equals(s2);
+    }
+}


### PR DESCRIPTION
Closes: #8010 

```
$ cat Test.java 
public class Test {
    String s1 = "ONE", s2 = "TWO", s3 = "THREE";
    private final boolean myList = someMethod(
        // Some comment here
        s1,
        s2,
        s3
        // ok
    );

    private boolean someMethod(String s1, String s2, String s3) {
        return s1.equals(s2) && s1.equals(s3);
    }
}

$ javac Test.java 

$ cat config.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">

<module name = "Checker">
    <module name="TreeWalker">
        <module name="CommentsIndentation"/>
    </module>
</module>
                 
<---------AFTER CHANGE---------->                          
$ java -jar checkstyle-8.42-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
Audit done.

<----------BEFORE CHANGE--------->
$ java -jar checkstyle-8.41.1-all.jar -c config.xml Test.java     
Starting audit...
[ERROR] /home/akmo/GitHub/Test/indentation/comment/Test.java:8:9: Comment has incorrect indentation level 8, expected is 4, indentation should be the same level as line 9. [CommentsIndentation]
Audit done.
Checkstyle ends with 1 errors.
```

Diff Regression config: https://raw.githubusercontent.com/AkMo3/akmo3.github.io/master/Indentation/config-Indentation-20210330121805.xml
Diff Regression projects: https://raw.githubusercontent.com/AkMo3/akmo3.github.io/master/Issue9010/projects-to-test-on.properties