### PR TITLE
infra: add github action regression report generation section to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,18 @@ Rules:
 To avoid multiple iterations of fixes and CIs failures, please read
 https://checkstyle.org/contributing.html
 
+_______________________________________________________
+
+Check regression report generation template (see details [here](https://github.com/checkstyle/contribution/tree/master/checkstyle-tester#report-generation)):
+
+Diff Regression config: {{URI to my_checks.xml}
+
+Diff Regression patch config: {{URI to patch_config.xml}} (optional)
+
+Diff Regression projects: {{URI to projects-to-test-on.properties}} (optional)
+
+_______________________________________________________
+
 ATTENTION: We are not merging Pull Requests that are not passing our CIs,
 but we will help to resolve issues.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ Rules:
    a) MUST match one of the following patterns:
       ^Issue #\\d+: .*$
       ^Pull #\\d+: .*$
-      ^(minor|config|infra|doc|spelling|dependency): .*$
+      ^(minor|config|infra|doc|spelling|dependency|supplemental): .*$
    b) MUST contain only one line of text
    c) MUST NOT end with a period, space, or tab
    d) MUST be less than or equal to 200 characters


### PR DESCRIPTION
infra: add github action regression report generation section to PR template

This will save contributors a few copy/pastes or remembering exact syntax to trigger action, and will allow for simply adding links in the appropriate spot.

I also noticed that we forgot to add the `supplemental` prefix to this template, so I added that in a separate commit.