### PR TITLE
Issue #10778: switch travis over to the partner queue solution

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -1024,6 +1024,7 @@ POJO
 Popup
 Postgresql
 powermock
+ppc
 Ppitest
 prebuilts
 printf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 version: ~> 1.0
-dist: xenial
+dist: focal
 os: linux
+# this arch is required as is for Partner Queue Solution - DO NOT MODIFY
+arch: s390x
+
 language: java
 
 cache:
@@ -13,6 +16,7 @@ addons:
       - xsltproc
       - xmlstarlet
       - ruby
+      - maven
 
 branches:
   only:


### PR DESCRIPTION
Issue #10778

This is only to switch travis over to the new solution to avoid credit usage. It is ok that travis still fails, I will very no credits are used.