### PR TITLE
Issue: #10049 Deprecate FullIdent.createFullIdent method

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
@@ -54,7 +54,7 @@ public final class FullIdent {
      * @return a {@code FullIdent} value
      */
     public static FullIdent createFullIdentBelow(DetailAST ast) {
-        return createFullIdent(ast.getFirstChild());
+        return extractFullIdent(null, ast.getFirstChild());
     }
 
     /**
@@ -63,6 +63,7 @@ public final class FullIdent {
      * @param ast the node to start from
      * @return a {@code FullIdent} value
      */
+    @Deprecated
     public static FullIdent createFullIdent(DetailAST ast) {
         final FullIdent ident = new FullIdent();
         extractFullIdent(ident, ast);
@@ -70,12 +71,15 @@ public final class FullIdent {
     }
 
     /**
-     * Recursively extract a FullIdent.
+     * Create and recursively extract a FullIdent.
      *
      * @param full the FullIdent to add to
      * @param ast the node to recurse from
      */
-    private static void extractFullIdent(FullIdent full, DetailAST ast) {
+    public static FullIdent extractFullIdent(FullIdent full, DetailAST ast) {
+        if(full == null) {
+            full = new FullIdent();
+        }
         if (ast != null) {
 
             final DetailAST firstChild = ast.getFirstChild();
@@ -111,6 +115,7 @@ public final class FullIdent {
                 full.append(ast);
             }
         }
+        return full;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
@@ -54,7 +54,7 @@ public final class FullIdent {
      * @return a {@code FullIdent} value
      */
     public static FullIdent createFullIdentBelow(DetailAST ast) {
-        return extractFullIdent(null, ast.getFirstChild());
+        return createFullIdent(ast.getFirstChild());
     }
 
     /**
@@ -63,7 +63,6 @@ public final class FullIdent {
      * @param ast the node to start from
      * @return a {@code FullIdent} value
      */
-    @Deprecated
     public static FullIdent createFullIdent(DetailAST ast) {
         final FullIdent ident = new FullIdent();
         extractFullIdent(ident, ast);
@@ -71,15 +70,12 @@ public final class FullIdent {
     }
 
     /**
-     * Create and recursively extract a FullIdent.
+     * Recursively extract a FullIdent.
      *
      * @param full the FullIdent to add to
      * @param ast the node to recurse from
      */
-    public static FullIdent extractFullIdent(FullIdent full, DetailAST ast) {
-        if(full == null) {
-            full = new FullIdent();
-        }
+    private static void extractFullIdent(FullIdent full, DetailAST ast) {
         if (ast != null) {
 
             final DetailAST firstChild = ast.getFirstChild();
@@ -115,7 +111,6 @@ public final class FullIdent {
                 full.append(ast);
             }
         }
-        return full;
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
@@ -179,7 +179,7 @@ public class UncommentedMainCheck
 
     @Override
     public void beginTree(DetailAST rootAST) {
-        packageName = FullIdent.extractFullIdent(null, null);
+        packageName = FullIdent.createFullIdent(null);
         currentClass = null;
         classDepth = 0;
     }
@@ -215,7 +215,7 @@ public class UncommentedMainCheck
      * @param packageDef node for package definition
      */
     private void visitPackageDef(DetailAST packageDef) {
-        packageName = FullIdent.extractFullIdent(null, packageDef.getLastChild()
+        packageName = FullIdent.createFullIdent(packageDef.getLastChild()
                 .getPreviousSibling());
     }
 
@@ -332,7 +332,7 @@ public class UncommentedMainCheck
      * @return true, if the type is java.lang.String.
      */
     private static boolean isStringType(DetailAST typeAst) {
-        final FullIdent type = FullIdent.extractFullIdent(null, typeAst);
+        final FullIdent type = FullIdent.createFullIdent(typeAst);
         return "String".equals(type.getText())
             || "java.lang.String".equals(type.getText());
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
@@ -179,7 +179,7 @@ public class UncommentedMainCheck
 
     @Override
     public void beginTree(DetailAST rootAST) {
-        packageName = FullIdent.createFullIdent(null);
+        packageName = FullIdent.extractFullIdent(null, null);
         currentClass = null;
         classDepth = 0;
     }
@@ -215,7 +215,7 @@ public class UncommentedMainCheck
      * @param packageDef node for package definition
      */
     private void visitPackageDef(DetailAST packageDef) {
-        packageName = FullIdent.createFullIdent(packageDef.getLastChild()
+        packageName = FullIdent.extractFullIdent(null, packageDef.getLastChild()
                 .getPreviousSibling());
     }
 
@@ -332,7 +332,7 @@ public class UncommentedMainCheck
      * @return true, if the type is java.lang.String.
      */
     private static boolean isStringType(DetailAST typeAst) {
-        final FullIdent type = FullIdent.createFullIdent(typeAst);
+        final FullIdent type = FullIdent.extractFullIdent(null, typeAst);
         return "String".equals(type.getText())
             || "java.lang.String".equals(type.getText());
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
@@ -194,7 +194,7 @@ public final class IllegalCatchCheck extends AbstractCheck {
         final List<DetailAST> excTypes = getAllExceptionTypes(excTypeParent);
 
         for (DetailAST excType : excTypes) {
-            final FullIdent ident = FullIdent.createFullIdent(excType);
+            final FullIdent ident = FullIdent.extractFullIdent(null, excType);
 
             if (illegalClassNames.contains(ident.getText())) {
                 log(detailAST, MSG_KEY, ident.getText());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
@@ -194,7 +194,7 @@ public final class IllegalCatchCheck extends AbstractCheck {
         final List<DetailAST> excTypes = getAllExceptionTypes(excTypeParent);
 
         for (DetailAST excType : excTypes) {
-            final FullIdent ident = FullIdent.extractFullIdent(null, excType);
+            final FullIdent ident = FullIdent.createFullIdent(excType);
 
             if (illegalClassNames.contains(ident.getText())) {
                 log(detailAST, MSG_KEY, ident.getText());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -315,7 +315,7 @@ public class IllegalInstantiationCheck
         final DetailAST packageNameAST = ast.getLastChild()
                 .getPreviousSibling();
         final FullIdent packageIdent =
-                FullIdent.createFullIdent(packageNameAST);
+                FullIdent.extractFullIdent(null, packageNameAST);
         pkgName = packageIdent.getText();
     }
 
@@ -341,7 +341,7 @@ public class IllegalInstantiationCheck
         final DetailAST nameSibling = typeNameAst.getNextSibling();
         if (nameSibling.getType() != TokenTypes.ARRAY_DECLARATOR) {
             // ast != "new Boolean[]"
-            final FullIdent typeIdent = FullIdent.createFullIdent(typeNameAst);
+            final FullIdent typeIdent = FullIdent.extractFullIdent(null, typeNameAst);
             final String typeName = typeIdent.getText();
             final String fqClassName = getIllegalInstantiation(typeName);
             if (fqClassName != null) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -315,7 +315,7 @@ public class IllegalInstantiationCheck
         final DetailAST packageNameAST = ast.getLastChild()
                 .getPreviousSibling();
         final FullIdent packageIdent =
-                FullIdent.extractFullIdent(null, packageNameAST);
+                FullIdent.createFullIdent(packageNameAST);
         pkgName = packageIdent.getText();
     }
 
@@ -341,7 +341,7 @@ public class IllegalInstantiationCheck
         final DetailAST nameSibling = typeNameAst.getNextSibling();
         if (nameSibling.getType() != TokenTypes.ARRAY_DECLARATOR) {
             // ast != "new Boolean[]"
-            final FullIdent typeIdent = FullIdent.extractFullIdent(null, typeNameAst);
+            final FullIdent typeIdent = FullIdent.createFullIdent(typeNameAst);
             final String typeName = typeIdent.getText();
             final String fqClassName = getIllegalInstantiation(typeName);
             if (fqClassName != null) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheck.java
@@ -208,7 +208,7 @@ public final class IllegalThrowsCheck extends AbstractCheck {
         if (!isIgnorableMethod(methodDef)) {
             DetailAST token = detailAST.getFirstChild();
             while (token != null) {
-                final FullIdent ident = FullIdent.extractFullIdent(null, token);
+                final FullIdent ident = FullIdent.createFullIdent(token);
                 if (illegalClassNames.contains(ident.getText())) {
                     log(token, MSG_KEY, ident.getText());
                 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheck.java
@@ -208,7 +208,7 @@ public final class IllegalThrowsCheck extends AbstractCheck {
         if (!isIgnorableMethod(methodDef)) {
             DetailAST token = detailAST.getFirstChild();
             while (token != null) {
-                final FullIdent ident = FullIdent.createFullIdent(token);
+                final FullIdent ident = FullIdent.extractFullIdent(null, token);
                 if (illegalClassNames.contains(ident.getText())) {
                     log(token, MSG_KEY, ident.getText());
                 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -644,7 +644,7 @@ public final class IllegalTypeCheck extends AbstractCheck {
      * @param type node to check.
      */
     private void checkIdent(DetailAST type) {
-        final FullIdent ident = FullIdent.createFullIdent(type);
+        final FullIdent ident = FullIdent.extractFullIdent(null, type);
         if (isMatchingClassName(ident.getText())) {
             log(ident.getDetailAst(), MSG_KEY, ident.getText());
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -644,7 +644,7 @@ public final class IllegalTypeCheck extends AbstractCheck {
      * @param type node to check.
      */
     private void checkIdent(DetailAST type) {
-        final FullIdent ident = FullIdent.extractFullIdent(null, type);
+        final FullIdent ident = FullIdent.createFullIdent(type);
         if (isMatchingClassName(ident.getText())) {
             log(ident.getDetailAst(), MSG_KEY, ident.getText());
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheck.java
@@ -163,7 +163,7 @@ public final class PackageDeclarationCheck extends AbstractCheck {
 
         if (matchDirectoryStructure) {
             final DetailAST packageNameAst = ast.getLastChild().getPreviousSibling();
-            final FullIdent fullIdent = FullIdent.extractFullIdent(null, packageNameAst);
+            final FullIdent fullIdent = FullIdent.createFullIdent(packageNameAst);
             final String packageName = fullIdent.getText().replace('.', File.separatorChar);
 
             final String directoryName = getDirectoryName();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheck.java
@@ -163,7 +163,7 @@ public final class PackageDeclarationCheck extends AbstractCheck {
 
         if (matchDirectoryStructure) {
             final DetailAST packageNameAst = ast.getLastChild().getPreviousSibling();
-            final FullIdent fullIdent = FullIdent.createFullIdent(packageNameAst);
+            final FullIdent fullIdent = FullIdent.extractFullIdent(null, packageNameAst);
             final String packageName = fullIdent.getText().replace('.', File.separatorChar);
 
             final String directoryName = getDirectoryName();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
@@ -223,7 +223,7 @@ public class FinalClassCheck
      * @return qualified name
      */
     private static String extractQualifiedName(DetailAST ast) {
-        return FullIdent.createFullIdent(ast).getText();
+        return FullIdent.extractFullIdent(null, ast).getText();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
@@ -223,7 +223,7 @@ public class FinalClassCheck
      * @return qualified name
      */
     private static String extractQualifiedName(DetailAST ast) {
-        return FullIdent.extractFullIdent(null, ast).getText();
+        return FullIdent.createFullIdent(ast).getText();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -1078,7 +1078,7 @@ public class VisibilityModifierCheck
             if (child.getType() == TokenTypes.ANNOTATION) {
                 final DetailAST ast = child.getFirstChild();
                 final String name =
-                    FullIdent.extractFullIdent(null, ast.getNextSibling()).getText();
+                    FullIdent.createFullIdent(ast.getNextSibling()).getText();
                 if (ignoreAnnotationCanonicalNames.contains(name)
                          || ignoreAnnotationShortNames.contains(name)) {
                     matchingAnnotation = child;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -1078,7 +1078,7 @@ public class VisibilityModifierCheck
             if (child.getType() == TokenTypes.ANNOTATION) {
                 final DetailAST ast = child.getFirstChild();
                 final String name =
-                    FullIdent.createFullIdent(ast.getNextSibling()).getText();
+                    FullIdent.extractFullIdent(null, ast.getNextSibling()).getText();
                 if (ignoreAnnotationCanonicalNames.contains(name)
                          || ignoreAnnotationShortNames.contains(name)) {
                     matchingAnnotation = child;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
@@ -250,7 +250,7 @@ public class AvoidStarImportCheck
      * @param startingDot the starting dot for the import statement
      */
     private void logsStarredImportViolation(DetailAST startingDot) {
-        final FullIdent name = FullIdent.extractFullIdent(null, startingDot);
+        final FullIdent name = FullIdent.createFullIdent(startingDot);
         final String importText = name.getText();
         if (importText.endsWith(STAR_IMPORT_SUFFIX) && !excludes.contains(importText)) {
             log(startingDot, MSG_KEY, importText);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
@@ -250,7 +250,7 @@ public class AvoidStarImportCheck
      * @param startingDot the starting dot for the import statement
      */
     private void logsStarredImportViolation(DetailAST startingDot) {
-        final FullIdent name = FullIdent.createFullIdent(startingDot);
+        final FullIdent name = FullIdent.extractFullIdent(null, startingDot);
         final String importText = name.getText();
         if (importText.endsWith(STAR_IMPORT_SUFFIX) && !excludes.contains(importText)) {
             log(startingDot, MSG_KEY, importText);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
@@ -149,7 +149,7 @@ public class AvoidStaticImportCheck
     public void visitToken(final DetailAST ast) {
         final DetailAST startingDot =
             ast.getFirstChild().getNextSibling();
-        final FullIdent name = FullIdent.createFullIdent(startingDot);
+        final FullIdent name = FullIdent.extractFullIdent(null, startingDot);
 
         if (!isExempt(name.getText())) {
             log(startingDot, MSG_KEY, name.getText());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
@@ -149,7 +149,7 @@ public class AvoidStaticImportCheck
     public void visitToken(final DetailAST ast) {
         final DetailAST startingDot =
             ast.getFirstChild().getNextSibling();
-        final FullIdent name = FullIdent.extractFullIdent(null, startingDot);
+        final FullIdent name = FullIdent.createFullIdent(startingDot);
 
         if (!isExempt(name.getText())) {
             log(startingDot, MSG_KEY, name.getText());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -1201,7 +1201,8 @@ public class CustomImportOrderCheck extends AbstractCheck {
     private static String getFullImportIdent(DetailAST token) {
         String ident = "";
         if (token != null) {
-            ident = FullIdent.createFullIdent(token.findFirstToken(TokenTypes.DOT)).getText();
+            ident = FullIdent.extractFullIdent(null,
+                    token.findFirstToken(TokenTypes.DOT)).getText();
         }
         return ident;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -1201,8 +1201,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
     private static String getFullImportIdent(DetailAST token) {
         String ident = "";
         if (token != null) {
-            ident = FullIdent.extractFullIdent(null,
-                    token.findFirstToken(TokenTypes.DOT)).getText();
+            ident = FullIdent.createFullIdent(token.findFirstToken(TokenTypes.DOT)).getText();
         }
         return ident;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java
@@ -384,7 +384,7 @@ public class IllegalImportCheck
             imp = FullIdent.createFullIdentBelow(ast);
         }
         else {
-            imp = FullIdent.createFullIdent(
+            imp = FullIdent.extractFullIdent(null, 
                 ast.getFirstChild().getNextSibling());
         }
         if (isIllegalImport(imp.getText())) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java
@@ -384,7 +384,7 @@ public class IllegalImportCheck
             imp = FullIdent.createFullIdentBelow(ast);
         }
         else {
-            imp = FullIdent.extractFullIdent(null, 
+            imp = FullIdent.createFullIdent(
                 ast.getFirstChild().getNextSibling());
         }
         if (isIllegalImport(imp.getText())) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
@@ -568,7 +568,7 @@ public class ImportControlCheck extends AbstractCheck implements ExternalResourc
      */
     private static String getPackageText(DetailAST ast) {
         final DetailAST nameAST = ast.getLastChild().getPreviousSibling();
-        return FullIdent.createFullIdent(nameAST).getText();
+        return FullIdent.extractFullIdent(null, nameAST).getText();
     }
 
     /**
@@ -584,7 +584,7 @@ public class ImportControlCheck extends AbstractCheck implements ExternalResourc
         }
         else {
             // know it is a static import
-            imp = FullIdent.createFullIdent(ast
+            imp = FullIdent.extractFullIdent(null, ast
                     .getFirstChild().getNextSibling());
         }
         return imp.getText();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
@@ -568,7 +568,7 @@ public class ImportControlCheck extends AbstractCheck implements ExternalResourc
      */
     private static String getPackageText(DetailAST ast) {
         final DetailAST nameAST = ast.getLastChild().getPreviousSibling();
-        return FullIdent.extractFullIdent(null, nameAST).getText();
+        return FullIdent.createFullIdent(nameAST).getText();
     }
 
     /**
@@ -584,7 +584,7 @@ public class ImportControlCheck extends AbstractCheck implements ExternalResourc
         }
         else {
             // know it is a static import
-            imp = FullIdent.extractFullIdent(null, ast
+            imp = FullIdent.createFullIdent(ast
                     .getFirstChild().getNextSibling());
         }
         return imp.getText();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -771,7 +771,7 @@ public class ImportOrderCheck
             isStatic = false;
         }
         else {
-            ident = FullIdent.extractFullIdent(null, ast.getFirstChild()
+            ident = FullIdent.createFullIdent(ast.getFirstChild()
                     .getNextSibling());
             isStatic = true;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -771,7 +771,7 @@ public class ImportOrderCheck
             isStatic = false;
         }
         else {
-            ident = FullIdent.createFullIdent(ast.getFirstChild()
+            ident = FullIdent.extractFullIdent(null, ast.getFirstChild()
                     .getNextSibling());
             isStatic = true;
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
@@ -124,7 +124,7 @@ public class RedundantImportCheck
     @Override
     public void visitToken(DetailAST ast) {
         if (ast.getType() == TokenTypes.PACKAGE_DEF) {
-            pkgName = FullIdent.createFullIdent(
+            pkgName = FullIdent.extractFullIdent(null, 
                     ast.getLastChild().getPreviousSibling()).getText();
         }
         else if (ast.getType() == TokenTypes.IMPORT) {
@@ -146,7 +146,7 @@ public class RedundantImportCheck
         else {
             // Check for a duplicate static import
             final FullIdent imp =
-                FullIdent.createFullIdent(
+                FullIdent.extractFullIdent(null, 
                     ast.getLastChild().getPreviousSibling());
             staticImports.stream().filter(full -> imp.getText().equals(full.getText()))
                 .forEach(full -> log(ast, MSG_DUPLICATE, full.getLineNo(), imp.getText()));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
@@ -124,7 +124,7 @@ public class RedundantImportCheck
     @Override
     public void visitToken(DetailAST ast) {
         if (ast.getType() == TokenTypes.PACKAGE_DEF) {
-            pkgName = FullIdent.extractFullIdent(null, 
+            pkgName = FullIdent.createFullIdent(
                     ast.getLastChild().getPreviousSibling()).getText();
         }
         else if (ast.getType() == TokenTypes.IMPORT) {
@@ -146,7 +146,7 @@ public class RedundantImportCheck
         else {
             // Check for a duplicate static import
             final FullIdent imp =
-                FullIdent.extractFullIdent(null, 
+                FullIdent.createFullIdent(
                     ast.getLastChild().getPreviousSibling());
             staticImports.stream().filter(full -> imp.getText().equals(full.getText()))
                 .forEach(full -> log(ast, MSG_DUPLICATE, full.getLineNo(), imp.getText()));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -295,7 +295,7 @@ public class UnusedImportsCheck extends AbstractCheck {
      */
     private void processStaticImport(DetailAST ast) {
         final FullIdent name =
-            FullIdent.extractFullIdent(null, 
+            FullIdent.createFullIdent(
                 ast.getFirstChild().getNextSibling());
         if (!name.getText().endsWith(STAR_IMPORT_SUFFIX)) {
             imports.add(name);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -295,7 +295,7 @@ public class UnusedImportsCheck extends AbstractCheck {
      */
     private void processStaticImport(DetailAST ast) {
         final FullIdent name =
-            FullIdent.createFullIdent(
+            FullIdent.extractFullIdent(null, 
                 ast.getFirstChild().getNextSibling());
         if (!name.getText().endsWith(STAR_IMPORT_SUFFIX)) {
             imports.add(name);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -776,7 +776,7 @@ public class JavadocMethodCheck extends AbstractCheck {
      * @return ExceptionInfo
      */
     private static ExceptionInfo getExceptionInfo(DetailAST ast) {
-        final FullIdent ident = FullIdent.createFullIdent(ast);
+        final FullIdent ident = FullIdent.extractFullIdent(null, ast);
         final DetailAST firstClassNameNode = getFirstClassNameNode(ast);
         return new ExceptionInfo(firstClassNameNode,
                 new ClassInfo(new Token(ident)));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -776,7 +776,7 @@ public class JavadocMethodCheck extends AbstractCheck {
      * @return ExceptionInfo
      */
     private static ExceptionInfo getExceptionInfo(DetailAST ast) {
-        final FullIdent ident = FullIdent.extractFullIdent(null, ast);
+        final FullIdent ident = FullIdent.createFullIdent(ast);
         final DetailAST firstClassNameNode = getFirstClassNameNode(ast);
         return new ExceptionInfo(firstClassNameNode,
                 new ClassInfo(new Token(ident)));

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -242,8 +242,7 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
      * @param pkg package definition.
      */
     private void visitPackageDef(DetailAST pkg) {
-        final FullIdent ident = FullIdent.extractFullIdent(null,
-                pkg.getLastChild().getPreviousSibling());
+        final FullIdent ident = FullIdent.createFullIdent(pkg.getLastChild().getPreviousSibling());
         packageName = ident.getText();
     }
 
@@ -268,7 +267,7 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
      * @param imp import definition.
      */
     private void registerImport(DetailAST imp) {
-        final FullIdent ident = FullIdent.extractFullIdent(null, 
+        final FullIdent ident = FullIdent.createFullIdent(
             imp.getLastChild().getPreviousSibling());
         final String fullName = ident.getText();
         final int lastDot = fullName.lastIndexOf(DOT);
@@ -398,7 +397,7 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
          * @param ast a node which represents referenced class.
          */
         private void addReferencedClassName(DetailAST ast) {
-            final String fullIdentName = FullIdent.extractFullIdent(null, ast).getText();
+            final String fullIdentName = FullIdent.createFullIdent(ast).getText();
             final String trimmed = BRACKET_PATTERN
                     .matcher(fullIdentName).replaceAll("");
             addReferencedClassName(trimmed);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -242,7 +242,8 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
      * @param pkg package definition.
      */
     private void visitPackageDef(DetailAST pkg) {
-        final FullIdent ident = FullIdent.createFullIdent(pkg.getLastChild().getPreviousSibling());
+        final FullIdent ident = FullIdent.extractFullIdent(null,
+                pkg.getLastChild().getPreviousSibling());
         packageName = ident.getText();
     }
 
@@ -267,7 +268,7 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
      * @param imp import definition.
      */
     private void registerImport(DetailAST imp) {
-        final FullIdent ident = FullIdent.createFullIdent(
+        final FullIdent ident = FullIdent.extractFullIdent(null, 
             imp.getLastChild().getPreviousSibling());
         final String fullName = ident.getText();
         final int lastDot = fullName.lastIndexOf(DOT);
@@ -397,7 +398,7 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
          * @param ast a node which represents referenced class.
          */
         private void addReferencedClassName(DetailAST ast) {
-            final String fullIdentName = FullIdent.createFullIdent(ast).getText();
+            final String fullIdentName = FullIdent.extractFullIdent(null, ast).getText();
             final String trimmed = BRACKET_PATTERN
                     .matcher(fullIdentName).replaceAll("");
             addReferencedClassName(trimmed);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheck.java
@@ -143,7 +143,7 @@ public class PackageNameCheck
     @Override
     public void visitToken(DetailAST ast) {
         final DetailAST nameAST = ast.getLastChild().getPreviousSibling();
-        final FullIdent full = FullIdent.createFullIdent(nameAST);
+        final FullIdent full = FullIdent.extractFullIdent(null, nameAST);
         if (!format.matcher(full.getText()).find()) {
             log(full.getDetailAst(),
                 MSG_KEY,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheck.java
@@ -143,7 +143,7 @@ public class PackageNameCheck
     @Override
     public void visitToken(DetailAST ast) {
         final DetailAST nameAST = ast.getLastChild().getPreviousSibling();
-        final FullIdent full = FullIdent.extractFullIdent(null, nameAST);
+        final FullIdent full = FullIdent.createFullIdent(nameAST);
         if (!format.matcher(full.getText()).find()) {
             log(full.getDetailAst(),
                 MSG_KEY,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtil.java
@@ -195,7 +195,7 @@ public final class AnnotationUtil {
         return findFirstAnnotation(ast, annotationNode -> {
             final DetailAST firstChild = annotationNode.findFirstToken(TokenTypes.AT);
             final String name =
-                    FullIdent.createFullIdent(firstChild.getNextSibling()).getText();
+                    FullIdent.extractFullIdent(null, firstChild.getNextSibling()).getText();
             return annotation.equals(name);
         });
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtil.java
@@ -195,7 +195,7 @@ public final class AnnotationUtil {
         return findFirstAnnotation(ast, annotationNode -> {
             final DetailAST firstChild = annotationNode.findFirstToken(TokenTypes.AT);
             final String name =
-                    FullIdent.extractFullIdent(null, firstChild.getNextSibling()).getText();
+                    FullIdent.createFullIdent(firstChild.getNextSibling()).getText();
             return annotation.equals(name);
         });
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
@@ -83,7 +83,7 @@ public final class CheckUtil {
      * @return {@code FullIdent} for given type.
      */
     public static FullIdent createFullType(final DetailAST typeAST) {
-        return FullIdent.createFullIdent(typeAST.getFirstChild());
+        return FullIdent.extractFullIdent(null, typeAST.getFirstChild());
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
@@ -83,7 +83,7 @@ public final class CheckUtil {
      * @return {@code FullIdent} for given type.
      */
     public static FullIdent createFullType(final DetailAST typeAST) {
-        return FullIdent.extractFullIdent(null, typeAST.getFirstChild());
+        return FullIdent.createFullIdent(typeAST.getFirstChild());
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FullIdentTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FullIdentTest.java
@@ -52,7 +52,7 @@ public class FullIdentTest extends AbstractModuleTestSupport {
         parent.setText("MyParent");
         parent.setFirstChild(ast);
 
-        final FullIdent indent = FullIdent.extractFullIdent(null, ast);
+        final FullIdent indent = FullIdent.createFullIdent(ast);
         assertEquals("MyTest[15x14]", indent.toString(), "Invalid full indent");
         assertEquals("MyTest", indent.getText(), "Invalid text");
         assertEquals(15, indent.getLineNo(), "Invalid line");
@@ -74,7 +74,7 @@ public class FullIdentTest extends AbstractModuleTestSupport {
                 System.getProperty("file.encoding", StandardCharsets.UTF_8.name()));
         final DetailAST packageDefinitionNode = JavaParser.parse(new FileContents(testFileText));
         final DetailAST packageName = packageDefinitionNode.getFirstChild().getNextSibling();
-        final FullIdent ident = FullIdent.extractFullIdent(null, packageName);
+        final FullIdent ident = FullIdent.createFullIdent(packageName);
         assertEquals("com[1x8]", ident.getDetailAst().toString(), "Invalid full indent");
     }
 
@@ -101,7 +101,7 @@ public class FullIdentTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.VARIABLE_DEF)
                 .findFirstToken(TokenTypes.TYPE)
                 .getFirstChild();
-        final FullIdent ident = FullIdent.extractFullIdent(null, arrayDeclarator);
+        final FullIdent ident = FullIdent.createFullIdent(arrayDeclarator);
         assertEquals("int[][][5x12]", ident.toString(), "Invalid full indent");
     }
 
@@ -125,7 +125,7 @@ public class FullIdentTest extends AbstractModuleTestSupport {
                 .getNextSibling()
                 .getFirstChild();
 
-        final FullIdent ident = FullIdent.extractFullIdent(null, parameter);
+        final FullIdent ident = FullIdent.createFullIdent(parameter);
         assertEquals("char[][7x29]", ident.toString(), "Invalid full indent");
     }
 
@@ -146,7 +146,7 @@ public class FullIdentTest extends AbstractModuleTestSupport {
                 .getFirstChild()
                 .getFirstChild();
 
-        final FullIdent ident = FullIdent.extractFullIdent(null, literalInt);
+        final FullIdent ident = FullIdent.createFullIdent(literalInt);
         assertEquals("int[4x32]", ident.toString(), "Invalid full indent");
     }
 
@@ -172,7 +172,7 @@ public class FullIdentTest extends AbstractModuleTestSupport {
         ast.addChild(ast1);
         ast.addChild(ast2);
 
-        return FullIdent.extractFullIdent(null, ast);
+        return FullIdent.createFullIdent(ast);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FullIdentTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FullIdentTest.java
@@ -52,7 +52,7 @@ public class FullIdentTest extends AbstractModuleTestSupport {
         parent.setText("MyParent");
         parent.setFirstChild(ast);
 
-        final FullIdent indent = FullIdent.createFullIdent(ast);
+        final FullIdent indent = FullIdent.extractFullIdent(null, ast);
         assertEquals("MyTest[15x14]", indent.toString(), "Invalid full indent");
         assertEquals("MyTest", indent.getText(), "Invalid text");
         assertEquals(15, indent.getLineNo(), "Invalid line");
@@ -74,7 +74,7 @@ public class FullIdentTest extends AbstractModuleTestSupport {
                 System.getProperty("file.encoding", StandardCharsets.UTF_8.name()));
         final DetailAST packageDefinitionNode = JavaParser.parse(new FileContents(testFileText));
         final DetailAST packageName = packageDefinitionNode.getFirstChild().getNextSibling();
-        final FullIdent ident = FullIdent.createFullIdent(packageName);
+        final FullIdent ident = FullIdent.extractFullIdent(null, packageName);
         assertEquals("com[1x8]", ident.getDetailAst().toString(), "Invalid full indent");
     }
 
@@ -101,7 +101,7 @@ public class FullIdentTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.VARIABLE_DEF)
                 .findFirstToken(TokenTypes.TYPE)
                 .getFirstChild();
-        final FullIdent ident = FullIdent.createFullIdent(arrayDeclarator);
+        final FullIdent ident = FullIdent.extractFullIdent(null, arrayDeclarator);
         assertEquals("int[][][5x12]", ident.toString(), "Invalid full indent");
     }
 
@@ -125,7 +125,7 @@ public class FullIdentTest extends AbstractModuleTestSupport {
                 .getNextSibling()
                 .getFirstChild();
 
-        final FullIdent ident = FullIdent.createFullIdent(parameter);
+        final FullIdent ident = FullIdent.extractFullIdent(null, parameter);
         assertEquals("char[][7x29]", ident.toString(), "Invalid full indent");
     }
 
@@ -146,7 +146,7 @@ public class FullIdentTest extends AbstractModuleTestSupport {
                 .getFirstChild()
                 .getFirstChild();
 
-        final FullIdent ident = FullIdent.createFullIdent(literalInt);
+        final FullIdent ident = FullIdent.extractFullIdent(null, literalInt);
         assertEquals("int[4x32]", ident.toString(), "Invalid full indent");
     }
 
@@ -172,7 +172,7 @@ public class FullIdentTest extends AbstractModuleTestSupport {
         ast.addChild(ast1);
         ast.addChild(ast2);
 
-        return FullIdent.createFullIdent(ast);
+        return FullIdent.extractFullIdent(null, ast);
     }
 
 }


### PR DESCRIPTION
Issue: #10049
Deprecates FullIdent.createFullIdent and replaces usages with extractFullIdent()
