### PR TITLE
Issue #11015: Fixed false negative about ternary operator in SimplifyBooleanExpressionCheck

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -295,7 +295,7 @@ no-error-xwiki)
   cd ..
   checkout_from https://github.com/xwiki/xwiki-platform.git
   cd .ci-temp/xwiki-platform
-  git checkout "1180900c""ea69d4235e20ff1ff0f156e9876d4b10"
+  git checkout "e469e5be6420c7c053863d0aa""bd5094ae4145a94"
   # Validate xwiki-platform
   mvn -e --no-transfer-progress checkstyle:check@default -Dcheckstyle.version=${CS_POM_VERSION}
   cd ..

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanExpressionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanExpressionCheck.java
@@ -48,16 +48,16 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *     boolean a, b;
  *     Foo c, d, e;
  *
- *     if (!false) {}; // violation, can be simplified to true
+ *     if (!false) {};       // violation, can be simplified to true
  *
- *     if (a == true) {}; // violation, can be simplified to a
- *     if (a == b) {}; // OK
- *     if (a == false) {}; // violation, can be simplified to !a
+ *     if (a == true) {};    // violation, can be simplified to a
+ *     if (a == b) {};       // OK
+ *     if (a == false) {};   // violation, can be simplified to !a
  *     if (!(a != true)) {}; // violation, can be simplified to a
  *
- *     e = (a || b) ? c : d; // OK
+ *     e = (a || b) ? c : d;     // OK
  *     e = (a || false) ? c : d; // violation, can be simplified to a
- *     e = (a &amp;&amp; b) ? c : d; // OK
+ *     e = (a &amp;&amp; b) ? c : d;     // OK
  *
  *  }
  *

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanExpressionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanExpressionCheck.java
@@ -23,11 +23,13 @@ import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
  * <p>
  * Checks for over-complicated boolean expressions. Currently finds code like
  * {@code if (b == true)}, {@code b || true}, {@code !false},
+ * {@code boolean a = q > 12 ? true : false},
  * etc.
  * </p>
  * <p>
@@ -59,6 +61,9 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *     e = (a || false) ? c : d; // violation, can be simplified to a
  *     e = (a &amp;&amp; b) ? c : d;     // OK
  *
+ *     int s = 12;
+ *     boolean m = s &gt; 1 ? true : false; // violation, can be simplified to s &gt; 1
+ *     boolean f = c == null ? false : c.someMethod(); // OK
  *  }
  *
  * }
@@ -112,6 +117,15 @@ public class SimplifyBooleanExpressionCheck
             case TokenTypes.LOR:
             case TokenTypes.LAND:
                 log(parent, MSG_KEY);
+                break;
+            case TokenTypes.QUESTION:
+                final DetailAST nextSibling = ast.getNextSibling();
+                if (TokenUtil.isBooleanLiteralType(parent.getFirstChild().getType())
+                        || nextSibling != null
+                        && TokenUtil.isBooleanLiteralType(
+                        nextSibling.getNextSibling().getType())) {
+                    log(parent, MSG_KEY);
+                }
                 break;
             default:
                 break;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanReturnCheck.java
@@ -23,6 +23,7 @@ import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
  * <p>
@@ -211,22 +212,9 @@ public class SimplifyBooleanReturnCheck
 
             if (expr.getType() != TokenTypes.SEMI) {
                 final DetailAST value = expr.getFirstChild();
-                booleanReturnStatement = isBooleanLiteralType(value.getType());
+                booleanReturnStatement = TokenUtil.isBooleanLiteralType(value.getType());
             }
         }
         return booleanReturnStatement;
     }
-
-    /**
-     * Checks if a token type is a literal true or false.
-     *
-     * @param tokenType the TokenType
-     * @return true iff tokenType is LITERAL_TRUE or LITERAL_FALSE
-     */
-    private static boolean isBooleanLiteralType(final int tokenType) {
-        final boolean isTrue = tokenType == TokenTypes.LITERAL_TRUE;
-        final boolean isFalse = tokenType == TokenTypes.LITERAL_FALSE;
-        return isTrue || isFalse;
-    }
-
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java
@@ -307,4 +307,16 @@ public final class TokenUtil {
         return ast.getType() == TokenTypes.COMPILATION_UNIT;
     }
 
+    /**
+     * Checks if a token type is a literal true or false.
+     *
+     * @param tokenType the TokenType
+     * @return true if tokenType is LITERAL_TRUE or LITERAL_FALSE
+     */
+    public static boolean isBooleanLiteralType(final int tokenType) {
+        final boolean isTrue = tokenType == TokenTypes.LITERAL_TRUE;
+        final boolean isFalse = tokenType == TokenTypes.LITERAL_FALSE;
+        return isTrue || isFalse;
+    }
+
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/SimplifyBooleanExpressionCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/SimplifyBooleanExpressionCheck.xml
@@ -7,6 +7,7 @@
          <description>&lt;p&gt;
  Checks for over-complicated boolean expressions. Currently finds code like
  {@code if (b == true)}, {@code b || true}, {@code !false},
