### PR TITLE
Issue #10859: FinalClass now exempts private-only constructor classes that are extended by another class in the same compilation unit

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -31,7 +31,7 @@ function checkPitestReport() {
 
 case $1 in
 
-pitest-annotation|pitest-design \
+pitest-annotation \
 |pitest-metrics|pitest-modifier|pitest-naming \
 |pitest-sizes|pitest-whitespace \
 |pitest-api|pitest-blocks \
@@ -185,6 +185,14 @@ pitest-utils)
 #   mvn -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;
 #   # post validation is skipped, we do not test gui throughly
 #   ;;
+
+pitest-design)
+  mvn --no-transfer-progress -e -P$1 clean test org.pitest:pitest-maven:mutationCoverage;
+  declare -a ignoredItems=(
+  "FinalClassCheck.java.html:<td class='covered'><pre><span  class='survived'>                        .count();</span></pre></td></tr>"
+  );
+  checkPitestReport "${ignoredItems[@]}"
+  ;;
 
 *)
   echo "Unexpected argument: $1"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
@@ -21,6 +21,8 @@ package com.puppycrawl.tools.checkstyle.checks.design;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
@@ -122,6 +124,12 @@ public class FinalClassCheck
     /** Keeps ClassDesc objects for stack of declared classes. */
     private Deque<ClassDesc> classes;
 
+    /**
+     * Keeps ClassDesc objects for stack of declared classes,
+     * pops the class out when all nested, inner, anonymous classes have been examined.
+     */
+    private Deque<ClassDesc> classesPoppedOutAfterExamination;
+
     /** Full qualified name of the package. */
     private String packageName;
 
@@ -147,6 +155,7 @@ public class FinalClassCheck
 
     @Override
     public void beginTree(DetailAST rootAST) {
+        classesPoppedOutAfterExamination = new ArrayDeque<>();
         classes = new ArrayDeque<>();
         packageName = "";
     }
@@ -161,18 +170,19 @@ public class FinalClassCheck
                 break;
 
             case TokenTypes.CLASS_DEF:
-                registerNestedSubclassToOuterSuperClasses(ast);
-
                 final boolean isFinal = modifiers.findFirstToken(TokenTypes.FINAL) != null;
                 final boolean isAbstract = modifiers.findFirstToken(TokenTypes.ABSTRACT) != null;
 
                 final String qualifiedClassName = getQualifiedClassName(ast);
