### PR TITLE
Issue #7368: replace Whitebox with JDK17-compatible utility methods

### DIFF
--- a/config/import-control-test.xml
+++ b/config/import-control-test.xml
@@ -19,18 +19,42 @@
 
   <!-- Conflicts with normal tests and pitest.
        See examples in https://github.com/checkstyle/checkstyle/issues/6439 -->
-  <allow class="org.powermock.reflect.Whitebox" />
   <allow class="org.mockito.internal.util.Checks" />
   <disallow pkg="org\.powermock.*" regex="true" />
   <disallow pkg="org\.mockito.*" regex="true" />
+  <!-- Reflection shouldn't be used in tests. -->
+  <disallow pkg="java\.lang\.reflect\.*" regex="true" />
 
   <allow pkg=".*" regex="true" />
 
-  <!-- Till https://github.com/checkstyle/checkstyle/issues/7368 -->
+  <subpackage name="api">
+    <file name="AutomaticBeanTest">
+      <!-- Catches InvocationTargetException. -->
+      <allow class="java.lang.reflect.InvocationTargetException" />
+    </file>
+
+  </subpackage>
   <subpackage name="internal">
+    <!-- Till https://github.com/checkstyle/checkstyle/issues/7368 -->
     <subpackage name="powermock">
+      <allow pkg="java.lang.reflect" />
       <allow pkg="org.junit" local-only="true"/>
     </subpackage>
+    <subpackage name="utils">
+      <file name="CheckUtil">
+        <!-- Uses reflection to collect violation messages. -->
+        <allow class="java.lang.reflect.Field" />
+      </file>
+      <file name="TestUtil">
+        <!-- All reflection usage should be in this class. -->
+        <allow pkg="java.lang.reflect" />
+      </file>
+    </subpackage>
   </subpackage>
+
+  <file name="JavaAstVisitorTest">
+    <!-- Uses reflection to validate method order. -->
+    <allow pkg="java.lang.reflect" />
+  </file>
 
 </import-control>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatterTest.java
