### PR TITLE
infra: update permissions for rebase workflow

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -13,7 +13,7 @@ on:
 name: Automatic Rebase
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
Hopefully fixes failure of `Github, rebase` workflow.

It was tough to find exact documentation that details which permission is necessary for this action, [this](https://docs.github.com/en/rest/reference/pulls#merge-a-pull-request) is somewhat related. Repo for [cirrus actions rebase ](https://github.com/cirrus-actions/rebase) does not specify exact permissions required for it's workflow, but there is an issue at https://github.com/cirrus-actions/rebase/issues/84#issuecomment-984248665 that states that the changes in this PR are required.