### PR TITLE
Issue #9519: updated example of AST for TokenTypes.MODIFIERS

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -48,6 +48,20 @@ public final class TokenTypes {
      * Modifiers for type, method, and field declarations.  The
      * modifiers element is always present even though it may have no
      * children.
+     * <p>For example:</p>
+     * <pre>
+     * public int x;
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * VARIABLE_DEF -&gt; VARIABLE_DEF
+     *  |--MODIFIERS -&gt; MODIFIERS
+     *  |   `--LITERAL_PUBLIC -&gt; public
+     *  |--TYPE -&gt; TYPE
+     *  |   `--LITERAL_INT -&gt; int
+     *  |--IDENT -&gt; x
+     *  `--SEMI -&gt; ;
+     * </pre>
      *
      * @see <a
      * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html">Java


### PR DESCRIPTION
fixes #9519 :

<img width="708" alt="Screenshot 2021-04-02 at 12 40 18 PM" src="https://user-images.githubusercontent.com/65589791/113391183-c2672980-93b0-11eb-8b70-80687e141d12.png">

Source used to generate AST:

```
public class MyClass {
    public int x;
}
```

Generated AST:

```
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> MyClass [1:13]
`--OBJBLOCK -> OBJBLOCK [1:21]
    |--LCURLY -> { [1:21]
    |--VARIABLE_DEF -> VARIABLE_DEF [2:4]
    |   |--MODIFIERS -> MODIFIERS [2:4]
    |   |   `--LITERAL_PUBLIC -> public [2:4]
    |   |--TYPE -> TYPE [2:11]
    |   |   `--LITERAL_INT -> int [2:11]
    |   |--IDENT -> x [2:15]
    |   `--SEMI -> ; [2:16]
    `--RCURLY -> } [3:0]
```

Expected Update for JavaDoc:

```
VARIABLE_DEF -> VARIABLE_DEF
|--MODIFIERS -> MODIFIERS
|   `--LITERAL_PUBLIC -> public
|--TYPE -> TYPE
|   `--LITERAL_INT -> int
|--IDENT -> x
`--SEMI -> ;
```