### PR TITLE
Issue #10924: Update UnicodeCharactersCheck to use code points

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3284,6 +3284,9 @@
                 <param>
                   com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheckTest
                 </param>
+                <param>
+                  com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheckTest
+                </param>
                 <!-- 2% mutation in ScopeUtil -->
                 <param>
                   com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheckTest

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java
@@ -295,6 +295,16 @@ public abstract class AbstractCheck extends AbstractViolationReporter {
     }
 
     /**
+     * Returns code point representation of file text from given line number.
+     *
+     * @param index index of the line
+     * @return the array of Unicode code points
+     */
+    public final int[] getLineCodePoints(int index) {
+        return getLine(index).codePoints().toArray();
+    }
+
+    /**
      * The actual context holder.
      */
     private static class FileContext {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -30,7 +31,7 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TextBlock;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
-import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+import com.puppycrawl.tools.checkstyle.utils.CodePointUtil;
 
 /**
  * <p>
@@ -431,8 +432,8 @@ public class AvoidEscapedUnicodeCharactersCheck
             final List<TextBlock> commentList = blockComments.get(lineNo);
             if (commentList != null) {
                 final TextBlock comment = commentList.get(commentList.size() - 1);
-                final String line = getLines()[lineNo - 1];
-                result = isTrailingBlockComment(comment, line);
+                final int[] codePoints = getLineCodePoints(lineNo - 1);
+                result = isTrailingBlockComment(comment, codePoints);
             }
         }
         return result;
@@ -442,12 +443,13 @@ public class AvoidEscapedUnicodeCharactersCheck
      * Whether the C style comment is trailing.
      *
      * @param comment the comment to check.
-     * @param line the line where the comment starts.
+     * @param codePoints the first line of the comment, in unicode code points
      * @return true if the comment is trailing.
      */
-    private static boolean isTrailingBlockComment(TextBlock comment, String line) {
+    private static boolean isTrailingBlockComment(TextBlock comment, int... codePoints) {
         return comment.getText().length != 1
-            || CommonUtil.isBlank(line.substring(comment.getEndColNo() + 1));
+            || CodePointUtil.isBlank(Arrays.copyOfRange(codePoints,
+                comment.getEndColNo() + 1, codePoints.length));
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CodePointUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CodePointUtil.java
@@ -1,0 +1,45 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2021 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.utils;
+
+import java.util.Arrays;
+
+/**
+ * Contains utility methods for code point.
+ */
+public final class CodePointUtil {
+
+    /** Stop instances being created. **/
+    private CodePointUtil() {
+    }
+
+    /**
+     * Checks if given code point array is blank by either being empty,
+     * or contains only whitespace characters.
+     *
+     * @param codePoints The array of unicode code points of string to check.
+     * @return true if codePoints is blank.
+     */
+    public static boolean isBlank(int... codePoints) {
+        return Arrays.stream(codePoints)
+                .allMatch(Character::isWhitespace);
+    }
+
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
@@ -180,6 +180,35 @@ public class AbstractCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testGetLineCodePoints() throws Exception {
+        final AbstractCheck check = new AbstractCheck() {
+            @Override
+            public int[] getDefaultTokens() {
+                return CommonUtil.EMPTY_INT_ARRAY;
+            }
+
+            @Override
+            public int[] getAcceptableTokens() {
+                return getDefaultTokens();
+            }
+
+            @Override
+            public int[] getRequiredTokens() {
+                return getDefaultTokens();
+            }
+        };
+        final FileContents fileContents = new FileContents(new FileText(
+                new File(getPath("InputAbstractCheckTestFileContents.java")),
+                Charset.defaultCharset().name()));
+        check.setFileContents(fileContents);
+
+        final int[] expectedCodePoints = "    public int getVariable() {".codePoints().toArray();
+        assertWithMessage("Invalid line content")
+                .that(check.getLineCodePoints(12))
+                .isEqualTo(expectedCodePoints);
+    }
+
+    @Test
     public void testGetTabWidth() {
         final AbstractCheck check = new AbstractCheck() {
             @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheckTest.java
@@ -382,6 +382,21 @@ public class AvoidEscapedUnicodeCharactersCheckTest extends AbstractModuleTestSu
     }
 
     @Test
+    public void testAllowByTailCommentWithEmoji() throws Exception {
+        final String[] expected = {
+            "15:24: " + getCheckMessage(MSG_KEY),
+            "18:24: " + getCheckMessage(MSG_KEY),
+            "22:30: " + getCheckMessage(MSG_KEY),
+            "32:18: " + getCheckMessage(MSG_KEY),
+            "35:18: " + getCheckMessage(MSG_KEY),
+            "37:18: " + getCheckMessage(MSG_KEY),
+            "40:18: " + getCheckMessage(MSG_KEY),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputAvoidEscapedUnicodeCharacters5.java"), expected);
+    }
+
+    @Test
     public void testAvoidEscapedUnicodeCharactersTextBlocksAllowByComment() throws Exception {
         final String[] expected = {
             "18:30: " + getCheckMessage(MSG_KEY),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CodePointUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CodePointUtilTest.java
@@ -1,0 +1,35 @@
+////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code for adherence to a set of rules.
+// Copyright (C) 2001-2021 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.utils;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
+
+import org.junit.jupiter.api.Test;
+
+public class CodePointUtilTest {
+
+    @Test
+    public void testIsProperUtilsClass() throws ReflectiveOperationException {
+        assertWithMessage("Constructor is not private")
+                .that(isUtilsClassHasPrivateConstructor(CodePointUtil.class))
+                .isTrue();
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharacters5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/avoidescapedunicodecharacters/InputAvoidEscapedUnicodeCharacters5.java
@@ -1,0 +1,46 @@
+/*
+AvoidEscapedUnicodeCharacters
+allowEscapesForControlCharacters = (default)false
+allowByTailComment = true
+allowIfAllCharactersEscaped = (default)false
+allowNonPrintableEscapes = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.avoidescapedunicodecharacters;
+
+public class InputAvoidEscapedUnicodeCharacters5 {
+    private String a = "🎄"; // violation below
+    private String b = "\uD83E\uDD73abs😀";
+    private String c = "\uD83C\uDF84😀\uD83C\uDF84"; // OK, allowed by trailing comment
+    // violation below
+    private String d = "\uD83C\uDF84😀\uD83C\uDF84asdas\uD83C\uDF84abcd";
+
+    public Object fooEmoji() {
+        String unitAbbrev = "Î¼sð😀"; // violation below
+        String unitAbbrev2 = "\u03bc😀";
+        String unitAbbrev3 = "😀\u03bcs"; // Greek letter mu, "s"
+        String fakeUnicode2 = "\\u23\\u123i\\u😀";
+        String content = null;
+        return "😀" + content + "\u03bc"; /* OK, allowed by trailing comment */
+    }
+
+    public boolean matches(String c) {
+        switch (c) {
+            //violation below
+            case "\u03bc🎄":
+            case "🎄\u03bc": /* OK, allowed by trailing comment */
+                // violation below
+            case "\t\u2028":
+                // violation below
+            case "\n😂\u3000":
+                return true;
+                // violation below
+            case "😂\uD83D\uDE02":
+                return false;
+            default:
+                return c.equals("\u2000😂\u2000"); // OK, allowed by trailing comment
+        }
+    }
+}


### PR DESCRIPTION
Issue #10924: Updated `AvoidEscapedUnicodeCharactersCheck` to use code point.
Diff Regression config: https://gist.githubusercontent.com/MUzairS15/4323d26bee52faf59d8ebab0e9f94dab/raw/2fe5691757afea0390518650016752c76508ca1f/config.xml