### PR TITLE
Issue #9994: Added support for LITERAL_SWITCH token in RightCurlyCheck

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -310,6 +310,7 @@
       <property name="tokens" value="LITERAL_ELSE"/>
       <property name="tokens" value="LITERAL_FINALLY"/>
       <property name="tokens" value="LITERAL_IF"/>
+      <property name="tokens" value="LITERAL_SWITCH"/>
       <property name="tokens" value="LITERAL_TRY"/>
       <property name="tokens" value="ANNOTATION_DEF"/>
       <property name="tokens" value="ENUM_DEF"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -32,7 +32,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 /**
  * <p>
  * Checks the placement of right curly braces ({@code '}'}) for code blocks. This check supports
- * if-else, try-catch-finally blocks, while-loops, for-loops,
+ * if-else, try-catch-finally blocks, switch-case statements, while-loops, for-loops,
  * method definitions, class definitions, constructor definitions,
  * instance, static initialization blocks, annotation definitions and enum definitions.
  * For right curly brace of expression blocks of arrays, lambdas and class instances
@@ -292,6 +292,7 @@ public class RightCurlyCheck extends AbstractCheck {
             TokenTypes.INTERFACE_DEF,
             TokenTypes.RECORD_DEF,
             TokenTypes.COMPACT_CTOR_DEF,
+            TokenTypes.LITERAL_SWITCH,
         };
     }
 
@@ -514,6 +515,7 @@ public class RightCurlyCheck extends AbstractCheck {
             TokenTypes.ANNOTATION_DEF,
             TokenTypes.INTERFACE_DEF,
             TokenTypes.RECORD_DEF,
+            TokenTypes.LITERAL_SWITCH,
         };
 
         /** Right curly. */
@@ -563,6 +565,9 @@ public class RightCurlyCheck extends AbstractCheck {
                 case TokenTypes.LITERAL_WHILE:
                 case TokenTypes.LITERAL_FOR:
                     details = getDetailsForLoops(ast);
+                    break;
+                case TokenTypes.LITERAL_SWITCH:
+                    details = getDetailsForSwitch(ast);
                     break;
                 default:
                     details = getDetailsForOthers(ast);
@@ -634,6 +639,18 @@ public class RightCurlyCheck extends AbstractCheck {
                 rcurly = lcurly.getLastChild();
             }
             return new Details(lcurly, rcurly, nextToken, shouldCheckLastRcurly);
+        }
+
+        /**
+         * Collects validation details for LITERAL_SWITCH.
+         *
+         * @param ast a {@code DetailAST} value
+         * @return object containing all details to make a validation
+         */
+        private static Details getDetailsForSwitch(DetailAST ast) {
+            final DetailAST lcurly = ast.findFirstToken(TokenTypes.LCURLY);
+            DetailAST rcurly = ast.getLastChild();
+            return new Details(lcurly, rcurly, getNextToken(ast), true);
         }
 
         /**

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/blocks/RightCurlyCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/blocks/RightCurlyCheck.xml
@@ -6,7 +6,7 @@
              parent="com.puppycrawl.tools.checkstyle.TreeWalker">
          <description>&lt;p&gt;
  Checks the placement of right curly braces ({@code '}'}) for code blocks. This check supports
- if-else, try-catch-finally blocks, while-loops, for-loops,
+ if-else, try-catch-finally blocks, switch-case statements, while-loops, for-loops,
  method definitions, class definitions, constructor definitions,
  instance, static initialization blocks, annotation definitions and enum definitions.
  For right curly brace of expression blocks of arrays, lambdas and class instances

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -94,7 +94,7 @@
       <property name="tokens"
                value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
                     INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
-                    COMPACT_CTOR_DEF"/>
+                    COMPACT_CTOR_DEF, LITERAL_SWITCH"/>
     </module>
     <module name="SuppressionXpathSingleFilter">
       <!-- suppresion is required till https://github.com/checkstyle/checkstyle/issues/7541 -->

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -1223,8 +1223,8 @@ allowedFuture.addCallback(result -> {
       <subsection name="Description" id="RightCurly_Description">
         <p>
           Checks the placement of right curly braces (<code>'}'</code>) for code blocks.
-          This check supports if-else, try-catch-finally blocks, while-loops, for-loops,
-          method definitions, class definitions, constructor definitions,
+          This check supports if-else, try-catch-finally blocks, switch-case statements,
+          while-loops, for-loops, method definitions, class definitions, constructor definitions,
           instance, static initialization blocks, annotation definitions and enum definitions.
           For right curly brace of expression blocks of arrays, lambdas and class instances
           please follow issue
@@ -1291,6 +1291,8 @@ allowedFuture.addCallback(result -> {
                   RECORD_DEF</a>
                 ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
                   COMPACT_CTOR_DEF</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">
+                  LITERAL_SWITCH</a>
                 .
               </td>
               <td>


### PR DESCRIPTION
Closes #9994 
LITERAL_SWITCH token support added in RightCurlyCheck.

P.S:- This PR is still incomplete and I am working on it. I am adding changes and will add the Diff Regression reports once done with these changes.