### PR TITLE
infra: update link to groovy zip, as bintray is deprecated

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -57,6 +57,7 @@ Arquillian
 arraycopy
 arraytrailingcomma
 arraytypestyle
+artifactory
 asda
 ASF
 ASingle
@@ -660,6 +661,7 @@ jep
 jetbrains
 JFile
 JFrame
+jfrog
 jgit
 jgrasp
 jguru

--- a/wercker.yml
+++ b/wercker.yml
@@ -33,7 +33,8 @@ build:
       name: install groovy
       code: |
          if [ ! -d ${WERCKER_CACHE_DIR}/groovy ]; then
-           GROOVY_LINK="https://dl.bintray.com/groovy/maven/apache-groovy-binary-2.4.7.zip"
+           GROOVY_LINK="https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/"
+           GROOVY_LINK=$GROOVY_LINK"apache-groovy-binary-2.4.7.zip"
            wget -O ${WERCKER_CACHE_DIR}/groovy.zip $GROOVY_LINK;
            unzip ${WERCKER_CACHE_DIR}/groovy.zip -d ${WERCKER_CACHE_DIR};
            mv ${WERCKER_CACHE_DIR}/groovy-2.4.7 ${WERCKER_CACHE_DIR}/groovy


### PR DESCRIPTION
I took a link from 
https://groovy.apache.org/download.html

![image](https://user-images.githubusercontent.com/812984/127756933-49b33ead-fbc7-4868-a0cb-6735153109c5.png)
