### PR TITLE
minor: remove BeforeExecutionExclusionFileFilter

### DIFF
--- a/.ci/openjdk16-excluded.files
+++ b/.ci/openjdk16-excluded.files
@@ -54,11 +54,6 @@
   <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]lambda[\\/]speculative[\\/]NestedLambdaNoGenerics.java$"/>
 </module>
 
-<!-- until https://github.com/checkstyle/checkstyle/issues/10515 -->
-<module name="BeforeExecutionExclusionFileFilter">
-  <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]parser[\\/]SingleCommaAnnotationValue.java$"/>
-</module>
-
 <!-- until https://github.com/checkstyle/checkstyle/issues/9267 -->
 <module name="BeforeExecutionExclusionFileFilter">
   <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]DeepStringConcat.java$"/>


### PR DESCRIPTION
`BeforeExecutionExclusionFileFilter` got added back into #10603 upon rebase: https://github.com/checkstyle/checkstyle/pull/10603/files . This PR removes it.