+ {@code boolean a = q &gt; 12 ? true : false},
  etc.
  &lt;/p&gt;
  &lt;p&gt;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanExpressionCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanExpressionCheckTest.java
@@ -42,6 +42,14 @@ public class SimplifyBooleanExpressionCheckTest
             "44:36: " + getCheckMessage(MSG_KEY),
             "45:16: " + getCheckMessage(MSG_KEY),
             "45:32: " + getCheckMessage(MSG_KEY),
+            "95:27: " + getCheckMessage(MSG_KEY),
+            "96:24: " + getCheckMessage(MSG_KEY),
+            "98:27: " + getCheckMessage(MSG_KEY),
+            "104:23: " + getCheckMessage(MSG_KEY),
+            "106:17: " + getCheckMessage(MSG_KEY),
+            "109:21: " + getCheckMessage(MSG_KEY),
+            "110:23: " + getCheckMessage(MSG_KEY),
+            "111:20: " + getCheckMessage(MSG_KEY),
         };
         verifyWithInlineConfigParser(
                 getPath("InputSimplifyBooleanExpression.java"), expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
@@ -335,4 +335,14 @@ public class TokenUtilTest {
         assertFalse(result3, "Token type should not match");
     }
 
+    @Test
+    public void testIsBooleanLiteralType() {
+        assertTrue(TokenUtil.isBooleanLiteralType(TokenTypes.LITERAL_TRUE),
+                   "Result is not expected");
+        assertTrue(TokenUtil.isBooleanLiteralType(TokenTypes.LITERAL_FALSE),
+                   "Result is not expected");
+        assertFalse(TokenUtil.isBooleanLiteralType(TokenTypes.LOR),
+                    "Result is not expected");
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/simplifybooleanexpression/InputSimplifyBooleanExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/simplifybooleanexpression/InputSimplifyBooleanExpression.java
@@ -87,4 +87,27 @@ public class InputSimplifyBooleanExpression
 
         return true;
     }
+
+    void testTernaryExpressions() {
+        boolean a = false;
+        boolean b = true;
+        int c = 13;
+        boolean m = c > 1 ? true : false; // violation
+        boolean e = (a == true) // violation
+                ? c > 1 : false; // ok
+        boolean h = false ? c > 13 : c < 21; // violation
+        boolean f = a == b ? false : c > 1; // ok
+        boolean q = c > 1 ? (c < 15
+                ? false : b) // ok
+                : a != b;
+        boolean v = c > 0 ? true :
+                c < 0 ? false : true; // violation
+        boolean g = (c > 0 ? true : c < 0)
+                ? false : false; // violation
+        Boolean value = null;
+        boolean temp = value != null ? value : false; // ok
+        temp = true ? a() : b(); // violation
+        int d = false ? 1 : 2; // violation
+        temp = a() ? true : true; // violation
+    }
 }

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -6397,6 +6397,7 @@ public class D {
         <p>
           Checks for over-complicated boolean expressions. Currently finds
           code like <code> if (b == true)</code>, <code>b || true</code>, <code>!false</code>,
+          <code>boolean a = q > 12 ? true : false</code>,
           etc.
         </p>
 
@@ -6433,6 +6434,9 @@ public class Test {
     e = (a || false) ? c : d; // violation, can be simplified to a
     e = (a &amp;&amp; b) ? c : d;     // OK
 
+    int s = 12;
+    boolean m = s &gt; 1 ? true : false; // violation, can be simplified to s &gt; 1
+    boolean f = c == null ? false : c.someMethod(); // OK
   }
 
 }

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -6422,16 +6422,16 @@ public class Test {
     boolean a, b;
     Foo c, d, e;
 
-    if (!false) {}; // violation, can be simplified to true
+    if (!false) {};       // violation, can be simplified to true
 
-    if (a == true) {}; // violation, can be simplified to a
-    if (a == b) {}; // OK
-    if (a == false) {}; // violation, can be simplified to !a
+    if (a == true) {};    // violation, can be simplified to a
+    if (a == b) {};       // OK
+    if (a == false) {};   // violation, can be simplified to !a
     if (!(a != true)) {}; // violation, can be simplified to a
 
-    e = (a || b) ? c : d; // OK
+    e = (a || b) ? c : d;     // OK
     e = (a || false) ? c : d; // violation, can be simplified to a
-    e = (a &amp;&amp; b) ? c : d; // OK
+    e = (a &amp;&amp; b) ? c : d;     // OK
 
   }
 


### PR DESCRIPTION
Resolves #11015: SimplifyBooleanExpression: A false negative about ternary operator
Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/f2165f24391044b23b73a312a7d05179ed70b188/my_checks.xml
Final report (clean) - https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/8b38dbc_2021055812/reports/diff/index.html
Website - https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/6db4c58_2021130029/config_coding.html#SimplifyBooleanExpression