### PR TITLE
Issue #9882: updated TrailingCommentCheckTest to use unique input fil…

### DIFF
--- a/config/checkstyle_input_suppressions.xml
+++ b/config/checkstyle_input_suppressions.xml
@@ -1401,8 +1401,6 @@
   <suppress id="ConfigCommentOnTopInputs"
             files="todocomment[\\/]InputTodoCommentSimple.java"/>
   <suppress id="ConfigCommentOnTopInputs"
-            files="trailingcomment[\\/]InputTrailingComment.java"/>
-  <suppress id="ConfigCommentOnTopInputs"
             files="uncommentedmain[\\/]InputUncommentedMain2.java"/>
   <suppress id="ConfigCommentOnTopInputs"
             files="uncommentedmain[\\/]InputUncommentedMain3.java"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckTest.java
@@ -57,16 +57,16 @@ public class TrailingCommentCheckTest extends AbstractModuleTestSupport {
     public void testDefaults() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(TrailingCommentCheck.class);
         final String[] expected = {
-            "4:12: " + getCheckMessage(MSG_KEY),
-            "7:12: " + getCheckMessage(MSG_KEY),
-            "8:22: " + getCheckMessage(MSG_KEY),
-            "18:19: " + getCheckMessage(MSG_KEY),
-            "19:21: " + getCheckMessage(MSG_KEY),
-            "29:50: " + getCheckMessage(MSG_KEY),
-            "30:51: " + getCheckMessage(MSG_KEY),
-            "31:31: " + getCheckMessage(MSG_KEY),
+            "6:12: " + getCheckMessage(MSG_KEY),
+            "9:12: " + getCheckMessage(MSG_KEY),
+            "10:22: " + getCheckMessage(MSG_KEY),
+            "20:19: " + getCheckMessage(MSG_KEY),
+            "21:21: " + getCheckMessage(MSG_KEY),
+            "31:50: " + getCheckMessage(MSG_KEY),
+            "32:51: " + getCheckMessage(MSG_KEY),
+            "33:31: " + getCheckMessage(MSG_KEY),
         };
-        verify(checkConfig, getPath("InputTrailingComment.java"), expected);
+        verify(checkConfig, getPath("InputTrailingCommentDefault.java"), expected);
     }
 
     @Test
@@ -74,12 +74,12 @@ public class TrailingCommentCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(TrailingCommentCheck.class);
         checkConfig.addAttribute("legalComment", "^NOI18N$");
         final String[] expected = {
-            "4:12: " + getCheckMessage(MSG_KEY),
             "7:12: " + getCheckMessage(MSG_KEY),
-            "8:22: " + getCheckMessage(MSG_KEY),
-            "18:19: " + getCheckMessage(MSG_KEY),
-            "19:21: " + getCheckMessage(MSG_KEY),
-            "31:31: " + getCheckMessage(MSG_KEY),
+            "10:12: " + getCheckMessage(MSG_KEY),
+            "11:22: " + getCheckMessage(MSG_KEY),
+            "21:19: " + getCheckMessage(MSG_KEY),
+            "22:21: " + getCheckMessage(MSG_KEY),
+            "34:31: " + getCheckMessage(MSG_KEY),
         };
         verify(checkConfig, getPath("InputTrailingComment.java"), expected);
     }
@@ -89,24 +89,25 @@ public class TrailingCommentCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(TrailingCommentCheck.class);
         checkConfig.addAttribute("format", "NOT MATCH");
         final String[] expected = {
-            "4:12: " + getCheckMessage(MSG_KEY),
-            "5:5: " + getCheckMessage(MSG_KEY),
-            "6:5: " + getCheckMessage(MSG_KEY),
+            "2:1: " + getCheckMessage(MSG_KEY),
             "7:12: " + getCheckMessage(MSG_KEY),
-            "8:22: " + getCheckMessage(MSG_KEY),
-            "13:17: " + getCheckMessage(MSG_KEY),
-            "14:7: " + getCheckMessage(MSG_KEY),
-            "15:5: " + getCheckMessage(MSG_KEY),
-            "18:19: " + getCheckMessage(MSG_KEY),
-            "19:21: " + getCheckMessage(MSG_KEY),
-            "26:5: " + getCheckMessage(MSG_KEY),
-            "29:50: " + getCheckMessage(MSG_KEY),
-            "30:51: " + getCheckMessage(MSG_KEY),
-            "31:31: " + getCheckMessage(MSG_KEY),
-            "34:9: " + getCheckMessage(MSG_KEY),
-            "35:9: " + getCheckMessage(MSG_KEY),
-            "43:5: " + getCheckMessage(MSG_KEY),
+            "8:5: " + getCheckMessage(MSG_KEY),
+            "9:5: " + getCheckMessage(MSG_KEY),
+            "10:12: " + getCheckMessage(MSG_KEY),
+            "11:22: " + getCheckMessage(MSG_KEY),
+            "16:17: " + getCheckMessage(MSG_KEY),
+            "17:7: " + getCheckMessage(MSG_KEY),
+            "18:5: " + getCheckMessage(MSG_KEY),
+            "21:19: " + getCheckMessage(MSG_KEY),
+            "22:21: " + getCheckMessage(MSG_KEY),
+            "29:5: " + getCheckMessage(MSG_KEY),
+            "32:50: " + getCheckMessage(MSG_KEY),
+            "33:51: " + getCheckMessage(MSG_KEY),
+            "34:31: " + getCheckMessage(MSG_KEY),
+            "37:9: " + getCheckMessage(MSG_KEY),
+            "38:9: " + getCheckMessage(MSG_KEY),
+            "46:5: " + getCheckMessage(MSG_KEY),
         };
