### PR TITLE
supplemental: correct order of param tags in existing Javadocs(#8990)

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
@@ -245,8 +245,8 @@ public class JavadocDetailNodeParser {
     /**
      * Creates child nodes for each node from 'nodes' array.
      *
-     * @param parseTreeParent original ParseTree parent node
      * @param nodes array of JavadocNodeImpl nodes
+     * @param parseTreeParent original ParseTree parent node
      */
     private void insertChildrenNodes(final JavadocNodeImpl[] nodes, ParseTree parseTreeParent) {
         for (int i = 0; i < nodes.length; i++) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -479,8 +479,8 @@ public class RequireThisCheck extends AbstractCheck {
     /**
      * Helper method to log a Violation.
      *
-     * @param ast a node to get line id column numbers associated with the message.
      * @param msgKey key to locale message format.
+     * @param ast a node to get line id column numbers associated with the message.
      * @param frame the class frame where the violation is found.
      */
     private void logViolation(String msgKey, DetailAST ast, AbstractFrame frame) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -565,8 +565,8 @@ public abstract class AbstractExpressionHandler {
     /**
      * Check the indentation of the right parenthesis.
      *
-     * @param rparen parenthesis to check
      * @param lparen left parenthesis associated with aRparen
+     * @param rparen parenthesis to check
      */
     protected final void checkRightParen(DetailAST lparen, DetailAST rparen) {
         if (rparen != null) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java
@@ -516,8 +516,8 @@ public class CommentsIndentationCheck extends AbstractCheck {
     /**
      * Checks whether case block is empty.
      *
-     * @param nextStmt previous statement.
      * @param prevStmt next statement.
+     * @param nextStmt previous statement.
      * @return true if case block is empty.
      */
     private static boolean isInEmptyCaseBlock(DetailAST prevStmt, DetailAST nextStmt) {
@@ -968,9 +968,9 @@ public class CommentsIndentationCheck extends AbstractCheck {
     /**
      * Logs comment which can have the same indentation level as next or previous statement.
      *
+     * @param prevStmt previous statement.
      * @param comment comment.
      * @param nextStmt next statement.
-     * @param prevStmt previous statement.
      */
     private void logMultilineIndentation(DetailAST prevStmt, DetailAST comment,
                                          DetailAST nextStmt) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java
@@ -91,11 +91,11 @@ public class HandlerFactory {
     /**
      * Registers a handler.
      *
+     * @param <T> type of the handler class object.
      * @param type
      *                type from TokenTypes
      * @param handlerClass
      *                the handler to register
-     * @param <T> type of the handler class object.
      */
     private <T> void register(int type, Class<T> handlerClass) {
         final Constructor<T> ctor = CommonUtil.getConstructor(handlerClass,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
@@ -312,11 +312,11 @@ public final class CommonUtil {
     /**
      * Gets constructor of targetClass.
      *
+     * @param <T> type of the target class object.
      * @param targetClass
      *            from which constructor is returned
      * @param parameterTypes
      *            of constructor
-     * @param <T> type of the target class object.
      * @return constructor of targetClass
      * @throws IllegalStateException if any exception occurs
      * @see Class#getConstructor(Class[])
@@ -334,12 +334,12 @@ public final class CommonUtil {
     /**
      * Returns new instance of a class.
      *
+     * @param <T>
+     *            type of constructor
      * @param constructor
      *            to invoke
      * @param parameters
      *            to pass to constructor
-     * @param <T>
-     *            type of constructor
      * @return new instance of class
      * @throws IllegalStateException if any exception occurs
      * @see Constructor#newInstance(Object...)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XmlUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XmlUtil.java
@@ -99,6 +99,7 @@ public final class XmlUtil {
      * Returns the {@code Node} that has an id attribute with the given value.
      * The id should be unique within the Xml Document.
      *
+     * @param node to retrieve information.
      * @param id the unique {@code id} value for a node.
      * @return the matching node or {@code null} if none matches.
      */


### PR DESCRIPTION
Supplemental to #8990 and just makes fixes to order of existing tags in javadocs.