### PR TITLE
Issue #10842: 'Regilar Expression' -> 'Pattern' in xdocs

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheck.java
@@ -30,7 +30,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <p>
  * Checks for {@code TODO:} comments. Actually it is a generic
  * <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html">
- * regular expression</a> matcher on Java comments. To check for other patterns
+ * pattern</a> matcher on Java comments. To check for other patterns
  * in Java comments, set the {@code format} property.
  * </p>
  * <p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
@@ -35,8 +35,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <ul>
  * <li>
  * Property {@code format} - Define the RegExp for illegal pattern.
- * Type is {@code java.lang.String}.
- * Validation type is {@code java.util.regex.Pattern}.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code "^$"}.
  * </li>
  * <li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
@@ -30,9 +30,9 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 /**
  * <p>
- * Ensures that exception classes (classes with names conforming to some regular
- * expression and explicitly extending classes with names conforming to other
- * regular expression) are immutable, that is, that they have only final fields.
+ * Ensures that exception classes (classes with names conforming to some pattern
+ * and explicitly extending classes with names conforming to other
+ * pattern) are immutable, that is, that they have only final fields.
  * </p>
  * <p>
  * The current algorithm is very simple: it checks that all members of exception are final.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
@@ -34,7 +34,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <p>
  * Checks the header of a source file against a header that contains a
  * <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html">
- * regular expression</a> for each line of the source header.
+ * pattern</a> for each line of the source header.
  * </p>
  * <p>
  * Rationale: In some projects <a href="https://checkstyle.org/config_header.html#Header">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -73,8 +73,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * (e.g. {@code /regexp/}). All type imports, which does not match any group, falls into an
  * additional group, located at the end.
  * Thus, the empty list of type groups (the default value) means one group for all type imports.
- * Type is {@code java.lang.String[]}.
- * Validation type is {@code java.util.regex.Pattern}.
+ * Type is {@code java.util.regex.Pattern[]}.
  * Default value is {@code ""}.
  * </li>
  * <li>
@@ -114,8 +113,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * an additional group, located at the end. Thus, the empty list of static groups (the default
  * value) means one group for all static imports. This property has effect only when the property
  * {@code option} is set to {@code top} or {@code bottom}.
- * Type is {@code java.lang.String[]}.
- * Validation type is {@code java.util.regex.Pattern}.
+ * Type is {@code java.util.regex.Pattern[]}.
  * Default value is {@code ""}.
  * </li>
  * <li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -48,7 +48,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * scope to one of the {@code Scope} constants. To define the format for an author
  * tag or a version tag, set property authorFormat or versionFormat respectively to a
  * <a href="https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">
- * regular expression</a>.
+ * pattern</a>.
  * </p>
  * <p>
  * Does not perform checks for author and version tags for inner classes,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassDataAbstractionCouplingCheck.java
@@ -100,8 +100,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <li>
  * Property {@code excludeClassesRegexps} - Specify user-configured regular
  * expressions to ignore classes.
- * Type is {@code java.lang.String[]}.
- * Validation type is {@code java.util.regex.Pattern}.
+ * Type is {@code java.util.regex.Pattern[]}.
  * Default value is {@code ^$}.
  * </li>
  * <li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheck.java
@@ -67,8 +67,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * <li>
  * Property {@code excludeClassesRegexps} - Specify user-configured regular
  * expressions to ignore classes.
- * Type is {@code java.lang.String[]}.
- * Validation type is {@code java.util.regex.Pattern}.
+ * Type is {@code java.util.regex.Pattern[]}.
  * Default value is {@code ^$}.
  * </li>
  * <li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
@@ -28,8 +28,8 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 
 /**
  * <p>
- * Ensures that the names of abstract classes conforming to some regular
- * expression and check that {@code abstract} modifier exists.
+ * Ensures that the names of abstract classes conforming to some pattern
+ * and check that {@code abstract} modifier exists.
  * </p>
  * <p>
  * Rationale: Abstract classes are convenience base class implementations of

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/IllegalIdentifierNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/IllegalIdentifierNameCheck.java
@@ -26,12 +26,12 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
  * <p>
- * Checks identifiers with a regular expression for a set of illegal names, such as those
+ * Checks identifiers with a pattern for a set of illegal names, such as those
  * that are restricted or contextual keywords. Examples include "yield", "record", "_", and
  * "var". Please read more at
  * <a href="https://docs.oracle.com/javase/specs/jls/se14/html/jls-3.html#jls-3.9">
  * Java Language Specification</a> to get to know more about restricted keywords. Since this
- * check uses a regular expression to specify valid identifiers, users can also prohibit the usage
+ * check uses a pattern to specify valid identifiers, users can also prohibit the usage
  * of certain symbols, such as "$", or any non-ascii character.
  * </p>
  * <ul>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheck.java
@@ -36,7 +36,7 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
  * <ul>
  * <li>
  * Property {@code format} - Specify the format of the regular expression to match.
- * Type is {@code java.lang.String}.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code "$."}.
  * </li>
  * <li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheck.java
@@ -37,7 +37,7 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
  * <ul>
  * <li>
  * Property {@code format} - Specify the format of the regular expression to match.
- * Type is {@code java.lang.String}.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code "$."}.
  * </li>
  * <li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheck.java
@@ -37,7 +37,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <ul>
  * <li>
  * Property {@code format} - Specify the format of the regular expression to match.
- * Type is {@code java.lang.String}.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code "$."}.
  * </li>
  * <li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -64,23 +64,23 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </li>
  * <li>
  * Property {@code checkFormat} - Specify check pattern to suppress.
- * Type is {@code java.lang.String}.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code ".*"}.
  * </li>
  * <li>
  * Property {@code messageFormat} - Define message pattern to suppress.
- * Type is {@code java.lang.String}.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code null}.
  * </li>
  * <li>
  * Property {@code idFormat} - Specify check ID pattern to suppress.
- * Type is {@code java.lang.String}.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code null}.
  * </li>
  * <li>
  * Property {@code influenceFormat} - Specify negative/zero/positive value that
  * defines the number of lines preceding/at/following the suppression comment.
- * Type is {@code java.lang.String}.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code "0"}.
  * </li>
  * <li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
@@ -87,17 +87,17 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </li>
  * <li>
  * Property {@code checkFormat} - Specify check pattern to suppress.
- * Type is {@code java.lang.String}.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code ".*"}.
  * </li>
  * <li>
  * Property {@code messageFormat} - Specify message pattern to suppress.
- * Type is {@code java.lang.String}.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code null}.
  * </li>
  * <li>
  * Property {@code idFormat} - Specify check ID pattern to suppress.
- * Type is {@code java.lang.String}.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code null}.
  * </li>
  * </ul>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -82,17 +82,17 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </li>
  * <li>
  * Property {@code checkFormat} - Specify check pattern to suppress.
- * Type is {@code java.lang.String}.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code ".*"}.
  * </li>
  * <li>
  * Property {@code messageFormat} - Specify message pattern to suppress.
- * Type is {@code java.lang.String}.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code null}.
  * </li>
  * <li>
  * Property {@code idFormat} - Specify check ID pattern to suppress.
- * Type is {@code java.lang.String}.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code null}.
  * </li>
  * <li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilter.java
@@ -57,8 +57,7 @@ import com.puppycrawl.tools.checkstyle.api.Filter;
  * <li>
  * Property {@code checks} - Define the RegExp for matching against the name of the check
  * associated with an audit event.
- * Type is {@code java.lang.String}.
- * Validation type is {@code java.util.regex.Pattern}.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code null}.
  * </li>
  * <li>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilter.java
@@ -51,22 +51,19 @@ import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
  * <li>
  * Property {@code files} - Define a Regular Expression matched against the file
  * name associated with an audit event.
- * Type is {@code java.lang.String}.
- * Validation type is {@code java.util.regex.Pattern}.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code null}.
  * </li>
  * <li>
  * Property {@code checks} - Define a Regular Expression matched against the name
  * of the check associated with an audit event.
- * Type is {@code java.lang.String}.
- * Validation type is {@code java.util.regex.Pattern}.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code null}.
  * </li>
  * <li>
  * Property {@code message} - Define a Regular Expression matched against the message
  * of the check associated with an audit event.
- * Type is {@code java.lang.String}.
- * Validation type is {@code java.util.regex.Pattern}.
+ * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code null}.
  * </li>
  * <li>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/TodoCommentCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/TodoCommentCheck.xml
@@ -7,7 +7,7 @@
          <description>&lt;p&gt;
  Checks for {@code TODO:} comments. Actually it is a generic
  &lt;a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html"&gt;
- regular expression&lt;/a&gt; matcher on Java comments. To check for other patterns
+ pattern&lt;/a&gt; matcher on Java comments. To check for other patterns
  in Java comments, set the {@code format} property.
  &lt;/p&gt;
  &lt;p&gt;

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/IllegalTokenTextCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/IllegalTokenTextCheck.xml
@@ -9,10 +9,7 @@
  By default no tokens are specified.
  &lt;/p&gt;</description>
          <properties>
-            <property default-value="^$"
-                      name="format"
-                      type="java.lang.String"
-                      validation-type="java.util.regex.Pattern">
+            <property default-value="^$" name="format" type="java.util.regex.Pattern">
                <description>Define the RegExp for illegal pattern.</description>
             </property>
             <property default-value="false" name="ignoreCase" type="boolean">

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/design/MutableExceptionCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/design/MutableExceptionCheck.xml
@@ -5,9 +5,9 @@
              name="MutableException"
              parent="com.puppycrawl.tools.checkstyle.TreeWalker">
          <description>&lt;p&gt;
- Ensures that exception classes (classes with names conforming to some regular
- expression and explicitly extending classes with names conforming to other
- regular expression) are immutable, that is, that they have only final fields.
+ Ensures that exception classes (classes with names conforming to some pattern
+ and explicitly extending classes with names conforming to other
+ pattern) are immutable, that is, that they have only final fields.
  &lt;/p&gt;
  &lt;p&gt;
  The current algorithm is very simple: it checks that all members of exception are final.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/header/RegexpHeaderCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/header/RegexpHeaderCheck.xml
@@ -7,7 +7,7 @@
          <description>&lt;p&gt;
  Checks the header of a source file against a header that contains a
  &lt;a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html"&gt;
- regular expression&lt;/a&gt; for each line of the source header.
+ pattern&lt;/a&gt; for each line of the source header.
  &lt;/p&gt;
  &lt;p&gt;
  Rationale: In some projects &lt;a href="https://checkstyle.org/config_header.html#Header"&gt;

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/imports/ImportOrderCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/imports/ImportOrderCheck.xml
@@ -40,10 +40,7 @@
                <description>specify policy on the relative order between type imports and static
  imports.</description>
             </property>
-            <property default-value=""
-                      name="groups"
-                      type="java.lang.String[]"
-                      validation-type="java.util.regex.Pattern">
+            <property default-value="" name="groups" type="java.util.regex.Pattern[]">
                <description>specify list of &lt;b&gt;type import&lt;/b&gt; groups (every group identified
  either by a common prefix string, or by a regular expression enclosed in forward slashes
  (e.g. {@code /regexp/}). All type imports, which does not match any group, falls into an
@@ -74,8 +71,7 @@
             </property>
             <property default-value=""
                       name="staticGroups"
-                      type="java.lang.String[]"
-                      validation-type="java.util.regex.Pattern">
+                      type="java.util.regex.Pattern[]">
                <description>specify list of &lt;b&gt;static&lt;/b&gt; import groups (every group
  identified either by a common prefix string, or by a regular expression enclosed in forward
  slashes (e.g. {@code /regexp/}). All static imports, which does not match any group, falls into

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocTypeCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocTypeCheck.xml
@@ -11,7 +11,7 @@
  scope to one of the {@code Scope} constants. To define the format for an author
  tag or a version tag, set property authorFormat or versionFormat respectively to a
  &lt;a href="https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html"&gt;
- regular expression&lt;/a&gt;.
+ pattern&lt;/a&gt;.
  &lt;/p&gt;
  &lt;p&gt;
  Does not perform checks for author and version tags for inner classes,

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/metrics/ClassDataAbstractionCouplingCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/metrics/ClassDataAbstractionCouplingCheck.xml
@@ -71,8 +71,7 @@
             </property>
             <property default-value="^$"
                       name="excludeClassesRegexps"
-                      type="java.lang.String[]"
-                      validation-type="java.util.regex.Pattern">
+                      type="java.util.regex.Pattern[]">
                <description>Specify user-configured regular
  expressions to ignore classes.</description>
             </property>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/metrics/ClassFanOutComplexityCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/metrics/ClassFanOutComplexityCheck.xml
@@ -38,8 +38,7 @@
             </property>
             <property default-value="^$"
                       name="excludeClassesRegexps"
-                      type="java.lang.String[]"
-                      validation-type="java.util.regex.Pattern">
+                      type="java.util.regex.Pattern[]">
                <description>Specify user-configured regular
  expressions to ignore classes.</description>
             </property>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/naming/AbstractClassNameCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/naming/AbstractClassNameCheck.xml
@@ -5,8 +5,8 @@
              name="AbstractClassName"
              parent="com.puppycrawl.tools.checkstyle.TreeWalker">
          <description>&lt;p&gt;
- Ensures that the names of abstract classes conforming to some regular
- expression and check that {@code abstract} modifier exists.
+ Ensures that the names of abstract classes conforming to some pattern
+ and check that {@code abstract} modifier exists.
  &lt;/p&gt;
  &lt;p&gt;
  Rationale: Abstract classes are convenience base class implementations of

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/naming/IllegalIdentifierNameCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/naming/IllegalIdentifierNameCheck.xml
@@ -5,12 +5,12 @@
              name="IllegalIdentifierName"
              parent="com.puppycrawl.tools.checkstyle.TreeWalker">
          <description>&lt;p&gt;
- Checks identifiers with a regular expression for a set of illegal names, such as those
+ Checks identifiers with a pattern for a set of illegal names, such as those
  that are restricted or contextual keywords. Examples include "yield", "record", "_", and
  "var". Please read more at
  &lt;a href="https://docs.oracle.com/javase/specs/jls/se14/html/jls-3.html#jls-3.9"&gt;
  Java Language Specification&lt;/a&gt; to get to know more about restricted keywords. Since this
- check uses a regular expression to specify valid identifiers, users can also prohibit the usage
+ check uses a pattern to specify valid identifiers, users can also prohibit the usage
  of certain symbols, such as "$", or any non-ascii character.
  &lt;/p&gt;</description>
          <properties>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/regexp/RegexpMultilineCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/regexp/RegexpMultilineCheck.xml
@@ -11,7 +11,7 @@
  Rationale: This check can be used to when the regular expression can be span multiple lines.
  &lt;/p&gt;</description>
          <properties>
-            <property default-value="$." name="format" type="java.lang.String">
+            <property default-value="$." name="format" type="java.util.regex.Pattern">
                <description>Specify the format of the regular expression to match.</description>
             </property>
             <property name="message" type="java.lang.String">

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/regexp/RegexpSinglelineCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/regexp/RegexpSinglelineCheck.xml
@@ -13,7 +13,7 @@
  {@code System.out.println()}, {@code System.exit()}, etc.
  &lt;/p&gt;</description>
          <properties>
-            <property default-value="$." name="format" type="java.lang.String">
+            <property default-value="$." name="format" type="java.util.regex.Pattern">
                <description>Specify the format of the regular expression to match.</description>
             </property>
             <property name="message" type="java.lang.String">

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/regexp/RegexpSinglelineJavaCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/regexp/RegexpSinglelineJavaCheck.xml
@@ -14,7 +14,7 @@
  It supports suppressing matches in Java comments.
  &lt;/p&gt;</description>
          <properties>
-            <property default-value="$." name="format" type="java.lang.String">
+            <property default-value="$." name="format" type="java.util.regex.Pattern">
                <description>Specify the format of the regular expression to match.</description>
             </property>
             <property name="message" type="java.lang.String">

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressWithNearbyCommentFilter.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressWithNearbyCommentFilter.xml
@@ -30,16 +30,20 @@
                       type="java.util.regex.Pattern">
                <description>Specify comment pattern to trigger filter to begin suppression.</description>
             </property>
-            <property default-value=".*" name="checkFormat" type="java.lang.String">
+            <property default-value=".*"
+                      name="checkFormat"
+                      type="java.util.regex.Pattern">
                <description>Specify check pattern to suppress.</description>
             </property>
-            <property name="messageFormat" type="java.lang.String">
+            <property name="messageFormat" type="java.util.regex.Pattern">
                <description>Define message pattern to suppress.</description>
             </property>
-            <property name="idFormat" type="java.lang.String">
+            <property name="idFormat" type="java.util.regex.Pattern">
                <description>Specify check ID pattern to suppress.</description>
             </property>
-            <property default-value="0" name="influenceFormat" type="java.lang.String">
+            <property default-value="0"
+                      name="influenceFormat"
+                      type="java.util.regex.Pattern">
                <description>Specify negative/zero/positive value that
  defines the number of lines preceding/at/following the suppression comment.</description>
             </property>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressWithPlainTextCommentFilter.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressWithPlainTextCommentFilter.xml
@@ -52,13 +52,15 @@
                <description>Specify comment pattern to trigger filter
  to end suppression.</description>
             </property>
-            <property default-value=".*" name="checkFormat" type="java.lang.String">
+            <property default-value=".*"
+                      name="checkFormat"
+                      type="java.util.regex.Pattern">
                <description>Specify check pattern to suppress.</description>
             </property>
-            <property name="messageFormat" type="java.lang.String">
+            <property name="messageFormat" type="java.util.regex.Pattern">
                <description>Specify message pattern to suppress.</description>
             </property>
-            <property name="idFormat" type="java.lang.String">
+            <property name="idFormat" type="java.util.regex.Pattern">
                <description>Specify check ID pattern to suppress.</description>
             </property>
          </properties>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressionCommentFilter.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressionCommentFilter.xml
@@ -47,13 +47,15 @@
                       type="java.util.regex.Pattern">
                <description>Specify comment pattern to trigger filter to end suppression.</description>
             </property>
-            <property default-value=".*" name="checkFormat" type="java.lang.String">
+            <property default-value=".*"
+                      name="checkFormat"
+                      type="java.util.regex.Pattern">
                <description>Specify check pattern to suppress.</description>
             </property>
-            <property name="messageFormat" type="java.lang.String">
+            <property name="messageFormat" type="java.util.regex.Pattern">
                <description>Specify message pattern to suppress.</description>
             </property>
-            <property name="idFormat" type="java.lang.String">
+            <property name="idFormat" type="java.util.regex.Pattern">
                <description>Specify check ID pattern to suppress.</description>
             </property>
             <property default-value="true" name="checkCPP" type="boolean">

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressionSingleFilter.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressionSingleFilter.xml
@@ -30,9 +30,7 @@
                <description>Define the RegExp for matching against the file name associated with
  an audit event.</description>
             </property>
-            <property name="checks"
-                      type="java.lang.String"
-                      validation-type="java.util.regex.Pattern">
+            <property name="checks" type="java.util.regex.Pattern">
                <description>Define the RegExp for matching against the name of the check
  associated with an audit event.</description>
             </property>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressionXpathSingleFilter.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressionXpathSingleFilter.xml
@@ -26,21 +26,15 @@
  SuppressionXpathSingleFilter can suppress Checks that have Treewalker as parent module.
  &lt;/p&gt;</description>
          <properties>
-            <property name="files"
-                      type="java.lang.String"
-                      validation-type="java.util.regex.Pattern">
+            <property name="files" type="java.util.regex.Pattern">
                <description>Define a Regular Expression matched against the file
  name associated with an audit event.</description>
             </property>
-            <property name="checks"
-                      type="java.lang.String"
-                      validation-type="java.util.regex.Pattern">
+            <property name="checks" type="java.util.regex.Pattern">
                <description>Define a Regular Expression matched against the name
  of the check associated with an audit event.</description>
             </property>
-            <property name="message"
-                      type="java.lang.String"
-                      validation-type="java.util.regex.Pattern">
+            <property name="message" type="java.util.regex.Pattern">
                <description>Define a Regular Expression matched against the message
  of the check associated with an audit event.</description>
             </property>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -86,8 +86,6 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
             .put("double[]", double[].class)
             .put("String", String.class)
             .put("String[]", String[].class)
-            .put("Regular Expression", String.class)
-            .put("Regular Expressions", String[].class)
             .put("Pattern", Pattern.class)
             .put("Pattern[]", Pattern[].class)
             .put("AccessModifierOption[]", AccessModifierOption[].class)
@@ -107,19 +105,6 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
             .put("URI", URI.class)
             .put("WrapOption", WrapOption.class)
             .put("PARAM_LITERAL", int[].class).build();
-
-    private static final Set<String> PATTERN_EXCEPTIONS = Collections.unmodifiableSet(
-        Arrays.stream(new String[] {
-            "ClassDataAbstractionCoupling - excludeClassesRegexps",
-            "ClassFanOutComplexity - excludeClassesRegexps",
-            "IllegalTokenText - format",
-            "ImportOrder - groups",
-            "ImportOrder - staticGroups",
-            "SuppressionSingleFilter - checks",
-            "SuppressionXpathSingleFilter - files",
-            "SuppressionXpathSingleFilter - checks",
-            "SuppressionXpathSingleFilter - message",
-        }).collect(Collectors.toSet()));
 
     private static final Set<String> NON_BASE_TOKEN_PROPERTIES = Collections.unmodifiableSet(
         Arrays.stream(new String[] {
@@ -383,9 +368,6 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
         String result = null;
         if (NON_BASE_TOKEN_PROPERTIES.contains(checkName + " - " + propertyName)) {
             result = " Validation type is {@code tokenTypesSet}.";
-        }
-        else if (PATTERN_EXCEPTIONS.contains(checkName + " - " + propertyName)) {
-            result = " Validation type is {@code java.util.regex.Pattern}.";
         }
         else if (isPropertyTokenType) {
             result = " Validation type is {@code tokenSet}.";

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -972,7 +972,6 @@ public class XdocsPagesTest {
             Object instance, String propertyName) {
         final String instanceName = instance.getClass().getSimpleName();
         String result = null;
-        final String checkProperty = sectionName + ":" + propertyName;
         if (("SuppressionCommentFilter".equals(sectionName)
                 || "SuppressWithNearbyCommentFilter".equals(sectionName)
                 || "SuppressWithPlainTextCommentFilter".equals(sectionName))
@@ -985,7 +984,7 @@ public class XdocsPagesTest {
                     || "RegexpSinglelineJava".equals(sectionName))
                     && "format".equals(propertyName)) {
             // dynamic custom expression
-            result = "Regular Expression";
+            result = "Pattern";
         }
         else if (fieldClass == boolean.class) {
             result = "boolean";
@@ -1029,27 +1028,10 @@ public class XdocsPagesTest {
             result = "URI";
         }
         else if (fieldClass == Pattern.class) {
-            if ("SuppressionSingleFilter:checks".equals(checkProperty)
-                || "SuppressionXpathSingleFilter:files".equals(checkProperty)
-                || "SuppressionXpathSingleFilter:checks".equals(checkProperty)
-                || "SuppressionXpathSingleFilter:message".equals(checkProperty)
-                || "IllegalTokenText:format".equals(checkProperty)) {
-                result = "Regular Expression";
-            }
-            else {
-                result = "Pattern";
-            }
+            result = "Pattern";
         }
         else if (fieldClass == Pattern[].class) {
-            if ("ImportOrder:groups".equals(checkProperty)
-                || "ImportOrder:staticGroups".equals(checkProperty)
-                || "ClassDataAbstractionCoupling:excludeClassesRegexps".equals(checkProperty)
-                || "ClassFanOutComplexity:excludeClassesRegexps".equals(checkProperty)) {
-                result = "Regular Expressions";
-            }
-            else {
-                result = "Pattern[]";
-            }
+            result = "Pattern[]";
         }
         else if (fieldClass == Scope.class) {
             result = "Scope";

--- a/src/xdocs/checks.xml
+++ b/src/xdocs/checks.xml
@@ -36,7 +36,7 @@
           <tr>
             <td><a href="config_naming.html#AbstractClassName">AbstractClassName</a></td>
             <td>
-              Ensures that the names of abstract classes conforming to some regular expression and
+              Ensures that the names of abstract classes conforming to some pattern and
               check that <code>abstract</code> modifier exists.
             </td>
           </tr>
@@ -309,7 +309,7 @@
               <a href="config_naming.html#IllegalIdentifierName">IllegalIdentifierName</a>
             </td>
             <td>
-              Checks identifiers with a regular expression for a set of illegal names, such as those
+              Checks identifiers with a pattern for a set of illegal names, such as those
               that are restricted or contextual keywords.
             </td>
           </tr>
@@ -599,8 +599,8 @@
             <td><a href="config_design.html#MutableException">MutableException</a></td>
             <td>
               Ensures that exception classes (classes with names conforming to
-              some regular expression and explicitly extending classes with names
-              conforming to other regular expression) are immutable, that is,
+              some pattern and explicitly extending classes with names
+              conforming to other pattern) are immutable, that is,
               that they have only final fields.
             </td>
           </tr>
@@ -801,7 +801,7 @@
             <td><a href="config_header.html#RegexpHeader">RegexpHeader</a></td>
             <td>
               Checks the header of a source file against a header that contains
-              a regular expression for each line of the source header.
+              a pattern for each line of the source header.
             </td>
           </tr>
           <tr>

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -2931,7 +2931,7 @@ public native void myTest(); // violation
             <tr>
               <td>format</td>
               <td>Define the RegExp for illegal pattern.</td>
-              <td><a href="property_types.html#RegularExpression">Regular Expression</a></td>
+              <td><a href="property_types.html#Pattern">Pattern</a></td>
               <td><code>&quot;^$&quot;</code></td>
               <td>3.2</td>
             </tr>

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -747,9 +747,9 @@ public interface Test2 { // violation
       <p>Since Checkstyle 3.2</p>
       <subsection name="Description" id="MutableException_Description">
         <p>
-          Ensures that exception classes (classes with names conforming to some regular
-          expression and explicitly extending classes with names conforming to other
-          regular expression) are immutable, that is, that they have only final fields.
+          Ensures that exception classes (classes with names conforming to some pattern
+          and explicitly extending classes with names conforming to other
+          pattern) are immutable, that is, that they have only final fields.
         </p>
 
         <p>

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -160,21 +160,21 @@
             <tr>
               <td>checkFormat</td>
               <td>Specify check pattern to suppress.</td>
-              <td><a href="property_types.html#RegularExpression">Regular Expression</a></td>
+              <td><a href="property_types.html#Pattern">Pattern</a></td>
               <td><code>".*"</code></td>
               <td>3.5</td>
             </tr>
             <tr>
               <td>messageFormat</td>
               <td>Specify message pattern to suppress.</td>
-              <td><a href="property_types.html#RegularExpression">Regular Expression</a></td>
+              <td><a href="property_types.html#Pattern">Pattern</a></td>
               <td><code>null</code></td>
               <td>3.5</td>
             </tr>
             <tr>
               <td>idFormat</td>
               <td>Specify check ID pattern to suppress.</td>
-              <td><a href="property_types.html#RegularExpression">Regular Expression</a></td>
+              <td><a href="property_types.html#Pattern">Pattern</a></td>
               <td><code>null</code></td>
               <td>8.24</td>
             </tr>
@@ -733,7 +733,7 @@ files=&quot;com[\\/]mycompany[\\/]app[\\/].*IT.java&quot;/&gt;
               <td>checks</td>
               <td>Define the RegExp for matching against the name of the check
                   associated with an audit event.</td>
-              <td><a href="property_types.html#RegularExpression">Regular Expression</a></td>
+              <td><a href="property_types.html#Pattern">Pattern</a></td>
               <td><code>null</code></td>
               <td>8.23</td>
             </tr>
@@ -1411,7 +1411,7 @@ CLASS_DEF -> CLASS_DEF [1:0]
               <td>files</td>
               <td>Define a Regular Expression matched against the file name associated
                   with an audit event.</td>
-              <td><a href="property_types.html#RegularExpression">Regular Expression</a></td>
+              <td><a href="property_types.html#Pattern">Pattern</a></td>
               <td><code>null</code></td>
               <td>8.18</td>
             </tr>
@@ -1419,7 +1419,7 @@ CLASS_DEF -> CLASS_DEF [1:0]
               <td>checks</td>
               <td>Define a Regular Expression matched against the name of the check
                   associated with an audit event.</td>
-              <td><a href="property_types.html#RegularExpression">Regular Expression</a></td>
+              <td><a href="property_types.html#Pattern">Pattern</a></td>
               <td><code>null</code></td>
               <td>8.18</td>
             </tr>
@@ -1427,7 +1427,7 @@ CLASS_DEF -> CLASS_DEF [1:0]
               <td>message</td>
               <td>Define a Regular Expression matched against the message of the check associated
                   with an audit event.</td>
-              <td><a href="property_types.html#RegularExpression">Regular Expression</a></td>
+              <td><a href="property_types.html#Pattern">Pattern</a></td>
               <td><code>null</code></td>
               <td>8.18</td>
             </tr>
@@ -1995,21 +1995,21 @@ public static void foo() {
             <tr>
               <td>checkFormat</td>
               <td>Specify check pattern to suppress.</td>
-              <td><a href="property_types.html#RegularExpression">Regular Expression</a></td>
+              <td><a href="property_types.html#Pattern">Pattern</a></td>
               <td><code>".*"</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>messageFormat</td>
               <td>Define message pattern to suppress.</td>
-              <td><a href="property_types.html#RegularExpression">Regular Expression</a></td>
+              <td><a href="property_types.html#Pattern">Pattern</a></td>
               <td><code>null</code></td>
               <td>5.0</td>
             </tr>
             <tr>
               <td>idFormat</td>
               <td>Specify check ID pattern to suppress.</td>
-              <td><a href="property_types.html#RegularExpression">Regular Expression</a></td>
+              <td><a href="property_types.html#Pattern">Pattern</a></td>
               <td><code>null</code></td>
               <td>8.24</td>
             </tr>
@@ -2017,7 +2017,7 @@ public static void foo() {
               <td>influenceFormat</td>
               <td>Specify negative/zero/positive value that defines the number of
                   lines preceding/at/following the suppression comment.</td>
-              <td><a href="property_types.html#RegularExpression">Regular Expression</a></td>
+              <td><a href="property_types.html#Pattern">Pattern</a></td>
               <td><code>"0"</code></td>
               <td>5.0</td>
             </tr>
@@ -2278,24 +2278,21 @@ public class UserService {
             <tr>
               <td>checkFormat</td>
               <td>Specify check pattern to suppress.</td>
-              <td><a href="property_types.html#RegularExpression">
-                Regular Expression</a></td>
+              <td><a href="property_types.html#Pattern">Pattern</a></td>
               <td><code>".*"</code></td>
               <td>8.6</td>
             </tr>
             <tr>
               <td>messageFormat</td>
               <td>Specify message pattern to suppress.</td>
-              <td><a href="property_types.html#RegularExpression">
-                Regular Expression</a></td>
+              <td><a href="property_types.html#Pattern">Pattern</a></td>
               <td><code>null</code></td>
               <td>8.6</td>
             </tr>
             <tr>
               <td>idFormat</td>
               <td>Specify check ID pattern to suppress.</td>
-              <td><a href="property_types.html#RegularExpression">
-                Regular Expression</a></td>
+              <td><a href="property_types.html#Pattern">Pattern</a></td>
               <td><code>null</code></td>
               <td>8.24</td>
             </tr>

--- a/src/xdocs/config_header.xml
+++ b/src/xdocs/config_header.xml
@@ -198,7 +198,7 @@ line 5: ////////////////////////////////////////////////////////////////////
         <p>
           Checks the header of a source file against a header that contains a
           <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html">
-          regular expression</a> for each line of the source header.
+            pattern</a> for each line of the source header.
         </p>
 
         <p>

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -1802,7 +1802,7 @@ import java.util.stream.IntStream;
                 Thus, the empty list of type groups (the default value) means
                 one group for all type imports.
               </td>
-              <td><a href="property_types.html#RegularExpression">Regular Expressions</a></td>
+              <td><a href="property_types.html#Pattern.5B.5D">Pattern[]</a></td>
               <td><code>{}</code></td>
               <td>3.2</td>
             </tr>
@@ -1861,7 +1861,7 @@ import java.util.stream.IntStream;
                 the property <code>option</code> is set to <code>top</code> or
                 <code>bottom</code>.
               </td>
-              <td><a href="property_types.html#RegularExpression">Regular Expressions</a></td>
+              <td><a href="property_types.html#Pattern.5B.5D">Pattern[]</a></td>
               <td><code>{}</code></td>
               <td>8.12</td>
             </tr>

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -2029,7 +2029,7 @@ public class Test {
           author tag or a version tag, set property authorFormat or
           versionFormat respectively to a
           <a href="https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">
-            regular expression</a>.
+            pattern</a>.
         </p>
         <p>
           Does not perform checks for author and version tags for inner

--- a/src/xdocs/config_metrics.xml
+++ b/src/xdocs/config_metrics.xml
@@ -311,7 +311,7 @@ public class Test
             <tr>
               <td>excludeClassesRegexps</td>
               <td>Specify user-configured regular expressions to ignore classes.</td>
-              <td><a href="property_types.html#RegularExpression">Regular Expressions</a></td>
+              <td><a href="property_types.html#Pattern.5B.5D">Pattern[]</a></td>
               <td><code>^$</code></td>
               <td>7.7</td>
             </tr>
@@ -695,7 +695,7 @@ class Foo {
             <tr>
               <td>excludeClassesRegexps</td>
               <td>Specify user-configured regular expressions to ignore classes.</td>
-              <td><a href="property_types.html#RegularExpression">Regular Expressions</a></td>
+              <td><a href="property_types.html#Pattern.5B.5D">Pattern[]</a></td>
               <td><code>^$</code></td>
               <td>7.7</td>
             </tr>

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -1859,8 +1859,7 @@ record Foo { // violation
           Checks for <code>TODO:</code> comments. Actually
           it is a generic
           <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html">
-          regular
-          expression</a> matcher on Java comments. To check for other
+          pattern</a> matcher on Java comments. To check for other
           patterns in Java comments, set the <code>format</code> property.
         </p>
       </subsection>

--- a/src/xdocs/config_naming.xml
+++ b/src/xdocs/config_naming.xml
@@ -22,7 +22,7 @@
         elements. Valid identifiers for a naming module are specified by its
         <code> format</code> property. The value of <code>format</code> is a <a
         href="https://docs.oracle.com/javase/1.5.0/docs/api/java/util/regex/Pattern.html">
-        regular expression</a> for valid identifiers.
+          pattern</a> for valid identifiers.
       </p>
     </section>
 
@@ -384,7 +384,7 @@ public class MyClass {
       <p>Since Checkstyle 3.2</p>
       <subsection name="Description" id="AbstractClassName_Description">
         <p>
-          Ensures that the names of abstract classes conforming to some regular expression and
+          Ensures that the names of abstract classes conforming to some pattern and
           check that <code>abstract</code> modifier exists.
         </p>
         <p>
@@ -970,13 +970,13 @@ class MyClass {
       <p>Since Checkstyle 8.36</p>
       <subsection name="Description" id="IllegalIdentifierName_Description">
         <p>
-          Checks identifiers with a regular expression for a set of illegal names, such as those
+          Checks identifiers with a pattern for a set of illegal names, such as those
           that are restricted or contextual keywords. Examples include "yield", "record",
           "_", and "var". Please read more at
           <a href="https://docs.oracle.com/javase/specs/jls/se14/html/jls-3.html#jls-3.9">
           Java Language Specification
           </a>to get to know more about restricted keywords. Since this check uses a
-          regular expression to specify valid identifiers, users can also prohibit the usage
+          pattern to specify valid identifiers, users can also prohibit the usage
           of certain symbols, such as "$", or any non-ascii character.
         </p>
       </subsection>

--- a/src/xdocs/config_regexp.xml
+++ b/src/xdocs/config_regexp.xml
@@ -517,7 +517,7 @@ public static final int A_SETPOINT = 1;
             <tr>
               <td>format</td>
               <td>Specify the format of the regular expression to match.</td>
-              <td><a href="property_types.html#RegularExpression">Regular Expression</a></td>
+              <td><a href="property_types.html#Pattern">Pattern</a></td>
               <td><code>&quot;$.&quot;</code></td>
               <td>5.0</td>
             </tr>
@@ -1068,7 +1068,7 @@ src/main/main_class.java  //violation, file names should be in Camel Case
             <tr>
               <td>format</td>
               <td>Specify the format of the regular expression to match.</td>
-              <td><a href="property_types.html#RegularExpression">Regular Expression</a></td>
+              <td><a href="property_types.html#Pattern">Pattern</a></td>
               <td><code>&quot;$.&quot;</code></td>
               <td>5.0</td>
             </tr>
@@ -1293,7 +1293,7 @@ CREATE DATABASE MyDB;
             <tr>
               <td>format</td>
               <td>Specify the format of the regular expression to match.</td>
-              <td><a href="property_types.html#RegularExpression">Regular Expression</a></td>
+              <td><a href="property_types.html#Pattern">Pattern</a></td>
               <td><code>&quot;$.&quot;</code></td>
               <td>5.0</td>
             </tr>

--- a/src/xdocs/property_types.xml
+++ b/src/xdocs/property_types.xml
@@ -677,14 +677,6 @@
       </p>
     </section>
 
-    <section name="RegularExpression">
-      <p>
-        This type represents a regular expression. The string representation is parsed using
-        <a href="https://docs.oracle.com/javase/8/docs/api/index.html?java/util/regex/package-summary.html">
-        java.util.regex package</a>.
-      </p>
-    </section>
-
     <section name="RightCurlyOption">
       <p>
         This type represents the policy for checking the placement of a

--- a/src/xdocs/writingfilefilters.xml
+++ b/src/xdocs/writingfilefilters.xml
@@ -45,7 +45,7 @@
       <p>
         The <code>BeforeExecutionFileFilter</code> that we demonstrate here rejects
         file uris whose name matches a <a
-        href="property_types.html#Pattern">regular expression</a>.  In order to
+        href="property_types.html#Pattern">Pattern</a>.  In order to
         enable the specification of the file name pattern as a property in a
         configuration file, the <code>BeforeExecutionFileFilter</code> is an <a
         href="apidocs/com/puppycrawl/tools/checkstyle/api/AutomaticBean.html">AutomaticBean</a>

--- a/src/xdocs/writingfilters.xml
+++ b/src/xdocs/writingfilters.xml
@@ -50,7 +50,7 @@
       <p>
         The <code>Filter</code> that we demonstrate here rejects
         audit events for files whose name matches a <a
-        href="property_types.html#Pattern">regular expression</a>.  In order to
+        href="property_types.html#Pattern">Pattern</a>.  In order to
         enable the specification of the file name pattern as a property in a
         configuration file, the <code>Filter</code> is an <a
         href="apidocs/com/puppycrawl/tools/checkstyle/api/AutomaticBean.html">AutomaticBean</a>


### PR DESCRIPTION
Issue #10842 

Property type "Regular Expression" removed in favor of "Pattern".
Property type "Regular Expressions" removed in favor of "Pattern[]".