### PR TITLE
supplemental: Convert from Todo check to better MatchXpath check

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -425,6 +425,21 @@
       <message key="matchxpath.match"
                value="Avoid using deprecated method 'DetailAst.branchContains()'."/>
     </module>
+    <module name="MatchXpath">
+      <property name="id" value="singleLineCommentStartWithSpace"/>
+      <property name="query"
+                value="//SINGLE_LINE_COMMENT[./COMMENT_CONTENT[not(starts-with(@text, ' '))
+                       and not(@text = '\n') and not(ends-with(@text, '//\n')) ]]"/>
+      <message key="matchxpath.match" value="Single line comment text should start with space."/>
+    </module>
+    <module name="MatchXpath">
+      <property name="id" value="blockCommentStartWithSpace"/>
+      <property name="query"
+                value="//BLOCK_COMMENT_BEGIN[./COMMENT_CONTENT[matches(@text, '\\n+ *\*[^\\n ]\S')
+                       or matches(@text, '^[^\* \\n]') and not(starts-with(@text, '*'))]]"/>
+      <message key="matchxpath.match"
+               value="Block comment text should start with space after asterisk."/>
+    </module>
     <module name="MissingCtor">
       <!--
         we will not use that fanatic validation, extra code is not good
@@ -676,12 +691,6 @@
     <module name="OuterTypeFilename"/>
     <module name="TodoComment">
       <property name="format" value="(TODO)|(FIXME)" />
-    </module>
-    <!-- till https://github.com/checkstyle/checkstyle/issues/8137 -->
-    <module name="TodoComment">
-      <property name="id" value="commentStartWithSpace"/>
-      <property name="format" value="^([^\s\/*])"/>
-      <message key="todo.match" value="Comment text should start with space."/>
     </module>
     <module name="TrailingComment"/>
     <module name="UncommentedMain">


### PR DESCRIPTION
From: https://github.com/checkstyle/checkstyle/pull/10368#discussion_r671740246

```
$ cat Test.java 
class Test{
    public void foo() {
    
      int num1; //Violation Comment
      
      int num2; // OK
      
      bool isTrue; //Incorrect Comment
      
      /*Incorrect Block Comment */
      int num3;
      
      /* Correct Block Comment */
      int num4;
      
      /**
       *Incorrect Block Comment.
       */
      int num5;
      
      /*
       *Incorrect Block Comment.
       */
      int num6;      
      
      /* Correct Block Comment
       */
      int num7;
      
      /*
       * Correct Block Comment
       */
      int num8;
      
      /*Incorrect Block Comment.
       * Correct Block Comment.
       */
      int num9;
      
      /* Correct Block Comment.
       *Incorrect Block Comment.
       */
      int num10;
    }
}

$ cat config.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
  <property name="charset" value="UTF-8"/>

  <module name="TreeWalker">
    <module name="MatchXpath">
      <property name="id" value="singleLineCommentStartWithSpace"/>
      <property name="query"
                value="//SINGLE_LINE_COMMENT[./COMMENT_CONTENT[not(starts-with(@text, ' '))
                       and not(@text = '\n') and not(ends-with(@text, '//\n')) ]]"/>
      <message key="matchxpath.match" value="Single line comment text should start with space."/>
    </module>
    <module name="MatchXpath">
      <property name="id" value="BlockCommentStartWithSpace"/>
      <property name="query"
                value="//BLOCK_COMMENT_BEGIN[./COMMENT_CONTENT[matches(@text, '\\n+ *\*[^\\n ]\S')
                or matches(@text, '^[^\* \\n]') and not(starts-with(@text, '*'))]]"/>
      <message key="matchxpath.match"
               value="Block comment text should start with space after asterisk."/>
    </module>
  </module>
</module>

$ java -jar checkstyle-8.45-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /home/akmo/GitHub/Test/MatchXpath/Test.java:4:17: Single line comment text should start with space. [singleLineCommentStartWithSpace]
[ERROR] /home/akmo/GitHub/Test/MatchXpath/Test.java:8:20: Single line comment text should start with space. [singleLineCommentStartWithSpace]
[ERROR] /home/akmo/GitHub/Test/MatchXpath/Test.java:10:7: Block comment text should start with space after asterisk. [blockCommentStartWithSpace]
[ERROR] /home/akmo/GitHub/Test/MatchXpath/Test.java:16:7: Block comment text should start with space after asterisk. [blockCommentStartWithSpace]
[ERROR] /home/akmo/GitHub/Test/MatchXpath/Test.java:21:7: Block comment text should start with space after asterisk. [blockCommentStartWithSpace]
[ERROR] /home/akmo/GitHub/Test/MatchXpath/Test.java:35:7: Block comment text should start with space after asterisk. [blockCommentStartWithSpace]
[ERROR] /home/akmo/GitHub/Test/MatchXpath/Test.java:40:7: Block comment text should start with space after asterisk. [blockCommentStartWithSpace]
Audit done.
Checkstyle ends with 7 errors.
```

Cases:
1. `not(@text = '\n')` - For cases like just `//` where `not(starts-with(@text, ' ')` is true. Found in almost all files. Eg: [Empty comment](https://github.com/checkstyle/checkstyle/blob/b557d011379afb9a647127fec95e20ae8d437f0d/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java#L4)

2. `not(ends-with(@text, '//\n'))` - For cases like `////////////////////////////\n` where `not(starts-with(@text, ' ')` is true. Found in almost all files. Eg: [Comment](https://github.com/checkstyle/checkstyle/blob/b557d011379afb9a647127fec95e20ae8d437f0d/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java#L18)
