### PR TITLE
minor: fix drone build by excluding archives from line length check

### DIFF
--- a/.ci/drone-io.sh
+++ b/.ci/drone-io.sh
@@ -6,9 +6,11 @@ source ./.ci/util.sh
 case $1 in
 
 restore-maven-cache)
-  curl -o cache.tar -SsL https://sourceforge.net/projects/checkstyle/files/drone-io/drone-io-m2-repository.tar/download
-  tar -xf cache.tar -C /
-  rm cache.tar
+  mkdir -p .ci-temp
+  curl -o .ci-temp/cache.tar -SsL \
+    https://sourceforge.net/projects/checkstyle/files/drone-io/drone-io-m2-repository.tar/download
+  tar -xf .ci-temp/cache.tar -C /
+  rm .ci-temp/cache.tar
   ;;
 
 *)


### PR DESCRIPTION
failed master build, looks like there is some issue with unpacking tar archive and checkstyle tried to run checks on tar archive. 
It makes no sense to check archives, so exclude them from processing
https://cloud.drone.io/checkstyle/checkstyle/5487/1/3

>`	[ERROR] [checkstyle] [ERROR] /drone/src/cache.tar:18: Line should not be longer than 100 symbols [lineLength]`