### PR TITLE
adds section for list of supported JREs

### DIFF
--- a/src/xdocs/index.xml.vm
+++ b/src/xdocs/index.xml.vm
@@ -119,6 +119,50 @@
       </p>
     </section>
 
+    <section name="JRE and JDK">
+      <p>
+        Runtime of Checkstyle is limited only by minimal version or JRE.
+      </p>
+      <div class="wrapper">
+        <table>
+          <tr>
+            <th>Checkstyle version</th>
+            <th>JRE version</th>
+          </tr>
+          <tr>
+            <td>
+              7.x, 8.x, 9.x
+            </td>
+            <td>
+              8 and above
+            </td>
+          </tr>
+          <tr>
+            <td>
+              6.x
+            </td>
+            <td>
+              6 and above
+            </td>
+          </tr>
+          <tr>
+            <td>
+              5.x
+            </td>
+            <td>
+              5 and above
+            </td>
+          </tr>
+        </table>
+      </div>
+      <p>
+        Checkstyle currently is confirmed to be build by all JDKs from 8 through 17.
+        Most recent JDKs may be supported. Please
+        <a href="https://checkstyle.org/report_issue.html">report an issue</a>
+        if there is any problems with most recent JDKs.
+      </p>
+    </section>
+
     <section name="Limitations">
       <p>
         Checkstyle is a single file static analysis tool, for more details please read


### PR DESCRIPTION
Identified at https://github.com/checkstyle/checkstyle/issues/10886 , added a new section on the main page to display the list of JREs checkstyle is currently supported on so it is clear to users.