### PR TITLE
Issue #10859: FinalClass now exempts private-only constructor classes that are extended by another class in the same compilation unit

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
@@ -20,7 +20,12 @@
 package com.puppycrawl.tools.checkstyle.checks.design;
 
 import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
@@ -28,6 +33,7 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
  * <p>
@@ -120,10 +126,16 @@ public class FinalClassCheck
     private static final String PACKAGE_SEPARATOR = ".";
 
     /** Keeps ClassDesc objects for stack of declared classes. */
+    private Map<String, ClassDesc> innerClasses;
+
+    /**
+     * Keeps ClassDesc objects for stack of declared classes,
+     * pops the class out when all nested, inner, anonymous classes have been examined.
+     */
     private Deque<ClassDesc> classes;
 
     /** Full qualified name of the package. */
-    private String packageName;
+    private String packageName = "";
 
     @Override
     public int[] getDefaultTokens() {
@@ -139,6 +151,8 @@ public class FinalClassCheck
     public int[] getRequiredTokens() {
         return new int[] {
             TokenTypes.CLASS_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.RECORD_DEF,
             TokenTypes.CTOR_DEF,
             TokenTypes.PACKAGE_DEF,
             TokenTypes.LITERAL_NEW,
@@ -148,38 +162,25 @@ public class FinalClassCheck
     @Override
     public void beginTree(DetailAST rootAST) {
         classes = new ArrayDeque<>();
+        innerClasses = new TreeMap<>();
         packageName = "";
     }
 
     @Override
     public void visitToken(DetailAST ast) {
-        final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);
-
         switch (ast.getType()) {
             case TokenTypes.PACKAGE_DEF:
                 packageName = extractQualifiedName(ast.getFirstChild().getNextSibling());
                 break;
 
             case TokenTypes.CLASS_DEF:
-                registerNestedSubclassToOuterSuperClasses(ast);
-
-                final boolean isFinal = modifiers.findFirstToken(TokenTypes.FINAL) != null;
-                final boolean isAbstract = modifiers.findFirstToken(TokenTypes.ABSTRACT) != null;
-
-                final String qualifiedClassName = getQualifiedClassName(ast);
-                classes.push(new ClassDesc(qualifiedClassName, isFinal, isAbstract));
+            case TokenTypes.ENUM_DEF:
+            case TokenTypes.RECORD_DEF:
+                visitType(ast);
                 break;
 
             case TokenTypes.CTOR_DEF:
-                if (!ScopeUtil.isInEnumBlock(ast) && !ScopeUtil.isInRecordBlock(ast)) {
-                    final ClassDesc desc = classes.peek();
-                    if (modifiers.findFirstToken(TokenTypes.LITERAL_PRIVATE) == null) {
-                        desc.registerNonPrivateCtor();
-                    }
-                    else {
-                        desc.registerPrivateCtor();
-                    }
-                }
+                visitCtor(ast);
                 break;
 
             case TokenTypes.LITERAL_NEW:
@@ -192,7 +193,6 @@ public class FinalClassCheck
                     }
                 }
                 break;
-
             default:
                 throw new IllegalStateException(ast.toString());
         }
@@ -200,20 +200,70 @@ public class FinalClassCheck
 
     @Override
     public void leaveToken(DetailAST ast) {
-        if (ast.getType() == TokenTypes.CLASS_DEF) {
-            final ClassDesc desc = classes.pop();
-            if (desc.isWithPrivateCtor()
+        if (TokenUtil.isTypeDeclaration(ast.getType())) {
+            classes.pop();
+            if (TokenUtil.isRootNode(ast.getParent())) {
+                innerClasses.forEach((key, value) -> {
+                    final DetailAST classAst = value.getClassAst();
+                    registerNestedSubclassToOuterSuperClasses(classAst, key);
+                });
+                innerClasses.forEach((key, value) -> {
+                    if (shouldBeDeclaredAsFinal(value)) {
+                        final String className = getClassNameFromQualifiedName(key);
+                        log(value.getClassAst(), MSG_KEY, className);
+                    }
+                });
+            }
+        }
+    }
+
+    /**
+     * Called to process a type definition.
+     *
+     * @param ast the token to process
+     */
+    private void visitType(DetailAST ast) {
+        final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);
+        final boolean isFinal = modifiers.findFirstToken(TokenTypes.FINAL) != null;
+        final boolean isAbstract = modifiers.findFirstToken(TokenTypes.ABSTRACT) != null;
+
+        final String qualifiedClassName = getQualifiedClassName(ast);
+        final ClassDesc currClass = new ClassDesc(
+                qualifiedClassName, isFinal, isAbstract, classes.size(), ast);
+        classes.push(currClass);
+        innerClasses.put(qualifiedClassName, currClass);
+    }
+
+    /**
+     * Called to process a constructor definition.
+     *
+     * @param ast the token to process
+     */
+    private void visitCtor(DetailAST ast) {
+        final DetailAST modifiers = ast.findFirstToken(TokenTypes.MODIFIERS);
+        final ClassDesc desc = classes.peek();
+        if (modifiers.findFirstToken(TokenTypes.LITERAL_PRIVATE) == null) {
+            desc.registerNonPrivateCtor();
+        }
+        else {
+            desc.registerPrivateCtor();
+        }
+    }
+
+    /**
+     * Checks whether a class should be declared as final or not.
+     *
+     * @param desc description of the class
+     * @return true if given class should be declared as final otherwise false
+     */
+    private static boolean shouldBeDeclaredAsFinal(ClassDesc desc) {
+        return desc.isWithPrivateCtor()
                 && !(desc.isDeclaredAsAbstract()
                     || desc.isWithAnonymousInnerClass())
                 && !desc.isDeclaredAsFinal()
                 && !desc.isWithNonPrivateCtor()
                 && !desc.isWithNestedSubclass()
-                && !ScopeUtil.isInInterfaceOrAnnotationBlock(ast)) {
-                final String qualifiedName = desc.getQualifiedName();
-                final String className = getClassNameFromQualifiedName(qualifiedName);
-                log(ast, MSG_KEY, className);
-            }
-        }
+                && !ScopeUtil.isInInterfaceOrAnnotationBlock(desc.getClassAst());
     }
 
     /**
@@ -227,23 +277,97 @@ public class FinalClassCheck
     }
 
     /**
-     * Register to outer super classes of given classAst that
+     * Register to outer super class of given classAst that
      * given classAst is extending them.
      *
-     * @param classAst class which outer super classes will be
+     * @param classAst class which outer super class will be
      *                 informed about nesting subclass
+     * @param qualifiedClassName qualifies class name(with package) of the current class
      */
