### PR TITLE
Issue #10138: test ecj jar after download to prevent hidden error of …

### DIFF
--- a/.ci/eclipse-compiler-javac.sh
+++ b/.ci/eclipse-compiler-javac.sh
@@ -15,9 +15,12 @@ ECJ_PATH=~/.m2/repository/$ECJ_MAVEN_VERSION/$ECJ_JAR
 
 if [ ! -f $ECJ_PATH ]; then
     echo "$ECJ_PATH is not found, downloading ..."
-    mkdir -p $(dirname "$ECJ_PATH")
     ECLIPSE_URL="http://ftp-stud.fht-esslingen.de/pub/Mirrors/eclipse/eclipse/downloads/drops4"
-    wget $ECLIPSE_URL/$ECJ_MAVEN_VERSION/$ECJ_JAR -O $ECJ_PATH
+    wget $ECLIPSE_URL/$ECJ_MAVEN_VERSION/$ECJ_JAR -O target/$ECJ_JAR
+    echo "test jar after download:"
+    jar -tvf target/$ECJ_JAR > /dev/null
+    mkdir -p $(dirname "$ECJ_PATH")
+    cp target/$ECJ_JAR $ECJ_PATH
 fi
 
 mkdir -p target/classes target/test-classes target/eclipse

--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -1262,6 +1262,7 @@ tstamp
 tt
 ttf
 ttype
+tvf
 tw
 typecastparenpad
 typename


### PR DESCRIPTION
Issue #10138

…download non-existing jar


```
✔ ~/java/github/checkstyle/checkstyle [master|✔] 
$ jar -tvf pom.xml
java.util.zip.ZipException: error in opening zip file
	at java.util.zip.ZipFile.open(Native Method)
	at java.util.zip.ZipFile.<init>(ZipFile.java:225)
	at java.util.zip.ZipFile.<init>(ZipFile.java:155)
	at java.util.zip.ZipFile.<init>(ZipFile.java:126)
	at sun.tools.jar.Main.list(Main.java:1115)
	at sun.tools.jar.Main.run(Main.java:293)
	at sun.tools.jar.Main.main(Main.java:1288)
✘-1 ~/java/github/checkstyle/checkstyle [master|✔] 
```

```
✔ ~/java/github/checkstyle/checkstyle [Issue-10138 L|✔] 
 $ jar -tvf ~/.m2/repository/junit/junit/4.11/junit-4.11.jar
     0 Wed Nov 14 20:21:28 PST 2012 META-INF/
   103 Wed Nov 14 20:21:26 PST 2012 META-INF/MANIFEST.MF
     0 Wed Nov 14 20:21:24 PST 2012 junit/
     0 Wed Nov 14 20:21:26 PST 2012 junit/extensions/
....
   123 Wed Nov 14 20:21:26 PST 2012 org/junit/runners/package-info.class
✔ ~/java/github/checkstyle/checkstyle [Issue-10138 L|✔]
```

main point is that exit code from such command, it will fail on non jar file.

suppression of output works fine:
```
✘-1 ~/java/github/checkstyle/checkstyle [Issue-10138 L|✔] 
$ jar -tvf ~/.m2/repository/junit/junit/4.11/junit-4.11.jar > /dev/null
✔ ~/java/github/checkstyle/checkstyle [Issue-10138 L|✔] 
$ jar -tvf pom.xml > /dev/null
java.util.zip.ZipException: error in opening zip file
	at java.util.zip.ZipFile.open(Native Method)
	at java.util.zip.ZipFile.<init>(ZipFile.java:225)
	at java.util.zip.ZipFile.<init>(ZipFile.java:155)
	at java.util.zip.ZipFile.<init>(ZipFile.java:126)
	at sun.tools.jar.Main.list(Main.java:1115)
	at sun.tools.jar.Main.run(Main.java:293)
	at sun.tools.jar.Main.main(Main.java:1288)
✘-1 ~/java/github/checkstyle/checkstyle [Issue-10138 L|✔] 
```