### PR TITLE
Issue #10798: Extend RedundantModifierCheck with STRICTFP token for Java 17

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/modifier/RedundantModifierCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/modifier/RedundantModifierCheck.xml
@@ -29,6 +29,10 @@
  &lt;li&gt;
  Nested {@code enum} definitions that are declared as {@code static}.
  &lt;/li&gt;
+ &lt;li&gt;
+ All {@code strictfp} modifiers are reported as violation when {@code TokenTypes.STRICTFP}
+ is included in configurations.
+ &lt;/li&gt;
  &lt;/ol&gt;
  &lt;p&gt;
  Interfaces by definition are abstract so the {@code abstract}
@@ -106,7 +110,14 @@
  public class ClassExtending extends ClassExample {
    ProtectedInnerClass pc = new ProtectedInnerClass();
  }
- &lt;/pre&gt;</description>
+ &lt;/pre&gt;
+ &lt;p&gt;
+ Starting from Java 17, all floating point operations remain consistently strict,
+ see &lt;a href="https://openjdk.java.net/jeps/306"&gt;JEP 306&lt;/a&gt;. Hence,
+ &lt;a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STRICTFP"&gt;
+ STRICTFP&lt;/a&gt; as been added to the list of acceptable tokens, and when added into the
+ check configuration, it shows all {@code strictfp} tokens as violations.
+ &lt;/p&gt;</description>
          <properties>
             <property default-value="METHOD_DEF,VARIABLE_DEF,ANNOTATION_FIELD_DEF,INTERFACE_DEF,CTOR_DEF,CLASS_DEF,ENUM_DEF,RESOURCE"
                       name="tokens"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheckTest.java
@@ -149,6 +149,7 @@ public class RedundantModifierCheckTest
             TokenTypes.CLASS_DEF,
             TokenTypes.ENUM_DEF,
             TokenTypes.RESOURCE,
+            TokenTypes.STRICTFP,
         };
         assertArrayEquals(expected, actual, "Invalid acceptable tokens");
     }
@@ -273,4 +274,26 @@ public class RedundantModifierCheckTest
         verifyWithInlineConfigParser(getPath(
                 "InputRedundantModifierNestedDef.java"), expected);
     }
+
+    @Test
+    public void testStrictFpAsRedundant() throws Exception {
+        final String[] expected = {
+            "12:12: " + getCheckMessage(MSG_KEY, "strictfp"),
+            "14:5: " + getCheckMessage(MSG_KEY, "strictfp"),
+            "16:5: " + getCheckMessage(MSG_KEY, "strictfp"),
+            "18:5: " + getCheckMessage(MSG_KEY, "strictfp"),
+            "20:14: " + getCheckMessage(MSG_KEY, "strictfp"),
+            "22:5: " + getCheckMessage(MSG_KEY, "abstract"),
+            "22:14: " + getCheckMessage(MSG_KEY, "strictfp"),
+            "23:9: " + getCheckMessage(MSG_KEY, "public"),
+            "23:16: " + getCheckMessage(MSG_KEY, "static"),
+            "23:23: " + getCheckMessage(MSG_KEY, "strictfp"),
+            "27:9: " + getCheckMessage(MSG_KEY, "final"),
+            "27:15: " + getCheckMessage(MSG_KEY, "strictfp"),
+        };
+
+        verifyWithInlineConfigParser(getNonCompilablePath(
+                "InputRedundantModifierWithStrictfpAsRedundant.java"), expected);
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -185,6 +185,9 @@ public class AllChecksTest extends AbstractModuleTestSupport {
                 "ELLIPSIS",
                 // these are covered by GenericWhitespaceCheck
                 "WILDCARD_TYPE", "GENERIC_END", "GENERIC_START").collect(Collectors.toSet()));
+        CHECKSTYLE_TOKENS_IN_CONFIG_TO_IGNORE.put("RedundantModifier", Stream.of(
+                // required only for java 17 and above
+                "STRICTFP").collect(Collectors.toSet()));
 
         // google
         GOOGLE_TOKENS_IN_CONFIG_TO_IGNORE.put("AnnotationLocation", Stream.of(

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierWithStrictfpAsRedundant.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierWithStrictfpAsRedundant.java
@@ -1,0 +1,29 @@
+/*
+RedundantModifier
+tokens = STRICTFP, METHOD_DEF, INTERFACE_DEF, ENUM_DEF,
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.modifier.redundantmodifier;
+
+//non-compiled with javac: Compilable with Java14
+public class InputRedundantModifierWithStrictfpAsRedundant {
+    public strictfp class Test {} // violation
+
+    strictfp interface MyInterface {} // violation
+
+    strictfp enum MyEnum {} // violation
+
+    strictfp record MyRecord() {} // violation
+
+    abstract strictfp class MyClass {} // violation
+
+    abstract strictfp interface MyStrictFPInterface { // 2 violations
+        public static strictfp enum MyInnerEnum {} // 3 violations
+    }
+
+    final class OtherClass {
+        final strictfp void m1() {} // 2 violations
+    }
+}

--- a/src/xdocs/config_modifier.xml
+++ b/src/xdocs/config_modifier.xml
@@ -556,6 +556,10 @@ public interface RoadFeature {
             Nested <code>enum</code> definitions that are declared
             as <code>static</code>.
           </li>
+          <li>
+            All <code>strictfp</code> modifiers are reported as violation when
+            <code>STRICTFP</code> token is included in configurations.
+          </li>
         </ol>
 
         <p>
@@ -656,6 +660,20 @@ public class ClassExtending extends ClassExample {
   ProtectedInnerClass pc = new ProtectedInnerClass();
 }
         </source>
+        <p>
+          Starting from Java 17, all floating point operations remain consistently strict,
+          see <a href="https://openjdk.java.net/jeps/306">JEP 306</a>. Hence,
+          <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STRICTFP">
+          STRICTFP</a> as been added to the list of acceptable tokens, and when added into the
+          check configuration, it shows all <code>strictfp</code> tokens as violations.
+        </p>
+        <source>
+public class ExampleClass {
+    abstract strictfp class MyClass {} // violation
+    strictfp interface MyInterface {} // violation
+    strictfp enum MyEnum {} // violation
+}
+        </source>
       </subsection>
 
       <subsection name="Properties" id="RedundantModifier_Properties">
@@ -689,6 +707,8 @@ public class ClassExtending extends ClassExample {
                   ENUM_DEF</a>
                 , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#RESOURCE">
                   RESOURCE</a>
+                , <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#STRICTFP">
+                  STRICTFP</a>
                 .
               </td>
               <td>


### PR DESCRIPTION
Resolves : #10798 

```java
$ cat Test.java                                                    
class Test {
    strictfp void method(){} // violation
}
$ javac Test.java                 
$ cat config.xml                                                 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">

<module name="Checker">
    <property name="charset" value="UTF-8"/>
    <property name="severity" value="error"/>

    <module name="TreeWalker">
        <module name="RedundantModifier">
         <property name="tokens" value="STRICTFP"/>
         <property name="strictfpRedundant" value="true"/>
    </module>

    </module>
</module>
$ java -jar checkstyle-9.1-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /home/akmo/GitHub/Test/strictfp/Test.java:2:5: Redundant 'strictfp' modifier. [RedundantModifier]
Audit done.
Checkstyle ends with 1 errors.
```

Diff Regression config: https://raw.githubusercontent.com/AkMo3/akmo3.github.io/master/strictfp/baseConfig.xml
Diff Regression patch config: https://raw.githubusercontent.com/AkMo3/akmo3.github.io/master/strictfp/config.xml