### PR TITLE
Issue #10107: Support for comment in MatchXpath

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java
@@ -264,6 +264,11 @@ public class MatchXpathCheck extends AbstractCheck {
     }
 
     @Override
+    public boolean isCommentNodesRequired() {
+        return true;
+    }
+
+    @Override
     public void beginTree(DetailAST rootAST) {
         if (xpathExpression != null) {
             final List<DetailAST> matchingNodes = findMatchingNodesByXpathQuery(rootAST);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheckTest.java
@@ -92,6 +92,47 @@ public class MatchXpathCheckTest
     }
 
     @Test
+    public void testCheckWithSingleLineCommentsStartsWithSpace() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(MatchXpathCheck.class);
+        checkConfig.addAttribute("query", "//SINGLE_LINE_COMMENT"
+                + "[./COMMENT_CONTENT[not(starts-with(@text, ' '))]]");
+        final String[] expected = {
+            "13:25: " + getCheckMessage(MatchXpathCheck.MSG_KEY),
+            "14:27: " + getCheckMessage(MatchXpathCheck.MSG_KEY),
+        };
+        verify(checkConfig, getPath("InputMatchXpathSingleLineComments.java"), expected);
+    }
+
+    @Test
+    public void testCheckWithBlockComments() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(MatchXpathCheck.class);
+        checkConfig.addAttribute("query", "//BLOCK_COMMENT_BEGIN"
+                + "[./COMMENT_CONTENT[contains(@text, '{') "
+                + "and not(starts-with(@text, '\\nMatchXpath'))]]");
+        final String[] expected = {
+            "11:5: " + getCheckMessage(MatchXpathCheck.MSG_KEY),
+            "13:5: " + getCheckMessage(MatchXpathCheck.MSG_KEY),
+        };
+        verify(checkConfig, getPath("InputMatchXpathBlockComments.java"), expected);
+    }
+
+    @Test
+    public void testCheckWithMultilineComments() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(MatchXpathCheck.class);
+        checkConfig.addAttribute("query", "//BLOCK_COMMENT_BEGIN"
+                + "[./COMMENT_CONTENT[contains(@text, '\\n    Forbidden comment\\n') "
+                + "and not(starts-with(@text, '\\nMatchXpath'))]]");
+        final String[] expected = {
+            "13:5: " + getCheckMessage(MatchXpathCheck.MSG_KEY),
+            "19:5: " + getCheckMessage(MatchXpathCheck.MSG_KEY),
+        };
+        verify(checkConfig, getPath("InputMatchXpathMultilineComments.java"), expected);
+    }
+
+    @Test
     public void testCheckWithDoubleBraceInitialization()
             throws Exception {
         final DefaultConfiguration checkConfig =

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/InputMatchXpathBlockComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/InputMatchXpathBlockComments.java
@@ -1,0 +1,18 @@
+/*
+MatchXpath
+query = //BLOCK_COMMENT_BEGIN[./COMMENT_CONTENT[contains(@text, '{') \
+        and not(starts-with(@text, '\nMatchXpath'))]]
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.matchxpath;
+
+public class InputMatchXpathBlockComments {
+    /* void foo() {} */ // violation
+
+    /* public class // violation
+        {
+            void foo2() {}
+        }
+     */
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/InputMatchXpathMultilineComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/InputMatchXpathMultilineComments.java
@@ -1,0 +1,24 @@
+/*
+MatchXpath
+query = //BLOCK_COMMENT_BEGIN[./COMMENT_CONTENT[contains(@text, '\n    Forbidden comment\n') \
+        and not(starts-with(@text, '\nMatchXpath'))]]
+
+*/
+
+
+package com.puppycrawl.tools.checkstyle.checks.coding.matchxpath;
+
+public class InputMatchXpathMultilineComments {
+
+    /* // violation
+    Forbidden comment
+    Some other comment
+     */
+    void foo1() {}
+
+    /* // violation
+    Some other comment
+    Forbidden comment
+    */
+    void foo2() {}
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/InputMatchXpathSingleLineComments.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/InputMatchXpathSingleLineComments.java
@@ -1,0 +1,16 @@
+/*
+MatchXpath
+query = //SINGLE_LINE_COMMENT[./COMMENT_CONTENT[not(starts-with (@text, ' '))]]
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.matchxpath;
+
+public class InputMatchXpathSingleLineComments {
+    void foo() {
+        int num; // Trailing comment // ok
+
+        boolean isTrue; //Some Comment // violation
+        double pi = 3.14; //Constant PI value // violation
+    }
+}


### PR DESCRIPTION
Closes: #10107

```
$ cat Test.java 
public class TestClass {
    void method() {
// test
    }
}
$ cat config.xml   
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <property name="charset" value="UTF-8"/>

    <module name="TreeWalker">
<module name="MatchXpath">
  <property name="query" value="//SINGLE_LINE_COMMENT" />
</module>
    </module>
</module>
$ java -jar checkstyle-8.45-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /home/akmo/GitHub/Test/MatchXpath/Test.java:3:1: Illegal code structure detected. [MatchXpath]
Audit done.
Checkstyle ends with 1 errors.
```
