### PR TITLE
Issue #9142: format Truth asserts to keep all 'that' on separate line

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -133,6 +133,13 @@
                 value="First sentence in a comment should start with a capital letter"/>
   </module>
   <module name="RegexpSingleline">
+    <property name="id" value="assertThatShouldBeOnSeparateLine"/>
+    <property name="format" value="assertWithMessage\(.*\).that\("/>
+    <property name="fileExtensions" value="java"/>
+    <property name="message"
+                value="Truth''s ''that'' method call should be on separate line"/>
+  </module>
+  <module name="RegexpSingleline">
     <property name="id" value="lineLengthGrammar"/>
     <property name="format" value="^(?!(.*http|import)).{101,}$"/>
     <property name="fileExtensions" value="g, g4"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatterTest.java
@@ -40,7 +40,9 @@ public class AuditEventDefaultFormatterTest {
         final String expected = "[WARN] InputMockFile.java:1:1: Mocked violation. "
                 + "[AuditEventDefaultFormatterTest$TestModule]";
 
-        assertWithMessage("Invalid format").that(formatter.format(event)).isEqualTo(expected);
+        assertWithMessage("Invalid format")
+                .that(formatter.format(event))
+                .isEqualTo(expected);
     }
 
     @Test
@@ -53,7 +55,9 @@ public class AuditEventDefaultFormatterTest {
         final String expected = "[WARN] InputMockFile.java:1:1: Mocked violation. "
                 + "[AuditEventDefaultFormatterTest$TestModule]";
 
-        assertWithMessage("Invalid format").that(formatter.format(event)).isEqualTo(expected);
+        assertWithMessage("Invalid format")
+                .that(formatter.format(event))
+                .isEqualTo(expected);
     }
 
     @Test
@@ -65,7 +69,9 @@ public class AuditEventDefaultFormatterTest {
 
         final String expected = "[WARN] InputMockFile.java:1:1: Mocked violation. [ModuleId]";
 
-        assertWithMessage("Invalid format").that(formatter.format(event)).isEqualTo(expected);
+        assertWithMessage("Invalid format")
+                .that(formatter.format(event))
+                .isEqualTo(expected);
     }
 
     @Test
@@ -77,7 +83,9 @@ public class AuditEventDefaultFormatterTest {
         final int result = TestUtil.invokeStaticMethod(AuditEventDefaultFormatter.class,
                 "calculateBufferLength", auditEvent, SeverityLevel.ERROR.ordinal());
 
-        assertWithMessage("Buffer length is not expected").that(result).isEqualTo(54);
+        assertWithMessage("Buffer length is not expected")
+                .that(result)
+                .isEqualTo(54);
     }
 
     private static class TestModuleCheck {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParserTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParserTest.java
@@ -50,7 +50,9 @@ public class JavadocDetailNodeParserTest extends AbstractModuleTestSupport {
         final String expected = toLfLineEnding(new String(Files.readAllBytes(Paths.get(
                 getPath("ExpectedJavadocDetailNodeParser.txt"))),
                 StandardCharsets.UTF_8));
-        assertWithMessage("Invalid parse result").that(actual).isEqualTo(expected);
+        assertWithMessage("Invalid parse result")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertiesExpanderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertiesExpanderTest.java
@@ -34,7 +34,8 @@ public class PropertiesExpanderTest {
             assertWithMessage("exception expected but got " + test).fail();
         }
         catch (IllegalArgumentException ex) {
-            assertWithMessage("Invalid exception message").that(ex.getMessage())
+            assertWithMessage("Invalid exception message")
+                    .that(ex.getMessage())
                     .isEqualTo("cannot pass null");
         }
     }
@@ -44,16 +45,20 @@ public class PropertiesExpanderTest {
         final Properties properties = new Properties(System.getProperties());
         properties.setProperty("test", "checkstyle");
         final String propertiesUserHome = properties.getProperty("user.home");
-        assertWithMessage("Invalid user.home property").that(propertiesUserHome)
+        assertWithMessage("Invalid user.home property")
+                .that(propertiesUserHome)
                 .isEqualTo(System.getProperty("user.home"));
-        assertWithMessage("Invalid checkstyle property").that(properties.getProperty("test"))
+        assertWithMessage("Invalid checkstyle property")
+                .that(properties.getProperty("test"))
                 .isEqualTo("checkstyle");
 
         final PropertiesExpander expander = new PropertiesExpander(properties);
         final String expanderUserHome = expander.resolve("user.home");
-        assertWithMessage("Invalid user.home property").that(expanderUserHome)
+        assertWithMessage("Invalid user.home property")
+                .that(expanderUserHome)
                 .isEqualTo(System.getProperty("user.home"));
-        assertWithMessage("Invalid checkstyle property").that(expander.resolve("test"))
+        assertWithMessage("Invalid checkstyle property")
+                .that(expander.resolve("test"))
                 .isEqualTo("checkstyle");
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ThreadModeSettingsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ThreadModeSettingsTest.java
@@ -32,10 +32,12 @@ public class ThreadModeSettingsTest {
     @Test
     public void testProperties() {
         final ThreadModeSettings config = new ThreadModeSettings(1, 2);
-        assertWithMessage("Invalid checker threads number").that(config.getCheckerThreadsNumber())
+        assertWithMessage("Invalid checker threads number")
+                .that(config.getCheckerThreadsNumber())
                 .isEqualTo(1);
         assertWithMessage("Invalid treewalker threads number")
-                .that(config.getTreeWalkerThreadsNumber()).isEqualTo(2);
+                .that(config.getTreeWalkerThreadsNumber())
+                .isEqualTo(2);
     }
 
     @Test
@@ -47,7 +49,8 @@ public class ThreadModeSettingsTest {
             assertWithMessage("An exception is expected").fail();
         }
         catch (IllegalArgumentException ex) {
-            assertWithMessage("Invalid exception message").that(ex.getMessage())
+            assertWithMessage("Invalid exception message")
+                    .that(ex.getMessage())
                     .isEqualTo("Multi thread mode for Checker module is not implemented");
         }
     }
@@ -57,7 +60,8 @@ public class ThreadModeSettingsTest {
         final ThreadModeSettings singleThreadMode = ThreadModeSettings.SINGLE_THREAD_MODE_INSTANCE;
 
         final String name = singleThreadMode.resolveName(ThreadModeSettings.CHECKER_MODULE_NAME);
-        assertWithMessage("Invalid name resolved").that(name)
+        assertWithMessage("Invalid name resolved")
+                .that(name)
                 .isEqualTo(ThreadModeSettings.CHECKER_MODULE_NAME);
     }
 
@@ -70,7 +74,8 @@ public class ThreadModeSettingsTest {
             assertWithMessage("Exception is expected").fail();
         }
         catch (IllegalArgumentException ex) {
-            assertWithMessage("Invalid exception message").that(ex.getMessage())
+            assertWithMessage("Invalid exception message")
+                    .that(ex.getMessage())
                     .isEqualTo("Multi thread mode for TreeWalker module is not implemented");
         }
     }
@@ -80,7 +85,8 @@ public class ThreadModeSettingsTest {
         final ThreadModeSettings singleThreadMode = ThreadModeSettings.SINGLE_THREAD_MODE_INSTANCE;
         final String actual =
                 singleThreadMode.resolveName(ThreadModeSettings.TREE_WALKER_MODULE_NAME);
-        assertWithMessage("Invalid name resolved: " + actual).that(actual)
+        assertWithMessage("Invalid name resolved: " + actual)
+                .that(actual)
                 .isEqualTo(ThreadModeSettings.TREE_WALKER_MODULE_NAME);
     }
 
@@ -100,9 +106,11 @@ public class ThreadModeSettingsTest {
 
             final String moduleName = module.getSimpleName();
             assertWithMessage("Invalid name resolved")
-                    .that(singleThreadModeSettings.resolveName(moduleName)).isEqualTo(moduleName);
+                    .that(singleThreadModeSettings.resolveName(moduleName))
+                    .isEqualTo(moduleName);
             assertWithMessage("Invalid name resolved")
-                    .that(multiThreadModeSettings.resolveName(moduleName)).isEqualTo(moduleName);
+                    .that(multiThreadModeSettings.resolveName(moduleName))
+                    .isEqualTo(moduleName);
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FullIdentTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FullIdentTest.java
@@ -53,11 +53,18 @@ public class FullIdentTest extends AbstractModuleTestSupport {
         parent.setFirstChild(ast);
 
         final FullIdent indent = FullIdent.createFullIdent(ast);
-        assertWithMessage("Invalid full indent").that(indent.toString())
-            .isEqualTo("MyTest[15x14]");
-        assertWithMessage("Invalid text").that(indent.getText()).isEqualTo("MyTest");
-        assertWithMessage("Invalid line").that(indent.getLineNo()).isEqualTo(15);
-        assertWithMessage("Invalid column").that(indent.getColumnNo()).isEqualTo(14);
+        assertWithMessage("Invalid full indent")
+                .that(indent.toString())
+                .isEqualTo("MyTest[15x14]");
+        assertWithMessage("Invalid text")
+                .that(indent.getText())
+                .isEqualTo("MyTest");
+        assertWithMessage("Invalid line")
+                .that(indent.getLineNo())
+                .isEqualTo(15);
+        assertWithMessage("Invalid column")
+                .that(indent.getColumnNo())
+                .isEqualTo(14);
     }
 
     @Test
@@ -65,7 +72,9 @@ public class FullIdentTest extends AbstractModuleTestSupport {
         final DetailAST ast = new DetailAstImpl();
 
         final FullIdent indent = FullIdent.createFullIdentBelow(ast);
-        assertWithMessage("Invalid full indent").that(indent.getText()).isEqualTo("");
+        assertWithMessage("Invalid full indent")
+                .that(indent.getText())
+                .isEqualTo("");
     }
 
     @Test
@@ -77,21 +86,24 @@ public class FullIdentTest extends AbstractModuleTestSupport {
                 JavaParser.parse(new FileContents(testFileText)).getFirstChild();
         final DetailAST packageName = packageDefinitionNode.getFirstChild().getNextSibling();
         final FullIdent ident = FullIdent.createFullIdent(packageName);
-        assertWithMessage("Invalid full indent").that(ident.getDetailAst().toString())
+        assertWithMessage("Invalid full indent")
+                .that(ident.getDetailAst().toString())
                 .isEqualTo("com[1x8]");
     }
 
     @Test
     public void testNonValidCoordinatesWithNegative() {
         final FullIdent fullIdent = prepareFullIdentWithCoordinates(14, 15);
-        assertWithMessage("Invalid full indent").that(fullIdent.toString())
+        assertWithMessage("Invalid full indent")
+                .that(fullIdent.toString())
                 .isEqualTo("MyTest.MyTestik[15x14]");
     }
 
     @Test
     public void testNonValidCoordinatesWithZero() {
         final FullIdent fullIdent = prepareFullIdentWithCoordinates(0, 0);
-        assertWithMessage("Invalid full indent").that(fullIdent.toString())
+        assertWithMessage("Invalid full indent")
+                .that(fullIdent.toString())
                 .isEqualTo("MyTest.MyTestik[15x14]");
     }
 
@@ -108,7 +120,9 @@ public class FullIdentTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.TYPE)
                 .getFirstChild();
         final FullIdent ident = FullIdent.createFullIdent(arrayDeclarator);
-        assertWithMessage("Invalid full indent").that(ident.toString()).isEqualTo("int[][][5x12]");
+        assertWithMessage("Invalid full indent")
+                .that(ident.toString())
+                .isEqualTo("int[][][5x12]");
     }
 
     @Test
