### PR TITLE
infra: parallelize no-exception javadoc github workflow

### DIFF
--- a/.github/workflows/no-exception-workflow.yml
+++ b/.github/workflows/no-exception-workflow.yml
@@ -5,36 +5,97 @@ on:
     branches: [ master ]
 
 jobs:
-  run:
-    name: Build
+  no-exception-lucene-and-others-javadoc:
     runs-on: ubuntu-latest
-
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
     - name: Set up JDK 8
       uses: actions/setup-java@v1
       with:
         java-version: 8
 
+    - name: Install dependencies
+      run: sudo apt install groovy
+
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
     - name: Install checkstyle
       run: mvn -e --no-transfer-progress clean install -Pno-validations
+
+    - run: ./.ci/no-exception-test.sh no-exception-lucene-and-others-javadoc
+
+  no-exception-cassandra-storm-tapestry-javadoc:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up JDK 8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
 
     - name: Install dependencies
       run: sudo apt install groovy
 
-    - name: no-exception-openjdk9-lucene-and-others-javadoc
-      run: ./.ci/no-exception-test.sh no-exception-lucene-and-others-javadoc
+    - name: Checkout repository
+      uses: actions/checkout@v2
 
-    - name: no-exception-cassandra-storm-tapestry-javadoc
-      run: ./.ci/no-exception-test.sh no-exception-cassandra-storm-tapestry-javadoc
+    - name: Install checkstyle
+      run: mvn -e --no-transfer-progress clean install -Pno-validations
 
-    - name: no-exception-hadoop-apache-groovy-scouter-javadoc
-      run: ./.ci/no-exception-test.sh no-exception-hadoop-apache-groovy-scouter-javadoc
+    - run: ./.ci/no-exception-test.sh no-exception-cassandra-storm-tapestry-javadoc
 
-    - name: no-exception-openjdk9-lucene-and-other
-      run: ./.ci/no-exception-test.sh no-exception-only-javadoc
+  no-exception-hadoop-apache-groovy-scouter-javadoc:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up JDK 8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
 
-    - name: non regression on XWiki project
-      run: ./.ci/validation.sh no-error-xwiki
+    - name: Install dependencies
+      run: sudo apt install groovy
+
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Install checkstyle
+      run: mvn -e --no-transfer-progress clean install -Pno-validations
+
+    - run: ./.ci/no-exception-test.sh no-exception-hadoop-apache-groovy-scouter-javadoc
+
+  no-error-xwiki:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up JDK 8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+
+    - name: Install dependencies
+      run: sudo apt install groovy
+
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Install checkstyle
+      run: mvn -e --no-transfer-progress clean install -Pno-validations
+
+    - run: ./.ci/validation.sh no-error-xwiki
+
+  no-exception-only-javadoc:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up JDK 8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+
+    - name: Install dependencies
+      run: sudo apt install groovy
+
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Install checkstyle
+      run: mvn -e --no-transfer-progress clean install -Pno-validations
+
+    - run: ./.ci/no-exception-test.sh no-exception-only-javadoc


### PR DESCRIPTION
From https://github.com/checkstyle/checkstyle/pull/10143#pullrequestreview-690624945:

> it would be better to split such big job (21 min) to multiple each execution separately, it will make it more quick by parallelism and easy to restart only single execution.