### PR TITLE
Issue #11107: remove checkConstructorIsPrivate parameter

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
@@ -48,7 +48,7 @@ public class AstTreeStringPrinterTest extends AbstractTreeTestSupport {
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         assertWithMessage("Constructor is not private")
-                .that(isUtilsClassHasPrivateConstructor(AstTreeStringPrinter.class, true))
+                .that(isUtilsClassHasPrivateConstructor(AstTreeStringPrinter.class))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DefinitionsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DefinitionsTest.java
@@ -29,7 +29,7 @@ public class DefinitionsTest {
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         assertWithMessage("Constructor is not private")
-                .that(isUtilsClassHasPrivateConstructor(Definitions.class, true))
+                .that(isUtilsClassHasPrivateConstructor(Definitions.class))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
@@ -44,7 +44,7 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         assertWithMessage("Constructor is not private")
-                .that(isUtilsClassHasPrivateConstructor(DetailNodeTreeStringPrinter.class, true))
+                .that(isUtilsClassHasPrivateConstructor(DetailNodeTreeStringPrinter.class))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavaParserTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavaParserTest.java
@@ -48,7 +48,7 @@ public class JavaParserTest extends AbstractModuleTestSupport {
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         assertWithMessage("Constructor is not private")
-                .that(TestUtil.isUtilsClassHasPrivateConstructor(JavaParser.class, false))
+                .that(TestUtil.isUtilsClassHasPrivateConstructor(JavaParser.class))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGeneratorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGeneratorTest.java
@@ -95,7 +95,7 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         assertWithMessage("Constructor is not private")
             .that(TestUtil.isUtilsClassHasPrivateConstructor(
-                                            JavadocPropertiesGenerator.class, false))
+                                            JavadocPropertiesGenerator.class))
             .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -248,7 +248,7 @@ public class MainTest {
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         assertWithMessage("Constructor is not private")
-                .that(isUtilsClassHasPrivateConstructor(Main.class, false))
+                .that(isUtilsClassHasPrivateConstructor(Main.class))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/SuppressionsStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SuppressionsStringPrinterTest.java
@@ -42,7 +42,7 @@ public class SuppressionsStringPrinterTest extends AbstractTreeTestSupport {
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         assertWithMessage("Constructor is not private")
-                .that(isUtilsClassHasPrivateConstructor(SuppressionsStringPrinter.class, true))
+                .that(isUtilsClassHasPrivateConstructor(SuppressionsStringPrinter.class))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/XmlLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/XmlLoaderTest.java
@@ -49,7 +49,7 @@ public class XmlLoaderTest {
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         assertWithMessage("Constructor is not private")
                 .that(isUtilsClassHasPrivateConstructor(
-                        XmlLoader.LoadExternalDtdFeatureProvider.class, true))
+                        XmlLoader.LoadExternalDtdFeatureProvider.class))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/JavadocTokenTypesTest.java
@@ -32,7 +32,7 @@ public class JavadocTokenTypesTest {
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         assertWithMessage("Constructor is not private")
-                .that(isUtilsClassHasPrivateConstructor(JavadocTokenTypes.class, true))
+                .that(isUtilsClassHasPrivateConstructor(JavadocTokenTypes.class))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/TokenTypesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/TokenTypesTest.java
@@ -92,7 +92,7 @@ public class TokenTypesTest {
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         assertWithMessage("Constructor is not private")
-                .that(isUtilsClassHasPrivateConstructor(TokenTypes.class, true))
+                .that(isUtilsClassHasPrivateConstructor(TokenTypes.class))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/BlockTagUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/BlockTagUtilTest.java
@@ -33,7 +33,7 @@ public class BlockTagUtilTest {
     @Test
     public void testHasPrivateConstructor() throws Exception {
         assertWithMessage("Constructor is not private")
-                .that(TestUtil.isUtilsClassHasPrivateConstructor(BlockTagUtil.class, true))
+                .that(TestUtil.isUtilsClassHasPrivateConstructor(BlockTagUtil.class))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/InlineTagUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/InlineTagUtilTest.java
@@ -33,7 +33,7 @@ public class InlineTagUtilTest {
     @Test
     public void testHasPrivateConstructor() throws Exception {
         assertWithMessage("Constructor is not private")
-                .that(TestUtil.isUtilsClassHasPrivateConstructor(InlineTagUtil.class, true))
+                .that(TestUtil.isUtilsClassHasPrivateConstructor(InlineTagUtil.class))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/TestUtil.java
@@ -62,25 +62,14 @@ public final class TestUtil {
      * Verifies that utils class has private constructor and invokes it to satisfy code coverage.
      *
      * @param utilClass class to test for c-tor
-     * @param checkConstructorIsPrivate flag to skip check for private visibility, it is useful
-     *                                  for Classes that are mocked by PowerMockRunner that make
-     *                                  private c-tors as public
      * @return true if constructor is expected.
-     * @noinspection BooleanParameter
      */
-    public static boolean isUtilsClassHasPrivateConstructor(final Class<?> utilClass,
-                                                             boolean checkConstructorIsPrivate)
+    public static boolean isUtilsClassHasPrivateConstructor(final Class<?> utilClass)
             throws ReflectiveOperationException {
         final Constructor<?> constructor = utilClass.getDeclaredConstructor();
-        final boolean result;
-        if (checkConstructorIsPrivate && !Modifier.isPrivate(constructor.getModifiers())) {
-            result = false;
-        }
-        else {
-            constructor.setAccessible(true);
-            constructor.newInstance();
-            result = true;
-        }
+        final boolean result = Modifier.isPrivate(constructor.getModifiers());
+        constructor.setAccessible(true);
+        constructor.newInstance();
         return result;
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtilTest.java
@@ -39,7 +39,7 @@ public class AnnotationUtilTest {
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         try {
-            isUtilsClassHasPrivateConstructor(AnnotationUtil.class, true);
+            isUtilsClassHasPrivateConstructor(AnnotationUtil.class);
             assertWithMessage("Exception is expected").fail();
         }
         catch (InvocationTargetException ex) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPositionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/BlockCommentPositionTest.java
@@ -39,7 +39,7 @@ public class BlockCommentPositionTest extends AbstractModuleTestSupport {
     @Test
     public void testPrivateConstr() throws Exception {
         assertWithMessage("Constructor is not private")
-                .that(TestUtil.isUtilsClassHasPrivateConstructor(BlockCommentPosition.class, true))
+                .that(TestUtil.isUtilsClassHasPrivateConstructor(BlockCommentPosition.class))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/ChainedPropertyUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/ChainedPropertyUtilTest.java
@@ -45,7 +45,7 @@ public class ChainedPropertyUtilTest extends AbstractModuleTestSupport {
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         assertWithMessage("Constructor is not private.")
-            .that(isUtilsClassHasPrivateConstructor(ChainedPropertyUtil.class, true))
+            .that(isUtilsClassHasPrivateConstructor(ChainedPropertyUtil.class))
             .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
@@ -51,7 +51,7 @@ public class CheckUtilTest extends AbstractPathTestSupport {
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         assertWithMessage("Constructor is not private")
-                .that(isUtilsClassHasPrivateConstructor(CheckUtil.class, true))
+                .that(isUtilsClassHasPrivateConstructor(CheckUtil.class))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CommonUtilTest.java
@@ -70,7 +70,7 @@ public class CommonUtilTest extends AbstractPathTestSupport {
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         assertWithMessage("Constructor is not private")
-                .that(isUtilsClassHasPrivateConstructor(CommonUtil.class, true))
+                .that(isUtilsClassHasPrivateConstructor(CommonUtil.class))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/FilterUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/FilterUtilTest.java
@@ -35,7 +35,7 @@ public class FilterUtilTest {
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         assertWithMessage("Constructor is not private")
-                .that(isUtilsClassHasPrivateConstructor(FilterUtil.class, true))
+                .that(isUtilsClassHasPrivateConstructor(FilterUtil.class))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtilTest.java
@@ -233,7 +233,7 @@ public class JavadocUtilTest {
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         assertWithMessage("Constructor is not private")
-                .that(isUtilsClassHasPrivateConstructor(JavadocUtil.class, true))
+                .that(isUtilsClassHasPrivateConstructor(JavadocUtil.class))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java
@@ -48,7 +48,7 @@ public class ModuleReflectionUtilTest {
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         assertWithMessage("Constructor is not private")
-                .that(isUtilsClassHasPrivateConstructor(ModuleReflectionUtil.class, true))
+                .that(isUtilsClassHasPrivateConstructor(ModuleReflectionUtil.class))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/ParserUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/ParserUtilTest.java
@@ -32,7 +32,7 @@ public class ParserUtilTest {
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         assertWithMessage("Constructor is not private")
-                .that(isUtilsClassHasPrivateConstructor(ParserUtil.class, true))
+                .that(isUtilsClassHasPrivateConstructor(ParserUtil.class))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtilTest.java
@@ -35,7 +35,7 @@ public class ScopeUtilTest {
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         assertWithMessage("Constructor is not private")
-                .that(isUtilsClassHasPrivateConstructor(ScopeUtil.class, true))
+                .that(isUtilsClassHasPrivateConstructor(ScopeUtil.class))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/TokenUtilTest.java
@@ -42,7 +42,7 @@ public class TokenUtilTest {
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         assertWithMessage("Constructor is not private")
-                .that(isUtilsClassHasPrivateConstructor(TokenUtil.class, true))
+                .that(isUtilsClassHasPrivateConstructor(TokenUtil.class))
                 .isTrue();
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/XpathUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/XpathUtilTest.java
@@ -52,7 +52,7 @@ public class XpathUtilTest {
     @Test
     public void testIsProperUtilsClass() throws ReflectiveOperationException {
         assertWithMessage("Constructor is not private")
-                .that(isUtilsClassHasPrivateConstructor(XpathUtil.class, true))
+                .that(isUtilsClassHasPrivateConstructor(XpathUtil.class))
                 .isTrue();
     }
 


### PR DESCRIPTION
Fixes #11107

We no longer need to pass `false` for this value. Therefore, we can simply remove this parameter.