### PR TITLE
infra: update xwiki commit

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -201,7 +201,7 @@ no-error-xwiki)
   cd ..
   checkout_from https://github.com/xwiki/xwiki-platform.git
   cd .ci-temp/xwiki-platform
-  git checkout "ec4cee44da""f56a76915f7445486f""bb502a""da791f"
+  git checkout "dc""f""b67ad6b5b78d7d506760c""e78d9a3d44b125af"
   # Validate xwiki-platform
   mvn -e --no-transfer-progress checkstyle:check@default -Dcheckstyle.version=${CS_POM_VERSION}
   cd ..


### PR DESCRIPTION
Noticed failure at https://app.circleci.com/pipelines/github/checkstyle/checkstyle/9288/workflows/2b9d1f8b-d3cb-41aa-8f9e-70d01fa0d915/jobs/102543, we need to update xwiki commit sha to latest head commit.