### PR TITLE
infra: update xwiki commit

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -201,7 +201,7 @@ no-error-xwiki)
   cd ..
   checkout_from https://github.com/xwiki/xwiki-platform.git
   cd .ci-temp/xwiki-platform
-  git checkout "f2a1b708329901""22f79f2fb372e0882d20b66b12"
+  git checkout "ec4cee44da""f56a76915f7445486f""bb502a""da791f"
   # Validate xwiki-platform
   mvn -e --no-transfer-progress checkstyle:check@default -Dcheckstyle.version=${CS_POM_VERSION}
   cd ..


### PR DESCRIPTION
Fixes failing `no-error-xwiki` CI item, noticed at https://app.circleci.com/pipelines/github/checkstyle/checkstyle/8952/workflows/87d98f45-0a8d-4f75-8343-b2d0d24caf1c/jobs/100876