### PR TITLE
config: remove old antrl reference from version plugin config

### DIFF
--- a/config/version-number-rules.xml
+++ b/config/version-number-rules.xml
@@ -16,12 +16,6 @@
         <ignoreVersion type="regex">.*-android</ignoreVersion>
       </ignoreVersions>
     </rule>
-    <rule groupId="antlr" artifactId="antlr">
-      <ignoreVersions>
-        <!-- this is really old version before versioning become semantic -->
-        <ignoreVersion type="regex">20030911</ignoreVersion>
-      </ignoreVersions>
-    </rule>
     <rule groupId="org.apache.maven.plugins" artifactId="maven-release-plugin">
       <ignoreVersions>
         <!-- we use 2.1 version that is defined at our parent


### PR DESCRIPTION
We migrated to antrl4