### PR TITLE
minor: correct the wrong format of AST

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -4701,16 +4701,13 @@ public final class TokenTypes {
      * <p>parses as:</p>
      *
      * <pre>
-     * +--PACKAGE_DEF (package)
-     *     |
-     *     +--ANNOTATIONS
-     *         |
-     *         +--ANNOTATION
-     *             |
-     *             +--AT (&#064;)
-     *             +--IDENT (MyAnnotation)
-     *     +--IDENT (blah)
-     *     +--SEMI (;)
+     * PACKAGE_DEF -&gt; package
+     *  |--ANNOTATIONS -&gt; ANNOTATIONS
+     *  |   `--ANNOTATION -&gt; ANNOTATION
+     *  |       |--AT -&gt; @
+     *  |       `--IDENT -&gt; MyAnnotation
+     *  |--IDENT -&gt; blah
+     *  `--SEMI -&gt; ;
      * </pre>
      *
      * @see <a href="https://www.jcp.org/en/jsr/detail?id=201">


### PR DESCRIPTION
<h3>Fixes Issue: #9393</h3> 
<br>

This PR changes all "+-" to "`-" , as mentioned in the issue. 
<br>

Here is the rendered javadoc file generated using `mvn javadoc:javadoc` :

![Screenshot (25)](https://user-images.githubusercontent.com/75962762/141647571-6c7aa591-546f-499d-9805-200dade3d846.png)

<br><br>

**TEST.java :**

```java
@MyAnnotation package blah;
````

**Command :**

```
java -jar checkstyle-9.1-all.jar -t TEST.java
COMPILATION_UNIT -> COMPILATION_UNIT [1:14]
`--PACKAGE_DEF -> package [1:14]
    |--ANNOTATIONS -> ANNOTATIONS [1:0]
    |   `--ANNOTATION -> ANNOTATION [1:0]
    |       |--AT -> @ [1:0]
    |       `--IDENT -> MyAnnotation [1:1]
    |--IDENT -> blah [1:22]
    `--SEMI -> ; [1:26]
```

**Code changes :**

```java
     * <pre>
     * `--PACKAGE_DEF -> package
     *     |--ANNOTATIONS -> ANNOTATIONS
     *     |   `--ANNOTATION -> ANNOTATION
     *     |       |--AT -> @
     *     |       `--IDENT -> MyAnnotation
     *     |--IDENT -> blah
     *     `--SEMI -> ;
     * </pre>
```