-        verify(checkConfig, getPath("InputTrailingComment.java"), expected);
+        verify(checkConfig, getPath("InputTrailingCommentFormat.java"), expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingCommentDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingCommentDefault.java
@@ -1,10 +1,9 @@
 package com.puppycrawl.tools.checkstyle.checks.trailingcomment;
 /*
- * Config:
- * legalComment = "^NOI18N$"
+ * Config : default
  */
-public class InputTrailingComment {
-    int i; // don't use trailing comments :) // violation
+public class InputTrailingCommentDefault {
+    int i; // violation // don't use trailing comments :)
     // it fine to have comment w/o any statement
     /* good c-style comment. */
     int j; // violation /* bad c-style comment. */
@@ -29,8 +28,8 @@ public class InputTrailingComment {
     /**
      * comment with trailing space.
      */
-    final static public String NAME="Some Name"; // NOI18N
-    final static public String NAME2="Some Name"; /*NOI18N*/
+    final static public String NAME="Some Name"; // violation // NOI18N
+    final static public String NAME2="Some Name"; // violation /*NOI18N*/
     String NAME3="Some Name"; /*NOI18N // violation
 */
     /* package */ void method3() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingCommentFormat.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingCommentFormat.java
@@ -1,21 +1,21 @@
 package com.puppycrawl.tools.checkstyle.checks.trailingcomment;
 /*
  * Config:
- * legalComment = "^NOI18N$"
+ * format = "NOT MATCH"
  */
-public class InputTrailingComment {
-    int i; // don't use trailing comments :) // violation
-    // it fine to have comment w/o any statement
-    /* good c-style comment. */
+public class InputTrailingCommentFormat {
+    int i; // violation // don't use trailing comments :)
+    // it fine to have comment w/o any statement // violation
+    // violation /* good c-style comment. */
     int j; // violation /* bad c-style comment. */
     void method1() { /* some c-style multi-line // violation
                         comment*/
         Runnable r = (new Runnable() {
                 public void run() {
                 }
-            }); /* we should allow this */
-    } // we should allow this
-    /*
+            }); // violation /* we should allow this */
+    } // we should allow this // violation
+    /* // violation
       Let's check multi-line comments.
     */
     /* c-style */ // violation // cpp-style
@@ -26,16 +26,16 @@ public class InputTrailingComment {
         /* int y */int y/**/;
     }
 
-    /**
+    /** // violation
      * comment with trailing space.
      */
-    final static public String NAME="Some Name"; // NOI18N
-    final static public String NAME2="Some Name"; /*NOI18N*/
+    final static public String NAME="Some Name"; // violation // NOI18N
+    final static public String NAME2="Some Name"; // violation /*NOI18N*/
     String NAME3="Some Name"; /*NOI18N // violation
 */
     /* package */ void method3() {
-        /* violation on this block */
-        // violation here for format NOT FOUND
+        // violation /* violation on this block */
+        // violation here for format NOT FOUND // violation
     }
 
     private static class TimerEntry {
@@ -43,7 +43,7 @@ public class InputTrailingComment {
         /* ok */ final long start = 0L;
     }
 
-    /**
+    /** // violation
      * violation above this line.
      **/
     /* package */ void addError() {


### PR DESCRIPTION
Closes: #9882 
TrailingCommentCheckTest.testFormat() test was failing because of unexpected trailing comment, the Config comment, So I added it to the expected list.
@timurt @romani  