### PR TITLE
Issue #10781: temporary disable spotbugs version update

### DIFF
--- a/config/version-number-rules.xml
+++ b/config/version-number-rules.xml
@@ -28,7 +28,13 @@
     </rule>
     <rule groupId="org.itsallcode" artifactId="junit5-system-extensions">
       <ignoreVersions>
-        <!-- util https://github.com/checkstyle/checkstyle/issues/9146 -->
+        <!-- until https://github.com/checkstyle/checkstyle/issues/9146 -->
+        <ignoreVersion type="regex">.*</ignoreVersion>
+      </ignoreVersions>
+    </rule>
+    <rule groupId="com.github.spotbugs" artifactId="spotbugs-maven-plugin">
+      <ignoreVersions>
+        <!-- until https://github.com/spotbugs/spotbugs/issues/1601 -->
         <ignoreVersion type="regex">.*</ignoreVersion>
       </ignoreVersions>
     </rule>


### PR DESCRIPTION
Fixes #10781 

Spotbugs version 4.3.0  reports too many false positives about exposing internal state of a mutable object.

Untill https://github.com/spotbugs/spotbugs/issues/1601 is fixed, this dependency should be excluded from version checking.