### PR TITLE
infra: verify removal of "failsOnError=false" maven arg

### DIFF
--- a/.ci/no-exception-test.sh
+++ b/.ci/no-exception-test.sh
@@ -21,8 +21,8 @@ guava-with-google-checks)
   export MAVEN_OPTS="-Xmx2048m"
   groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
       --patchConfig ../../google_checks.xml \
-      --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}" -p "$BRANCH" -r ../../..
+      --mode single -xm "-Dcheckstyle.version=${CS_POM_VERSION}" \
+      -p "$BRANCH" -r ../../..
   cd ../..
   removeFolderWithProtectedFiles contribution
   rm google_checks.*
@@ -44,8 +44,8 @@ guava-with-sun-checks)
   export MAVEN_OPTS="-Xmx2048m"
   groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
       --patchConfig ../../sun_checks.xml \
-      --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"  -p "$BRANCH" -r ../../..
+      --mode single -xm "-Dcheckstyle.version=${CS_POM_VERSION}" \
+      -p "$BRANCH" -r ../../..
   cd ../..
   removeFolderWithProtectedFiles contribution
   rm sun_checks.*
@@ -65,7 +65,7 @@ openjdk14-with-checks-nonjavadoc-error)
       --mode single \
       --patchConfig checks-nonjavadoc-error.xml \
       --localGitRepo  "$LOCAL_GIT_REPO" \
-      --patchBranch "$BRANCH" -xm "-Dcheckstyle.failsOnError=false"
+      --patchBranch "$BRANCH"
 
   cd ../../
   removeFolderWithProtectedFiles contribution

--- a/.ci/shippable.sh
+++ b/.ci/shippable.sh
@@ -24,7 +24,7 @@ no-exception-openjdk7-openjdk8)
   sed -i'' 's/#openjdk8/openjdk8/' projects-for-circle.properties
   groovy diff.groovy --listOfProjects projects-for-circle.properties \
     --config checks-nonjavadoc-error.xml --checkstyleVersion ${CS_POM_VERSION} \
-    --allowExcludes -xm "-Dcheckstyle.failsOnError=false"
+    --allowExcludes
   cd ../..
   removeFolderWithProtectedFiles .ci-temp/contribution
   ;;
@@ -44,7 +44,7 @@ no-exception-openjdk9-lucene-and-others)
   sed -i'' 's/#lucene-solr/lucene-solr/' projects-for-circle.properties
   groovy diff.groovy --listOfProjects projects-for-circle.properties \
     --config checks-nonjavadoc-error.xml --checkstyleVersion ${CS_POM_VERSION} \
-    --allowExcludes -xm "-Dcheckstyle.failsOnError=false"
+    --allowExcludes
   cd ../..
   removeFolderWithProtectedFiles contribution
   ;;
@@ -61,7 +61,7 @@ no-exception-cassandra-storm-tapestry)
   sed -i'' 's/#cassandra/cassandra/' projects-for-circle.properties
   groovy diff.groovy --listOfProjects projects-for-circle.properties \
     --config checks-nonjavadoc-error.xml --checkstyleVersion ${CS_POM_VERSION} \
-    --allowExcludes -xm "-Dcheckstyle.failsOnError=false"
+    --allowExcludes
   cd ../..
   removeFolderWithProtectedFiles contribution
   ;;
@@ -79,7 +79,7 @@ no-exception-hadoop-apache-groovy-scouter)
   sed -i'' 's/#scouter/scouter/' projects-for-circle.properties
   groovy diff.groovy --listOfProjects projects-for-circle.properties \
     --config checks-nonjavadoc-error.xml --checkstyleVersion ${CS_POM_VERSION} \
-    --allowExcludes -xm "-Dcheckstyle.failsOnError=false"
+    --allowExcludes
   cd ../..
   removeFolderWithProtectedFiles contribution
   ;;
@@ -98,7 +98,7 @@ no-exception-only-javadoc)
   sed -i.'' 's/#apache-ant/apache-ant/' projects-to-test-on.properties
   groovy diff.groovy --listOfProjects projects-to-test-on.properties \
     --config checks-only-javadoc-error.xml --checkstyleVersion ${CS_POM_VERSION} \