-                classes.push(new ClassDesc(qualifiedClassName, isFinal, isAbstract));
+                final ClassDesc currClass = new ClassDesc(
+                        qualifiedClassName, isFinal, isAbstract, ast);
+                classesPoppedOutAfterExamination.push(currClass);
+                classes.push(currClass);
                 break;
 
             case TokenTypes.CTOR_DEF:
                 if (!ScopeUtil.isInEnumBlock(ast) && !ScopeUtil.isInRecordBlock(ast)) {
-                    final ClassDesc desc = classes.peek();
+                    final ClassDesc desc = classesPoppedOutAfterExamination.peek();
                     if (modifiers.findFirstToken(TokenTypes.LITERAL_PRIVATE) == null) {
                         desc.registerNonPrivateCtor();
                     }
@@ -185,14 +195,13 @@ public class FinalClassCheck
             case TokenTypes.LITERAL_NEW:
                 if (ast.getFirstChild() != null
                         && ast.getLastChild().getType() == TokenTypes.OBJBLOCK) {
-                    for (ClassDesc classDesc : classes) {
+                    for (ClassDesc classDesc : classesPoppedOutAfterExamination) {
                         if (doesNameOfClassMatchAnonymousInnerClassName(ast, classDesc)) {
                             classDesc.registerAnonymousInnerClass();
                         }
                     }
                 }
                 break;
-
             default:
                 throw new IllegalStateException(ast.toString());
         }
@@ -201,19 +210,57 @@ public class FinalClassCheck
     @Override
     public void leaveToken(DetailAST ast) {
         if (ast.getType() == TokenTypes.CLASS_DEF) {
-            final ClassDesc desc = classes.pop();
-            if (desc.isWithPrivateCtor()
+            classesPoppedOutAfterExamination.pop();
+            if (isTopLevelClass(ast)) {
+                classes.forEach(desc -> {
+                    final DetailAST classAst = desc.getClassAst();
+                    registerNestedSubclassToOuterSuperClasses(classAst, desc.getQualifiedName());
+                });
+                int size = classes.size();
+                while (size > 0) {
+                    final ClassDesc pop = classes.pop();
+                    final DetailAST classAst = pop.getClassAst();
+                    if (shouldBeDeclaredAsFinal(pop, classAst)) {
+                        final String qualifiedName = pop.getQualifiedName();
+                        final String className = getClassNameFromQualifiedName(qualifiedName);
+                        log(classAst, MSG_KEY, className);
+                    }
+                    size--;
+                }
+            }
+        }
+    }
+
+    /**
+     * Checks if the current class is one of the outermost class.
+     *
+     * @param classAst classAst
+     * @return true if current class is one of the outermost class
+     */
+    private static boolean isTopLevelClass(DetailAST classAst) {
+        boolean result = true;
+        final DetailAST grandParent = classAst.getParent().getParent();
+        if (grandParent != null) {
+            result = grandParent.getType() != TokenTypes.CLASS_DEF;
+        }
+        return result;
+    }
+
+    /**
+     * Checks whether a class should be declared as final or not.
+     *
+     * @param desc description of the class
+     * @param classAst classAst
+     * @return true if given class should be declared as final otherwise false
+     */
+    private static boolean shouldBeDeclaredAsFinal(ClassDesc desc, DetailAST classAst) {
+        return desc.isWithPrivateCtor()
                 && !(desc.isDeclaredAsAbstract()
-                    || desc.isWithAnonymousInnerClass())
+                || desc.isWithAnonymousInnerClass())
                 && !desc.isDeclaredAsFinal()
                 && !desc.isWithNonPrivateCtor()
                 && !desc.isWithNestedSubclass()
-                && !ScopeUtil.isInInterfaceOrAnnotationBlock(ast)) {
-                final String qualifiedName = desc.getQualifiedName();
-                final String className = getClassNameFromQualifiedName(qualifiedName);
-                log(ast, MSG_KEY, className);
-            }
-        }
+                && !ScopeUtil.isInInterfaceOrAnnotationBlock(classAst);
     }
 
     /**
@@ -227,23 +274,136 @@ public class FinalClassCheck
     }
 
     /**
-     * Register to outer super classes of given classAst that
+     * Register to outer super class of given classAst that
      * given classAst is extending them.
      *
-     * @param classAst class which outer super classes will be
+     * @param classAst class which outer super class will be
      *                 informed about nesting subclass
+     * @param qualifiedClassName qualifies class name(with package) of the current class
      */
