### PR TITLE
Issue #10815: make build fail on javadoc warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -445,8 +445,15 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.3.1</version>
           <configuration>
+            <!-- Exclude generated sources. -->
+            <excludePackageNames>
+              com.puppycrawl.tools.checkstyle.grammar.java:
+              com.puppycrawl.tools.checkstyle.grammar.javadoc:
+            </excludePackageNames>
             <source>${java.version}</source>
+            <show>package</show>
             <failOnError>true</failOnError>
+            <failOnWarnings>true</failOnWarnings>
             <linksource>true</linksource>
             <tags>
               <tag>


### PR DESCRIPTION
Issue #10815 

Turn on `failOnWarnings` and exclude all generated code.