### PR TITLE
infra: rename JavaAstVisitor pitest

### DIFF
--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -636,7 +636,7 @@ jobs:
           path: staging
           retention-days: 7
 
-  pitest9:
+  pitest-java-ast-visitor:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Noticed at https://github.com/checkstyle/checkstyle/pull/10574 :

![image](https://user-images.githubusercontent.com/31252532/129114663-9c42a194-ff6f-4145-953e-24c4c5897f0a.png)


pitest naming scheme should be consistent in github CI. 