### PR TITLE
Add support for inline return tag in SummaryJavadoc

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/SummaryJavadocCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/SummaryJavadocCheck.xml
@@ -9,7 +9,9 @@
  &lt;a href="https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html#firstsentence"&gt;
  Javadoc summary sentence&lt;/a&gt; does not contain phrases that are not recommended to use.
  Summaries that contain only the {@code {@inheritDoc}} tag are skipped.
- Check also violate Javadoc that does not contain first sentence.
+ Summaries that contain a non-empty {@code {@return}} are allowed.
+ Check also violate Javadoc that does not contain first sentence, though with {@code {@return}} a
+ period is not required as the Javadoc tool adds it.
  &lt;/p&gt;</description>
          <properties>
             <property default-value="false"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
@@ -172,6 +172,28 @@ public class SummaryJavadocCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testInlineReturn() throws Exception {
+        final String[] expected = {
+            "74: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputSummaryJavadocInlineReturn.java"), expected);
+    }
+
+    @Test
+    public void testInlineReturnForbidden() throws Exception {
+        final String[] expected = {
+            "14: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
+            "21: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
+            "28: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputSummaryJavadocInlineReturnForbidden.java"), expected);
+    }
+
+    @Test
     public void testPeriodAtEnd() throws Exception {
         final String[] expected = {
             "19: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturn.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturn.java
@@ -1,0 +1,89 @@
+/*
+SummaryJavadoc
+violateExecutionOnNonTightHtml = (default)false
+forbiddenSummaryFragments = (default)^$
+period = (default).
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
+
+class InputSummaryJavadocInlineReturn {
+    /**
+     * {@return a zero, note that no period is ok as it is set by javadoc tool}
+     */
+    private int returnFoo1() // ok
+    {
+        return 0;
+    }
+
+    /**
+     * {@return a {@code 0}}
+     */
+    private int returnFoo2() // ok
+    {
+        return 0;
+    }
+
+    /**
+     * Text before the return tag. {@return a {@code 0}}
+     */
+    private int returnFoo3() // ok, javadoc tool produces a warning
+    {
+        return 0;
+    }
+
+    /**
+     * {@return a {@code 0}} Text after the return tag.
+     */
+    private int returnFoo4() // ok
+    {
+        return 0;
+    }
+
+    /**
+     * {@return a {@code 0}
+     * there's more text on another line
+     * and even more lines}
+     */
+    private int returnMultiline() // ok
+    {
+        return 0;
+    }
+
+    /**
+     * {@return a {@code 0}<br>
+     * there's more text on another line<br>
+     * and even more lines}
+     */
+    private int returnMultiline2() // ok
+    {
+        return 0;
+    }
+
+    /**
+     * {@return nothing, this is a void method}
+     */
+    private void voidMethod() // ok, javadoc tool produces an error
+    {
+    }
+
+    // the return tag is empty, which is not allowed
+    /**
+     // violation below
+     * {@return}
+     */
+    int returnNothing() {
+        return 0;
+    }
+
+    /**
+     * {@return nothing, this is a field}
+     */
+    private static final byte NOT_A_METHOD = 0; // ok, javadoc tool produces an error
+
+    /**
+     * {@return nothing, this is a class}
+     */
+    private class NotAMethod {} // ok, javadoc tool produces an error
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturnForbidden.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturnForbidden.java
@@ -1,0 +1,33 @@
+/*
+SummaryJavadoc
+violateExecutionOnNonTightHtml = (default)false
+forbiddenSummaryFragments = the .*|This method returns
+period = (default).
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
+
+public class InputSummaryJavadocInlineReturnForbidden {
+    /**
+     // violation below
+     * {@return the nothing}
+     */
+    int returnNothing() {
+        return 0;
+    }
+    /**
+     // violation below
+     * {@return This method returns something}
+     */
+    int returnSomething() {
+        return 0;
+    }
+    /**
+     // violation below
+     * {@return This method returns something.}
+     */
+    int returnSomethingElse() {
+        return 0;
+    }
+}

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -3619,8 +3619,10 @@ public int foobar() {
           Checks that
           <a href="https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html#firstsentence">
           Javadoc summary sentence</a> does not contain phrases that are not recommended to use.
-          Summaries that contain only the <code>{@inheritDoc}</code> tag are skipped. Check also
-          violate Javadoc that does not contain first sentence.
+          Summaries that contain only the <code>{@inheritDoc}</code> tag are skipped. Summaries
+          that contain a non-empty {@code {@return}} are allowed. Check also violate Javadoc that
+          does not contain first sentence, though with {@code {@return}} a period is not required
+          as the Javadoc tool adds it.
         </p>
       </subsection>
 


### PR DESCRIPTION
This fixes #10776.

Diff Regression config: https://gist.githubusercontent.com/octylFractal/4fd8d417bc3c14e0e2567f512e3769c2/raw/9fb50b87f3a6afc102e846a707693d91e08a2c8a/config.xml