### PR TITLE
Issue #9925: avoid comments break 'isDistributedExpression' flow

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
@@ -404,13 +404,11 @@ public class CommentsIndentationCheck extends AbstractCheck {
                     && isOnPreviousLineIgnoringComments(comment, previousSibling)) {
                 DetailAST currentToken = previousSibling.getPreviousSibling();
                 while (currentToken.getFirstChild() != null) {
-                    currentToken = currentToken.getFirstChild();
-                }
-                if (currentToken.getType() == TokenTypes.COMMENT_CONTENT) {
-                    currentToken = currentToken.getParent();
-                    while (isComment(currentToken)) {
-                        currentToken = currentToken.getNextSibling();
+                    DetailAST child = currentToken.getFirstChild();
+                    while (isComment(child)) {
+                        child = child.getNextSibling();
                     }
+                    currentToken = child;
                 }
                 if (!TokenUtil.areOnSameLine(previousSibling, currentToken)) {
                     isDistributed = true;


### PR DESCRIPTION
Issue: #9925

Skip the comments in `isDistributedExpression.`