### PR TITLE
infra: allow file exclusions in diff report generation

### DIFF
--- a/.github/workflows/diff_report.yml
+++ b/.github/workflows/diff_report.yml
@@ -176,13 +176,16 @@ jobs:
          BASE_BRANCH="upstream/master"
          if [ -f new_module_config.xml ]; then
            groovy diff.groovy -r $REPO -p $REF -pc new_module_config.xml -m single\
-             -l project.properties -xm "-Dcheckstyle.failsOnError=false"
+             -l project.properties -xm "-Dcheckstyle.failsOnError=false"\
+             --allowExcludes
          elif [ -f patch_config.xml ]; then
            groovy diff.groovy -r $REPO -b $BASE_BRANCH -p $REF -bc diff_config.xml\
-             -pc patch_config.xml -l project.properties -xm "-Dcheckstyle.failsOnError=false"
+             -pc patch_config.xml -l project.properties -xm "-Dcheckstyle.failsOnError=false"\
+             --allowExcludes
          else
            groovy diff.groovy -r $REPO -b $BASE_BRANCH -p $REF -c diff_config.xml\
-             -l project.properties -xm "-Dcheckstyle.failsOnError=false"
+             -l project.properties -xm "-Dcheckstyle.failsOnError=false"\
+             --allowExcludes
          fi
 
      - name: Copy Report to AWS S3 Bucket


### PR DESCRIPTION
Related to discussion at https://github.com/checkstyle/contribution/pull/527#issuecomment-969376283 , allowing file exclusions in diff report generation will permit us to run check regression on newer openjdk's.

I do not think that github actions will use the proposed changes in this PR to execute a diff report created by a comment in this PR, so we will need to merge this, then try https://github.com/checkstyle/checkstyle/pull/10911 again to show that exclusions work. I will also update #10911 to use openjdk16.
