### PR TITLE
Issue #6873: Convert JavadocMethodCheck to be based on AbstractJavadocCheck (AST based)

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java
@@ -258,17 +258,17 @@ public abstract class AbstractJavadocCheck extends AbstractCheck {
      * @return default tokens
      */
     @Override
-    public final int[] getDefaultTokens() {
+    public int[] getDefaultTokens() {
         return getRequiredTokens();
     }
 
     @Override
-    public final int[] getAcceptableTokens() {
+    public int[] getAcceptableTokens() {
         return getRequiredTokens();
     }
 
     @Override
-    public final int[] getRequiredTokens() {
+    public int[] getRequiredTokens() {
         return new int[] {TokenTypes.BLOCK_COMMENT_BEGIN };
     }
 
@@ -283,7 +283,7 @@ public abstract class AbstractJavadocCheck extends AbstractCheck {
     }
 
     @Override
-    public final void beginTree(DetailAST rootAST) {
+    public void beginTree(DetailAST rootAST) {
         TREE_CACHE.get().clear();
     }
 
@@ -293,7 +293,7 @@ public abstract class AbstractJavadocCheck extends AbstractCheck {
     }
 
     @Override
-    public final void visitToken(DetailAST blockCommentNode) {
+    public void visitToken(DetailAST blockCommentNode) {
         if (JavadocUtil.isJavadocComment(blockCommentNode)) {
             // store as field, to share with child Checks
             context.get().blockCommentAst = blockCommentNode;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -33,8 +33,10 @@ import java.util.regex.Pattern;
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
+import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
 import com.puppycrawl.tools.checkstyle.api.TextBlock;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption;
@@ -287,7 +289,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * @since 3.0
  */
 @FileStatefulCheck
-public class JavadocMethodCheck extends AbstractCheck {
+public class JavadocMethodCheck extends AbstractJavadocCheck {
 
     /**
      * A key is pointing to the warning message text in "messages.properties"
@@ -435,6 +437,21 @@ public class JavadocMethodCheck extends AbstractCheck {
      */
     public void setAllowMissingReturnTag(boolean flag) {
         allowMissingReturnTag = flag;
+    }
+    
+    @Override
+    public int[] getDefaultJavadocTokens() {
+        return new int[] {
+            JavadocTokenTypes.INHERIT_DOC_LITERAL,
+            JavadocTokenTypes.PARAM_LITERAL,
+            JavadocTokenTypes.RETURN_LITERAL,
+            JavadocTokenTypes.THROWS_LITERAL,
+        };
+    }
+    
+    @Override
+    public void visitJavadocToken(DetailNode ast) {
+
     }
 
     @Override


### PR DESCRIPTION
To fix #6873

PR is not finished yet. There are still many files to be updated.