### PR TITLE
Sun Style Convention Coverage Update - Blank Spaces

### DIFF
--- a/src/it/java/com/sun/checkstyle/test/chapter8whitespace/rule82blankspaces/WhitespaceAroundTest.java
+++ b/src/it/java/com/sun/checkstyle/test/chapter8whitespace/rule82blankspaces/WhitespaceAroundTest.java
@@ -1,0 +1,52 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2021 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.sun.checkstyle.test.chapter8whitespace.rule82blankspaces;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck;
+import com.sun.checkstyle.test.base.AbstractSunModuleTestSupport;
+
+public class WhitespaceAroundTest
+    extends AbstractSunModuleTestSupport {
+
+    @Override
+    protected String getPackageLocation() {
+        return "com/sun/checkstyle/test/chapter8whitespace/rule82blankspaces";
+    }
+
+    @Test
+    public void testSimpleInput()
+            throws Exception {
+        final Configuration checkConfig = getModuleConfig("WhitespaceAround");
+        final String[] expected = {
+            "153:26: " + getCheckMessage(WhitespaceAroundCheck.class, "ws.notFollowed", "="),
+            "154:26: " + getCheckMessage(WhitespaceAroundCheck.class, "ws.notFollowed", "="),
+            "155:26: " + getCheckMessage(WhitespaceAroundCheck.class, "ws.notFollowed", "="),
+            "156:26: " + getCheckMessage(WhitespaceAroundCheck.class, "ws.notFollowed", "="),
+            "157:26: " + getCheckMessage(WhitespaceAroundCheck.class, "ws.notFollowed", "="),
+            "158:26: " + getCheckMessage(WhitespaceAroundCheck.class, "ws.notFollowed", "="),
+        };
+        final String filePath = getPath("InputWhitespaceAroundSimple.java");
+        final Integer[] warnList = getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
+    }
+}

