### PR TITLE
Issue #8929: add if to avoid lineWrapIdentation check for switch cases

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
@@ -174,6 +174,11 @@ public class LineWrappingHandler {
         for (DetailAST node : firstNodesOnLines.values()) {
             final int currentType = node.getType();
 
+            if (currentType == TokenTypes.LITERAL_CASE
+                || currentType == TokenTypes.LITERAL_DEFAULT) {
+                continue;
+            }
+
             if (currentType == TokenTypes.RPAREN) {
                 logWarningMessage(node, firstNodeIndent);
             }


### PR DESCRIPTION
Issue #8929

The issue happens because the lineWrappingHandler checks the line that starts from "string" and contains the switch statement as describes in Issue 8929. And when the AST go through "switch", it triggers switchRuleHandler and checks each case line base on
offset 4 ( offset base on 8 in lineWrappingHandler).
So my idea is to avoid both checks in the same case lines. I choose  to avoid the check of lineWrapHandler for switch case and add an if statement to remove corresponding tokenTypes (case and default).
But I did not fully pass the test varify,  because the Cyclomatic Complexity is 11 (max allowed is 10) after I add this if statement.
This is my first PR. if I miss something, please tell me.