### PR TITLE
infra: specify heap size for diff report generation

### DIFF
--- a/.github/workflows/diff_report.yml
+++ b/.github/workflows/diff_report.yml
@@ -174,6 +174,7 @@ jobs:
          REF="origin/${{needs.parse_body.outputs.branch}}"
          REPO="../../checkstyle"
          BASE_BRANCH="upstream/master"
+         export MAVEN_OPTS="-Xmx2048m"
          if [ -f new_module_config.xml ]; then
            groovy diff.groovy -r $REPO -p $REF -pc new_module_config.xml -m single\
              -l project.properties -xm "-Dcheckstyle.failsOnError=false"\


### PR DESCRIPTION
As we do for other `diff.groovy` usages such as `no-exception-test` CI tasks, we should specify a larger heap size for checkstyle execution while generating check behavior regression reports.

Examples:
https://github.com/checkstyle/checkstyle/blob/003704a000881455349bd42bf9b16b91f2724ab9/.ci/no-exception-test.sh#L86
https://github.com/checkstyle/checkstyle/blob/003704a000881455349bd42bf9b16b91f2724ab9/.ci/no-exception-test.sh#L106
https://github.com/checkstyle/checkstyle/blob/003704a000881455349bd42bf9b16b91f2724ab9/.ci/no-exception-test.sh#L127
https://github.com/checkstyle/checkstyle/blob/003704a000881455349bd42bf9b16b91f2724ab9/.ci/no-exception-test.sh#L148

This should allow us to use openjdk16 project in https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/projects-to-test-on-for-github-action.properties after https://github.com/checkstyle/checkstyle/issues/10934, as evidenced by successful `openjdk16-with-checks-nonjavadoc-error` execution at https://github.com/checkstyle/checkstyle/runs/4422293694?check_suite_focus=true with same heap size.

Right now, report generation is failing with OOM error on openjdk16: https://github.com/checkstyle/checkstyle/actions/runs/1541241529

Once this is merged, I will re-run report at https://github.com/checkstyle/checkstyle/pull/10999#issue-1070774832 to show successful report generation.