-    private void registerNestedSubclassToOuterSuperClasses(DetailAST classAst) {
+    private void registerNestedSubclassToOuterSuperClasses(DetailAST classAst,
+                                                           String qualifiedClassName) {
         final String currentAstSuperClassName = getSuperClassName(classAst);
+
         if (currentAstSuperClassName != null) {
+            String classToBeRegisteredAsSuperClass = currentAstSuperClassName;
+
+            final List<ClassDesc> sameNamedClassList = classesWithSameName(
+                    currentAstSuperClassName);
+            if (!sameNamedClassList.isEmpty()) {
+                classToBeRegisteredAsSuperClass = getClassToBeRegisteredAsSuperClass(
+                        qualifiedClassName, sameNamedClassList);
+            }
+
             for (ClassDesc classDesc : classes) {
                 final String classDescQualifiedName = classDesc.getQualifiedName();
-                if (doesNameInExtendMatchSuperClassName(classDescQualifiedName,
-                        currentAstSuperClassName)) {
+                if (classToBeRegisteredAsSuperClass.equals(classDescQualifiedName)) {
                     classDesc.registerNestedSubclass();
+                    break;
                 }
             }
         }
+    }
+
+    /**
+     * Checks if there is a class with same name.
+     *
+     * @param className name of the class
+     * @return true if there is another class with same name.
+     */
+    private List<ClassDesc> classesWithSameName(String className) {
+        return classes.stream()
+                .filter(classDesc -> {
+                    return classDesc.getQualifiedName().endsWith(
+                            PACKAGE_SEPARATOR + className);
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Get name of the class to be registered as super class.
+     * This method after getting the {@link ClassDesc#classNameMatchingCount}
+     * compares the classes on basis of it. It at a time compares two classes
+     * and keeps updating {@code classToBeRegisteredAsSuperClass} on basis of it.
+     *
+     * @param currentClassName current class name
+     * @param classesWithSameName classes which same name as super class
+     * @return name of the class to be registered as super class
+     */
+    private static String getClassToBeRegisteredAsSuperClass(String currentClassName,
+                                                             List<ClassDesc> classesWithSameName) {
+        for (ClassDesc desc : classesWithSameName) {
+            final String classWithSameName = desc.getQualifiedName();
+            desc.setClassNameMatchingCount(classNameMatchingCount(
+                    currentClassName, classWithSameName));
+        }
+        ClassDesc classToBeRegisteredAsSuperClass = classesWithSameName.get(0);
+        for (int i = 1; i < classesWithSameName.size(); i++) {
+            final ClassDesc classWithSameName = classesWithSameName.get(i);
+            if (classToBeRegisteredAsSuperClass.getClassNameMatchingCount()
+                    < classWithSameName.getClassNameMatchingCount()) {
+                classToBeRegisteredAsSuperClass = classWithSameName;
+            }
+            else if (classToBeRegisteredAsSuperClass.getClassNameMatchingCount()
+                    == classWithSameName.getClassNameMatchingCount()
+                    && isFormerClassNestedMoreThanTheLatterClass(
+                    classToBeRegisteredAsSuperClass.getQualifiedName(),
+                    classWithSameName.getQualifiedName())) {
+                classToBeRegisteredAsSuperClass = classWithSameName;
+            }
+        }
+        return classToBeRegisteredAsSuperClass.getQualifiedName();
+    }
+
+    /**
+     * Calculates and returns the class name matching count.
+     * Eg-
+     * <br>
+     * Suppose our pattern class is {@code foo.a.b} and class to be matched is
+     * {@code foo.a.ball} then classNameMatchingCount would be calculated by comparing every
+     * character, and updating main counter when we hit "."
+     * to prevent matching "a.b" with "a.ball". In this case classNameMatchingCount would
+     * be equal to 6 and not 7 (b of ball is not counted).
+     *
+     * @param patternClass class against which the given class has to be matched
+     * @param classToBeMatched class to be matched
+     * @return class name matching count
+     */
+    private static int classNameMatchingCount(String patternClass, String classToBeMatched) {
+        final int minLength = Math.min(classToBeMatched.length(), patternClass.length());
+        int counter = 0;
+        int countToBeRegistered = 0;
+        for (int i = 0; i < minLength; i++) {
+            if (patternClass.charAt(i) == classToBeMatched.charAt(i)) {
+                counter++;
+                if (patternClass.charAt(i) == PACKAGE_SEPARATOR.charAt(0)) {
+                    countToBeRegistered = counter;
+                }
+            }
+            else {
+                break;
+            }
+        }
+        return countToBeRegistered;
+    }
+
+    /**
+     * Checks if former class is nested more than the latter class.
+     *
+     * @param formerClass former class
+     * @param latterClass latter class
+     * @return true if former class is nested more than the latter class
+     */
+    private static boolean isFormerClassNestedMoreThanTheLatterClass(
+            String formerClass, String latterClass) {
+        final char packageSeparator = PACKAGE_SEPARATOR.charAt(0);
+
+        return formerClass.chars()
+                .filter(character -> character == packageSeparator)
+                .count()
+                > latterClass.chars()
+                        .filter(character -> character == packageSeparator)
+                        .count();
     }
 
     /**
@@ -269,8 +429,8 @@ public class FinalClassCheck
     private String getQualifiedClassName(DetailAST classAst) {
         final String className = classAst.findFirstToken(TokenTypes.IDENT).getText();
         String outerClassQualifiedName = null;
-        if (!classes.isEmpty()) {
-            outerClassQualifiedName = classes.peek().getQualifiedName();
+        if (!classesPoppedOutAfterExamination.isEmpty()) {
+            outerClassQualifiedName = classesPoppedOutAfterExamination.peek().getQualifiedName();
         }
         return getQualifiedClassName(packageName, outerClassQualifiedName, className);
     }
@@ -319,23 +479,6 @@ public class FinalClassCheck
     }
 
     /**
-     * Checks if given super class name in extend clause match super class qualified name.
-     *
-     * @param superClassQualifiedName super class qualified name (with package)
-     * @param superClassInExtendClause name in extend clause
-     * @return true if given super class name in extend clause match super class qualified name,
-     *         false otherwise
-     */
-    private static boolean doesNameInExtendMatchSuperClassName(String superClassQualifiedName,
-                                                               String superClassInExtendClause) {
-        String superClassNormalizedName = superClassQualifiedName;
-        if (!superClassInExtendClause.contains(PACKAGE_SEPARATOR)) {
-            superClassNormalizedName = getClassNameFromQualifiedName(superClassQualifiedName);
-        }
-        return superClassNormalizedName.equals(superClassInExtendClause);
-    }
-
-    /**
      * Get class name from qualified name.
      *
      * @param qualifiedName qualified class name
@@ -347,6 +490,9 @@ public class FinalClassCheck
 
     /** Maintains information about class' ctors. */
     private static final class ClassDesc {
+
+        /** Corresponding node. */
+        private final DetailAST classAst;
 
         /** Qualified class name(with package). */
         private final String qualifiedName;
@@ -370,6 +516,12 @@ public class FinalClassCheck
         private boolean withAnonymousInnerClass;
 
         /**
+         * Counts how much the class's qualified name
+         * is similar to a given class.
+         */
+        private int classNameMatchingCount;
+
+        /**
          *  Create a new ClassDesc instance.
          *
          *  @param qualifiedName qualified class name(with package)
@@ -377,12 +529,14 @@ public class FinalClassCheck
          *         class declared as final
          *  @param declaredAsAbstract indicates if the
          *         class declared as abstract
+         *  @param classAst classAst node
          */
         /* package */ ClassDesc(String qualifiedName, boolean declaredAsFinal,
-                boolean declaredAsAbstract) {
+                boolean declaredAsAbstract, DetailAST classAst) {
             this.qualifiedName = qualifiedName;
             this.declaredAsFinal = declaredAsFinal;
             this.declaredAsAbstract = declaredAsAbstract;
+            this.classAst = classAst;
         }
 
         /**
@@ -392,6 +546,15 @@ public class FinalClassCheck
          */
         private String getQualifiedName() {
             return qualifiedName;
+        }
+
+        /**
+         * Get the classAst node.
+         *
+         * @return classAst node
+         */
+        public DetailAST getClassAst() {
+            return classAst;
         }
 
         /** Adds private ctor. */
@@ -468,6 +631,22 @@ public class FinalClassCheck
             return withAnonymousInnerClass;
         }
 
-    }
+        /**
+         * Get the classNameMatchingCount.
+         *
+         * @return classNameMatchingCount
+         */
+        public int getClassNameMatchingCount() {
+            return classNameMatchingCount;
+        }
 
+        /**
+         * Set the classNameMatchingCount.
+         *
+         * @param classNameMatchingCount classNameMatchingCount
+         */
+        public void setClassNameMatchingCount(int classNameMatchingCount) {
+            this.classNameMatchingCount = classNameMatchingCount;
+        }
+    }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
@@ -134,4 +134,30 @@ public class FinalClassCheckTest
         assertEquals("ClassName", actual, "unexpected result");
     }
 
+    @Test
+    public void testFinalClassInnerAndNestedClasses() throws Exception {
+        final String[] expected = {
+            "19:5: " + getCheckMessage(MSG_KEY, "SameName"),
+            "45:9: " + getCheckMessage(MSG_KEY, "SameName"),
+            "69:13: " + getCheckMessage(MSG_KEY, "B"),
+        };
+        verifyWithInlineConfigParser(getPath("InputFinalClassInnerAndNestedClass.java"), expected);
+    }
+
+    @Test
+    public void testFinalClassStaticNestedClasses() throws Exception {
+
+        final String[] expected = {
+            "14:17: " + getCheckMessage(MSG_KEY, "C"),
+            "32:9: " + getCheckMessage(MSG_KEY, "B"),
+            "43:9: " + getCheckMessage(MSG_KEY, "C"),
+            "60:13: " + getCheckMessage(MSG_KEY, "Q"),
+            "76:9: " + getCheckMessage(MSG_KEY, "F"),
+            "83:9: " + getCheckMessage(MSG_KEY, "c"),
+        };
+
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputFinalClassNestedStaticClassInsideInnerClass.java"),
+                expected);
+    }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassNestedStaticClassInsideInnerClass.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassNestedStaticClassInsideInnerClass.java
@@ -1,0 +1,98 @@
+/*
+FinalClass
+
+
+*/
+
+//non-compiled with javac: Compilable with Java16
+package com.puppycrawl.tools.checkstyle.checks.design.finalclass;
+
+public class InputFinalClassNestedStaticClassInsideInnerClass {
+    class M {
+        class A {
+            static class B {
+                static class C { // violation
+                    private C() {
+                    }
+                }
+            }
+        }
+    }
+
+    class Mw {
+        static class B {
+            static class C { // ok
+                private C() {
+                }
+            }
+        }
+    }
+
+    class A {
+        class B { // violation
+            class C { // ok
+                private C() {}
+            }
+            class D extends C {
+            }
+            private B() {}
+        }
+    }
+
+    class B {
+        class C { // violation
+            private C() {}
+            class D extends Mw.B.C {
+            }
+        }
+    }
+
+    class P extends Q {
+    }
+
+    class Q { // ok
+        private Q() {
+        }
+    }
+
+    class PR {
+        static class P {
+            static class Q { // violation
+                private Q() {
+                }
+            }
+        }
+    }
+
+    class F {
+        private F() {
+        }
+    }
+
+    class K extends F {
+    }
+
+    class X {
+        class F { // violation
+            private F() {
+            }
+        }
+    }
+
+    class a {
+        static class c { // violation
+            private c() {
+            }
+        }
+    }
+
+    class d {
+        class e extends c {
+        }
+    }
+
+    class c {
+        private c() {
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassInnerAndNestedClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassInnerAndNestedClass.java
@@ -1,0 +1,76 @@
+/*
+FinalClass
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.design.finalclass;
+
+public class InputFinalClassInnerAndNestedClass {
+
+    private class SuperClass { // ok
+        private SuperClass() {
+        }
+    }
+
+    private class SubClass extends SuperClass {
+    }
+
+    class SameName { // violation
+        private SameName() {
+        }
+    }
+
+    static class Test {
+        static class SameName { // ok
+            private SameName() {
+            }
+            class Test3 {
+            }
+        }
+    }
+
+    class TestInnerClass {
+        class SameName { // ok
+            class Test3 {
+                class Test4 extends SameName {
+                }
+            }
+            private SameName() {
+            }
+        }
+    }
+
+    class TestNestedClasses {
+        class SameName { // violation
+            private SameName() {
+            }
+            class Test3 {
+                class Test4 extends Test.SameName {
+                }
+            }
+        }
+    }
+}
+
+enum foo {
+    VALUE_1, VALUE_2;
+
+    class A {
+        class B { // ok
+            private B() {
+            }
+        }
+
+        class c extends B {
+        }
+
+        class D {
+            class B { // violation
+                private B() {
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Resolves #10859: FinalClass now exempts private-only constructor classes that are extended by another class in the same compilation unit
Diff Regression projects: https://gist.githubusercontent.com/Vyom-Yadav/91807e6244cff60698d9e33e32ba2d51/raw/eb228fa41edadc10eea264a914ea1411f0e52122/projects-to-test-on.properties
Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/2e9e29be66f99b22505651aa211886535402b6cf/my_checks.xml
Final Report - https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/ed983f4_2021110358/reports/diff/index.html