### PR TITLE
Issue #10745: Added new TestInputConfiguration to hold child modules and violations

### DIFF
--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -22,7 +22,8 @@
     <properties>
       <!-- The PMD gives false positive for Builder patterns. Fixed in PMD 7. -->
       <property name="violationSuppressXPath"
-                value="//ClassOrInterfaceDeclaration[@SimpleName='ModuleInputConfiguration']"/>
+                value="//ClassOrInterfaceDeclaration
+                [@SimpleName='TestInputConfiguration' or @SimpleName='ModuleInputConfiguration']"/>
     </properties>
   </rule>
   <rule ref="category/java/bestpractices.xml/AvoidPrintStackTrace">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -45,6 +45,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.api.Violation;
 import com.puppycrawl.tools.checkstyle.bdd.InlineConfigParser;
 import com.puppycrawl.tools.checkstyle.bdd.ModuleInputConfiguration;
+import com.puppycrawl.tools.checkstyle.bdd.TestInputConfiguration;
 import com.puppycrawl.tools.checkstyle.bdd.TestInputViolation;
 import com.puppycrawl.tools.checkstyle.internal.utils.BriefUtLogger;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
@@ -221,20 +222,22 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
                                              String filePath, String[] expectedUnfiltered,
                                              String... expectedFiltered)
             throws Exception {
-        final ModuleInputConfiguration checkModuleInputConfiguration =
+        final TestInputConfiguration checkTestInputConfiguration =
                 InlineConfigParser.parseWithFilteredViolations(filePath);
-        final Configuration parsedCheckConfig = checkModuleInputConfiguration.createConfiguration();
-        verifyConfig(aConfig, parsedCheckConfig, checkModuleInputConfiguration);
-        verifyViolations(parsedCheckConfig, filePath, checkModuleInputConfiguration);
+        final Configuration parsedCheckConfig = checkTestInputConfiguration.createConfiguration();
+        verifyConfig(aConfig, parsedCheckConfig,
+                checkTestInputConfiguration.getChildrenModules().get(0));
+        verifyViolations(parsedCheckConfig, filePath, checkTestInputConfiguration);
         verify(parsedCheckConfig, filePath, expectedUnfiltered);
-        final ModuleInputConfiguration filterModuleInputConfiguration =
+        final TestInputConfiguration filterTestInputConfiguration =
                 InlineConfigParser.parseFilter(filePath);
         final Configuration parsedFilterConfig =
-                filterModuleInputConfiguration.createConfiguration();
-        verifyConfig(filterConfig, parsedFilterConfig, filterModuleInputConfiguration);
+                filterTestInputConfiguration.createConfiguration();
+        verifyConfig(filterConfig, parsedFilterConfig,
+                filterTestInputConfiguration.getChildrenModules().get(0));
         final DefaultConfiguration rootConfig = createRootConfig(parsedCheckConfig);
         rootConfig.addChild(parsedFilterConfig);
-        verifyViolations(rootConfig, filePath, filterModuleInputConfiguration);
+        verifyViolations(rootConfig, filePath, filterTestInputConfiguration);
         verify(rootConfig, filePath, expectedFiltered);
     }
 
@@ -251,11 +254,11 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
     protected final void verifyWithInlineConfigParser(Configuration aConfig,
                                              String filePath, String... expected)
             throws Exception {
-        final ModuleInputConfiguration moduleInputConfiguration =
+        final TestInputConfiguration testInputConfiguration =
                 InlineConfigParser.parse(filePath);
-        final Configuration parsedConfig = moduleInputConfiguration.createConfiguration();
-        verifyConfig(aConfig, parsedConfig, moduleInputConfiguration);
-        verifyViolations(parsedConfig, filePath, moduleInputConfiguration);
+        final Configuration parsedConfig = testInputConfiguration.createConfiguration();
+        verifyConfig(aConfig, parsedConfig, testInputConfiguration.getChildrenModules().get(0));
+        verifyViolations(parsedConfig, filePath, testInputConfiguration);
         verify(parsedConfig, filePath, expected);
     }
 
@@ -427,16 +430,16 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      *
      * @param config parsed config.
      * @param file file path.
