### PR TITLE
infra: turn off curl's verification of the certificate for test-spell…

### DIFF
--- a/.ci/test-spelling-unknown-words.sh
+++ b/.ci/test-spelling-unknown-words.sh
@@ -18,7 +18,7 @@ if [ ! -e "$dict" ]; then
   # english.words is taken from rpm:
   # https://rpmfind.net/linux/fedora/linux/development/rawhide/Everything/aarch64/os/Packages/w/"
   # "words-.*.noarch.rpm"
-  curl https://checkstyle.sourceforge.io/reports/english.words -o $dict
+  curl -k https://checkstyle.sourceforge.io/reports/english.words -o $dict
 fi
 
 if [ ! -e "$word_splitter" ]; then


### PR DESCRIPTION
…ing-unknown-words.sh while there is problem

https://dev.azure.com/romanivanovjr/romanivanovjr/_build/results?buildId=5478&view=logs&j=6a833393-c551-5000-0916-5000fd3b86e7&t=bdbbd129-77f0-5d73-ce7d-db58d34c8358

```
 ~/java/github/romani/checkstyle [master|✔] 
 $ ./.ci/test-spelling-unknown-words.sh 
Retrieve cached english.words from checkstyle.sourceforge.io
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (60) server certificate verification failed. CAfile: /etc/ssl/certs/ca-certificates.crt CRLfile: none
More details here: http://curl.haxx.se/docs/sslcerts.html

curl performs SSL certificate verification by default, using a "bundle"
 of Certificate Authority (CA) public keys (CA certs). If the default
 bundle file isn't adequate, you can specify an alternate file
 using the --cacert option.
If this HTTPS server uses a certificate signed by a CA represented in
 the bundle, the certificate verification probably failed due to a
 problem with the certificate (it might be expired, or the name might
 not match the domain name in the URL).
If you'd like to turn off curl's verification of the certificate, use
 the -k (or --insecure) option.
```