### PR TITLE
Issue #10866: Fix false positive for switch expressions with operator in MissingSwitchDefault

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheck.java
@@ -65,6 +65,14 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *  default: // OK
  *    break;
  * }
+ * return switch (option) { // OK, the compiler requires switch expression to be exhaustive
+ *  case ONE:
+ *    yield 1;
+ *  case TWO:
+ *    yield 2;
+ *  case THREE:
+ *    yield 3;
+ * }
  * </pre>
  * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
@@ -156,7 +164,8 @@ public class MissingSwitchDefaultCheck extends AbstractCheck {
      * @return true if part of a switch expression
      */
     private static boolean isSwitchExpression(DetailAST ast) {
-        return ast.getParent().getType() == TokenTypes.EXPR;
+        return ast.getParent().getType() == TokenTypes.EXPR
+                || ast.getParent().getParent().getType() == TokenTypes.EXPR;
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheckTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class MissingSwitchDefaultCheckTest
     extends AbstractModuleTestSupport {
@@ -72,6 +73,14 @@ public class MissingSwitchDefaultCheckTest
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputMissingSwitchDefaultCheckSwitchExpressionsTwo.java"),
+                expected);
+    }
+
+    @Test
+    public void testMissingSwitchDefaultSwitchExpressionsThree() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputMissingSwitchDefaultCheckSwitchExpressionsThree.java"),
                 expected);
     }
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefaultCheckSwitchExpressionsThree.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefaultCheckSwitchExpressionsThree.java
@@ -1,0 +1,84 @@
+/*
+MissingSwitchDefault
+
+
+*/
+
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.coding.missingswitchdefault;
+
+public class InputMissingSwitchDefaultCheckSwitchExpressionsThree {
+    public enum Options {
+        ONE,
+        TWO,
+        THREE
+    }
+
+    public enum Day {
+        MON,
+        TUE,
+        WED,
+        THU,
+        FRI,
+        SAT,
+        SUN,
+    }
+
+    public void foo1(Options option) {
+        int num = switch (option) { // ok
+            case ONE:
+                yield 1;
+            case TWO:
+                yield 2;
+            case THREE:
+                yield 3;
+        };
+    }
+
+    public void foo2(Options option) {
+        assert Integer.valueOf(1).equals(switch (option) { // ok
+            case ONE -> 1;
+            case TWO -> 2;
+            case THREE -> 3;
+        });
+    }
+
+    public void bar1(Options option) {
+        int num;
+        num = switch (option) { // ok
+            case ONE -> 1;
+            case TWO -> 2;
+            case THREE -> 3;
+        };
+    }
+
+    public void bar2(Options option) {
+        assert 1 < switch (option) { // ok
+            case ONE -> 1;
+            case TWO -> 2;
+            case THREE -> 3;
+        };
+    }
+
+    public void bar3(Options option) {
+        int num = 0;
+        num += switch (option) { // ok
+            case ONE -> 1;
+            case TWO -> 2;
+            case THREE -> 3;
+        };
+    }
+
+    int usedOnBothSidesOfArithmeticExpression(Day day) {
+        return switch (day) { // ok
+            case MON, TUE -> 0;
+            case WED -> 1;
+            default -> 2;
+        } * switch (day) { // ok
+            case WED, THU -> 3;
+            case FRI -> 4;
+            default -> 5;
+        };
+    }
+
+}

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -4265,6 +4265,14 @@ switch (i) {
   default: // OK
     break;
 }
+return switch (option) { // OK, the compiler requires switch expression to be exhaustive
+  case ONE:
+    yield 1;
+  case TWO:
+    yield 2;
+  case THREE:
+    yield 3;
+}
         </source>
       </subsection>
 


### PR DESCRIPTION
Issue #10866: Fix false positive for switch expressions with operator in MissingSwitchDefault

Diff Regression config: https://gist.githubusercontent.com/KENNYSOFT/617d1d36499254a787df66c050902248/raw/3e2f9ab80feafd78176475ff15b22da50e24e5d6/my_check-MissingSwitchDefault.xml