### PR TITLE
infra: Fix branch name (remove quotes)

### DIFF
--- a/.github/workflows/diff_report.yml
+++ b/.github/workflows/diff_report.yml
@@ -58,8 +58,8 @@ jobs:
         echo "$ISSUE_BODY" > text
         echo "$USER_LOGIN" > user
         wget -q "$PULL_REQUEST_URL" -O info.json
-        jq .head.ref info.json > branch
-        jq .head.sha info.json > commit_sha
+        jq --raw-output .head.ref info.json > branch
+        jq --raw-output .head.sha info.json > commit_sha
 
      - name: Parsing content of PR description
        id: parse
@@ -88,7 +88,7 @@ jobs:
        id: branch
        run: |
         echo ::set-output name=ref::$(cat branch)
-        echo ::set-output name=commit_sha::$(cat commit_sha | xargs | cut -c 1-7)
+        echo ::set-output name=commit_sha::$(cat commit_sha | cut -c 1-7)
 
   make_report:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/checkstyle/checkstyle/runs/4453342391?check_suite_focus=true#step:9:36

```
Error: git repository ../../checkstyle does not have a branch with name 'origin/"issue-11001"'!
Error: origin/"issue-11001" is not an exiting git branch!
Caught: java.lang.IllegalArgumentException: Error: invalid command line arguments!
```
The `diff_report.yml` workflow was failing because the `REF` environment variable was getting set in the form `origin/"branchname"` (extra doublequotes around the branch name)

The extra quotes were coming from the jq command, which outputs strings in json format (that is, doublequoted). This PR uses jq's --raw-output option:

>With this option, if the filter's result is a string then it will be written directly to standard output rather than being formatted as a JSON string with quotes. This can be useful for making jq filters talk to non-JSON-based systems.

It also removes `xargs` from the commit_sha pipeline, as it's no longer needed.