@@ -133,7 +147,9 @@ public class FullIdentTest extends AbstractModuleTestSupport {
                 .getFirstChild();
 
         final FullIdent ident = FullIdent.createFullIdent(parameter);
-        assertWithMessage("Invalid full indent").that(ident.toString()).isEqualTo("char[][7x29]");
+        assertWithMessage("Invalid full indent")
+                .that(ident.toString())
+                .isEqualTo("char[][7x29]");
     }
 
     @Test
@@ -155,7 +171,9 @@ public class FullIdentTest extends AbstractModuleTestSupport {
                 .getFirstChild();
 
         final FullIdent ident = FullIdent.createFullIdent(literalInt);
-        assertWithMessage("Invalid full indent").that(ident.toString()).isEqualTo("int[4x32]");
+        assertWithMessage("Invalid full indent")
+                .that(ident.toString())
+                .isEqualTo("int[4x32]");
     }
 
     private static FullIdent prepareFullIdentWithCoordinates(int columnNo, int lineNo) {
@@ -200,7 +218,8 @@ public class FullIdentTest extends AbstractModuleTestSupport {
         final DetailAST annotationNode = packageDefinitionNode.getFirstChild();
         final FullIdent ident = FullIdent.createFullIdent(annotationNode);
         assertWithMessage("Full ident text should be empty.")
-                .that(ident.getText()).isEmpty();
+                .that(ident.getText())
+                .isEmpty();
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/TokenTypesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/TokenTypesTest.java
@@ -45,7 +45,9 @@ public class TokenTypesTest {
             .filter(name -> name.charAt(0) != '$')
             .collect(Collectors.toSet());
         final Set<String> actual = bundle.keySet();
-        assertWithMessage("TokenTypes without description").that(actual).isEqualTo(expected);
+        assertWithMessage("TokenTypes without description")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -55,7 +57,8 @@ public class TokenTypesTest {
             .filter(name -> name.charAt(0) != '$')
             .map(TokenUtil::getShortDescription)
             .filter(desc -> desc.charAt(desc.length() - 1) != '.').collect(Collectors.toSet());
-        assertWithMessage("Malformed TokenType descriptions").that(badDescriptions)
+        assertWithMessage("Malformed TokenType descriptions")
+                .that(badDescriptions)
                 .isEqualTo(Collections.emptySet());
     }
 
@@ -65,7 +68,8 @@ public class TokenTypesTest {
                 .that(TokenUtil.getShortDescription("EQUAL"))
                 .isEqualTo("The <code>==</code> (equal) operator.");
 
-        assertWithMessage("short description for LAND").that(TokenUtil.getShortDescription("LAND"))
+        assertWithMessage("short description for LAND")
+                .that(TokenUtil.getShortDescription("LAND"))
                 .isEqualTo("The <code>&&</code> (conditional AND) operator.");
 
         assertWithMessage("short description for LCURLY")
@@ -76,17 +80,20 @@ public class TokenTypesTest {
                 .that(TokenUtil.getShortDescription("SR_ASSIGN"))
                 .isEqualTo("The <code>>>=</code> (signed right shift assignment) operator.");
 
-        assertWithMessage("short description for SL").that(TokenUtil.getShortDescription("SL"))
+        assertWithMessage("short description for SL")
+                .that(TokenUtil.getShortDescription("SL"))
                 .isEqualTo("The <code><<</code> (shift left) operator.");
 
-        assertWithMessage("short description for BSR").that(TokenUtil.getShortDescription("BSR"))
+        assertWithMessage("short description for BSR")
+                .that(TokenUtil.getShortDescription("BSR"))
                 .isEqualTo("The <code>>>></code> (unsigned shift right) operator.");
     }
 
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         assertWithMessage("Constructor is not private")
-                .that(isUtilsClassHasPrivateConstructor(TokenTypes.class, true)).isTrue();
+                .that(isUtilsClassHasPrivateConstructor(TokenTypes.class, true))
+                .isTrue();
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheckTest.java
@@ -96,9 +96,11 @@ public class ArrayTypeStyleCheckTest
         final int[] expected = {TokenTypes.ARRAY_DECLARATOR };
         final ArrayTypeStyleCheck check = new ArrayTypeStyleCheck();
         final int[] actual = check.getAcceptableTokens();
-        assertWithMessage("Amount of acceptable tokens differs from expected").that(actual)
+        assertWithMessage("Amount of acceptable tokens differs from expected")
+                .that(actual)
                 .hasLength(1);
-        assertWithMessage("Acceptable tokens differs from expected").that(actual)
+        assertWithMessage("Acceptable tokens differs from expected")
+                .that(actual)
                 .isEqualTo(expected);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
@@ -129,7 +129,8 @@ public class NewlineAtEndOfFileCheckTest
             assertWithMessage("exception expected").fail();
         }
         catch (CheckstyleException ex) {
-            assertWithMessage("Error message is unexpected").that(ex.getMessage())
+            assertWithMessage("Error message is unexpected")
+                    .that(ex.getMessage())
                     .isEqualTo("cannot initialize module com.puppycrawl.tools.checkstyle."
                             + "checks.NewlineAtEndOfFileCheck - "
                             + "Cannot set property 'lineSeparator' to 'ct'");
@@ -184,7 +185,9 @@ public class NewlineAtEndOfFileCheckTest
         final File impossibleFile = new File("");
         final FileText fileText = new FileText(impossibleFile, lines);
         final Set<Violation> violations = check.process(impossibleFile, fileText);
-        assertWithMessage("Amount of violations is unexpected").that(violations).hasSize(1);
+        assertWithMessage("Amount of violations is unexpected")
+                .that(violations)
+                .hasSize(1);
         final Iterator<Violation> iterator = violations.iterator();
         assertWithMessage("Violation message differs from expected")
                 .that(iterator.next().getViolation())

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheckTest.java
@@ -131,10 +131,13 @@ public class OrderedPropertiesCheckTest extends AbstractModuleTestSupport {
         final FileText fileText = new FileText(file, Collections.emptyList());
         final SortedSet<Violation> violations =
                 check.process(file, fileText);
-        assertWithMessage("Wrong violations count").that(violations).hasSize(1);
+        assertWithMessage("Wrong violations count")
+                .that(violations)
+                .hasSize(1);
         final Violation violation = violations.iterator().next();
         final String retrievedMessage = violations.iterator().next().getKey();
-        assertWithMessage("violation key is not valid").that(retrievedMessage)
+        assertWithMessage("violation key is not valid")
+                .that(retrievedMessage)
                 .isEqualTo("unable.open.cause");
         assertWithMessage("violation is not valid")
                 .that(getCheckMessage(MSG_IO_EXCEPTION_KEY, fileName, getFileNotFoundDetail(file)))
@@ -163,14 +166,17 @@ public class OrderedPropertiesCheckTest extends AbstractModuleTestSupport {
         final FileText fileText = new FileText(file, Collections.emptyList());
         final SortedSet<Violation> violations = check.process(file, fileText);
 
-        assertWithMessage("Wrong violations count").that(violations).hasSize(1);
+        assertWithMessage("Wrong violations count")
+                .that(violations)
+                .hasSize(1);
     }
 
     @Test
     public void testFileExtension() {
 
         final OrderedPropertiesCheck check = new OrderedPropertiesCheck();
-        assertWithMessage("File extension should be set").that(".properties")
+        assertWithMessage("File extension should be set")
+                .that(".properties")
                 .isEqualTo(check.getFileExtensions()[0]);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheckTest.java
@@ -74,7 +74,8 @@ public class OuterTypeFilenameCheckTest extends AbstractModuleTestSupport {
             TokenTypes.ANNOTATION_DEF,
             TokenTypes.RECORD_DEF,
         };
-        assertWithMessage("Acceptable tokens array differs from expected").that(actual)
+        assertWithMessage("Acceptable tokens array differs from expected")
+                .that(actual)
                 .isEqualTo(expected);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheckTest.java
@@ -40,7 +40,8 @@ public class TrailingCommentCheckTest extends AbstractModuleTestSupport {
         final TrailingCommentCheck checkObj = new TrailingCommentCheck();
         final int[] expected = {TokenTypes.SINGLE_LINE_COMMENT,
             TokenTypes.BLOCK_COMMENT_BEGIN, };
-        assertWithMessage("Required tokens array is not empty").that(checkObj.getRequiredTokens())
+        assertWithMessage("Required tokens array is not empty")
+                .that(checkObj.getRequiredTokens())
                 .isEqualTo(expected);
     }
 
@@ -50,7 +51,8 @@ public class TrailingCommentCheckTest extends AbstractModuleTestSupport {
         final int[] expected = {TokenTypes.SINGLE_LINE_COMMENT,
             TokenTypes.BLOCK_COMMENT_BEGIN, };
         assertWithMessage("Acceptable tokens array is not empty")
-                .that(checkObj.getAcceptableTokens()).isEqualTo(expected);
+                .that(checkObj.getAcceptableTokens())
+                .isEqualTo(expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
@@ -134,8 +134,9 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
             TokenTypes.RECORD_DEF,
             TokenTypes.COMPACT_CTOR_DEF,
         };
-        assertWithMessage("Default acceptable tokens are invalid").that(actual)
-            .isEqualTo(expected);
+        assertWithMessage("Default acceptable tokens are invalid")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationOnSameLineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationOnSameLineCheckTest.java
@@ -66,7 +66,9 @@ public class AnnotationOnSameLineCheckTest extends AbstractModuleTestSupport {
             TokenTypes.RECORD_DEF,
             TokenTypes.COMPACT_CTOR_DEF,
         };
-        assertWithMessage("Default acceptable tokens are invalid").that(actual).isEqualTo(expected);
+        assertWithMessage("Default acceptable tokens are invalid")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/PackageAnnotationCheckTest.java
@@ -52,7 +52,9 @@ public class PackageAnnotationCheckTest extends AbstractModuleTestSupport {
         final PackageAnnotationCheck constantNameCheckObj = new PackageAnnotationCheck();
         final int[] actual = constantNameCheckObj.getAcceptableTokens();
         final int[] expected = {TokenTypes.PACKAGE_DEF};
-        assertWithMessage("Invalid acceptable tokens").that(actual).isEqualTo(expected);
+        assertWithMessage("Invalid acceptable tokens")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheckTest.java
@@ -39,7 +39,8 @@ public class AvoidNestedBlocksCheckTest
     public void testGetRequiredTokens() {
         final AvoidNestedBlocksCheck checkObj = new AvoidNestedBlocksCheck();
         final int[] expected = {TokenTypes.SLIST};
-        assertWithMessage("Default required tokens are invalid").that(checkObj.getRequiredTokens())
+        assertWithMessage("Default required tokens are invalid")
+                .that(checkObj.getRequiredTokens())
                 .isEqualTo(expected);
     }
 
@@ -74,8 +75,9 @@ public class AvoidNestedBlocksCheckTest
         final AvoidNestedBlocksCheck constantNameCheckObj = new AvoidNestedBlocksCheck();
         final int[] actual = constantNameCheckObj.getAcceptableTokens();
         final int[] expected = {TokenTypes.SLIST };
-        assertWithMessage("Default acceptable tokens are invalid").that(actual)
-            .isEqualTo(expected);
+        assertWithMessage("Default acceptable tokens are invalid")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheckTest.java
@@ -38,7 +38,8 @@ public class EmptyCatchBlockCheckTest extends AbstractModuleTestSupport {
     public void testGetRequiredTokens() {
         final EmptyCatchBlockCheck checkObj = new EmptyCatchBlockCheck();
         final int[] expected = {TokenTypes.LITERAL_CATCH};
-        assertWithMessage("Default required tokens are invalid").that(checkObj.getRequiredTokens())
+        assertWithMessage("Default required tokens are invalid")
+                .that(checkObj.getRequiredTokens())
                 .isEqualTo(expected);
     }
 
@@ -96,7 +97,9 @@ public class EmptyCatchBlockCheckTest extends AbstractModuleTestSupport {
         final EmptyCatchBlockCheck constantNameCheckObj = new EmptyCatchBlockCheck();
         final int[] actual = constantNameCheckObj.getAcceptableTokens();
         final int[] expected = {TokenTypes.LITERAL_CATCH };
-        assertWithMessage("Default acceptable tokens are invalid").that(actual).isEqualTo(expected);
+        assertWithMessage("Default acceptable tokens are invalid")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheckTest.java
@@ -50,10 +50,15 @@ public class ArrayTrailingCommaCheckTest
     @Test
     public void testTokensNotNull() {
         final ArrayTrailingCommaCheck check = new ArrayTrailingCommaCheck();
-        assertWithMessage("Invalid acceptable tokens").that(check.getAcceptableTokens())
+        assertWithMessage("Invalid acceptable tokens")
+                .that(check.getAcceptableTokens())
                 .isNotNull();
-        assertWithMessage("Invalid default tokens").that(check.getDefaultTokens()).isNotNull();
-        assertWithMessage("Invalid required tokens").that(check.getRequiredTokens()).isNotNull();
+        assertWithMessage("Invalid default tokens")
+                .that(check.getDefaultTokens())
+                .isNotNull();
+        assertWithMessage("Invalid required tokens")
+                .that(check.getRequiredTokens())
+                .isNotNull();
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidDoubleBraceInitializationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidDoubleBraceInitializationCheckTest.java
@@ -65,9 +65,11 @@ public class AvoidDoubleBraceInitializationCheckTest extends AbstractModuleTestS
         };
         assertWithMessage("Acceptable required tokens are invalid")
                 .that(check.getAcceptableTokens()).isEqualTo(expected);
-        assertWithMessage("Default required tokens are invalid").that(check.getDefaultTokens())
+        assertWithMessage("Default required tokens are invalid")
+                .that(check.getDefaultTokens())
                 .isEqualTo(expected);
-        assertWithMessage("Required required tokens are invalid").that(check.getRequiredTokens())
+        assertWithMessage("Required required tokens are invalid")
+                .that(check.getRequiredTokens())
                 .isEqualTo(expected);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidInlineConditionalsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidInlineConditionalsCheckTest.java
@@ -49,11 +49,14 @@ public class AvoidInlineConditionalsCheckTest
     @Test
     public void testTokensNotNull() {
         final AvoidInlineConditionalsCheck check = new AvoidInlineConditionalsCheck();
-        assertWithMessage("Acceptable tokens should not be null").that(check.getAcceptableTokens())
+        assertWithMessage("Acceptable tokens should not be null")
+                .that(check.getAcceptableTokens())
                 .isNotNull();
-        assertWithMessage("Default tokens should not be null").that(check.getDefaultTokens())
+        assertWithMessage("Default tokens should not be null")
+                .that(check.getDefaultTokens())
                 .isNotNull();
-        assertWithMessage("Required tokens should not be null").that(check.getRequiredTokens())
+        assertWithMessage("Required tokens should not be null")
+                .that(check.getRequiredTokens())
                 .isNotNull();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidNoArgumentSuperConstructorCallCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidNoArgumentSuperConstructorCallCheckTest.java
@@ -57,10 +57,13 @@ public class AvoidNoArgumentSuperConstructorCallCheckTest
             TokenTypes.SUPER_CTOR_CALL,
         };
         assertWithMessage("Acceptable required tokens are invalid")
-                .that(check.getAcceptableTokens()).isEqualTo(expected);
-        assertWithMessage("Default required tokens are invalid").that(check.getDefaultTokens())
+                .that(check.getAcceptableTokens())
                 .isEqualTo(expected);
-        assertWithMessage("Required required tokens are invalid").that(check.getRequiredTokens())
+        assertWithMessage("Default required tokens are invalid")
+                .that(check.getDefaultTokens())
+                .isEqualTo(expected);
+        assertWithMessage("Required required tokens are invalid")
+                .that(check.getRequiredTokens())
                 .isEqualTo(expected);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/CovariantEqualsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/CovariantEqualsCheckTest.java
@@ -63,11 +63,14 @@ public class CovariantEqualsCheckTest
     @Test
     public void testTokensNotNull() {
         final CovariantEqualsCheck check = new CovariantEqualsCheck();
-        assertWithMessage("Acceptable tokens should not be null").that(check.getAcceptableTokens())
+        assertWithMessage("Acceptable tokens should not be null")
+                .that(check.getAcceptableTokens())
                 .isNotNull();
-        assertWithMessage("Default tokens should not be null").that(check.getDefaultTokens())
+        assertWithMessage("Default tokens should not be null")
+                .that(check.getDefaultTokens())
                 .isNotNull();
-        assertWithMessage("Required tokens should not be null").that(check.getRequiredTokens())
+        assertWithMessage("Required tokens should not be null")
+                .that(check.getRequiredTokens())
                 .isNotNull();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/DefaultComesLastCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/DefaultComesLastCheckTest.java
@@ -112,11 +112,14 @@ public class DefaultComesLastCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testTokensNotNull() {
         final DefaultComesLastCheck check = new DefaultComesLastCheck();
-        assertWithMessage("Acceptable tokens should not be null").that(check.getAcceptableTokens())
+        assertWithMessage("Acceptable tokens should not be null")
+                .that(check.getAcceptableTokens())
                 .isNotNull();
-        assertWithMessage("Default tokens should not be null").that(check.getDefaultTokens())
+        assertWithMessage("Default tokens should not be null")
+                .that(check.getDefaultTokens())
                 .isNotNull();
-        assertWithMessage("Required tokens should not be null").that(check.getRequiredTokens())
+        assertWithMessage("Required tokens should not be null")
+                .that(check.getRequiredTokens())
                 .isNotNull();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/EmptyStatementCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/EmptyStatementCheckTest.java
@@ -63,11 +63,14 @@ public class EmptyStatementCheckTest
     @Test
     public void testTokensNotNull() {
         final EmptyStatementCheck check = new EmptyStatementCheck();
-        assertWithMessage("Acceptable tokens should not be null").that(check.getAcceptableTokens())
+        assertWithMessage("Acceptable tokens should not be null")
+                .that(check.getAcceptableTokens())
                 .isNotNull();
-        assertWithMessage("Default tokens should not be null").that(check.getDefaultTokens())
+        assertWithMessage("Default tokens should not be null")
+                .that(check.getDefaultTokens())
                 .isNotNull();
-        assertWithMessage("Required tokens should not be null").that(check.getRequiredTokens())
+        assertWithMessage("Required tokens should not be null")
+                .that(check.getRequiredTokens())
                 .isNotNull();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheckTest.java
@@ -246,11 +246,14 @@ public class EqualsAvoidNullCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testTokensNotNull() {
         final EqualsAvoidNullCheck check = new EqualsAvoidNullCheck();
-        assertWithMessage("Acceptable tokens should not be null").that(check.getAcceptableTokens())
+        assertWithMessage("Acceptable tokens should not be null")
+                .that(check.getAcceptableTokens())
                 .isNotNull();
-        assertWithMessage("Default tokens should not be null").that(check.getDefaultTokens())
+        assertWithMessage("Default tokens should not be null")
+                .that(check.getDefaultTokens())
                 .isNotNull();
-        assertWithMessage("Required tokens should not be null").that(check.getRequiredTokens())
+        assertWithMessage("Required tokens should not be null")
+                .that(check.getRequiredTokens())
                 .isNotNull();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocPackageCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocPackageCheckTest.java
@@ -144,9 +144,11 @@ public class MissingJavadocPackageCheckTest extends AbstractModuleTestSupport {
         };
         assertWithMessage("Acceptable required tokens are invalid")
                 .that(check.getAcceptableTokens()).isEqualTo(expected);
-        assertWithMessage("Default required tokens are invalid").that(check.getDefaultTokens())
+        assertWithMessage("Default required tokens are invalid")
+                .that(check.getDefaultTokens())
                 .isEqualTo(expected);
-        assertWithMessage("Required required tokens are invalid").that(check.getRequiredTokens())
+        assertWithMessage("Required required tokens are invalid")
+                .that(check.getRequiredTokens())
                 .isEqualTo(expected);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckTest.java
@@ -56,7 +56,9 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
             TokenTypes.RECORD_DEF,
         };
 
-        assertWithMessage("Default acceptable tokens are invalid").that(actual).isEqualTo(expected);
+        assertWithMessage("Default acceptable tokens are invalid")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/RequireEmptyLineBeforeBlockTagGroupCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/RequireEmptyLineBeforeBlockTagGroupCheckTest.java
@@ -41,8 +41,9 @@ public class RequireEmptyLineBeforeBlockTagGroupCheckTest extends AbstractModule
         final RequireEmptyLineBeforeBlockTagGroupCheck checkObj =
                 new RequireEmptyLineBeforeBlockTagGroupCheck();
         final int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN};
-        assertWithMessage("Default required tokens are invalid").that(checkObj.getRequiredTokens())
-            .isEqualTo(expected);
+        assertWithMessage("Default required tokens are invalid")
+                .that(checkObj.getRequiredTokens())
+                .isEqualTo(expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheckTest.java
@@ -46,8 +46,9 @@ public class SingleLineJavadocCheckTest extends AbstractModuleTestSupport {
     public void testGetRequiredTokens() {
         final SingleLineJavadocCheck checkObj = new SingleLineJavadocCheck();
         final int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN };
-        assertWithMessage("Default required tokens are invalid").that(checkObj.getRequiredTokens())
-            .isEqualTo(expected);
+        assertWithMessage("Default required tokens are invalid")
+                .that(checkObj.getRequiredTokens())
+                .isEqualTo(expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
@@ -42,8 +42,9 @@ public class SummaryJavadocCheckTest extends AbstractModuleTestSupport {
     public void testGetRequiredTokens() {
         final SummaryJavadocCheck checkObj = new SummaryJavadocCheck();
         final int[] expected = {TokenTypes.BLOCK_COMMENT_BEGIN };
-        assertWithMessage("Default required tokens are invalid").that(checkObj.getRequiredTokens())
-            .isEqualTo(expected);
+        assertWithMessage("Default required tokens are invalid")
+                .that(checkObj.getRequiredTokens())
+                .isEqualTo(expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheckTest.java
@@ -257,10 +257,13 @@ public class WriteTagCheckTest extends AbstractModuleTestSupport {
             for (int i = 0; i < expected.length; i++) {
                 final String expectedResult = messageFileName + ":" + expected[i];
                 final String actual = lnr.readLine();
-                assertWithMessage("error message " + i).that(actual).isEqualTo(expectedResult);
+                assertWithMessage("error message " + i)
+                        .that(actual)
+                        .isEqualTo(expectedResult);
             }
 
-            assertWithMessage("unexpected output: " + lnr.readLine()).that(errs)
+            assertWithMessage("unexpected output: " + lnr.readLine())
+                    .that(errs)
                     .isAtMost(expected.length);
         }
         checker.destroy();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheckTest.java
@@ -40,8 +40,9 @@ public class PackageNameCheckTest
     public void testGetRequiredTokens() {
         final PackageNameCheck checkObj = new PackageNameCheck();
         final int[] expected = {TokenTypes.PACKAGE_DEF};
-        assertWithMessage("Default required tokens are invalid").that(checkObj.getRequiredTokens())
-            .isEqualTo(expected);
+        assertWithMessage("Default required tokens are invalid")
+                .that(checkObj.getRequiredTokens())
+                .isEqualTo(expected);
     }
 
     @Test
@@ -73,7 +74,9 @@ public class PackageNameCheckTest
         final int[] expected = {
             TokenTypes.PACKAGE_DEF,
         };
-        assertWithMessage("Default acceptable tokens are invalid").that(actual).isEqualTo(expected);
+        assertWithMessage("Default acceptable tokens are invalid")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
@@ -40,8 +40,9 @@ public class ParameterNameCheckTest
     public void testGetRequiredTokens() {
         final ParameterNameCheck checkObj = new ParameterNameCheck();
         final int[] expected = {TokenTypes.PARAMETER_DEF};
-        assertWithMessage("Default required tokens are invalid").that(checkObj.getRequiredTokens())
-            .isEqualTo(expected);
+        assertWithMessage("Default required tokens are invalid")
+                .that(checkObj.getRequiredTokens())
+                .isEqualTo(expected);
     }
 
     @Test
@@ -82,7 +83,9 @@ public class ParameterNameCheckTest
         final int[] expected = {
             TokenTypes.PARAMETER_DEF,
         };
-        assertWithMessage("Default acceptable tokens are invalid").that(actual).isEqualTo(expected);
+        assertWithMessage("Default acceptable tokens are invalid")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/RecordComponentNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/RecordComponentNameCheckTest.java
@@ -39,8 +39,9 @@ public class RecordComponentNameCheckTest extends AbstractModuleTestSupport {
         final RecordComponentNameCheck checkObj =
                 new RecordComponentNameCheck();
         final int[] expected = {TokenTypes.RECORD_COMPONENT_DEF};
-        assertWithMessage("Default required tokens are invalid").that(checkObj.getRequiredTokens())
-            .isEqualTo(expected);
+        assertWithMessage("Default required tokens are invalid")
+                .that(checkObj.getRequiredTokens())
+                .isEqualTo(expected);
     }
 
     @Test
@@ -83,6 +84,8 @@ public class RecordComponentNameCheckTest extends AbstractModuleTestSupport {
         final int[] expected = {
             TokenTypes.RECORD_COMPONENT_DEF,
         };
-        assertWithMessage("Default acceptable tokens are invalid").that(actual).isEqualTo(expected);
+        assertWithMessage("Default acceptable tokens are invalid")
+                .that(actual)
+                .isEqualTo(expected);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/RecordTypeParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/RecordTypeParameterNameCheckTest.java
@@ -39,7 +39,8 @@ public class RecordTypeParameterNameCheckTest extends AbstractModuleTestSupport 
         final RecordTypeParameterNameCheck checkObj =
                 new RecordTypeParameterNameCheck();
         final int[] expected = {TokenTypes.TYPE_PARAMETER};
-        assertWithMessage("Default required tokens are invalid").that(checkObj.getRequiredTokens())
+        assertWithMessage("Default required tokens are invalid")
+                .that(checkObj.getRequiredTokens())
                 .isEqualTo(expected);
     }
 
@@ -81,6 +82,8 @@ public class RecordTypeParameterNameCheckTest extends AbstractModuleTestSupport 
         final int[] expected = {
             TokenTypes.TYPE_PARAMETER,
         };
-        assertWithMessage("Default acceptable tokens are invalid").that(actual).isEqualTo(expected);
+        assertWithMessage("Default acceptable tokens are invalid")
+                .that(actual)
+                .isEqualTo(expected);
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/StaticVariableNameCheckTest.java
@@ -40,7 +40,8 @@ public class StaticVariableNameCheckTest
     public void testGetRequiredTokens() {
         final StaticVariableNameCheck checkObj = new StaticVariableNameCheck();
         final int[] expected = {TokenTypes.VARIABLE_DEF};
-        assertWithMessage("Default required tokens are invalid").that(checkObj.getRequiredTokens())
+        assertWithMessage("Default required tokens are invalid")
+                .that(checkObj.getRequiredTokens())
                 .isEqualTo(expected);
     }
 
@@ -80,8 +81,8 @@ public class StaticVariableNameCheckTest
         final int[] expected = {
             TokenTypes.VARIABLE_DEF,
         };
-        assertWithMessage("Default acceptable tokens are invalid").that(actual)
-            .isEqualTo(expected);
+        assertWithMessage("Default acceptable tokens are invalid")
+                .that(actual).isEqualTo(expected);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckTest.java
@@ -149,7 +149,8 @@ public class RegexpMultilineCheckTest extends AbstractModuleTestSupport {
 
         detector.processLines(new FileText(file, StandardCharsets.UTF_8.name()));
         detector.processLines(new FileText(file, StandardCharsets.UTF_8.name()));
-        assertWithMessage("Logged unexpected amount of issues").that(reporter.getLogCount())
+        assertWithMessage("Logged unexpected amount of issues")
+                .that(reporter.getLogCount())
                 .isEqualTo(2);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheckTest.java
@@ -125,7 +125,8 @@ public class RegexpSinglelineCheckTest extends AbstractModuleTestSupport {
 
         detector.processLines(new FileText(file, StandardCharsets.UTF_8.name()));
         detector.processLines(new FileText(file, StandardCharsets.UTF_8.name()));
-        assertWithMessage("Logged unexpected amount of issues").that(reporter.getLogCount())
+        assertWithMessage("Logged unexpected amount of issues")
+                .that(reporter.getLogCount())
                 .isEqualTo(0);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheckTest.java
@@ -47,7 +47,8 @@ public class RegexpSinglelineJavaCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testGetRequiredTokens() {
         final RegexpSinglelineJavaCheck checkObj = new RegexpSinglelineJavaCheck();
-        assertWithMessage("Default required tokens are invalid").that(checkObj.getRequiredTokens())
+        assertWithMessage("Default required tokens are invalid")
+                .that(checkObj.getRequiredTokens())
                 .isEmpty();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCaseDefaultColonCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCaseDefaultColonCheckTest.java
@@ -83,7 +83,8 @@ public class NoWhitespaceBeforeCaseDefaultColonCheckTest
     public void testAcceptableTokenIsColon() {
         final NoWhitespaceBeforeCaseDefaultColonCheck check =
                 new NoWhitespaceBeforeCaseDefaultColonCheck();
-        assertWithMessage("Acceptable token should be colon").that(new int[] {TokenTypes.COLON})
+        assertWithMessage("Acceptable token should be colon")
+                .that(new int[] {TokenTypes.COLON})
                 .isEqualTo(check.getAcceptableTokens());
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheckTest.java
@@ -337,8 +337,9 @@ public class WhitespaceAroundCheckTest
             TokenTypes.GENERIC_END,
             TokenTypes.ELLIPSIS,
         };
-        assertWithMessage("Default acceptable tokens are invalid").that(actual)
-            .isEqualTo(expected);
+        assertWithMessage("Default acceptable tokens are invalid")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filefilters/BeforeExecutionExclusionFileFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filefilters/BeforeExecutionExclusionFileFilterTest.java
@@ -43,7 +43,8 @@ public class BeforeExecutionExclusionFileFilterTest extends AbstractModuleTestSu
         final BeforeExecutionExclusionFileFilter filter =
                 createExclusionBeforeExecutionFileFilter(fileName);
 
-        assertWithMessage("Should accept if file does not exist").that(filter.accept("ATest.java"))
+        assertWithMessage("Should accept if file does not exist")
+                .that(filter.accept("ATest.java"))
                 .isTrue();
     }
 
@@ -53,7 +54,8 @@ public class BeforeExecutionExclusionFileFilterTest extends AbstractModuleTestSu
         final BeforeExecutionExclusionFileFilter filter =
                 createExclusionBeforeExecutionFileFilter(fileName);
 
-        assertWithMessage("Should accept if file is null").that(filter.accept("AnyJava.java"))
+        assertWithMessage("Should accept if file is null")
+                .that(filter.accept("AnyJava.java"))
                 .isTrue();
     }
 
@@ -63,7 +65,8 @@ public class BeforeExecutionExclusionFileFilterTest extends AbstractModuleTestSu
         final BeforeExecutionExclusionFileFilter filter =
                 createExclusionBeforeExecutionFileFilter(fileName);
 
-        assertWithMessage("Should reject file, but did not").that(filter.accept("ATest.java"))
+        assertWithMessage("Should reject file, but did not")
+                .that(filter.accept("ATest.java"))
                 .isFalse();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/CsvFilterElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/CsvFilterElementTest.java
@@ -31,55 +31,103 @@ public class CsvFilterElementTest {
     @Test
     public void testDecideSingle() {
         final IntFilterElement filter = new CsvFilterElement("0");
-        assertWithMessage("less than").that(filter.accept(-1)).isFalse();
-        assertWithMessage("equal").that(filter.accept(0)).isTrue();
-        assertWithMessage("greater than").that(filter.accept(1)).isFalse();
+        assertWithMessage("less than")
+                .that(filter.accept(-1))
+                .isFalse();
+        assertWithMessage("equal")
+                .that(filter.accept(0))
+                .isTrue();
+        assertWithMessage("greater than")
+                .that(filter.accept(1))
+                .isFalse();
     }
 
     @Test
     public void testDecidePair() {
         final IntFilterElement filter = new CsvFilterElement("0, 2");
-        assertWithMessage("less than").that(filter.accept(-1)).isFalse();
-        assertWithMessage("equal 0").that(filter.accept(0)).isTrue();
-        assertWithMessage("greater than").that(filter.accept(1)).isFalse();
-        assertWithMessage("equal 2").that(filter.accept(2)).isTrue();
+        assertWithMessage("less than")
+                .that(filter.accept(-1))
+                .isFalse();
+        assertWithMessage("equal 0")
+                .that(filter.accept(0))
+                .isTrue();
+        assertWithMessage("greater than")
+                .that(filter.accept(1))
+                .isFalse();
+        assertWithMessage("equal 2")
+                .that(filter.accept(2))
+                .isTrue();
     }
 
     @Test
     public void testDecideRange() {
         final IntFilterElement filter = new CsvFilterElement("0-2");
-        assertWithMessage("less than").that(filter.accept(-1)).isFalse();
-        assertWithMessage("equal 0").that(filter.accept(0)).isTrue();
-        assertWithMessage("equal 1").that(filter.accept(1)).isTrue();
-        assertWithMessage("equal 2").that(filter.accept(2)).isTrue();
-        assertWithMessage("greater than").that(filter.accept(3)).isFalse();
+        assertWithMessage("less than")
+                .that(filter.accept(-1))
+                .isFalse();
+        assertWithMessage("equal 0")
+                .that(filter.accept(0))
+                .isTrue();
+        assertWithMessage("equal 1")
+                .that(filter.accept(1))
+                .isTrue();
+        assertWithMessage("equal 2")
+                .that(filter.accept(2))
+                .isTrue();
+        assertWithMessage("greater than")
+                .that(filter.accept(3))
+                .isFalse();
     }
 
     @Test
     public void testDecideEmptyRange() {
         final IntFilterElement filter = new CsvFilterElement("2-0");
-        assertWithMessage("less than").that(filter.accept(-1)).isFalse();
-        assertWithMessage("equal 0").that(filter.accept(0)).isFalse();
-        assertWithMessage("equal 1").that(filter.accept(1)).isFalse();
-        assertWithMessage("equal 2").that(filter.accept(2)).isFalse();
-        assertWithMessage("greater than").that(filter.accept(3)).isFalse();
+        assertWithMessage("less than")
+                .that(filter.accept(-1))
+                .isFalse();
+        assertWithMessage("equal 0")
+                .that(filter.accept(0))
+                .isFalse();
+        assertWithMessage("equal 1")
+                .that(filter.accept(1))
+                .isFalse();
+        assertWithMessage("equal 2")
+                .that(filter.accept(2))
+                .isFalse();
+        assertWithMessage("greater than")
+                .that(filter.accept(3))
+                .isFalse();
     }
 
     @Test
     public void testDecideRangePlusValue() {
         final IntFilterElement filter = new CsvFilterElement("0-2, 10");
-        assertWithMessage("less than").that(filter.accept(-1)).isFalse();
-        assertWithMessage("equal 0").that(filter.accept(0)).isTrue();
-        assertWithMessage("equal 1").that(filter.accept(1)).isTrue();
-        assertWithMessage("equal 2").that(filter.accept(2)).isTrue();
-        assertWithMessage("greater than").that(filter.accept(3)).isFalse();
-        assertWithMessage("equal 10").that(filter.accept(10)).isTrue();
+        assertWithMessage("less than")
+                .that(filter.accept(-1))
+                .isFalse();
+        assertWithMessage("equal 0")
+                .that(filter.accept(0))
+                .isTrue();
+        assertWithMessage("equal 1")
+                .that(filter.accept(1))
+                .isTrue();
+        assertWithMessage("equal 2")
+                .that(filter.accept(2))
+                .isTrue();
+        assertWithMessage("greater than")
+                .that(filter.accept(3))
+                .isFalse();
+        assertWithMessage("equal 10")
+                .that(filter.accept(10))
+                .isTrue();
     }
 
     @Test
     public void testEmptyChain() {
         final CsvFilterElement filter = new CsvFilterElement("");
-        assertWithMessage("0").that(filter.accept(0)).isFalse();
+        assertWithMessage("0")
+                .that(filter.accept(0))
+                .isFalse();
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilterElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilterElementTest.java
@@ -31,9 +31,15 @@ public class IntMatchFilterElementTest {
     @Test
     public void testDecide() {
         final IntFilterElement filter = new IntMatchFilterElement(0);
-        assertWithMessage("less than").that(filter.accept(-1)).isFalse();
-        assertWithMessage("equal").that(filter.accept(0)).isTrue();
-        assertWithMessage("greater than").that(filter.accept(1)).isFalse();
+        assertWithMessage("less than")
+                .that(filter.accept(-1))
+                .isFalse();
+        assertWithMessage("equal")
+                .that(filter.accept(0))
+                .isTrue();
+        assertWithMessage("greater than")
+                .that(filter.accept(1))
+                .isFalse();
     }
 
     @Test
@@ -48,7 +54,8 @@ public class IntMatchFilterElementTest {
     @Test
     public void testToString() {
         final IntFilterElement filter = new IntMatchFilterElement(6);
-        assertWithMessage("Invalid toString result").that(filter.toString())
+        assertWithMessage("Invalid toString result")
+                .that(filter.toString())
                 .isEqualTo("IntMatchFilterElement[6]");
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilterElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilterElementTest.java
@@ -31,29 +31,55 @@ public class IntRangeFilterElementTest {
     @Test
     public void testDecide() {
         final IntFilterElement filter = new IntRangeFilterElement(0, 10);
-        assertWithMessage("less than").that(filter.accept(-1)).isFalse();
-        assertWithMessage("in range").that(filter.accept(0)).isTrue();
-        assertWithMessage("in range").that(filter.accept(5)).isTrue();
-        assertWithMessage("in range").that(filter.accept(10)).isTrue();
-        assertWithMessage("greater than").that(filter.accept(11)).isFalse();
+        assertWithMessage("less than")
+                .that(filter.accept(-1))
+                .isFalse();
+        assertWithMessage("in range")
+                .that(filter.accept(0))
+                .isTrue();
+        assertWithMessage("in range")
+                .that(filter.accept(5))
+                .isTrue();
+        assertWithMessage("in range")
+                .that(filter.accept(10))
+                .isTrue();
+        assertWithMessage("greater than")
+                .that(filter.accept(11))
+                .isFalse();
     }
 
     @Test
     public void testDecideSingle() {
         final IntFilterElement filter = new IntRangeFilterElement(0, 0);
-        assertWithMessage("less than").that(filter.accept(-1)).isFalse();
-        assertWithMessage("in range").that(filter.accept(0)).isTrue();
-        assertWithMessage("greater than").that(filter.accept(1)).isFalse();
+        assertWithMessage("less than")
+                .that(filter.accept(-1))
+                .isFalse();
+        assertWithMessage("in range")
+                .that(filter.accept(0))
+                .isTrue();
+        assertWithMessage("greater than")
+                .that(filter.accept(1))
+                .isFalse();
     }
 
     @Test
     public void testDecideEmpty() {
         final IntFilterElement filter = new IntRangeFilterElement(10, 0);
-        assertWithMessage("out").that(filter.accept(-1)).isFalse();
-        assertWithMessage("out").that(filter.accept(0)).isFalse();
-        assertWithMessage("out").that(filter.accept(5)).isFalse();
-        assertWithMessage("out").that(filter.accept(10)).isFalse();
-        assertWithMessage("out").that(filter.accept(11)).isFalse();
+        assertWithMessage("out")
+                .that(filter.accept(-1))
+                .isFalse();
+        assertWithMessage("out")
+                .that(filter.accept(0))
+                .isFalse();
+        assertWithMessage("out")
+                .that(filter.accept(5))
+                .isFalse();
+        assertWithMessage("out")
+                .that(filter.accept(10))
+                .isFalse();
+        assertWithMessage("out")
+                .that(filter.accept(11))
+                .isFalse();
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/CodeSelectorPresentationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/CodeSelectorPresentationTest.java
@@ -80,9 +80,11 @@ public class CodeSelectorPresentationTest extends AbstractPathTestSupport {
         final CodeSelectorPresentation selector = new CodeSelectorPresentation(tree,
                 linesToPosition);
         selector.findSelectionPositions();
-        assertWithMessage("Invalid selection start").that(selector.getSelectionStart())
+        assertWithMessage("Invalid selection start")
+                .that(selector.getSelectionStart())
                 .isEqualTo(94);
-        assertWithMessage("Invalid selection end").that(selector.getSelectionEnd()).isEqualTo(279);
+        assertWithMessage("Invalid selection end")
+                .that(selector.getSelectionEnd()).isEqualTo(279);
     }
 
     @Test
@@ -91,9 +93,12 @@ public class CodeSelectorPresentationTest extends AbstractPathTestSupport {
         final CodeSelectorPresentation selector = new CodeSelectorPresentation(leaf,
                 linesToPosition);
         selector.findSelectionPositions();
-        assertWithMessage("Invalid selection start").that(selector.getSelectionStart())
+        assertWithMessage("Invalid selection start")
+                .that(selector.getSelectionStart())
                 .isEqualTo(130);
-        assertWithMessage("Invalid selection end").that(selector.getSelectionEnd()).isEqualTo(131);
+        assertWithMessage("Invalid selection end")
+                .that(selector.getSelectionEnd())
+                .isEqualTo(131);
     }
 
     @Test
@@ -102,9 +107,12 @@ public class CodeSelectorPresentationTest extends AbstractPathTestSupport {
         final CodeSelectorPresentation selector = new CodeSelectorPresentation(leaf,
                 linesToPosition);
         selector.findSelectionPositions();
-        assertWithMessage("Invalid selection start").that(selector.getSelectionStart())
+        assertWithMessage("Invalid selection start")
+                .that(selector.getSelectionStart())
                 .isEqualTo(94);
-        assertWithMessage("Invalid selection end").that(selector.getSelectionEnd()).isEqualTo(94);
+        assertWithMessage("Invalid selection end")
+                .that(selector.getSelectionEnd())
+                .isEqualTo(94);
     }
 
     @Test
@@ -114,9 +122,12 @@ public class CodeSelectorPresentationTest extends AbstractPathTestSupport {
         final CodeSelectorPresentation selector = new CodeSelectorPresentation(javadoc,
                 linesToPosition);
         selector.findSelectionPositions();
-        assertWithMessage("Invalid selection start").that(selector.getSelectionStart())
+        assertWithMessage("Invalid selection start")
+                .that(selector.getSelectionStart())
                 .isEqualTo(74);
-        assertWithMessage("Invalid selection end").that(selector.getSelectionEnd()).isEqualTo(96);
+        assertWithMessage("Invalid selection end")
+                .that(selector.getSelectionEnd())
+                .isEqualTo(96);
     }
 
     @Test
@@ -127,9 +138,12 @@ public class CodeSelectorPresentationTest extends AbstractPathTestSupport {
         final CodeSelectorPresentation selector = new CodeSelectorPresentation(javadocLeaf,
                 linesToPosition);
         selector.findSelectionPositions();
-        assertWithMessage("Invalid selection start").that(selector.getSelectionStart())
+        assertWithMessage("Invalid selection start")
+                .that(selector.getSelectionStart())
                 .isEqualTo(76);
-        assertWithMessage("Invalid selection end").that(selector.getSelectionEnd()).isEqualTo(90);
+        assertWithMessage("Invalid selection end")
+                .that(selector.getSelectionEnd())
+                .isEqualTo(90);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
@@ -139,23 +139,31 @@ public class CommitValidationTest {
 
     @Test
     public void testSupplementalPrefix() {
-        assertWithMessage("should accept commit message with supplemental prefix").that(0)
+        assertWithMessage("should accept commit message with supplemental prefix")
+                .that(0)
                 .isEqualTo(validateCommitMessage("supplemental: Test message for supplemental for"
                         + " Issue #XXXX"));
         assertWithMessage("should not accept commit message with periods on end")
-                .that(3).isEqualTo(validateCommitMessage("supplemental: Test. Test."));
+                .that(3)
+                .isEqualTo(validateCommitMessage("supplemental: Test. Test."));
         assertWithMessage("should not accept commit message with spaces on end")
-                .that(3).isEqualTo(validateCommitMessage("supplemental: Test. "));
+                .that(3)
+                .isEqualTo(validateCommitMessage("supplemental: Test. "));
         assertWithMessage("should not accept commit message with tabs on end")
-                .that(3).isEqualTo(validateCommitMessage("supplemental: Test.\t"));
+                .that(3)
+                .isEqualTo(validateCommitMessage("supplemental: Test.\t"));
         assertWithMessage("should not accept commit message with period on end, ignoring new line")
-                .that(3).isEqualTo(validateCommitMessage("supplemental: Test.\n"));
+                .that(3)
+                .isEqualTo(validateCommitMessage("supplemental: Test.\n"));
         assertWithMessage("should not accept commit message with multiple lines with text")
-                .that(2).isEqualTo(validateCommitMessage("supplemental: Test.\nTest"));
+                .that(2)
+                .isEqualTo(validateCommitMessage("supplemental: Test.\nTest"));
         assertWithMessage("should accept commit message with a new line on end")
-                .that(0).isEqualTo(validateCommitMessage("supplemental: Test\n"));
+                .that(0)
+                .isEqualTo(validateCommitMessage("supplemental: Test\n"));
         assertWithMessage("should accept commit message with multiple new lines on end")
-                .that(0).isEqualTo(validateCommitMessage("supplemental: Test\n\n"));
+                .that(0)
+                .isEqualTo(validateCommitMessage("supplemental: Test\n\n"));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsMobileWrapperTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsMobileWrapperTest.java
@@ -56,7 +56,9 @@ public class XdocsMobileWrapperTest {
             final String fileName = file.getName();
 
             final String input = new String(Files.readAllBytes(path), UTF_8);
-            assertWithMessage(fileName + ": input file cannot be empty").that(input).isNotEmpty();
+            assertWithMessage(fileName + ": input file cannot be empty")
+                    .that(input)
+                    .isNotEmpty();
             final Document document = XmlUtil.getRawXml(fileName, input, input);
             final NodeList sources = document.getElementsByTagName("section");
 
@@ -82,11 +84,16 @@ public class XdocsMobileWrapperTest {
                 assertWithMessage(wrapperMessage)
                         .that("div".equals(node.getNodeName()) || "span".equals(node.getNodeName()))
                         .isTrue();
-                assertWithMessage(wrapperMessage).that(node.hasAttributes()).isTrue();
-                assertWithMessage(wrapperMessage).that(node.getAttributes().getNamedItem("class"))
+                assertWithMessage(wrapperMessage)
+                        .that(node.hasAttributes())
+                        .isTrue();
+                assertWithMessage(wrapperMessage)
+                        .that(node.getAttributes().getNamedItem("class"))
                         .isNotNull();
-                assertWithMessage(wrapperMessage).that(node.getAttributes().getNamedItem("class")
-                        .getNodeValue().contains("wrapper")).isTrue();
+                assertWithMessage(wrapperMessage)
+                        .that(node.getAttributes().getNamedItem("class")
+                                .getNodeValue().contains("wrapper"))
+                        .isTrue();
 
                 if ("table".equals(child.getNodeName())) {
                     iterateNode(child, fileName, sectionName);
@@ -95,8 +102,9 @@ public class XdocsMobileWrapperTest {
                     final String dataImageInlineMessage = fileName + "/" + sectionName + ": img "
                             + "needs the additional class inline if it should be displayed inline "
                             + "or block if scrolling in mobile view should be enabled.";
-                    assertWithMessage(dataImageInlineMessage).that(node.getAttributes()
-                            .getNamedItem("class").getNodeValue().matches(".*(block|inline).*"))
+                    assertWithMessage(dataImageInlineMessage)
+                            .that(node.getAttributes().getNamedItem("class")
+                                    .getNodeValue().matches(".*(block|inline).*"))
                             .isTrue();
                 }
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsUrlTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsUrlTest.java
@@ -122,22 +122,30 @@ public class XdocsUrlTest {
                     checkNameInAttribute, moduleName);
             if (COMMENTS_INDENTATION.equals(checkNameInAttribute)
                     || INDENTATION.equals(checkNameInAttribute)) {
-                assertWithMessage(checkNameModuleErrorMsg).that(moduleName).matches(MISC);
+                assertWithMessage(checkNameModuleErrorMsg)
+                        .that(moduleName)
+                        .matches(MISC);
             }
             else if (SUPPRESS_WARNINGS_HOLDER.equals(checkNameInAttribute)) {
-                assertWithMessage(checkNameModuleErrorMsg).that(moduleName).matches(ANNOTATION);
+                assertWithMessage(checkNameModuleErrorMsg)
+                        .that(moduleName)
+                        .matches(ANNOTATION);
             }
             else {
                 final List<String> moduleFileNames = checksNamesMap.get(moduleName);
                 final String moduleNameErrorMsg = String.format(Locale.ROOT,
                         "module name: '%s' does not exist in '%s'", moduleName, PACKAGE_NAME);
-                assertWithMessage(moduleNameErrorMsg).that(moduleFileNames).isNotNull();
+                assertWithMessage(moduleNameErrorMsg)
+                        .that(moduleFileNames)
+                        .isNotNull();
                 boolean match = false;
                 final String checkNameWithSuffix = checkNameInAttribute + SUFFIX_CHECK;
                 if (moduleFileNames.contains(checkNameWithSuffix)) {
                     match = true;
                 }
-                assertWithMessage(checkNameModuleErrorMsg).that(match).isTrue();
+                assertWithMessage(checkNameModuleErrorMsg)
+                        .that(match)
+                        .isTrue();
             }
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -218,7 +218,8 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
         final Pattern pattern = Pattern.compile("^XpathRegression(.+)Test\\.java$");
         try (DirectoryStream<Path> javaPaths = Files.newDirectoryStream(javaDir)) {
             for (Path path : javaPaths) {
-                assertWithMessage(path + " is not a regular file").that(Files.isRegularFile(path))
+                assertWithMessage(path + " is not a regular file")
+                        .that(Files.isRegularFile(path))
                         .isTrue();
                 final String filename = path.toFile().getName();
                 if (filename.startsWith("Abstract")) {
@@ -227,22 +228,26 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
 
                 final Matcher matcher = pattern.matcher(filename);
                 assertWithMessage(
-                        "Invalid test file: " + filename + ", expected pattern: " + pattern)
-                                .that(matcher.matches()).isTrue();
+                            "Invalid test file: " + filename + ", expected pattern: " + pattern)
+                        .that(matcher.matches())
+                        .isTrue();
 
                 final String check = matcher.group(1);
                 assertWithMessage("Unknown check '" + check + "' in test file: " + filename)
-                        .that(simpleCheckNames.contains(check)).isTrue();
+                        .that(simpleCheckNames.contains(check))
+                        .isTrue();
 
                 assertWithMessage(
-                        "Check '" + check + "' is now tested. Please update the todo list in"
+                            "Check '" + check + "' is now tested. Please update the todo list in"
                                 + " XpathRegressionTest.MISSING_CHECK_NAMES")
-                                        .that(MISSING_CHECK_NAMES.contains(check)).isFalse();
+                        .that(MISSING_CHECK_NAMES.contains(check))
+                        .isFalse();
                 assertWithMessage(
-                        "Check '" + check + "' is now compatible with SuppressionXpathFilter."
+                            "Check '" + check + "' is now compatible with SuppressionXpathFilter."
                                 + " Please update the todo list in"
                                 + " XpathRegressionTest.INCOMPATIBLE_CHECK_NAMES")
-                                        .that(INCOMPATIBLE_CHECK_NAMES.contains(check)).isFalse();
+                        .that(INCOMPATIBLE_CHECK_NAMES.contains(check))
+                        .isFalse();
                 compatibleChecks.add(check);
             }
         }
@@ -267,18 +272,21 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
         try (DirectoryStream<Path> dirs = Files.newDirectoryStream(inputDir)) {
             for (Path dir : dirs) {
                 // input directory must be named in lower case
-                assertWithMessage(dir + " is not a directory").that(Files.isDirectory(dir))
+                assertWithMessage(dir + " is not a directory")
+                        .that(Files.isDirectory(dir))
                         .isTrue();
                 final String dirName = dir.toFile().getName();
                 assertWithMessage("Invalid directory name: " + dirName)
-                        .that(allowedDirectoryAndChecks.containsKey(dirName)).isTrue();
+                        .that(allowedDirectoryAndChecks.containsKey(dirName))
+                        .isTrue();
 
                 // input directory must be connected to an existing test
                 final String check = allowedDirectoryAndChecks.get(dirName);
                 final Path javaPath = javaDir.resolve("XpathRegression" + check + "Test.java");
                 assertWithMessage("Input directory '" + dir
-                        + "' is not connected to Java test case: " + javaPath)
-                                .that(Files.exists(javaPath)).isTrue();
+                            + "' is not connected to Java test case: " + javaPath)
+                        .that(Files.exists(javaPath))
+                        .isTrue();
 
                 // input files should named correctly
                 validateInputDirectory(dir);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPositionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPositionTest.java
@@ -77,7 +77,8 @@ public class BlockCommentPositionTest extends AbstractModuleTestSupport {
             final DetailAST ast = JavaParser.parseFile(new File(getPath(metadata.getFileName())),
                 JavaParser.Options.WITH_COMMENTS);
             final int matches = getJavadocsCount(ast, metadata.getAssertion());
-            assertWithMessage("Invalid javadoc count").that(matches)
+            assertWithMessage("Invalid javadoc count")
+                    .that(matches)
                     .isEqualTo(metadata.getMatchesNum());
         }
     }
@@ -96,7 +97,8 @@ public class BlockCommentPositionTest extends AbstractModuleTestSupport {
                 new File(getNonCompilablePath(metadata.getFileName())),
                     JavaParser.Options.WITH_COMMENTS);
             final int matches = getJavadocsCount(ast, metadata.getAssertion());
-            assertWithMessage("Invalid javadoc count").that(matches)
+            assertWithMessage("Invalid javadoc count")
+                    .that(matches)
                     .isEqualTo(metadata.getMatchesNum());
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/FilterUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/FilterUtilTest.java
@@ -41,7 +41,8 @@ public class FilterUtilTest {
     @Test
     public void testExistingFile() throws Exception {
         final File file = File.createTempFile("junit", null, temporaryFolder);
-        assertWithMessage("Suppression file exists").that(FilterUtil.isFileExists(file.getPath()))
+        assertWithMessage("Suppression file exists")
+                .that(FilterUtil.isFileExists(file.getPath()))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/ParserUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/ParserUtilTest.java
@@ -39,23 +39,36 @@ public class ParserUtilTest {
     public void testCreationOfFakeCommentBlock() {
         final DetailAST testCommentBlock =
             ParserUtil.createBlockCommentNode("test_comment");
-        assertWithMessage("Invalid token type").that(testCommentBlock.getType())
+        assertWithMessage("Invalid token type")
+                .that(testCommentBlock.getType())
                 .isEqualTo(TokenTypes.BLOCK_COMMENT_BEGIN);
-        assertWithMessage("Invalid text").that(testCommentBlock.getText()).isEqualTo("/*");
-        assertWithMessage("Invalid line number").that(testCommentBlock.getLineNo()).isEqualTo(0);
+        assertWithMessage("Invalid text")
+                .that(testCommentBlock.getText())
+                .isEqualTo("/*");
+        assertWithMessage("Invalid line number")
+                .that(testCommentBlock.getLineNo())
+                .isEqualTo(0);
 
         final DetailAST contentCommentBlock = testCommentBlock.getFirstChild();
-        assertWithMessage("Invalid token type").that(contentCommentBlock.getType())
+        assertWithMessage("Invalid token type")
+                .that(contentCommentBlock.getType())
                 .isEqualTo(TokenTypes.COMMENT_CONTENT);
-        assertWithMessage("Invalid text").that(contentCommentBlock.getText())
+        assertWithMessage("Invalid text")
+                .that(contentCommentBlock.getText())
                 .isEqualTo("*test_comment");
-        assertWithMessage("Invalid line number").that(contentCommentBlock.getLineNo()).isEqualTo(0);
-        assertWithMessage("Invalid column number").that(contentCommentBlock.getColumnNo())
+        assertWithMessage("Invalid line number")
+                .that(contentCommentBlock.getLineNo())
+                .isEqualTo(0);
+        assertWithMessage("Invalid column number")
+                .that(contentCommentBlock.getColumnNo())
                 .isEqualTo(-1);
 
         final DetailAST endCommentBlock = contentCommentBlock.getNextSibling();
-        assertWithMessage("Invalid token type").that(endCommentBlock.getType())
+        assertWithMessage("Invalid token type")
+                .that(endCommentBlock.getType())
                 .isEqualTo(TokenTypes.BLOCK_COMMENT_END);
-        assertWithMessage("Invalid text").that(endCommentBlock.getText()).isEqualTo("*/");
+        assertWithMessage("Invalid text")
+                .that(endCommentBlock.getText())
+                .isEqualTo("*/");
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
@@ -78,7 +78,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .getNextSibling()
                 .getNextSibling();
         final DetailAST[] expected = {expectedVariableDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -93,7 +95,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.METHOD_DEF)
                 .findFirstToken(TokenTypes.SLIST);
         final DetailAST[] expected = {expectedVariableDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -109,7 +113,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.SLIST)
                 .findFirstToken(TokenTypes.RCURLY);
         final DetailAST[] expected = {expectedCurlyNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -126,7 +132,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final DetailAST expectedMethodDefNode2 = expectedMethodDefNode1.getNextSibling();
         final DetailAST[] expected = {expectedClassDefNode, expectedMethodDefNode1,
             expectedMethodDefNode2};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -140,7 +148,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final DetailAST expectedObjblockNode = expectedClassDefNode
                 .findFirstToken(TokenTypes.OBJBLOCK);
         final DetailAST[] expected = {expectedClassDefNode, expectedObjblockNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -154,7 +164,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final DetailAST expectedAnnotationsNode = expectedPackageDefNode
                 .findFirstToken(TokenTypes.ANNOTATIONS);
         final DetailAST[] expected = {expectedPackageDefNode, expectedAnnotationsNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -175,7 +187,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .getNextSibling();
         final DetailAST[] expected = {expectedClassDefNode, expectedObjblockNode,
             expectedMethodDefNode, expectedMethodDefNode2};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -192,7 +206,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.METHOD_DEF)
                 .getNextSibling();
         final DetailAST[] expected = {expectedMethodDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -208,7 +224,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.OBJBLOCK)
                 .findFirstToken(TokenTypes.METHOD_DEF);
         final DetailAST[] expected = {expectedMethodDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -216,7 +234,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final String xpath = "//*[./IDENT[@text]]";
         final RootNode rootNode = getRootNode("InputXpathMapperAst.java");
         final List<NodeInfo> nodes = getXpathItems(xpath, rootNode);
-        assertWithMessage("Invalid number of nodes").that(nodes).hasSize(18);
+        assertWithMessage("Invalid number of nodes")
+                .that(nodes)
+                .hasSize(18);
     }
 
     @Test
@@ -224,7 +244,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final String xpath = "(//VARIABLE_DEF)[1]";
         final RootNode rootNode = getRootNode("InputXpathMapperAst.java");
         final DetailAST[] actual = convertToArray(getXpathItems(xpath, rootNode));
-        assertWithMessage("Invalid number of nodes").that(actual).hasLength(1);
+        assertWithMessage("Invalid number of nodes")
+                .that(actual)
+                .hasLength(1);
         final DetailAST expectedVariableDefNode = getSiblingByType(rootNode.getUnderlyingNode(),
                 TokenTypes.COMPILATION_UNIT)
                 .findFirstToken(TokenTypes.CLASS_DEF)
@@ -233,7 +255,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.SLIST)
                 .findFirstToken(TokenTypes.VARIABLE_DEF);
         final DetailAST[] expected = {expectedVariableDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -241,7 +265,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final String xpath = "//VARIABLE_DEF[./IDENT[@*]]";
         final RootNode rootNode = getRootNode("InputXpathMapperAst.java");
         final List<NodeInfo> nodes = getXpathItems(xpath, rootNode);
-        assertWithMessage("Invalid number of nodes").that(nodes).hasSize(4);
+        assertWithMessage("Invalid number of nodes")
+                .that(nodes)
+                .hasSize(4);
     }
 
     @Test
@@ -249,7 +275,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final String xpath = "//VARIABLE_DEF[@qwe]";
         final RootNode rootNode = getRootNode("InputXpathMapperAst.java");
         final List<NodeInfo> nodes = getXpathItems(xpath, rootNode);
-        assertWithMessage("Invalid number of nodes").that(nodes).hasSize(0);
+        assertWithMessage("Invalid number of nodes")
+                .that(nodes)
+                .hasSize(0);
     }
 
     @Test
@@ -257,11 +285,15 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final String objectXpath = "//CLASS_DEF[./IDENT[@text='InputXpathMapperAst']]//OBJBLOCK";
         final RootNode rootNode = getRootNode("InputXpathMapperAst.java");
         final List<NodeInfo> objectNodes = getXpathItems(objectXpath, rootNode);
-        assertWithMessage("Invalid number of nodes").that(objectNodes).hasSize(1);
+        assertWithMessage("Invalid number of nodes")
+                .that(objectNodes)
+                .hasSize(1);
         final AbstractNode objNode = (AbstractNode) objectNodes.get(0);
         final String methodsXpath = "METHOD_DEF";
         final List<NodeInfo> methodsNodes = getXpathItems(methodsXpath, objNode);
-        assertWithMessage("Invalid number of nodes").that(methodsNodes).hasSize(2);
+        assertWithMessage("Invalid number of nodes")
+                .that(methodsNodes)
+                .hasSize(2);
         final DetailAST[] actual = convertToArray(methodsNodes);
         final DetailAST expectedMethodDefNode = getSiblingByType(rootNode.getUnderlyingNode(),
                 TokenTypes.COMPILATION_UNIT)
@@ -270,10 +302,14 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.METHOD_DEF);
         final DetailAST[] expected = {expectedMethodDefNode,
             expectedMethodDefNode.getNextSibling()};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
-        assertWithMessage("Invalid token type").that(actual[0].getType())
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
+        assertWithMessage("Invalid token type")
+                .that(actual[0].getType())
                 .isEqualTo(TokenTypes.METHOD_DEF);
-        assertWithMessage("Invalid token type").that(actual[1].getType())
+        assertWithMessage("Invalid token type")
+                .that(actual[1].getType())
                 .isEqualTo(TokenTypes.METHOD_DEF);
     }
 
@@ -282,17 +318,24 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final String xpath = "/COMPILATION_UNIT/CLASS_DEF";
         final RootNode rootNode = getRootNode("InputXpathMapperAst.java");
         final List<NodeInfo> nodes = getXpathItems(xpath, rootNode);
-        assertWithMessage("Invalid number of nodes").that(nodes).hasSize(1);
+        assertWithMessage("Invalid number of nodes")
+                .that(nodes)
+                .hasSize(1);
         final AbstractNode classDefNode = (AbstractNode) nodes.get(0);
-        assertWithMessage("Invalid line number").that(classDefNode.getLineNumber()).isEqualTo(3);
-        assertWithMessage("Invalid column number").that(classDefNode.getColumnNumber())
+        assertWithMessage("Invalid line number")
+                .that(classDefNode.getLineNumber())
+                .isEqualTo(3);
+        assertWithMessage("Invalid column number")
+                .that(classDefNode.getColumnNumber())
                 .isEqualTo(0);
         final DetailAST[] actual = convertToArray(nodes);
         final DetailAST expectedClassDefNode = getSiblingByType(rootNode.getUnderlyingNode(),
                 TokenTypes.COMPILATION_UNIT)
                 .findFirstToken(TokenTypes.CLASS_DEF);
         final DetailAST[] expected = {expectedClassDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -307,7 +350,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.METHOD_DEF)
                 .getNextSibling();
         final DetailAST[] expected = {expectedMethodDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -323,10 +368,14 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.METHOD_DEF);
         final DetailAST[] expected = {expectedMethodDefNode,
             expectedMethodDefNode.getNextSibling()};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
-        assertWithMessage("Invalid token type").that(actual[0].getType())
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
+        assertWithMessage("Invalid token type")
+                .that(actual[0].getType())
                 .isEqualTo(TokenTypes.METHOD_DEF);
-        assertWithMessage("Invalid token type").that(actual[1].getType())
+        assertWithMessage("Invalid token type")
+                .that(actual[1].getType())
                 .isEqualTo(TokenTypes.METHOD_DEF);
     }
 
@@ -343,7 +392,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.METHOD_DEF)
                 .getNextSibling();
         final DetailAST[] expected = {expectedMethodDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -357,9 +408,12 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.CLASS_DEF);
         final DetailAST[] expected = {expectedClassDefNode};
         final ElementNode classDefNode = (ElementNode) nodes.get(0);
-        assertWithMessage("Invalid node name").that(classDefNode.getLocalPart())
+        assertWithMessage("Invalid node name")
+                .that(classDefNode.getLocalPart())
                 .isEqualTo("CLASS_DEF");
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -367,7 +421,8 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final String xpath = "/CLASS_DEF[@text='WrongName']";
         final RootNode rootNode = getRootNode("InputXpathMapperAst.java");
         final List<NodeInfo> nodes = getXpathItems(xpath, rootNode);
-        assertWithMessage("Should return true, because no item matches xpath").that(nodes)
+        assertWithMessage("Should return true, because no item matches xpath")
+                .that(nodes)
                 .isEmpty();
     }
 
@@ -376,7 +431,8 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final String xpath = "/WRONG_XPATH";
         final RootNode rootNode = getRootNode("InputXpathMapperAst.java");
         final List<NodeInfo> nodes = getXpathItems(xpath, rootNode);
-        assertWithMessage("Should return true, because no item matches xpath").that(nodes)
+        assertWithMessage("Should return true, because no item matches xpath")
+                .that(nodes)
                 .isEmpty();
     }
 
@@ -391,7 +447,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.OBJBLOCK)
                 .findFirstToken(TokenTypes.METHOD_DEF);
         final DetailAST[] expected = {expectedMethodDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -410,7 +468,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .getNextSibling()
                 .getNextSibling();
         final DetailAST[] expected = {expectedVariableDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -418,7 +478,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final String xpath = "//METHOD_DEF/descendant::EXPR";
         final RootNode rootNode = getRootNode("InputXpathMapperAst.java");
         final List<NodeInfo> nodes = getXpathItems(xpath, rootNode);
-        assertWithMessage("Invalid number of nodes").that(nodes).hasSize(6);
+        assertWithMessage("Invalid number of nodes")
+                .that(nodes)
+                .hasSize(6);
     }
 
     @Test
@@ -433,10 +495,14 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.METHOD_DEF);
         final DetailAST[] expected = {expectedMethodDefNode,
             expectedMethodDefNode.getNextSibling()};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
-        assertWithMessage("Invalid token type").that(actual[0].getType())
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
+        assertWithMessage("Invalid token type")
+                .that(actual[0].getType())
                 .isEqualTo(TokenTypes.METHOD_DEF);
-        assertWithMessage("Invalid token type").that(actual[1].getType())
+        assertWithMessage("Invalid token type")
+                .that(actual[1].getType())
                 .isEqualTo(TokenTypes.METHOD_DEF);
     }
 
@@ -445,7 +511,8 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final String xpath = "//RCURLY/METHOD_DEF";
         final RootNode rootNode = getRootNode("InputXpathMapperAst.java");
         final List<NodeInfo> nodes = getXpathItems(xpath, rootNode);
-        assertWithMessage("Should return true, because no item matches xpath").that(nodes)
+        assertWithMessage("Should return true, because no item matches xpath")
+                .that(nodes)
                 .isEmpty();
     }
 
@@ -454,7 +521,8 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final String xpath = "//RCURLY/descendant::METHOD_DEF";
         final RootNode rootNode = getRootNode("InputXpathMapperAst.java");
         final List<NodeInfo> nodes = getXpathItems(xpath, rootNode);
-        assertWithMessage("Should return true, because no item matches xpath").that(nodes)
+        assertWithMessage("Should return true, because no item matches xpath")
+                .that(nodes)
                 .isEmpty();
     }
 
@@ -467,7 +535,8 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
             assertWithMessage("Exception is excepted").fail();
         }
         catch (UnsupportedOperationException ex) {
-            assertWithMessage("Invalid exception").that(ex.getMessage())
+            assertWithMessage("Invalid exception")
+                    .that(ex.getMessage())
                     .isEqualTo("Operation is not supported");
         }
     }
@@ -481,7 +550,8 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
             assertWithMessage("Exception is excepted").fail();
         }
         catch (UnsupportedOperationException ex) {
-            assertWithMessage("Invalid exception").that(ex.getMessage())
+            assertWithMessage("Invalid exception")
+                    .that(ex.getMessage())
                     .isEqualTo("Operation is not supported");
         }
     }
@@ -491,7 +561,8 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final String objectXpath = "//CLASS_DEF[./IDENT[@text='InputXpathMapperAst']]//OBJBLOCK";
         final RootNode rootNode = getRootNode("InputXpathMapperAst.java");
         final List<NodeInfo> objectNodes = getXpathItems(objectXpath, rootNode);
-        assertWithMessage("Invalid number of nodes").that(objectNodes).hasSize(1);
+        assertWithMessage("Invalid number of nodes")
+                .that(objectNodes).hasSize(1);
         final AbstractNode objNode = (AbstractNode) objectNodes.get(0);
         final String methodsXpath = "self::OBJBLOCK";
         final DetailAST[] actual = convertToArray(getXpathItems(methodsXpath, objNode));
@@ -500,7 +571,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.CLASS_DEF)
                 .findFirstToken(TokenTypes.OBJBLOCK);
         final DetailAST[] expected = {expectedObjBlockNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -510,7 +583,8 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final List<NodeInfo> nodes = getXpathItems(xpath, rootNode);
         final ElementNode classDefNode = (ElementNode) nodes.get(0);
         assertWithMessage("Not existing attribute should have null value")
-                .that(classDefNode.getAttributeValue("", "noneExistingAttribute")).isNull();
+                .that(classDefNode.getAttributeValue("", "noneExistingAttribute"))
+                .isNull();
     }
 
     @Test
@@ -518,7 +592,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final String xpath = "self::node()";
         final RootNode rootNode = getRootNode("InputXpathMapperAst.java");
         final List<NodeInfo> nodes = getXpathItems(xpath, rootNode);
-        assertWithMessage("Invalid number of nodes").that(nodes).hasSize(1);
+        assertWithMessage("Invalid number of nodes")
+                .that(nodes)
+                .hasSize(1);
     }
 
     @Test
@@ -532,7 +608,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.MODIFIERS)
                 .findFirstToken(TokenTypes.ANNOTATION);
         final DetailAST[] expected = {expectedAnnotationNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -540,7 +618,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final String xpath = "//ANNOTATION[@text='SpringBootApplication']";
         final RootNode rootNode = getRootNode("InputXpathMapperAnnotation.java");
         final List<NodeInfo> nodes = getXpathItems(xpath, rootNode);
-        assertWithMessage("Invalid number of nodes").that(nodes).hasSize(0);
+        assertWithMessage("Invalid number of nodes")
+                .that(nodes)
+                .hasSize(0);
     }
 
     @Test
@@ -552,7 +632,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 TokenTypes.COMPILATION_UNIT)
                 .findFirstToken(TokenTypes.ENUM_DEF);
         final DetailAST[] expected = {expectedEnumDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -560,7 +642,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final String xpath = "/COMPILATION_UNIT/ENUM_DEF/OBJBLOCK/ENUM_CONSTANT_DEF";
         final RootNode enumRootNode = getRootNode("InputXpathMapperEnum.java");
         final List<NodeInfo> nodes = getXpathItems(xpath, enumRootNode);
-        assertWithMessage("Invalid number of nodes").that(nodes).hasSize(3);
+        assertWithMessage("Invalid number of nodes")
+                .that(nodes)
+                .hasSize(3);
     }
 
     @Test
@@ -577,7 +661,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .getNextSibling()
                 .getNextSibling();
         final DetailAST[] expected = {expectedEnumConstantDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -590,7 +676,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 TokenTypes.COMPILATION_UNIT)
                 .findFirstToken(TokenTypes.INTERFACE_DEF);
         final DetailAST[] expected = {expectedInterfaceDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -598,7 +686,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final String xpath = "//INTERFACE_DEF/OBJBLOCK/METHOD_DEF";
         final RootNode interfaceRootNode = getRootNode("InputXpathMapperInterface.java");
         final List<NodeInfo> nodes = getXpathItems(xpath, interfaceRootNode);
-        assertWithMessage("Invalid number of nodes").that(nodes).hasSize(4);
+        assertWithMessage("Invalid number of nodes")
+                .that(nodes)
+                .hasSize(4);
     }
 
     @Test
@@ -614,7 +704,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.METHOD_DEF)
                 .getNextSibling();
         final DetailAST[] expected = {expectedMethodDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -629,7 +721,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.IDENT);
 
         final DetailAST[] expected = {expectedIdentNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -648,7 +742,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.IDENT)
                 .getNextSibling();
         final DetailAST[] expected = {expectedMethodDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -664,7 +760,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.SLIST)
                 .findFirstToken(TokenTypes.VARIABLE_DEF);
         final DetailAST[] expected = {expectedVariableDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -683,7 +781,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .getNextSibling()
                 .getNextSibling();
         final DetailAST[] expected = {expectedVariableDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -693,7 +793,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final RootNode rootNode = getRootNode("InputXpathMapperAst.java");
         final DetailAST[] actual1 = convertToArray(getXpathItems(xpath1, rootNode));
         final DetailAST[] actual2 = convertToArray(getXpathItems(xpath2, rootNode));
-        assertWithMessage("Result nodes differ from expected").that(actual2).isEqualTo(actual1);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual2)
+                .isEqualTo(actual1);
     }
 
     @Test
@@ -709,7 +811,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.METHOD_DEF)
                 .getNextSibling();
         final DetailAST[] expected = {expectedAnnotationNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -721,7 +825,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 TokenTypes.COMPILATION_UNIT)
                 .findFirstToken(TokenTypes.IMPORT);
         final DetailAST[] expected = {expectedVariableDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -734,7 +840,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.IMPORT)
                 .getNextSibling();
         final DetailAST[] expected = {expectedVariableDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -748,7 +856,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .getNextSibling()
                 .getNextSibling();
         final DetailAST[] expected = {expectedVariableDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -768,7 +878,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .getNextSibling()
                 .getNextSibling();
         final DetailAST[] expected = {expectedVariableDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -787,7 +899,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.LITERAL_SWITCH)
                 .findFirstToken(TokenTypes.CASE_GROUP);
         final DetailAST[] expected = {expectedVariableDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -807,7 +921,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.CASE_GROUP)
                 .getNextSibling();
         final DetailAST[] expected = {expectedVariableDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -828,7 +944,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .getNextSibling()
                 .getNextSibling();
         final DetailAST[] expected = {expectedVariableDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -850,7 +968,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .getNextSibling()
                 .getNextSibling();
         final DetailAST[] expected = {expectedVariableDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -866,10 +986,14 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .getNextSibling();
         final DetailAST[] expected = {expectedMethodDefNode,
                 expectedMethodDefNode.getNextSibling()};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
-        assertWithMessage("Invalid token type").that(actual[0].getType())
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
+        assertWithMessage("Invalid token type")
+                .that(actual[0].getType())
                 .isEqualTo(TokenTypes.METHOD_DEF);
-        assertWithMessage("Invalid token type").that(actual[1].getType())
+        assertWithMessage("Invalid token type")
+                .that(actual[1].getType())
                 .isEqualTo(TokenTypes.RCURLY);
     }
 
@@ -878,7 +1002,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final String xpath = "//CLASS_DEF/following-sibling::*";
         final RootNode rootNode = getRootNode("InputXpathMapperAst.java");
         final DetailAST[] actual = convertToArray(getXpathItems(xpath, rootNode));
-        assertWithMessage("Invalid number of nodes").that(actual).isEmpty();
+        assertWithMessage("Invalid number of nodes")
+                .that(actual)
+                .isEmpty();
     }
 
     @Test
@@ -893,7 +1019,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.METHOD_DEF)
                 .getNextSibling().getNextSibling();
         final DetailAST[] expected = {expectedRightCurlyNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -915,7 +1043,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final DetailAST expectedExprNode = expectedAssignNode.getFirstChild();
         final DetailAST expectedNumIntNode = expectedExprNode.getFirstChild();
         final DetailAST[] expected = {expectedAssignNode, expectedExprNode, expectedNumIntNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -930,10 +1060,14 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.METHOD_DEF);
         final DetailAST[] expected = {expectedMethodDefNode,
             expectedMethodDefNode.getNextSibling()};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
-        assertWithMessage("Invalid token type").that(actual[0].getType())
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
+        assertWithMessage("Invalid token type")
+                .that(actual[0].getType())
                 .isEqualTo(TokenTypes.METHOD_DEF);
-        assertWithMessage("Invalid token type").that(actual[1].getType())
+        assertWithMessage("Invalid token type")
+                .that(actual[1].getType())
                 .isEqualTo(TokenTypes.METHOD_DEF);
     }
 
@@ -942,7 +1076,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final String xpath = "//CLASS_DEF/following::*";
         final RootNode rootNode = getRootNode("InputXpathMapperAst.java");
         final DetailAST[] actual = convertToArray(getXpathItems(xpath, rootNode));
-        assertWithMessage("Invalid number of nodes").that(actual).isEmpty();
+        assertWithMessage("Invalid number of nodes")
+                .that(actual)
+                .isEmpty();
     }
 
     @Test
@@ -962,7 +1098,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final DetailAST expectedSemiNode2 = expectedVariableDefNode2.getNextSibling();
         final DetailAST[] expected = {expectedVariableDefNode1, expectedSemiNode1,
             expectedVariableDefNode2, expectedSemiNode2};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -981,7 +1119,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final DetailAST expectedVariableDefNode2 = expectedVariableDefNode1.getNextSibling()
                 .getNextSibling();
         final DetailAST[] expected = {expectedVariableDefNode1, expectedVariableDefNode2};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -997,7 +1137,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.SLIST)
                 .findFirstToken(TokenTypes.VARIABLE_DEF);
         final DetailAST[] expected = {expectedVariableDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -1006,7 +1148,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
         final RootNode rootNode = getRootNode("InputXpathMapperSingleTopClass.java");
         final DetailAST[] actual = convertToArray(getXpathItems(xpath,
                 rootNode.createChildren().get(0)));
-        assertWithMessage("Invalid number of nodes").that(actual).hasLength(18);
+        assertWithMessage("Invalid number of nodes")
+                .that(actual)
+                .hasLength(18);
     }
 
     @Test
@@ -1023,7 +1167,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
             expectedPackageDefNode,
             expectedAnnotationsNode,
         };
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -1037,7 +1183,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .getFirstChild()
                 .getFirstChild();
         final DetailAST[] expected = {expectedLiteralPublicNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -1055,7 +1203,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.EXPR)
                 .findFirstToken(TokenTypes.TEXT_BLOCK_LITERAL_BEGIN);
         final DetailAST[] expected = {expectedVariableDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     @Test
@@ -1069,7 +1219,9 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.OBJBLOCK)
                 .findFirstToken(TokenTypes.SINGLE_LINE_COMMENT);
         final DetailAST[] expected = {expectedVariableDefNode};
-        assertWithMessage("Result nodes differ from expected").that(actual).isEqualTo(expected);
+        assertWithMessage("Result nodes differ from expected")
+                .that(actual)
+                .isEqualTo(expected);
     }
 
     private RootNode getRootNode(String fileName) throws Exception {


### PR DESCRIPTION
Issue #9142

this PR is quick step before https://github.com/checkstyle/checkstyle/issues/11087 

Example of violation:
```
✔ ~/java/github/romani/checkstyle [9142-truth-formatting L|✚ 1] 
12:09 $ git diff
diff --git a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
index 0a8618f..26b2ad9 100644
--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java
@@ -1219,8 +1219,7 @@ public class XpathMapperTest extends AbstractModuleTestSupport {
                 .findFirstToken(TokenTypes.OBJBLOCK)
                 .findFirstToken(TokenTypes.SINGLE_LINE_COMMENT);
         final DetailAST[] expected = {expectedVariableDefNode};
-        assertWithMessage("Result nodes differ from expected")
-                .that(actual)
+        assertWithMessage("Result nodes differ from expected").that(actual)
                 .isEqualTo(expected);
     }

$ mvn compile antrun:run@ant-phase-verify
....
[INFO] [checkstyle] Running Checkstyle  on 1430 files
[ERROR] [checkstyle] [ERROR] /home/rivanov/java/github/romani/checkstyle/src/test/java/
com/puppycrawl/tools/checkstyle/xpath/XpathMapperTest.java:1222: 
Truth's 'that' method call should be on separate line [assertThatShouldBeOnSeparateLine]

```