### PR TITLE
infra: move xwiki validation to checkstyle org repo

### DIFF
--- a/.ci/travis/travis.sh
+++ b/.ci/travis/travis.sh
@@ -266,7 +266,7 @@ no-error-xwiki)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo version:$CS_POM_VERSION
   mvn -e --no-transfer-progress clean install -Pno-validations
-  checkout_from "-b checkstyle_7417 https://github.com/nmancus1/xwiki-commons.git"
+  checkout_from "-b checkstyle_7417 https://github.com/checkstyle/xwiki-commons.git"
   cd .ci-temp/xwiki-commons
   # Build custom Checkstyle rules
   mvn -e --no-transfer-progress -f \


### PR DESCRIPTION
https://travis-ci.org/github/checkstyle/checkstyle/jobs/767598726#L3290
```
INFO] Scanning for projects...

[ERROR] [ERROR] Some problems were encountered while processing the POMs:

[FATAL] Non-resolvable parent POM for org.xwiki.rendering:xwiki-rendering:13.4-SNAPSHOT: 
Could not find artifact org.xwiki.commons:xwiki-commons-pom:pom:13.4-SNAPSHOT in
 sonatype-snapshots (https://oss.sonatype.org/content/repositories/snapshots/) 
and 'parent.relativePath' points at no local POM @ line 23, column 11
```