### PR TITLE
Issue #9476: updated example of AST for TokenTypes.LITERAL_FINALLY

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -2894,6 +2894,20 @@ public final class TokenTypes {
     /**
      * The {@code finally} keyword.
      *
+     * <p>For example:</p>
+     * <pre>
+     * try {} finally {}
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * LITERAL_TRY -&gt; try
+     *  |--SLIST -&gt; {
+     *  |   `--RCURLY -&gt; }
+     *  `--LITERAL_FINALLY -&gt; finally
+     *      `--SLIST -&gt; {
+     *          `--RCURLY -&gt; }
+     * </pre>
+     *
      * @see #SLIST
      * @see #LITERAL_TRY
      **/


### PR DESCRIPTION
Closes #9476 
![CheckStyle_Finally_PR_photo](https://user-images.githubusercontent.com/62554685/115387194-55250800-a1a8-11eb-8fa4-868f8600f1d4.png)


```
$ cat Test.java

public class Test{
    void foo() {
        try {} finally {}
    }
}
```
AST in CLI for the above Java file:-
```
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> Test [1:13]
`--OBJBLOCK -> OBJBLOCK [1:17]
    |--LCURLY -> { [1:17]
    |--METHOD_DEF -> METHOD_DEF [2:4]
    |   |--MODIFIERS -> MODIFIERS [2:4]
    |   |--TYPE -> TYPE [2:4]
    |   |   `--LITERAL_VOID -> void [2:4]
    |   |--IDENT -> foo [2:9]
    |   |--LPAREN -> ( [2:12]
    |   |--PARAMETERS -> PARAMETERS [2:13]
    |   |--RPAREN -> ) [2:13]
    |   `--SLIST -> { [2:15]
    |       |--LITERAL_TRY -> try [3:8]
    |       |   |--SLIST -> { [3:12]
    |       |   |   `--RCURLY -> } [3:13]
    |       |   `--LITERAL_FINALLY -> finally [3:15]
    |       |       `--SLIST -> { [3:23]
    |       |           `--RCURLY -> } [3:24]
    |       `--RCURLY -> } [4:4]
    `--RCURLY -> } [5:0]
```
```
# printing lines we are concerned with:-
$ java -jar checkstyle-8.41-all.jar -T Test.java | grep "3:"
|       |--LITERAL_TRY -> try [3:8]
|       |   |--SLIST -> { [3:12]
|       |   |   `--RCURLY -> } [3:13]
|       |   `--LITERAL_FINALLY -> finally [3:15]
|       |       `--SLIST -> { [3:23]
|       |           `--RCURLY -> } [3:24]
```
Expected update for JavaDoc:-
```
LITERAL_TRY -> try 
 |--SLIST -> { 
 |   `--RCURLY -> } 
 `--LITERAL_FINALLY -> finally 
     `--SLIST -> { 
         `--RCURLY -> } 
```