### PR TITLE
Issue #5982: Added example to ImportOrder about other groups

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -406,6 +406,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * &lt;module name=&quot;ImportOrder&quot;&gt;
  *   &lt;property name=&quot;staticGroups&quot; value=&quot;org,java&quot;/&gt;
  *   &lt;property name=&quot;sortStaticImportsAlphabetically&quot; value=&quot;true&quot;/&gt;
+ *   &lt;property name=&quot;option&quot; value=&quot;top&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
  * <pre>
@@ -492,6 +493,44 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * import static javax.WindowConstants.*; // OK
  *
  * import java.net.URL;
+ *
+ * public class SomeClass { }
+ * </pre>
+ * <p>
+ * To configure the Check with groups of static imports when staticGroups=&quot;&quot;
+ * represents all imports as {@code everything else} group:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;ImportOrder&quot;&gt;
+ *   &lt;property name=&quot;staticGroups&quot; value=&quot;&quot;/&gt;
+ *   &lt;property name=&quot;option&quot; value=&quot;top&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <pre>
+ * import static java.io.File.listRoots;   // OK
+ * import static javax.swing.WindowConstants.*; // OK
+ * import static java.io.File.createTempFile; // OK
+ * import static com.puppycrawl.tools.checkstyle;  // OK
+ *
+ * public class SomeClass { }
+ * </pre>
+ * <p>
+ * To configure the Check with groups of static imports when
+ * staticGroups=&quot;java, javax&quot; represents three groups i.e java*, javax*
+ * and * (everything else). In below example the static imports <code> com...</code>
+ * should be in last group:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;ImportOrder&quot;&gt;
+ *   &lt;property name=&quot;staticGroups&quot; value=&quot;java, javax&quot;/&gt;
+ *   &lt;property name=&quot;option&quot; value=&quot;top&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <pre>
+ * import static java.io.File.listRoots;   // OK
+ * import static javax.swing.WindowConstants.*; // OK
+ * import static java.io.File.createTempFile; // violation should be before javax
+ * import static com.puppycrawl.tools.checkstyle;  // OK
  *
  * public class SomeClass { }
  * </pre>

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -2110,7 +2110,7 @@ public class SomeClass { }
           There is always a wildcard group to which everything not in a named group
           belongs. If an import does not match a named group, the group belongs to
           this wildcard group. The wildcard group position can be specified using the
-          {@code *} character.
+          <code>*</code> character.
         </p>
         <p>
           Check also has on option making it more flexible:
@@ -2147,12 +2147,13 @@ public class SomeClass { }
           To configure the Check with groups of static imports:
         </p>
 
-        <source>
-&lt;module name=&quot;ImportOrder&quot;&gt;
-  &lt;property name=&quot;staticGroups&quot; value=&quot;org,java&quot;/&gt;
-  &lt;property name=&quot;sortStaticImportsAlphabetically&quot; value=&quot;true&quot;/&gt;
-&lt;/module&gt;
-        </source>
+        <source><![CDATA[
+<module name="ImportOrder">
+  <property name="staticGroups" value="org,java"/>
+  <property name="sortStaticImportsAlphabetically" value="true"/>
+  <property name="option" value="top"/>
+</module>
+        ]]></source>
 
         <source>
 import static org.abego.treelayout.Configuration.AlignmentInLevel; // Group 1
@@ -2239,6 +2240,47 @@ import static javax.swing.JComponent; // violation, should be separated from pre
 import static javax.WindowConstants.*; // OK
 
 import java.net.URL;
