### PR TITLE
Issue #10747: MetadataGeneratorUtil now reports errors back to the users

### DIFF
--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -211,6 +211,11 @@
     <allow class="com.puppycrawl.tools.checkstyle.FileStatefulCheck"/>
     <allow class="com.puppycrawl.tools.checkstyle.TreeWalker"/>
     <allow class="com.puppycrawl.tools.checkstyle.utils.TokenUtil"/>
+
+    <file name="MetadataGeneratorUtil">
+      <allow class="com.puppycrawl.tools.checkstyle.MetadataGeneratorLogger"/>
+    </file>
+
   </subpackage>
 
   <subpackage name="xpath">

--- a/pom.xml
+++ b/pom.xml
@@ -1583,6 +1583,8 @@
                 <exclude>**/WriteTagCheckTest.class</exclude>
 
                 <exclude>**/AbstractJavadocCheckTest.class</exclude>
+
+                <exclude>**/MetadataGeneratorUtilTest.class</exclude>
               </excludes>
             </configuration>
           </execution>
@@ -2873,6 +2875,7 @@
                 <param>com.puppycrawl.tools.checkstyle.Definitions*</param>
                 <param>com.puppycrawl.tools.checkstyle.XMLLogger*</param>
                 <param>com.puppycrawl.tools.checkstyle.SarifLogger*</param>
+                <param>com.puppycrawl.tools.checkstyle.MetadataGeneratorLogger*</param>
                 <param>com.puppycrawl.tools.checkstyle.PackageObjectFactory*</param>
                 <param>com.puppycrawl.tools.checkstyle.PropertiesExpander*</param>
                 <param>com.puppycrawl.tools.checkstyle.PropertyCacheFile*</param>
@@ -2900,6 +2903,7 @@
                 <param>com.puppycrawl.tools.checkstyle.DefinitionsTest</param>
                 <param>com.puppycrawl.tools.checkstyle.XMLLoggerTest</param>
                 <param>com.puppycrawl.tools.checkstyle.SarifLoggerTest</param>
+                <param>com.puppycrawl.tools.checkstyle.MetadataGeneratorLoggerTest</param>
                 <param>com.puppycrawl.tools.checkstyle.PackageObjectFactoryTest</param>
                 <param>com.puppycrawl.tools.checkstyle.PropertiesExpanderTest</param>
                 <param>com.puppycrawl.tools.checkstyle.PropertyCacheFileTest</param>
@@ -2909,6 +2913,8 @@
                 <param>com.puppycrawl.tools.checkstyle.grammar.javadoc.JavadocParseTreeTest</param>
                 <!-- this test is required for Checker -->
                 <param>com.puppycrawl.tools.checkstyle.filefilters.BeforeExecutionExclusionFileFilterTest</param>
+                <!-- This test is the primary user of metadataGeneratorLogger -->
+                <param>com.puppycrawl.tools.checkstyle.meta.MetadataGeneratorUtilTest</param>
               </targetTests>
               <coverageThreshold>99</coverageThreshold>
               <mutationThreshold>95</mutationThreshold>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/MetadataGeneratorLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/MetadataGeneratorLogger.java
