### PR TITLE
infra: update xwiki commit in no-error testing

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -201,7 +201,7 @@ no-error-xwiki)
   cd ..
   checkout_from https://github.com/xwiki/xwiki-platform.git
   cd .ci-temp/xwiki-platform
-  git checkout "b31a47e4f84b1981c27fd55716c""eb89f6983af5b"
+  git checkout "f52fa56cc13fd""c64dc80c29a96cd545e023e7121"
   # Validate xwiki-platform
   mvn -e --no-transfer-progress checkstyle:check@default -Dcheckstyle.version=${CS_POM_VERSION}
   cd ..


### PR DESCRIPTION
From https://github.com/checkstyle/checkstyle/pull/10280/checks?check_run_id=3120338838:

`Error:      Non-resolvable parent POM for org.xwiki.platform:xwiki-platform:13.6-SNAPSHOT: Could not find artifact org.xwiki.commons:xwiki-commons-pom:pom:13.6-SNAPSHOT and 'parent.relativePath' points at no local POM @ line 23, column 11 -> [Help 2]`

The `no-error-xwiki` task needs to have specific commit updated.