### PR TITLE
Issue #9854: ModiferOrderCheck should support 'sealed' and 'non-sealed'

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java
@@ -31,7 +31,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 /**
  * <p>
  * Checks that the order of modifiers conforms to the suggestions in the
- * <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-8.html">
+ * <a href="https://docs.oracle.com/javase/specs/jls/se16/preview/specs/sealed-classes-jls.html">
  * Java Language specification, &#167; 8.1.1, 8.3.1, 8.4.3</a> and
  * <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-9.html">9.4</a>.
  * The correct order is:
@@ -43,6 +43,8 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <li> {@code abstract} </li>
  * <li> {@code default} </li>
  * <li> {@code static} </li>
+ * <li> {@code sealed} </li>
+ * <li> {@code non-sealed} </li>
  * <li> {@code final} </li>
  * <li> {@code transient} </li>
  * <li> {@code volatile} </li>
@@ -108,7 +110,8 @@ public class ModifierOrderCheck
      */
     private static final String[] JLS_ORDER = {
         "public", "protected", "private", "abstract", "default", "static",
-        "final", "transient", "volatile", "synchronized", "native", "strictfp",
+        "sealed", "non-sealed", "final", "transient", "volatile",
+        "synchronized", "native", "strictfp",
     };
 
     @Override

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/modifier/ModifierOrderCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/modifier/ModifierOrderCheck.xml
@@ -6,7 +6,7 @@
              parent="com.puppycrawl.tools.checkstyle.TreeWalker">
          <description>&lt;p&gt;
  Checks that the order of modifiers conforms to the suggestions in the
- &lt;a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-8.html"&gt;
+ &lt;a href="https://docs.oracle.com/javase/specs/jls/se16/preview/specs/sealed-classes-jls.html"&gt;
  Java Language specification, &amp;#167; 8.1.1, 8.3.1, 8.4.3&lt;/a&gt; and
  &lt;a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-9.html"&gt;9.4&lt;/a&gt;.
  The correct order is:
@@ -18,6 +18,8 @@
  &lt;li&gt; {@code abstract} &lt;/li&gt;
  &lt;li&gt; {@code default} &lt;/li&gt;
  &lt;li&gt; {@code static} &lt;/li&gt;
+ &lt;li&gt; {@code sealed} &lt;/li&gt;
+ &lt;li&gt; {@code non-sealed} &lt;/li&gt;
  &lt;li&gt; {@code final} &lt;/li&gt;
  &lt;li&gt; {@code transient} &lt;/li&gt;
  &lt;li&gt; {@code volatile} &lt;/li&gt;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheckTest.java
@@ -125,4 +125,27 @@ public class ModifierOrderCheckTest
         verify(checkConfig, getPath("InputModifierOrderAnnotationDeclaration.java"), expected);
     }
 
