### PR TITLE
minor: replace broken links with new ones

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
@@ -30,7 +30,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Since <code>==</code> will compare the object references, not the actual value of the strings,
  * <code>String.equals()</code> should be used.
  * More information can be found
- * <a href="http://www.thejavageek.com/2013/07/27/string-comparison-with-equals-and-assignment-operator/">
+ * <a href="https://stackoverflow.com/questions/513832/how-do-i-compare-strings-in-java/">
  * in this article</a>.
  * </p>
  * <p>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/StringLiteralEqualityCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/StringLiteralEqualityCheck.xml
@@ -9,7 +9,7 @@
  Since &lt;code&gt;==&lt;/code&gt; will compare the object references, not the actual value of the strings,
  &lt;code&gt;String.equals()&lt;/code&gt; should be used.
  More information can be found
- &lt;a href="http://www.thejavageek.com/2013/07/27/string-comparison-with-equals-and-assignment-operator/"&gt;
+ &lt;a href="https://stackoverflow.com/questions/513832/how-do-i-compare-strings-in-java/"&gt;
  in this article&lt;/a&gt;.
  &lt;/p&gt;
  &lt;p&gt;

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -6602,7 +6602,7 @@ public class Test {
           not the actual value of the strings,
           <code>String.equals()</code> should be used.
           More information can be found
-          <a href="http://www.thejavageek.com/2013/07/27/string-comparison-with-equals-and-assignment-operator/">
+          <a href="https://stackoverflow.com/questions/513832/how-do-i-compare-strings-in-java/">
           in this article</a>.
         </p>
 


### PR DESCRIPTION
failed master job
https://github.com/checkstyle/checkstyle/runs/2403748349?check_suite_focus=true
```
------------ grep of linkcheck.html--BEGIN
<td><i><a class="externalLink" href="http://www.thejavageek.com/2013/07/27/string-comparison-with-equals-and-assignment-operator/">http://www.thejavageek.com/2013/07/27/string-comparison-with-equals-and-assignment-operator/</a>: 404 Not Found</i></td></tr></table></td></tr>
<td><i><a class="externalLink" href="http://www.thejavageek.com/2013/07/27/string-comparison-with-equals-and-assignment-operator/">http://www.thejavageek.com/2013/07/27/string-comparison-with-equals-and-assignment-operator/</a>: 404 Not Found</i></td></tr></table></td></tr>
------------ grep of linkcheck.html--END
```

Link is replaced with stackoverflow question