### PR TITLE
Issue #10844: UT output should be silent

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReaderTest.java
@@ -27,11 +27,17 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
 
 public class XmlMetaReaderTest extends AbstractPathTestSupport {
+
+    @BeforeAll
+    public static void init() {
+        System.setProperty("org.slf4j.simpleLogger.log.org.reflections", "off");
+    }
 
     @Override
     protected String getPackageLocation() {


### PR DESCRIPTION
Fixes #10844 As suggested by @rnveach, setting `simplelogger` to `off` in system property resolved the issue.