### PR TITLE
#10778 activate hibernate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,14 +59,13 @@ jobs:
         - CMD="$CMD1 && $CMD2"
         - USE_MAVEN_REPO="true"
 
-    # until https://github.com/checkstyle/checkstyle/issues/10778
-    # - jdk: openjdk8
-    #   env:
-    #     - DESC="NoErrorTest - Hibernate Search"
-    #     - CMD1="mvn -e --no-transfer-progress clean install -Pno-validations"
-    #     - CMD2="./.ci/wercker.sh no-error-hibernate-search"
-    #     - CMD="$CMD1 && $CMD2"
-    #     - USE_MAVEN_REPO="true"
+    - jdk: openjdk8
+      env:
+        - DESC="NoErrorTest - Hibernate Search"
+        - CMD1="mvn -e --no-transfer-progress clean install -Pno-validations"
+        - CMD2="./.ci/wercker.sh no-error-hibernate-search"
+        - CMD="$CMD1 && $CMD2"
+        - USE_MAVEN_REPO="true"
 
     # until https://github.com/sevntu-checkstyle/sevntu.checkstyle/pull/858
     # - jdk: openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,13 @@ addons:
     packages:
       - xsltproc
       - xmlstarlet
-      - ruby
 
 branches:
   only:
     - master
 
 install:
-  - gem install chef-utils:16.6.14 mdl
+  -
 
 jobs:
   fast_finish: true


### PR DESCRIPTION
fixes #10778

master build is already on free tier, looks like green. So no more unexpected stops for Travis CI, no more email to support for extra credits.


actual migration to new arch:
https://github.com/checkstyle/checkstyle/commit/2567947c88a67521e2ec5b51c9c2ea52a5bbf0a6
https://github.com/checkstyle/checkstyle/commit/f565da197f26212b1cedaa742384c98e91428a1d

all old builds/PRs will continue to use credits, so please rebase.