### PR TITLE
infra: Update permissions for codeql workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,11 @@ on:
   schedule:
     - cron: '29 2 * * 0'
 
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
The CodeQL workflow currently works on PRs but not on pushes to `master`:

https://github.com/checkstyle/checkstyle/runs/4489527012?check_suite_focus=true#step:4:10

This PR sets the permissions required for it to work on push.

```
request: {
    method: 'PUT',
    url: 'https://api.github.com/repos/
checkstyle/checkstyle/code-scanning/analysis/status',
```