### PR TITLE
Issue #10817: Fix IllegalTypeCheck on Record with configured member modifiers

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -497,9 +497,11 @@ public final class IllegalTypeCheck extends AbstractCheck {
     private boolean isVerifiable(DetailAST methodOrVariableDef) {
         boolean result = true;
         if (!memberModifiers.isEmpty()) {
-            final DetailAST modifiersAst = methodOrVariableDef
-                    .findFirstToken(TokenTypes.MODIFIERS);
-            result = isContainVerifiableType(modifiersAst);
+            if (methodOrVariableDef.getType() != TokenTypes.RECORD_COMPONENT_DEF) {
+                final DetailAST modifiersAst = methodOrVariableDef
+                        .findFirstToken(TokenTypes.MODIFIERS);
+                result = isContainVerifiableType(modifiersAst);
+            }
         }
         return result;
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheckTest.java
@@ -62,6 +62,15 @@ public class IllegalTypeCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testValidateRecordsWithConfiguredMemberModifiersPass() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputIllegalTypeRecordsAndMemberModifiersSpecified.java"),
+                expected);
+    }
+
+    @Test
     public void testDefaults() throws Exception {
         final String[] expected = {
             "34:13: " + getCheckMessage(MSG_KEY, "java.util.TreeSet"),

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeRecordsAndMemberModifiersSpecified.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/illegaltype/InputIllegalTypeRecordsAndMemberModifiersSpecified.java
@@ -1,0 +1,30 @@
+/*
+IllegalType
+validateAbstractClassNames = (default)false
+illegalClassNames = (default)HashMap, HashSet, LinkedHashMap, LinkedHashSet, TreeMap, TreeSet, \
+                    java.util.HashMap, java.util.HashSet, java.util.LinkedHashMap, \
+                    java.util.LinkedHashSet, java.util.TreeMap, java.util.TreeSet
+legalAbstractClassNames = (default)
+ignoredMethodNames = (default)getEnvironment, getInitialContext
+illegalAbstractClassNameFormat = (default)^(.*[.])?Abstract.*$
+memberModifiers = LITERAL_PUBLIC, LITERAL_PROTECTED, LITERAL_STATIC
+tokens = (default)ANNOTATION_FIELD_DEF, CLASS_DEF, INTERFACE_DEF, METHOD_CALL, METHOD_DEF, \
+         METHOD_REF, PARAMETER_DEF, VARIABLE_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF, \
+         RECORD_COMPONENT_DEF
+
+
+*/
+
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.coding.illegaltype;
+
+import java.lang.String; // ok
+import java.util.UUID; // ok
+
+public record InputIllegalTypeRecordsAndMemberModifiersSpecified( // ok
+    UUID productId, // ok
+    @Nullable String identifier // ok
+) // ok
+{ // ok
+
+} // ok


### PR DESCRIPTION
Fixes #10817

I'm not sure if this is the best way to fix it, but since record members visibility cannot be changed, it should either always accept, or behave as if it was public (since it will be exposed with the accessor methods) 