### PR TITLE
Issue #9464: updated example of AST for TokenTypes.LITERAL_BREAK

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -2598,6 +2598,28 @@ public final class TokenTypes {
      * The {@code break} keyword.  The first child is an optional
      * identifier and the last child is a semicolon.
      *
+     * <p>For example:</p>
+     * <pre>
+     * for (;;) {
+     *     break;
+     * }
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * LITERAL_FOR -&gt; for
+     *  |--LPAREN -&gt; (
+     *  |--FOR_INIT -&gt; FOR_INIT
+     *  |--SEMI -&gt; ;
+     *  |--FOR_CONDITION -&gt; FOR_CONDITION
+     *  |--SEMI -&gt; ;
+     *  |--FOR_ITERATOR -&gt; FOR_ITERATOR
+     *  |--RPAREN -&gt; )
+     *  `--SLIST -&gt; {
+     *      |--LITERAL_BREAK -&gt; break
+     *      |   `--SEMI -&gt; ;
+     *      `--RCURLY -&gt; }
+     * </pre>
+     *
      * @see #IDENT
      * @see #SEMI
      * @see #SLIST


### PR DESCRIPTION
Fixes #9464 : update example of AST for TokenTypes.LITERAL_BREAK