### PR TITLE
Issue #11061: False negative around TokenTypes.LOR in UnnecessaryParenthesesCheck

### DIFF
--- a/config/checkstyle_resources_suppressions.xml
+++ b/config/checkstyle_resources_suppressions.xml
@@ -573,8 +573,6 @@
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]innerassignment[\\/]InputInnerAssignment\.java"/>
   <suppress checks="FileLength"
-    files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]unnecessaryparentheses[\\/]InputUnnecessaryParenthesesIfStatement\.java"/>
-  <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]equalshashcode[\\/]InputEqualsHashCodeSemantic\.java"/>
   <suppress checks="FileLength"
     files="[\\/]test[\\/]resources[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]coding[\\/]finallocalvariable[\\/]InputFinalLocalVariableFalsePositives\.java"/>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
@@ -46,9 +46,9 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </pre>
  * <p>
  * The check is not "type aware", that is to say, it can't tell if parentheses
- * are unnecessary based on the types in an expression.  It also doesn't know
- * about operator precedence and associativity; therefore it won't catch
- * something like
+ * are unnecessary based on the types in an expression. The check is partially aware about
+ * operator precedence but unaware about operator associativity.
+ * It won't catch cases such as:
  * </p>
  * <pre>
  * int x = (a + b) + c; // 1st Case
@@ -66,6 +66,29 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * and <em>r</em> were {@code boolean} still there will be no violation
  * raised as check is not "type aware".
  * </p>
+ * <p>
+ * The partial support for operator precedence includes cases of the following type:
+ * </p>
+ * <pre>
+ * boolean a = true, b = true;
+ * boolean c = false, d = false;
+ * if ((a &amp;&amp; b) || c) { // violation, unnecessary paren
+ * }
+ * if (a &amp;&amp; (b || c)) { // ok
+ * }
+ * if ((a == b) &amp;&amp; c) { // violation, unnecessary paren
+ * }
+ * String e = &quot;e&quot;;
+ * if ((e instanceof String) &amp;&amp; a || b) { // violation, unnecessary paren
+ * }
+ * int f = 0;
+ * int g = 0;
+ * if (!(f &gt;= g) // ok
+ *         &amp;&amp; (g &gt; f)) { // violation, unnecessary paren
+ * }
+ * if ((++f) &gt; g &amp;&amp; a) { // violation, unnecessary paren
+ * }
+ * </pre>
  * <ul>
  * <li>
  * Property {@code tokens} - tokens to check
@@ -122,6 +145,8 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * TEXT_BLOCK_LITERAL_BEGIN</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">
  * LAND</a>,
+ * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">
+ * LOR</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_INSTANCEOF">
  * LITERAL_INSTANCEOF</a>,
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GT">
@@ -376,6 +401,7 @@ public class UnnecessaryParenthesesCheck extends AbstractCheck {
             TokenTypes.LAMBDA,
             TokenTypes.TEXT_BLOCK_LITERAL_BEGIN,
             TokenTypes.LAND,
+            TokenTypes.LOR,
             TokenTypes.LITERAL_INSTANCEOF,
             TokenTypes.GT,
             TokenTypes.LT,
@@ -422,6 +448,7 @@ public class UnnecessaryParenthesesCheck extends AbstractCheck {
             TokenTypes.LAMBDA,
             TokenTypes.TEXT_BLOCK_LITERAL_BEGIN,
             TokenTypes.LAND,
+            TokenTypes.LOR,
             TokenTypes.LITERAL_INSTANCEOF,
             TokenTypes.GT,
             TokenTypes.LT,
@@ -508,7 +535,7 @@ public class UnnecessaryParenthesesCheck extends AbstractCheck {
             else if (TokenUtil.isOfType(type, ASSIGNMENTS)) {
                 assignDepth--;
             }
-            else if (isSurrounded(ast) && checkAroundOperators(ast)) {
+            else if (isSurrounded(ast) && unnecessaryParenAroundOperators(ast)) {
                 log(ast.getPreviousSibling(), MSG_EXPR);
             }
         }
@@ -571,19 +598,22 @@ public class UnnecessaryParenthesesCheck extends AbstractCheck {
 
     /**
      * Checks if conditional, relational, unary and postfix operators
-     * in expressions are surrounded by parentheses.
+     * in expressions are surrounded by unnecessary parentheses.
      *
      * @param ast the {@code DetailAST} to check if it is surrounded by
-     *        parentheses.
+     *        unnecessary parentheses.
      * @return {@code true} if the expression is surrounded by
-     *         parentheses.
+     *         unnecessary parentheses.
      */
-    private static boolean checkAroundOperators(DetailAST ast) {
+    private static boolean unnecessaryParenAroundOperators(DetailAST ast) {
         final int type = ast.getType();
         final int parentType = ast.getParent().getType();
         final boolean isConditional = TokenUtil.isOfType(type, CONDITIONALS_AND_RELATIONAL);
         boolean result = TokenUtil.isOfType(parentType, CONDITIONALS_AND_RELATIONAL);
         if (isConditional) {
+            if (type == TokenTypes.LOR) {
+                result = result && !TokenUtil.isOfType(parentType, TokenTypes.LAND);
+            }
             result = result && !TokenUtil.isOfType(parentType, TokenTypes.EQUAL,
                 TokenTypes.NOT_EQUAL);
         }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/UnnecessaryParenthesesCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/UnnecessaryParenthesesCheck.xml
@@ -21,9 +21,9 @@
  &lt;/pre&gt;
  &lt;p&gt;
  The check is not "type aware", that is to say, it can't tell if parentheses
- are unnecessary based on the types in an expression.  It also doesn't know
- about operator precedence and associativity; therefore it won't catch
- something like
+ are unnecessary based on the types in an expression. The check is partially aware about
+ operator precedence but unaware about operator associativity.
+ It won't catch cases such as:
  &lt;/p&gt;
  &lt;pre&gt;
  int x = (a + b) + c; // 1st Case
@@ -40,9 +40,32 @@
  and removing parentheses will give a compile time error. Even if &lt;em&gt;q&lt;/em&gt;
  and &lt;em&gt;r&lt;/em&gt; were {@code boolean} still there will be no violation
  raised as check is not "type aware".
- &lt;/p&gt;</description>
+ &lt;/p&gt;
+ &lt;p&gt;
+ The partial support for operator precedence includes cases of the following type:
+ &lt;/p&gt;
+ &lt;pre&gt;
+ boolean a = true, b = true;
+ boolean c = false, d = false;
+ if ((a &amp;amp;&amp;amp; b) || c) { // violation, unnecessary paren
+ }
+ if (a &amp;amp;&amp;amp; (b || c)) { // ok
+ }
+ if ((a == b) &amp;amp;&amp;amp; c) { // violation, unnecessary paren
+ }
+ String e = &amp;quot;e&amp;quot;;
+ if ((e instanceof String) &amp;amp;&amp;amp; a || b) { // violation, unnecessary paren
+ }
+ int f = 0;
+ int g = 0;
+ if (!(f &amp;gt;= g) // ok
+         &amp;amp;&amp;amp; (g &amp;gt; f)) { // violation, unnecessary paren
+ }
+ if ((++f) &amp;gt; g &amp;amp;&amp;amp; a) { // violation, unnecessary paren
+ }
+ &lt;/pre&gt;</description>
          <properties>
-            <property default-value="EXPR,IDENT,NUM_DOUBLE,NUM_FLOAT,NUM_INT,NUM_LONG,STRING_LITERAL,LITERAL_NULL,LITERAL_FALSE,LITERAL_TRUE,ASSIGN,BAND_ASSIGN,BOR_ASSIGN,BSR_ASSIGN,BXOR_ASSIGN,DIV_ASSIGN,MINUS_ASSIGN,MOD_ASSIGN,PLUS_ASSIGN,SL_ASSIGN,SR_ASSIGN,STAR_ASSIGN,LAMBDA,TEXT_BLOCK_LITERAL_BEGIN,LAND,LITERAL_INSTANCEOF,GT,LT,GE,LE,EQUAL,NOT_EQUAL,UNARY_MINUS,UNARY_PLUS,INC,DEC,LNOT,BNOT,POST_INC,POST_DEC"
+            <property default-value="EXPR,IDENT,NUM_DOUBLE,NUM_FLOAT,NUM_INT,NUM_LONG,STRING_LITERAL,LITERAL_NULL,LITERAL_FALSE,LITERAL_TRUE,ASSIGN,BAND_ASSIGN,BOR_ASSIGN,BSR_ASSIGN,BXOR_ASSIGN,DIV_ASSIGN,MINUS_ASSIGN,MOD_ASSIGN,PLUS_ASSIGN,SL_ASSIGN,SR_ASSIGN,STAR_ASSIGN,LAMBDA,TEXT_BLOCK_LITERAL_BEGIN,LAND,LOR,LITERAL_INSTANCEOF,GT,LT,GE,LE,EQUAL,NOT_EQUAL,UNARY_MINUS,UNARY_PLUS,INC,DEC,LNOT,BNOT,POST_INC,POST_DEC"
                       name="tokens"
                       type="java.lang.String[]"
                       validation-type="tokenSet">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheckTest.java
@@ -220,16 +220,27 @@ public class UnnecessaryParenthesesCheckTest extends AbstractModuleTestSupport {
             "108:13: " + getCheckMessage(MSG_EXPR),
             "109:21: " + getCheckMessage(MSG_EXPR),
             "112:13: " + getCheckMessage(MSG_EXPR),
-            "124:21: " + getCheckMessage(MSG_EXPR),
-            "130:13: " + getCheckMessage(MSG_EXPR),
-            "131:30: " + getCheckMessage(MSG_EXPR),
-            "132:28: " + getCheckMessage(MSG_EXPR),
-            "134:21: " + getCheckMessage(MSG_EXPR),
-            "145:20: " + getCheckMessage(MSG_EXPR),
         };
 
         verifyWithInlineConfigParser(
                 getPath("InputUnnecessaryParenthesesIfStatement.java"), expected);
+    }
+
+    @Test
+    public void testIfStatement2() throws Exception {
+        final String[] expected = {
+            "28:17: " + getCheckMessage(MSG_EXPR),
+            "39:17: " + getCheckMessage(MSG_EXPR),
+            "51:25: " + getCheckMessage(MSG_EXPR),
+            "57:13: " + getCheckMessage(MSG_EXPR),
+            "59:28: " + getCheckMessage(MSG_EXPR),
+            "60:28: " + getCheckMessage(MSG_EXPR),
+            "61:20: " + getCheckMessage(MSG_EXPR),
+            "63:20: " + getCheckMessage(MSG_EXPR),
+            "74:20: " + getCheckMessage(MSG_EXPR),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputUnnecessaryParenthesesIfStatement2.java"), expected);
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesIfStatement.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesIfStatement.java
@@ -114,49 +114,4 @@ public class InputUnnecessaryParenthesesIfStatement {
             return;
         }
     }
-
-    public void checkBooleanStatements() {
-        boolean a = true;
-        int b = 42;
-        int c = 42;
-        int d = 32;
-        if ((b == c) == a
-                && (( // violation
-                                (b==c)==(d>=b)==a!=(c==d))
-                || (b<=c)!=a==(c>=d))) {
-            return;
-        }
-
-        if (( // violation
-                a!=(b==c) && (a // violation
-                        && (b==c))) // violation
-                 || (a || a!=(b<=c))     // ok
-                 || (a==(b!=d==(c==b) && a!=(b<=c)))) { // violation
-                                                        // after '||'
-            return;
-        }
-
-        if (a==(b>=c && a==(c==d && d!=b)) // ok
-                && a==(c<=d)) { // ok
-           return;
-        }
-
-        if (a && a==(b<=c)==(a
-                && (b<=c))) { // violation
-            return;
-        }
-
-        if (a==(b==c) // ok
-                || a!=(b<=c)) { // ok
-            return;
-        }
-
-        if ((b==0) == (c==d) // ok
-                && (Integer.valueOf(d) instanceof Integer) == true) { // ok
-            return;
-        }
-    }
-
-
 }
-

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesIfStatement2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesIfStatement2.java
@@ -1,0 +1,88 @@
+/*
+UnnecessaryParentheses
+tokens = (default)EXPR, IDENT, NUM_DOUBLE, NUM_FLOAT, NUM_INT, NUM_LONG, \
+         STRING_LITERAL, LITERAL_NULL, LITERAL_FALSE, LITERAL_TRUE, ASSIGN, \
+         BAND_ASSIGN, BOR_ASSIGN, BSR_ASSIGN, BXOR_ASSIGN, DIV_ASSIGN, \
+         MINUS_ASSIGN, MOD_ASSIGN, PLUS_ASSIGN, SL_ASSIGN, SR_ASSIGN, STAR_ASSIGN, \
+         LAMBDA, TEXT_BLOCK_LITERAL_BEGIN, LAND, LITERAL_INSTANCEOF, GT, LT, GE, \
+         LE, EQUAL, NOT_EQUAL, UNARY_MINUS, UNARY_PLUS, INC, DEC, LNOT, BNOT, \
+         POST_INC, POST_DEC
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.unnecessaryparentheses;
+
+public class InputUnnecessaryParenthesesIfStatement2 {
+
+    void testShortCircuitOrIfStatement() {
+        boolean a = false;
+        boolean x = false, y = true, z = false;
+        boolean v = true, w = true, u = true;
+        boolean vy = x && y || (x || y || z) && v; // ok
+        if (a && !(v && w || (x || y) && z || u && x)) { // ok
+        }
+        if (a && !(v && w || x || y && z || u && x)) { // ok
+        }
+        if (v ||
+                (u || x || y)) { // violation
+        }
+        if ((v || x) == // ok
+                (w || y)) {
+        }
+        if ((v || x) & // ok
+                (w || y)) {
+        }
+        if (a && v || (w || z) && u || y) { // ok
+        }
+        if (a && x ||
+                (y || z) // violation
+                || vy && u) {
+        }
+    }
+
+    public void checkBooleanStatements() {
+        boolean a = true;
+        int b = 42;
+        int c = 42;
+        int d = 32;
+        if ((b == c) == a
+                && (
+                        ( // violation
+                            (b==c)==(d>=b)==a!=(c==d))
+                    || (b<=c)!=a==(c>=d))) {
+            return;
+        }
+
+        if (( // violation
+                a!=(b==c)
+                        && (a // violation
+                        && (b==c))) // violation
+                || (a // violation
+                || a!=(b<=c)) // ok
+                || (a==(b!=d==(c==b) && a!=(b<=c)))) { // violation
+                                                       // after '||'
+            return;
+        }
+
+        if (a==(b>=c && a==(c==d && d!=b)) // ok
+                && a==(c<=d)) { // ok
+            return;
+        }
+
+        if (a && a==(b<=c)==(a
+                && (b<=c))) { // violation
+            return;
+        }
+
+        if (a==(b==c) // ok
+                || a!=(b<=c)) { // ok
+            return;
+        }
+
+        if ((b==0) == (c==d) // ok
+                && (Integer.valueOf(d) instanceof Integer) == true) { // ok
+            return;
+        }
+    }
+}

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -6878,8 +6878,9 @@ boolean b = (~a) &gt; -27            // parens around ~a
       <subsection name="Notes" id="UnnecessaryParentheses_Notes">
         <p>
           The check is not "type aware", that is to say, it can't tell if parentheses
-          are unnecessary based on the types in an expression.  It also doesn't know about
-          operator precedence and associativity; therefore it won't catch something like
+          are unnecessary based on the types in an expression. The check is partially aware about
+          operator precedence but unaware about operator associativity.
+          It won't catch cases such as:
         </p>
         <source>
 int x = (a + b) + c; // 1st Case
@@ -6898,6 +6899,29 @@ if (p == (q &lt;= r)) {}
           and <em>r</em> were <code>boolean</code> still there will be no violation
           raised as check is not "type aware".
         </p>
+        <p>
+          The partial support for operator precedence includes cases of the following type:
+        </p>
+        <source>
+boolean a = true, b = true;
+boolean c = false, d = false;
+if ((a &amp;&amp; b) || c) { // violation, unnecessary paren
+}
+if (a &amp;&amp; (b || c)) { // ok
+}
+if ((a == b) &amp;&amp; c) { // violation, unnecessary paren
+}
+String e = &quot;e&quot;;
+if ((e instanceof String) &amp;&amp; a || b) { // violation, unnecessary paren
+}
+int f = 0;
+int g = 0;
+if (!(f &gt;= g) // ok
+        &amp;&amp; (g &gt; f)) { // violation, unnecessary paren
+}
+if ((++f) &gt; g &amp;&amp; a) { // violation, unnecessary paren
+}
+        </source>
       </subsection>
 
       <subsection name="Properties" id="UnnecessaryParentheses_Properties">
@@ -6965,6 +6989,8 @@ if (p == (q &lt;= r)) {}
                 TEXT_BLOCK_LITERAL_BEGIN</a>
                 ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">
                 LAND</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">
+                LOR</a>
                 ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_INSTANCEOF">
                 LITERAL_INSTANCEOF</a>
                 ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GT">
@@ -7048,6 +7074,8 @@ if (p == (q &lt;= r)) {}
                   TEXT_BLOCK_LITERAL_BEGIN</a>
                 ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LAND">
                   LAND</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LOR">
+                  LOR</a>
                 ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_INSTANCEOF">
                   LITERAL_INSTANCEOF</a>
                 ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#GT">


### PR DESCRIPTION
Resolves #11061:  UnnecessaryParentheses: false negative
Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/5b2e5d76bc8d10c8f0e3619697156e49d80ab85f/my_checks.xml
Final Report(clean) - https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/cd3cb0c_2021122340/reports/diff/index.html