### PR TITLE
Issue #10059: Replace ANTLR2 dependencies in test inputs

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -844,7 +844,7 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
             "9:1: " + getCheckMessage(MSG_LINE_SEPARATOR,
                 "com.puppycrawl.tools.checkstyle.*"),
             "13:1: " + getCheckMessage(MSG_LINE_SEPARATOR,
-                "antlr.*"),
+                "picocli.*"),
         };
         verify(checkConfig, getPath("InputCustomImportOrderSingleLine.java"),
             expected);
@@ -941,8 +941,8 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
             "33:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "java.util.HashSet"),
             "37:1: " + getCheckMessage(MSG_LINE_SEPARATOR, "org.apache.tools.ant.*"),
             "42:1: " + getCheckMessage(MSG_LINE_SEPARATOR, "com.puppycrawl.tools.checkstyle.*"),
-            "46:1: " + getCheckMessage(MSG_LINE_SEPARATOR, "antlr.*"),
-            "49:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "antlr.Token"),
+            "46:1: " + getCheckMessage(MSG_LINE_SEPARATOR, "picocli.*"),
+            "49:1: " + getCheckMessage(MSG_SEPARATED_IN_GROUP, "picocli.CommandLine"),
         };
         verify(checkConfig, getPath("InputCustomImportOrderSpanMultipleLines.java"), expected);
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderSingleLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderSingleLine.java
@@ -10,6 +10,6 @@ import com.puppycrawl.tools.checkstyle.*;
 
 
 
-import antlr.*;
+import picocli.*;
 
 class InputCustomImportOrderSingleLine {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderSpanMultipleLines.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderSpanMultipleLines.java
@@ -43,9 +43,9 @@ import com.puppycrawl.tools.checkstyle.*; // warn
 
 
 // comment between import groups
-import antlr.*; // warn
+import picocli.*; // warn
 
 // comment within import group
-import antlr.Token;
+import picocli.CommandLine;
 
 class InputCustomImportOrderSpanMultipleLines {}


### PR DESCRIPTION
Closes #10059 in support of https://github.com/checkstyle-antlr4/checkstyle-antlr4/issues/6

```bash
➜  checkstyle git:(issue-10059) grep -R antlr | grep -v "v4" | grep Input | grep -v "noncompilable"
src/test/java/com/puppycrawl/tools/checkstyle/grammar/AstRegressionTest.java:import antlr.ParserSharedInputState;


```