-    --allowExcludes -xm "-Dcheckstyle.failsOnError=false"
+    --allowExcludes
   cd ../..
   removeFolderWithProtectedFiles contribution
   ;;

--- a/.ci/wercker.sh
+++ b/.ci/wercker.sh
@@ -222,8 +222,7 @@ no-exception-struts)
   sed -i'' 's/#apache-struts/apache-struts/' projects-for-wercker.properties
   groovy ./diff.groovy --listOfProjects projects-for-wercker.properties \
       --patchConfig checks-nonjavadoc-error.xml  -p "$BRANCH" -r ../../..  \
-      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"
+      --allowExcludes --mode single -xm "-Dcheckstyle.version=${CS_POM_VERSION}"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -240,8 +239,7 @@ no-exception-checkstyle-sevntu)
   sed -i'' 's/#sevntu-checkstyle/sevntu-checkstyle/' projects-for-wercker.properties
   groovy ./diff.groovy --listOfProjects projects-for-wercker.properties \
       --patchConfig checks-nonjavadoc-error.xml  -p "$BRANCH" -r ../../..  \
-      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"
+      --allowExcludes --mode single -xm "-Dcheckstyle.version=${CS_POM_VERSION}"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -258,8 +256,7 @@ no-exception-checkstyle-sevntu-javadoc)
   sed -i'' 's/#sevntu-checkstyle/sevntu-checkstyle/' projects-for-wercker.properties
   groovy ./diff.groovy --listOfProjects projects-for-wercker.properties \
       --patchConfig checks-only-javadoc-error.xml  -p "$BRANCH" -r ../../..  \
-      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"
+      --allowExcludes --mode single -xm "-Dcheckstyle.version=${CS_POM_VERSION}"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -274,8 +271,7 @@ no-exception-guava)
   sed -i'' 's/#guava/guava/' projects-for-wercker.properties
   groovy ./diff.groovy --listOfProjects projects-for-wercker.properties \
       --patchConfig checks-nonjavadoc-error.xml  -p "$BRANCH" -r ../../..  \
-      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"
+      --allowExcludes --mode single -xm "-Dcheckstyle.version=${CS_POM_VERSION}"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -290,8 +286,7 @@ no-exception-hibernate-orm)
   sed -i.'' 's/#hibernate-orm/hibernate-orm/' projects-to-test-on.properties
   groovy ./diff.groovy --listOfProjects projects-for-wercker.properties \
       --patchConfig checks-nonjavadoc-error.xml  -p "$BRANCH" -r ../../..  \
-       --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"
+       --allowExcludes --mode single -xm "-Dcheckstyle.version=${CS_POM_VERSION}"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -306,8 +301,7 @@ no-exception-spotbugs)
   sed -i.'' 's/#spotbugs/spotbugs/' projects-to-test-on.properties
   groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
       --patchConfig checks-nonjavadoc-error.xml  -p "$BRANCH" -r ../../..  \
-      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"
+      --allowExcludes --mode single -xm "-Dcheckstyle.version=${CS_POM_VERSION}"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -322,8 +316,7 @@ no-exception-spoon)
   sed -i.'' 's/#spoon/spoon/' projects-to-test-on.properties
   groovy ./diff.groovy --listOfProjects projects-for-wercker.properties \
       --patchConfig checks-nonjavadoc-error.xml  -p "$BRANCH" -r ../../..  \
-      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"
+      --allowExcludes --mode single -xm "-Dcheckstyle.version=${CS_POM_VERSION}"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -338,8 +331,7 @@ no-exception-spring-framework)
   sed -i.'' 's/#spring-framework/spring-framework/' projects-to-test-on.properties
   groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
       --patchConfig checks-nonjavadoc-error.xml  -p "$BRANCH" -r ../../..  \
-       --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"
+       --allowExcludes --mode single -xm "-Dcheckstyle.version=${CS_POM_VERSION}"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -354,8 +346,7 @@ no-exception-hbase)
   sed -i.'' 's/#Hbase/Hbase/' projects-to-test-on.properties
   groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
       --patchConfig checks-nonjavadoc-error.xml  -p "$BRANCH" -r ../../..  \
