### PR TITLE
Issue #11031: Fixed false negative about concatenated strings in StringLiteralEqualityCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
@@ -112,12 +112,35 @@ public class StringLiteralEqualityCheck extends AbstractCheck {
     @Override
     public void visitToken(DetailAST ast) {
         final boolean hasStringLiteralChild =
-            ast.findFirstToken(TokenTypes.STRING_LITERAL) != null
-                || ast.findFirstToken(TokenTypes.TEXT_BLOCK_LITERAL_BEGIN) != null;
+                ast.findFirstToken(TokenTypes.STRING_LITERAL) != null
+                    || ast.findFirstToken(TokenTypes.TEXT_BLOCK_LITERAL_BEGIN) != null
+                    || areStringsConcatenated(ast);
 
         if (hasStringLiteralChild) {
             log(ast, MSG_KEY, ast.getText());
         }
+    }
+
+    /**
+     * Checks whether string literal or text block literals are concatenated.
+     *
+     * @param ast ast
+     * @return {@code true} if string literal or text block literals are concatenated
+     */
+    private static boolean areStringsConcatenated(DetailAST ast) {
+        DetailAST plusAst = ast.findFirstToken(TokenTypes.PLUS);
+        boolean result = false;
+        while (plusAst != null) {
+            if (plusAst.findFirstToken(TokenTypes.STRING_LITERAL) == null
+                    && plusAst.findFirstToken(TokenTypes.TEXT_BLOCK_LITERAL_BEGIN) == null) {
+                plusAst = plusAst.findFirstToken(TokenTypes.PLUS);
+            }
+            else {
+                result = true;
+                break;
+            }
+        }
+        return result;
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheckTest.java
@@ -59,6 +59,43 @@ public class StringLiteralEqualityCheckTest
     }
 
     @Test
+    public void testConcatenatedStringLiterals() throws Exception {
+        final String[] expected = {
+            "14:15: " + getCheckMessage(MSG_KEY, "=="),
+            "17:24: " + getCheckMessage(MSG_KEY, "=="),
+            "20:31: " + getCheckMessage(MSG_KEY, "!="),
+            "23:15: " + getCheckMessage(MSG_KEY, "=="),
+            "28:26: " + getCheckMessage(MSG_KEY, "=="),
+            "31:26: " + getCheckMessage(MSG_KEY, "!="),
+            "34:15: " + getCheckMessage(MSG_KEY, "!="),
+            "37:32: " + getCheckMessage(MSG_KEY, "=="),
+            "39:33: " + getCheckMessage(MSG_KEY, "!="),
+            "41:31: " + getCheckMessage(MSG_KEY, "!="),
+            "42:27: " + getCheckMessage(MSG_KEY, "=="),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputStringLiteralEqualityConcatenatedString.java"), expected);
+    }
+
+    @Test
+    public void testConcatenatedTextBlocks() throws Exception {
+        final String[] expected = {
+            "15:15: " + getCheckMessage(MSG_KEY, "=="),
+            "21:23: " + getCheckMessage(MSG_KEY, "=="),
+            "26:23: " + getCheckMessage(MSG_KEY, "!="),
+            "29:15: " + getCheckMessage(MSG_KEY, "=="),
+            "38:26: " + getCheckMessage(MSG_KEY, "=="),
+            "42:26: " + getCheckMessage(MSG_KEY, "!="),
+            "46:15: " + getCheckMessage(MSG_KEY, "!="),
+            "51:28: " + getCheckMessage(MSG_KEY, "!="),
+            "53:31: " + getCheckMessage(MSG_KEY, "=="),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputStringLiteralEqualityConcatenatedTextBlocks.java"),
+                expected);
+    }
+
+    @Test
     public void testTokensNotNull() {
         final StringLiteralEqualityCheck check = new StringLiteralEqualityCheck();
         assertNotNull(check.getAcceptableTokens(), "Acceptable tokens should not be null");

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/stringliteralequality/InputStringLiteralEqualityConcatenatedTextBlocks.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/stringliteralequality/InputStringLiteralEqualityConcatenatedTextBlocks.java
@@ -1,0 +1,57 @@
+/*
+StringLiteralEquality
+
+
+*/
+
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.coding.stringliteralequality;
+
+public class InputStringLiteralEqualityConcatenatedTextBlocks {
+
+    public void testMethod() {
+        String s = "abc";
+        String p = "asd";
+        if (s == """
+                a""" + "bc") { // violation above
+        }
+
+        if ("""
+                a""" + """
+                bc""" == s) { // violation
+        }
+
+        if ("a" + ("""
+                b""" + """
+                c""") != s) { // violation
+        }
+
+        if (s == """
+                a""" + """
+                b""" + """
+                c""") { // violation 3 lines above
+        }
+        if ((s += """
+                asd""") != p) { // ok, can't be detected as check in not type aware.
+        }
+
+        if ((s += "asd") == s + (p + """
+                asd""")) { // violation above
+        }
+
+        if ((s += "asd") != s + """
+                p""" + p) { // violation above
+        }
+
+        if (s != s + """
+                p""" + p) { // violation above
+        }
+
+        String c = ("""
+                ab""" + s) != null ? // violation
+                (p + """
+                        ab""" == null ? p : s) : p; // violation
+
+    }
+
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/stringliteralequality/InputStringLiteralEqualityConcatenatedString.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/stringliteralequality/InputStringLiteralEqualityConcatenatedString.java
@@ -1,0 +1,46 @@
+/*
+StringLiteralEquality
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.stringliteralequality;
+
+public class InputStringLiteralEqualityConcatenatedString {
+
+    public void testMethod() {
+        String s = "abc";
+        String p = "asd";
+        if (s == "a" + "bc") { // violation
+        }
+
+        if ("a" + "bc" == s) { // violation
+        }
+
+        if ("a" + ("b" + "c") != s) { // violation
+        }
+
+        if (s == "a" + "b" + "c") { // violation
+        }
+        if ((s += "asd") != p) { // ok, can't be detected as check in not type aware.
+        }
+
+        if ((s += "asd") == s + (p + "asd")) { // violation
+        }
+
+        if ((s += "asd") != s + "p" + p) { // violation
+        }
+
+        if (s != s + "p" + p) { // violation
+        }
+
+        String a = (s + "asd") == null ? "asd" : s; // violation
+
+        String b = s + "ab" + p != null ? s : p; // violation
+
+        String c = ("ab" + s) != null ? // violation
+                (p + "ab" == null ? p : s) : p; // violation
+
+    }
+
+}


### PR DESCRIPTION
Resolves #11031: StringLiteralEquality FN about String literal expression
Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/62103529e941c23abb7b23b61df366427b0fbf02/my_checks.xml
Final Report (clean): https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/8479596_2021003141/reports/diff/index.html