### PR TITLE
Issue #6191: add config file for crowdin integration

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,10 @@
+files:
+  - source: /**/messages.properties
+    translation: /**/messages_%two_letters_code%.properties
+    update_option: update_without_changes
+    # Escape single quote with another single quote
+    escape_quotes: 1
+    # Avoid escape of colons, exclamation marks, etc.
+    escape_special_characters: 0
+commit_message: 'doc: new translations: %original_file_name% (%language%)'
+append_commit_message: false


### PR DESCRIPTION
Issue #6191 

Added config for crowdin integration.
It takes as original all messages.properties files, output will be added to same location with country code suffix, as it is now.