### PR TITLE
infra: move config for no-exception execution of javadoc in repo

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -923,6 +923,7 @@ onevariableperline
 oo
 OOL
 oopsla
+OOQ
 opencollective
 openjdk
 openstreetmap
@@ -1000,6 +1001,7 @@ pmdruleset
 PModel
 png
 Pno
+poetix
 Pointcut
 POJO
 Popup

--- a/.ci/no-exception-test.sh
+++ b/.ci/no-exception-test.sh
@@ -76,14 +76,15 @@ no-exception-lucene-and-others-javadoc)
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   echo 'CS_POM_VERSION='${CS_POM_VERSION}
   checkout_from https://github.com/checkstyle/contribution
+  cp .ci/projects-for-no-exception-javadoc.properties .ci-temp/contribution/checkstyle-tester
   cd .ci-temp/contribution/checkstyle-tester
-  sed -i'' 's/^guava/#guava/' projects-for-circle.properties
-  sed -i'' 's/#infinispan/infinispan/' projects-for-circle.properties
-  sed -i'' 's/#protonpack/protonpack/' projects-for-circle.properties
-  sed -i'' 's/#jOOL/jOOL/' projects-for-circle.properties
-  sed -i'' 's/#lucene-solr/lucene-solr/' projects-for-circle.properties
+  sed -i'' 's/^guava/#guava/' projects-for-no-exception-javadoc.properties
+  sed -i'' 's/#infinispan/infinispan/' projects-for-no-exception-javadoc.properties
+  sed -i'' 's/#protonpack/protonpack/' projects-for-no-exception-javadoc.properties
+  sed -i'' 's/#jOOL/jOOL/' projects-for-no-exception-javadoc.properties
+  sed -i'' 's/#lucene-solr/lucene-solr/' projects-for-no-exception-javadoc.properties
   export MAVEN_OPTS="-Xmx2048m"
-  groovy ./diff.groovy --listOfProjects projects-for-circle.properties \
+  groovy ./diff.groovy --listOfProjects projects-for-no-exception-javadoc.properties \
       --patchConfig checks-only-javadoc-error.xml \
       --mode single --allowExcludes -xm "-Dcheckstyle.failsOnError=false \
       -Dcheckstyle.version=${CS_POM_VERSION}"  -p "$BRANCH" -r ../../..
@@ -96,13 +97,14 @@ no-exception-cassandra-storm-tapestry-javadoc)
   echo 'CS_POM_VERSION='${CS_POM_VERSION}
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   checkout_from https://github.com/checkstyle/contribution
+  cp .ci/projects-for-no-exception-javadoc.properties .ci-temp/contribution/checkstyle-tester
   cd .ci-temp/contribution/checkstyle-tester
-  sed -i'' 's/^guava/#guava/' projects-for-circle.properties
-  sed -i'' 's/#tapestry-5/tapestry-5/' projects-for-circle.properties
-  sed -i'' 's/#storm/storm/' projects-for-circle.properties
-  sed -i'' 's/#cassandra/cassandra/' projects-for-circle.properties
+  sed -i'' 's/^guava/#guava/' projects-for-no-exception-javadoc.properties
+  sed -i'' 's/#tapestry-5/tapestry-5/' projects-for-no-exception-javadoc.properties
+  sed -i'' 's/#storm/storm/' projects-for-no-exception-javadoc.properties
+  sed -i'' 's/#cassandra/cassandra/' projects-for-no-exception-javadoc.properties
   export MAVEN_OPTS="-Xmx2048m"
-  groovy ./diff.groovy --listOfProjects projects-for-circle.properties \
+  groovy ./diff.groovy --listOfProjects projects-for-no-exception-javadoc.properties \
       --patchConfig checks-only-javadoc-error.xml \
       --mode single --allowExcludes  -xm "-Dcheckstyle.failsOnError=false \
       -Dcheckstyle.version=${CS_POM_VERSION}"  -p "$BRANCH" -r ../../..
@@ -115,14 +117,15 @@ no-exception-hadoop-apache-groovy-scouter-javadoc)
   echo 'CS_POM_VERSION='${CS_POM_VERSION}
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
   checkout_from https://github.com/checkstyle/contribution
+  cp .ci/projects-for-no-exception-javadoc.properties .ci-temp/contribution/checkstyle-tester
   cd .ci-temp/contribution/checkstyle-tester
-  sed -i'' 's/^guava/#guava/' projects-for-circle.properties
-  sed -i'' 's/#apache-commons/apache-commons/' projects-for-circle.properties
-  sed -i'' 's/#hadoop/hadoop/' projects-for-circle.properties
-  sed -i'' 's/#groovy/groovy/' projects-for-circle.properties
-  sed -i'' 's/#scouter/scouter/' projects-for-circle.properties
+  sed -i'' 's/^guava/#guava/' projects-for-no-exception-javadoc.properties
+  sed -i'' 's/#apache-commons/apache-commons/' projects-for-no-exception-javadoc.properties
+  sed -i'' 's/#hadoop/hadoop/' projects-for-no-exception-javadoc.properties
+  sed -i'' 's/#groovy/groovy/' projects-for-no-exception-javadoc.properties
+  sed -i'' 's/#scouter/scouter/' projects-for-no-exception-javadoc.properties
   export MAVEN_OPTS="-Xmx2048m"
-  groovy ./diff.groovy --listOfProjects projects-for-circle.properties \
+  groovy ./diff.groovy --listOfProjects projects-for-no-exception-javadoc.properties \
       --patchConfig checks-only-javadoc-error.xml \
       --mode single --allowExcludes -xm "-Dcheckstyle.failsOnError=false \
       -Dcheckstyle.version=${CS_POM_VERSION}"  -p "$BRANCH" -r ../../..

--- a/.ci/projects-for-no-exception-javadoc.properties
+++ b/.ci/projects-for-no-exception-javadoc.properties
@@ -1,0 +1,19 @@
+# List of GIT repositories to clone / pull for checking with Checkstyle
+# File format: REPO_NAME|[local|git|hg]|URL|[COMMIT_ID]|[EXCLUDE FOLDERS]
+# Please note that bash comments works in this file
+
+guava|git|https://github.com/google/guava|v28.2||
+
+#infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
+#protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
+#jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
+#lucene-solr|git|https://github.com/apache/lucene-solr|releases/lucene-solr/5.4.0||
+
+#tapestry-5|git|https://github.com/apache/tapestry-5|5.4.0|**/archetype-resources/**/*|
+#storm|git|https://github.com/apache/storm|v0.9.6||
+#cassandra|git|https://github.com/apache/cassandra|cassandra-3.2||
+
+#apache-commons|git|https://github.com/apache/commons-lang|LANG_3_4||
+#hadoop|git|https://github.com/apache/hadoop|release-2.6.3||
+#scouter|git|https://github.com/scouter-project/scouter|v0.4.4||
+#groovy|git|https://github.com/apache/groovy|GROOVY_2_4_5||


### PR DESCRIPTION
reason: it is very strange that we keep config for CI of checkstyle in another repo.

file projects-for-circle.properties was added at https://github.com/checkstyle/contribution/pull/52
and it is clearly have bad name now as location was changed.

We should keep configs for checkstyle CI in checkstyle repo.