### PR TITLE
Issue #7688: update doc for RedundantImport

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java
@@ -48,6 +48,20 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * &lt;module name="RedundantImport"/&gt;
  * </pre>
  * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * package Test;
+ * import static Test.MyClass.*; // OK, static import
+ * import static java.lang.Integer.MAX_VALUE; // OK, static import
+ *
+ * import Test.MyClass; // violation, imported from the same package as the current package
+ * import java.lang.String; // violation, the class imported is from the 'java.lang' package
+ * import java.util.Scanner; // OK
+ * import java.util.Scanner; // violation, it is a duplicate of another import
+ * public class MyClass{ };
+ * </pre>
+ * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
  * </p>
  * <p>

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -2359,6 +2359,20 @@ public class SomeClass { }
         <source>
 &lt;module name=&quot;RedundantImport&quot;/&gt;
         </source>
+        <p>
+            Example:
+        </p>
+        <source>
+package Test;
+import static Test.MyClass.*; // OK, static import
+import static java.lang.Integer.MAX_VALUE; // OK, static import
+
+import Test.MyClass; // violation, imported from the same package as the current package
+import java.lang.String; // violation, the class imported is from the 'java.lang' package
+import java.util.Scanner; // OK
+import java.util.Scanner; // violation, it is a duplicate of another import
+public class MyClass{ };
+        </source>
       </subsection>
 
       <subsection name="Example of Usage" id="RedundantImport_Example_of_Usage">


### PR DESCRIPTION
Fixes #7688
![ayy](https://user-images.githubusercontent.com/78761614/146316285-62ca8157-1d5e-4be8-8d1b-03eced6c9a1d.png)

**Default examples:**
```
$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="RedundantImport"/>
    </module>
</module>

$ cat MyClass.java
package Test;
import static Test.MyClass.*; // OK, static import
import static java.lang.Integer.MAX_VALUE; // OK, static import

import Test.MyClass; // violation, imported from the same package as the current package
import java.lang.String; // violation, the class imported is from the 'java.lang' package
import java.util.Scanner; // OK
import java.util.Scanner; // violation, it is a duplicate of another import
public class MyClass{ };

$ java -jar checkstyle-9.2-all.jar -c config.xml MyClass.java
Starting audit...
[ERROR] C:\Users\Dell\Desktop\Checkstyle\Test\MyClass.java:5:1: Redundant import from the same package - Test.MyClass. [RedundantImport]
[ERROR] C:\Users\Dell\Desktop\Checkstyle\Test\MyClass.java:6:1: Redundant import from the java.lang package - java.lang.String. [RedundantImport]
[ERROR] C:\Users\Dell\Desktop\Checkstyle\Test\MyClass.java:8:1: Duplicate import to line 7 - java.util.Scanner. [RedundantImport]
Audit done.
Checkstyle ends with 3 errors.



```