### PR TITLE
Issue #9876: Fix default scope for enum/interface/annotation members

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3249,11 +3249,19 @@
                 <param>
                   com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheckTest
                 </param>
+                <!-- 2% mutation in ScopeUtil -->
+                <param>
+                  com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheckTest
+                </param>
                 <param>
                   com.puppycrawl.tools.checkstyle.checks.javadoc.SingleLineJavadocCheckTest
                 </param>
                 <param>
                   com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocVariableCheckTest
+                </param>
+                <!-- 1% mutation in ScopeUtil -->
+                <param>
+                  com.puppycrawl.tools.checkstyle.checks.coding.DeclarationOrderCheckTest
                 </param>
                 <param>
                   com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheckTest

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -426,15 +426,7 @@ public class JavadocStyleCheck
             check = getFileContents().inPackageInfo();
         }
         else if (!ScopeUtil.isInCodeBlock(ast)) {
-            final Scope customScope;
-
-            if (ScopeUtil.isInInterfaceOrAnnotationBlock(ast)
-                    || ast.getType() == TokenTypes.ENUM_CONSTANT_DEF) {
-                customScope = Scope.PUBLIC;
-            }
-            else {
-                customScope = ScopeUtil.getScopeFromMods(ast.findFirstToken(TokenTypes.MODIFIERS));
-            }
+            final Scope customScope = ScopeUtil.getScope(ast);
             final Scope surroundingScope = ScopeUtil.getSurroundingScope(ast);
 
             check = customScope.isIn(scope)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfo.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfo.java
@@ -149,8 +149,7 @@ public enum JavadocTagInfo {
             return astType == TokenTypes.METHOD_DEF
                 && ast.findFirstToken(TokenTypes.MODIFIERS)
                     .findFirstToken(TokenTypes.LITERAL_STATIC) == null
-                && ScopeUtil.getScopeFromMods(ast
-                    .findFirstToken(TokenTypes.MODIFIERS)) != Scope.PRIVATE;
+                && ScopeUtil.getScope(ast) != Scope.PRIVATE;
         }
 
     },

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -403,15 +403,7 @@ public class JavadocTypeCheck
      * @return whether we should check a given node.
      */
     private boolean shouldCheck(DetailAST ast) {
-        final Scope customScope;
-
-        if (ScopeUtil.isInInterfaceOrAnnotationBlock(ast)) {
-            customScope = Scope.PUBLIC;
-        }
-        else {
-            final DetailAST mods = ast.findFirstToken(TokenTypes.MODIFIERS);
-            customScope = ScopeUtil.getScopeFromMods(mods);
-        }
+        final Scope customScope = ScopeUtil.getScope(ast);
         final Scope surroundingScope = ScopeUtil.getSurroundingScope(ast);
 
         return customScope.isIn(scope)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
@@ -277,13 +277,7 @@ public class JavadocVariableCheck
     private boolean shouldCheck(final DetailAST ast) {
         boolean result = false;
         if (!ScopeUtil.isInCodeBlock(ast) && !isIgnored(ast)) {
-            Scope customScope = Scope.PUBLIC;
-            if (ast.getType() != TokenTypes.ENUM_CONSTANT_DEF
-                    && !ScopeUtil.isInInterfaceOrAnnotationBlock(ast)) {
-                final DetailAST mods = ast.findFirstToken(TokenTypes.MODIFIERS);
-                customScope = ScopeUtil.getScopeFromMods(mods);
-            }
-
+            final Scope customScope = ScopeUtil.getScope(ast);
             final Scope surroundingScope = ScopeUtil.getSurroundingScope(ast);
             result = customScope.isIn(scope) && surroundingScope.isIn(scope)
                 && (excludeScope == null

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java
@@ -372,7 +372,7 @@ public class MissingJavadocMethodCheck extends AbstractCheck {
 
     @Override
     public final void visitToken(DetailAST ast) {
-        final Scope theScope = calculateScope(ast);
+        final Scope theScope = ScopeUtil.getScope(ast);
         if (shouldCheck(ast, theScope)) {
             final FileContents contents = getFileContents();
             final TextBlock textBlock = contents.getJavadocBefore(ast.getLineNo());
@@ -467,33 +467,6 @@ public class MissingJavadocMethodCheck extends AbstractCheck {
                 && surroundingScope != excludeScope)
             && nodeScope.isIn(scope)
             && surroundingScope.isIn(scope);
-    }
-
-    /**
-     * Returns the scope for the method/constructor at the specified AST. If
-     * the method is in an interface or annotation block, the scope is assumed
-     * to be public.
-     *
-     * @param ast the token of the method/constructor
-     * @return the scope of the method/constructor
-     */
-    private static Scope calculateScope(final DetailAST ast) {
-        final Scope scope;
-
-        if (ScopeUtil.isInAnnotationBlock(ast)) {
-            scope = Scope.PUBLIC;
-        }
-        else {
-            final DetailAST mods = ast.findFirstToken(TokenTypes.MODIFIERS);
-            final Scope modifiersScope = ScopeUtil.getScopeFromMods(mods);
-            if (modifiersScope == Scope.PACKAGE && ScopeUtil.isInInterfaceBlock(ast)) {
-                scope = Scope.PUBLIC;
-            }
-            else {
-                scope = modifiersScope;
-            }
-        }
-        return scope;
     }
 
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheck.java
@@ -248,15 +248,7 @@ public class MissingJavadocTypeCheck extends AbstractCheck {
      * @return whether we should check a given node.
      */
     private boolean shouldCheck(final DetailAST ast) {
-        final Scope customScope;
-
-        if (ScopeUtil.isInInterfaceOrAnnotationBlock(ast)) {
-            customScope = Scope.PUBLIC;
-        }
-        else {
-            final DetailAST mods = ast.findFirstToken(TokenTypes.MODIFIERS);
-            customScope = ScopeUtil.getScopeFromMods(mods);
-        }
+        final Scope customScope = ScopeUtil.getScope(ast);
         final Scope surroundingScope = ScopeUtil.getSurroundingScope(ast);
 
         return customScope.isIn(scope)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
@@ -290,8 +290,7 @@ public final class MethodCountCheck extends AbstractCheck {
      */
     private void raiseCounter(DetailAST method) {
         final MethodCounter actualCounter = counters.peek();
-        final DetailAST temp = method.findFirstToken(TokenTypes.MODIFIERS);
-        final Scope scope = ScopeUtil.getScopeFromMods(temp);
+        final Scope scope = ScopeUtil.getScope(method);
         actualCounter.increment(scope);
     }
 
@@ -381,8 +380,6 @@ public final class MethodCountCheck extends AbstractCheck {
 
         /** Maintains the counts. */
         private final Map<Scope, Integer> counts = new EnumMap<>(Scope.class);
-        /** Indicated is an interface, in which case all methods are public. */
-        private final boolean inInterface;
         /**
          * The surrounding scope definition (class, enum, etc.) which the method counts are connect
          * to.
@@ -400,7 +397,6 @@ public final class MethodCountCheck extends AbstractCheck {
          */
         /* package */ MethodCounter(DetailAST scopeDefinition) {
             this.scopeDefinition = scopeDefinition;
-            inInterface = scopeDefinition.getType() == TokenTypes.INTERFACE_DEF;
         }
 
         /**
@@ -410,12 +406,7 @@ public final class MethodCountCheck extends AbstractCheck {
          */
         private void increment(Scope scope) {
             total++;
-            if (inInterface) {
-                counts.put(Scope.PUBLIC, 1 + value(Scope.PUBLIC));
-            }
-            else {
-                counts.put(scope, 1 + value(scope));
-            }
+            counts.put(scope, 1 + value(scope));
         }
 
         /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
@@ -19,6 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.utils;
 
+import java.util.Optional;
+
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -34,28 +36,87 @@ public final class ScopeUtil {
     }
 
     /**
-     * Returns the Scope specified by the modifier set.
+     * Returns the {@code Scope} explicitly specified by the modifier set.
+     * Returns {@code null} if there are no modifiers.
+     *
+     * @param aMods root node of a modifier set
+     * @return a {@code Scope} value or {@code null}
+     */
+    public static Scope getDeclaredScopeFromMods(DetailAST aMods) {
+        Scope result = null;
+        for (DetailAST token = aMods.getFirstChild(); token != null;
+                token = token.getNextSibling()) {
+            if ("public".equals(token.getText())) {
+                result = Scope.PUBLIC;
+            }
+            else if ("protected".equals(token.getText())) {
+                result = Scope.PROTECTED;
+            }
+            else if ("private".equals(token.getText())) {
+                result = Scope.PRIVATE;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns the {@code Scope} for a given {@code DetailAST}.
+     *
+     * @param ast the DetailAST to examine
+     * @return a {@code Scope} value
+     */
+    public static Scope getScope(DetailAST ast) {
+        return Optional.ofNullable(ast.findFirstToken(TokenTypes.MODIFIERS))
+                .map(ScopeUtil::getDeclaredScopeFromMods)
+                .orElseGet(() -> getDefaultScope(ast));
+    }
+
+    /**
+     * Returns the {@code Scope} specified by the modifier set. If no modifiers are present,
+     * the default scope is used.
      *
      * @param aMods root node of a modifier set
      * @return a {@code Scope} value
+     * @see #getDefaultScope(DetailAST)
      */
     public static Scope getScopeFromMods(DetailAST aMods) {
-        // default scope
-        Scope returnValue = Scope.PACKAGE;
-        for (DetailAST token = aMods.getFirstChild(); token != null
-                && returnValue == Scope.PACKAGE;
-                token = token.getNextSibling()) {
-            if ("public".equals(token.getText())) {
-                returnValue = Scope.PUBLIC;
+        return Optional.ofNullable(getDeclaredScopeFromMods(aMods))
+                .orElseGet(() -> getDefaultScope(aMods.getParent()));
+    }
+
+    /**
+     * Returns the default {@code Scope} for a {@code DetailAST}.
+     * <p>The following rules are taken into account:</p>
+     * <ul>
+     *     <li>enum constants are public</li>
+     *     <li>enum constructors are private</li>
+     *     <li>interface members are public</li>
+     *     <li>everything else is package private</li>
+     * </ul>
+     *
+     * @param ast DetailAST to process
+     * @return a {@code Scope} value
+     */
+    private static Scope getDefaultScope(DetailAST ast) {
+        final Scope result;
+        if (isInEnumBlock(ast)) {
+            if (ast.getType() == TokenTypes.ENUM_CONSTANT_DEF) {
+                result = Scope.PUBLIC;
             }
-            else if ("protected".equals(token.getText())) {
-                returnValue = Scope.PROTECTED;
+            else if (ast.getType() == TokenTypes.CTOR_DEF) {
+                result = Scope.PRIVATE;
             }
-            else if ("private".equals(token.getText())) {
-                returnValue = Scope.PRIVATE;
+            else {
+                result = Scope.PACKAGE;
             }
         }
-        return returnValue;
+        else if (isInInterfaceOrAnnotationBlock(ast)) {
+            result = Scope.PUBLIC;
+        }
+        else {
+            result = Scope.PACKAGE;
+        }
+        return result;
     }
 
     /**
@@ -71,11 +132,9 @@ public final class ScopeUtil {
              token = token.getParent()) {
             final int type = token.getType();
             if (TokenUtil.isTypeDeclaration(type)) {
-                final DetailAST mods =
-                    token.findFirstToken(TokenTypes.MODIFIERS);
-                final Scope modScope = getScopeFromMods(mods);
-                if (returnValue == null || returnValue.isIn(modScope)) {
-                    returnValue = modScope;
+                final Scope tokenScope = getScope(token);
+                if (returnValue == null || returnValue.isIn(tokenScope)) {
+                    returnValue = tokenScope;
                 }
             }
             else if (type == TokenTypes.LITERAL_NEW) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheckTest.java
@@ -206,6 +206,17 @@ public class DeclarationOrderCheckTest
     }
 
     @Test
+    public void testDeclarationOrderInterfaceMemberScopeIsPublic() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(DeclarationOrderCheck.class);
+        final String[] expected = {
+            "21:5: " + getCheckMessage(MSG_STATIC),
+        };
+        verify(checkConfig,
+            getPath("InputDeclarationOrderInterfaceMemberScopeIsPublic.java"),
+            expected);
+    }
+
+    @Test
     public void testVariableAccess() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(DeclarationOrderCheck.class);
         final String[] expected = {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheckTest.java
@@ -163,4 +163,15 @@ public class DesignForExtensionCheckTest
         verify(checkConfig, getPath("InputDesignForExtensionRequiredJavadocPhraseMultiLine.java"),
             expected);
     }
+
+    @Test
+    public void testInterfaceMemberScopeIsPublic() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(DesignForExtensionCheck.class);
+        final String[] expected = {
+            "13:9: " + getCheckMessage(MSG_KEY, "Inner", "getProperty"),
+        };
+        verify(checkConfig, getPath("InputDesignForExtensionInterfaceMemberScopeIsPublic.java"),
+            expected);
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
@@ -468,6 +469,39 @@ public class JavadocStyleCheckTest
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
         verify(checkConfig, getPath("InputJavadocStyleNeverEndingXmlComment.java"), expected);
+    }
+
+    @Test
+    public void testInterfaceMemberScopeIsPublic()
+            throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(JavadocStyleCheck.class);
+        checkConfig.addProperty("scope", Scope.PUBLIC.getName());
+        checkConfig.addProperty("checkEmptyJavadoc", "true");
+        final String[] expected = {
+            "20: " + getCheckMessage(MSG_EMPTY),
+            "23: " + getCheckMessage(MSG_EMPTY),
+        };
+
+        verify(checkConfig, getPath("InputJavadocStyleInterfaceMemberScopeIsPublic.java"),
+                expected);
+    }
+
+    @Test
+    public void testEnumCtorScopeIsPrivate()
+            throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(JavadocStyleCheck.class);
+        checkConfig.addProperty("scope", Scope.PACKAGE.getName());
+        checkConfig.addProperty("checkEmptyJavadoc", "true");
+        final String[] expected = {
+            "20: " + getCheckMessage(MSG_EMPTY),
+            "23: " + getCheckMessage(MSG_EMPTY),
+            "31: " + getCheckMessage(MSG_EMPTY),
+        };
+
+        verify(checkConfig, getPath("InputJavadocStyleEnumCtorScopeIsPrivate.java"),
+                expected);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -453,4 +453,19 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
         verify(checkConfig,
             getNonCompilablePath("InputJavadocTypeRecordComponents2.java"), expected);
     }
+
+    @Test
+    public void testJavadocTypeInterfaceMemberScopeIsPublic() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(JavadocTypeCheck.class);
+        checkConfig.addProperty("scope", Scope.PUBLIC.getName());
+
+        final String[] expected = {
+            "19:5: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<T>"),
+            "24:5: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<T>"),
+        };
+        verify(checkConfig,
+            getPath("InputJavadocTypeInterfaceMemberScopeIsPublic.java"), expected);
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheckTest.java
@@ -347,4 +347,19 @@ public class JavadocVariableCheckTest
                 expected);
     }
 
+    @Test
+    public void testInterfaceMemberScopeIsPublic() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(JavadocVariableCheck.class);
+        checkConfig.addProperty("scope", Scope.PUBLIC.getName());
+        checkConfig.addProperty("tokens", "ENUM_CONSTANT_DEF, VARIABLE_DEF");
+        final String[] expected = {
+            "18:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "20:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "27:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verify(checkConfig,
+                getPath("InputJavadocVariableInterfaceMemberScopeIsPublic.java"),
+                expected);
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
@@ -167,6 +167,31 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testInterfaceMemberScopeIsPublic() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(
+                MissingJavadocMethodCheck.class);
+        checkConfig.addProperty("scope", Scope.PUBLIC.getName());
+        final String[] expected = {
+            "20:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "28:9: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verify(checkConfig, getPath("InputMissingJavadocMethodInterfaceMemberScopeIsPublic.java"),
+                expected);
+    }
+
+    @Test
+    public void testEnumCtorScopeIsPrivate() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(
+                MissingJavadocMethodCheck.class);
+        checkConfig.addProperty("scope", Scope.PACKAGE.getName());
+        final String[] expected = {
+            "24:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verify(checkConfig, getPath("InputMissingJavadocMethodEnumCtorScopeIsPrivate.java"),
+                expected);
+    }
+
+    @Test
     public void testScopeAnonInnerPrivate() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(
                 MissingJavadocMethodCheck.class);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckTest.java
@@ -335,4 +335,20 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
             expected);
     }
 
+    @Test
+    public void testInterfaceMemberScopeIsPublic() throws Exception {
+        final DefaultConfiguration checkConfig =
+            createModuleConfig(MissingJavadocTypeCheck.class);
+        checkConfig.addProperty("scope", Scope.PUBLIC.getName());
+
+        final String[] expected = {
+            "12:1: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "14:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "18:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            };
+        verify(checkConfig,
+            getPath("InputMissingJavadocTypeInterfaceMemberScopeIsPublic.java"),
+            expected);
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheckTest.java
@@ -176,6 +176,21 @@ public class MethodCountCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testInterfaceMemberScopeIsPublic() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(MethodCountCheck.class);
+        checkConfig.addProperty("maxPublic", "1");
+        checkConfig.addProperty("tokens", "ENUM_DEF, CLASS_DEF");
+
+        final String[] expected = {
+            "18:5: " + getCheckMessage(MSG_PUBLIC_METHODS, 2, 1),
+            "28:5: " + getCheckMessage(MSG_PUBLIC_METHODS, 2, 1),
+        };
+
+        verify(checkConfig, getPath("InputMethodCountInterfaceMemberScopeIsPublic.java"),
+                expected);
+    }
+
+    @Test
     public void testMethodCountRecords() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(MethodCountCheck.class);
         checkConfig.addProperty("maxTotal", "2");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/declarationorder/InputDeclarationOrderInterfaceMemberScopeIsPublic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/declarationorder/InputDeclarationOrderInterfaceMemberScopeIsPublic.java
@@ -1,0 +1,23 @@
+/*
+DeclarationOrder
+ignoreConstructors = (default)false
+ignoreModifiers = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.declarationorder;
+
+public interface InputDeclarationOrderInterfaceMemberScopeIsPublic {
+
+    public static final int explicitPublicField1 = 0;
+
+    static final int implicitPublicField1 = 0;
+
+    public static final int explicitPublicField2 = 0;
+
+    void method();
+
+    static final int implicitPublicField2 = 0; // violation
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionInterfaceMemberScopeIsPublic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/designforextension/InputDesignForExtensionInterfaceMemberScopeIsPublic.java
@@ -1,0 +1,19 @@
+/*
+DesignForExtension
+ignoredAnnotations = (default)After, AfterClass, Before, BeforeClass, Test
+requiredJavadocPhrase = (default).*
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.design.designforextension;
+
+public interface InputDesignForExtensionInterfaceMemberScopeIsPublic {
+
+    class Inner {
+
+        public String getProperty() { // violation
+            return null;
+        }
+
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleEnumCtorScopeIsPrivate.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleEnumCtorScopeIsPrivate.java
@@ -1,0 +1,35 @@
+/*
+JavadocStyle
+scope = package
+excludeScope = (default)null
+checkFirstSentence = (default)true
+endOfSentenceFormat = (default)([.?!][ \t\n\r\f<])|([.?!]$)
+checkEmptyJavadoc = true
+checkHtml = (default)true
+tokens = (default)ANNOTATION_DEF, ANNOTATION_FIELD_DEF, CLASS_DEF, CTOR_DEF, \
+         ENUM_CONSTANT_DEF, ENUM_DEF, INTERFACE_DEF, METHOD_DEF, PACKAGE_DEF, \
+         VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocstyle;
+
+public enum InputJavadocStyleEnumCtorScopeIsPrivate {
+
+    /** */ // violation
+    CONSTANT(0);
+
+    /** */ // violation
+    final int value;
+
+    /** */ // ok
+    InputJavadocStyleEnumCtorScopeIsPrivate(int value) {
+        this.value = value;
+    }
+
+    /** */ // violation
+    void method() {
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleInterfaceMemberScopeIsPublic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleInterfaceMemberScopeIsPublic.java
@@ -1,0 +1,40 @@
+/*
+JavadocStyle
+scope = public
+excludeScope = (default)null
+checkFirstSentence = (default)true
+endOfSentenceFormat = (default)([.?!][ \t\n\r\f<])|([.?!]$)
+checkEmptyJavadoc = true
+checkHtml = (default)true
+tokens = (default)ANNOTATION_DEF, ANNOTATION_FIELD_DEF, CLASS_DEF, CTOR_DEF, \
+         ENUM_CONSTANT_DEF, ENUM_DEF, INTERFACE_DEF, METHOD_DEF, PACKAGE_DEF, \
+         VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocstyle;
+
+public interface InputJavadocStyleInterfaceMemberScopeIsPublic {
+
+    /** */ // violation
+    enum Enum {
+
+        /** */ // violation
+        CONSTANT(0);
+
+        /** */ // ok
+        final int value;
+
+        /** */ // ok
+        Enum(int value) {
+            this.value = value;
+        }
+
+        /** */ // ok
+        void method() {
+        }
+
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeInterfaceMemberScopeIsPublic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeInterfaceMemberScopeIsPublic.java
@@ -1,0 +1,29 @@
+/*
+JavadocType
+scope = public
+excludeScope = (default)null
+authorFormat = (default)null
+versionFormat = (default)null
+allowMissingParamTags = (default)false
+allowUnknownTags = (default)false
+allowedAnnotations = (default)Generated
+tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
+
+public interface InputJavadocTypeInterfaceMemberScopeIsPublic {// ok
+
+    /** @param <T> unused */  // violation
+    enum Enum {
+
+    }
+
+    /** @param <T> unused */  // violation
+    class Class {
+
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableInterfaceMemberScopeIsPublic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocvariable/InputJavadocVariableInterfaceMemberScopeIsPublic.java
@@ -1,0 +1,31 @@
+/*
+JavadocVariable
+scope = public
+excludeScope = (default)null
+ignoreNamePattern = (default)null
+tokens = ENUM_CONSTANT_DEF, VARIABLE_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocvariable;
+
+public interface InputJavadocVariableInterfaceMemberScopeIsPublic {
+
+    /** First field */
+    public static int field1 = 0;
+
+    public static int field2 = 0; // violation
+
+    int field3 = 0; // violation
+
+    enum Enum {
+
+        /** First constant */
+        A,
+
+        B; // violation
+
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodEnumCtorScopeIsPrivate.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodEnumCtorScopeIsPrivate.java
@@ -1,0 +1,27 @@
+/*
+MissingJavadocMethod
+minLineCount = (default)-1
+allowedAnnotations = (default)Override
+scope = package
+excludeScope = (default)null
+allowMissingPropertyJavadoc = (default)false
+ignoreMethodNamesRegex = (default)null
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocmethod;
+
+public enum InputMissingJavadocMethodEnumCtorScopeIsPrivate {
+
+    CONSTANT(0);
+
+    private final int value;
+
+    InputMissingJavadocMethodEnumCtorScopeIsPrivate(int value) { // ok
+        this.value = value;
+    }
+
+    void packagePrivateMethod() { // violation
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodInterfaceMemberScopeIsPublic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodInterfaceMemberScopeIsPublic.java
@@ -1,0 +1,34 @@
+/*
+MissingJavadocMethod
+minLineCount = (default)-1
+allowedAnnotations = (default)Override
+scope = public
+excludeScope = (default)null
+allowMissingPropertyJavadoc = (default)false
+ignoreMethodNamesRegex = (default)null
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocmethod;
+
+public interface InputMissingJavadocMethodInterfaceMemberScopeIsPublic {
+
+    enum Enum {
+
+        ;
+
+        public static void method() {} // violation
+
+        void packagePrivateMethod() {}
+
+    }
+
+    class Class {
+
+        public void method() {} // violation
+
+        void packagePrivateMethod() {}
+
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeInterfaceMemberScopeIsPublic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeInterfaceMemberScopeIsPublic.java
@@ -1,0 +1,22 @@
+/*
+MissingJavadocType
+scope = public
+excludeScope = (default)null
+skipAnnotations = (default)Generated
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
+
+public interface InputMissingJavadocTypeInterfaceMemberScopeIsPublic { // violation
+
+    enum Enum { // violation
+
+    }
+
+    class Class { // violation
+
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCountInterfaceMemberScopeIsPublic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodcount/InputMethodCountInterfaceMemberScopeIsPublic.java
@@ -1,0 +1,36 @@
+/*
+MethodCount
+maxPackage = (default)100
+maxPrivate = (default)100
+maxProtected = (default)100
+maxPublic = 1
+maxTotal = (default)100
+tokens = (default)CLASS_DEF, ENUM_CONSTANT_DEF, ENUM_DEF, INTERFACE_DEF, ANNOTATION_DEF, \
+         METHOD_DEF, RECORD_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.sizes.methodcount;
+
+public interface InputMethodCountInterfaceMemberScopeIsPublic {
+
+    enum Enum { // violation
+
+        ;
+
+        public static void method1() {}
+
+        public static void method2() {}
+
+    }
+
+    class Class { // violation
+
+        public void method1() {}
+
+        public void method2() {}
+
+    }
+
+}


### PR DESCRIPTION
Issue #9876 

The method `ScopeUtils.getScopeFromMods` always return `package` scope if no scope is explicitly set.
There is a local workaround for this bug in `MissingJavadocMethodCheck.calculateScope` and `MethodCountCheck.ctor`.
This PR removes these workarounds and fixes the broken method.

PR to fix xwiki: https://github.com/xwiki/xwiki-platform/pull/1652

Diff Regression config: https://gist.githubusercontent.com/pbludov/f91134ed24d58a1f210a2871829b4df0/raw/b00cf34d60e1a232b83a89e078a72ae6b46e9d2b/issue-9876-config.xml

Affected checks
============
* DeclarationOrder
* DesignForExtension
* JavadocStyle
* JavadocType
* JavadocVariable
* MethodCount
* MissingJavadocMethod
* MissingJavadocType

Not affected checks
===============
* RequireThis uses this method only to [detect](https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java#L505) package/import scopes
* HiddenField  uses this method only to [detect](https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java#L587) anonymous scope
* JavadocTagInfo uses this method only to [detect](https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfo.java#L152) private scope

Regression
=========

* **DeclarationOrder**, **MethodCount** https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/6c28569_2021211656/reports/diff/index.html
* **JavadocStyle**, **JavadocType**, **JavadocVariable** https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/6c28569_2021204718/reports/diff/index.html
* **MissingJavadocMethod**, **MissingJavadocType** https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/6c28569_2021202150/reports/diff/index.html
* **DesignForExtension** https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/6c28569_2021195357/reports/diff/index.html
* **RequireThis**, **HiddenField** (empty): https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/6c28569_2021174045/reports/diff/index.html