### PR TITLE
Issue #9495: update example of AST for TokenTypes.LITERAL_SUPER

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1875,6 +1875,22 @@ public final class TokenTypes {
     /**
      * The {@code super} keyword.
      *
+     * <p>For example:</p>
+     * <pre>
+     * super.toString()；
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * |--EXPR -&gt; EXPR
+     * |   `--METHOD_CALL -&gt; (
+     * |       |--DOT -&gt; .
+     * |       |  |--LITERAL_SUPER -&gt; super
+     * |       |  `--IDENT -&gt; toString
+     * |       |--ELIST -&gt; ELIST
+     * |       `--RPAREN -&gt; )
+     * |--SEMI -&gt; ;
+     * </pre>
+     *
      * @see #EXPR
      * @see #SUPER_CTOR_CALL
      **/


### PR DESCRIPTION
Closes: #9495

![image](https://user-images.githubusercontent.com/46078550/114298431-f3e6a000-9ae8-11eb-9245-da0fe768e5b1.png)

```
% javac Test.java
% 
% cat Test.java
class Test {
	void sub() {
		super.toString();
	}
}
%
%  java -jar checkstyle-8.42-SNAPSHOT-all.jar -t Test.java
|--MODIFIERS -> MODIFIERS [1:0]
|--LITERAL_CLASS -> class [1:0]
|--IDENT -> Test [1:6]
`--OBJBLOCK -> OBJBLOCK [1:11]
    |--LCURLY -> { [1:11]
    |--METHOD_DEF -> METHOD_DEF [2:1]
    |   |--MODIFIERS -> MODIFIERS [2:1]
    |   |--TYPE -> TYPE [2:1]
    |   |   `--LITERAL_VOID -> void [2:1]
    |   |--IDENT -> sub [2:6]
    |   |--LPAREN -> ( [2:9]
    |   |--PARAMETERS -> PARAMETERS [2:10]
    |   |--RPAREN -> ) [2:10]
    |   `--SLIST -> { [2:12]
    |       |--EXPR -> EXPR [3:16]
    |       |   `--METHOD_CALL -> ( [3:16]
    |       |       |--DOT -> . [3:7]
    |       |       |   |--LITERAL_SUPER -> super [3:2]
    |       |       |   `--IDENT -> toString [3:8]
    |       |       |--ELIST -> ELIST [3:17]
    |       |       `--RPAREN -> ) [3:17]
    |       |--SEMI -> ; [3:18]
    |       `--RCURLY -> } [4:1]
    `--RCURLY -> } [5:0]
# printing a line only for code that we care
% java -jar checkstyle-8.42-SNAPSHOT-all.jar -t Test.java | grep "3:"
    |       |--EXPR -> EXPR [3:16]
    |       |   `--METHOD_CALL -> ( [3:16]
    |       |       |--DOT -> . [3:7]
    |       |       |   |--LITERAL_SUPER -> super [3:2]
    |       |       |   `--IDENT -> toString [3:8]
    |       |       |--ELIST -> ELIST [3:17]
    |       |       `--RPAREN -> ) [3:17]
    |       |--SEMI -> ; [3:18]                     
```
expected update for javadoc is :
```
    |--EXPR  -> EXPR
    |   `--METHOD_CALL -> (
    |       |--DOT -> .
    |       |   |--LITERAL_SUPER -> super
    |       |   `--IDENT -> toString
    |       |--ELIST -> ELIST
    |       `--RPAREN -> )
    |--SEMI -> ;
```
