### PR TITLE
Issue #9441: updated example of AST for TokenTypes.FINAL

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1123,6 +1123,25 @@ public final class TokenTypes {
     /**
      * The {@code final} keyword.
      *
+     * <p>For example:</p>
+     * <pre>
+     * public final int x = 0;
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * VARIABLE_DEF -&gt; VARIABLE_DEF
+     *  |--MODIFIERS -&gt; MODIFIERS
+     *  |   |--LITERAL_PUBLIC -&gt; public
+     *  |   `--FINAL -&gt; final
+     *  |--TYPE -&gt; TYPE
+     *  |   `--LITERAL_INT -&gt; int
+     *  |--IDENT -&gt; x
+     *  |--ASSIGN -&gt; =
+     *  |   `--EXPR -&gt; EXPR
+     *  |       `--NUM_INT -&gt; 0
+     *  `--SEMI -&gt; ;
+     * </pre>
+     *
      * @see #MODIFIERS
      **/
     public static final int FINAL = GeneratedJavaTokenTypes.FINAL;


### PR DESCRIPTION
fixes #9441 : 

<img width="708" alt="Screenshot 2021-04-02 at 1 58 23 PM" src="https://user-images.githubusercontent.com/65589791/113398070-a4eb8d00-93bb-11eb-9805-8dfd06ec20d1.png">

Source used to generate AST:

```
public class MyClass {
    public final int x= 0;
}
```

Generated AST:

```
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> MyClass [1:13]
`--OBJBLOCK -> OBJBLOCK [1:21]
    |--LCURLY -> { [1:21]
    |--VARIABLE_DEF -> VARIABLE_DEF [2:4]
    |   |--MODIFIERS -> MODIFIERS [2:4]
    |   |   |--LITERAL_PUBLIC -> public [2:4]
    |   |   `--FINAL -> final [2:11]
    |   |--TYPE -> TYPE [2:17]
    |   |   `--LITERAL_INT -> int [2:17]
    |   |--IDENT -> x [2:21]
    |   |--ASSIGN -> = [2:22]
    |   |   `--EXPR -> EXPR [2:24]
    |   |       `--NUM_INT -> 0 [2:24]
    |   `--SEMI -> ; [2:25]
    `--RCURLY -> } [3:0]
```

Expected update for JavaDoc:

```
VARIABLE_DEF -> VARIABLE_DEF
|--MODIFIERS -> MODIFIERS
|   |--LITERAL_PUBLIC -> public
|   `--FINAL -> final
|--TYPE -> TYPE
|   `--LITERAL_INT -> int
|--IDENT -> x
|--ASSIGN -> =
|   `--EXPR -> EXPR
|       `--NUM_INT -> 0
`--SEMI -> ;
```