### PR TITLE
infra: add permissions for site workflow

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -19,6 +19,10 @@ on:
   issue_comment:
     types: [created, edited]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   parse_pr_info:
     if: github.event.comment.body == 'GitHub, generate web site'


### PR DESCRIPTION
Similar to https://github.com/checkstyle/checkstyle/pull/11014#issue-1073832545, hopefully this fixes site generation issue.

Example of failure: https://github.com/checkstyle/checkstyle/actions/runs/1559956127

Failure seems to be related to writing rocket emoji to comment where `Github, generate site` is placed.

Even if this does not fix failure, it is a good idea to update permissions.

From https://github.com/checkstyle/checkstyle/pull/11014#issue-1073832545:

> It's still worth taking [this PR] even if you undo the repo settings change; it limits the permissions for this workflow to the minimum required.