### PR TITLE
Issue #9487: updated example of AST for TokenTypes.LITERAL_NULL

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -3180,6 +3180,23 @@ public final class TokenTypes {
     /**
      * The {@code null} keyword.
      *
+     * <p>For example:</p>
+     * <pre>
+     * String s = null;
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * VARIABLE_DEF -&gt; VARIABLE_DEF
+     *  |--MODIFIERS -&gt; MODIFIERS
+     *  |--TYPE -&gt; TYPE
+     *  |   `--IDENT -&gt; String
+     *  |--IDENT -&gt; s
+     *  |--ASSIGN -&gt; =
+     *  |   `--EXPR -&gt; EXPR
+     *  |       `--LITERAL_NULL -&gt; null
+     *  `--SEMI -&gt; ;
+     * </pre>
+     *
      * @see <a
      * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.7">Java
      * Language Specification, &sect;3.10.7</a>


### PR DESCRIPTION
fixes #9487:

<img width="708" alt="Screenshot 2021-04-02 at 1 34 36 PM" src="https://user-images.githubusercontent.com/65589791/113395961-55579200-93b8-11eb-8c0f-3db56f17b72e.png">

Source used to generate AST:

```
public class MyClass {
    String s = null;
}
```

Generated AST:

```
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> MyClass [1:13]
`--OBJBLOCK -> OBJBLOCK [1:21]
    |--LCURLY -> { [1:21]
    |--VARIABLE_DEF -> VARIABLE_DEF [2:4]
    |   |--MODIFIERS -> MODIFIERS [2:4]
    |   |--TYPE -> TYPE [2:4]
    |   |   `--IDENT -> String [2:4]
    |   |--IDENT -> s [2:11]
    |   |--ASSIGN -> = [2:13]
    |   |   `--EXPR -> EXPR [2:15]
    |   |       `--LITERAL_NULL -> null [2:15]
    |   `--SEMI -> ; [2:19]
    `--RCURLY -> } [3:0]
```

Expected update for JavaDoc:

```
VARIABLE_DEF -> VARIABLE_DEF
|--MODIFIERS -> MODIFIERS
|--TYPE -> TYPE
|   `--IDENT -> String
|--IDENT -> s
|--ASSIGN -> =
|   `--EXPR -> EXPR
|       `--LITERAL_NULL -> null
`--SEMI -> ;
```