### PR TITLE
minor: restructures message testing to clarify messages come from

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -528,14 +528,17 @@ public class AllChecksTest extends AbstractModuleTestSupport {
     public void testAllCheckstyleChecksHaveMessage() throws Exception {
         for (Class<?> module : CheckUtil.getCheckstyleChecks()) {
             final String name = module.getSimpleName();
+            final Set<Field> messages = CheckUtil.getCheckMessages(module, false);
 
             // No messages in just module
-            if ("SuppressWarningsHolder".equals(name)) {
-                continue;
+            if ("SuppressWarningsHolder".equals(name) || "JavadocMetadataScraper".equals(name)) {
+                assertTrue(messages.isEmpty(),
+                        name + " should not have any 'MSG_*' fields for error messages");
             }
-
-            assertFalse(CheckUtil.getCheckMessages(module).isEmpty(),
-                    name + " should have at least one 'MSG_*' field for error messages");
+            else {
+                assertFalse(messages.isEmpty(),
+                        name + " should have at least one 'MSG_*' field for error messages");
+            }
         }
     }
 
@@ -545,7 +548,7 @@ public class AllChecksTest extends AbstractModuleTestSupport {
 
         // test validity of messages from modules
         for (Class<?> module : CheckUtil.getCheckstyleModules()) {
-            for (Field message : CheckUtil.getCheckMessages(module)) {
+            for (Field message : CheckUtil.getCheckMessages(module, true)) {
                 assertEquals(Modifier.PUBLIC | Modifier.STATIC | Modifier.FINAL,
                         message.getModifiers(),
                         module.getSimpleName() + "." + message.getName()

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -1374,7 +1374,7 @@ public class XdocsPagesTest {
                                                  Node subSection,
                                                  Object instance) throws Exception {
         final Class<?> clss = instance.getClass();
-        final Set<Field> fields = CheckUtil.getCheckMessages(clss);
+        final Set<Field> fields = CheckUtil.getCheckMessages(clss, true);
         final Set<String> list = new TreeSet<>();
 
         for (Field field : fields) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CheckUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CheckUtil.java
@@ -41,9 +41,13 @@ import org.w3c.dom.NodeList;
 
 import com.google.common.reflect.ClassPath;
 import com.puppycrawl.tools.checkstyle.api.FileText;
+import com.puppycrawl.tools.checkstyle.checks.coding.AbstractSuperCheck;
+import com.puppycrawl.tools.checkstyle.checks.naming.AbstractAccessControlNameCheck;
+import com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.regexp.RegexpMultilineCheck;
 import com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck;
 import com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck;
+import com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 import com.puppycrawl.tools.checkstyle.utils.ModuleReflectionUtil;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
@@ -198,10 +202,13 @@ public final class CheckUtil {
      * Get's the check's messages.
      *
      * @param module class to examine.
+     * @param deepScan scan subclasses.
      * @return a set of checkstyle's module message fields.
      * @throws ClassNotFoundException if the attempt to read a protected class fails.
+     * @noinspection BooleanParameter Test code for easy usage.
      */
-    public static Set<Field> getCheckMessages(Class<?> module) throws ClassNotFoundException {
+    public static Set<Field> getCheckMessages(Class<?> module, boolean deepScan)
+            throws ClassNotFoundException {
         final Set<Field> checkstyleMessages = new HashSet<>();
 
         // get all fields from current class
@@ -216,22 +223,37 @@ public final class CheckUtil {
         // deep scan class through hierarchy
         final Class<?> superModule = module.getSuperclass();
 
-        if (superModule != null) {
-            checkstyleMessages.addAll(getCheckMessages(superModule));
+        if (superModule != null && (deepScan || shouldScanDeepClassForMessages(superModule))) {
+            checkstyleMessages.addAll(getCheckMessages(superModule, deepScan));
         }
 
         // special cases that require additional classes
         if (module == RegexpMultilineCheck.class) {
             checkstyleMessages.addAll(getCheckMessages(Class
-                    .forName("com.puppycrawl.tools.checkstyle.checks.regexp.MultilineDetector")));
+                    .forName("com.puppycrawl.tools.checkstyle.checks.regexp.MultilineDetector"),
+                    deepScan));
         }
         else if (module == RegexpSinglelineCheck.class
                 || module == RegexpSinglelineJavaCheck.class) {
             checkstyleMessages.addAll(getCheckMessages(Class
-                    .forName("com.puppycrawl.tools.checkstyle.checks.regexp.SinglelineDetector")));
+                    .forName("com.puppycrawl.tools.checkstyle.checks.regexp.SinglelineDetector"),
+                    deepScan));
         }
 
         return checkstyleMessages;
+    }
+
+    /**
+     * Should the class be deep scanned for messages.
+     *
+     * @param superModule The class to examine.
+     * @return {@code true} if the class should be deep scanned.
+     */
+    private static boolean shouldScanDeepClassForMessages(Class<?> superModule) {
+        return superModule == AbstractNameCheck.class
+                || superModule == AbstractAccessControlNameCheck.class
+                || superModule == AbstractParenPadCheck.class
+                || superModule == AbstractSuperCheck.class;
     }
 
     /**


### PR DESCRIPTION
Identified at https://github.com/checkstyle/checkstyle/pull/10805 where it was noticed the class had no messages, but the test wasn't failing or documenting it.

Slightly redid the tests and util method to clarify when to scan super classes and when not to. Originally, the test was thinking `JavadocMetadataScraper` had messages from `AbstractJavadocCheck` which shouldn't be considered since those are parsing messages and not related to the check. The point of the test is to ensure all checks are logging some message and we are identifying it.