### PR TITLE
Issue #9491: updated example of AST for TokenTypes.LITERAL_RECORD

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -4359,6 +4359,27 @@ public final class TokenTypes {
      * The {@code record} keyword.  This element appears
      * as part of a record declaration.
      *
+     * <p>For example:</p>
+     * <pre>
+     * public record MyRecord () {
+     *
+     * }
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * RECORD_DEF -&gt; RECORD_DEF
+     * |--MODIFIERS -&gt; MODIFIERS
+     * |   `--LITERAL_PUBLIC -&gt; public
+     * |--LITERAL_RECORD -&gt; record
+     * |--IDENT -&gt; MyRecord
+     * |--LPAREN -&gt; (
+     * |--RECORD_COMPONENTS -&gt; RECORD_COMPONENTS
+     * |--RPAREN -&gt; )
+     * `--OBJBLOCK -&gt; OBJBLOCK
+     *     |--LCURLY -&gt; {
+     *     `--RCURLY -&gt; }
+     * </pre>
+     *
      * @since 8.35
      **/
     public static final int LITERAL_RECORD =


### PR DESCRIPTION
fixes #9491:
<img width="708" alt="Screenshot 2021-04-02 at 2 12 30 PM" src="https://user-images.githubusercontent.com/65589791/113399268-91d9bc80-93bd-11eb-94f8-ab3f6784e3a9.png">

Source used to generate AST:

```
public record MyRecord () {

}
```

Generated AST:

```
RECORD_DEF -> RECORD_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_RECORD -> record [1:7]
|--IDENT -> MyRecord [1:14]
|--LPAREN -> ( [1:23]
|--RECORD_COMPONENTS -> RECORD_COMPONENTS [1:24]
|--RPAREN -> ) [1:24]
`--OBJBLOCK -> OBJBLOCK [1:26]
    |--LCURLY -> { [1:26]
    `--RCURLY -> } [3:0]
```

Expected update for JavaDoc:

```
RECORD_DEF -> RECORD_DEF
|--MODIFIERS -> MODIFIERS
|   `--LITERAL_PUBLIC -> public
|--LITERAL_RECORD -> record
|--IDENT -> MyRecord
|--LPAREN -> (
|--RECORD_COMPONENTS -> RECORD_COMPONENTS
|--RPAREN -> )
`--OBJBLOCK -> OBJBLOCK
    |--LCURLY -> {
    `--RCURLY -> }
```