-    private void registerNestedSubclassToOuterSuperClasses(DetailAST classAst) {
+    private void registerNestedSubclassToOuterSuperClasses(DetailAST classAst,
+                                                           String qualifiedClassName) {
         final String currentAstSuperClassName = getSuperClassName(classAst);
         if (currentAstSuperClassName != null) {
-            for (ClassDesc classDesc : classes) {
-                final String classDescQualifiedName = classDesc.getQualifiedName();
-                if (doesNameInExtendMatchSuperClassName(classDescQualifiedName,
-                        currentAstSuperClassName)) {
+            final List<ClassDesc> sameNamedClassList = classesWithSameName(
+                    currentAstSuperClassName);
+            if (sameNamedClassList.isEmpty()) {
+                final ClassDesc classDesc = innerClasses.get(currentAstSuperClassName);
+                if (classDesc != null) {
                     classDesc.registerNestedSubclass();
                 }
             }
+            else {
+                registerNearestAsSuperClass(qualifiedClassName, sameNamedClassList);
+            }
         }
+    }
+
+    /**
+     * Checks if there is a class with same name.
+     *
+     * @param className name of the class
+     * @return true if there is another class with same name.
+     */
+    private List<ClassDesc> classesWithSameName(String className) {
+        return innerClasses.entrySet().stream()
+                .filter(entry -> {
+                    return entry.getKey().endsWith(
+                            PACKAGE_SEPARATOR + className);
+                })
+                .map(Map.Entry::getValue)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * For all classes with the same name as the superclass, finds the nearest one
+     * and registers a subclass for it.
+     *
+     * @param superClassName current class name
+     * @param classesWithSameName classes which same name as super class
+     */
+    private static void registerNearestAsSuperClass(String superClassName,
+                                                    List<ClassDesc> classesWithSameName) {
+        final ClassDesc nearest = Collections.min(classesWithSameName, (first, second) -> {
+            int diff = classNameMatchingCount(superClassName, second.getQualifiedName())
+                        - classNameMatchingCount(superClassName, first.getQualifiedName());
+            if (diff == 0) {
+                diff = first.getDepth() - second.getDepth();
+            }
+            return diff;
+        });
+        nearest.registerNestedSubclass();
+    }
+
+    /**
+     * Calculates and returns the class name matching count.
+     * Eg-
+     * <br>
+     * Suppose our pattern class is {@code foo.a.b} and class to be matched is
+     * {@code foo.a.ball} then classNameMatchingCount would be calculated by comparing every
+     * character, and updating main counter when we hit "."
+     * to prevent matching "a.b" with "a.ball". In this case classNameMatchingCount would
+     * be equal to 6 and not 7 (b of ball is not counted).
+     *
+     * @param patternClass class against which the given class has to be matched
+     * @param classToBeMatched class to be matched
+     * @return class name matching count
+     */
+    private static int classNameMatchingCount(String patternClass, String classToBeMatched) {
+        final int minLength = Math.min(classToBeMatched.length(), patternClass.length());
+        int counter = 0;
+        int countToBeRegistered = 0;
+        for (int i = 0; i < minLength; i++) {
+            if (patternClass.charAt(i) == classToBeMatched.charAt(i)) {
+                counter++;
+                if (patternClass.charAt(i) == PACKAGE_SEPARATOR.charAt(0)) {
+                    countToBeRegistered = counter;
+                }
+            }
+            else {
+                break;
+            }
+        }
+        return countToBeRegistered;
     }
 
     /**
@@ -319,23 +443,6 @@ public class FinalClassCheck
     }
 
     /**
-     * Checks if given super class name in extend clause match super class qualified name.
-     *
-     * @param superClassQualifiedName super class qualified name (with package)
-     * @param superClassInExtendClause name in extend clause
-     * @return true if given super class name in extend clause match super class qualified name,
-     *         false otherwise
-     */
-    private static boolean doesNameInExtendMatchSuperClassName(String superClassQualifiedName,
-                                                               String superClassInExtendClause) {
-        String superClassNormalizedName = superClassQualifiedName;
-        if (!superClassInExtendClause.contains(PACKAGE_SEPARATOR)) {
-            superClassNormalizedName = getClassNameFromQualifiedName(superClassQualifiedName);
-        }
-        return superClassNormalizedName.equals(superClassInExtendClause);
-    }
-
-    /**
      * Get class name from qualified name.
      *
      * @param qualifiedName qualified class name
@@ -348,6 +455,9 @@ public class FinalClassCheck
     /** Maintains information about class' ctors. */
     private static final class ClassDesc {
 
+        /** Corresponding node. */
+        private final DetailAST classAst;
+
         /** Qualified class name(with package). */
         private final String qualifiedName;
 
@@ -356,6 +466,9 @@ public class FinalClassCheck
 
         /** Is class declared as abstract. */
         private final boolean declaredAsAbstract;
+
+        /** Class nesting level. */
+        private final int depth;
 
         /** Does class have non-private ctors. */
         private boolean withNonPrivateCtor;
@@ -377,12 +490,16 @@ public class FinalClassCheck
          *         class declared as final
          *  @param declaredAsAbstract indicates if the
          *         class declared as abstract
+         *  @param depth class nesting level
+         *  @param classAst classAst node
          */
         /* package */ ClassDesc(String qualifiedName, boolean declaredAsFinal,
-                boolean declaredAsAbstract) {
+                boolean declaredAsAbstract, int depth, DetailAST classAst) {
             this.qualifiedName = qualifiedName;
             this.declaredAsFinal = declaredAsFinal;
             this.declaredAsAbstract = declaredAsAbstract;
+            this.depth = depth;
+            this.classAst = classAst;
         }
 
         /**
@@ -392,6 +509,15 @@ public class FinalClassCheck
          */
         private String getQualifiedName() {
             return qualifiedName;
+        }
+
+        /**
+         * Get the classAst node.
+         *
+         * @return classAst node
+         */
+        public DetailAST getClassAst() {
+            return classAst;
         }
 
         /** Adds private ctor. */
@@ -451,6 +577,15 @@ public class FinalClassCheck
         }
 
         /**
+         *  Returns class nesting level.
+         *
+         *  @return class nesting level
+         */
+        private int getDepth() {
+            return depth;
+        }
+
+        /**
          *  Is class declared as abstract.
          *
          *  @return true if class is declared as final
@@ -469,5 +604,4 @@ public class FinalClassCheck
         }
 
     }
-
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheckTest.java
@@ -30,7 +30,6 @@ import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class FinalClassCheckTest
     extends AbstractModuleTestSupport {
@@ -43,12 +42,14 @@ public class FinalClassCheckTest
     @Test
     public void testGetRequiredTokens() {
         final FinalClassCheck checkObj = new FinalClassCheck();
-        final int[] expected =
-            {TokenTypes.CLASS_DEF,
-             TokenTypes.CTOR_DEF,
-             TokenTypes.PACKAGE_DEF,
-             TokenTypes.LITERAL_NEW,
-            };
+        final int[] expected = {
+            TokenTypes.CLASS_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.RECORD_DEF,
+            TokenTypes.CTOR_DEF,
+            TokenTypes.PACKAGE_DEF,
+            TokenTypes.LITERAL_NEW,
+        };
         assertArrayEquals(expected, checkObj.getRequiredTokens(),
                 "Default required tokens are invalid");
     }
@@ -92,7 +93,9 @@ public class FinalClassCheckTest
     @Test
     public void testFinalClassConstructorInRecord() throws Exception {
 
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        final String[] expected = {
+            "27:9: " + getCheckMessage(MSG_KEY, "F"),
+        };
 
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputFinalClassConstructorInRecord.java"),
@@ -117,12 +120,14 @@ public class FinalClassCheckTest
     @Test
     public void testGetAcceptableTokens() {
         final FinalClassCheck obj = new FinalClassCheck();
-        final int[] expected =
-            {TokenTypes.CLASS_DEF,
-             TokenTypes.CTOR_DEF,
-             TokenTypes.PACKAGE_DEF,
-             TokenTypes.LITERAL_NEW,
-            };
+        final int[] expected = {
+            TokenTypes.CLASS_DEF,
+            TokenTypes.ENUM_DEF,
+            TokenTypes.RECORD_DEF,
+            TokenTypes.CTOR_DEF,
+            TokenTypes.PACKAGE_DEF,
+            TokenTypes.LITERAL_NEW,
+        };
         assertArrayEquals(expected, obj.getAcceptableTokens(),
                 "Default acceptable tokens are invalid");
     }
@@ -134,4 +139,30 @@ public class FinalClassCheckTest
         assertEquals("ClassName", actual, "unexpected result");
     }
 
+    @Test
+    public void testFinalClassInnerAndNestedClasses() throws Exception {
+        final String[] expected = {
+            "19:5: " + getCheckMessage(MSG_KEY, "SameName"),
+            "45:9: " + getCheckMessage(MSG_KEY, "SameName"),
+            "69:13: " + getCheckMessage(MSG_KEY, "B"),
+        };
+        verifyWithInlineConfigParser(getPath("InputFinalClassInnerAndNestedClass.java"), expected);
+    }
+
+    @Test
+    public void testFinalClassStaticNestedClasses() throws Exception {
+
+        final String[] expected = {
+            "14:17: " + getCheckMessage(MSG_KEY, "C"),
+            "32:9: " + getCheckMessage(MSG_KEY, "B"),
+            "43:9: " + getCheckMessage(MSG_KEY, "C"),
+            "60:13: " + getCheckMessage(MSG_KEY, "Q"),
+            "76:9: " + getCheckMessage(MSG_KEY, "F"),
+            "83:9: " + getCheckMessage(MSG_KEY, "c"),
+        };
+
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputFinalClassNestedStaticClassInsideInnerClass.java"),
+                expected);
+    }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassConstructorInRecord.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassConstructorInRecord.java
@@ -14,4 +14,20 @@ public record InputFinalClassConstructorInRecord(String string) { // ok
     public InputFinalClassConstructorInRecord(int x) {
         this(String.valueOf(x));
     }
+
+    class F {
+        private F() {
+        }
+    }
+
+    class K extends F {
+    }
+
+    class X {
+        class F { // violation
+            private F() {
+            }
+        }
+    }
+
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassNestedStaticClassInsideInnerClass.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassNestedStaticClassInsideInnerClass.java
@@ -1,0 +1,98 @@
+/*
+FinalClass
+
+
+*/
+
+//non-compiled with javac: Compilable with Java16
+package com.puppycrawl.tools.checkstyle.checks.design.finalclass;
+
+public class InputFinalClassNestedStaticClassInsideInnerClass {
+    class M {
+        class A {
+            static class B {
+                static class C { // violation
+                    private C() {
+                    }
+                }
+            }
+        }
+    }
+
+    class Mw {
+        static class B {
+            static class C { // ok
+                private C() {
+                }
+            }
+        }
+    }
+
+    class A {
+        class B { // violation
+            class C { // ok
+                private C() {}
+            }
+            class D extends C {
+            }
+            private B() {}
+        }
+    }
+
+    class B {
+        class C { // violation
+            private C() {}
+            class D extends Mw.B.C {
+            }
+        }
+    }
+
+    class P extends Q {
+    }
+
+    class Q { // ok
+        private Q() {
+        }
+    }
+
+    class PR {
+        static class P {
+            static class Q { // violation
+                private Q() {
+                }
+            }
+        }
+    }
+
+    class F {
+        private F() {
+        }
+    }
+
+    class K extends F {
+    }
+
+    class X {
+        class F { // violation
+            private F() {
+            }
+        }
+    }
+
+    class a {
+        static class c { // violation
+            private c() {
+            }
+        }
+    }
+
+    class d {
+        class e extends c {
+        }
+    }
+
+    class c {
+        private c() {
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassInnerAndNestedClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/design/finalclass/InputFinalClassInnerAndNestedClass.java
@@ -1,0 +1,76 @@
+/*
+FinalClass
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.design.finalclass;
+
+public class InputFinalClassInnerAndNestedClass {
+
+    private class SuperClass { // ok
+        private SuperClass() {
+        }
+    }
+
+    private class SubClass extends SuperClass {
+    }
+
+    class SameName { // violation
+        private SameName() {
+        }
+    }
+
+    static class Test {
+        static class SameName { // ok
+            private SameName() {
+            }
+            class Test3 {
+            }
+        }
+    }
+
+    class TestInnerClass {
+        class SameName { // ok
+            class Test3 {
+                class Test4 extends SameName {
+                }
+            }
+            private SameName() {
+            }
+        }
+    }
+
+    class TestNestedClasses {
+        class SameName { // violation
+            private SameName() {
+            }
+            class Test3 {
+                class Test4 extends Test.SameName {
+                }
+            }
+        }
+    }
+}
+
+enum foo {
+    VALUE_1, VALUE_2;
+
+    class A {
+        class B { // ok
+            private B() {
+            }
+        }
+
+        class c extends B {
+        }
+
+        class D {
+            class B { // violation
+                private B() {
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Resolves #10859: FinalClass now exempts private-only constructor classes that are extended by another class in the same compilation unit

Original PR: https://github.com/checkstyle/checkstyle/pull/10887

Diff Regression projects: https://gist.githubusercontent.com/Vyom-Yadav/91807e6244cff60698d9e33e32ba2d51/raw/eb228fa41edadc10eea264a914ea1411f0e52122/projects-to-test-on.properties
Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/2e9e29be66f99b22505651aa211886535402b6cf/my_checks.xml