-     * @param moduleInputConfiguration ModuleInputConfiguration object.
+     * @param testInputConfiguration TestInputConfiguration object.
      * @throws Exception if exception occurs during verification process.
      */
     private void verifyViolations(Configuration config,
                                   String file,
-                                  ModuleInputConfiguration moduleInputConfiguration)
+                                  TestInputConfiguration testInputConfiguration)
             throws Exception {
         final List<String> actualViolations = getActualViolationsForFile(config, file);
         final List<TestInputViolation> testInputViolations =
-                moduleInputConfiguration.getViolations();
+                testInputConfiguration.getViolations();
         assertWithMessage("Number of actual and expected violations differ.")
                 .that(actualViolations)
                 .hasSize(testInputViolations.size());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/ModuleInputConfiguration.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/ModuleInputConfiguration.java
@@ -19,10 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.bdd;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -41,19 +39,14 @@ public final class ModuleInputConfiguration {
     /** Map of module messages. */
     private final Map<String, String> moduleMessages;
 
-    /** List of parsed violations. */
-    private final List<TestInputViolation> violations;
-
     private ModuleInputConfiguration(String moduleName,
                                      Map<String, String> defaultProperties,
                                      Map<String, String> nonDefaultProperties,
-                                     Map<String, String> moduleMessages,
-                                     List<TestInputViolation> violations) {
+                                     Map<String, String> moduleMessages) {
         this.moduleName = moduleName;
         this.defaultProperties = defaultProperties;
         this.nonDefaultProperties = nonDefaultProperties;
         this.moduleMessages = moduleMessages;
-        this.violations = violations;
     }
 
     public String getModuleName() {
@@ -79,10 +72,6 @@ public final class ModuleInputConfiguration {
         return Collections.unmodifiableMap(moduleMessages);
     }
 
-    public List<TestInputViolation> getViolations() {
-        return Collections.unmodifiableList(violations);
-    }
-
     public DefaultConfiguration createConfiguration() {
         final DefaultConfiguration parsedConfig = new DefaultConfiguration(moduleName);
         nonDefaultProperties.forEach(parsedConfig::addProperty);
@@ -102,8 +91,6 @@ public final class ModuleInputConfiguration {
 
         private final Map<String, String> moduleMessages = new HashMap<>();
 
-        private final List<TestInputViolation> violations = new ArrayList<>();
-
         private String moduleName;
 
         public void setModuleName(String moduleName) {
@@ -122,17 +109,12 @@ public final class ModuleInputConfiguration {
             moduleMessages.put(messageKey, messageString);
         }
 
-        public void addViolation(int violationLine, String violationMessage) {
-            violations.add(new TestInputViolation(violationLine, violationMessage));
-        }
-
         public ModuleInputConfiguration build() {
             return new ModuleInputConfiguration(
                     moduleName,
                     defaultProperties,
                     nonDefaultProperties,
-                    moduleMessages,
-                    violations
+                    moduleMessages
             );
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputConfiguration.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputConfiguration.java
@@ -1,0 +1,73 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2021 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.bdd;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+
+public final class TestInputConfiguration {
+
+    private final List<ModuleInputConfiguration> childrenModules;
+
+    private final List<TestInputViolation> violations;
+
+    private TestInputConfiguration(List<ModuleInputConfiguration> childrenModules,
+                                   List<TestInputViolation> violations) {
+        this.childrenModules = childrenModules;
+        this.violations = violations;
+    }
+
+    public List<TestInputViolation> getViolations() {
+        return Collections.unmodifiableList(violations);
+    }
+
+    public List<ModuleInputConfiguration> getChildrenModules() {
+        return Collections.unmodifiableList(childrenModules);
+    }
+
+    public DefaultConfiguration createConfiguration() {
+        return childrenModules.get(0).createConfiguration();
+    }
+
+    public static final class Builder {
+
+        private final List<ModuleInputConfiguration> childrenModules = new ArrayList<>();
+
+        private final List<TestInputViolation> violations = new ArrayList<>();
+
+        public void addViolation(int violationLine, String violationMessage) {
+            violations.add(new TestInputViolation(violationLine, violationMessage));
+        }
+
+        public void addChildModule(ModuleInputConfiguration childModule) {
+            childrenModules.add(childModule);
+        }
+
+        public TestInputConfiguration build() {
+            return new TestInputConfiguration(
+                    childrenModules,
+                    violations
+            );
+        }
+    }
+}


### PR DESCRIPTION
#10745

This PR adds a new class TestInputConfiguration to hold list of child modules and list of violations. However, the functionality for multiple child modules will be implemented in next PRs.