### PR TITLE
Issue #9009: Violations from TrailingComment should possible to suppress by xpath by content of comment

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -888,7 +888,9 @@ nonnull
 nonrequiredjavadoc
 nonvalidating
 noparentfile
+NOPMD
 noscript
+NOSONAR
 nospace
 Nothin
 notjava

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionCommentsIndentationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionCommentsIndentationTest.java
@@ -54,7 +54,7 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
         final List<String> expectedXpathQueries = Collections.singletonList(
             "/CLASS_DEF[./IDENT"
                 + "[@text='SuppressionXpathRegressionCommentsIndentationSingleLine']]"
-                + "/OBJBLOCK/SINGLE_LINE_COMMENT"
+                + "/OBJBLOCK/SINGLE_LINE_COMMENT[./COMMENT_CONTENT[@text=' Comment // warn\\n']]"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
@@ -77,8 +77,9 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
 
         final List<String> expectedXpathQueries = Collections.singletonList(
             "/CLASS_DEF[./IDENT"
-                + "[@text='SuppressionXpathRegressionCommentsIndentationBlock']]"
-                + "/OBJBLOCK/VARIABLE_DEF[./IDENT[@text='f']]/TYPE/BLOCK_COMMENT_BEGIN"
+                + "[@text='SuppressionXpathRegressionCommentsIndentationBlock']]/OBJBLOCK/"
+                + "VARIABLE_DEF[./IDENT[@text='f']]/TYPE/BLOCK_COMMENT_BEGIN[./COMMENT_CONTENT"
+                + "[@text=' // warn\\n           * Javadoc comment\\n           ']]"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
@@ -103,6 +104,7 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
             "/CLASS_DEF[./IDENT"
                 + "[@text='SuppressionXpathRegressionCommentsIndentationSeparator']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]/MODIFIERS/SINGLE_LINE_COMMENT"
+                + "[./COMMENT_CONTENT[@text='///////////// Comment separator // warn\\n']]"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
@@ -127,6 +129,7 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
             "/CLASS_DEF[./IDENT"
                 + "[@text='SuppressionXpathRegressionCommentsIndentationDistributedStatement']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]/SLIST/SINGLE_LINE_COMMENT"
+                + "[./COMMENT_CONTENT[@text=' Comment // warn\\n']]"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
@@ -150,7 +153,8 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
         final List<String> expectedXpathQueries = Collections.singletonList(
             "/CLASS_DEF[./IDENT"
                 + "[@text='SuppressionXpathRegressionCommentsIndentationSingleLineBlock']]"
-                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]/SLIST/SINGLE_LINE_COMMENT[2]"
+                + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]/SLIST/SINGLE_LINE_COMMENT"
+                + "[./COMMENT_CONTENT[@text=' block Comment // warn\\n']]"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
@@ -175,7 +179,7 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
             "/CLASS_DEF[./IDENT"
                 + "[@text='SuppressionXpathRegressionCommentsIndentationNonEmptyCase']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]/SLIST/LITERAL_SWITCH/"
-                + "CASE_GROUP/SINGLE_LINE_COMMENT"
+                + "CASE_GROUP/SINGLE_LINE_COMMENT[./COMMENT_CONTENT[@text=' Comment // warn\\n']]"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
@@ -200,7 +204,7 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
             "/CLASS_DEF[./IDENT"
                 + "[@text='SuppressionXpathRegressionCommentsIndentationEmptyCase']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]/SLIST/LITERAL_SWITCH/"
-                + "CASE_GROUP/SINGLE_LINE_COMMENT"
+                + "CASE_GROUP/SINGLE_LINE_COMMENT[./COMMENT_CONTENT[@text=' Comment // warn\\n']]"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
@@ -226,7 +230,7 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
                 + "[@text='SuppressionXpathRegressionCommentsIndentationWithinBlockStatement']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]/SLIST/VARIABLE_DEF"
                 + "[./IDENT[@text='s']]/ASSIGN/EXPR/PLUS[./STRING_LITERAL[@text='O']]"
-                + "/SINGLE_LINE_COMMENT"
+                + "/SINGLE_LINE_COMMENT[./COMMENT_CONTENT[@text=' Comment // warn\\n']]"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionEmptyLineSeparatorTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionEmptyLineSeparatorTest.java
@@ -153,7 +153,7 @@ public class XpathRegressionEmptyLineSeparatorTest extends AbstractXpathTestSupp
         final List<String> expectedXpathQueries = Collections.singletonList(
                 "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionEmptyLineSeparator5']]"
                         + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo1']]/SLIST/LITERAL_TRY/SLIST"
-                        + "/SINGLE_LINE_COMMENT/COMMENT_CONTENT"
+                        + "/SINGLE_LINE_COMMENT/COMMENT_CONTENT[@text=' warn\\n']"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation, expectedXpathQueries);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionInvalidJavadocPositionTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionInvalidJavadocPositionTest.java
@@ -52,7 +52,8 @@ public class XpathRegressionInvalidJavadocPositionTest extends AbstractXpathTest
 
         final List<String> expectedXpathQueries = Collections.singletonList(
             "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionInvalidJavadocPositionOne']]"
-                + "/MODIFIERS/BLOCK_COMMENT_BEGIN"
+                    + "/MODIFIERS/BLOCK_COMMENT_BEGIN[./COMMENT_CONTENT"
+                    + "[@text='* // warn\\n * Javadoc Comment\\n ']]"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
@@ -74,7 +75,8 @@ public class XpathRegressionInvalidJavadocPositionTest extends AbstractXpathTest
 
         final List<String> expectedXpathQueries = Collections.singletonList(
             "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionInvalidJavadocPositionTwo']]"
-                + "/OBJBLOCK/BLOCK_COMMENT_BEGIN"
+                    + "/OBJBLOCK/BLOCK_COMMENT_BEGIN[./COMMENT_CONTENT"
+                    + "[@text='* // warn\\n * Javadoc comment\\n ']]"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
@@ -95,8 +97,9 @@ public class XpathRegressionInvalidJavadocPositionTest extends AbstractXpathTest
         };
 
         final List<String> expectedXpathQueries = Collections.singletonList(
-            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionInvalidJavadocPositionThree']]"
-                + "/OBJBLOCK/BLOCK_COMMENT_BEGIN"
+            "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionInvalidJavadocPositionThree']]/"
+                    + "OBJBLOCK/BLOCK_COMMENT_BEGIN[./COMMENT_CONTENT"
+                    + "[@text='* // warn\\n     * Javadoc comment\\n     ']]"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
@@ -118,7 +121,8 @@ public class XpathRegressionInvalidJavadocPositionTest extends AbstractXpathTest
 
         final List<String> expectedXpathQueries = Collections.singletonList(
             "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionInvalidJavadocPositionFour']]"
-                + "/OBJBLOCK/BLOCK_COMMENT_BEGIN"
+                + "/OBJBLOCK/BLOCK_COMMENT_BEGIN[./COMMENT_CONTENT"
+                + "[@text='* // warn\\n     * Javadoc Comment\\n     ']]"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
@@ -141,7 +145,8 @@ public class XpathRegressionInvalidJavadocPositionTest extends AbstractXpathTest
         final List<String> expectedXpathQueries = Collections.singletonList(
             "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionInvalidJavadocPositionFive']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='foo']]"
-                + "/SLIST/BLOCK_COMMENT_BEGIN"
+                + "/SLIST/BLOCK_COMMENT_BEGIN[./COMMENT_CONTENT"
+                + "[@text='* // warn\\n         * Javadoc comment\\n         ']]"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
@@ -163,7 +168,8 @@ public class XpathRegressionInvalidJavadocPositionTest extends AbstractXpathTest
 
         final List<String> expectedXpathQueries = Collections.singletonList(
             "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionInvalidJavadocPositionSix']]"
-                + "/OBJBLOCK/BLOCK_COMMENT_BEGIN"
+                + "/OBJBLOCK/BLOCK_COMMENT_BEGIN[./COMMENT_CONTENT"
+                + "[@text='* // warn\\n     * Javadoc Comment\\n     ']]"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionJavadocContentLocationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionJavadocContentLocationTest.java
@@ -53,7 +53,7 @@ public class XpathRegressionJavadocContentLocationTest extends AbstractXpathTest
         final List<String> expectedXpathQueries = Collections.singletonList(
             "/INTERFACE_DEF[./IDENT[@text='SuppressionXpathRegressionJavadocContentLocationOne']]"
                 + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/TYPE/BLOCK_COMMENT_BEGIN"
-
+                + "[./COMMENT_CONTENT[@text='* Text. // warn\\n     ']]"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
@@ -78,8 +78,8 @@ public class XpathRegressionJavadocContentLocationTest extends AbstractXpathTest
         final List<String> expectedXpathQueries = Collections.singletonList(
             "/INTERFACE_DEF[./IDENT"
                     + "[@text='SuppressionXpathRegressionJavadocContentLocationTwo']]"
-                    + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/TYPE/BLOCK_COMMENT_BEGIN[2]"
-
+                    + "/OBJBLOCK/METHOD_DEF[./IDENT[@text='test']]/TYPE/BLOCK_COMMENT_BEGIN"
+                    + "[./COMMENT_CONTENT[@text='*\\n     * Text.\\n     ']]"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionSingleSpaceSeparatorTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionSingleSpaceSeparatorTest.java
@@ -77,7 +77,8 @@ public class XpathRegressionSingleSpaceSeparatorTest extends AbstractXpathTestSu
         final List<String> expectedXpathQueries = Collections.singletonList(
             "/CLASS_DEF[."
                 + "/IDENT[@text='SuppressionXpathRegressionSingleSpaceSeparatorValidateComments']]"
-                + "/OBJBLOCK/SINGLE_LINE_COMMENT"
+                + "/OBJBLOCK/SINGLE_LINE_COMMENT[./COMMENT_CONTENT"
+                + "[@text=' an invalid comment // warn\\n']]"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionTodoCommentTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionTodoCommentTest.java
@@ -54,7 +54,7 @@ public class XpathRegressionTodoCommentTest extends AbstractXpathTestSupport {
         final List<String> expectedXpathQueries = Collections.singletonList(
                 "/CLASS_DEF[./IDENT[@text="
                         + "'SuppressionXpathRegressionTodoCommentOne']]/OBJBLOCK/"
-                        + "SINGLE_LINE_COMMENT/COMMENT_CONTENT");
+                        + "SINGLE_LINE_COMMENT/COMMENT_CONTENT[@text=' warn FIXME:\\n']");
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);
@@ -76,7 +76,9 @@ public class XpathRegressionTodoCommentTest extends AbstractXpathTestSupport {
         final List<String> expectedXpathQueries = Collections.singletonList(
                 "/CLASS_DEF[./IDENT[@text="
                         + "'SuppressionXpathRegressionTodoCommentTwo']]/"
-                        + "OBJBLOCK/BLOCK_COMMENT_BEGIN/COMMENT_CONTENT");
+                        + "OBJBLOCK/BLOCK_COMMENT_BEGIN/COMMENT_CONTENT"
+                        + "[@text=' // warn\\n     * FIXME:\\n     * TODO\\n     ']"
+        );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
                 expectedXpathQueries);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionTrailingCommentTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionTrailingCommentTest.java
@@ -50,8 +50,9 @@ public class XpathRegressionTrailingCommentTest extends AbstractXpathTestSupport
         };
 
         final List<String> expectedXpathQueries = Collections.singletonList(
-                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionTrailingComment1']]"
-                        + "/OBJBLOCK/SINGLE_LINE_COMMENT"
+                "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionTrailingComment1']]/"
+                        + "OBJBLOCK/SINGLE_LINE_COMMENT[./COMMENT_CONTENT[@text=' don&apos;"
+                        + "&apos;t use trailing comments :) // warn\\n']]"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,
@@ -73,7 +74,7 @@ public class XpathRegressionTrailingCommentTest extends AbstractXpathTestSupport
 
         final List<String> expectedXpathQueries = Collections.singletonList(
                 "/CLASS_DEF[./IDENT[@text='SuppressionXpathRegressionTrailingComment2']]"
-                        + "/OBJBLOCK/SINGLE_LINE_COMMENT"
+                        + "/OBJBLOCK/SINGLE_LINE_COMMENT[./COMMENT_CONTENT[@text=' warn\\n']]"
         );
 
         runVerifications(moduleConfig, fileToProcess, expectedViolation,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
@@ -109,7 +109,45 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *   &lt;property name=&quot;format&quot; value=&quot;^\\s*$&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
- *
+ * <p>
+ * Example for trailing comments check to suppress specific trailing comment:
+ * </p>
+ * <pre>
+ * public class Test {
+ *   int a; // SUPPRESS CHECKSTYLE
+ *   int b; // NOPMD
+ *   int c; // NOSONAR
+ *   int d; // violation, not suppressed
+ * }
+ * </pre>
+ * <p>
+ * To configure check so that trailing comment with exact comments like "SUPPRESS CHECKSTYLE",
+ * "NOPMD", "NOSONAR" are suppressed:
+ * </p>
+ * <pre>
+ * &lt;module name="TrailingComment"/&gt;
+ * &lt;module name="SuppressionXpathSingleFilter"&gt;
+ *   &lt;property name="checks" value="TrailingCommentCheck"/&gt;
+ *   &lt;property name="query" value="//SINGLE_LINE_COMMENT
+ *       [./COMMENT_CONTENT[@text=' NOSONAR\n' or @text=' NOPMD\n'
+ *       or @text=' SUPPRESS CHECKSTYLE\n']]"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * To configure check so that trailing comment starting with "SUPPRESS CHECKSTYLE", "NOPMD",
+ * "NOSONAR" are suppressed:
+ * </p>
+ * <pre>
+ * &lt;module name="TrailingComment"/&gt; &lt;module name="SuppressionXpathSingleFilter"&gt;
+ * &lt;property name="checks" value="TrailingCommentCheck"/&gt;
+ *   &lt;property name="query" value="//SINGLE_LINE_COMMENT
+ *       [./COMMENT_CONTENT[starts-with(@text, ' NOPMD')]]"/&gt;
+ *   &lt;property name="query" value="//SINGLE_LINE_COMMENT
+ *       [./COMMENT_CONTENT[starts-with(@text, ' SUPPRESS CHECKSTYLE')]]"/&gt;
+ *   &lt;property name="query" value="//SINGLE_LINE_COMMENT
+ *       [./COMMENT_CONTENT[starts-with(@text, ' NOSONAR')]]"/&gt;
+ * &lt;/module&gt;
+ * </pre>
  * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
  * </p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/XpathUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/XpathUtil.java
@@ -106,7 +106,7 @@ public final class XpathUtil {
         Stream.of(
             TokenTypes.IDENT, TokenTypes.STRING_LITERAL, TokenTypes.CHAR_LITERAL,
             TokenTypes.NUM_LONG, TokenTypes.NUM_INT, TokenTypes.NUM_DOUBLE, TokenTypes.NUM_FLOAT,
-            TokenTypes.TEXT_BLOCK_CONTENT)
+            TokenTypes.TEXT_BLOCK_CONTENT, TokenTypes.COMMENT_CONTENT)
         .collect(Collectors.toSet());
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
@@ -988,9 +988,28 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         assertThat("Result nodes differ from expected", actual, equalTo(expected));
     }
 
+    @Test
+    public void testQuerySingleLineCommentByCommentContent() throws Exception {
+        final String xpath = "//SINGLE_LINE_COMMENT[./COMMENT_CONTENT[@text=' some comment\\n']]";
+        final RootNode rootNode = getRootNodeWithComments("InputXpathMapperSingleLineComment.java");
+        final DetailAST[] actual = convertToArray(getXpathItems(xpath, rootNode));
+        final DetailAST expectedVariableDefNode = getSiblingByType(rootNode.getUnderlyingNode(),
+                TokenTypes.CLASS_DEF)
+                .findFirstToken(TokenTypes.OBJBLOCK)
+                .findFirstToken(TokenTypes.SINGLE_LINE_COMMENT);
+        final DetailAST[] expected = {expectedVariableDefNode};
+        assertThat("Result nodes differ from expected", actual, equalTo(expected));
+    }
+
     private RootNode getRootNode(String fileName) throws Exception {
         final File file = new File(getPath(fileName));
         final DetailAST rootAst = JavaParser.parseFile(file, JavaParser.Options.WITHOUT_COMMENTS);
+        return new RootNode(rootAst);
+    }
+
+    private RootNode getRootNodeWithComments(String fileName) throws Exception {
+        final File file = new File(getPath(fileName));
+        final DetailAST rootAst = JavaParser.parseFile(file, JavaParser.Options.WITH_COMMENTS);
         return new RootNode(rootAst);
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/xpathmapper/InputXpathMapperSingleLineComment.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/xpath/xpathmapper/InputXpathMapperSingleLineComment.java
@@ -1,0 +1,5 @@
+package com.puppycrawl.tools.checkstyle.xpath.xpathmapper;
+
+public class InputXpathMapperSingleLineComment {
+    int num; // some comment
+}

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -2078,6 +2078,54 @@ d = e / f;        // Another comment for this line
   &lt;property name=&quot;format&quot; value=&quot;^\\s*$&quot;/&gt;
 &lt;/module&gt;
         </source>
+
+        <p>
+          Example for trailing comments check to suppress specific trailing comment:
+        </p>
+
+        <source>
+public class Test {
+int a; // SUPPRESS CHECKSTYLE
+int b; // NOPMD
+int c; // NOSONAR
+int d; // violation, not suppressed
+}
+        </source>
+
+        <p>
+          To configure check so that trailing comment with exact comments like
+          &quot;SUPPRESS CHECKSTYLE&quot;, &quot;NOPMD&quot;, &quot;NOSONAR&quot;
+          are suppressed:
+        </p>
+
+        <source>
+&lt;module name=&quot;TrailingComment&quot;/&gt;
+&lt;module name=&quot;SuppressionXpathSingleFilter&quot;&gt;
+&lt;property name=&quot;checks&quot; value=&quot;TrailingCommentCheck&quot;/&gt;
+&lt;property name=&quot;query&quot; value=&quot;//SINGLE_LINE_COMMENT
+[./COMMENT_CONTENT[@text=&apos; NOSONAR\n&apos; or @text=&apos; NOPMD\n&apos;
+or @text=&apos; SUPPRESS CHECKSTYLE\n&apos;]]&quot;/&gt;
+&lt;/module&gt;
+        </source>
+
+        <p>
+          To configure check so that trailing comment starting with &quot;SUPPRESS CHECKSTYLE&quot;,
+          &quot;NOPMD&quot;, &quot;NOSONAR&quot; are suppressed:
+        </p>
+
+        <source>
+&lt;module name=&quot;TrailingComment&quot;/&gt;
+&lt;module name=&quot;SuppressionXpathSingleFilter&quot;&gt;
+&lt;property name=&quot;checks&quot; value=&quot;TrailingCommentCheck&quot;/&gt;
+&lt;property name=&quot;query&quot; value=&quot;//SINGLE_LINE_COMMENT
+[./COMMENT_CONTENT[starts-with(@text, &apos; NOPMD&apos;)]]&quot;/&gt;
+&lt;property name=&quot;query&quot; value=&quot;//SINGLE_LINE_COMMENT
+[./COMMENT_CONTENT[starts-with(@text, &apos; SUPPRESS CHECKSTYLE&apos;)]]&quot;/&gt;
+&lt;property name=&quot;query&quot; value=&quot;//SINGLE_LINE_COMMENT
+[./COMMENT_CONTENT[starts-with(@text, &apos; NOSONAR&apos;)]]&quot;/&gt;
+&lt;/module&gt;
+        </source>
+
       </subsection>
 
       <subsection name="Example of Usage" id="TrailingComment_Example_of_Usage">


### PR DESCRIPTION
Closes #9009, #5819

```
$ cat Test.java 
public class Test {
  int a; // SUPPRESS CHECKSTYLE
  int b; // NOPMD
  int c; // NOSONAR
  int d; // violation, not suppressed
}

$ cat config.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">

<module name = "Checker">
  <module name="TreeWalker">
    <module name="TrailingComment"/>
    <module name="SuppressionXpathSingleFilter">
        <property name="checks" value="TrailingCommentCheck"/>
        <property name="query" value="//SINGLE_LINE_COMMENT
                [./COMMENT_CONTENT[@text=' NOSONAR\n' or @text=' NOPMD\n'
                or @text=' SUPPRESS CHECKSTYLE\n']]"/>
    </module>
  </module>
</module>

$ java -jar checkstyle-8.45-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /home/akmo/GitHub/Test/TrailingComment/Test.java:5:10: Don't use trailing comments. [TrailingComment]
Audit done.
Checkstyle ends with 1 errors.

$ cat configTwo.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">

<module name = "Checker">
  <module name="TreeWalker">
    <module name="TrailingComment"/>
  </module>
</module>

$ java -jar checkstyle-8.45-SNAPSHOT-all.jar -c configTwo.xml Test.java
Starting audit...
[ERROR] /home/akmo/GitHub/Test/TrailingComment/Test.java:2:10: Don't use trailing comments. [TrailingComment]
[ERROR] /home/akmo/GitHub/Test/TrailingComment/Test.java:3:10: Don't use trailing comments. [TrailingComment]
[ERROR] /home/akmo/GitHub/Test/TrailingComment/Test.java:4:10: Don't use trailing comments. [TrailingComment]
[ERROR] /home/akmo/GitHub/Test/TrailingComment/Test.java:5:10: Don't use trailing comments. [TrailingComment]
Audit done.
Checkstyle ends with 4 errors.
```

![Screenshot from 2021-07-11 21-06-38](https://user-images.githubusercontent.com/69365878/125201320-3c4e5f00-e28c-11eb-8852-f25633daeba0.png)


Link to new examples: [TrailingComment Examples](https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/917133a_2021152613/config_misc.html#TrailingComment_Examples)
