### PR TITLE
Issue #10725: Add support for file path in Inline Config Parser

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
@@ -68,7 +68,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
         checkConfig.addProperty("file", getPath("InputImportControlOne.xml"));
         final String[] expected = {"13:1: " + getCheckMessage(MSG_DISALLOWED, "java.io.File")};
 
-        verify(checkConfig, getPath("InputImportControl.java"), expected);
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl.java"), expected);
     }
 
     @Test
@@ -81,7 +82,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
             "14:1: " + getCheckMessage(MSG_DISALLOWED, "java.awt.Button.ABORT"),
         };
 
-        verify(checkConfig, getPath("InputImportControl2.java"), expected);
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl2.java"), expected);
     }
 
     @Test
@@ -89,14 +91,16 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(ImportControlCheck.class);
         checkConfig.addProperty("file", getPath("InputImportControlWrong.xml"));
         final String[] expected = {"9:1: " + getCheckMessage(MSG_UNKNOWN_PKG)};
-        verify(checkConfig, getPath("InputImportControl3.java"), expected);
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl3.java"), expected);
     }
 
     @Test
     public void testMissing() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(ImportControlCheck.class);
         final String[] expected = {"9:1: " + getCheckMessage(MSG_MISSING_FILE)};
-        verify(checkConfig, getPath("InputImportControl4.java"), expected);
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl4.java"), expected);
     }
 
     @Test
@@ -104,7 +108,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(ImportControlCheck.class);
         checkConfig.addProperty("file", "   ");
         final String[] expected = {"9:1: " + getCheckMessage(MSG_MISSING_FILE)};
-        verify(checkConfig, getPath("InputImportControl5.java"), expected);
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl5.java"), expected);
     }
 
     @Test
@@ -112,7 +117,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(ImportControlCheck.class);
         checkConfig.addProperty("file", null);
         final String[] expected = {"9:1: " + getCheckMessage(MSG_MISSING_FILE)};
-        verify(checkConfig, getPath("InputImportControl6.java"), expected);
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl6.java"), expected);
     }
 
     @Test
@@ -121,7 +127,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
         checkConfig.addProperty("file", "unknown-file");
         try {
             final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-            verify(checkConfig, getPath("InputImportControl7.java"), expected);
+            verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl7.java"), expected);
             fail("Test should fail if exception was not thrown");
         }
         catch (CheckstyleException ex) {
@@ -157,7 +164,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
         checkConfig.addProperty("file", getPath("InputImportControlOneRegExp.xml"));
         final String[] expected = {"13:1: " + getCheckMessage(MSG_DISALLOWED, "java.io.File")};
 
-        verify(checkConfig, getPath("InputImportControl9.java"), expected);
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl9.java"), expected);
     }
 
     @Test
@@ -170,7 +178,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
             "14:1: " + getCheckMessage(MSG_DISALLOWED, "java.awt.Button.ABORT"),
         };
 
-        verify(checkConfig, getPath("InputImportControl10.java"), expected);
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl10.java"), expected);
     }
 
     @Test
@@ -178,7 +187,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(ImportControlCheck.class);
         checkConfig.addProperty("file", getPath("InputImportControlNotRegExpNoMatch.xml"));
 
-        verify(checkConfig, getPath("InputImportControl11.java"), CommonUtil.EMPTY_STRING_ARRAY);
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl11.java"), CommonUtil.EMPTY_STRING_ARRAY);
     }
 
     @Test
@@ -192,7 +202,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
             "15:1: " + getCheckMessage(MSG_DISALLOWED, "java.util.stream.IntStream"),
         };
 
-        verify(checkConfig, getPath("InputImportControl_Blacklist.java"), expected);
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl_Blacklist.java"), expected);
     }
 
     @Test
@@ -205,7 +216,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
             "14:1: " + getCheckMessage(MSG_DISALLOWED, "java.awt.Button.ABORT"),
         };
 