@@ -1,0 +1,111 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2022 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+
+import com.puppycrawl.tools.checkstyle.api.AuditEvent;
+import com.puppycrawl.tools.checkstyle.api.AuditListener;
+import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
+import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
+
+/**
+ * Simple logger for metadata generator util.
+ */
+public class MetadataGeneratorLogger extends AutomaticBean implements AuditListener {
+
+    /**
+     * Where to write error messages.
+     */
+    private final PrintWriter errorWriter;
+
+    /**
+     * Formatter for the log message.
+     */
+    private final AuditEventFormatter formatter;
+
+    /**
+     * Close output stream in audit finished.
+     */
+    private final boolean closeErrorWriter;
+
+    /**
+     * Creates a new MetadataGeneratorLogger instance.
+     *
+     * @param outputStream where to log audit events
+     * @param outputStreamOptions if {@code CLOSE} error should be closed in auditFinished()
+     */
+    public MetadataGeneratorLogger(OutputStream outputStream,
+            OutputStreamOptions outputStreamOptions) {
+        final Writer errorStreamWriter = new OutputStreamWriter(outputStream,
+                StandardCharsets.UTF_8);
+        errorWriter = new PrintWriter(errorStreamWriter);
+        formatter = new AuditEventDefaultFormatter();
+        closeErrorWriter = outputStreamOptions == OutputStreamOptions.CLOSE;
+    }
+
+    @Override
+    public void auditStarted(AuditEvent event) {
+        errorWriter.flush();
+    }
+
+    @Override
+    public void auditFinished(AuditEvent event) {
+        errorWriter.flush();
+        if (closeErrorWriter) {
+            errorWriter.close();
+        }
+    }
+
+    @Override
+    public void fileStarted(AuditEvent event) {
+        // No code by default.
+    }
+
+    @Override
+    public void fileFinished(AuditEvent event) {
+        errorWriter.flush();
+    }
+
+    @Override
+    public void addError(AuditEvent event) {
+        final SeverityLevel severityLevel = event.getSeverityLevel();
+        if (severityLevel != SeverityLevel.IGNORE) {
+            final String errorMessage = formatter.format(event);
+            errorWriter.println(errorMessage);
+        }
+    }
+
+    @Override
+    public void addException(AuditEvent event, Throwable throwable) {
+        synchronized (errorWriter) {
+            throwable.printStackTrace(errorWriter);
+        }
+    }
+
+    @Override
+    protected void finishLocalSetup() {
+        // No code by default.
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java
@@ -236,7 +236,9 @@ public class JavadocMetadataScraper extends AbstractJavadocCheck {
         moduleDetails.setDescription(getDescriptionText());
         if (isTopLevelClassJavadoc()) {
             if (moduleDetails.getDescription().isEmpty()) {
-                log(rootAst.getLineNumber(), MSG_DESC_MISSING, moduleDetails.getName());
+                final String fullQualifiedName = moduleDetails.getFullQualifiedName();
+                log(rootAst.getLineNumber(), MSG_DESC_MISSING,
+                        fullQualifiedName.substring(fullQualifiedName.lastIndexOf('.') + 1));
             }
             else if (writeXmlOutput) {
                 try {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtil.java
@@ -58,7 +58,8 @@ public final class MetadataGeneratorUtil {
         checker.setModuleClassLoader(Checker.class.getClassLoader());
         final DefaultConfiguration scraperCheckConfig =
                         new DefaultConfiguration(JavadocMetadataScraper.class.getName());
-        final DefaultConfiguration defaultConfiguration = new DefaultConfiguration("configuration");
+        final DefaultConfiguration defaultConfiguration =
+                new DefaultConfiguration("configuration");
         final DefaultConfiguration treeWalkerConfig =
                 new DefaultConfiguration(TreeWalker.class.getName());
         defaultConfiguration.addProperty("charset", StandardCharsets.UTF_8.name());
@@ -94,7 +95,6 @@ public final class MetadataGeneratorUtil {
                         .collect(Collectors.toList()));
             }
         }
-
         checker.process(validFiles);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtil.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.meta;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -32,7 +33,9 @@ import java.util.stream.Stream;
 
 import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.MetadataGeneratorLogger;
 import com.puppycrawl.tools.checkstyle.TreeWalker;
+import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 
 /** Class which handles all the metadata generation and writing calls. */
@@ -46,11 +49,12 @@ public final class MetadataGeneratorUtil {
      * Generate metadata from the module source files available in the input argument path.
      *
      * @param path arguments
+     * @param out OutputStream for error messages
      * @param moduleFolders folders to check
      * @throws IOException ioException
      * @throws CheckstyleException checkstyleException
      */
-    public static void generate(String path, String... moduleFolders)
+    public static void generate(String path, OutputStream out, String... moduleFolders)
             throws IOException, CheckstyleException {
         JavadocMetadataScraper.resetModuleDetailsStore();
 
@@ -66,6 +70,10 @@ public final class MetadataGeneratorUtil {
         defaultConfiguration.addChild(treeWalkerConfig);
         treeWalkerConfig.addChild(scraperCheckConfig);
         checker.configure(defaultConfiguration);
+
+        checker.addListener(new MetadataGeneratorLogger(out,
+                AutomaticBean.OutputStreamOptions.NONE));
+
         dumpMetadata(checker, path, moduleFolders);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MetadataGeneratorLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MetadataGeneratorLoggerTest.java
@@ -1,0 +1,112 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2022 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.api.AuditEvent;
+import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
+import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
+import com.puppycrawl.tools.checkstyle.api.Violation;
+import com.puppycrawl.tools.checkstyle.internal.utils.CloseAndFlushTestByteArrayOutputStream;
+
+public class MetadataGeneratorLoggerTest {
+
+    @Test
+    public void testIgnoreSeverityLevel() {
+        final OutputStream outputStream = new ByteArrayOutputStream();
+        final MetadataGeneratorLogger logger = new MetadataGeneratorLogger(outputStream,
+                AutomaticBean.OutputStreamOptions.CLOSE);
+        final AuditEvent event = new AuditEvent(this, "fileName",
+                new Violation(1, 2, "bundle", "key",
+                        null, SeverityLevel.IGNORE, null, getClass(), "customViolation"));
+        logger.finishLocalSetup();
+        logger.addError(event);
+        logger.auditFinished(event);
+        assertWithMessage("Output stream should be empty")
+                .that(outputStream.toString())
+                .isEmpty();
+    }
+
+    @Test
+    public void testAddException() {
+        final OutputStream outputStream = new ByteArrayOutputStream();
+        final MetadataGeneratorLogger logger = new MetadataGeneratorLogger(outputStream,
+                AutomaticBean.OutputStreamOptions.CLOSE);
+        final AuditEvent event = new AuditEvent(1);
+        logger.addException(event, new IllegalStateException("Test Exception"));
+        logger.auditFinished(event);
+        assertWithMessage("Violation should contain exception message")
+                .that(outputStream.toString())
+                .contains("java.lang.IllegalStateException: Test Exception");
+    }
+
+    @Test
+    public void testClose() throws IOException {
+        try (CloseAndFlushTestByteArrayOutputStream outputStream =
+                     new CloseAndFlushTestByteArrayOutputStream()) {
+            final MetadataGeneratorLogger logger = new MetadataGeneratorLogger(outputStream,
+                    AutomaticBean.OutputStreamOptions.CLOSE);
+            logger.auditFinished(new AuditEvent(1));
+            assertWithMessage("Unexpected close count")
+                    .that(outputStream.getCloseCount())
+                    .isEqualTo(1);
+        }
+    }
+
+    @Test
+    public void testCloseOutputStreamOptionNone() throws IOException {
+        try (CloseAndFlushTestByteArrayOutputStream outputStream =
+                     new CloseAndFlushTestByteArrayOutputStream()) {
+            final MetadataGeneratorLogger logger = new MetadataGeneratorLogger(outputStream,
+                    AutomaticBean.OutputStreamOptions.NONE);
+            final AuditEvent event = new AuditEvent(1);
+            logger.auditFinished(event);
+            assertWithMessage("Unexpected close count")
+                    .that(outputStream.getCloseCount())
+                    .isEqualTo(0);
+        }
+    }
+
+    @Test
+    public void testFlushStreams() throws Exception {
+        try (CloseAndFlushTestByteArrayOutputStream outputStream =
+                     new CloseAndFlushTestByteArrayOutputStream()) {
+            final MetadataGeneratorLogger logger = new MetadataGeneratorLogger(outputStream,
+                    AutomaticBean.OutputStreamOptions.NONE);
+            final AuditEvent event = new AuditEvent(1);
+            logger.auditStarted(event);
+            logger.fileFinished(event);
+            assertWithMessage("Unexpected flush count")
+                    .that(outputStream.getFlushCount())
+                    .isEqualTo(2);
+            logger.auditFinished(event);
+            assertWithMessage("Unexpected flush count")
+                    .that(outputStream.getFlushCount())
+                    .isEqualTo(3);
+        }
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraperTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraperTest.java
@@ -199,7 +199,7 @@ public class JavadocMetadataScraperTest extends AbstractModuleTestSupport {
 
         final String[] expected = {
             "19: " + getCheckMessage(MSG_DESC_MISSING,
-                    "InputJavadocMetadataScraperAbstractSuper"),
+                    "InputJavadocMetadataScraperAbstractSuperCheck"),
         };
         verifyWithInlineConfigParser(getPath(
                 "InputJavadocMetadataScraperAbstractSuperCheck.java"), expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtilTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.meta;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.meta.JavadocMetadataScraper.MSG_DESC_MISSING;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -28,14 +29,21 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.itsallcode.io.Capturable;
+import org.itsallcode.junit.sysextensions.SystemOutGuard;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
 
-public final class MetadataGeneratorUtilTest {
+@ExtendWith(SystemOutGuard.class)
+public final class MetadataGeneratorUtilTest extends AbstractModuleTestSupport {
 
     private final List<String> modulesContainingNoMetadataFile = Arrays.asList(
             "Checker",
@@ -43,14 +51,55 @@ public final class MetadataGeneratorUtilTest {
             "JavadocMetadataScraper"
     );
 
+    @Override
+    protected String getPackageLocation() {
+        return null;
+    }
+
+    /**
+     * Generates metadata for checkstyle modules and verifies number of
+     * generated metadata modules match the number of checkstyle modules.
+     * Also verifies whether every checkstyle module contains description.
+     *
+     * @param systemOut wrapper for {@code System.out}
+     * @throws Exception if exception occurs during generating metadata or
+     *                   if an I/O error is thrown when accessing the starting file.
+     * @noinspection UseOfSystemOutOrSystemErr
+     */
     @Test
-    public void testMetadataFilesGenerationAllFiles() throws Exception {
+    public void testMetadataFilesGenerationAllFiles(@SystemOutGuard.SysOut Capturable systemOut)
+            throws Exception {
+        systemOut.captureMuted();
 
         MetadataGeneratorUtil.generate(System.getProperty("user.dir")
                         + "/src/main/java/com/puppycrawl/tools/checkstyle",
-                "checks", "filters", "filefilters");
-        final Set<String> metaFiles;
+                System.out, "checks", "filters", "filefilters");
 
+        final String[] expectedErrorMessages = {
+            "31: " + getCheckMessage(MSG_DESC_MISSING, "AbstractSuperCheck"),
+            "45: " + getCheckMessage(MSG_DESC_MISSING, "AbstractHeaderCheck"),
+            "42: " + getCheckMessage(MSG_DESC_MISSING, "AbstractJavadocCheck"),
+            "45: " + getCheckMessage(MSG_DESC_MISSING, "AbstractClassCouplingCheck"),
+            "26: " + getCheckMessage(MSG_DESC_MISSING, "AbstractAccessControlNameCheck"),
+            "30: " + getCheckMessage(MSG_DESC_MISSING, "AbstractNameCheck"),
+            "29: " + getCheckMessage(MSG_DESC_MISSING, "AbstractParenPadCheck"),
+        };
+
+        final String[] actualViolations = systemOut.getCapturedData().split("\\n");
+        final Pattern violationExtractingPattern = Pattern.compile("((?<=:)\\d.*:.*(?=\\s\\[))");
+
+        Arrays.setAll(actualViolations, id -> {
+            final Matcher matcher = violationExtractingPattern.matcher(actualViolations[id]);
+            matcher.find();
+            return matcher.group(1);
+        });
+
+        assertWithMessage("Expected and actual errors do not match")
+                .that(expectedErrorMessages)
+                .asList()
+                .containsExactlyElementsIn(actualViolations);
+
+        final Set<String> metaFiles;
         try (Stream<Path> fileStream = Files.walk(
                 Paths.get(System.getProperty("user.dir") + "/src/main/resources/com/puppycrawl"
                         + "/tools/checkstyle/meta"))) {
@@ -67,8 +116,10 @@ public final class MetadataGeneratorUtilTest {
                 .sorted()
                 .collect(Collectors.toCollection(LinkedHashSet::new));
         checkstyleModules.removeAll(modulesContainingNoMetadataFile);
-        assertWithMessage("Number of generated metadata files dont match with number of checkstyle "
-                + "module").that(metaFiles).isEqualTo(checkstyleModules);
+        assertWithMessage("Number of generated metadata files dont match with "
+                + "number of checkstyle module")
+                .that(metaFiles)
+                .isEqualTo(checkstyleModules);
     }
 
     /**


### PR DESCRIPTION
Continuing #10805 
Resolves #10747: MetadataGeneratorUtil now reports errors back to the users
Summary-
The previous PR #10805 added the support of logging a violation in `JavadocMetadataScraper` when the module doesn't contain javadoc description. As `JavadocMetadataScraper` is not a part of checkstyle_checks and we need metadata beforehand we execute it with the help of `MetadataGeneraotrUtilTest`. In this PR support was added to show the violations we logged in `JavadocMetadataScraper`.

A separate logger has been created to get rid of `Audit starting...` messages which are printed by the `DefaultLogger`. Inside the test, we capture the output silently and then compare it with the expected violations.