### PR TITLE
Issue #9473: updated example of AST for TokenTypes.LITERAL_DOUBLE

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1597,6 +1597,21 @@ public final class TokenTypes {
     /**
      * The {@code double} keyword.
      *
+     * <p>For example:</p>
+     * <pre>
+     * public double x;
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * VARIABLE_DEF -&gt; VARIABLE_DEF
+     *  |--MODIFIERS -&gt; MODIFIERS
+     *  |   `--LITERAL_PUBLIC -&gt; public
+     *  |--TYPE -&gt; TYPE
+     *  |   `--LITERAL_DOUBLE -&gt; double
+     *  |--IDENT -&gt; x
+     *  `--SEMI -&gt; ;
+     * </pre>
+     *
      * @see #TYPE
      **/
     public static final int LITERAL_DOUBLE =


### PR DESCRIPTION
Closes #9473 
![CheckStyle_double_PR](https://user-images.githubusercontent.com/62554685/115028346-bd1adc00-9e92-11eb-9ff7-8fe0d609e7e2.png)

```
$ cat Test.java

public class Test{
    public double x;
}
```
AST in CLI for the above Java file:-
```
$ java -jar checkstyle-8.41-all.jar -T Test.java
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> Test [1:13]
`--OBJBLOCK -> OBJBLOCK [1:17]
    |--LCURLY -> { [1:17]
    |--VARIABLE_DEF -> VARIABLE_DEF [2:4]
    |   |--MODIFIERS -> MODIFIERS [2:4]
    |   |   `--LITERAL_PUBLIC -> public [2:4]
    |   |--TYPE -> TYPE [2:11]
    |   |   `--LITERAL_DOUBLE -> double [2:11]
    |   |--IDENT -> x [2:18]
    |   `--SEMI -> ; [2:19]
    `--RCURLY -> } [3:0] 
```
```
# printing lines we are concerned with:-
$ java -jar checkstyle-8.41-all.jar -T Test.java | grep "2:"

|--VARIABLE_DEF -> VARIABLE_DEF [2:4]
|   |--MODIFIERS -> MODIFIERS [2:4]
|   |   `--LITERAL_PUBLIC -> public [2:4]
|   |--TYPE -> TYPE [2:11]
|   |   `--LITERAL_DOUBLE -> double [2:11]
|   |--IDENT -> x [2:18]
|   `--SEMI -> ; [2:19]
```
Expected update for JavaDoc:-

```
VARIABLE_DEF -> VARIABLE_DEF 
 |--MODIFIERS -> MODIFIERS 
 |   `--LITERAL_PUBLIC -> public 
 |--TYPE -> TYPE 
 |   `--LITERAL_DOUBLE -> double 
 |--IDENT -> x 
 `--SEMI -> ; 
```