-      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"
+      --allowExcludes --mode single -xm "-Dcheckstyle.version=${CS_POM_VERSION}"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -372,8 +363,7 @@ no-exception-Pmd-elasticsearch-lombok-ast)
   sed -i.'' 's/#lombok-ast/lombok-ast/' projects-to-test-on.properties
   groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
       --patchConfig checks-nonjavadoc-error.xml  -p "$BRANCH" -r ../../..  \
-      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"
+      --allowExcludes --mode single -xm "-Dcheckstyle.version=${CS_POM_VERSION}"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -393,8 +383,7 @@ no-exception-alot-of-projects)
   sed -i.'' 's/#android-launcher/android-launcher/' projects-to-test-on.properties
   groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
       --patchConfig checks-nonjavadoc-error.xml  -p "$BRANCH" -r ../../.. \
-      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"
+      --allowExcludes --mode single -xm "-Dcheckstyle.version=${CS_POM_VERSION}"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -410,7 +399,7 @@ no-warning-imports-guava)
   cd .ci-temp/contribution/checkstyle-tester
   groovy ./diff.groovy --listOfProjects $PROJECTS --patchConfig $CONFIG \
       --allowExcludes -p "$BRANCH" -r ../../.. \
-      --mode single -xm "-Dcheckstyle.failsOnError=false -Dcheckstyle.version=${CS_POM_VERSION}"
+      --mode single -xm "-Dcheckstyle.version=${CS_POM_VERSION}"
   RESULT=`grep -A 5 "&#160;Warning</td>" $REPORT | cat`
   cd ../../
   removeFolderWithProtectedFiles contribution


### PR DESCRIPTION
Before:

```
➜  checkstyle git:(ci-patch) grep -R "failsOnError"
.github/workflows/diff_report.yml:             -l project.properties -xm "-Dcheckstyle.failsOnError=false"
.github/workflows/diff_report.yml:             -pc patch_config.xml -l project.properties -xm "-Dcheckstyle.failsOnError=false"
.github/workflows/diff_report.yml:             -l project.properties -xm "-Dcheckstyle.failsOnError=false"
.ci/no-exception-test.sh:      --mode single -xm "-Dcheckstyle.failsOnError=false \
.ci/no-exception-test.sh:      --mode single -xm "-Dcheckstyle.failsOnError=false \
.ci/no-exception-test.sh:      --patchBranch "$BRANCH" -xm "-Dcheckstyle.failsOnError=false"
.ci/wercker.sh:      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
.ci/wercker.sh:      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
.ci/wercker.sh:      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
.ci/wercker.sh:      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
.ci/wercker.sh:       --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
.ci/wercker.sh:      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
.ci/wercker.sh:      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
.ci/wercker.sh:       --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
.ci/wercker.sh:      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
.ci/wercker.sh:      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
.ci/wercker.sh:      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
.ci/wercker.sh:      --mode single -xm "-Dcheckstyle.failsOnError=false -Dcheckstyle.version=${CS_POM_VERSION}"
.ci/shippable.sh:    --allowExcludes -xm "-Dcheckstyle.failsOnError=false"
.ci/shippable.sh:    --allowExcludes -xm "-Dcheckstyle.failsOnError=false"
.ci/shippable.sh:    --allowExcludes -xm "-Dcheckstyle.failsOnError=false"
.ci/shippable.sh:    --allowExcludes -xm "-Dcheckstyle.failsOnError=false"
.ci/shippable.sh:    --allowExcludes -xm "-Dcheckstyle.failsOnError=false"

```

After:

```
➜  checkstyle git:(ci-patch) grep -R "failsOnError"
.github/workflows/diff_report.yml:             -l project.properties -xm "-Dcheckstyle.failsOnError=false"
.github/workflows/diff_report.yml:             -pc patch_config.xml -l project.properties -xm "-Dcheckstyle.failsOnError=false"
.github/workflows/diff_report.yml:             -l project.properties -xm "-Dcheckstyle.failsOnError=false"

```