### PR TITLE
Issue #10744: use annotation to specify the property type

### DIFF
--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -127,6 +127,8 @@
     <allow class="java.nio.file.NoSuchFileException" local-only="true"/>
     <allow class="com.puppycrawl.tools.checkstyle.Definitions" local-only="true"/>
 
+    <allow class="com.puppycrawl.tools.checkstyle.XdocsPropertyType"/>
+    <allow class="com.puppycrawl.tools.checkstyle.PropertyType"/>
     <allow class="com.puppycrawl.tools.checkstyle.StatelessCheck"/>
     <allow class="com.puppycrawl.tools.checkstyle.FileStatefulCheck"/>
     <allow class="com.puppycrawl.tools.checkstyle.GlobalStatefulCheck"/>
@@ -166,6 +168,8 @@
     <allow class="com.puppycrawl.tools.checkstyle.TreeWalkerAuditEvent" local-only="true"/>
     <allow class="com.puppycrawl.tools.checkstyle.TreeWalkerFilter" local-only="true"/>
     <allow class="com.puppycrawl.tools.checkstyle.XmlLoader" local-only="true"/>
+    <allow class="com.puppycrawl.tools.checkstyle.XdocsPropertyType" local-only="true"/>
+    <allow class="com.puppycrawl.tools.checkstyle.PropertyType" local-only="true"/>
     <allow pkg="com.puppycrawl.tools.checkstyle.utils"/>
     <allow pkg="com.puppycrawl.tools.checkstyle.xpath"/>
     <allow class="java.nio.charset.StandardCharsets" local-only="true"/>

--- a/config/pmd-test.xml
+++ b/config/pmd-test.xml
@@ -69,16 +69,12 @@
            GeneratedJavadocTokenTypesTest#testTokenNumbers.
            JavadocTokenTypesTest.TokenValues contains several asserts as it checks each
              token explicitly.
-           XdocsPagesTest.getModulePropertyExpectedTypeName is a complicated list of
-             different checks.
            IndentationCheckTest has a lot of cases. -->
       <property name="violationSuppressXPath"
               value="//ClassOrInterfaceDeclaration[@SimpleName='JavadocTokenTypesTest']
                        //MethodDeclaration[@Name='testTokenValues']
                    | //ClassOrInterfaceDeclaration[@SimpleName='GeneratedJavaTokenTypesTest']
                        //MethodDeclaration[@Name='testTokenNumbering']
-                   | //ClassOrInterfaceDeclaration[@SimpleName='XdocsPagesTest']
-                       //MethodDeclaration[@Name='getModulePropertyExpectedTypeName']
                    | //ClassOrInterfaceDeclaration[@SimpleName='GeneratedJavadocTokenTypesTest']
                        //MethodDeclaration[@Name='testTokenNumbers']
                    | //ClassOrInterfaceDeclaration[@SimpleName='IndentationCheckTest']"/>
@@ -92,8 +88,6 @@
            ParenPadCheckTest.testNospaceWithComplexInput is intended to keep all in one method.
            JavadocTokenTypesTest.TokenValues contains several asserts as it checks each
              token explicitly.
-           XdocsPagesTest.getModulePropertyExpectedTypeName is a complicated list of
-             different checks.
           MainTest.testGenerateXpathSuppressionOptionOne requires a very long 'expected' string
       -->
       <property name="violationSuppressXPath"
@@ -105,8 +99,6 @@
                         //MethodDeclaration[@Name='testMethodParen']
                     | //ClassOrInterfaceDeclaration[@SimpleName='JavadocTokenTypesTest']
                         //MethodDeclaration[@Name='testTokenValues']
-                    | //ClassOrInterfaceDeclaration[@SimpleName='XdocsPagesTest']
-                        //MethodDeclaration[@Name='getModulePropertyExpectedTypeName']
                     | //ClassOrInterfaceDeclaration[@SimpleName='GeneratedJavadocTokenTypesTest']
                         //MethodDeclaration[@Name='testTokenNumbers']
                     | //ClassOrInterfaceDeclaration[@SimpleName='MainTest']

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -77,6 +77,7 @@
   <suppress checks="ClassFanOutComplexity" files="[\\/]Main\.java"/>
   <suppress checks="ClassFanOutComplexity" files="CheckerTest\.java"/>
   <suppress checks="ClassFanOutComplexity" files="Checker\.java"/>
