### PR TITLE
Issue #9451: updated example of AST for TokenTypes.IMPLEMENTS_CLAUSE

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -568,15 +568,22 @@ public final class TokenTypes {
      *
      * <p>For example:</p>
      * <pre>
-     * implements Serializable, Comparable
+     * public class MyClass implements Collection {
+     *
+     * }
      * </pre>
      * <p>parses as:</p>
      * <pre>
-     * +--IMPLEMENTS_CLAUSE
-     *     |
-     *     +--IDENT (Serializable)
-     *     +--COMMA (,)
-     *     +--IDENT (Comparable)
+     * CLASS_DEF -&gt; CLASS_DEF
+     * |--MODIFIERS -&gt; MODIFIERS
+     * |   `--LITERAL_PUBLIC -&gt; public
+     * |--LITERAL_CLASS -&gt; class
+     * |--IDENT -&gt; MyClass
+     * |--IMPLEMENTS_CLAUSE -&gt; implements
+     * |   `--IDENT -&gt; Collection
+     * `--OBJBLOCK -&gt; OBJBLOCK
+     *     |--LCURLY -&gt; {
+     *     `--RCURLY -&gt; }
      * </pre>
      *
      * @see #IDENT


### PR DESCRIPTION
fixes #9451 : 

<img width="708" alt="Screenshot 2021-04-02 at 12 57 45 PM" src="https://user-images.githubusercontent.com/65589791/113393031-afa22400-93b3-11eb-9370-c818d384fa15.png">

Source used to generate AST:

```
public class MyClass implements Collection {

}
```

Generated AST:

```
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> MyClass [1:13]
|--IMPLEMENTS_CLAUSE -> implements [1:21]
|   `--IDENT -> Collection [1:32]
`--OBJBLOCK -> OBJBLOCK [1:43]
    |--LCURLY -> { [1:43]
    `--RCURLY -> } [3:0]
```

Expected Update for JavaDoc:

```
CLASS_DEF -> CLASS_DEF
|--MODIFIERS -> MODIFIERS
|   `--LITERAL_PUBLIC -> public
|--LITERAL_CLASS -> class
|--IDENT -> MyClass
|--IMPLEMENTS_CLAUSE -> implements
|   `--IDENT -> Collection
`--OBJBLOCK -> OBJBLOCK
    |--LCURLY -> {
    `--RCURLY -> }
```