### PR TITLE
Issue #9499: update example of AST for TokenTypes.LITERAL_THROW

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -2070,6 +2070,22 @@ public final class TokenTypes {
      * The {@code throws} keyword.  The children are a number of
      * one or more identifiers separated by commas.
      *
+     * <p>For example:</p>
+     * <pre>
+     * new throw ArithmeticException();
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * |--LITERAL_THROW -&gt; throw
+     * |   |--EXPR -&gt; EXPR
+     * |   |   `--LITERAL_NEW -&gt; new
+     * |   |       |--IDENT -&gt; ArithmeticException
+     * |   |       |--LPAREN -&gt; (
+     * |   |       |--ELIST -&gt; ELIST
+     * |   |       `--RPAREN -&gt; )
+     * |   `--SEMI -&gt; ;
+     * </pre>
+     *
      * @see <a
      * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.4.4">Java
      * Language Specification, &sect;8.4.4</a>


### PR DESCRIPTION
Issue #9499

![image](https://user-images.githubusercontent.com/46078550/114491638-81410600-9c49-11eb-94ff-048424c8a1ee.png)

```
% javac Test.java

% cat Test.java
public class Test {
	void sub() {
		new throw ArithmeticException();
	}
}

% java -jar checkstyle-8.42-SNAPSHOT-all.jar -t Test.java
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|--LITERAL_CLASS -> class [1:0]
|--IDENT -> Test [1:6]
`--OBJBLOCK -> OBJBLOCK [1:11]
    |--LCURLY -> { [1:11]
    |--METHOD_DEF -> METHOD_DEF [2:1]
    |   |--MODIFIERS -> MODIFIERS [2:1]
    |   |--TYPE -> TYPE [2:1]
    |   |   `--LITERAL_VOID -> void [2:1]
    |   |--IDENT -> sub [2:6]
    |   |--LPAREN -> ( [2:9]
    |   |--PARAMETERS -> PARAMETERS [2:10]
    |   |--RPAREN -> ) [2:10]
    |   `--SLIST -> { [2:12]
    |       |--LITERAL_THROW -> throw [3:2]
    |       |   |--EXPR -> EXPR [3:8]
    |       |   |   `--LITERAL_NEW -> new [3:8]
    |       |   |       |--IDENT -> ArithmeticException [3:12]
    |       |   |       |--LPAREN -> ( [3:31]
    |       |   |       |--ELIST -> ELIST [3:32]
    |       |   |       `--RPAREN -> ) [3:32]
    |       |   `--SEMI -> ; [3:33]
    |       `--RCURLY -> } [4:1]
    `--RCURLY -> } [5:0]

# printing a line only for code that we care
% java -jar checkstyle-8.42-SNAPSHOT-all.jar -t Test.java | grep "3:"
|--LITERAL_THROW -> throw [3:2]
|    |--EXPR -> EXPR [3:8]
|    |    `--LITERAL_NEW -> new [3:8]
|    |       |--IDENT -> ArithmeticException [3:12]
|    |       |--LPAREN -> ( [3:31]
|    |       |--ELIST -> ELIST [3:32]
|    |      `--RPAREN -> ) [3:32]
|   `--SEMI -> ; [3:33]
```
expected update for javodoc is:
```
 |--LITERAL_THROW -> throw
 |   |--EXPR -> EXPR
 |   |   `--LITERAL_NEW -> new
 |   |       |--IDENT -> ArithmeticException
 |   |       |--LPAREN -> (
 |   |       |--ELIST -> ELIST
 |   |       `--RPAREN -> )
 |   `--SEMI -> ;
```