### PR TITLE
infra: update pmd CI execution to not use forked repository

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -832,6 +832,7 @@ multithreading
 mutableexception
 MVC
 mvn
+mvnw
 Mycheckstyle
 mycompany
 mycompanychecks

--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -205,19 +205,19 @@ markdownlint)
 no-error-pmd)
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo "CS_version: ${CS_POM_VERSION}"
-  checkout_from "-b checkstyle-7417 https://github.com/checkstyle/build-tools.git"
+  checkout_from "https://github.com/pmd/build-tools.git"
   cd .ci-temp/build-tools/
-  PMD_POM_VERSION=$(mvn -e --no-transfer-progress -q -Dexec.executable='echo' \
-    -Dexec.args='${project.version}' \
-     --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
   mvn -e --no-transfer-progress install
   cd ..
   git clone https://github.com/pmd/pmd.git
   cd pmd
-  # Using specific commit so that build-tools dependencies match
-  git checkout 342dc1d03aaa1082e42f7496d6869d15859af321
-  mvn -e --no-transfer-progress install checkstyle:check -Dcheckstyle.version=${CS_POM_VERSION} \
-    -Dpmd.build-tools.version=${PMD_POM_VERSION}
+  ./mvnw verify --show-version --errors --batch-mode --no-transfer-progress \
+                -DskipTests \
+                -Dmaven.javadoc.skip=true \
+                -Dmaven.source.skip=true \
+                -Dpmd.skip=true \
+                -Dcheckstyle.skip=false \
+                -Dcheckstyle.version=${CS_POM_VERSION}
   cd ..
   removeFolderWithProtectedFiles build-tools
   removeFolderWithProtectedFiles pmd

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -74,9 +74,6 @@ blocks:
             - env_var: CMD
               values:
                 - "true"
-                # until https://github.com/checkstyle/checkstyle/pull/11060
-                # - mvn -e --no-transfer-progress clean install -Pno-validations
-                #    && .ci/validation.sh no-error-pmd
                 # until https://github.com/checkstyle/checkstyle/issues/9248
                 # - mvn -e clean install -Pno-validations
                 #    && .ci/validation.sh no-violation-test-configurate

--- a/wercker.yml
+++ b/wercker.yml
@@ -109,6 +109,16 @@ build:
   #       fi
 
   - script:
+      name: NoErrorTest - PMD
+      code: |
+        if [[ $RUN_JOB == 1 ]]; then
+          echo "Command: ./.ci/validation.sh no-error-pmd"
+          ./.ci/validation.sh no-error-pmd
+        else
+          echo "build is skipped ..."
+        fi
+
+  - script:
       name: NoExceptiontest - Apache Struts
       code: |
         if [[ $RUN_JOB == 1 ]]; then


### PR DESCRIPTION
stable failure of semaphoreci on pmd validation
https://checkstyle.semaphoreci.com/jobs/25bf624f-4f4c-4380-8de4-2ee08fe6d4b8

`[ERROR] Failed to execute goal org.jetbrains.kotlin:kotlin-maven-plugin:1.4.10:compile (kotlin-compile) on project pmd-lang-test: Execution kotlin-compile of goal org.jetbrains.kotlin:kotlin-maven-plugin:1.4.10:compile failed: A required class was missing while executing org.jetbrains.kotlin:kotlin-maven-plugin:1.4.10:compile: kotlin/reflect/full/KClasses 02:02`


commands is taken from https://github.com/pmd/pmd/blob/master/.ci/build.sh#L93