-        verify(checkConfig, getPath("InputImportControl12.java"), expected);
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl12.java"), expected);
     }
 
     @Test
@@ -217,7 +229,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
             "14:1: " + getCheckMessage(MSG_DISALLOWED, "java.awt.Button.ABORT"),
         };
 
-        verify(checkConfig, getPath("InputImportControl13.java"), expected);
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl13.java"), expected);
     }
 
     @Test
@@ -228,7 +241,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
             "11:1: " + getCheckMessage(MSG_DISALLOWED, "java.awt.Image"),
         };
 
-        verify(checkConfig, getPath("InputImportControl14.java"), expected);
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl14.java"), expected);
     }
 
     @Test
@@ -240,31 +254,38 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
             "12:1: " + getCheckMessage(MSG_DISALLOWED, "javax.swing.border.*"),
         };
 
-        verify(checkConfig, getPath("InputImportControl15.java"), expected);
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl15.java"), expected);
     }
 
     @Test
     public void testPkgRegExpInParent() throws Exception {
-        testRegExpInPackage("InputImportControlPkgRegExpInParent.xml");
+        final DefaultConfiguration checkConfig = createModuleConfig(ImportControlCheck.class);
+        checkConfig.addProperty("file", getPath("InputImportControlPkgRegExpInParent.xml"));
+        final String[] expected = {"13:1: " + getCheckMessage(MSG_DISALLOWED, "java.io.File")};
+
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl16.java"), expected);
     }
 
     @Test
     public void testPkgRegExpInChild() throws Exception {
-        testRegExpInPackage("InputImportControlPkgRegExpInChild.xml");
+        final DefaultConfiguration checkConfig = createModuleConfig(ImportControlCheck.class);
+        checkConfig.addProperty("file", getPath("InputImportControlPkgRegExpInChild.xml"));
+        final String[] expected = {"13:1: " + getCheckMessage(MSG_DISALLOWED, "java.io.File")};
+
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl162.java"), expected);
     }
 
     @Test
     public void testPkgRegExpInBoth() throws Exception {
-        testRegExpInPackage("InputImportControlPkgRegExpInBoth.xml");
-    }
-
-    // all import-control_pkg-re* files should be equivalent so use one test for all
-    private void testRegExpInPackage(String file) throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(ImportControlCheck.class);
-        checkConfig.addProperty("file", getPath(file));
+        checkConfig.addProperty("file", getPath("InputImportControlPkgRegExpInBoth.xml"));
         final String[] expected = {"13:1: " + getCheckMessage(MSG_DISALLOWED, "java.io.File")};
 
-        verify(checkConfig, getPath("InputImportControl16.java"), expected);
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl163.java"), expected);
     }
 
     @Test
@@ -287,7 +308,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
         checkConfig.addProperty("file", getResourcePath("InputImportControlOne.xml"));
         final String[] expected = {"13:1: " + getCheckMessage(MSG_DISALLOWED, "java.io.File")};
 
-        verify(checkConfig, getPath("InputImportControl17.java"), expected);
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl17.java"), expected);
     }
 
     @Test
@@ -315,7 +337,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
         checkConfig.addProperty("file", getUriString("InputImportControlOne.xml"));
         final String[] expected = {"13:1: " + getCheckMessage(MSG_DISALLOWED, "java.io.File")};
 
-        verify(checkConfig, getPath("InputImportControl19.java"), expected);
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl19.java"), expected);
     }
 
     @Test
@@ -325,7 +348,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
 
         try {
             final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-            verify(checkConfig, getPath("InputImportControl20.java"), expected);
+            verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl20.java"), expected);
             fail("Test should fail if exception was not thrown");
         }
         catch (CheckstyleException ex) {
@@ -369,7 +393,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
         checkConfig.addProperty("path", "^.*[\\\\/]src[\\\\/]test[\\\\/].*$");
         final String[] expected = {"13:1: " + getCheckMessage(MSG_DISALLOWED, "java.io.File")};
 
-        verify(checkConfig, getPath("InputImportControl21.java"), expected);
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl21.java"), expected);
     }
 
     @Test
