### PR TITLE
Issue #9941: Fixing AtclauseOrder falsely ignoring method with annotation

### DIFF
--- a/.ci/wercker.sh
+++ b/.ci/wercker.sh
@@ -45,7 +45,7 @@ no-error-pgjdbc)
   checkout_from https://github.com/pgjdbc/pgjdbc.git
   cd .ci-temp/pgjdbc
   # pgjdbc easily damage build, we should use stable versions
-  git checkout "bad34f1c2985225b8809eb1c3fee5c5684d363a7"
+  git checkout "ab0d7c64d619f2b4f5692f1b2d041204ed676333"
   ./gradlew --no-parallel --no-daemon checkstyleAll \
             -PenableMavenLocal -Pcheckstyle.version=${CS_POM_VERSION}
   cd ../

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -90,13 +90,13 @@ public interface DetailAST {
      * Checks if this branch of the parse tree contains a token
      * of the provided type.
      *
+     * @param type a TokenType
+     * @return true if and only if this branch (including this node)
+     *     contains a token of type {@code type}.
      * @deprecated
      *      Usage of this method is no longer accepted. We encourage
      *      traversal of subtrees to be written per the needs of each check
      *      to avoid unintended side effects.
-     * @param type a TokenType
-     * @return true if and only if this branch (including this node)
-     *     contains a token of type {@code type}.
      */
     @Deprecated
     boolean branchContains(int type);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
@@ -272,6 +272,10 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck {
             if (result == TokenTypes.TYPE || result == TokenTypes.MODIFIERS) {
                 result = parentNode.getParent().getType();
             }
+            else if (parentNode.getParent() != null
+                    && parentNode.getParent().getType() == TokenTypes.MODIFIERS) {
+                result = parentNode.getParent().getParent().getType();
+            }
         }
         return result;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheckTest.java
@@ -188,4 +188,36 @@ public class AtclauseOrderCheckTest extends AbstractModuleTestSupport {
         verify(checkConfig, getNonCompilablePath("InputAtclauseOrderLotsOfRecords.java"), expected);
     }
 
+    @Test
+    public void testAtclause() throws Exception {
+        final String tagOrder = "[@author, @version, @param, @return, @throws, @exception, @see,"
+                + " @since, @serial, @serialField, @serialData, @deprecated]";
+        final DefaultConfiguration checkConfig = createModuleConfig(AtclauseOrderCheck.class);
+        final String[] expected = {
+            "12: " + getCheckMessage(MSG_KEY, tagOrder),
+            "13: " + getCheckMessage(MSG_KEY, tagOrder),
+            "14: " + getCheckMessage(MSG_KEY, tagOrder),
+            "24: " + getCheckMessage(MSG_KEY, tagOrder),
+            "25: " + getCheckMessage(MSG_KEY, tagOrder),
+            "26: " + getCheckMessage(MSG_KEY, tagOrder),
+            "36: " + getCheckMessage(MSG_KEY, tagOrder),
+            "37: " + getCheckMessage(MSG_KEY, tagOrder),
+            "38: " + getCheckMessage(MSG_KEY, tagOrder),
+            "51: " + getCheckMessage(MSG_KEY, tagOrder),
+            "52: " + getCheckMessage(MSG_KEY, tagOrder),
+            "53: " + getCheckMessage(MSG_KEY, tagOrder),
+            "65: " + getCheckMessage(MSG_KEY, tagOrder),
+            "66: " + getCheckMessage(MSG_KEY, tagOrder),
+            "67: " + getCheckMessage(MSG_KEY, tagOrder),
+            "80: " + getCheckMessage(MSG_KEY, tagOrder),
+            "81: " + getCheckMessage(MSG_KEY, tagOrder),
+            "82: " + getCheckMessage(MSG_KEY, tagOrder),
+            "92: " + getCheckMessage(MSG_KEY, tagOrder),
+            "93: " + getCheckMessage(MSG_KEY, tagOrder),
+            "94: " + getCheckMessage(MSG_KEY, tagOrder),
+        };
+
+        verify(checkConfig,
+                getPath("InputAtclauseOrderWithAnnotationsOutsideJavadoc.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderWithAnnotationsOutsideJavadoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/atclauseorder/InputAtclauseOrderWithAnnotationsOutsideJavadoc.java
@@ -1,0 +1,97 @@
+package com.puppycrawl.tools.checkstyle.checks.javadoc.atclauseorder;
+
+/* Config: default
+ */
+
+public class InputAtclauseOrderWithAnnotationsOutsideJavadoc {
+    /**
+     * Some javadoc.
+     *
+     * @author max
+     * @deprecated Some javadoc.
+     * @see Some javadoc.   // violation
+     * @version 1.0         // violation
+     * @since Some javadoc. // violation
+     */
+    @Deprecated
+    public boolean branchContains(int type) { return true; }
+
+    /**
+     * Some javadoc.
+     *
+     * @author max
+     * @deprecated Some javadoc.
+     * @see Some javadoc.   // violation
+     * @version 1.0         // violation
+     * @since Some javadoc. // violation
+     */
+    public boolean branchContains2(int type) { return true; }
+}
+
+/**
+ * Some javadoc.
+ *
+ * @author max
+ * @deprecated Some javadoc.
+ * @see Some javadoc.   // violation
+ * @version 1.0         // violation
+ * @since Some javadoc. // violation
+ */
+@Deprecated
+class TestClass {
+
+}
+
+class TestInnerClasses extends InputAtclauseOrderWithAnnotationsOutsideJavadoc{
+    /**
+     * Some javadoc.
+     *
+     * @author max
+     * @deprecated Some javadoc.
+     * @see Some javadoc.   // violation
+     * @version 1.0         // violation
+     * @since Some javadoc. // violation
+     */
+    @Deprecated
+    TestClass one = new TestClass(){
+
+    };
+
+    /**
+     * Some javadoc.
+     *
+     * @author max
+     * @deprecated Some javadoc.
+     * @see Some javadoc.   // violation
+     * @version 1.0         // violation
+     * @since Some javadoc. // violation
+     */
+    @Override
+    public boolean branchContains(int type) {
+        return false;
+    }
+}
+
+/**
+ * Some javadoc.
+ *
+ * @author max
+ * @deprecated Some javadoc.
+ * @see Some javadoc.   // violation
+ * @version 1.0         // violation
+ * @since Some javadoc. // violation
+ */
+@Deprecated
+enum TestEnums {}
+
+/**
+ * Some javadoc.
+ *
+ * @author max
+ * @deprecated Some javadoc.
+ * @see Some javadoc.   // violation
+ * @version 1.0         // violation
+ * @since Some javadoc. // violation
+ */
+@Deprecated
+interface TestInterfaces {}


### PR DESCRIPTION
Resolves #9941: Fixing AtclauseOrder falsely ignoring method with annotation
Diff Regression projects: https://gist.githubusercontent.com/Vyom-Yadav/91807e6244cff60698d9e33e32ba2d51/raw/eb228fa41edadc10eea264a914ea1411f0e52122/projects-to-test-on.properties
Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/4e042b7368c2ab4a66635033e0cb338c81f1d7f8/my_checks.xml