### PR TITLE
Issue #9475: add code example of AST for TokenTypes.LITERAL_FALSE

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -3724,6 +3724,23 @@ public final class TokenTypes {
     /**
      * The {@code false} keyword.
      *
+     * <p>For example:</p>
+     * <pre>
+     * boolean a = false;
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * VARIABLE_DEF -&gt; VARIABLE_DEF
+     *  |--MODIFIERS -&gt; MODIFIERS
+     *  |--TYPE -&gt; TYPE
+     *  |   `--LITERAL_BOOLEAN -&gt; boolean
+     *  |--IDENT -&gt; a
+     *  |--ASSIGN -&gt; =
+     *  |   `--EXPR -&gt; EXPR
+     *  |       `--LITERAL_FALSE -&gt; false
+     *  `--SEMI -&gt; ;
+     * </pre>
+     *
      * @see <a
      * href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.10.3">Java
      * Language Specification, &sect;3.10.3</a>


### PR DESCRIPTION
Closes: #9475 
![image](https://user-images.githubusercontent.com/56120837/116246153-57c6c500-a787-11eb-8e55-69577324cc3f.png)

**Successfully Compiled**
![image](https://user-images.githubusercontent.com/56120837/116246354-8cd31780-a787-11eb-99e0-7f65c7293084.png)

**Test.java**
`$ cat Test.java`
```
public class Test {

	boolean a = false;
}
```

**AST**
`$ java -jar checkstyle-8.42-all.jar -t Test.java`
```
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> Test [1:13]
`--OBJBLOCK -> OBJBLOCK [1:18]
    |--LCURLY -> { [1:18]
    |--VARIABLE_DEF -> VARIABLE_DEF [3:1]
    |   |--MODIFIERS -> MODIFIERS [3:1]
    |   |--TYPE -> TYPE [3:1]
    |   |   `--LITERAL_BOOLEAN -> boolean [3:1]
    |   |--IDENT -> a [3:9]
    |   |--ASSIGN -> = [3:11]
    |   |   `--EXPR -> EXPR [3:13]
    |   |       `--LITERAL_FALSE -> false [3:13]
    |   `--SEMI -> ; [3:18]
    `--RCURLY -> } [4:0]
```

```
# printing the code that we care
$ java -jar checkstyle-8.42-all.jar -t Test.java | grep "3:"
    |--VARIABLE_DEF -> VARIABLE_DEF [3:1]
    |   |--MODIFIERS -> MODIFIERS [3:1]
    |   |--TYPE -> TYPE [3:1]
    |   |   `--LITERAL_BOOLEAN -> boolean [3:1]
    |   |--IDENT -> a [3:9]
    |   |--ASSIGN -> = [3:11]
    |   |   `--EXPR -> EXPR [3:13]
    |   |       `--LITERAL_FALSE -> false [3:13]
    |   `--SEMI -> ; [3:18]
```

### Expected update for javadoc
```
 VARIABLE_DEF -> VARIABLE_DEF
  |--MODIFIERS -> MODIFIERS
  |--TYPE -> TYPE
  |   `--LITERAL_BOOLEAN -> boolean
  |--IDENT -> a
  |--ASSIGN -> =
  |   `--EXPR -> EXPR
  |       `--LITERAL_FALSE -> false
  `--SEMI -> ;
```