+    @Test
+    public void testModifierOrderSealedAndNonSealed() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(ModifierOrderCheck.class);
+        final String[] expected = {
+            "8:8: " + getCheckMessage(MSG_MODIFIER_ORDER, "public"),
+            "24:12: " + getCheckMessage(MSG_MODIFIER_ORDER, "private"),
+            "42:10: " + getCheckMessage(MSG_MODIFIER_ORDER, "sealed"),
+            "48:11: " + getCheckMessage(MSG_MODIFIER_ORDER, "public"),
+            "51:14: " + getCheckMessage(MSG_MODIFIER_ORDER, "static"),
+            "56:10: " + getCheckMessage(MSG_MODIFIER_ORDER, "non-sealed"),
+        };
+        verify(checkConfig,
+            getNonCompilablePath("InputModifierOrderSealedAndNonSealed.java"), expected);
+    }
+
+    @Test
+    public void testModifierOrderSealedAndNonSealedNoViolation() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(ModifierOrderCheck.class);
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verify(checkConfig,
+            getNonCompilablePath("InputModifierOrderSealedAndNonSealedNoViolation.java"), expected);
+    }
+
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/modifierorder/InputModifierOrderSealedAndNonSealed.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/modifierorder/InputModifierOrderSealedAndNonSealed.java
@@ -1,0 +1,62 @@
+//non-compiled with javac: Compilable with Java15
+package com.puppycrawl.tools.checkstyle.checks.modifier.modifierorder;
+
+/* Config:
+ * default
+ */
+
+sealed public class InputModifierOrderSealedAndNonSealed // violation
+    permits Circle, Square, Rectangle {
+}
+
+final class Circle extends InputModifierOrderSealedAndNonSealed implements Squircle {
+}
+
+sealed class Rectangle extends InputModifierOrderSealedAndNonSealed // ok
+    implements Cloneable
+    permits TransparentRectangle, FilledRectangle {
+}
+
+final class TransparentRectangle extends Rectangle {
+}
+
+sealed class Square extends InputModifierOrderSealedAndNonSealed implements Squircle {
+    sealed private class OtherSquare extends Square permits OtherSquare2 { // violation
+    }
+
+    private final class OtherSquare2 extends OtherSquare {
+    }
+
+
+    static non-sealed strictfp class StaticClass implements Squircle {
+
+    }
+}
+
+final strictfp class FilledRectangle extends Rectangle {
+}
+
+sealed interface Squircle permits Circle, Square, Ellipse, Square.StaticClass { // ok
+}
+
+strictfp sealed interface Rhombus permits Parallelogram, Parallelogram.Diamond, // violation
+        Parallelogram.Trapezoid {
+
+}
+
+record Parallelogram(int x, int y, double z) implements Rhombus{
+    final public record Diamond(int x, int y, double z)implements Rhombus { // violation
+    }
+
+    strictfp static public final record Trapezoid(int x, int y, // violation
+        double z)implements Rhombus {
+    }
+}
+
+strictfp non-sealed interface Ellipse extends Squircle { // violation
+
+}
+
+class Oval implements Ellipse {
+
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/modifierorder/InputModifierOrderSealedAndNonSealedNoViolation.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/modifierorder/InputModifierOrderSealedAndNonSealedNoViolation.java
@@ -1,0 +1,35 @@
+//non-compiled with javac: Compilable with Java15
+package com.puppycrawl.tools.checkstyle.checks.modifier.modifierorder;
+
+/* Config:
+ * default
+ */
+
+public sealed class InputModifierOrderSealedAndNonSealedNoViolation // ok
+    permits Circle, Square, Rectangle {
+}
+
+final class Circle extends InputModifierOrderSealedAndNonSealedNoViolation implements Squircle {
+}
+
+sealed class Rectangle extends InputModifierOrderSealedAndNonSealedNoViolation // ok
+    implements Cloneable
+    permits TransparentRectangle, FilledRectangle {
+}
+
+final class TransparentRectangle extends Rectangle {
+}
+
+sealed class Square extends InputModifierOrderSealedAndNonSealedNoViolation implements Squircle {
+    private sealed class OtherSquare extends Square permits OtherSquare2 { // ok
+    }
+
+    private final class OtherSquare2 extends OtherSquare {
+    }
+}
+
+final strictfp class FilledRectangle extends Rectangle {
+}
+
+sealed interface Squircle permits Circle, Square { // ok
+}

--- a/src/xdocs/config_modifier.xml
+++ b/src/xdocs/config_modifier.xml
@@ -416,7 +416,7 @@ public interface RoadFeature {
       <subsection name="Description" id="ModifierOrder_Description">
         <p>
           Checks that the order of modifiers conforms to the suggestions in
-          the <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-8.html">Java
+          the <a href="https://docs.oracle.com/javase/specs/jls/se16/preview/specs/sealed-classes-jls.html">Java
           Language specification, &#167; 8.1.1, 8.3.1, 8.4.3</a> and
           <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-9.html">
           9.4</a>. The correct order is:
@@ -440,6 +440,12 @@ public interface RoadFeature {
           </li>
           <li>
             <code>static</code>
+          </li>
+          <li>
+            <code>sealed</code>
+          </li>
+          <li>
+            <code>non-sealed</code>
           </li>
           <li>
             <code>final</code>


### PR DESCRIPTION
Issue #9854: ModiferOrderCheck should support 'sealed' and 'non-sealed'

Diff Regression projects: https://gist.githubusercontent.com/nmancus1/79c9d575d541725cd0b861497d2e7aa1/raw/38c5c2e22dc7809dcbd89c488bf37f39914b6e15/projects.properties

Diff Regression config: https://gist.githubusercontent.com/nmancus1/b111673a252cfdfa990b562361608e29/raw/344468c69278dbff8c8834a43db19f5c6a7b6eb5/config.xml