### PR TITLE
Issue #9503: updated example of AST for TokenTypes.LITERAL_TRY

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -2620,66 +2620,16 @@ public final class TokenTypes {
      *
      * <p>For example:</p>
      * <pre>
-     * try
-     * {
-     *   FileReader in = new FileReader("abc.txt");
-     * }
-     * catch(IOException ioe)
-     * {
-     * }
-     * finally
-     * {
-     * }
+     * try { } finally {}
      * </pre>
      * <p>parses as:</p>
      * <pre>
-     * +--LITERAL_TRY (try)
-     *     |
-     *     +--SLIST ({)
-     *         |
-     *         +--VARIABLE_DEF
-     *             |
-     *             +--MODIFIERS
-     *             +--TYPE
-     *                 |
-     *                 +--IDENT (FileReader)
-     *             +--IDENT (in)
-     *             +--ASSIGN (=)
-     *                 |
-     *                 +--EXPR
-     *                     |
-     *                     +--LITERAL_NEW (new)
-     *                         |
-     *                         +--IDENT (FileReader)
-     *                         +--LPAREN (()
-     *                         +--ELIST
-     *                             |
-     *                             +--EXPR
-     *                                 |
-     *                                 +--STRING_LITERAL ("abc.txt")
-     *                         +--RPAREN ())
-     *         +--SEMI (;)
-     *         +--RCURLY (})
-     *     +--LITERAL_CATCH (catch)
-     *         |
-     *         +--LPAREN (()
-     *         +--PARAMETER_DEF
-     *             |
-     *             +--MODIFIERS
-     *             +--TYPE
-     *                 |
-     *                 +--IDENT (IOException)
-     *             +--IDENT (ioe)
-     *         +--RPAREN ())
-     *         +--SLIST ({)
-     *             |
-     *             +--RCURLY (})
-     *     +--LITERAL_FINALLY (finally)
-     *         |
-     *         +--SLIST ({)
-     *             |
-     *             +--RCURLY (})
-     * +--RCURLY (})
+     * LITERAL_TRY -&gt; try
+     *  |--SLIST -&gt; {
+     *  |   `--RCURLY -&gt; }
+     *  `--LITERAL_FINALLY -&gt; finally
+     *      `--SLIST -&gt; {
+     *          `--RCURLY -&gt; }
      * </pre>
      *
      * @see <a


### PR DESCRIPTION
Closes #9503 
![CheckStyle_try_changed_PR_photo](https://user-images.githubusercontent.com/62554685/115140463-739ece00-a005-11eb-953b-eeaf5d088973.png)


```
$ cat Test.java

public class Test{
    void foo() {
        try { } finally {}
    }
}
```
AST in CLI for the above Java file:-
```
$ java -jar checkstyle-8.41-all.jar -T Test.java
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> Test [1:13]
`--OBJBLOCK -> OBJBLOCK [1:17]
    |--LCURLY -> { [1:17]
    |--METHOD_DEF -> METHOD_DEF [2:4]
    |   |--MODIFIERS -> MODIFIERS [2:4]
    |   |--TYPE -> TYPE [2:4]
    |   |   `--LITERAL_VOID -> void [2:4]
    |   |--IDENT -> foo [2:9]
    |   |--LPAREN -> ( [2:12]
    |   |--PARAMETERS -> PARAMETERS [2:13]
    |   |--RPAREN -> ) [2:13]
    |   `--SLIST -> { [2:15]
    |       |--LITERAL_TRY -> try [3:8]
    |       |   |--SLIST -> { [3:12]
    |       |   |   `--RCURLY -> } [3:14]
    |       |   `--LITERAL_FINALLY -> finally [3:16]
    |       |       `--SLIST -> { [3:24]
    |       |           `--RCURLY -> } [3:25]
    |       `--RCURLY -> } [4:4]
    `--RCURLY -> } [5:0]
```
```
# printing lines we are concerned with:-
$ java -jar checkstyle-8.41-all.jar -T Test.java | grep "3:"
|       |--LITERAL_TRY -> try [3:8]
|       |   |--SLIST -> { [3:12]
|       |   |   `--RCURLY -> } [3:14]
|       |   `--LITERAL_FINALLY -> finally [3:16]
|       |       `--SLIST -> { [3:24]
|       |           `--RCURLY -> } [3:25]
```
Expected update for JavaDoc:-
```
LITERAL_TRY -> try 
 |--SLIST -> { 
 |   `--RCURLY -> } 
 `--LITERAL_FINALLY -> finally 
     `--SLIST -> { 
         `--RCURLY -> } 
```