### PR TITLE
Issue #10997: TrailingCommentsCheck ignores first comment character

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
@@ -246,8 +246,7 @@ public class TrailingCommentCheck extends AbstractCheck {
         final String line = getLines()[lineNo - 1];
         final String lineBefore = line.substring(0, ast.getColumnNo());
 
-        if (!format.matcher(lineBefore).find()
-                && !isLegalSingleLineComment(comment)) {
+        if (!format.matcher(lineBefore).find() && !isLegalCommentContent(comment)) {
             log(ast, MSG_KEY);
         }
     }
@@ -259,46 +258,36 @@ public class TrailingCommentCheck extends AbstractCheck {
      */
     private void checkBlockComment(DetailAST ast) {
         final int lineNo = ast.getLineNo();
-        final String comment = ast.getFirstChild().getText();
+        final DetailAST firstChild = ast.getFirstChild();
+        final DetailAST lastChild = ast.getLastChild();
+        final String comment = firstChild.getText();
         String line = getLines()[lineNo - 1];
 
-        if (line.length() > ast.getLastChild().getColumnNo() + 1) {
-            line = line.substring(ast.getLastChild().getColumnNo() + 2);
+        if (line.length() > lastChild.getColumnNo() + 1) {
+            line = line.substring(lastChild.getColumnNo() + 2);
         }
 
         line = FORMAT_LINE.matcher(line).replaceAll("");
 
         final String lineBefore = getLines()[lineNo - 1].substring(0, ast.getColumnNo());
+        final boolean isCommentAtEndOfLine = ast.getLineNo() != lastChild.getLineNo()
+                || CommonUtil.isBlank(line);
+        final boolean isLegalBlockComment = isLegalCommentContent(comment)
+                && TokenUtil.areOnSameLine(firstChild, lastChild)
+                || format.matcher(lineBefore).find();
 
-        // do not check comment which doesn't end line
-        if ((ast.getLineNo() != ast.getLastChild().getLineNo() || CommonUtil.isBlank(line))
-                && !format.matcher(lineBefore).find()
-                && !isLegalBlockComment(ast, comment)) {
+        if (isCommentAtEndOfLine && !isLegalBlockComment) {
             log(ast, MSG_KEY);
         }
     }
 
     /**
-     * Checks if block comment is legal and matches to the pattern.
+     * Checks if given comment content is legal.
      *
-     * @param ast Detail ast element to be checked.
-     * @param comment comment to check.
-     * @return true if the comment if legal.
+     * @param commentContent comment content to check.
+     * @return true if the content is legal.
      */
-    private boolean isLegalBlockComment(DetailAST ast, String comment) {
-        return legalComment != null
-                && TokenUtil.areOnSameLine(ast.getFirstChild(), ast.getLastChild())
-                && legalComment.matcher(comment).find();
-    }
-
-    /**
-     * Checks if given single line comment is legal (single-line and matches to the
-     * pattern).
-     *
-     * @param comment comment to check.
-     * @return true if the comment if legal.
-     */
-    private boolean isLegalSingleLineComment(String comment) {
-        return legalComment != null && legalComment.matcher(comment).find();
+    private boolean isLegalCommentContent(String commentContent) {
+        return legalComment != null && legalComment.matcher(commentContent).find();
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
@@ -89,8 +89,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </li>
  * <li>
  * Property {@code legalComment} - Define pattern for text allowed in trailing comments.
- * (This pattern will not be applied to multiline comments and the text of
- * the comment will be trimmed before matching.)
+ * This pattern will not be applied to multiline comments.
  * Type is {@code java.util.regex.Pattern}.
  * Default value is {@code null}.
  * </li>
@@ -177,8 +176,7 @@ public class TrailingCommentCheck extends AbstractCheck {
 
     /**
      * Define pattern for text allowed in trailing comments.
-     * (This pattern will not be applied to multiline comments and the text
-     * of the comment will be trimmed before matching.)
+     * This pattern will not be applied to multiline comments.
      */
     private Pattern legalComment;
 
@@ -187,8 +185,7 @@ public class TrailingCommentCheck extends AbstractCheck {
 
     /**
      * Setter to define pattern for text allowed in trailing comments.
-     * (This pattern will not be applied to multiline comments and the text
-     * of the comment will be trimmed before matching.)
+     * This pattern will not be applied to multiline comments.
      *
      * @param legalComment pattern to set.
      */
@@ -289,18 +286,9 @@ public class TrailingCommentCheck extends AbstractCheck {
      * @return true if the comment if legal.
      */
     private boolean isLegalBlockComment(DetailAST ast, String comment) {
-        final boolean legal;
-
-        // multi-line comment can not be legal
-        if (legalComment == null
-                || !TokenUtil.areOnSameLine(ast.getFirstChild(), ast.getLastChild())) {
-            legal = false;
-        }
-        else {
-            final String commentText = comment.trim();
-            legal = legalComment.matcher(commentText).find();
-        }
-        return legal;
+        return legalComment != null
+                && TokenUtil.areOnSameLine(ast.getFirstChild(), ast.getLastChild())
+                && legalComment.matcher(comment).find();
     }
 
     /**
@@ -311,15 +299,6 @@ public class TrailingCommentCheck extends AbstractCheck {
      * @return true if the comment if legal.
      */
     private boolean isLegalSingleLineComment(String comment) {
-        final boolean legal;
-        if (legalComment == null) {
-            legal = false;
-        }
-        else {
-            // remove chars which start comment
-            final String commentText = comment.substring(1).trim();
-            legal = legalComment.matcher(commentText).find();
-        }
-        return legal;
+        return legalComment != null && legalComment.matcher(comment).find();
     }
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/TrailingCommentCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/TrailingCommentCheck.xml
@@ -62,8 +62,7 @@
             </property>
             <property name="legalComment" type="java.util.regex.Pattern">
                <description>Define pattern for text allowed in trailing comments.
- (This pattern will not be applied to multiline comments and the text of
- the comment will be trimmed before matching.)</description>
+ This pattern will not be applied to multiline comments.</description>
             </property>
          </properties>
          <message-keys>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class TrailingCommentCheckTest extends AbstractModuleTestSupport {
 
@@ -76,6 +77,7 @@ public class TrailingCommentCheckTest extends AbstractModuleTestSupport {
             "19:22: " + getCheckMessage(MSG_KEY),
             "30:19: " + getCheckMessage(MSG_KEY),
             "32:21: " + getCheckMessage(MSG_KEY),
+            "42:50: " + getCheckMessage(MSG_KEY),
             "45:31: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(
@@ -106,5 +108,13 @@ public class TrailingCommentCheckTest extends AbstractModuleTestSupport {
         };
         verifyWithInlineConfigParser(
                 getPath("InputTrailingComment3.java"), expected);
+    }
+
+    @Test
+    public void testLegalCommentWithNoPrecedingWhitespace() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWithInlineConfigParser(
+                getPath("InputTrailingCommentWithNoPrecedingWhitespace.java"), expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingComment2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingComment2.java
@@ -37,8 +37,8 @@ public class InputTrailingComment2 {
     }
 
     /**
-     * comment with trailing space.
-     */
+     * comment with trailing space.      */
+    // violation below
     final static public String NAME="Some Name"; // NOI18N
     final static public String NAME2="Some Name"; /*NOI18N*/
     // violation below

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingCommentWithNoPrecedingWhitespace.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/trailingcomment/InputTrailingCommentWithNoPrecedingWhitespace.java
@@ -1,0 +1,14 @@
+/*
+TrailingComment
+format = (default)^[\s});]*$
+legalComment = \\$NON-NLS
+
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.trailingcomment;
+
+public class InputTrailingCommentWithNoPrecedingWhitespace {
+    public static void main(String[] args) {
+        System.out.println("foo"); //$NON-NLS-1$
+    }                              // ok ^
+}

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -2050,9 +2050,8 @@ d = e / f;        // Another comment for this line
             </tr>
             <tr>
               <td>legalComment</td>
-              <td>Define pattern for text allowed in trailing comments. (This
-                  pattern will not be applied to multiline comments and the text of the
-                  comment will be trimmed before matching.)</td>
+              <td>Define pattern for text allowed in trailing comments. This
+                  pattern will not be applied to multiline comments.</td>
               <td><a href="property_types.html#Pattern">Pattern</a></td>
               <td><code>null</code></td>
               <td>4.2</td>


### PR DESCRIPTION
Closes #10997.

Link to new docs: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/27d4f52_2021135942/config_misc.html#TrailingComment

Diff Regression config: https://gist.githubusercontent.com/nmancus1/fadf235ea645a5f13bab96df8158792c/raw/75b61a9420213e2f3ac89d9732cdd256a6442361/config.xml

I suspected that others may be using the same trailing comment for Eclipse internationalization for non-localized strings, so I included the config from #10997 in check regression report configs(as TC2) to show that we are now ignoring these comments if `legalComment` property is set accordingly. These are the only differences. The default config shows no differences(TC1).

https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/27d4f52_2021143110/reports/diff/index.html