### PR TITLE
Issue #10835: Fixing default access modifier for CheckUtil

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
@@ -439,14 +439,17 @@ public final class CheckUtil {
      * @return the access modifier of the method/constructor.
      */
     public static AccessModifierOption getAccessModifierFromModifiersToken(DetailAST ast) {
-        final AccessModifierOption accessModifier;
+        final DetailAST modsToken = ast.findFirstToken(TokenTypes.MODIFIERS);
+        AccessModifierOption accessModifier =
+                getAccessModifierFromModifiersTokenDirectly(modsToken);
 
-        if (ScopeUtil.isInInterfaceOrAnnotationBlock(ast)) {
-            accessModifier = AccessModifierOption.PUBLIC;
-        }
-        else {
-            final DetailAST modsToken = ast.findFirstToken(TokenTypes.MODIFIERS);
-            accessModifier = getAccessModifierFromModifiersTokenDirectly(modsToken);
+        if (accessModifier == AccessModifierOption.PACKAGE) {
+            if (ScopeUtil.isInEnumBlock(ast) && ast.getType() == TokenTypes.CTOR_DEF) {
+                accessModifier = AccessModifierOption.PRIVATE;
+            }
+            else if (ScopeUtil.isInInterfaceOrAnnotationBlock(ast)) {
+                accessModifier = AccessModifierOption.PUBLIC;
+            }
         }
 
         return accessModifier;
@@ -466,7 +469,6 @@ public final class CheckUtil {
             throw new IllegalArgumentException("expected non-null AST-token with type 'MODIFIERS'");
         }
 
-        // default access modifier
         AccessModifierOption accessModifier = AccessModifierOption.PACKAGE;
         for (DetailAST token = modifiersToken.getFirstChild(); token != null;
              token = token.getNextSibling()) {
@@ -500,9 +502,7 @@ public final class CheckUtil {
                 || type == TokenTypes.INTERFACE_DEF
                 || type == TokenTypes.ANNOTATION_DEF
                 || type == TokenTypes.ENUM_DEF) {
-                final DetailAST mods =
-                    token.findFirstToken(TokenTypes.MODIFIERS);
-                returnValue = getAccessModifierFromModifiersTokenDirectly(mods);
+                returnValue = getAccessModifierFromModifiersToken(token);
             }
             else if (type == TokenTypes.LITERAL_NEW) {
                 break;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -456,4 +456,22 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
                 CommonUtil.EMPTY_STRING_ARRAY);
     }
 
+    @Test
+    public void testDefaultAccessModifier() throws Exception {
+        final String[] expected = {
+            "21:32: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "a"),
+            "26:43: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "b"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocMethodDefaultAccessModifier.java"), expected);
+    }
+
+    @Test
+    public void testAccessModifierEnum() throws Exception {
+        final String[] expected = {
+            "27:17: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "i"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocMethodEnum.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodDefaultAccessModifier.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodDefaultAccessModifier.java
@@ -1,0 +1,34 @@
+/*
+JavadocMethod
+allowedAnnotations = (default)Override
+validateThrows = (default)false
+accessModifiers = public
+allowMissingParamTags = (default)false
+allowMissingReturnTag = true
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
+
+public interface InputJavadocMethodDefaultAccessModifier {
+    /** Javadoc ok here. */
+    void testNoViolation(); // ok
+
+    class MyClass {
+        /** Missing parameter here. */
+        public MyClass(Integer a) { // violation
+        }
+    }
+
+    /** Missing parameter here, public method by default */
+    int testViolationMissingParameter(int b); // violation
+
+    /**
+     * Test method.
+     *
+     * @param c test parameter
+     */
+    double testNoViolationParameterPresent(int c); // ok
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodEnum.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodEnum.java
@@ -1,0 +1,30 @@
+/*
+JavadocMethod
+allowedAnnotations = (default)Override
+validateThrows = true
+accessModifiers = private
+allowMissingParamTags = (default)false
+allowMissingReturnTag = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
+
+public class InputJavadocMethodEnum {
+
+    private enum DAY {
+
+        SOME_CONSTANT(1) {
+            /** Test Method */
+            int someMethod() { // ok
+                return 0;
+            }
+        };
+
+        /** Test constructor */
+        DAY(int i) { // violation
+        }
+    }
+}


### PR DESCRIPTION
Resolves #10835: JavadocMethod accessModifiers incorrectly interpreted for interface class 
Diff Reports-
All related variations of JavadocMethod: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/5d631da_2021155102/reports/diff/index.html
All related variations of ParameterName: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/5d631da_2021061820/reports/diff/index.html
All related variations of RecordComponentNumber: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/5d631da_2021065848/reports/diff/index.html