### PR TITLE
Issue #9999: LineLengthCheck should check for import and package statements

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
@@ -45,10 +45,6 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * property {@code tabWidth} which applies to all Checks, including {@code LineLength};
  * or can set property {@code tabWidth} for {@code LineLength} alone.
  * </li>
- * <li>
- * Package and import statements (lines matching pattern {@code ^(package|import) .*})
- * are not verified by this check.
- * </li>
  * </ul>
  * <ul>
  * <li>
@@ -65,6 +61,16 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * Property {@code max} - Specify the maximum line length allowed.
  * Type is {@code int}.
  * Default value is {@code 80}.
+ * </li>
+ * <li>
+ * Property {@code validateImport} - Validate checking of import statements.
+ * Type is {@code boolean}.
+ * Default value is {@code false}.
+ * </li>
+ * <li>
+ * Property {@code validatePackage} - Validate checking of package statements.
+ * Type is {@code boolean}.
+ * Default value is {@code false}.
  * </li>
  * </ul>
  * <p>
@@ -130,14 +136,23 @@ public class LineLengthCheck extends AbstractFileSetCheck {
     /** Default maximum number of columns in a line. */
     private static final int DEFAULT_MAX_COLUMNS = 80;
 
-    /** Patterns matching package, import, and import static statements. */
-    private static final Pattern IGNORE_PATTERN = Pattern.compile("^(package|import) .*");
+    /** Pattern matching import and import static statements. */
+    private static final Pattern IMPORT_PATTERN = Pattern.compile("^import .*");
+
+    /** Pattern matching package statements. */
+    private static final Pattern PACKAGE_PATTERN = Pattern.compile("^package .*");
 
     /** Specify the maximum line length allowed. */
     private int max = DEFAULT_MAX_COLUMNS;
 
     /** Specify pattern for lines to ignore. */
     private Pattern ignorePattern = Pattern.compile("^$");
+
+    /** Validate checking of import statements. */
+    private boolean validateImport;
+
+    /** Validate checking of package statements. */
+    private boolean validatePackage;
 
     @Override
     protected void processFiltered(File file, FileText fileText) {
@@ -146,9 +161,19 @@ public class LineLengthCheck extends AbstractFileSetCheck {
             final int realLength = CommonUtil.lengthExpandedTabs(
                 line, line.codePointCount(0, line.length()), getTabWidth());
 
-            if (realLength > max && !IGNORE_PATTERN.matcher(line).find()
-                && !ignorePattern.matcher(line).find()) {
-                log(i + 1, MSG_KEY, max, realLength);
+            if (realLength > max && !ignorePattern.matcher(line).find()) {
+
+                final boolean matchPackage = PACKAGE_PATTERN.matcher(line).find();
+                final boolean matchImport = IMPORT_PATTERN.matcher(line).find();
+                final boolean validateForPackage = validatePackage && matchPackage;
+                final boolean validateForImport = validateImport && matchImport;
+
+                if (validateForImport || validateForPackage) {
+                    log(i + 1, MSG_KEY, max, realLength);
+                }
+                else if (!matchImport && !matchPackage) {
+                    log(i + 1, MSG_KEY, max, realLength);
+                }
             }
         }
     }
@@ -169,6 +194,24 @@ public class LineLengthCheck extends AbstractFileSetCheck {
      */
     public final void setIgnorePattern(Pattern pattern) {
         ignorePattern = pattern;
+    }
+
+    /**
+     * Setter to validate checking of package statements.
+     *
+     * @param validate {@code true} to validate package statements.
+     */
+    public void setValidatePackage(boolean validate) {
+        validatePackage = validate;
+    }
+
+    /**
+     * Setter to validate checking of import statements.
+     *
+     * @param validate {@code true} to validate import statements.
+     */
+    public void setValidateImport(boolean validate) {
+        validateImport = validate;
     }
 
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/sizes/LineLengthCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/sizes/LineLengthCheck.xml
@@ -21,10 +21,6 @@
  property {@code tabWidth} which applies to all Checks, including {@code LineLength};
  or can set property {@code tabWidth} for {@code LineLength} alone.
  &lt;/li&gt;
- &lt;li&gt;
- Package and import statements (lines matching pattern {@code ^(package|import) .*})
- are not verified by this check.
- &lt;/li&gt;
  &lt;/ul&gt;</description>
          <properties>
             <property default-value="" name="fileExtensions" type="java.lang.String[]">
@@ -37,6 +33,12 @@
             </property>
             <property default-value="80" name="max" type="int">
                <description>Specify the maximum line length allowed.</description>
+            </property>
+            <property default-value="false" name="validateImport" type="boolean">
+               <description>Validate checking of import statements.</description>
+            </property>
+            <property default-value="false" name="validatePackage" type="boolean">
+               <description>Validate checking of package statements.</description>
             </property>
          </properties>
          <message-keys>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheckTest.java
@@ -118,4 +118,33 @@ public class LineLengthCheckTest extends AbstractModuleTestSupport {
 
     }
 
+    @Test
+    public void testValidateImportStatements() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(LineLengthCheck.class);
+        checkConfig.addAttribute("validateImport", "true");
+
+        final String[] expected = {
+            "7: " + getCheckMessage(MSG_KEY, 80, 99),
+            "8: " + getCheckMessage(MSG_KEY, 80, 111),
+            "13: " + getCheckMessage(MSG_KEY, 80, 107),
+        };
+
+        verify(checkConfig, getPath("InputLineLengthValidateImportStatements.java"), expected);
+    }
+
+    @Test
+    public void testValidatePackageStatements() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(LineLengthCheck.class);
+        checkConfig.addAttribute("validatePackage", "true");
+        checkConfig.addAttribute("max", "60");
+        final String[] expected = {
+            "1: " + getCheckMessage(MSG_KEY, 60, 64),
+            "15: " + getCheckMessage(MSG_KEY, 60, 108),
+        };
+
+        verify(checkConfig, getPath("InputLineLengthValidatePackageStatements.java"), expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthValidateImportStatements.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthValidateImportStatements.java
@@ -1,0 +1,16 @@
+package com.puppycrawl.tools.checkstyle.checks.sizes.linelength; // ok
+
+/* Config:
+ * validateImport = true
+ */
+
+import com.puppycrawl.tools.checkstyle.grammar.comments.InputFullOfSinglelineComments; // Violation
+import static com.puppycrawl.tools.checkstyle.grammar.comments.InputFullOfSinglelineComments.main; // Violation
+
+public class InputLineLengthValidateImportStatements {
+    @Override
+    public String toString() {
+        return "This is very long line that should be logged because alongside validateImport set to true";
+        // ^--- Violation
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthValidatePackageStatements.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/linelength/InputLineLengthValidatePackageStatements.java
@@ -1,0 +1,18 @@
+package com.puppycrawl.tools.checkstyle.checks.sizes.linelength;
+// ^--- Violation
+
+/* Config:
+ * validatePackage = true
+ * max = 60
+ */
+
+import com.puppycrawl.tools.checkstyle.grammar.comments.InputFullOfSinglelineComments; // ok
+import static com.puppycrawl.tools.checkstyle.grammar.comments.InputFullOfSinglelineComments.main; // ok
+
+public class InputLineLengthValidatePackageStatements {
+    @Override
+    public String toString() {
+        return "This is very long line that should be logged because alongside validatePackage set to true";
+        // ^--- Violation
+    }
+}

--- a/src/xdocs/config_sizes.xml
+++ b/src/xdocs/config_sizes.xml
@@ -524,6 +524,20 @@ class Test {
               <td><code>80</code></td>
               <td>3.0</td>
             </tr>
+            <tr>
+              <td>validateImport</td>
+              <td>Validate checking of import statements.</td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
+              <td><code>false</code></td>
+              <td>8.43</td>
+            </tr>
+            <tr>
+              <td>validatePackage</td>
+              <td>Validate checking of package statements.</td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
+              <td><code>false</code></td>
+              <td>8.43</td>
+            </tr>
           </table>
         </div>
       </subsection>
@@ -584,11 +598,6 @@ class Test {
             <a href="config.html#TreeWalker"><code>TreeWalker</code></a> property
             <code>tabWidth</code> which applies to all Checks, including <code>LineLength</code>;
             or can set property <code>tabWidth</code> for <code>LineLength</code> alone.
-          </li>
-          <li>
-            Package and import statements (lines matching pattern
-            <code>^(package|import) .*</code>) are not verified by
-            this check.
           </li>
         </ul>
       </subsection>


### PR DESCRIPTION
Resolves #9999: LineLengthCheck now checks for import and package statements.

To be generated/To be done-
- Regression reports.
- Updating examples.