@@ -21,14 +21,12 @@ package com.puppycrawl.tools.checkstyle;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.lang.reflect.Method;
-
 import org.junit.jupiter.api.Test;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
 import com.puppycrawl.tools.checkstyle.api.Violation;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 public class AuditEventDefaultFormatterTest {
 
@@ -72,15 +70,12 @@ public class AuditEventDefaultFormatterTest {
 
     @Test
     public void testCalculateBufferLength() throws Exception {
-        final Method calculateBufferLengthMethod =
-                Whitebox.getMethod(AuditEventDefaultFormatter.class,
-                        "calculateBufferLength", AuditEvent.class, int.class);
         final Violation violation = new Violation(1, 1,
                 "messages.properties", "key", null, SeverityLevel.ERROR, null,
                 getClass(), null);
         final AuditEvent auditEvent = new AuditEvent(new Object(), "fileName", violation);
-        final int result = (int) calculateBufferLengthMethod.invoke(null,
-                auditEvent, SeverityLevel.ERROR.ordinal());
+        final int result = TestUtil.invokeStaticMethod(AuditEventDefaultFormatter.class,
+                "calculateBufferLength", auditEvent, SeverityLevel.ERROR.ordinal());
 
         assertEquals(54, result, "Buffer length is not expected");
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -60,7 +60,6 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
@@ -310,7 +309,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
         // comparing to 1 as there is only one legal file in input
         final int numLegalFiles = 1;
-        final PropertyCacheFile cache = Whitebox.getInternalState(checker, "cacheFile");
+        final PropertyCacheFile cache = TestUtil.getInternalState(checker, "cacheFile");
         assertEquals(numLegalFiles, counter, "There were more legal files than expected");
         assertEquals(numLegalFiles, auditAdapter.getNumFilesStarted(),
                 "Audit was started on larger amount of files than expected");
@@ -396,7 +395,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
         checker.setModuleClassLoader(classLoader);
         checker.finishLocalSetup();
-        final Context actualCtx = Whitebox.getInternalState(checker, "childContext");
+        final Context actualCtx = TestUtil.getInternalState(checker, "childContext");
 
         assertNotNull(actualCtx.get("moduleFactory"),
                 "Default module factory should be created when it is not specified");
@@ -415,7 +414,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.setLocaleCountry("IT");
         checker.finishLocalSetup();
 
-        final Context context = Whitebox.getInternalState(checker, "childContext");
+        final Context context = TestUtil.getInternalState(checker, "childContext");
         final String encoding = StandardCharsets.UTF_8.name();
         assertEquals(encoding, context.get("charset"), "Charset was different than expected");
         assertEquals("error", context.get("severity"), "Severity is set to unexpected value");
@@ -473,7 +472,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
             DebugAuditAdapter.class.getCanonicalName());
         checker.setupChild(config);
 
-        final List<AuditListener> listeners = Whitebox.getInternalState(checker, "listeners");
+        final List<AuditListener> listeners = TestUtil.getInternalState(checker, "listeners");
         assertTrue(listeners.get(listeners.size() - 1) instanceof DebugAuditAdapter,
                 "Invalid child listener class");
     }
@@ -636,7 +635,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.process(Collections.singletonList(new File("dummy.java")));
         checker.clearCache();
         // invoke destroy to persist cache
-        final PropertyCacheFile cache = Whitebox.getInternalState(checker, "cacheFile");
+        final PropertyCacheFile cache = TestUtil.getInternalState(checker, "cacheFile");
         cache.persist();
 
         final Properties cacheAfterClear = new Properties();
@@ -651,7 +650,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
     public void setFileExtension() {
         final Checker checker = new Checker();
         checker.setFileExtensions(".test1", "test2");
-        final String[] actual = Whitebox.getInternalState(checker, "fileExtensions");
+        final String[] actual = TestUtil.getInternalState(checker, "fileExtensions");
         assertArrayEquals(new String[] {".test1", ".test2"}, actual,
                 "Extensions are not expected");
     }
@@ -662,7 +661,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         // the invocation of clearCache method does not throw an exception.
         final Checker checker = new Checker();
         checker.clearCache();
-        assertNull(Whitebox.getInternalState(checker, "cacheFile"),
+        assertNull(TestUtil.getInternalState(checker, "cacheFile"),
                 "If cache file is not set the cache should default to null");
     }
 
@@ -1407,7 +1406,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         checker.configure(root);
         // BriefUtLogger does not print the module name or id postfix,
         // so we need to set logger manually
-        final ByteArrayOutputStream out = Whitebox.getInternalState(this, "stream");
+        final ByteArrayOutputStream out = TestUtil.getInternalState(this, "stream");
         final DefaultLogger logger = new DefaultLogger(out, OutputStreamOptions.CLOSE, out,
                 OutputStreamOptions.NONE, new AuditEventDefaultFormatter());
         checker.addListener(logger);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle;
 
+import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -35,13 +36,13 @@ import java.util.List;
 import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
-import org.powermock.reflect.Whitebox;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import com.puppycrawl.tools.checkstyle.ConfigurationLoader.IgnoredModulesOptions;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 /**
  * Unit test for ConfigurationLoader.
@@ -462,13 +463,16 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         final Object obj = constructor.newInstance(objParent);
 
         try {
-            Whitebox.invokeMethod(obj, "startElement", "", "", "hello", null);
+            TestUtil.invokeMethod(obj, "startElement", "", "", "hello", null);
 
-            fail("Exception is expected");
+            fail("InvocationTargetException is expected");
         }
-        catch (IllegalStateException ex) {
-            assertEquals("Unknown name:" + "hello" + ".", ex.getMessage(),
-                    "Invalid exception cause message");
+        catch (InvocationTargetException ex) {
+            assertWithMessage("Invalid exception cause message")
+                .that(ex)
+                    .hasCauseThat()
+                        .hasMessageThat()
+                        .isEqualTo("Unknown name:" + "hello" + ".");
         }
     }
 
@@ -586,7 +590,7 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         final List<String> propertyRefs = new ArrayList<>();
         final List<String> fragments = new ArrayList<>();
 
-        Whitebox.invokeMethod(ConfigurationLoader.class,
+        TestUtil.invokeStaticMethod(ConfigurationLoader.class,
                 "parsePropertyString", "$",
                fragments, propertyRefs);
         assertEquals(1, fragments.size(), "Fragments list has unexpected amount of items");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
@@ -38,12 +38,12 @@ import java.util.ResourceBundle;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.DefaultLocale;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean.OutputStreamOptions;
 import com.puppycrawl.tools.checkstyle.api.Violation;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 public class DefaultLoggerTest {
 
@@ -53,7 +53,7 @@ public class DefaultLoggerTest {
     public void tearDown() throws Exception {
         final Constructor<?> cons = getConstructor();
         final Map<String, ResourceBundle> bundleCache =
-                Whitebox.getInternalState(cons.getDeclaringClass(), "BUNDLE_CACHE");
+                TestUtil.getInternalStaticState(cons.getDeclaringClass(), "BUNDLE_CACHE");
         bundleCache.clear();
     }
 
@@ -252,7 +252,7 @@ public class DefaultLoggerTest {
         final Method message = messageClass.getClass().getDeclaredMethod("getMessage");
         message.setAccessible(true);
         final Map<String, ResourceBundle> bundleCache =
-                Whitebox.getInternalState(message.getDeclaringClass(), "BUNDLE_CACHE");
+                TestUtil.getInternalStaticState(message.getDeclaringClass(), "BUNDLE_CACHE");
         assertEquals("Une erreur est survenue {0}", message.invoke(messageClass),
                 "Invalid message");
         assertEquals(1, bundleCache.size(), "Invalid bundle cache size");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
@@ -47,11 +47,11 @@ import java.util.function.Consumer;
 import org.antlr.v4.runtime.CommonToken;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
@@ -307,7 +307,7 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
                 child::addChild,
             ast -> {
                 try {
-                    Whitebox.invokeMethod(child, "setParent", ast);
+                    TestUtil.invokeMethod(child, "setParent", ast);
                 }
                 // -@cs[IllegalCatch] Cannot avoid catching it.
                 catch (Exception exception) {
@@ -317,9 +317,9 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
         );
 
         for (Consumer<DetailAstImpl> method : clearBranchTokenTypesMethods) {
-            final BitSet branchTokenTypes = Whitebox.invokeMethod(parent, "getBranchTokenTypes");
+            final BitSet branchTokenTypes = TestUtil.invokeMethod(parent, "getBranchTokenTypes");
             method.accept(null);
-            final BitSet branchTokenTypes2 = Whitebox.invokeMethod(parent, "getBranchTokenTypes");
+            final BitSet branchTokenTypes2 = TestUtil.invokeMethod(parent, "getBranchTokenTypes");
             assertEquals(branchTokenTypes, branchTokenTypes2, "Branch token types are not equal");
             assertNotSame(branchTokenTypes, branchTokenTypes2,
                     "Branch token types should not be the same");
@@ -332,7 +332,7 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
         final BitSet bitSet = new BitSet();
         bitSet.set(999);
 
-        Whitebox.setInternalState(root, "branchTokenTypes", bitSet);
+        TestUtil.setInternalState(root, "branchTokenTypes", bitSet);
         assertTrue(root.branchContains(999), "Branch tokens has changed");
     }
 
@@ -351,7 +351,7 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
         for (Consumer<DetailAstImpl> method : clearChildCountCacheMethods) {
             final int startCount = parent.getChildCount();
             method.accept(null);
-            final int intermediateCount = Whitebox.getInternalState(parent, "childCount");
+            final int intermediateCount = TestUtil.getInternalState(parent, "childCount");
             final int finishCount = parent.getChildCount();
             assertEquals(startCount, finishCount, "Child count has changed");
             assertEquals(Integer.MIN_VALUE, intermediateCount, "Invalid child count");
@@ -359,7 +359,7 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
 
         final int startCount = child.getChildCount();
         child.addChild(null);
-        final int intermediateCount = Whitebox.getInternalState(child, "childCount");
+        final int intermediateCount = TestUtil.getInternalState(child, "childCount");
         final int finishCount = child.getChildCount();
         assertEquals(startCount, finishCount, "Child count has changed");
         assertEquals(Integer.MIN_VALUE, intermediateCount, "Invalid child count");
@@ -369,7 +369,7 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
     public void testCacheGetChildCount() {
         final DetailAST root = new DetailAstImpl();
 
-        Whitebox.setInternalState(root, "childCount", 999);
+        TestUtil.setInternalState(root, "childCount", 999);
         assertEquals(999, root.getChildCount(), "Child count has changed");
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
@@ -28,21 +28,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
-import java.lang.reflect.Method;
 
 import org.junit.jupiter.api.Test;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.ParseErrorMessage;
 import com.puppycrawl.tools.checkstyle.api.Violation;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
-
-    // [REFLECTION]
-    // DetailNodeTreeStringPrinter#getParseErrorMessage is used for creating violations
-    // for validating those obtained in UTs against the ones created.
-    private static final Method GET_PARSE_ERROR_MESSAGE = Whitebox.getMethod(
-            DetailNodeTreeStringPrinter.class, "getParseErrorMessage", ParseErrorMessage.class);
 
     @Override
     protected String getPackageLocation() {
@@ -70,7 +63,8 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             fail("Javadoc parser didn't fail on missing end tag");
         }
         catch (IllegalArgumentException ex) {
-            final String expected = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
+            final String expected = TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
+                    "getParseErrorMessage",
                     new ParseErrorMessage(0, MSG_JAVADOC_MISSED_HTML_CLOSE, 1, "qwe"));
             assertEquals(expected, ex.getMessage(),
                     "Generated and expected parse error messages don't match");
@@ -86,7 +80,8 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
 
     @Test
     public void testMissedHtmlTagParseErrorMessage() throws Exception {
-        final String actual = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
+        final String actual = TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
+                "getParseErrorMessage",
                 new ParseErrorMessage(35, MSG_JAVADOC_MISSED_HTML_CLOSE, 7, "xyz"));
         final Violation violation = new Violation(
                 35,
@@ -103,7 +98,8 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
 
     @Test
     public void testParseErrorMessage() throws Exception {
-        final String actual = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
+        final String actual = TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
+                "getParseErrorMessage",
                 new ParseErrorMessage(10, MSG_JAVADOC_PARSE_RULE_ERROR,
                         9, "no viable alternative at input ' xyz'", "SOME_JAVADOC_ELEMENT"));
         final Violation violation = new Violation(
@@ -120,7 +116,8 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
 
     @Test
     public void testWrongSingletonParseErrorMessage() throws Exception {
-        final String actual = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
+        final String actual = TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
+                "getParseErrorMessage",
                 new ParseErrorMessage(100, MSG_JAVADOC_WRONG_SINGLETON_TAG,
                         9, "tag"));
         final Violation violation = new Violation(
@@ -147,7 +144,8 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             fail("Exception is expected");
         }
         catch (IllegalArgumentException ex) {
-            final String expected = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
+            final String expected = TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
+                    "getParseErrorMessage",
                     new ParseErrorMessage(35, MSG_JAVADOC_MISSED_HTML_CLOSE, 7, "parsing"));
             assertEquals(expected, ex.getMessage(),
                     "Generated and expected parse error messages don't match");
@@ -163,7 +161,8 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             fail("Exception is expected");
         }
         catch (IllegalArgumentException ex) {
-            final String expected = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
+            final String expected = TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
+                    "getParseErrorMessage",
                     new ParseErrorMessage(0, MSG_JAVADOC_PARSE_RULE_ERROR,
                             9, "no viable alternative at input '<<'", "HTML_ELEMENT"));
             assertEquals(expected, ex.getMessage(),
@@ -180,7 +179,8 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             fail("Exception is expected");
         }
         catch (IllegalArgumentException ex) {
-            final String expected = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
+            final String expected = TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
+                    "getParseErrorMessage",
                     new ParseErrorMessage(0, MSG_JAVADOC_PARSE_RULE_ERROR,
                             4, "no viable alternative at input '</tag'", "HTML_ELEMENT"));
             assertEquals(expected, ex.getMessage(),
@@ -197,7 +197,8 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             fail("Exception is expected");
         }
         catch (IllegalArgumentException ex) {
-            final String expected = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
+            final String expected = TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
+                    "getParseErrorMessage",
                     new ParseErrorMessage(0, MSG_JAVADOC_MISSED_HTML_CLOSE, 10, "tag2"));
             assertEquals(expected, ex.getMessage(),
                     "Generated and expected parse error messages don't match");
@@ -213,7 +214,8 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
             fail("Exception is expected");
         }
         catch (IllegalArgumentException ex) {
-            final String expected = (String) GET_PARSE_ERROR_MESSAGE.invoke(null,
+            final String expected = TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
+                    "getParseErrorMessage",
                     new ParseErrorMessage(0, MSG_JAVADOC_MISSED_HTML_CLOSE, 3, "a"));
             assertEquals(expected, ex.getMessage(),
                     "Generated and expected parse error messages don't match");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -61,7 +61,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.api.AuditListener;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
@@ -405,7 +404,6 @@ public class MainTest {
     public void testNonClosedSystemStreams() throws Exception {
         Main.main("-c", getPath("InputMainConfig-classname.xml"), "-f", "xml",
                 getPath("InputMain.java"));
-
         final Boolean closedOut = (Boolean) TestUtil
                 .getClassDeclaredField(System.out.getClass(), "closing").get(System.out);
         assertThat("System.out stream should not be closed", closedOut, is(false));
@@ -427,9 +425,7 @@ public class MainTest {
     public void testGetOutputStreamOptionsMethod() throws Exception {
         final Path path = new File(getPath("InputMain.java")).toPath();
         final AutomaticBean.OutputStreamOptions option =
-                (AutomaticBean.OutputStreamOptions) TestUtil
-                    .getClassDeclaredMethod(Main.class, "getOutputStreamOptions")
-                    .invoke(null, path);
+                TestUtil.invokeStaticMethod(Main.class, "getOutputStreamOptions", path);
         assertThat("Main.getOutputStreamOptions return CLOSE on not null Path",
                 option, is(AutomaticBean.OutputStreamOptions.CLOSE));
     }
@@ -794,7 +790,7 @@ public class MainTest {
             }
         };
 
-        final List<File> result = Whitebox.invokeMethod(Main.class, "listFiles",
+        final List<File> result = TestUtil.invokeStaticMethod(Main.class, "listFiles",
                 fileMock, new ArrayList<Pattern>());
         assertEquals(0, result.size(), "Invalid result size");
     }
@@ -826,7 +822,7 @@ public class MainTest {
             }
         };
 
-        final List<File> result = Whitebox.invokeMethod(Main.class, "listFiles",
+        final List<File> result = TestUtil.invokeStaticMethod(Main.class, "listFiles",
                 fileMock, new ArrayList<Pattern>());
         assertEquals(0, result.size(), "Invalid result size");
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -40,7 +40,6 @@ import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.internal.util.Checks;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -63,6 +62,7 @@ import com.puppycrawl.tools.checkstyle.checks.whitespace.WhitespaceAroundCheck;
 import com.puppycrawl.tools.checkstyle.filters.SuppressWithNearbyCommentFilter;
 import com.puppycrawl.tools.checkstyle.filters.SuppressionCommentFilter;
 import com.puppycrawl.tools.checkstyle.filters.SuppressionXpathFilter;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
@@ -186,9 +186,9 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         treeWalker.setTabWidth(1);
         treeWalker.configure(config);
 
-        final int tabWidth = Whitebox.getInternalState(treeWalker, "tabWidth");
+        final int tabWidth = TestUtil.getInternalState(treeWalker, "tabWidth");
         assertEquals(1, tabWidth, "Invalid setter result");
-        final Object configuration = Whitebox.getInternalState(treeWalker, "configuration");
+        final Object configuration = TestUtil.getInternalState(treeWalker, "configuration");
         assertEquals(config, configuration, "Invalid configuration");
     }
 
@@ -242,7 +242,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         final File file = new File(getPath("InputTreeWalkerNotJava.xml"));
         final FileText fileText = new FileText(file, StandardCharsets.ISO_8859_1.name());
         treeWalker.processFiltered(file, fileText);
-        final Collection<Checks> checks = Whitebox.getInternalState(treeWalker, "ordinaryChecks");
+        final Collection<Checks> checks = TestUtil.getInternalState(treeWalker, "ordinaryChecks");
         assertTrue(checks.isEmpty(), "No checks -> No parsing");
     }
 
@@ -328,7 +328,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         final FileText fileText = new FileText(file, new ArrayList<>());
 
         treeWalker.processFiltered(file, fileText);
-        final Collection<Checks> checks = Whitebox.getInternalState(treeWalker, "ordinaryChecks");
+        final Collection<Checks> checks = TestUtil.getInternalState(treeWalker, "ordinaryChecks");
         assertTrue(checks.isEmpty(), "No checks -> No parsing");
     }
 
@@ -373,8 +373,8 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
 
         treeWalker.setupChild(config);
 
-        final Set<TreeWalkerFilter> filters = Whitebox.getInternalState(treeWalker, "filters");
-        final int tabWidth = Whitebox.getInternalState(filters.iterator().next(), "tabWidth");
+        final Set<TreeWalkerFilter> filters = TestUtil.getInternalState(treeWalker, "filters");
+        final int tabWidth = TestUtil.getInternalState(filters.iterator().next(), "tabWidth");
 
         assertEquals(99, tabWidth, "expected tab width");
     }
@@ -427,7 +427,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         treeWalker.setTabWidth(100);
         treeWalker.finishLocalSetup();
 
-        final Context context = Whitebox.getInternalState(treeWalker, "childContext");
+        final Context context = TestUtil.getInternalState(treeWalker, "childContext");
         assertEquals("error", context.get("severity"), "Severity differs from expected");
         assertEquals(String.valueOf(100), context.get("tabWidth"),
                 "Tab width differs from expected");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XmlLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XmlLoaderTest.java
@@ -31,16 +31,17 @@ import java.util.Map;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.junit.jupiter.api.Test;
-import org.powermock.reflect.Whitebox;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
+
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 public class XmlLoaderTest {
 
     @Test
     public void testParserConfiguredSuccessfully() throws Exception {
         final DummyLoader dummyLoader = new DummyLoader(new HashMap<>(1));
-        final XMLReader parser = Whitebox.getInternalState(dummyLoader, "parser");
+        final XMLReader parser = TestUtil.getInternalState(dummyLoader, "parser");
         assertEquals(dummyLoader, parser.getEntityResolver(), "Invalid entity resolver");
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -38,7 +38,6 @@ import org.apache.tools.ant.types.Path;
 import org.apache.tools.ant.types.Reference;
 import org.apache.tools.ant.types.resources.FileResource;
 import org.junit.jupiter.api.Test;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultLogger;
@@ -46,6 +45,7 @@ import com.puppycrawl.tools.checkstyle.Definitions;
 import com.puppycrawl.tools.checkstyle.XMLLogger;
 import com.puppycrawl.tools.checkstyle.api.Violation;
 import com.puppycrawl.tools.checkstyle.internal.testmodules.TestRootModuleChecker;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
 
@@ -676,7 +676,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         antTask.setClasspath(new Path(project, path1));
         antTask.setClasspath(new Path(project, path2));
 
-        final Path classpath = Whitebox.getInternalState(antTask, "classpath");
+        final Path classpath = TestUtil.getInternalState(antTask, "classpath");
         final String classpathString = classpath.toString();
         assertWithMessage("Classpath should not be null")
                 .that(classpath)
@@ -695,7 +695,7 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         antTask.setClasspathRef(new Reference(new Project(), "id"));
 
         assertWithMessage("Classpath should not be null")
-                .that((Object) Whitebox.getInternalState(antTask, "classpath"))
+                .that(TestUtil.<Path>getInternalState(antTask, "classpath"))
                 .isNotNull();
     }
 
@@ -708,10 +708,10 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         antTask.setClasspathRef(new Reference(project, "idXX"));
 
         assertWithMessage("Classpath should not be null")
-                .that((Object) Whitebox.getInternalState(antTask, "classpath"))
+                .that(TestUtil.<Path>getInternalState(antTask, "classpath"))
                 .isNotNull();
 
-        final Path classpath = Whitebox.getInternalState(antTask, "classpath");
+        final Path classpath = TestUtil.getInternalState(antTask, "classpath");
         try {
             classpath.list();
             assertWithMessage("Exception is expected")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporterTest.java
@@ -21,12 +21,12 @@ package com.puppycrawl.tools.checkstyle.api;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
-import java.lang.reflect.Method;
 import java.util.SortedSet;
 
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
@@ -37,15 +37,6 @@ public class AbstractViolationReporterTest {
 
     private final AbstractCheck emptyCheck = new EmptyCheck();
 
-    private static Method getGetMessageBundleMethod() throws Exception {
-        final Class<AbstractViolationReporter> abstractViolationReporterClass =
-            AbstractViolationReporter.class;
-        final Method getMessageBundleMethod =
-            abstractViolationReporterClass.getDeclaredMethod("getMessageBundle", String.class);
-        getMessageBundleMethod.setAccessible(true);
-        return getMessageBundleMethod;
-    }
-
     protected static DefaultConfiguration createModuleConfig(Class<?> clazz) {
         return new DefaultConfiguration(clazz.getName());
     }
@@ -53,14 +44,16 @@ public class AbstractViolationReporterTest {
     @Test
     public void testGetMessageBundleWithPackage() throws Exception {
         assertWithMessage("violation bundle differs from expected")
-                .that(getGetMessageBundleMethod().invoke(null, "com.mycompany.checks.MyCoolCheck"))
+                .that(TestUtil.<String>invokeStaticMethod(AbstractViolationReporter.class,
+                        "getMessageBundle", "com.mycompany.checks.MyCoolCheck"))
                 .isEqualTo("com.mycompany.checks.messages");
     }
 
     @Test
     public void testGetMessageBundleWithoutPackage() throws Exception {
         assertWithMessage("violation bundle differs from expected")
-                .that(getGetMessageBundleMethod().invoke(null, "MyCoolCheck"))
+                .that(TestUtil.<String>invokeStaticMethod(AbstractViolationReporter.class,
+                        "getMessageBundle", "MyCoolCheck"))
                 .isEqualTo("messages");
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle.api;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.util.Arrays;
@@ -31,11 +30,11 @@ import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.beanutils.ConvertUtilsBean;
 import org.apache.commons.beanutils.Converter;
 import org.junit.jupiter.api.Test;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.DefaultContext;
 import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 public class AutomaticBeanTest {
 
@@ -107,13 +106,11 @@ public class AutomaticBeanTest {
     }
 
     @Test
-    public void testSetupInvalidChildFromBaseClass() throws Exception {
+    public void testSetupInvalidChildFromBaseClass() {
         final TestBean testBean = new TestBean();
         final DefaultConfiguration parentConf = new DefaultConfiguration("parentConf");
         final DefaultConfiguration childConf = new DefaultConfiguration("childConf");
-        final Field field = AutomaticBean.class.getDeclaredField("configuration");
-        field.setAccessible(true);
-        field.set(testBean, parentConf);
+        TestUtil.setInternalState(testBean, "configuration", parentConf);
 
         try {
             testBean.setupChild(childConf);
@@ -198,7 +195,7 @@ public class AutomaticBeanTest {
     @Test
     public void testRegisterIntegralTypes() throws Exception {
         final ConvertUtilsBeanStub convertUtilsBean = new ConvertUtilsBeanStub();
-        Whitebox.invokeMethod(AutomaticBean.class, "registerIntegralTypes", convertUtilsBean);
+        TestUtil.invokeStaticMethod(AutomaticBean.class, "registerIntegralTypes", convertUtilsBean);
         assertWithMessage("Number of converters registered differs from expected")
                 .that(convertUtilsBean.getRegisterCount())
                 .isEqualTo(81);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
@@ -29,7 +29,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
-import org.powermock.reflect.Whitebox;
+
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 public class FileContentsTest {
 
@@ -282,7 +283,7 @@ public class FileContentsTest {
                 new FileText(new File("filename"), Collections.singletonList("    ")));
         final Map<Integer, TextBlock> javadoc = new HashMap<>();
         javadoc.put(0, new Comment(new String[] {"// "}, 2, 1, 2));
-        Whitebox.setInternalState(fileContents, "javadocComments", javadoc);
+        TestUtil.setInternalState(fileContents, "javadocComments", javadoc);
         final TextBlock javadocBefore = fileContents.getJavadocBefore(2);
 
         assertWithMessage("Invalid before javadoc")
@@ -309,14 +310,14 @@ public class FileContentsTest {
     public void testHasIntersectionEarlyOut() throws Exception {
         final FileContents fileContents = new FileContents(
                 new FileText(new File("filename"), Collections.emptyList()));
-        final Map<Integer, List<TextBlock>> clangComments = Whitebox.getInternalState(fileContents,
+        final Map<Integer, List<TextBlock>> clangComments = TestUtil.getInternalState(fileContents,
                 "clangComments");
         final TextBlock textBlock = new Comment(new String[] {""}, 1, 1, 1);
         clangComments.put(1, Collections.singletonList(textBlock));
         clangComments.put(2, Collections.emptyList());
 
         assertWithMessage("Invalid results")
-                .that((Boolean) Whitebox.invokeMethod(fileContents,
+                .that(TestUtil.<Boolean>invokeMethod(fileContents,
                         "hasIntersectionWithBlockComment", 1, 1, 1, 1))
                 .isTrue();
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
@@ -31,10 +31,10 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
 import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 public class FileTextTest extends AbstractPathTestSupport {
 
@@ -96,7 +96,7 @@ public class FileTextTest extends AbstractPathTestSupport {
         final LineColumn lineColumn = fileText.lineColumn(100);
         final FileText copy = new FileText(fileText);
         assertWithMessage("LineBreaks not copied")
-                .that((Object) Whitebox.getInternalState(copy, "lineBreaks"))
+                .that(TestUtil.<int[]>getInternalState(copy, "lineBreaks"))
                 .isNotNull();
         final LineColumn actual = copy.lineColumn(100);
         assertWithMessage("Invalid linecolumn")
@@ -111,7 +111,7 @@ public class FileTextTest extends AbstractPathTestSupport {
         final FileText fileText = new FileText(new File(filepath), charset.name());
         final FileText copy = new FileText(fileText);
         assertWithMessage("LineBreaks not null")
-                .that((Object) Whitebox.getInternalState(copy, "lineBreaks"))
+                .that(TestUtil.<int[]>getInternalState(copy, "lineBreaks"))
                 .isNull();
         final LineColumn lineColumn = copy.lineColumn(100);
         assertWithMessage("Invalid line")
@@ -159,14 +159,14 @@ public class FileTextTest extends AbstractPathTestSupport {
         final FileText fileText = new FileText(new File("fileName"), Arrays.asList("1", "2"));
 
         assertWithMessage("Invalid line breaks")
-                .that((int[]) Whitebox.invokeMethod(fileText, "findLineBreaks"))
+                .that(TestUtil.<int[]>invokeMethod(fileText, "findLineBreaks"))
                 .isEqualTo(new int[] {0, 2, 4});
 
         final FileText fileText2 = new FileText(new File("fileName"), Arrays.asList("1", "2"));
-        Whitebox.setInternalState(fileText2, "fullText", "1\n2");
+        TestUtil.setInternalState(fileText2, "fullText", "1\n2");
 
         assertWithMessage("Invalid line breaks")
-                .that((int[]) Whitebox.invokeMethod(fileText2, "findLineBreaks"))
+                .that(TestUtil.<int[]>invokeMethod(fileText2, "findLineBreaks"))
                 .isEqualTo(new int[] {0, 2, 3});
     }
 
@@ -181,12 +181,12 @@ public class FileTextTest extends AbstractPathTestSupport {
     public void testFindLineBreaksCache() throws Exception {
         final FileText fileText = new FileText(new File("fileName"), Collections.emptyList());
         final int[] lineBreaks = {5};
-        Whitebox.setInternalState(fileText, "lineBreaks", lineBreaks);
+        TestUtil.setInternalState(fileText, "lineBreaks", lineBreaks);
         // produces NPE if used
-        Whitebox.setInternalState(fileText, "fullText", (Object) null);
+        TestUtil.setInternalState(fileText, "fullText", null);
 
         assertWithMessage("Invalid line breaks")
-                .that((int[]) Whitebox.invokeMethod(fileText, "findLineBreaks"))
+                .that(TestUtil.<int[]>invokeMethod(fileText, "findLineBreaks"))
                 .isEqualTo(lineBreaks);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/ViolationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/ViolationTest.java
@@ -44,8 +44,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.DefaultLocale;
-import org.powermock.reflect.Whitebox;
 
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.EqualsVerifierReport;
 
@@ -305,7 +305,7 @@ public class ViolationTest {
         assertEquals("Empty statement.", violation.getViolation(), "Invalid violation");
 
         final Map<String, ResourceBundle> bundleCache =
-                Whitebox.getInternalState(Violation.class, "BUNDLE_CACHE");
+                TestUtil.getInternalStaticState(Violation.class, "BUNDLE_CACHE");
 
         assertEquals(1, bundleCache.size(), "Invalid bundle cache size");
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
@@ -24,15 +24,12 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -474,10 +471,8 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
      */
     @Test
     public void testCountMatches() throws Exception {
-        final Method countMatches = Whitebox.getMethod(AvoidEscapedUnicodeCharactersCheck.class,
-                "countMatches", Pattern.class, String.class);
         final AvoidEscapedUnicodeCharactersCheck check = new AvoidEscapedUnicodeCharactersCheck();
-        final int actual = (int) countMatches.invoke(check,
+        final int actual = TestUtil.invokeMethod(check, "countMatches",
                 Pattern.compile("\\\\u[a-fA-F0-9]{4}"), "\\u1234");
         assertEquals(1, actual, "Unexpected matches count");
     }
@@ -485,16 +480,11 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
     /**
      * Testing, that all elements in the constant NON_PRINTABLE_CHARS are sorted.
      * This is very convenient for the sake of maintainability.
-     *
-     * @throws Exception when code tested throws some exception
      */
     @Test
-    public void testNonPrintableCharsAreSorted() throws Exception {
-        // Getting Field Value via Reflection, because the field is private
-        final Field field = TestUtil.getClassDeclaredField(
-                AvoidEscapedUnicodeCharactersCheck.class, "NON_PRINTABLE_CHARS");
-        field.setAccessible(true);
-        String expression = ((Pattern) field.get(null)).pattern();
+    public void testNonPrintableCharsAreSorted() {
+        String expression = TestUtil.<Pattern>getInternalStaticState(
+                AvoidEscapedUnicodeCharactersCheck.class, "NON_PRINTABLE_CHARS").pattern();
 
         // Replacing expressions like "\\u000[bB]" with "\\u000B"
         final String[] charExpressions = {"Aa", "Bb", "Cc", "Dd", "Ee", "Ff"};

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks;
 
+import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck.MSG_KEY_NO_NEWLINE_EOF;
 import static com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck.MSG_KEY_UNABLE_OPEN;
 import static com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck.MSG_KEY_WRONG_ENDING;
@@ -27,21 +28,21 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.Violation;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class NewlineAtEndOfFileCheckTest
@@ -196,13 +197,16 @@ public class NewlineAtEndOfFileCheckTest
     public void testWrongSeparatorLength() throws Exception {
         try (RandomAccessFile file =
                      new ReadZeroRandomAccessFile(getPath("InputNewlineAtEndOfFileLf.java"), "r")) {
-            Whitebox.invokeMethod(new NewlineAtEndOfFileCheck(), "endsWithNewline", file,
+            TestUtil.invokeMethod(new NewlineAtEndOfFileCheck(), "endsWithNewline", file,
                 LineSeparatorOption.LF);
-            fail("Exception is expected");
+            fail("InvocationTargetException is expected");
         }
-        catch (IOException ex) {
-            assertEquals("Unable to read 1 bytes, got 0", ex.getMessage(),
-                    "Error message is unexpected");
+        catch (InvocationTargetException ex) {
+            assertWithMessage("Error message is unexpected")
+                .that(ex)
+                    .hasCauseThat()
+                        .hasMessageThat()
+                        .isEqualTo("Unable to read 1 bytes, got 0");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -35,7 +35,6 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.Checker;
@@ -69,8 +68,8 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
 
         new SuppressWarningsHolder().beginTree(null);
 
-        final Map<String, String> map = Whitebox.getInternalState(SuppressWarningsHolder.class,
-                "CHECK_ALIAS_MAP");
+        final Map<String, String> map = TestUtil.getInternalStaticState(
+                SuppressWarningsHolder.class, "CHECK_ALIAS_MAP");
         map.clear();
     }
 
@@ -426,8 +425,8 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
         final Object entryInstance = entryConstr.newInstance(checkName, firstLine,
                 firstColumn, lastLine, lastColumn);
 
-        final ThreadLocal<List<Object>> entries = Whitebox
-                .getInternalState(SuppressWarningsHolder.class, "ENTRIES");
+        final ThreadLocal<List<Object>> entries = TestUtil
+                .getInternalStaticState(SuppressWarningsHolder.class, "ENTRIES");
         entries.get().add(entryInstance);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
@@ -43,7 +43,6 @@ import java.util.TreeSet;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.powermock.reflect.Whitebox;
 import org.w3c.dom.Node;
 
 import com.google.common.collect.ImmutableMap;
@@ -57,6 +56,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.MessageDispatcher;
 import com.puppycrawl.tools.checkstyle.api.Violation;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.internal.utils.XmlUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
@@ -228,7 +228,7 @@ public class TranslationCheckTest extends AbstractXmlTestSupport {
         check.configure(checkConfig);
         check.setMessageDispatcher(dispatcher);
 
-        final Set<String> keys = Whitebox.invokeMethod(check, "getTranslationKeys",
+        final Set<String> keys = TestUtil.invokeMethod(check, "getTranslationKeys",
                 new File(".no.such.file"));
         assertTrue(keys.isEmpty(), "Translation keys should be empty when File is not found");
 
@@ -252,7 +252,7 @@ public class TranslationCheckTest extends AbstractXmlTestSupport {
         check.setMessageDispatcher(dispatcher);
 
         final Exception exception = new IOException("test exception");
-        Whitebox.invokeMethod(check, "logException", exception, new File(""));
+        TestUtil.invokeMethod(check, "logException", exception, new File(""));
 
         assertEquals(1, dispatcher.savedErrors.size(), "expected number of errors to fire");
         final Violation violation = new Violation(1,

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
@@ -478,22 +478,11 @@ public class HiddenFieldCheckTest
             boolean result = frame != null;
 
             // verify object is cleared
-            if (result) {
-                final Class<?> frameClass = frame.getClass();
-
-                try {
-                    if (TestUtil.getClassDeclaredField(frameClass, "parent").get(frame) != null
-                            || !((Boolean) TestUtil.getClassDeclaredField(frameClass, "staticType")
-                                    .get(frame))
-                            || TestUtil.getClassDeclaredField(frameClass, "frameName")
-                                    .get(frame) != null) {
-                        result = false;
-                    }
-                }
-                catch (NoSuchFieldException | IllegalArgumentException
-                        | IllegalAccessException ex) {
-                    throw new IllegalStateException(ex);
-                }
+            if (result
+                    && (TestUtil.getInternalState(frame, "parent") != null
+                        || !TestUtil.<Boolean>getInternalState(frame, "staticType")
+                        || TestUtil.getInternalState(frame, "frameName") != null)) {
+                result = false;
             }
 
             return result;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckTest.java
@@ -138,14 +138,13 @@ public class IllegalTokenTextCheckTest
     }
 
     @Test
-    public void testOrderOfProperties() throws Exception {
+    public void testOrderOfProperties() {
         // pure class must be used as configuration doesn't guarantee order of
         // attributes
         final IllegalTokenTextCheck check = new IllegalTokenTextCheck();
         check.setFormat("test");
         check.setIgnoreCase(true);
-        final Pattern actual = (Pattern) TestUtil.getClassDeclaredField(
-                IllegalTokenTextCheck.class, "format").get(check);
+        final Pattern actual = TestUtil.getInternalState(check, "format");
         assertEquals(Pattern.CASE_INSENSITIVE, actual.flags(), "should match");
         assertEquals("test", actual.pattern(), "should match");
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
@@ -23,6 +23,7 @@ import static com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck.MSG
 import static com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck.MSG_VARIABLE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -439,10 +440,10 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
         constructor.setAccessible(true);
         final Object o = constructor.newInstance(null, ident);
 
-        final Object actual = TestUtil.getClassDeclaredMethod(cls, "getFrameNameIdent").invoke(o);
-        assertEquals(ident, actual, "expected ident token");
+        final DetailAstImpl actual = TestUtil.invokeMethod(o, "getFrameNameIdent");
+        assertSame(ident, actual, "expected ident token");
         assertEquals("CATCH_FRAME",
-            TestUtil.getClassDeclaredMethod(cls, "getType").invoke(o).toString(),
+            TestUtil.invokeMethod(o, "getType").toString(),
                 "expected catch frame type");
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
@@ -24,14 +24,12 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import java.lang.reflect.Method;
-
 import org.junit.jupiter.api.Test;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class FinalClassCheckTest
@@ -131,10 +129,9 @@ public class FinalClassCheckTest
 
     @Test
     public void testQualifiedClassName() throws Exception {
-        final Method method = Whitebox.getMethod(FinalClassCheck.class, "getQualifiedClassName",
-                String.class, String.class, String.class);
-        assertEquals("ClassName", method.invoke(null, "", null, "ClassName"),
-                "unexpected result");
+        final String actual = TestUtil.invokeStaticMethod(FinalClassCheck.class,
+                "getQualifiedClassName", "", null, "ClassName");
+        assertEquals("ClassName", actual, "unexpected result");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheckTest.java
@@ -26,17 +26,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
-import java.lang.reflect.Method;
 
 import org.antlr.v4.runtime.CommonToken;
 import org.junit.jupiter.api.Test;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.JavaParser;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class VisibilityModifierCheckTest
@@ -423,10 +422,9 @@ public class VisibilityModifierCheckTest
             new File(getPath("InputVisibilityModifierIsStarImport.java")),
             JavaParser.Options.WITHOUT_COMMENTS).getFirstChild().getNextSibling();
         final VisibilityModifierCheck check = new VisibilityModifierCheck();
-        final Method method = Whitebox.getMethod(VisibilityModifierCheck.class,
-            "isStarImport", DetailAST.class);
+        final boolean actual = TestUtil.invokeMethod(check, "isStarImport", importAst);
 
-        assertTrue((boolean) method.invoke(check, importAst),
+        assertTrue(actual,
                 "Should return true when star import is passed");
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.header;
 
+import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck.MSG_MISMATCH;
 import static com.puppycrawl.tools.checkstyle.checks.header.HeaderCheck.MSG_MISSING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -26,16 +27,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class HeaderCheckTest extends AbstractModuleTestSupport {
@@ -196,12 +198,15 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
         check.setHeaderFile(new URI("test://bad"));
 
         try {
-            Whitebox.invokeMethod(check, "loadHeaderFile");
-            fail("Exception expected");
+            TestUtil.invokeMethod(check, "loadHeaderFile");
+            fail("InvocationTargetException expected");
         }
-        catch (CheckstyleException ex) {
-            assertTrue(ex.getMessage().startsWith("unable to load header file "),
-                    "Invalid exception cause message");
+        catch (InvocationTargetException ex) {
+            assertWithMessage("Invalid exception cause message")
+                .that(ex)
+                    .hasCauseThat()
+                        .hasMessageThat()
+                        .startsWith("unable to load header file ");
         }
     }
 
@@ -253,13 +258,16 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
         final HeaderCheck check = new HeaderCheck();
         check.setHeader("Header");
         try {
-            Whitebox.invokeMethod(check, "loadHeaderFile");
-            fail("ConversionException is expected");
+            TestUtil.invokeMethod(check, "loadHeaderFile");
+            fail("InvocationTargetException is expected");
         }
-        catch (IllegalArgumentException ex) {
-            assertEquals("header has already been set - "
-                    + "set either header or headerFile, not both", ex.getMessage(),
-                    "Invalid exception message");
+        catch (InvocationTargetException ex) {
+            assertWithMessage("Invalid exception cause message")
+                .that(ex)
+                    .hasCauseThat()
+                        .hasMessageThat()
+                        .isEqualTo("header has already been set - "
+                                + "set either header or headerFile, not both");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheckTest.java
@@ -30,11 +30,11 @@ import java.util.Locale;
 import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
@@ -57,7 +57,7 @@ public class RegexpHeaderCheckTest extends AbstractModuleTestSupport {
         // recreate for each test because multiple invocations fail
         final String header = null;
         instance.setHeader(header);
-        final List<Pattern> headerRegexps = Whitebox.getInternalState(instance, "headerRegexps");
+        final List<Pattern> headerRegexps = TestUtil.getInternalState(instance, "headerRegexps");
 
         assertTrue(headerRegexps.isEmpty(), "When header is null regexps should not be set");
     }
@@ -72,7 +72,7 @@ public class RegexpHeaderCheckTest extends AbstractModuleTestSupport {
         // check empty string passes
         final String header = "";
         instance.setHeader(header);
-        final List<Pattern> headerRegexps = Whitebox.getInternalState(instance, "headerRegexps");
+        final List<Pattern> headerRegexps = TestUtil.getInternalState(instance, "headerRegexps");
 
         assertTrue(headerRegexps.isEmpty(), "When header is empty regexps should not be set");
     }
@@ -86,7 +86,7 @@ public class RegexpHeaderCheckTest extends AbstractModuleTestSupport {
         // check valid header passes
         final String header = "abc.*";
         instance.setHeader(header);
-        final List<Pattern> headerRegexps = Whitebox.getInternalState(instance, "headerRegexps");
+        final List<Pattern> headerRegexps = TestUtil.getInternalState(instance, "headerRegexps");
         assertEquals(1, headerRegexps.size(), "Expected one pattern");
         assertEquals(header, headerRegexps.get(0).pattern(), "Invalid header regexp");
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -561,11 +561,9 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
      * exception that gets thrown when a unsupported option is used. The field has a value by
      * default and the setter for the property will throw it's own exception when an unsupported
      * option is given, so there is no other way to cover this code.
-     *
-     * @throws Exception if there is an error.
      */
     @Test
-    public void testVisitTokenSwitchReflection() throws Exception {
+    public void testVisitTokenSwitchReflection() {
         // Create mock ast
         final DetailAstImpl astImport = mockAST(TokenTypes.IMPORT, "import", 0, 0);
         final DetailAstImpl astIdent = mockAST(TokenTypes.IDENT, "myTestImport", 0, 0);
@@ -575,7 +573,7 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
 
         // Set unsupported option
         final ImportOrderCheck mock = new ImportOrderCheck();
-        TestUtil.getClassDeclaredField(ImportOrderCheck.class, "option").set(mock, null);
+        TestUtil.setInternalState(mock, "option", null);
 
         // expecting IllegalStateException
         try {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheckTest.java
@@ -122,7 +122,7 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testStatefulFieldsClearedOnBeginTree1() throws Exception {
+    public void testStatefulFieldsClearedOnBeginTree1() {
         final DetailAstImpl ast = new DetailAstImpl();
         ast.setType(TokenTypes.LITERAL_ELSE);
 
@@ -139,7 +139,7 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testStatefulFieldsClearedOnBeginTree2() throws Exception {
+    public void testStatefulFieldsClearedOnBeginTree2() {
         final DetailAstImpl ast = new DetailAstImpl();
         ast.setType(TokenTypes.LITERAL_RETURN);
         ast.setLineNo(5);
@@ -170,13 +170,9 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
                 question.get(),
                 "processingTokenEnd",
                 processingTokenEnd -> {
-                    try {
-                        return getFieldValue(processingTokenEnd, "endLineNo") == 0
-                            && getFieldValue(processingTokenEnd, "endColumnNo") == 0;
-                    }
-                    catch (IllegalAccessException | NoSuchFieldException ex) {
-                        throw new IllegalStateException(ex);
-                    }
+                    return TestUtil.<Integer>getInternalState(processingTokenEnd, "endLineNo") == 0
+                        && TestUtil.<Integer>getInternalState(
+                                processingTokenEnd, "endColumnNo") == 0;
                 }), "State is not cleared on beginTree");
     }
 
@@ -307,15 +303,14 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testTokenEndIsAfterSameLineColumn() throws Exception {
         final NPathComplexityCheck check = new NPathComplexityCheck();
-        final Object tokenEnd = TestUtil.getClassDeclaredField(NPathComplexityCheck.class,
-                "processingTokenEnd").get(check);
+        final Object tokenEnd = TestUtil.getInternalState(check, "processingTokenEnd");
         final DetailAstImpl token = new DetailAstImpl();
         token.setLineNo(0);
         token.setColumnNo(0);
 
         assertTrue(
-            (Boolean) TestUtil.getClassDeclaredMethod(tokenEnd.getClass(), "isAfter")
-                .invoke(tokenEnd, token), "isAfter must be true for same line/column");
+            TestUtil.<Boolean>invokeMethod(tokenEnd, "isAfter", token),
+                "isAfter must be true for same line/column");
     }
 
     @Test
@@ -367,18 +362,6 @@ public class NPathComplexityCheckTest extends AbstractModuleTestSupport {
         final DetailAstImpl astSemi = new DetailAstImpl();
         astSemi.initialize(tokenImportSemi);
         return astSemi;
-    }
-
-    /**
-     * Get int value of provided field in object.
-     *
-     * @param object object to get field from
-     * @param fieldName field name
-     * @return int value of field
-     */
-    private static Integer getFieldValue(Object object, String fieldName)
-            throws IllegalAccessException, NoSuchFieldException {
-        return (Integer) TestUtil.getClassDeclaredField(object.getClass(), fieldName).get(object);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheckTest.java
@@ -46,7 +46,7 @@ public class ExecutableStatementCountCheckTest
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testStatefulFieldsClearedOnBeginTree() throws Exception {
+    public void testStatefulFieldsClearedOnBeginTree() {
         final DetailAstImpl ast = new DetailAstImpl();
         ast.setType(TokenTypes.STATIC_INIT);
         final ExecutableStatementCountCheck check = new ExecutableStatementCountCheck();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheckTest.java
@@ -27,15 +27,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import java.lang.reflect.Method;
-
 import org.junit.jupiter.api.Test;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
-import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
@@ -507,15 +504,13 @@ public class ParenPadCheckTest
     @Test
     public void testIsAcceptableToken() throws Exception {
         final ParenPadCheck check = new ParenPadCheck();
-        final Method method = Whitebox.getMethod(ParenPadCheck.class,
-            "isAcceptableToken", DetailAST.class);
         final DetailAstImpl ast = new DetailAstImpl();
         final String message = "Expected that all acceptable tokens will pass isAcceptableToken "
             + "method, but some token don't: ";
 
         for (int token : check.getAcceptableTokens()) {
             ast.setType(token);
-            assertTrue((boolean) method.invoke(check, ast),
+            assertTrue(TestUtil.<Boolean>invokeMethod(check, "isAcceptableToken", ast),
                     message + TokenUtil.getTokenName(token));
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilterTest.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -48,6 +47,7 @@ import com.puppycrawl.tools.checkstyle.checks.coding.IllegalCatchCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.EqualsVerifierReport;
@@ -753,7 +753,7 @@ public class SuppressWithNearbyCommentFilterTest
         final TreeWalkerAuditEvent dummyEvent = new TreeWalkerAuditEvent(contents, filename,
                 new Violation(1, null, null, null, null, Object.class, null), null);
         filter.accept(dummyEvent);
-        return Whitebox.getInternalState(filter, "tags");
+        return TestUtil.getInternalState(filter, "tags");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterTest.java
@@ -34,7 +34,6 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -46,6 +45,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.api.Violation;
 import com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck;
 import com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheck;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.EqualsVerifierReport;
@@ -363,7 +363,7 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
      */
     @Test
     public void testEqualsAndHashCodeOfSuppressionClass() throws ClassNotFoundException {
-        final Class<?> suppressionClass = Whitebox.getInnerClassType(
+        final Class<?> suppressionClass = TestUtil.getInnerClassType(
                 SuppressWithPlainTextCommentFilter.class, "Suppression");
         final EqualsVerifierReport ev = EqualsVerifier
                 .forClass(suppressionClass).usingGetClass()

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilterTest.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -49,6 +48,7 @@ import com.puppycrawl.tools.checkstyle.checks.coding.IllegalCatchCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.EqualsVerifierReport;
@@ -657,7 +657,7 @@ public class SuppressionCommentFilterTest
         final TreeWalkerAuditEvent dummyEvent = new TreeWalkerAuditEvent(contents, filename,
                 new Violation(1, null, null, null, null, Object.class, ""), null);
         filter.accept(dummyEvent);
-        return Whitebox.getInternalState(filter, "tags");
+        return TestUtil.getInternalState(filter, "tags");
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -19,24 +19,26 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
+import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
-import org.powermock.reflect.Whitebox;
 import org.xml.sax.InputSource;
 
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
 import com.puppycrawl.tools.checkstyle.TreeWalkerFilter;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.FilterSet;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 /**
  * Tests SuppressionsLoader.
@@ -225,13 +227,16 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         final String sourceName = "InputSuppressionsLoaderNone.xml";
 
         try {
-            Whitebox.invokeMethod(SuppressionsLoader.class, "loadSuppressions",
+            TestUtil.invokeStaticMethod(SuppressionsLoader.class, "loadSuppressions",
                     new InputSource(sourceName), sourceName);
-            fail("CheckstyleException is expected");
+            fail("InvocationTargetException is expected");
         }
-        catch (CheckstyleException ex) {
-            assertEquals("Unable to find: " + sourceName,
-                    ex.getMessage(), "Invalid exception message");
+        catch (InvocationTargetException ex) {
+            assertWithMessage("Invalid exception cause message")
+                .that(ex)
+                    .hasCauseThat()
+                        .hasMessageThat()
+                        .isEqualTo("Unable to find: " + sourceName);
         }
     }
 
@@ -240,13 +245,16 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         final String sourceName = "InputSuppressionsLoaderNone.xml";
 
         try {
-            Whitebox.invokeMethod(SuppressionsLoader.class, "loadSuppressions",
+            TestUtil.invokeStaticMethod(SuppressionsLoader.class, "loadSuppressions",
                     new InputSource(), sourceName);
-            fail("CheckstyleException is expected");
+            fail("InvocationTargetException is expected");
         }
-        catch (CheckstyleException ex) {
-            assertEquals("Unable to read " + sourceName,
-                    ex.getMessage(), "Invalid exception message");
+        catch (InvocationTargetException ex) {
+            assertWithMessage("Invalid exception cause message")
+                .that(ex)
+                    .hasCauseThat()
+                        .hasMessageThat()
+                        .isEqualTo("Unable to read " + sourceName);
         }
     }
 
@@ -301,7 +309,7 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         final SuppressFilterElement suppressElement = (SuppressFilterElement) fc.getFilters()
                 .toArray()[0];
 
-        final String id = Whitebox.getInternalState(suppressElement, "moduleId");
+        final String id = TestUtil.getInternalState(suppressElement, "moduleId");
         assertEquals("someId", id, "Id has to be defined");
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/MainFrameModelPowerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/MainFrameModelPowerTest.java
@@ -33,12 +33,12 @@ import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.gui.MainFrameModel;
 import com.puppycrawl.tools.checkstyle.gui.MainFrameModel.ParseMode;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(ParseMode.class)
@@ -87,7 +87,7 @@ public class MainFrameModelPowerTest extends AbstractModuleTestSupport {
     @Test
     public void testOpenFileWithUnknownParseMode() throws CheckstyleException {
         final ParseMode unknownParseMode = PowerMockito.mock(ParseMode.class);
-        Whitebox.setInternalState(unknownParseMode, "ordinal", 3);
+        TestUtil.setInternalState(unknownParseMode, "ordinal", 3);
 
         PowerMockito.when(unknownParseMode.toString()).thenReturn("Unknown parse mode");
         PowerMockito.mockStatic(ParseMode.class);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/PackageObjectFactoryPowerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/PackageObjectFactoryPowerTest.java
@@ -36,9 +36,9 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.PackageObjectFactory;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.ModuleReflectionUtil;
 
 @RunWith(PowerMockRunner.class)
@@ -50,10 +50,10 @@ public class PackageObjectFactoryPowerTest {
      * This method is for testing the case of an exception caught inside
      * {@code PackageObjectFactory.generateThirdPartyNameToFullModuleName}, a private method used
      * to initialize private field {@code PackageObjectFactory.thirdPartyNameToFullModuleNames}.
-     * Since the method and the field both are private, the {@link Whitebox} is required to ensure
-     * that the field is changed. Also, the expected exception should be thrown from the static
-     * method {@link ModuleReflectionUtil#getCheckstyleModules}, so {@link PowerMockito#mockStatic}
-     * is required to mock this exception.
+     * Since the method and the field both are private, the {@link TestUtil#getInternalState} is
+     * required to ensure that the field is changed. Also, the expected exception should be thrown
+     * from the static method {@link ModuleReflectionUtil#getCheckstyleModules}, so
+     * {@link PowerMockito#mockStatic} is required to mock this exception.
      *
      * @throws Exception when the code tested throws an exception
      */
@@ -71,14 +71,14 @@ public class PackageObjectFactoryPowerTest {
         ModuleReflectionUtil.getCheckstyleModules(packages, classLoader);
 
         final String internalFieldName = "thirdPartyNameToFullModuleNames";
-        final Map<String, String> nullMap = Whitebox.getInternalState(objectFactory,
+        final Map<String, String> nullMap = TestUtil.getInternalState(objectFactory,
                 internalFieldName);
         assertNull("Expected uninitialized field", nullMap);
 
         final Object instance = objectFactory.createModule(name);
         assertEquals("Expected empty string", "", instance);
 
-        final Map<String, String> emptyMap = Whitebox.getInternalState(objectFactory,
+        final Map<String, String> emptyMap = TestUtil.getInternalState(objectFactory,
                 internalFieldName);
         assertEquals("Expected empty map", Collections.emptyMap(), emptyMap);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/TreeWalkerPowerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/powermock/TreeWalkerPowerTest.java
@@ -35,7 +35,6 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.PackageObjectFactory;
@@ -45,6 +44,7 @@ import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.checks.indentation.CommentsIndentationCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.TypeNameCheck;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(TreeWalker.class)
@@ -73,7 +73,7 @@ public class TreeWalkerPowerTest extends AbstractModuleTestSupport {
         lines.add("class Test {}");
         final FileText fileText = new FileText(file, lines);
         treeWalkerSpy.setFileContents(new FileContents(fileText));
-        Whitebox.invokeMethod(treeWalkerSpy, "processFiltered", file, fileText);
+        TestUtil.invokeMethod(treeWalkerSpy, "processFiltered", file, fileText);
         verifyPrivate(treeWalkerSpy, times(1)).invoke("walk",
                 any(DetailAST.class), any(FileContents.class), any(classAstState));
         verifyPrivate(treeWalkerSpy, times(0)).invoke("getFilteredViolations",
@@ -95,7 +95,7 @@ public class TreeWalkerPowerTest extends AbstractModuleTestSupport {
         lines.add("class Test {}");
         final FileText fileText = new FileText(file, lines);
         treeWalkerSpy.setFileContents(new FileContents(fileText));
-        Whitebox.invokeMethod(treeWalkerSpy, "processFiltered", file, fileText);
+        TestUtil.invokeMethod(treeWalkerSpy, "processFiltered", file, fileText);
         verifyPrivate(treeWalkerSpy, times(1)).invoke("walk",
                 any(DetailAST.class), any(FileContents.class), any(classAstState));
         verifyPrivate(treeWalkerSpy, times(0)).invoke("getFilteredViolations",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java
@@ -25,12 +25,14 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import com.puppycrawl.tools.checkstyle.PackageNamesLoader;
 import com.puppycrawl.tools.checkstyle.PackageObjectFactory;
@@ -83,49 +85,52 @@ public final class TestUtil {
     }
 
     /**
-     * Retrieves the specified field by it's name in the class or it's direct super.
+     * Retrieves the specified field by its name in the class or its direct super.
      *
-     * @param clss The class to retrieve the field for.
-     * @param fieldName The name of the field to retrieve.
-     * @return The class' field.
-     * @throws NoSuchFieldException if the requested field cannot be found in the class.
+     * @param clss the class to retrieve the field for
+     * @param fieldName the name of the field to retrieve
+     * @return the class' field if found
      */
-    public static Field getClassDeclaredField(Class<?> clss, String fieldName)
-            throws NoSuchFieldException {
-        final Optional<Field> classField = Arrays.stream(clss.getDeclaredFields())
-                .filter(field -> fieldName.equals(field.getName())).findFirst();
-        final Field resultField;
-        if (classField.isPresent()) {
-            resultField = classField.get();
-        }
-        else {
-            resultField = clss.getSuperclass().getDeclaredField(fieldName);
-        }
-        resultField.setAccessible(true);
-        return resultField;
+    public static Field getClassDeclaredField(Class<?> clss, String fieldName) {
+        return Stream.<Class<?>>iterate(clss, Class::getSuperclass)
+            .flatMap(cls -> Arrays.stream(cls.getDeclaredFields()))
+            .filter(field -> fieldName.equals(field.getName()))
+            .findFirst()
+            .map(field -> {
+                field.setAccessible(true);
+                return field;
+            })
+            .orElseThrow(() -> {
+                return new IllegalStateException(String.format(Locale.ROOT,
+                        "Field '%s' not found in '%s'", fieldName, clss.getCanonicalName()));
+            });
     }
 
     /**
-     * Retrieves the specified method by it's name in the class or it's direct super.
+     * Retrieves the specified method by its name in the class or its direct super.
      *
-     * @param clss The class to retrieve the field for.
-     * @param methodName The name of the method to retrieve.
-     * @return The class' field.
-     * @throws NoSuchMethodException if the requested method cannot be found in the class.
+     * @param clss the class to retrieve the method for
+     * @param methodName the name of the method to retrieve
+     * @param parameters the expected number of parameters
+     * @return the class' method
      */
-    public static Method getClassDeclaredMethod(Class<?> clss, String methodName)
-            throws NoSuchMethodException {
-        final Optional<Method> classMethod = Arrays.stream(clss.getDeclaredMethods())
-                .filter(method -> methodName.equals(method.getName())).findFirst();
-        final Method resultMethod;
-        if (classMethod.isPresent()) {
-            resultMethod = classMethod.get();
-        }
-        else {
-            resultMethod = clss.getSuperclass().getDeclaredMethod(methodName);
-        }
-        resultMethod.setAccessible(true);
-        return resultMethod;
+    public static Method getClassDeclaredMethod(Class<?> clss, String methodName, int parameters) {
+        return Stream.<Class<?>>iterate(clss, Class::getSuperclass)
+            .flatMap(cls -> Arrays.stream(cls.getDeclaredMethods()))
+            .filter(method -> {
+                return methodName.equals(method.getName())
+                    && parameters == method.getParameterCount();
+            })
+            .findFirst()
+            .map(method -> {
+                method.setAccessible(true);
+                return method;
+            })
+            .orElseThrow(() -> {
+                return new IllegalStateException(String.format(Locale.ROOT,
+                        "Method '%s' with %d parameters not found in '%s'",
+                        methodName, parameters, clss.getCanonicalName()));
+            });
     }
 
     /**
@@ -136,20 +141,15 @@ public final class TestUtil {
      * @param fieldName  name of the field to be checked
      * @param isClear    function for checking field state
      * @return {@code true} if state of the field is cleared
-     * @throws NoSuchFieldException   if there is no field with the
-     *                                {@code fieldName} in the {@code check}
-     * @throws IllegalAccessException if the field is inaccessible
      */
     public static boolean isStatefulFieldClearedDuringBeginTree(AbstractCheck check,
                                                                 DetailAST astToVisit,
                                                                 String fieldName,
-                                                                Predicate<Object> isClear)
-            throws NoSuchFieldException, IllegalAccessException {
+                                                                Predicate<Object> isClear) {
         check.beginTree(astToVisit);
         check.visitToken(astToVisit);
         check.beginTree(null);
-        final Field resultField = getClassDeclaredField(check.getClass(), fieldName);
-        return isClear.test(resultField.get(check));
+        return isClear.test(getInternalState(check, fieldName));
     }
 
     /**
@@ -166,7 +166,7 @@ public final class TestUtil {
             TreeWalkerFilter filter, TreeWalkerAuditEvent event,
             String fieldName, Predicate<Object> isClear) throws Exception {
         filter.accept(event);
-        getClassDeclaredMethod(filter.getClass(), "finishLocalSetup").invoke(filter);
+        invokeMethod(filter, "finishLocalSetup");
         final Field resultField = getClassDeclaredField(filter.getClass(), fieldName);
         return isClear.test(resultField.get(filter));
     }
@@ -268,4 +268,120 @@ public final class TestUtil {
         thread.start();
         return futureTask.get(10, TimeUnit.SECONDS);
     }
+
+    /**
+     * Reads the value of a field using reflection. This method will traverse the
+     * super class hierarchy until a field with name {@code fieldName} is found.
+     *
+     * @param instance the instance to read
+     * @param fieldName the name of the field
+     * @throws RuntimeException if the field  can't be read
+     * @noinspection unchecked
+     */
+    public static <T> T getInternalState(Object instance, String fieldName) {
+        try {
+            final Field field = getClassDeclaredField(instance.getClass(), fieldName);
+            return (T) field.get(instance);
+        }
+        catch (ReflectiveOperationException ex) {
+            final String message = String.format(Locale.ROOT,
+                    "Failed to get field '%s' for instance of class '%s'",
+                    fieldName, instance.getClass().getSimpleName());
+            throw new IllegalStateException(message, ex);
+        }
+    }
+
+    /**
+     * Reads the value of a static field using reflection. This method will traverse the
+     * super class hierarchy until a field with name {@code fieldName} is found.
+     *
+     * @param clss the class of the field
+     * @param fieldName the name of the field
+     * @throws RuntimeException if the field  can't be read
+     * @noinspection unchecked
+     */
+    public static <T> T getInternalStaticState(Class<?> clss, String fieldName) {
+        try {
+            final Field field = getClassDeclaredField(clss, fieldName);
+            return (T) field.get(null);
+        }
+        catch (ReflectiveOperationException ex) {
+            final String message = String.format(Locale.ROOT,
+                    "Failed to get static field '%s' for class '%s'",
+                    fieldName, clss);
+            throw new IllegalStateException(message, ex);
+        }
+    }
+
+    /**
+     * Writes the value of a field using reflection. This method will traverse the
+     * super class hierarchy until a field with name {@code fieldName} is found.
+     *
+     * @param instance the instance whose field to modify
+     * @param fieldName the name of the field
+     * @param value the new value of the field
+     * @throws RuntimeException if the field  can't be changed
+     */
+    public static void setInternalState(Object instance, String fieldName, Object value) {
+        try {
+            final Field field = getClassDeclaredField(instance.getClass(), fieldName);
+            field.set(instance, value);
+        }
+        catch (ReflectiveOperationException ex) {
+            final String message = String.format(Locale.ROOT,
+                    "Failed to set field '%s' for instance of class '%s'",
+                    fieldName, instance.getClass().getSimpleName());
+            throw new IllegalStateException(message, ex);
+        }
+    }
+
+    /**
+     * Invokes a private method for an instance.
+     *
+     * @param instance the instance whose method to invoke
+     * @param methodToExecute the name of the method to invoke
+     * @param arguments the optional arguments
+     * @param <T> the type of the result
+     * @return the method's result
+     * @throws ReflectiveOperationException if the method invocation failed
+     * @noinspection unchecked
+     */
+    public static <T> T invokeMethod(Object instance,
+            String methodToExecute, Object... arguments) throws ReflectiveOperationException {
+        final Class<?> clss = instance.getClass();
+        final Method method = getClassDeclaredMethod(clss, methodToExecute, arguments.length);
+        return (T) method.invoke(instance, arguments);
+    }
+
+    /**
+     * Invokes a static private method for a class.
+     *
+     * @param clss the class whose static method to invoke
+     * @param methodToExecute the name of the method to invoke
+     * @param arguments the optional arguments
+     * @param <T> the type of the result
+     * @return the method's result
+     * @throws ReflectiveOperationException if the method invocation failed
+     * @noinspection unchecked
+     */
+    public static <T> T invokeStaticMethod(Class<?> clss,
+            String methodToExecute, Object... arguments) throws ReflectiveOperationException {
+        final Method method = getClassDeclaredMethod(clss, methodToExecute, arguments.length);
+        return (T) method.invoke(null, arguments);
+    }
+
+    /**
+     * Returns the inner class type by its name.
+     *
+     * @param declaringClass the class in which the inner class is declared
+     * @param name the unqualified name (simple name) of the inner class
+     * @return the inner class type
+     * @throws ClassNotFoundException if the class not found
+     * @noinspection unchecked
+     */
+    public static <T> Class<T> getInnerClassType(Class<?> declaringClass, String name)
+            throws ClassNotFoundException {
+        return (Class<T>) Class.forName(declaringClass.getName() + "$" + name);
+    }
+
 }


### PR DESCRIPTION
Part of #7368 

This PR if a prerequisite for enabling JDK17 build.
We are doing a bit of reflection in the tests, with `Whitebox` class from Powermocks library.
The problem is that `Whitebox` blindly makes accessible every field in the hierarchy: https://github.com/powermock/powermock/issues/1094

This PR introduces some `Whitebox`-compatible methods in the `TestUtil` class. With two differences: these methods make accessible only the requested field/method, not all of them including methods from `Object` class and do not "unwrap" `InvocationTargetException` cause.

The import config now forbids usage of `Whitebox` and low-level reflection API (with some exceptions).