### PR TITLE
Issue #9930: Resolved issues with links detected by Linkcheck plugin

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -161,8 +161,8 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * }
  * </pre>
  * <p>
- * To configure the check with policy {@code alone_or_singleline} for {@code if}
- * and <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
+ * To configure the check with policy {@code alone_or_singleline} for {@code if} and
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
  * METHOD_DEF</a>
  * tokens:
  * </p>

--- a/src/xdocs/cmdline.xml.vm
+++ b/src/xdocs/cmdline.xml.vm
@@ -62,10 +62,9 @@ java -D&lt;property&gt;=&lt;value&gt;  \
           <code>-f format</code> - Specifies the output
           format. Valid values: <code>xml</code>, <code>sarif</code>, <code>plain</code> for <a
           href="apidocs/com/puppycrawl/tools/checkstyle/XMLLogger.html">XMLLogger</a>,
-          <a href="apidocs/com/puppycrawl/tools/checkstyle/SarifLogger.html">SarifLogger</a>,
-          and <a href="apidocs/com/puppycrawl/tools/checkstyle/DefaultLogger
-          .html">DefaultLogger</a> respectively.
-          Defaults to <code>plain</code>.
+          <a href="apidocs/com/puppycrawl/tools/checkstyle/SarifLogger.html">SarifLogger</a>, and
+          <a href="apidocs/com/puppycrawl/tools/checkstyle/DefaultLogger.html">DefaultLogger</a>
+          respectively. Defaults to <code>plain</code>.
         </li>
         <li>
           <code>-p propertiesFile</code> - Sets the property files to load.

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -163,7 +163,7 @@ public abstract class Plant {
                 Specify the comment text pattern which qualifies a method as designed for
                 extension. Supports multi-line regex.
               </td>
-              <td><a href="property_types.html#pattern">Pattern</a></td>
+              <td><a href="property_types.html#Pattern">Pattern</a></td>
               <td><code>&quot;.*&quot;</code></td>
               <td>8.40</td>
             </tr>

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -709,7 +709,8 @@ public int checkReturnTag(final int aTagIndex,
             <tr>
               <td>accessModifiers</td>
               <td>Specify the access modifiers where Javadoc comments are checked.</td>
-              <td><a href="property_types.html#access_modifiers">AccessModifierOption[]</a></td>
+              <td><a href="property_types.html#AccessModifierOption.5B.5D">AccessModifierOption[]
+              </a></td>
               <td><code>public, protected, package, private</code></td>
               <td>8.42</td>
             </tr>

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -2580,7 +2580,7 @@ class MyClass {
             <tr>
               <td>format</td>
               <td>Specifies valid identifiers.</td>
-              <td><a href="property_types.html#regexp">Pattern</a></td>
+              <td><a href="property_types.html#Pattern">Pattern</a></td>
               <td><code>"^[a-z][a-zA-Z0-9]*$"</code></td>
               <td>8.36</td>
             </tr>

--- a/src/xdocs/releasenotes.xml
+++ b/src/xdocs/releasenotes.xml
@@ -10832,7 +10832,7 @@ used in the MT mode.
           Do not verify overriding methods in <a href="config_design.html#ThrowsCount">ThrowsCount</a> check. Author: Vladislav Lisetskii <a href="https://github.com/checkstyle/checkstyle/issues/1085">#1085</a>
         </li>
         <li>
-          Fix <a href="config_misc.html#Regexp">Regexp</a> check causing exception on file with newline on top. Author: Michal Kordas <a href="https://github.com/checkstyle/checkstyle/issues/1129">#1129</a>
+          Fix <a href="config_regexp.html#Regexp">Regexp</a> check causing exception on file with newline on top. Author: Michal Kordas <a href="https://github.com/checkstyle/checkstyle/issues/1129">#1129</a>
         </li>
         <li>
           Fix <a href="config_regexp.html#RegexpMultiline">RegexpMultiline</a> check causing exception with default config. Author: Michal Kordas <a href="https://github.com/checkstyle/checkstyle/issues/1129">#1129</a>


### PR DESCRIPTION
Closes #9930 
Made changes in links in `src/xdocs` and `RightCurlyCheck.java`.

According to the [Linkcheck reports](https://checkstyle.org/linkcheck.html) as described in #9930 the following links were changes:-

1) For `config_design.html`
`property_types.html#pattern` => `property_types.html#Pattern`

2) For `config_javadoc.html`
`property_types.html#access_modifiers` => `property_types.html#AccessModifierOption.5B.5D`

3) For `apidocs/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.html`
`https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/checks/blocks/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF` => `apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF`

4) For `config_naming.html`
`property_types.html#regexp` => `property_types.html#Pattern`

5) For `releasenotes.html`
`config_misc.html#Regexp` => `config_regexp.html#Regexp`

6) For `cmdline.html`
`apidocs/com/puppycrawl/tools/checkstyle/DefaultLogger .html` => `apidocs/com/puppycrawl/tools/checkstyle/DefaultLogger.html`