### PR TITLE
Issue #10513: Update maven to 3.8.1 and use ntp option in Appveyor

### DIFF
--- a/.ci/validation.cmd
+++ b/.ci/validation.cmd
@@ -9,20 +9,20 @@
 SET OPTION=%1
 
 if "%OPTION%" == "sevntu" (
-  call mvn -e verify -DskipTests -DskipITs -Dpmd.skip=true^
+  call mvn -e --no-transfer-progress verify -DskipTests -DskipITs -Dpmd.skip=true^
     -Dspotbugs.skip=true -Djacoco.skip=true -Dxml.skip=true^
     || goto :ERROR
   goto :END_CASE
 )
 
 if "%OPTION%" ==  "verify_without_checkstyle" (
-  call mvn -e verify -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true^
+  call mvn -e --no-transfer-progress verify -Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true^
     || goto :ERROR
   goto :END_CASE
 )
 
 if "%OPTION%" ==  "site_without_verify" (
-  call mvn -e -Pno-validations site^
+  call mvn -e --no-transfer-progress -Pno-validations site^
     || goto :ERROR
   goto :END_CASE
 )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,21 +11,21 @@ branches:
 install:
   - ps: |
       Add-Type -AssemblyName System.IO.Compression.FileSystem
-      if (!(Test-Path -Path "C:\maven\apache-maven-3.2.5" )) {
+      if (!(Test-Path -Path "C:\maven\apache-maven-3.8.1" )) {
         (new-object System.Net.WebClient).DownloadFile(
-          'https://downloads.apache.org/maven/maven-3/3.2.5/binaries/apache-maven-3.2.5-bin.zip',
+          'https://downloads.apache.org/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.zip',
           'C:\maven-bin.zip'
         )
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
       }
-  - cmd: SET M2_HOME=C:\maven\apache-maven-3.2.5
+  - cmd: SET M2_HOME=C:\maven\apache-maven-3.8.1
   - cmd: SET PATH=%M2_HOME%\bin;%JAVA_HOME%\bin;%PATH%
   - cmd: git config core.autocrlf
   - cmd: mvn --version
   - cmd: java -version
 
 cache:
-  - C:\maven\apache-maven-3.2.5
+  - C:\maven\apache-maven-3.8.1
   - C:\Users\appveyor\.m2
 
 matrix:
@@ -79,5 +79,5 @@ build_script:
         Write-Host "build is skipped ..."
       }
   - ps: echo "Size of caches (bytes):"
-  - ps: Get-ChildItem -Recurse 'C:\maven\apache-maven-3.2.5' | Measure-Object -Property Length -Sum
+  - ps: Get-ChildItem -Recurse 'C:\maven\apache-maven-3.8.1' | Measure-Object -Property Length -Sum
   - ps: Get-ChildItem -Recurse 'C:\Users\appveyor\.m2' | Measure-Object -Property Length -Sum


### PR DESCRIPTION
Resolves #10513 

We used to only see downloads when the cached content is not used as in the case of https://ci.appveyor.com/project/Checkstyle/checkstyle/builds/40209636/job/9gdq17n6xvaqy4n7. 

Now, we do not see the downloads as in https://ci.appveyor.com/project/AkMo3/checkstyle-appveyor/builds/40223247 in whatsoever case