### PR TITLE
Issue #9936: Deprecate 'DetailAST.branchContains`

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -417,6 +417,13 @@
       <property name="query" value="//ANNOTATION[./IDENT[@text='Issue']]"/>
       <message key="matchxpath.match" value="Avoid using @Issue annotation."/>
     </module>
+    <!-- until https://github.com/checkstyle/checkstyle/issues/5234 -->
+    <module name="MatchXpath">
+      <property name="id" value="MatchXPathBranchContains"/>
+      <property name="query" value="//METHOD_CALL//DOT[.//IDENT[@text = 'branchContains']]"/>
+      <message key="matchxpath.match"
+               value="Avoid using deprecated method 'DetailAst.branchContains()'."/>
+    </module>
     <module name="MissingCtor">
       <!--
         we will not use that fanatic validation, extra code is not good

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -113,4 +113,7 @@
   <!-- Usage of unicode characters to assert the functioning of Xpath on escape character.  -->
   <suppress id="RegexpSinglelineJava" files="[\\/]XpathQueryGeneratorTest.java"/>
 
+  <!-- until https://github.com/checkstyle/checkstyle/issues/5234 -->
+  <suppress id="MatchXPathBranchContains" files="[\\/]DetailAstImplTest.java"/>
+
 </suppressions>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -90,10 +90,15 @@ public interface DetailAST {
      * Checks if this branch of the parse tree contains a token
      * of the provided type.
      *
+     * @deprecated
+     *      Usage of this method is no longer accepted. We encourage
+     *      traversal of subtrees to be written per the needs of each check
+     *      to avoid unintended side effects.
      * @param type a TokenType
      * @return true if and only if this branch (including this node)
      *     contains a token of type {@code type}.
      */
+    @Deprecated
     boolean branchContains(int type);
 
     /**


### PR DESCRIPTION
closes #9936

New MatchXPath module before suppression:

```bash

[INFO] --- maven-antrun-plugin:3.0.0:run (ant-phase-verify) @ checkstyle ---
[INFO] Executing tasks
[INFO]      [echo] Checkstyle started (checkstyle_checks.xml): 28/04/2021 12:05:10 AM
[INFO] [checkstyle] Running Checkstyle  on 1408 files
[ERROR] [checkstyle] [ERROR] /home/nick/IdeaProjects/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java:281:24: Avoid using deprecated method DetailAst.branchContains(). [MatchXPathBranchContains]
[ERROR] [checkstyle] [ERROR] /home/nick/IdeaProjects/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java:282:25: Avoid using deprecated method DetailAst.branchContains(). [MatchXPathBranchContains]
[ERROR] [checkstyle] [ERROR] /home/nick/IdeaProjects/checkstyle/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java:334:24: Avoid using deprecated method DetailAst.branchContains(). [MatchXPathBranchContains]
[INFO]      [echo] Checkstyle finished (checkstyle_checks.xml) : 28/04/2021 12:06:00 AM


```

~~New sevntu violations, PR for suppression is here: https://github.com/sevntu-checkstyle/sevntu.checkstyle/pull/842~~

<details>

```
[INFO] --- maven-checkstyle-plugin:3.1.2:check (default) @ sevntu-checks ---
[INFO] There are 8 errors reported by Checkstyle 8.43-SNAPSHOT with ../../../config/checkstyle_checks.xml ruleset.
[ERROR] src/main/java/com/github/sevntu/checkstyle/checks/coding/LogicConditionNeedOptimizationCheck.java:[181,30] (extension) MatchXPathBranchContains: Avoid using deprecated method DetailAst.branchContains().
[ERROR] src/main/java/com/github/sevntu/checkstyle/checks/coding/NoNullForCollectionReturnCheck.java:[244,48] (extension) MatchXPathBranchContains: Avoid using deprecated method DetailAst.branchContains().
[ERROR] src/main/java/com/github/sevntu/checkstyle/checks/coding/ConfusingConditionCheck.java:[227,24] (extension) MatchXPathBranchContains: Avoid using deprecated method DetailAst.branchContains().
[ERROR] src/main/java/com/github/sevntu/checkstyle/checks/coding/ConfusingConditionCheck.java:[239,49] (extension) MatchXPathBranchContains: Avoid using deprecated method DetailAst.branchContains().
[ERROR] src/main/java/com/github/sevntu/checkstyle/checks/coding/ConfusingConditionCheck.java:[352,18] (extension) MatchXPathBranchContains: Avoid using deprecated method DetailAst.branchContains().
[ERROR] src/main/java/com/github/sevntu/checkstyle/checks/coding/ConfusingConditionCheck.java:[365,20] (extension) MatchXPathBranchContains: Avoid using deprecated method DetailAst.branchContains().
[ERROR] src/main/java/com/github/sevntu/checkstyle/checks/design/StaticMethodCandidateCheck.java:[425,18] (extension) MatchXPathBranchContains: Avoid using deprecated method DetailAst.branchContains().
[ERROR] src/main/java/com/github/sevntu/checkstyle/checks/design/StaticMethodCandidateCheck.java:[666,46] (extension) MatchXPathBranchContains: Avoid using deprecated method DetailAst.branchContains().
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.941 s
[INFO] Finished at: 2021-04-26T23:12:21-04:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:3.1.2:check (default) on project sevntu-checks: You have 8 Checkstyle violations. -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:3.1.2:check (default) on project sevntu-checks: You have 8 Checkstyle violations.
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:215)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:957)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:289)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:193)
    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:498)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: org.apache.maven.plugin.MojoFailureException: You have 8 Checkstyle violations.

```

</details>