+  <suppress checks="ClassFanOutComplexity" files="XdocsPagesTest\.java"/>
   <!-- a lot of GUI elements is OK -->
   <suppress checks="ClassDataAbstractionCoupling" files="(TreeTable|MainFrame)\.java"/>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2898,6 +2898,8 @@
                 <param>com.puppycrawl.tools.checkstyle.grammar.CrAwareLexerSimulator</param>
                 <!-- interfaces -->
                 <param>com.puppycrawl.tools.checkstyle.AuditEventFormatter</param>
+                <param>com.puppycrawl.tools.checkstyle.XdocsPropertyType</param>
+                <param>com.puppycrawl.tools.checkstyle.PropertyType</param>
                 <param>com.puppycrawl.tools.checkstyle.FileStatefulCheck</param>
                 <param>com.puppycrawl.tools.checkstyle.ModuleFactory</param>
                 <param>com.puppycrawl.tools.checkstyle.PropertyResolver</param>
@@ -2908,6 +2910,7 @@
               </targetClasses>
               <targetTests>
                 <param>com.puppycrawl.tools.checkstyle.AuditEventDefaultFormatterTest</param>
+                <param>com.puppycrawl.tools.checkstyle.XdocsPropertyTypeTest</param>
                 <param>com.puppycrawl.tools.checkstyle.ConfigurationLoaderTest</param>
                 <param>com.puppycrawl.tools.checkstyle.DefaultConfigurationTest</param>
                 <param>com.puppycrawl.tools.checkstyle.DefaultLoggerTest</param>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -90,8 +90,10 @@ public class Checker extends AutomaticBean implements MessageDispatcher, RootMod
     private String basedir;
 
     /** Locale country to report messages . **/
+    @XdocsPropertyType(PropertyType.LOCALE_COUNTRY)
     private String localeCountry = Locale.getDefault().getCountry();
     /** Locale language to report messages . **/
+    @XdocsPropertyType(PropertyType.LOCALE_LANGUAGE)
     private String localeLanguage = Locale.getDefault().getLanguage();
 
     /** The factory for instantiating submodules. */
@@ -122,6 +124,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher, RootMod
     private String charset = StandardCharsets.UTF_8.name();
 
     /** Cache file. **/
