### PR TITLE
Issue #10749: Add support to take list of moduleFolders as input

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtil.java
@@ -26,7 +26,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -46,11 +45,13 @@ public final class MetadataGeneratorUtil {
     /**
      * Generate metadata from the module source files available in the input argument path.
      *
-     * @param args arguments
+     * @param path arguments
+     * @param moduleFolders folders to check
      * @throws IOException ioException
      * @throws CheckstyleException checkstyleException
      */
-    public static void generate(String... args) throws IOException, CheckstyleException {
+    public static void generate(String path, String... moduleFolders)
+            throws IOException, CheckstyleException {
         JavadocMetadataScraper.resetModuleDetailsStore();
 
         final Checker checker = new Checker();
@@ -64,21 +65,22 @@ public final class MetadataGeneratorUtil {
         defaultConfiguration.addChild(treeWalkerConfig);
         treeWalkerConfig.addChild(scraperCheckConfig);
         checker.configure(defaultConfiguration);
-        dumpMetadata(checker, args[0]);
+        dumpMetadata(checker, path, moduleFolders);
     }
 
     /**
      * Process files using the checker passed and write to corresponding XML files.
      *
+     * @param moduleFolders folders to check
      * @param checker checker
      * @param path rootPath
      * @throws CheckstyleException checkstyleException
      * @throws IOException ioException
      */
-    private static void dumpMetadata(Checker checker, String path) throws CheckstyleException,
+    private static void dumpMetadata(Checker checker, String path, String... moduleFolders)
+            throws CheckstyleException,
             IOException {
         final List<File> validFiles = new ArrayList<>();
-        final List<String> moduleFolders = Arrays.asList("checks", "filters", "filefilters");
         for (String folder : moduleFolders) {
             try (Stream<Path> files = Files.walk(Paths.get(path
                     + "/" + folder))) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtilTest.java
@@ -45,8 +45,10 @@ public final class MetadataGeneratorUtilTest {
 
     @Test
     public void testMetadataFilesGenerationAllFiles() throws Exception {
+
         MetadataGeneratorUtil.generate(System.getProperty("user.dir")
-                + "/src/main/java/com/puppycrawl/tools/checkstyle");
+                        + "/src/main/java/com/puppycrawl/tools/checkstyle",
+                "checks", "filters", "filefilters");
         final Set<String> metaFiles;
 
         try (Stream<Path> fileStream = Files.walk(


### PR DESCRIPTION
Fixes issue #10749: Currently moduleFolders names are hardcoded `checks`, `filters`, `filefilters`. It is not necessary for all folders to exist, if all three folders doesn't exist, util will stop. Instead the folders can be taken as inputs.
