### PR TITLE
infra: remove from travis all executions that we alrerady moved to github actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,13 +35,6 @@ jobs:
         - DEPLOY="true"
         - USE_MAVEN_REPO="true"
 
-    # No error testing - XWiki project non regression
-    - jdk: openjdk8
-      env:
-        - DESC="non regression on XWiki project"
-        - USE_MAVEN_REPO="true"
-        - CMD="./.ci/validation.sh no-error-xwiki"
-
     # until https://github.com/checkstyle/checkstyle/issues/9984
     # Ensure that all modules are used in no exception configs
     # - env:
@@ -50,38 +43,6 @@ jobs:
     #    - CMD2="./.ci/travis/validation.sh verify-no-exception-configs"
     #    - CMD="$CMD1 && $CMD2"
 
-    - jdk: openjdk8
-      env:
-        - DESC="no-exception-openjdk9-lucene-and-others-javadoc"
-        - CMD1="mvn -e --no-transfer-progress clean install -Pno-validations"
-        - CMD2="./.ci/no-exception-test.sh no-exception-lucene-and-others-javadoc"
-        - CMD="$CMD1 && $CMD2"
-        - USE_MAVEN_REPO="true"
-
-    - jdk: openjdk8
-      env:
-        - DESC="no-exception-cassandra-storm-tapestry-javadoc"
-        - CMD1="mvn -e --no-transfer-progress clean install -Pno-validations"
-        - CMD2="./.ci/no-exception-test.sh no-exception-cassandra-storm-tapestry-javadoc"
-        - CMD="$CMD1 && $CMD2"
-        - USE_MAVEN_REPO="true"
-
-    - jdk: openjdk8
-      env:
-        - DESC="no-exception-hadoop-apache-groovy-scouter-javadoc"
-        - CMD1="mvn -e --no-transfer-progress clean install -Pno-validations"
-        - CMD2="./.ci/no-exception-test.sh no-exception-hadoop-apache-groovy-scouter-javadoc"
-        - CMD="$CMD1 && $CMD2"
-        - USE_MAVEN_REPO="true"
-
-    - jdk: openjdk8
-      env:
-        - DESC="no-exception-openjdk9-lucene-and-others"
-        - CMD1="mvn -e --no-transfer-progress clean install -Pno-validations"
-        - CMD2="./.ci/no-exception-test.sh no-exception-only-javadoc"
-        - CMD="$CMD1 && $CMD2"
-        - USE_MAVEN_REPO="true"
-
 script:
   - SKIP_FILES1=".github|codeship-*|appveyor.yml|circleci"
   - SKIP_FILES2="|fast-forward-merge.sh|LICENSE|LICENSE.apache20|README.md|release.sh|RIGHTS.antlr"
@@ -89,13 +50,6 @@ script:
   - SKIP_FILES4="|Jenkinsfile"
   - SKIP_FILES=$SKIP_FILES1$SKIP_FILES2$SKIP_FILES3$SKIP_FILES4
   - export RUN_JOB=1
-  # - source ./.ci/common.sh
-#  - |
-#    if [ -z ${SKIP_JOB_BY_FILES+x} ]; then
-#        SKIP_JOB_BY_FILES="recheck";
-#    fi
-  # should_run_job will change RUN_JOB variable
-#  - should_run_job $SKIP_JOB_BY_FILES $SKIP_FILES
   - |
     set -e
     if [[ $RUN_JOB == 1 ]]; then


### PR DESCRIPTION
this RP is mostly to test PRs triggering for Travis.

and it works again - https://travis-ci.com/github/checkstyle/checkstyle/builds/230727986
for PRs and for master.

Lets keep travis ready for new tasks, no need to move items from actions back.

All my problems with migration from travis.org and travis.com are described at https://travis-ci.community/t/cant-find-a-repository-that-i-just-added-travis-yml-to/10909/18