### PR TITLE
Issue #10756: JavadocMetadataScraper now correctly identifies check name

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java
@@ -181,8 +181,9 @@ public class JavadocMetadataScraper extends AbstractJavadocCheck {
             final String filePath = getFileContents().getFileName();
             String moduleName = getModuleSimpleName();
             final String checkModuleExtension = "Check";
-            if (moduleName.contains(checkModuleExtension)) {
-                moduleName = moduleName.substring(0, moduleName.indexOf(checkModuleExtension));
+            if (moduleName.endsWith(checkModuleExtension)) {
+                moduleName = moduleName
+                        .substring(0, moduleName.length() - checkModuleExtension.length());
             }
             moduleDetails.setName(moduleName);
             moduleDetails.setFullQualifiedName(getPackageName(filePath));


### PR DESCRIPTION
Resolves #10756: JavadocMetadataScraper now correctly identifies check name