### PR TITLE
Issue #9400: updated example of AST for TokenTypes.BLOCK_COMMENT_END

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -5420,12 +5420,17 @@ public final class TokenTypes {
     /**
      * End of block comment: '&#42;/'.
      *
+     * <p>For example:</p>
      * <pre>
-     * +--BLOCK_COMMENT_BEGIN
-     *         |
-     *         +--COMMENT_CONTENT
-     *         +--BLOCK_COMMENT_END
+     * /&#42;comment&#42;/
      * </pre>
+     * <p>parses as:</p>
+     * <pre>
+     * BLOCK_COMMENT_BEGIN -&gt; /&#42;
+     *  |--COMMENT_CONTENT -&gt; comment
+     *  `--BLOCK_COMMENT_END -&gt; &#42;/
+     * </pre>
+     *
      */
     public static final int BLOCK_COMMENT_END =
             JavaLanguageLexer.BLOCK_COMMENT_END;


### PR DESCRIPTION
Fixes #9400 : updated example of AST for TokenTypes.BLOCK_COMMENT_END
![Screenshot (579)](https://user-images.githubusercontent.com/80591258/143889741-69ad3feb-e3d4-470a-a839-95f2e7134c28.png)

```
PS C:\Users\abhin\Desktop> cat Test.java
class A {
  /*comment*/
}
PS C:\Users\abhin\Desktop> java -jar checkstyle-9.1-all.jar -T Test.java
COMPILATION_UNIT -> COMPILATION_UNIT [1:0]
`--CLASS_DEF -> CLASS_DEF [1:0]
    |--MODIFIERS -> MODIFIERS [1:0]
    |--LITERAL_CLASS -> class [1:0]
    |--IDENT -> A [1:6]
    `--OBJBLOCK -> OBJBLOCK [1:8]
        |--LCURLY -> { [1:8]
        |--BLOCK_COMMENT_BEGIN -> /* [2:2]
        |   |--COMMENT_CONTENT -> comment [2:4]
        |   `--BLOCK_COMMENT_END -> */ [2:10]
        `--RCURLY -> } [3:0]
```

        
expected update for javodoc is:

```
 BLOCK_COMMENT_BEGIN -> /*
  |--COMMENT_CONTENT -> comment
  `--BLOCK_COMMENT_END -> */
```