### PR TITLE
minor: move no-exception-openjdk14 to github action

### DIFF
--- a/.github/workflows/no-exception-workflow.yml
+++ b/.github/workflows/no-exception-workflow.yml
@@ -99,3 +99,22 @@ jobs:
       run: mvn -e --no-transfer-progress clean install -Pno-validations
 
     - run: ./.ci/no-exception-test.sh no-exception-only-javadoc
+
+  no-exception-openjdk14:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up JDK 8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+
+    - name: Install dependencies
+      run: sudo apt install groovy
+
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Install checkstyle
+      run: mvn -e --no-transfer-progress clean install -Pno-validations
+
+    - run: .ci/no-exception-test.sh openjdk14-with-checks-nonjavadoc-error

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -78,8 +78,6 @@ blocks:
                 # until https://github.com/checkstyle/checkstyle/issues/9248
                 # - mvn -e clean install -Pno-validations
                 #    && .ci/validation.sh no-violation-test-configurate
-                - mvn -e --no-transfer-progress clean install -Pno-validations
-                    && .ci/no-exception-test.sh openjdk14-with-checks-nonjavadoc-error
           commands:
             - sem-version java 11
             - echo "eval of CMD is starting";


### PR DESCRIPTION
Checking runtime for `move no-exception-openjdk14` as github action.