### PR TITLE
infra: upgrade wercker docker image

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -1,5 +1,5 @@
 box:
-  id: maven:3.6.3-jdk-11
+  id: maven:3.8.1-jdk-11
   username: $DOCKERHUB_USER
   password: $DOCKERHUB_TOKEN
 


### PR DESCRIPTION
From https://github.com/checkstyle/checkstyle/pull/10019#discussion_r637354929:

Wercker is failing on `./.ci/wercker.sh no-error-hibernate-search`:

```bash
[WARNING] Rule 1: org.apache.maven.plugins.enforcer.RequireMavenVersion failed with message:
Detected Maven Version: 3.6.3 is not in the allowed range 3.8.1.

```

Appears to be related to https://github.com/hibernate/hibernate-search/commit/4e4918306334ee5ef2d984297efe2f4dc93c4deb