+    @XdocsPropertyType(PropertyType.FILE)
     private PropertyCacheFile cacheFile;
 
     /** Controls whether exceptions should halt execution or not. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PropertyType.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PropertyType.java
@@ -1,0 +1,66 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2021 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+/**
+ * Represents the custom property type used in documentation and configuration files.
+ */
+public enum PropertyType {
+
+    /** This property is a file. */
+    FILE("File"),
+
+    /** This property is a string represents an ISO 3166 2-letter code. */
+    LOCALE_COUNTRY("String (either the empty string or an uppercase ISO 3166 2-letter code)"),
+
+    /** This property is a string represents an ISO 639 code. */
+    LOCALE_LANGUAGE("String (either the empty string or a lowercase ISO 639 code)"),
+
+    /** This property is a regular expression pattern. */
+    PATTERN("Pattern"),
+
+    /** This property is a string. */
+    STRING("String"),
+
+    /** This property is a set of tokens. */
+    TOKEN_ARRAY("subset of tokens TokenTypes");
+
+    /** The human-readable property description. */
+    private final String description;
+
+    /**
+     * Creates a new {@code PropertyType} instance.
+     *
+     * @param description the human-readable property description
+     */
+    PropertyType(String description) {
+        this.description = description;
+    }
+
+    /**
+     * Returns the human-readable property description.
+     *
+     * @return human-readable property description
+     */
+    public String getDescription() {
+        return description;
+    }
+
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/XdocsPropertyType.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XdocsPropertyType.java
@@ -1,0 +1,45 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2021 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The type of property used in documentation and configuration files
+ * for clarification of the user friendly type.
+ * For example, some string array property may represent a set of tokens.
+ *
+ * @noinspection AnnotationClass
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface XdocsPropertyType {
+
+    /**
+     * Returns the property type for documentation.
+     *
+     * @return the property type for documentation
+     */
+    PropertyType value();
+
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java
@@ -22,6 +22,8 @@ package com.puppycrawl.tools.checkstyle.checks;
 import java.util.Arrays;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.PropertyType;
+import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
@@ -344,6 +346,7 @@ public class DescendantTokenCheck extends AbstractCheck {
      */
     private boolean sumTokenCounts;
     /** Specify set of tokens with limited occurrences as descendants. */
+    @XdocsPropertyType(PropertyType.TOKEN_ARRAY)
     private int[] limitedTokens = CommonUtil.EMPTY_INT_ARRAY;
     /** Define the violation message when the minimum count is not reached. */
     private String minimumMessage;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -28,6 +28,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.PropertyType;
+import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -382,6 +384,7 @@ public final class IllegalTypeCheck extends AbstractCheck {
      * Control whether to check only methods and fields with any of the specified modifiers.
      * This property does not affect method calls nor method references nor record components.
      */
+    @XdocsPropertyType(PropertyType.TOKEN_ARRAY)
     private List<Integer> memberModifiers = Collections.emptyList();
 
     /** Specify RegExp for illegal abstract class names. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
@@ -21,7 +21,9 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.util.Arrays;
 
+import com.puppycrawl.tools.checkstyle.PropertyType;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
+import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -291,6 +293,7 @@ public class MagicNumberCheck extends AbstractCheck {
      * Specify tokens that are allowed in the AST path from the
      * number literal to the enclosing constant definition.
      */
+    @XdocsPropertyType(PropertyType.TOKEN_ARRAY)
     private int[] constantWaiverParentToken = {
         TokenTypes.ASSIGN,
         TokenTypes.ARRAY_INIT,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.PropertyType;
+import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -137,6 +139,7 @@ public class MultipleStringLiteralsCheck extends AbstractCheck {
      * don't match ignoredStringsRegexp. This allows you to exclude syntactical
      * contexts like annotations or static initializers from the check.
      */
+    @XdocsPropertyType(PropertyType.TOKEN_ARRAY)
     private final BitSet ignoreOccurrenceContext = new BitSet();
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
@@ -35,6 +35,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import com.puppycrawl.tools.checkstyle.PropertyType;
+import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.ExternalResourceHolder;
@@ -57,6 +59,7 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck
     private URI headerFile;
 
     /** Specify the character encoding to use when reading the headerFile. */
+    @XdocsPropertyType(PropertyType.STRING)
     private Charset charset = createCharset(System.getProperty("file.encoding",
         StandardCharsets.UTF_8.name()));
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
@@ -23,7 +23,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import com.puppycrawl.tools.checkstyle.PropertyType;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
+import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
@@ -170,6 +172,7 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck {
     /**
      * Specify the list of block tags targeted.
      */
+    @XdocsPropertyType(PropertyType.TOKEN_ARRAY)
     private List<Integer> target = Arrays.asList(
         TokenTypes.CLASS_DEF,
         TokenTypes.INTERFACE_DEF,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheck.java
@@ -22,7 +22,9 @@ package com.puppycrawl.tools.checkstyle.checks.regexp;
 import java.io.File;
 import java.util.regex.Pattern;
 
+import com.puppycrawl.tools.checkstyle.PropertyType;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
+import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 
@@ -250,6 +252,7 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
 public class RegexpMultilineCheck extends AbstractFileSetCheck {
 
     /** Specify the format of the regular expression to match. */
+    @XdocsPropertyType(PropertyType.PATTERN)
     private String format = "$.";
     /**
      * Specify the message which is used to notify about violations,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheck.java
@@ -21,7 +21,9 @@ package com.puppycrawl.tools.checkstyle.checks.regexp;
 
 import java.io.File;
 
+import com.puppycrawl.tools.checkstyle.PropertyType;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
+import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 
@@ -195,6 +197,7 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
 public class RegexpSinglelineCheck extends AbstractFileSetCheck {
 
     /** Specify the format of the regular expression to match. */
+    @XdocsPropertyType(PropertyType.PATTERN)
     private String format = "$.";
     /**
      * Specify the message which is used to notify about violations,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheck.java
@@ -19,7 +19,9 @@
 
 package com.puppycrawl.tools.checkstyle.checks.regexp;
 
+import com.puppycrawl.tools.checkstyle.PropertyType;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
+import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
@@ -210,6 +212,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 public class RegexpSinglelineJavaCheck extends AbstractCheck {
 
     /** Specify the format of the regular expression to match. */
+    @XdocsPropertyType(PropertyType.PATTERN)
     private String format = "$.";
     /**
      * Specify the message which is used to notify about violations,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -28,8 +28,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import com.puppycrawl.tools.checkstyle.PropertyType;
 import com.puppycrawl.tools.checkstyle.TreeWalkerAuditEvent;
 import com.puppycrawl.tools.checkstyle.TreeWalkerFilter;
+import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.TextBlock;
@@ -286,12 +288,15 @@ public class SuppressWithNearbyCommentFilter
     private Pattern commentFormat = Pattern.compile(DEFAULT_COMMENT_FORMAT);
 
     /** Specify check pattern to suppress. */
+    @XdocsPropertyType(PropertyType.PATTERN)
     private String checkFormat = DEFAULT_CHECK_FORMAT;
 
     /** Define message pattern to suppress. */
+    @XdocsPropertyType(PropertyType.PATTERN)
     private String messageFormat;
 
     /** Specify check ID pattern to suppress. */
+    @XdocsPropertyType(PropertyType.PATTERN)
     private String idFormat;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
@@ -30,6 +30,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import com.puppycrawl.tools.checkstyle.PropertyType;
+import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.FileText;
@@ -331,12 +333,15 @@ public class SuppressWithPlainTextCommentFilter extends AutomaticBean implements
     private Pattern onCommentFormat = CommonUtil.createPattern(DEFAULT_ON_FORMAT);
 
     /** Specify check pattern to suppress. */
+    @XdocsPropertyType(PropertyType.PATTERN)
     private String checkFormat = DEFAULT_CHECK_FORMAT;
 
     /** Specify message pattern to suppress. */
+    @XdocsPropertyType(PropertyType.PATTERN)
     private String messageFormat;
 
     /** Specify check ID pattern to suppress. */
+    @XdocsPropertyType(PropertyType.PATTERN)
     private String idFormat;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -29,8 +29,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import com.puppycrawl.tools.checkstyle.PropertyType;
 import com.puppycrawl.tools.checkstyle.TreeWalkerAuditEvent;
 import com.puppycrawl.tools.checkstyle.TreeWalkerFilter;
+import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.TextBlock;
@@ -373,12 +375,15 @@ public class SuppressionCommentFilter
     private Pattern onCommentFormat = Pattern.compile(DEFAULT_ON_FORMAT);
 
     /** Specify check pattern to suppress. */
+    @XdocsPropertyType(PropertyType.PATTERN)
     private String checkFormat = DEFAULT_CHECK_FORMAT;
 
     /** Specify message pattern to suppress. */
+    @XdocsPropertyType(PropertyType.PATTERN)
     private String messageFormat;
 
     /** Specify check ID pattern to suppress. */
+    @XdocsPropertyType(PropertyType.PATTERN)
     private String idFormat;
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XdocsPropertyTypeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XdocsPropertyTypeTest.java
@@ -1,0 +1,65 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2021 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.checks.header.AbstractHeaderCheck;
+import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+
+public class XdocsPropertyTypeTest {
+
+    @Test
+    public void testAllPropertyTypesAreUsed() throws IOException {
+        final Set<PropertyType> propertyTypes = Stream.concat(
+                Stream.of(AbstractHeaderCheck.class, Checker.class),
+                CheckUtil.getCheckstyleChecks().stream())
+            .map(Class::getDeclaredFields)
+            .flatMap(Arrays::stream)
+            .map(field -> field.getAnnotation(XdocsPropertyType.class))
+            .filter(Objects::nonNull)
+            .map(XdocsPropertyType::value)
+            .collect(Collectors.toSet());
+
+        assertWithMessage("All property types should be used")
+            .that(propertyTypes)
+            .containsExactlyElementsIn(PropertyType.values());
+    }
+
+    @Test
+    public void testAllPropertyTypesHaveDescription() {
+        for (PropertyType value : PropertyType.values()) {
+            assertWithMessage("Property type '%s' has no description", value)
+                .that(CommonUtil.isBlank(value.getDescription()))
+                .isFalse();
+        }
+    }
+
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -31,7 +31,6 @@ import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.net.URI;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -47,6 +46,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
@@ -68,11 +68,12 @@ import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
 import com.puppycrawl.tools.checkstyle.ConfigurationLoader.IgnoredModulesOptions;
 import com.puppycrawl.tools.checkstyle.ModuleFactory;
 import com.puppycrawl.tools.checkstyle.PropertiesExpander;
+import com.puppycrawl.tools.checkstyle.PropertyType;
+import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
-import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption;
 import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
@@ -887,13 +888,23 @@ public class XdocsPagesTest {
                         .isNotEmpty();
 
         final Field field = getField(instance.getClass(), propertyName);
-        final Class<?> fieldClss = getFieldClass(fileName, sectionName, instance, field,
+        final Class<?> fieldClass = getFieldClass(fileName, sectionName, instance, field,
                 propertyName);
 
-        final String expectedTypeName = getModulePropertyExpectedTypeName(sectionName, fieldClss,
-                instance, propertyName);
+        final String expectedTypeName;
+        // SuppressWarningsHolder#aliasList is backed by a static (upper case) property.
+        if ("SuppressWarningsHolder".equals(sectionName) && "aliasList".equals(propertyName)) {
+            expectedTypeName = "String[] in a format of comma separated attribute=value entries. "
+                + "The attribute is the fully qualified name of the Check and value is its alias.";
+        }
+        else {
+            expectedTypeName = Optional.ofNullable(field)
+                .map(nonNullField -> nonNullField.getAnnotation(XdocsPropertyType.class))
+                .map(propertyType -> propertyType.value().getDescription())
+                .orElse(fieldClass.getSimpleName());
+        }
         final String expectedValue = getModulePropertyExpectedValue(sectionName, propertyName,
-                field, fieldClss, instance);
+                field, fieldClass, instance);
 
         assertWithMessage(fileName + " section '" + sectionName
                         + "' should have the type for " + propertyName)
@@ -1009,170 +1020,6 @@ public class XdocsPagesTest {
     }
 
     /**
-     * Get's the name of the bean property's type for the class.
-     *
-     * @param sectionName The name of the section/module being worked on.
-     * @param fieldClass The bean property's type.
-     * @param instance The class instance to work with.
-     * @param propertyName The property name to work with.
-     * @return String form of property's type.
-     * @noinspection IfStatementWithTooManyBranches
-     */
-    private static String getModulePropertyExpectedTypeName(String sectionName, Class<?> fieldClass,
-            Object instance, String propertyName) {
-        final String instanceName = instance.getClass().getSimpleName();
-        String result = null;
-        if (isDynamicCustomExpression(sectionName, propertyName)) {
-            // dynamic custom expression
-            result = "Pattern";
-        }
-        else if (fieldClass == int[].class) {
-            result = getPropertyTypeNameForIntArray(sectionName, propertyName);
-        }
-        else if (fieldClass == String.class || fieldClass == Charset.class) {
-            result = getPropertyTypeNameForString(sectionName, propertyName);
-        }
-        else if (fieldClass == String[].class) {
-            result = getPropertyTypeNameForStringArray(propertyName, instanceName);
-        }
-        else if (fieldClass == Pattern.class) {
-            result = "Pattern";
-        }
-        else if (fieldClass == Pattern[].class) {
-            result = "Pattern[]";
-        }
-        else if (fieldClass == Scope.class) {
-            result = "Scope";
-        }
-        else if ("PropertyCacheFile".equals(fieldClass.getSimpleName())) {
-            result = "File";
-        }
-        else if (fieldClass.isEnum()) {
-            result = fieldClass.getSimpleName();
-        }
-        else if (isKnownPropertyType(fieldClass)) {
-            result = fieldClass.getSimpleName();
-        }
-        else {
-            assertWithMessage("Unknown property type: " + fieldClass.getSimpleName()).fail();
-        }
-
-        if ("SuppressWarningsHolder".equals(instanceName)) {
-            result = result + " in a format of comma separated attribute=value entries. The "
-                    + "attribute is the fully qualified name of the Check and value is its alias.";
-        }
-
-        return result;
-    }
-
-    /**
-     * Checks whether property is a dynamic custom expression.
-     *
-     * @param sectionName the name of the section/module being worked on.
-     * @param propertyName the property name to work with.
-     * @return true if it is a dynamic custom expression.
-     */
-    private static boolean isDynamicCustomExpression(String sectionName, String propertyName) {
-        return isSuppressionFilter(sectionName)
-                && ("checkFormat".equals(propertyName)
-                || "messageFormat".equals(propertyName)
-                || "idFormat".equals(propertyName))
-                || isRegexpCheck(sectionName)
-                && "format".equals(propertyName);
-    }
-
-    /**
-     * Checks Whether the section is a type of suppression filter.
-     *
-     * @param sectionName the name of the section/module being worked on.
-     * @return true if it is a type of suppression filter.
-     */
-    private static boolean isSuppressionFilter(String sectionName) {
-        return "SuppressionCommentFilter".equals(sectionName)
-                || "SuppressWithNearbyCommentFilter".equals(sectionName)
-                || "SuppressWithPlainTextCommentFilter".equals(sectionName);
-    }
-
-    /**
-     * Checks whether the section is a RegexpCheck.
-     *
-     * @param sectionName the name of the section/module being worked on.
-     * @return true if the section is a RegexpCheck.
-     */
-    private static boolean isRegexpCheck(String sectionName) {
-        return "RegexpMultiline".equals(sectionName)
-                || "RegexpSingleline".equals(sectionName)
-                || "RegexpSinglelineJava".equals(sectionName);
-    }
-
-    /**
-     * Get's the name of the bean property's type for the Int[] class.
-     *
-     * @param sectionName the name of the section/module being worked on.
-     * @param propertyName the property name to work with.
-     * @return String form of property's type.
-     */
-    private static String getPropertyTypeNameForIntArray(String sectionName, String propertyName) {
-        String result = "int[]";
-        if (isPropertyTokenType(sectionName, propertyName)) {
-            result = "subset of tokens TokenTypes";
-        }
-        return result;
-    }
-
-    /**
-     * Get's the name of the bean property's type for the String class.
-     *
-     * @param sectionName the name of the section/module being worked on.
-     * @param propertyName the property name to work with.
-     * @return String form of property's type.
-     */
-    private static String getPropertyTypeNameForString(String sectionName, String propertyName) {
-        String result = "String";
-
-        if ("Checker".equals(sectionName) && "localeCountry".equals(propertyName)) {
-            result += " (either the empty string or an uppercase ISO 3166 2-letter code)";
-        }
-        else if ("Checker".equals(sectionName) && "localeLanguage".equals(propertyName)) {
-            result += " (either the empty string or a lowercase ISO 639 code)";
-        }
-        return result;
-    }
-
-    /**
-     * Get's the name of the bean property's type for the String[] class.
-     *
-     * @param propertyName the property name to work with.
-     * @param instanceName the simple name of class instance to work with.
-     * @return String form of property's type.
-     */
-    private static String getPropertyTypeNameForStringArray(
-            String propertyName, String instanceName) {
-        String result = "String[]";
-        if (propertyName.endsWith("Tokens") || propertyName.endsWith("Token")
-                || "AtclauseOrderCheck".equals(instanceName) && "target".equals(propertyName)
-                || "MultipleStringLiteralsCheck".equals(instanceName)
-                && "ignoreOccurrenceContext".equals(propertyName)) {
-            result = "subset of tokens TokenTypes";
-        }
-        return result;
-    }
-
-    /**
-     * Checks whether given property is a known property type.
-     *
-     * @param propertyType the bean property's type.
-     * @return true if given property type matches with one of the known property type.
-     */
-    private static boolean isKnownPropertyType(Class<?> propertyType) {
-        return propertyType == int.class
-                || propertyType == boolean.class
-                || propertyType == double[].class
-                || propertyType == URI.class
-                || propertyType == AccessModifierOption[].class;
-    }
-
-    /**
      * Get's the name of the bean property's default value for the class.
      *
      * @param sectionName The name of the section/module being worked on.
@@ -1181,14 +1028,13 @@ public class XdocsPagesTest {
      * @param fieldClass The bean property's type.
      * @param instance The class instance to work with.
      * @return String form of property's default value.
-     * @noinspection OverlyNestedMethod
      */
     private static String getModulePropertyExpectedValue(String sectionName, String propertyName,
             Field field, Class<?> fieldClass, Object instance) throws Exception {
         String result = null;
 
         if (field != null) {
-            Object value = field.get(instance);
+            final Object value = field.get(instance);
 
             // noinspection IfStatementWithTooManyBranches
             if ("Checker".equals(sectionName) && "localeCountry".equals(propertyName)) {
@@ -1210,73 +1056,10 @@ public class XdocsPagesTest {
                 result = value.toString();
             }
             else if (fieldClass == int.class) {
-                if (value.equals(Integer.MAX_VALUE)) {
-                    result = "2147483647";
-                }
-                else {
-                    result = value.toString();
-                }
+                result = value.toString();
             }
             else if (fieldClass == int[].class) {
-                if (value instanceof Collection) {
-                    final Collection<?> collection = (Collection<?>) value;
-                    final int[] newArray = new int[collection.size()];
-                    final Iterator<?> iterator = collection.iterator();
-                    int index = 0;
-
-                    while (iterator.hasNext()) {
-                        newArray[index] = (Integer) iterator.next();
-                        index++;
-                    }
-
-                    value = newArray;
-                }
-
-                if (isPropertyTokenType(sectionName, propertyName)) {
-                    boolean first = true;
-
-                    if (value instanceof BitSet) {
-                        final BitSet list = (BitSet) value;
-                        final StringBuilder sb = new StringBuilder(20);
-
-                        for (int i = 0; i < list.size(); i++) {
-                            if (list.get(i)) {
-                                if (first) {
-                                    first = false;
-                                }
-                                else {
-                                    sb.append(", ");
-                                }
-
-                                sb.append(TokenUtil.getTokenName(i));
-                            }
-                        }
-
-                        result = sb.toString();
-                    }
-                    else {
-                        final StringBuilder sb = new StringBuilder(20);
-
-                        for (int i = 0; i < Array.getLength(value); i++) {
-                            if (first) {
-                                first = false;
-                            }
-                            else {
-                                sb.append(", ");
-                            }
-
-                            sb.append(TokenUtil.getTokenName((int) Array.get(value, i)));
-                        }
-
-                        result = sb.toString();
-                    }
-                }
-                else {
-                    result = Arrays.toString((int[]) value).replace("[", "").replace("]", "");
-                }
-                if (result.isEmpty()) {
-                    result = "{}";
-                }
+                result = getIntArrayPropertyValue(field, value);
             }
             else if (fieldClass == double[].class) {
                 result = Arrays.toString((double[]) value).replace("[", "").replace("]", "")
@@ -1286,33 +1069,7 @@ public class XdocsPagesTest {
                 }
             }
             else if (fieldClass == String[].class) {
-                if (value == null) {
-                    result = "";
-                }
-                else {
-                    final Stream<?> valuesStream;
-                    if (value instanceof Collection) {
-                        final Collection<?> collection = (Collection<?>) value;
-                        valuesStream = collection.stream();
-                    }
-                    else {
-                        final Object[] array = (Object[]) value;
-                        valuesStream = Arrays.stream(array);
-                    }
-                    result = valuesStream
-                        .map(String.class::cast)
-                        .sorted()
-                        .collect(Collectors.joining(", "));
-                }
-
-                if (result.isEmpty()) {
-                    if ("fileExtensions".equals(propertyName)) {
-                        result = "all files";
-                    }
-                    else {
-                        result = "{}";
-                    }
-                }
+                result = getStringArrayPropertyValue(propertyName, value);
             }
             else if (fieldClass == URI.class || fieldClass == String.class) {
                 if (value != null) {
@@ -1326,38 +1083,7 @@ public class XdocsPagesTest {
                 }
             }
             else if (fieldClass == Pattern[].class) {
-                if (value instanceof Collection) {
-                    final Collection<?> collection = (Collection<?>) value;
-                    final Pattern[] newArray = new Pattern[collection.size()];
-                    final Iterator<?> iterator = collection.iterator();
-                    int index = 0;
-
-                    while (iterator.hasNext()) {
-                        final Object next = iterator.next();
-                        newArray[index] = (Pattern) next;
-                        index++;
-                    }
-
-                    value = newArray;
-                }
-
-                if (value != null && Array.getLength(value) > 0) {
-                    final String[] newArray = new String[Array.getLength(value)];
-
-                    for (int i = 0; i < newArray.length; i++) {
-                        newArray[i] = ((Pattern) Array.get(value, i)).pattern();
-                    }
-
-                    result = Arrays.toString(newArray).replace("[", "")
-                            .replace("]", "");
-                }
-                else {
-                    result = "";
-                }
-
-                if (result.isEmpty()) {
-                    result = "{}";
-                }
+                result = getPatternArrayPropertyValue(value);
             }
             else if (fieldClass.isEnum()) {
                 if (value != null) {
@@ -1380,33 +1106,189 @@ public class XdocsPagesTest {
     }
 
     /**
-     * Checks if the given property is takes token names as a type.
+     * Get's the name of the bean property's default value for the Pattern array class.
      *
-     * @param sectionName The name of the section/module being worked on.
-     * @param propertyName The property name to work with.
-     * @return {@code true} if the property is takes token names as a type.
-     * @noinspection OverlyComplexBooleanExpression
+     * @param fieldValue The bean property's value.
+     * @return String form of property's default value.
      */
-    private static boolean isPropertyTokenType(String sectionName, String propertyName) {
-        return "AtclauseOrder".equals(sectionName) && "target".equals(propertyName)
-            || "IllegalType".equals(sectionName) && "memberModifiers".equals(propertyName)
-            || "MagicNumber".equals(sectionName)
-                    && "constantWaiverParentToken".equals(propertyName)
-            || "MultipleStringLiterals".equals(sectionName)
-                    && "ignoreOccurrenceContext".equals(propertyName)
-            || "DescendantToken".equals(sectionName) && "limitedTokens".equals(propertyName);
+    private static String getPatternArrayPropertyValue(Object fieldValue) {
+        Object value = fieldValue;
+        String result;
+        if (value instanceof Collection) {
+            final Collection<?> collection = (Collection<?>) value;
+            final Pattern[] newArray = new Pattern[collection.size()];
+            final Iterator<?> iterator = collection.iterator();
+            int index = 0;
+
+            while (iterator.hasNext()) {
+                final Object next = iterator.next();
+                newArray[index] = (Pattern) next;
+                index++;
+            }
+
+            value = newArray;
+        }
+
+        if (value != null && Array.getLength(value) > 0) {
+            final String[] newArray = new String[Array.getLength(value)];
+
+            for (int i = 0; i < newArray.length; i++) {
+                newArray[i] = ((Pattern) Array.get(value, i)).pattern();
+            }
+
+            result = Arrays.toString(newArray).replace("[", "").replace("]", "");
+        }
+        else {
+            result = "";
+        }
+
+        if (result.isEmpty()) {
+            result = "{}";
+        }
+        return result;
     }
 
-    private static Field getField(Class<?> clss, String propertyName) {
-        Field result = null;
+    /**
+     * Get's the name of the bean property's default value for the string array class.
+     *
+     * @param propertyName The bean property's name.
+     * @param value The bean property's value.
+     * @return String form of property's default value.
+     */
+    private static String getStringArrayPropertyValue(String propertyName, Object value) {
+        String result;
+        if (value == null) {
+            result = "";
+        }
+        else {
+            final Stream<?> valuesStream;
+            if (value instanceof Collection) {
+                final Collection<?> collection = (Collection<?>) value;
+                valuesStream = collection.stream();
+            }
+            else {
+                final Object[] array = (Object[]) value;
+                valuesStream = Arrays.stream(array);
+            }
+            result = valuesStream
+                .map(String.class::cast)
+                .sorted()
+                .collect(Collectors.joining(", "));
+        }
 
-        if (clss != null) {
+        if (result.isEmpty()) {
+            if ("fileExtensions".equals(propertyName)) {
+                result = "all files";
+            }
+            else {
+                result = "{}";
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns the name of the bean property's default value for the int array class.
+     *
+     * @param field The bean property's field.
+     * @param fieldValue The bean property's value.
+     * @return String form of property's default value.
+     */
+    private static String getIntArrayPropertyValue(Field field, Object fieldValue) {
+        Object value = fieldValue;
+        String result;
+        if (value instanceof Collection) {
+            final Collection<?> collection = (Collection<?>) value;
+            final int[] newArray = new int[collection.size()];
+            final Iterator<?> iterator = collection.iterator();
+            int index = 0;
+
+            while (iterator.hasNext()) {
+                newArray[index] = (Integer) iterator.next();
+                index++;
+            }
+
+            value = newArray;
+        }
+
+        if (isPropertyTokenType(field)) {
+            boolean first = true;
+
+            if (value instanceof BitSet) {
+                final BitSet list = (BitSet) value;
+                final StringBuilder sb = new StringBuilder(20);
+
+                for (int i = 0; i < list.size(); i++) {
+                    if (list.get(i)) {
+                        if (first) {
+                            first = false;
+                        }
+                        else {
+                            sb.append(", ");
+                        }
+
+                        sb.append(TokenUtil.getTokenName(i));
+                    }
+                }
+
+                result = sb.toString();
+            }
+            else {
+                final StringBuilder sb = new StringBuilder(20);
+
+                for (int i = 0; i < Array.getLength(value); i++) {
+                    if (first) {
+                        first = false;
+                    }
+                    else {
+                        sb.append(", ");
+                    }
+
+                    sb.append(TokenUtil.getTokenName((int) Array.get(value, i)));
+                }
+
+                result = sb.toString();
+            }
+        }
+        else {
+            result = Arrays.toString((int[]) value).replace("[", "").replace("]", "");
+        }
+        if (result.isEmpty()) {
+            result = "{}";
+        }
+        return result;
+    }
+
+    /**
+     * Checks if the given property is takes token names as a type.
+     *
+     * @param field The backed field of the section/module being worked on.
+     * @return {@code true} if the property is takes token names as a type.
+     */
+    private static boolean isPropertyTokenType(Field field) {
+        final XdocsPropertyType propertyType = field.getDeclaredAnnotation(XdocsPropertyType.class);
+        return propertyType != null && propertyType.value() == PropertyType.TOKEN_ARRAY;
+    }
+
+    /**
+     * Returns the bean property's field.
+     *
+     * @param fieldClass The bean property's type
+     * @param propertyName The bean property's name
+     * @return the bean property's field
+     */
+    private static Field getField(Class<?> fieldClass, String propertyName) {
+        Field result = null;
+        Class<?> currentClass = fieldClass;
+
+        while (!Object.class.equals(currentClass)) {
             try {
-                result = clss.getDeclaredField(propertyName);
+                result = currentClass.getDeclaredField(propertyName);
                 result.setAccessible(true);
+                break;
             }
             catch (NoSuchFieldException ignored) {
-                result = getField(clss.getSuperclass(), propertyName);
+                currentClass = currentClass.getSuperclass();
             }
         }
 


### PR DESCRIPTION
Issue #10744

New annotation: `XdocsPropertyType`. This annotation should be accessible with checks and filters,
Method `getModulePropertyExpectedValue` refactored to satisfy size checks.
Method `getModulePropertyExpectedTypeName` removed.