### PR TITLE
supplemental: Output should be silent for Issue #10844

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/ArchUnitTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/ArchUnitTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.internal;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
@@ -30,6 +31,13 @@ import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.ArchRule;
 
 public class ArchUnitTest {
+
+    @BeforeAll
+    public static void init() {
+        System.setProperty(
+                "org.slf4j.simpleLogger.log.com.tngtech.archunit.core.PluginLoader", "off");
+    }
+
     /**
      * The goal is to ensure all classes of a specific name pattern have non-protected methods,
      * except for those which are annotated with {@code Override}. In the bytecode there is no


### PR DESCRIPTION
Follow up for issue #10844 [reference](https://github.com/checkstyle/checkstyle/pull/10850#issuecomment-939095228) 

arch still works:
```
[ERROR] Failures: 
[ERROR]   ArchUnitTest.nonProtectedCheckMethodsTest:74 Architecture Violation [Priority: MEDIUM] - Rule 'methods that have name not matching '.*(processFiltered|getMethodName|mustCheckName|postProcessHeaderLines|getLogMessageId)' and are declared in classes that have simple name ending with 'Check' and are declared in classes that do not have modifier ABSTRACT should not be protected' was violated (1 times):
Method <com.puppycrawl.tools.checkstyle.checks.ArrayTypeStyleCheck.sewert1(boolean)> has modifier PROTECTED in (ArrayTypeStyleCheck.java:168)
[INFO] 
[ERROR] Tests run: 3642, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:57 min
[INFO] Finished at: 2021-10-08T17:00:45-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.22.2:test (default-test) on project checkstyle: There are test failures.
[ERROR] 
[ERROR] Please refer to /home/rivanov/java/github/romani/checkstyle/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
✘-1 ~/java/github/romani/checkstyle [amarlearning/fix-sup-10844 L|✚ 1] 
17:00 $ git diff
diff --git a/src/main/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheck.java b/src/main/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheck.java
index 0206ecf..6a301b4 100644
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheck.java
@@ -164,4 +164,8 @@ public class ArrayTypeStyleCheck extends AbstractCheck {
         this.javaStyle = javaStyle;
     }
 
+    protected void sewert1(boolean javaStyle) {
+        this.javaStyle = javaStyle;
+    }
+
 }

```