### PR TITLE
infra: Set permissions required by the workflow

### DIFF
--- a/.github/workflows/diff_report.yml
+++ b/.github/workflows/diff_report.yml
@@ -22,6 +22,10 @@ on:
   issue_comment:
     types: [created, edited]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
 # Parse PR Body, search for links to .properties and .xml files
   parse_body:


### PR DESCRIPTION
This fixes the `diff_report.yml` workflow, which is currently not working properly:

https://github.com/checkstyle/checkstyle/runs/4446596762?check_suite_focus=true#step:2:12

The repo settings for actions permission have been changed to:

>Read repository contents permission
>Workflows have read permissions in the repository for the contents scope only. 

The `diff_report.yml` workflow needs the `pull-requests: write` permission so it can react and reply to PR comments. This PR sets the required permissions to fix the issue.

It's still worth taking even if you undo the repo settings change; it limits the permissions for this workflow to the minimum required.