### PR TITLE
Issue #9463: update example of AST for TokenTypes.LITERAL_BOOLEAN

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1536,6 +1536,21 @@ public final class TokenTypes {
     /**
      * The {@code boolean} keyword.
      *
+     * <p>For example:</p>
+     * <pre>
+     * public boolean flag;
+     * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * VARIABLE_DEF -&gt; VARIABLE_DEF
+     *  |--MODIFIERS -&gt; MODIFIERS
+     *  |   `--LITERAL_PUBLIC -&gt; public
+     *  |--TYPE -&gt; TYPE
+     *  |   `--LITERAL_BOOLEAN -&gt; boolean
+     *  |--IDENT -&gt; flag
+     *  `--SEMI -&gt; ;
+     * </pre>
+     *
      * @see #TYPE
      **/
     public static final int LITERAL_BOOLEAN =


### PR DESCRIPTION
Closes: #9463

![Screenshot from 2021-11-15 12-33-37](https://user-images.githubusercontent.com/89348343/141736619-5774267b-0435-4d54-a883-e5607f688433.png)

```
**Test.java**
public class Test { 
  public boolean flag;
}

**AST**
java -jar checkstyle-9.0.1-all.jar -t Test.java
`--CLASS_DEF -> CLASS_DEF [4:0]
    |--MODIFIERS -> MODIFIERS [4:0]
    |   `--LITERAL_PUBLIC -> public [4:0]
    |--LITERAL_CLASS -> class [4:7]
    |--IDENT -> Test [4:13]
    `--OBJBLOCK -> OBJBLOCK [4:18]
        |--LCURLY -> { [4:18]
        |--VARIABLE_DEF -> VARIABLE_DEF [5:2]
        |   |--MODIFIERS -> MODIFIERS [5:2]
        |   |   `--LITERAL_PUBLIC -> public [5:2]
        |   |--TYPE -> TYPE [5:9]
        |   |   `--LITERAL_BOOLEAN -> boolean [5:9]
        |   |--IDENT -> flag [5:17]
        |   `--SEMI -> ; [5:21]
        `--RCURLY -> } [6:0]

# Printing the code that we care
java -jar checkstyle-9.0.1-all.jar -t Test.java | grep 5:
|--VARIABLE_DEF -> VARIABLE_DEF [5:2]
|   |--MODIFIERS -> MODIFIERS [5:2]
|   |   `--LITERAL_PUBLIC -> public [5:2]
|   |--TYPE -> TYPE [5:9]
|   |   `--LITERAL_BOOLEAN -> boolean [5:9]
|   |--IDENT -> flag [5:17]
|   `--SEMI -> ; [5:21]
```
**Expected update for javadoc**

```
VARIABLE_DEF -> VARIABLE_DEF
  |--MODIFIERS -> MODIFIERS
  |   `--LITERAL_PUBLIC -> public
  |--TYPE -> TYPE
  |   `--LITERAL_BOOLEAN -> boolean
  |--IDENT -> flag
  `--SEMI -> ;
```