### PR TITLE
infra: add permissions for rebase workflow

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -11,6 +11,11 @@ on:
   issue_comment:
     types: [created, edited]
 name: Automatic Rebase
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   rebase:
     name: Rebase PR


### PR DESCRIPTION
Similar to #11014 (comment), this should fix rebase issue.

Failure seems to be related to writing rocket emoji to comment where Github, generate site is placed.

Even if this does not fix failure, it is a good idea to update permissions.

From #11014 (comment):

> It's still worth taking [this PR] even if you undo the repo settings change; it limits the permissions for this workflow to the minimum required.