### PR TITLE
Literal boolean

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -4400,26 +4400,25 @@ public final class TokenTypes {
      * <p>parses as:</p>
      * <pre>
      * ANNOTATION_DEF -&gt ANNOTATION_DEF
-     *  |   |--MODIFIERS -&gt MODIFIERS
-     *  |   |   `--LITERAL_PUBLIC -&gt public
-     *  |   |--AT -&gt @
-     *  |   |--LITERAL_INTERFACE -&gt interface
-     *  |   |--IDENT -&gt MyAnnotation
-     *  |   `--OBJBLOCK -&gt OBJBLOCK
-     *  |       |--LCURLY -&gt {
-     *  |       |--ANNOTATION_FIELD_DEF -&gt ANNOTATION_FIELD_DEF
-     *  |       |   |--MODIFIERS -&gt MODIFIERS
-     *  |       |   |--TYPE -&gt TYPE
-     *  |       |   |   `--LITERAL_INT -&gt int
-     *  |       |   |--IDENT -&gt value
-     *  |       |   |--LPAREN -&gt (
-     *  |       |   |--RPAREN -&gt )
-     *  |       |   |--LITERAL_DEFAULT -&gt default
-     *  |       |   |   `--EXPR -&gt EXPR
-     *  |       |   |       `--NUM_INT -&gt 1
-     *  |       |   `--SEMI -&gt ;
-     *  |       `--RCURLY -&gt }
-     *  `--RCURLY -&gt }
+     *      |--MODIFIERS -&gt MODIFIERS
+     *      |   `--LITERAL_PUBLIC -&gt public
+     *      |--AT -&gt @
+     *      |--LITERAL_INTERFACE -&gt interface
+     *      |--IDENT -&gt MyAnnotation
+     *      `--OBJBLOCK -&gt OBJBLOCK
+     *          |--LCURLY -&gt {
+     *          |--ANNOTATION_FIELD_DEF -&gt ANNOTATION_FIELD_DEF
+     *          |   |--MODIFIERS -&gt MODIFIERS
+     *          |   |--TYPE -&gt TYPE
+     *          |   |   `--LITERAL_INT -&gt int
+     *          |   |--IDENT -&gt value
+     *          |   |--LPAREN -&gt (
+     *          |   |--RPAREN -&gt )
+     *          |   |--LITERAL_DEFAULT -&gt default
+     *          |   |   `--EXPR -&gt EXPR
+     *          |   |       `--NUM_INT -&gt 1
+     *          |   `--SEMI -&gt ;
+     *          `--RCURLY -&gt }
      * </pre>
      *
      * @see <a href="https://www.jcp.org/en/jsr/detail?id=201">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -4399,28 +4399,27 @@ public final class TokenTypes {
      * </pre>
      * <p>parses as:</p>
      * <pre>
-     * +--ANNOTATION_DEF
-     *     |
-     *     +--MODIFIERS
-     *         |
-     *         +--LITERAL_PUBLIC (public)
-     *     +--AT (@)
-     *     +--LITERAL_INTERFACE (interface)
-     *     +--IDENT (MyAnnotation)
-     *     +--OBJBLOCK
-     *         |
-     *         +--LCURLY ({)
-     *         +--ANNOTATION_FIELD_DEF
-     *             |
-     *             +--MODIFIERS
-     *             +--TYPE
-     *                 |
-     *                 +--LITERAL_INT (int)
-     *             +--IDENT (someValue)
-     *             +--LPAREN (()
-     *             +--RPAREN ())
-     *             +--SEMI (;)
-     *         +--RCURLY (})
+     * ANNOTATION_DEF -&gt ANNOTATION_DEF
+     *  |   |--MODIFIERS -&gt MODIFIERS
+     *  |   |   `--LITERAL_PUBLIC -&gt public
+     *  |   |--AT -&gt @
+     *  |   |--LITERAL_INTERFACE -&gt interface
+     *  |   |--IDENT -&gt MyAnnotation
+     *  |   `--OBJBLOCK -&gt OBJBLOCK
+     *  |       |--LCURLY -&gt {
+     *  |       |--ANNOTATION_FIELD_DEF -&gt ANNOTATION_FIELD_DEF
+     *  |       |   |--MODIFIERS -&gt MODIFIERS
+     *  |       |   |--TYPE -&gt TYPE
+     *  |       |   |   `--LITERAL_INT -&gt int
+     *  |       |   |--IDENT -&gt value
+     *  |       |   |--LPAREN -&gt (
+     *  |       |   |--RPAREN -&gt )
+     *  |       |   |--LITERAL_DEFAULT -&gt default
+     *  |       |   |   `--EXPR -&gt EXPR
+     *  |       |   |       `--NUM_INT -&gt 1
+     *  |       |   `--SEMI -&gt ;
+     *  |       `--RCURLY -&gt }
+     *  `--RCURLY -&gt }
      * </pre>
      *
      * @see <a href="https://www.jcp.org/en/jsr/detail?id=201">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1495,13 +1495,13 @@ public final class TokenTypes {
      *
      * @see #TYPE
      * <pre>
-     *--VARIABLE_DEF -&gt; VARIABLE_DEF
-     *    |--MODIFIERS -&gt; MODIFIERS
-     *    |   `--LITERAL_PUBLIC -&gt; public
-     *    |--TYPE -&gt; TYPE
-     *    |   `--LITERAL_BOOLEAN -&gt; boolean
-     *    |--IDENT -&gt; x
-     *     `--SEMI -&gt; ;
+     * VARIABLE_DEF -&gt; VARIABLE_DEF
+     *  |--MODIFIERS -&gt; MODIFIERS
+     *  |   `--LITERAL_PUBLIC -&gt; public
+     *  |--TYPE -&gt; TYPE
+     *  |   `--LITERAL_BOOLEAN -&gt; boolean
+     *  |--IDENT -&gt; x
+     *   `--SEMI -&gt; ;
      * </pre>
      *
      *

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1494,6 +1494,20 @@ public final class TokenTypes {
      * The {@code boolean} keyword.
      *
      * @see #TYPE
+     * <pre>
+     *--VARIABLE_DEF -&gt; VARIABLE_DEF
+     *    |--MODIFIERS -&gt; MODIFIERS
+     *    |   `--LITERAL_PUBLIC -&gt; public
+     *    |--TYPE -&gt; TYPE
+     *    |   `--LITERAL_BOOLEAN -&gt; boolean
+     *    |--IDENT -&gt; x
+     *     `--SEMI -&gt; ;
+     * </pre>
+     *
+     *
+     *
+     *
+     *
      **/
     public static final int LITERAL_BOOLEAN =
         GeneratedJavaTokenTypes.LITERAL_boolean;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -4399,26 +4399,26 @@ public final class TokenTypes {
      * </pre>
      * <p>parses as:</p>
      * <pre>
-     * ANNOTATION_DEF -&gt ANNOTATION_DEF
-     *      |--MODIFIERS -&gt MODIFIERS
-     *      |   `--LITERAL_PUBLIC -&gt public
-     *      |--AT -&gt @
-     *      |--LITERAL_INTERFACE -&gt interface
-     *      |--IDENT -&gt MyAnnotation
-     *      `--OBJBLOCK -&gt OBJBLOCK
-     *          |--LCURLY -&gt {
-     *          |--ANNOTATION_FIELD_DEF -&gt ANNOTATION_FIELD_DEF
-     *          |   |--MODIFIERS -&gt MODIFIERS
-     *          |   |--TYPE -&gt TYPE
-     *          |   |   `--LITERAL_INT -&gt int
-     *          |   |--IDENT -&gt value
-     *          |   |--LPAREN -&gt (
-     *          |   |--RPAREN -&gt )
-     *          |   |--LITERAL_DEFAULT -&gt default
-     *          |   |   `--EXPR -&gt EXPR
-     *          |   |       `--NUM_INT -&gt 1
-     *          |   `--SEMI -&gt ;
-     *          `--RCURLY -&gt }
+     * ANNOTATION_DEF -&gt; ANNOTATION_DEF
+     *  |--MODIFIERS -&gt; MODIFIERS
+     *  |   `--LITERAL_PUBLIC -&gt; public
+     *  |--AT -&gt; @
+     *  |--LITERAL_INTERFACE -&gt; interface
+     *  |--IDENT -&gt; MyAnnotation
+     *  `--OBJBLOCK -&gt; OBJBLOCK
+     *      |--LCURLY -&gt; {
+     *      |--ANNOTATION_FIELD_DEF -&gt; ANNOTATION_FIELD_DEF
+     *      |   |--MODIFIERS -&gt; MODIFIERS
+     *      |   |--TYPE -&gt; TYPE
+     *      |   |   `--LITERAL_INT -&gt; int
+     *      |   |--IDENT -&gt; value
+     *      |   |--LPAREN -&gt; (
+     *      |   |--RPAREN -&gt; )
+     *      |   |--LITERAL_DEFAULT -&gt; default
+     *      |   |   `--EXPR -&gt; EXPR
+     *      |   |       `--NUM_INT -&gt; 1
+     *      |   `--SEMI -&gt; ;
+     *       `--RCURLY -&gt; }
      * </pre>
      *
      * @see <a href="https://www.jcp.org/en/jsr/detail?id=201">


### PR DESCRIPTION
fixes #9463 
![Image](https://user-images.githubusercontent.com/71710042/119384631-a1e98a80-bce2-11eb-848c-a71dd5c61921.png)

Java Code:
<pre>
<code>
public class MyClass {
  public boolean x;
}
</code>
</pre>

AST Format of Java Code:
<pre>
<code>
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> MyClass [1:13]
`--OBJBLOCK -> OBJBLOCK [1:21]
    |--LCURLY -> { [1:21]
    |--VARIABLE_DEF -> VARIABLE_DEF [2:2]
    |   |--MODIFIERS -> MODIFIERS [2:2]
    |   |   `--LITERAL_PUBLIC -> public [2:2]
    |   |--TYPE -> TYPE [2:9]
    |   |   `--LITERAL_BOOLEAN -> boolean [2:9]
    |   |--IDENT -> x [2:17]
    |   `--SEMI -> ; [2:18]
    `--RCURLY -> } [3:0]
</code>
</pre>

Expected update for JavaDoc:

<pre>
<code>
     --VARIABLE_DEF -> VARIABLE_DEF 
         --MODIFIERS -> MODIFIERS 
            `--LITERAL_PUBLIC -> public 
         --TYPE -> TYPE 
            `--LITERAL_BOOLEAN -> boolean 
         --IDENT -> x 
        `--SEMI -> ; 
    `--RCURLY -> } 
</code>
</pre>



