### PR TITLE
Issue #9391: update example of AST for TokenTypes.ANNOTATIONS.DEF

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -4399,28 +4399,23 @@ public final class TokenTypes {
      * </pre>
      * <p>parses as:</p>
      * <pre>
-     * +--ANNOTATION_DEF
-     *     |
-     *     +--MODIFIERS
-     *         |
-     *         +--LITERAL_PUBLIC (public)
-     *     +--AT (@)
-     *     +--LITERAL_INTERFACE (interface)
-     *     +--IDENT (MyAnnotation)
-     *     +--OBJBLOCK
-     *         |
-     *         +--LCURLY ({)
-     *         +--ANNOTATION_FIELD_DEF
-     *             |
-     *             +--MODIFIERS
-     *             +--TYPE
-     *                 |
-     *                 +--LITERAL_INT (int)
-     *             +--IDENT (someValue)
-     *             +--LPAREN (()
-     *             +--RPAREN ())
-     *             +--SEMI (;)
-     *         +--RCURLY (})
+     * ANNOTATION_DEF -&gt; ANNOTATION_DEF
+     *  |--MODIFIERS -&gt; MODIFIERS
+     *  |   `--LITERAL_PUBLIC -&gt; public
+     *  |--AT -&gt; @
+     *  |--LITERAL_INTERFACE -&gt; interface
+     *  |--IDENT -&gt; MyAnnotation
+     *  `--OBJBLOCK -&gt; OBJBLOCK
+     *      |--LCURLY -&gt; {
+     *      |--ANNOTATION_FIELD_DEF -&gt; ANNOTATION_FIELD_DEF
+     *      |   |--MODIFIERS -&gt; MODIFIERS
+     *      |   |--TYPE -&gt; TYPE
+     *      |   |   `--LITERAL_INT -&gt; int
+     *      |   |--IDENT -&gt; someValue
+     *      |   |--LPAREN -&gt; (
+     *      |   |--RPAREN -&gt; )
+     *      |   `--SEMI -&gt; ;
+     *      `--RCURLY -&gt; }
      * </pre>
      *
      * @see <a href="https://www.jcp.org/en/jsr/detail?id=201">


### PR DESCRIPTION
fixes #9391 
![picture](https://user-images.githubusercontent.com/71710042/119345507-9a13f100-bcb6-11eb-9ad7-5e4fa6c72519.png)

Java Code used here:
<pre>
<code>
public class MyClass {
  public @interface MyAnnotation {
    int someValue();
  }
}
 
</code>
</pre>

AST Format of the Java Doc:
<pre>
<code>
CLASS_DEF -> CLASS_DEF [1:0]
|--MODIFIERS -> MODIFIERS [1:0]
|   `--LITERAL_PUBLIC -> public [1:0]
|--LITERAL_CLASS -> class [1:7]
|--IDENT -> MyClass [1:13]
`--OBJBLOCK -> OBJBLOCK [1:21]
    |--LCURLY -> { [1:21]
    |--ANNOTATION_DEF -> ANNOTATION_DEF [2:2]
    |   |--MODIFIERS -> MODIFIERS [2:2]
    |   |   `--LITERAL_PUBLIC -> public [2:2]
    |   |--AT -> @ [2:9]
    |   |--LITERAL_INTERFACE -> interface [2:10]
    |   |--IDENT -> MyAnnotation [2:20]
    |   `--OBJBLOCK -> OBJBLOCK [2:33]
    |       |--LCURLY -> { [2:33]
    |       |--ANNOTATION_FIELD_DEF -> ANNOTATION_FIELD_DEF [3:4]
    |       |   |--MODIFIERS -> MODIFIERS [3:4]
    |       |   |--TYPE -> TYPE [3:4]
    |       |   |   `--LITERAL_INT -> int [3:4]
    |       |   |--IDENT -> someValue [3:8]
    |       |   |--LPAREN -> ( [3:17]
    |       |   |--RPAREN -> ) [3:18]
    |       |   `--SEMI -> ; [3:19]
    |       `--RCURLY -> } [4:2]
    `--RCURLY -> } [5:0]
</code>
</pre>

Expected Java Doc to changes:
<pre>
<code>

|   |--MODIFIERS -> MODIFIERS 
|   |--TYPE -&gt; TYPE 
|   |   `--LITERAL_INT -&gt; int 
|   |--IDENT -&gt; someValue 
|   |--LPAREN -&gt; ( 
|   |--RPAREN -&gt; ) 
|   `--SEMI -&gt; ; 
`--RCURLY -&gt;
</code>
</pre>