### PR TITLE
infra: verify behavior of javadoc check NPE in CI

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
@@ -226,6 +226,9 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck {
 
     @Override
     public void visitJavadocToken(DetailNode ast) {
+        if (ast != null) {
+            throw new NullPointerException("This should fail report generation!");
+        }
         final int parentType = getParentType(getBlockCommentAst());
 
         if (target.contains(parentType)) {


### PR DESCRIPTION
All javadoc regression CI travis jobs have failed: https://travis-ci.org/github/checkstyle/checkstyle/builds/769231966

Expecting failure in werker at https://app.wercker.com/checkstyle/checkstyle/runs/build/608ed777237ec900085417f5, will post direct link later