@@ -379,7 +404,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
         checkConfig.addProperty("path", "[\\\\/]InputImportControl22\\.java");
         final String[] expected = {"13:1: " + getCheckMessage(MSG_DISALLOWED, "java.io.File")};
 
-        verify(checkConfig, getPath("InputImportControl22.java"), expected);
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl22.java"), expected);
     }
 
     @Test
@@ -389,7 +415,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
         checkConfig.addProperty("path", "^.*[\\\\/]src[\\\\/]main[\\\\/].*$");
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputImportControl23.java"), expected);
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl23.java"), expected);
     }
 
     @Test
@@ -399,7 +426,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
         checkConfig.addProperty("path", "[\\\\/]NoMatch\\.java");
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputImportControl24.java"), expected);
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControl24.java"), expected);
     }
 
     @Test
@@ -411,7 +439,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
             "12:1: " + getCheckMessage(MSG_DISALLOWED, "java.util.Date"),
         };
 
-        verify(checkConfig, getPath("InputImportControlDisallowClassOfAllowPackage.java"),
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControlDisallowClassOfAllowPackage.java"),
                 expected);
     }
 
@@ -423,7 +452,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
             "11:1: " + getCheckMessage(MSG_DISALLOWED, "java.awt.Image"),
         };
 
-        verify(checkConfig, getPath("InputImportControlFileName.java"), expected);
+        verifyWithInlineConfigParser(checkConfig,
+                getPath("InputImportControlFileName.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl10.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl10.java
@@ -1,6 +1,6 @@
 /*
 ImportControl
-file = InputImportControlTwoRegExp.xml
+file = (file)InputImportControlTwoRegExp.xml
 path = (default).*
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl11.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl11.java
@@ -1,6 +1,6 @@
 /*
 ImportControl
-file = InputImportControlNotRegExpNoMatch.xml
+file = (file)InputImportControlNotRegExpNoMatch.xml
 path = (default).*
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl12.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl12.java
@@ -1,6 +1,6 @@
 /*
 ImportControl
-file = InputImportControlStrategyOnMismatchOne.xml
+file = (file)InputImportControlStrategyOnMismatchOne.xml
 path = (default).*
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl13.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl13.java
@@ -1,6 +1,6 @@
 /*
 ImportControl
-file = InputImportControlStrategyOnMismatchTwo.xml
+file = (file)InputImportControlStrategyOnMismatchTwo.xml
 path = (default).*
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl14.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl14.java
@@ -1,6 +1,6 @@
 /*
 ImportControl
-file = InputImportControlStrategyOnMismatchThree.xml
+file = (file)InputImportControlStrategyOnMismatchThree.xml
 path = (default).*
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl15.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl15.java
@@ -1,6 +1,6 @@
 /*
 ImportControl
-file = InputImportControlStrategyOnMismatchFour.xml
+file = (file)InputImportControlStrategyOnMismatchFour.xml
 path = (default).*
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl16.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl16.java
@@ -1,6 +1,6 @@
 /*
 ImportControl
-file = (default)null
+file = (file)InputImportControlPkgRegExpInParent.xml
 path = (default).*
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl162.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl162.java
@@ -1,6 +1,6 @@
 /*
 ImportControl
-file = (file)InputImportControlOne.xml
+file = (file)InputImportControlPkgRegExpInChild.xml
 path = (default).*
 
 
@@ -13,7 +13,7 @@ import javax.swing.border.*;
 import java.io.File; // violation
 import static java.awt.Button.ABORT;
 
-public class InputImportControl
+public class InputImportControl162
 {
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl163.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl163.java
@@ -1,6 +1,6 @@
 /*
 ImportControl
-file = (file)InputImportControlOne.xml
+file = (file)InputImportControlPkgRegExpInBoth.xml
 path = (default).*
 
 
@@ -13,7 +13,7 @@ import javax.swing.border.*;
 import java.io.File; // violation
 import static java.awt.Button.ABORT;
 
-public class InputImportControl
+public class InputImportControl163
 {
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl17.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl17.java
@@ -1,6 +1,6 @@
 /*
 ImportControl
-file = InputImportControlOne.xml
+file = (file)(resource)InputImportControlOne.xml
 path = (default).*
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl19.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl19.java
@@ -1,6 +1,6 @@
 /*
 ImportControl
-file = InputImportControlOne.xml
+file = (file)(uri)InputImportControlOne.xml
 path = (default).*
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl2.java
@@ -1,6 +1,6 @@
 /*
 ImportControl
-file = InputImportControlTwo.xml
+file = (file)InputImportControlTwo.xml
 path = (default).*
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl21.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl21.java
@@ -1,7 +1,7 @@
 /*
 ImportControl
-file = InputImportControlOne.xml
-path = ^.*[\\/]src[\\/]test[\\/].*$
+file = (file)(resource)InputImportControlOne.xml
+path = ^.*[\\\\/]src[\\\\/]test[\\\\/].*$
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl22.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl22.java
@@ -1,7 +1,7 @@
 /*
 ImportControl
-file = InputImportControlOne.xml
-path = [\\/]InputImportControl22\.java
+file = (file)(resource)InputImportControlOne.xml
+path = [\\\\/]InputImportControl22\\.java
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl23.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl23.java
@@ -1,7 +1,7 @@
 /*
 ImportControl
-file = InputImportControlOne.xml
-path = ^.*[\\/]src[\\/]main[\\/].*$
+file = (file)(resource)InputImportControlOne.xml
+path = ^.*[\\\\/]src[\\\\/]main[\\\\/].*$
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl24.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl24.java
@@ -1,7 +1,7 @@
 /*
 ImportControl
-file = InputImportControlOne.xml
-path = [\\/]NoMatch\.java
+file = (file)(resource)InputImportControlOne.xml
+path = [\\\\/]NoMatch\\.java
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl3.java
@@ -1,6 +1,6 @@
 /*
 ImportControl
-file = InputImportControlWrong.xml
+file = (file)InputImportControlWrong.xml
 path = (default).*
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl4.java
@@ -1,6 +1,6 @@
 /*
 ImportControl
-file = (default)null
+file = (default)(null)
 path = (default).*
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl5.java
@@ -1,6 +1,6 @@
 /*
 ImportControl
-file =
+file = \u0020\u0020\u0020
 path = (default).*
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl6.java
@@ -1,6 +1,6 @@
 /*
 ImportControl
-file = (default)null
+file = (default)(null)
 path = (default).*
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl9.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl9.java
@@ -1,6 +1,6 @@
 /*
 ImportControl
-file = InputImportControlOneRegExp.xml
+file = (file)InputImportControlOneRegExp.xml
 path = (default).*
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControlDisallowClassOfAllowPackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControlDisallowClassOfAllowPackage.java
@@ -1,6 +1,6 @@
 /*
 ImportControl
-file = InputImportControlDisallowClassOfAllowPackage.xml
+file = (file)InputImportControlDisallowClassOfAllowPackage.xml
 path = (default).*
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControlFileName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControlFileName.java
@@ -1,6 +1,6 @@
 /*
 ImportControl
-file = InputImportControlFileName.xml
+file = (file)(resource)InputImportControlFileName.xml
 path = (default).*
 
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl_Blacklist.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControl_Blacklist.java
@@ -1,6 +1,6 @@
 /*
 ImportControl
-file = InputImportControlBlacklist.xml
+file = (file)InputImportControlBlacklist.xml
 path = (default).*
 
 


### PR DESCRIPTION
Resolves #10725 
Resolves #10671 

>Shashwat
Today at 6:45 AM
(file) gives C:\Users\checkstyle\ABCD.xml
(file)(resource) gives /com/puppycrawl/tools/...ABCD.xml

