### PR TITLE
minor: specify internal class for DocumentBuilderFactory

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java
@@ -146,7 +146,9 @@ public final class XmlMetaReader {
             throws ParserConfigurationException, IOException, SAXException {
         ModuleDetails result = null;
         if (moduleType != null) {
-            final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance(
+                    "com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl",
+                    null);
             factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
             factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
             final DocumentBuilder builder = factory.newDocumentBuilder();


### PR DESCRIPTION
Begin investigation regarding  https://github.com/checkstyle/sonar-checkstyle/pull/366#issuecomment-823258678

Checkstyle deps that depend on `xerces`:

```bash


[INFO] The following plugins have been resolved:
[INFO]    org.apache.maven.plugins:maven-linkcheck-plugin:maven-plugin:1.2:runtime
[INFO]       xerces:xercesImpl:jar:2.9.1

[INFO]    org.apache.maven.plugins:maven-surefire-report-plugin:maven-plugin:2.22.2:runtime
[INFO]       xerces:xercesImpl:jar:2.9.1

[INFO]    com.github.sevntu-checkstyle:dsm-maven-plugin:maven-plugin:2.2.0:runtime
[INFO]       xerces:xercesImpl:jar:2.9.1

[INFO]    org.codehaus.mojo:versions-maven-plugin:maven-plugin:2.8.1:runtime
[INFO]       nekohtml:xercesMinimal:jar:1.9.6.2

[INFO]    org.apache.maven.plugins:maven-failsafe-plugin:maven-plugin:2.22.2:runtime
[INFO]       nekohtml:xercesMinimal:jar:1.9.6.2

[INFO]    org.apache.maven.plugins:maven-eclipse-plugin:maven-plugin:2.10:runtime
[INFO]       nekohtml:xercesMinimal:jar:1.9.6.2

[INFO]    org.apache.maven.plugins:maven-surefire-plugin:maven-plugin:2.22.2:runtime
[INFO]       nekohtml:xercesMinimal:jar:1.9.6.2


```