### PR TITLE
Issue #8929: fix indent checks in switch expressions

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
@@ -77,11 +77,14 @@ public class LineWrappingHandler {
      * @see NewHandler#getIndentImpl()
      * @see BlockParentHandler#curlyIndent()
      * @see ArrayInitHandler#getIndentImpl()
+     * @see CaseHandler#getIndentImpl()
      */
     private static final int[] IGNORED_LIST = {
         TokenTypes.RCURLY,
         TokenTypes.LITERAL_NEW,
         TokenTypes.ARRAY_INIT,
+        TokenTypes.LITERAL_DEFAULT,
+        TokenTypes.LITERAL_CASE,
     };
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -2728,6 +2728,27 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testIndentationSwitchExpressionDeclaration() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
+        checkConfig.addProperty("tabWidth", "4");
+        checkConfig.addProperty("caseIndent", "4");
+        checkConfig.addProperty("lineWrappingIndentation", "8");
+        final String[] expected = {
+            "33:17: " + getCheckMessage(MSG_CHILD_ERROR, "case", 16, 12),
+            "34:17: " + getCheckMessage(MSG_CHILD_ERROR, "case", 16, 12),
+            "41:17: " + getCheckMessage(MSG_CHILD_ERROR, "case", 16, 12),
+            "42:17: " + getCheckMessage(MSG_CHILD_ERROR, "case", 16, 12),
+            "49:9: " + getCheckMessage(MSG_CHILD_ERROR, "case", 8, 12),
+            "50:9: " + getCheckMessage(MSG_CHILD_ERROR, "case", 8, 12),
+            "57:9: " + getCheckMessage(MSG_CHILD_ERROR, "case", 8, 12),
+            "58:9: " + getCheckMessage(MSG_CHILD_ERROR, "case", 8, 12),
+        };
+        verifyWarns(checkConfig,
+            getNonCompilablePath("InputIndentationCheckSwitchExpressionDeclaration.java"),
+            expected);
+    }
+
+    @Test
     public void testIndentationRecords() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(IndentationCheck.class);
         checkConfig.addProperty("tabWidth", "4");

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckSwitchExpressionDeclaration.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCheckSwitchExpressionDeclaration.java
@@ -1,0 +1,62 @@
+//non-compiled with javac: Compilable with Java14                                   //indent:0 exp:0
+package com.puppycrawl.tools.checkstyle.checks.indentation.indentation;             //indent:0 exp:0
+                                                                                  //indent:82 exp:82
+/* Config:                                                                          //indent:0 exp:0
+ *                                                                                  //indent:1 exp:1
+ * basicOffset = 4                                                                  //indent:1 exp:1
+ * braceAdjustment = 0                                                              //indent:1 exp:1
+ * caseIndent = 4                                                                   //indent:1 exp:1
+ * throwsIndent = 4                                                                 //indent:1 exp:1
+ * arrayInitIndent = 4                                                              //indent:1 exp:1
+ * lineWrappingIndentation = 8                                                      //indent:1 exp:1
+ * forceStrictCondition = false                                                     //indent:1 exp:1
+ */                                                                                 //indent:1 exp:1
+public class InputIndentationCheckSwitchExpressionDeclaration {                     //indent:0 exp:0
+                                                                                  //indent:82 exp:82
+    public void validDeclare() {                                                    //indent:4 exp:4
+        String requestId = switch ("in") {                                          //indent:8 exp:8
+            case "correct" -> "true";                                             //indent:12 exp:12
+            default -> "also correct";                                            //indent:12 exp:12
+        };                                                                          //indent:8 exp:8
+    }                                                                               //indent:4 exp:4
+                                                                                  //indent:82 exp:82
+    public void validAssign(String result) {                                        //indent:4 exp:4
+        result = switch ("in") {                                                    //indent:8 exp:8
+            case "correct" -> "true";                                             //indent:12 exp:12
+            default -> "also correct";                                            //indent:12 exp:12
+        };                                                                          //indent:8 exp:8
+    }                                                                               //indent:4 exp:4
+                                                                                  //indent:82 exp:82
+    public void invalidDeclareWithBiggerIndent() {                                  //indent:4 exp:4
+        String requestId = switch ("in") {                                          //indent:8 exp:8
+            case "correct" -> "true";                                             //indent:12 exp:12
+                case "incorrect" -> "true";                                  //indent:16 exp:12 warn
+                default -> "also incorrect";                                 //indent:16 exp:12 warn
+        };                                                                          //indent:8 exp:8
+    }                                                                               //indent:4 exp:4
+                                                                                  //indent:82 exp:82
+    public void invalidAssignWithBiggerIndent(String result) {                      //indent:4 exp:4
+        result = switch ("in") {                                                    //indent:8 exp:8
+            case "correct" -> "true";                                             //indent:12 exp:12
+                case "incorrect" -> "true";                                  //indent:16 exp:12 warn
+                default -> "also incorrect";                                 //indent:16 exp:12 warn
+        };                                                                          //indent:8 exp:8
+    }                                                                               //indent:4 exp:4
+                                                                                  //indent:82 exp:82
+    public void invalidDeclareWithLesserIndent() {                                  //indent:4 exp:4
+        String requestId = switch ("in") {                                          //indent:8 exp:8
+            case "correct" -> "true";                                             //indent:12 exp:12
+        case "incorrect" -> "true";                                           //indent:8 exp:12 warn
+        default -> "also incorrect";                                          //indent:8 exp:12 warn
+        };                                                                          //indent:8 exp:8
+    }                                                                               //indent:4 exp:4
+                                                                                  //indent:82 exp:82
+    public void invalidAssignWithLesserIndent(String result) {                      //indent:4 exp:4
+        result = switch ("in") {                                                    //indent:8 exp:8
+            case "correct" -> "true";                                             //indent:12 exp:12
+        case "incorrect" -> "true";                                           //indent:8 exp:12 warn
+        default -> "also incorrect";                                          //indent:8 exp:12 warn
+        };                                                                          //indent:8 exp:8
+    }                                                                               //indent:4 exp:4
+}                                                                                   //indent:0 exp:0
+                                                                                  //indent:82 exp:82

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCaseLevel.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCaseLevel.java
@@ -6,7 +6,7 @@ package com.puppycrawl.tools.checkstyle.checks.indentation.indentation; //indent
  * arrayInitIndent = 4                                                        //indent:1 exp:1
  * basicOffset = 4                                                            //indent:1 exp:1
  * braceAdjustment = 0                                                        //indent:1 exp:1
- * caseIndent = 4                                                             //indent:1 exp:1
+ * caseIndent = 0                                                             //indent:1 exp:1
  * forceStrictCondition = false                                               //indent:1 exp:1
  * lineWrappingIndentation = 4                                                //indent:1 exp:1
  * tabWidth = 4                                                               //indent:1 exp:1


### PR DESCRIPTION
Issue #8929 fix indent checks for case/default nodes by marking them as ignored in LineWrappingHandler.

Diff Regression config: https://gist.githubusercontent.com/sukolenvo/ee40ee2c7772e4f5cfb709d6c665a078/raw/a26e8cb549354f145f40ecf94b2463a31b2c98ca/checkstyle.xml

Report: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/384112a_2021141432/reports/diff/index.html