### PR TITLE
Issue #9954: replace branch name with commit sha in site generation a…

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       branch: ${{ steps.branch.outputs.ref }}
+      commit_sha: ${{ steps.branch.outputs.commit_sha }}
 
     steps:
       - uses: khan/pull-request-comment-trigger@master
@@ -42,11 +43,13 @@ jobs:
         run: |
           wget -q "${{github.event.issue.pull_request.url}}" -O info.json
           jq .head.ref info.json > branch
+          jq .head.sha info.json > commit_sha
 
       - name: Set branch
         id: branch
         run: |
           echo ::set-output name=ref::$(cat branch | xargs)
+          echo ::set-output name=commit_sha::$(cat commit_sha | xargs | cut -c 1-7)
 
   generate_site:
     needs: parse_pr_info
@@ -91,7 +94,7 @@ jobs:
         run: |
           bash
           TIME=`date +%Y%H%M%S`
-          FOLDER="${{needs.parse_pr_info.outputs.branch}}_$TIME"
+          FOLDER="${{needs.parse_pr_info.outputs.commit_sha}}_$TIME"
           SITE="./checkstyle/target/site"
           LINK="https://${{env.AWS_BUCKET_NAME}}.s3.${{env.AWS_REGION}}.amazonaws.com"
           aws s3 cp $SITE s3://${{env.AWS_BUCKET_NAME}}/$FOLDER/ --recursive


### PR DESCRIPTION
Closes: #9954

The branch name is replaced with 7 chars commit SHA, which protects the link from any special chars that can be in the branch name.

Travis failure due to issue not approved
```
Issue number: #9954
PR Description grepped:"Closes: #9954\r\n\r\nThe branch name is replaced with 7 chars commit SHA, which
You are providing a PR for an Issue that is not approved yet,
please ask admins to approve your Issue first
PR validation failed.
```