--- a/src/it/resources/com/sun/checkstyle/test/chapter8whitespace/rule82blankspaces/InputWhitespaceAroundSimple.java
+++ b/src/it/resources/com/sun/checkstyle/test/chapter8whitespace/rule82blankspaces/InputWhitespaceAroundSimple.java
@@ -1,0 +1,225 @@
+////////////////////////////////////////////////////////////////////////////////
+// Test case file for checkstyle.
+// Created: Feb-2001
+// Ignore violation
+////////////////////////////////////////////////////////////////////////////////
+package com.sun.checkstyle.test.chapter8whitespace.rule82blankspaces;
+
+/**
+ * Contains simple mistakes:
+ * - Long lines
+ * - Tabs
+ * - Format of variables and parameters
+ * - Order of modifiers
+ * @author Oliver Burn
+ **/
+final class InputWhitespaceAroundSimple
+{
+    // Long line ----------------------------------------------------------------
+    // Contains a tab ->	<-
+    // Contains trailing whitespace ->
+
+    // Name format tests
+    //
+    /** Invalid format **/
+    public static final int badConstant = 2;
+    /** Valid format **/
+    public static final int MAX_ROWS = 2;
+
+    /** Invalid format **/
+    private static int badStatic = 2;
+    /** Valid format **/
+    private static int sNumCreated = 0;
+
+    /** Invalid format **/
+    private int badMember = 2;
+    /** Valid format **/
+    private int mNumCreated1 = 0;
+    /** Valid format **/
+    protected int mNumCreated2 = 0;
+
+    /** commas are wrong **/
+    private int[] mInts = new int[] {1,2, 3,
+                                     4};
+
+    //
+    // Accessor tests
+    //
+    /** should be private **/
+    public static int sTest1;
+    /** should be private **/
+    protected static int sTest3;
+    /** should be private **/
+    static int sTest2;
+
+    /** should be private **/
+    int mTest1;
+    /** should be private **/
+    public int mTest2;
+
+    //
+    // Parameter name format tests
+    //
+
+    /**
+     * @return hack
+     * @param badFormat1 bad format
+     * @param badFormat2 bad format
+     * @param badFormat3 bad format
+     * @throws Exception abc
+     **/
+    int test1(int badFormat1,int badFormat2,
+              final int badFormat3)
+        throws Exception
+    {
+        return 0;
+    }
+
+    /** method that is 20 lines long **/
+    private void longMethod()
+    {
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+    }
+
+    /** constructor that is 10 lines long **/
+    private InputWhitespaceAroundSimple()
+    {
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+        // a line
+    }
+
+    /** test local variables */
+    private void localVariables()
+    {
+        // normal decl
+        int abc = 0;
+        int ABC = 0;
+
+        // final decls
+        final int cde = 0;
+        final int CDE = 0;
+
+        // decl in for loop init statement
+        for (int k = 0; k < 1; k++)
+        {
+            String innerBlockVariable = "";
+        }
+        for (int I = 0; I < 1; I++)
+        {
+            String InnerBlockVariable = "";
+        }
+    }
+
+    /** test method pattern */
+    void ALL_UPPERCASE_METHOD()
+    {
+    }
+
+    /** test illegal constant **/
+    private static final int BAD__NAME = 3;
+
+    // A very, very long line that is OK because it matches the regexp "^.*is OK.*regexp.*$"
+    // long line that has a tab ->	<- and would be OK if tab counted as 1 char
+    // tabs that count as one char because of their position ->	<-   ->	<-, OK
+
+    /** some lines to test the violation column after tabs */
+    void errorColumnAfterTabs()
+    {
+        // with tab-width 8 all statements below start at the same column,
+        // with different combinations of ' ' and '\t' before the statement
+                int tab0 =1; // warning
+        	int tab1 =1; // warning
+         	int tab2 =1; // warning
+		int tab3 =1; // warning
+  	  	int tab4 =1; // warning
+  	        int tab5 =1; // warning
+    }
+
+    // MEMME:
+    /* MEMME: a
+     * MEMME:
+     * OOOO
+     */
+    /* NOTHING */
+    /* YES */ /* MEMME: x */ /* YES!! */
+
+    /** test long comments **/
+    void veryLong()
+    {
+        /*
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          blah blah blah blah
+          enough talk */
+    }
+
+    /**
+     * @see to lazy to document all args. Testing excessive # args
+     **/
+    void toManyArgs(int aArg1, int aArg2, int aArg3, int aArg4, int aArg5,
+                    int aArg6, int aArg7, int aArg8, int aArg9)
+    {
+    }
+}
+
+/** Test class for variable naming in for each clauses. */
+class InputWhitespaceAroundSimple2
+{
+    /** Some more Javadoc. */
+    public void doSomething()
+    {
+        //"O" should be named "o"
+        for (Object O : new java.util.ArrayList())
+        {
+
+        }
+    }
+}
+
+/** Test enum for member naming check */
+enum MyEnum1
+{
+    /** ABC constant */
+    ABC,
+
+    /** XYZ constant */
+    XYZ;
+
+    /** Should be mSomeMember */
+    private int someMember;
+}

--- a/src/xdocs/sun_style.xml
+++ b/src/xdocs/sun_style.xml
@@ -770,8 +770,23 @@
                     8.2 Blank Spaces
                   </a>
                 </td>
-                <td>???</td>
-                <td/>
+                <td>
+                  <span class="wrapper inline">
+                    <img src="images/ok_blue.png" alt=""/>
+                  </span>
+                  <a href="config_whitespace.html#WhitespaceAround">
+                    WhitespaceAround
+                  </a>
+                </td>
+                <td>
+                  <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources+filename%3Asun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+WhitespaceAround">
+                    config
+                  </a>
+                  <br/>
+                  <a href="https://github.com/checkstyle/checkstyle/blob/master/src/it/java/com/sun/checkstyle/test/chapter8whitespace/rule82blankspaces/WhitespaceAroundTest.java">
+                    test
+                  </a>
+                </td>
               </tr>
               <tr>
                 <td>


### PR DESCRIPTION
Closes #9843 
This updates the blank lines coverage of the sun style convention.
Added the test file to the sun test package.
Added a reference link to the configuration file lines and the test file.
Note: I've only created one test method (whitespaceAroundSimple) as an example, but the same process can be applied to all other methods.

![image](https://user-images.githubusercontent.com/43009893/114273026-d0ecbb00-9a18-11eb-9088-458f5601509f.png)

![image](https://user-images.githubusercontent.com/43009893/114273038-dba75000-9a18-11eb-94ed-6aa6ff13c9ad.png)

![image](https://user-images.githubusercontent.com/43009893/114273060-ecf05c80-9a18-11eb-995c-588c4dc473bc.png)

