### PR TITLE
infra: update url to maven, as it is not working any more

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ install:
       Add-Type -AssemblyName System.IO.Compression.FileSystem
       if (!(Test-Path -Path "C:\maven\apache-maven-3.2.5" )) {
         (new-object System.Net.WebClient).DownloadFile(
-          'http://www.us.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.zip',
+          'https://downloads.apache.org/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.zip',
           'C:\maven-bin.zip'
         )
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")


### PR DESCRIPTION
https://ci.appveyor.com/project/Checkstyle/checkstyle/builds/40209511/job/urk18dde17mp582b

```
Running Install scripts
Add-Type -AssemblyName System.IO.Compression.FileSystem
if (!(Test-Path -Path "C:\maven\apache-maven-3.2.5" )) {
  (new-object System.Net.WebClient).DownloadFile(
    'http://www.us.apache.org/dist/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.zip',
    'C:\maven-bin.zip'
  )
  [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
}
Exception calling "DownloadFile" with "2" argument(s): "The remote name could not be resolved: 'www.us.apache.org'"
At line:3 char:3
+   (new-object System.Net.WebClient).DownloadFile(
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : WebException
 

Exception calling "ExtractToDirectory" with "2" argument(s): "Could not find file 'C:\maven-bin.zip'."
At line:7 char:3
+   [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.z ...
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : FileNotFoundException
 
Command executed with exception: Exception calling "ExtractToDirectory" with "2" argument(s): "Could not find file 'C:\maven-bin.zip'."
```

url is taken from https://maven.apache.org/download.cgi