### PR TITLE
Issue #10905: setup Java17 build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,10 +18,10 @@ task:
     folder: .m2
   matrix:
     # add more JDK versions here
-    - name: Cirrus - JDK16
+    - name: Cirrus - JDK17
       env:
-        OPENJDK_VERSION: "16.0.0"
-        OPENJDK_PATH: "jdk-16"
+        OPENJDK_VERSION: "17.0.0"
+        OPENJDK_PATH: "jdk-17"
   env:
     # disable ANSI output for picocli (may affect tests)
     NO_COLOR: "1"
@@ -29,7 +29,7 @@ task:
     MAVEN_OPTS: "-Dhttp.keepAlive=false \
       -Dmaven.repo.local=%CIRRUS_WORKING_DIR%/.m2 \
       -Dmaven.wagon.http.retryHandler.count=3"
-    MAVEN_VERSION: "3.8.1"
+    MAVEN_VERSION: "3.8.4"
     PATH: "%PATH%;C:/Program Files/OpenJDK/%OPENJDK_PATH%/bin;\
       C:/ProgramData/chocolatey/lib/maven/apache-maven-%MAVEN_VERSION%/bin;\
       C:/ProgramData/chocolatey/bin"


### PR DESCRIPTION
Issue #10905 

Java16 build removed. Java16 is no more supported by the vendor.
Java17 (LTS) build added.