+
+public class SomeClass { }
+        </source>
+        <p>
+          To configure the Check with groups of static imports when staticGroups=&quot;&quot;
+          represents all imports as {@code everything else} group:
+        </p>
+        <source>
+&lt;module name=&quot;ImportOrder&quot;&gt;
+  &lt;property name=&quot;staticGroups&quot; value=&quot;&quot;/&gt;
+  &lt;property name=&quot;option&quot; value=&quot;top&quot;/&gt;
+&lt;/module&gt;
+        </source>
+
+        <source>
+import static java.io.File.listRoots;   // OK
+import static javax.swing.WindowConstants.*; // OK
+import static java.io.File.createTempFile; // OK
+import static com.puppycrawl.tools.checkstyle;  // OK
+
+public class SomeClass { }
+        </source>
+        <p>
+          To configure the Check with groups of static imports when
+          staticGroups=&quot;java, javax&quot; represents three groups i.e java*, javax*
+          and * (everything else). In below example the static imports <code> com...</code>
+          should be in last group:
+        </p>
+
+        <source>
+&lt;module name=&quot;ImportOrder&quot;&gt;
+  &lt;property name=&quot;staticGroups&quot; value=&quot;java, javax&quot;/&gt;
+  &lt;property name=&quot;option&quot; value=&quot;top&quot;/&gt;
+&lt;/module&gt;
+        </source>
+
+        <source>
+import static java.io.File.listRoots;   // OK
+import static javax.swing.WindowConstants.*; // OK
+import static java.io.File.createTempFile; // violation should be before javax
+import static com.puppycrawl.tools.checkstyle;  // OK
 
 public class SomeClass { }
         </source>


### PR DESCRIPTION
fixes Issue #5982:

![import doc](https://user-images.githubusercontent.com/49342895/113508931-677c3080-9570-11eb-94c3-7a72ff7c15b4.PNG)

Output of  first example with no value parameters in command line:-

```
$ cat config.xml

<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <property name="tabWidth" value="7"/>
    <module name="ImportOrder">
      <property name="staticGroups" value=""/>
      <property name="sortStaticImportsAlphabetically" value="true"/>
  </module>
  </module>
</module>


```
```
$ cat Test.java

import static java.io.File.listRoots;
import static javax.swing.WindowConstants.*; // OK
import static java.io.File.createTempFile; // violation should be before javax
import static com.puppycrawl.tools.checkstyle.checks.imports.avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClass;  // violation should be before java and javax

public class Test{
	
}
```
2 violations as in code 
```
$ java -jar checkstyle-8.41-all.jar -c config.xml Test.java

Starting audit...
[ERROR] C:\Users\nares\Downloads\checkstyle\Test.java:3:1: Wrong order for 'java.io.File.createTempFile' import. [ImportOrder]
[ERROR] C:\Users\nares\Downloads\checkstyle\Test.java:4:1: Wrong order for 'com.puppycrawl.tools.checkstyle.checks.imports.avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClas
s' import. [ImportOrder]
Audit done.
Checkstyle ends with 2 errors.

```
2nd Example with value parameters

```
$ cat config.xml

<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <module name="TreeWalker">
    <property name="tabWidth" value="7"/>
     <module name="ImportOrder">
       <property name="staticGroups" value="java, javax, org"/>
       <property name="sortStaticImportsAlphabetically" value="true"/>
     </module>
  </module>
</module>



```
```
$ cat Test.java

import static java.io.File.listRoots; // OK
import static javax.swing.WindowConstants.*; // OK
import static java.io.File.createTempFile; // violation should be before javax
import static com.puppycrawl.tools.checkstyle.checks.imports.avoidstaticimport
.InputAvoidStaticImportNestedClass.InnerClass;  // OK
import static com.puppycrawl.tools.checkstyle.checks.imports.avoidstaticimport
.InputAvoidStaticImportNestedClass.InnerClass.one; // OK

public class SomeClass { }

public class Test{
	
}
```
2 violations as in code 
```
$ java -jar checkstyle-8.41-all.jar -c config.xml Test.java

Starting audit...
[ERROR] C:\Users\nares\Downloads\checkstyle\Test.java:3:1: Wrong order for 'java.io.File.createTempFile' import. [ImportOrder]
[ERROR] C:\Users\nares\Downloads\checkstyle\Test.java:4:1: Wrong order for 'com.puppycrawl.tools.checkstyle.checks.imports.avoidstaticimport.InputAvoidStaticImportNestedClass.InnerClas
s' import. [ImportOrder]
Audit done.
Checkstyle ends with 2 errors.

```

