### PR TITLE
Issue #11054: rewrote RightCurlyCheck avoid a possible exception

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -460,15 +460,14 @@ public class RightCurlyCheck extends AbstractCheck {
      */
     private static boolean isBlockAloneOnSingleLine(Details details) {
         DetailAST nextToken = details.nextToken;
-        if (nextToken != null) {
-            while (nextToken.getType() == TokenTypes.LITERAL_ELSE) {
-                nextToken = Details.getNextToken(nextToken);
-            }
 
-            if (nextToken.getType() == TokenTypes.DO_WHILE) {
-                final DetailAST doWhileSemi = nextToken.getParent().getLastChild();
-                nextToken = Details.getNextToken(doWhileSemi);
-            }
+        while (nextToken != null && nextToken.getType() == TokenTypes.LITERAL_ELSE) {
+            nextToken = Details.getNextToken(nextToken);
+        }
+
+        if (nextToken != null && nextToken.getType() == TokenTypes.DO_WHILE) {
+            final DetailAST doWhileSemi = nextToken.getParent().getLastChild();
+            nextToken = Details.getNextToken(doWhileSemi);
         }
 
         return TokenUtil.areOnSameLine(details.lcurly, details.rcurly)


### PR DESCRIPTION
Issue #11054

Local pitest confirmed that duplicating the code is acceptable, though I don't think this is really desirable.