### PR TITLE
Issue #3847: wrong processing of return

### DIFF
--- a/src/xdocs/config_metrics.xml
+++ b/src/xdocs/config_metrics.xml
@@ -469,7 +469,7 @@ class InputClassCoupling {
 }
         </source>
 
-        <p>
+        <p> 
           The check results in a violation in the following:
         </p>
         <source>
@@ -1614,6 +1614,7 @@ class Test2 {
                     operators - 0</td></tr>
             <tr><td>continue</td><td>1</td></tr>
             <tr><td>return</td><td>1</td></tr>
+            <tr><td>return ([expr])</td><td>NP(expr) + 1</td></tr>
             <tr><td>Statement (even sequential statements)</td><td>1</td></tr>
             <tr><td>Empty block {}</td><td>1</td></tr>
             <tr><td>Function call</td><td>1</td></tr>


### PR DESCRIPTION
Closes #3847 

http://checkstyle.sourceforge.net/config_metrics.html#NPathComplexity

**Test.java**
```
public class Test {
    public boolean getResult(boolean a, boolean b, boolean c) {
        return a || b || c;  // NP(expr) + 1 => 1 + 1 = 2
    }

    // return - NP(return) = 1
    // NP(expr) = 1 
    // Total NP = 1 + 1 = 2
}

Starting audit...
[WARN] /home/loges/Documents/Venkatesh Interview/gsoc/checkstyle/Test.java:2:5: NPath Complexity is 2 (max allowed is 1). [NPathComplexity]
Audit done.
```
**config.xml**
```
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
<module name="Checker">
    <property name="charset" value="UTF-8"/>
    <property name="severity" value="warning"/>
    <module name="TreeWalker">
        <module name="NPathComplexity">
            <property name="max" value="1"/>
        </module>
    </module>
</module>
```