### PR TITLE
Issue #11131: replace 'if' with assumeTrue/False in tests

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -222,11 +223,10 @@ public class DefaultLoggerTest {
     @Test
     public void testLanguageIsValid() {
         final String language = DEFAULT_LOCALE.getLanguage();
-        if (!language.isEmpty()) {
-            assertWithMessage("Invalid language")
-                    .that(Arrays.asList(Locale.getISOLanguages()))
-                    .contains(language);
-        }
+        assumeFalse(language.isEmpty(), "Locale not set");
+        assertWithMessage("Invalid language")
+                .that(Arrays.asList(Locale.getISOLanguages()))
+                .contains(language);
     }
 
     /**
@@ -235,11 +235,10 @@ public class DefaultLoggerTest {
     @Test
     public void testCountryIsValid() {
         final String country = DEFAULT_LOCALE.getCountry();
-        if (!country.isEmpty()) {
-            assertWithMessage("Invalid country")
-                    .that(Arrays.asList(Locale.getISOCountries()))
-                    .contains(country);
-        }
+        assumeFalse(country.isEmpty(), "Locale not set");
+        assertWithMessage("Invalid country")
+                .that(Arrays.asList(Locale.getISOCountries()))
+                .contains(country);
     }
 
     /**
@@ -249,17 +248,17 @@ public class DefaultLoggerTest {
     @Test
     public void testLocaleIsSupported() throws Exception {
         final String language = DEFAULT_LOCALE.getLanguage();
-        if (!language.isEmpty() && !Locale.ENGLISH.getLanguage().equals(language)) {
-            final Class<?> localizedMessage = getDefaultLoggerClass().getDeclaredClasses()[0];
-            final Object messageCon = localizedMessage.getConstructor(String.class, String[].class)
-                    .newInstance(DefaultLogger.ADD_EXCEPTION_MESSAGE, null);
-            final Method message = messageCon.getClass().getDeclaredMethod("getMessage");
-            final Object constructor = localizedMessage.getConstructor(String.class)
-                    .newInstance(DefaultLogger.ADD_EXCEPTION_MESSAGE);
-            assertWithMessage("Unsupported language: " + DEFAULT_LOCALE)
-                    .that(message.invoke(constructor))
-                    .isEqualTo("Error auditing {0}");
-        }
+        assumeFalse(language.isEmpty() || Locale.ENGLISH.getLanguage().equals(language),
+                "Custom locale not set");
+        final Class<?> localizedMessage = getDefaultLoggerClass().getDeclaredClasses()[0];
+        final Object messageCon = localizedMessage.getConstructor(String.class, String[].class)
+                .newInstance(DefaultLogger.ADD_EXCEPTION_MESSAGE, null);
+        final Method message = messageCon.getClass().getDeclaredMethod("getMessage");
+        final Object constructor = localizedMessage.getConstructor(String.class)
+                .newInstance(DefaultLogger.ADD_EXCEPTION_MESSAGE);
+        assertWithMessage("Unsupported language: " + DEFAULT_LOCALE)
+                .that(message.invoke(constructor))
+                .isEqualTo("Error auditing {0}");
     }
 
     @DefaultLocale("fr")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
@@ -384,16 +384,16 @@ public class PackageObjectFactoryTest {
                     return !canonicalNames.contains(clazz.getCanonicalName())
                             && !Definitions.INTERNAL_MODULES.contains(clazz.getName());
                 }).findFirst();
-        if (optional1.isPresent()) {
-            assertWithMessage("Invalid canonical name: " + optional1.get()).fail();
-        }
+        assertWithMessage("Invalid canonical name: %s", optional1)
+                .that(optional1.isPresent())
+                .isFalse();
         final Optional<String> optional2 = canonicalNames.stream().filter(canonicalName -> {
             return classes.stream().map(Class::getCanonicalName)
                     .noneMatch(clssCanonicalName -> clssCanonicalName.equals(canonicalName));
         }).findFirst();
-        if (optional2.isPresent()) {
-            assertWithMessage("Invalid class: " + optional2.get()).fail();
-        }
+        assertWithMessage("Invalid class: %s", optional2)
+                .that(optional2.isPresent())
+                .isFalse();
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/ViolationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/ViolationTest.java
@@ -21,13 +21,13 @@ package com.puppycrawl.tools.checkstyle.api;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_OBJECT_ARRAY;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
-import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
@@ -58,11 +58,10 @@ public class ViolationTest {
     @Test
     public void testLanguageIsValid() {
         final String language = DEFAULT_LOCALE.getLanguage();
-        if (!language.isEmpty()) {
-            assertWithMessage("Invalid language")
-                .that(Arrays.asList(Locale.getISOLanguages()))
+        assumeFalse(language.isEmpty(), "Locale not set");
+        assertWithMessage("Invalid language")
+                .that(Locale.getISOLanguages()).asList()
                 .contains(language);
-        }
     }
 
     /**
@@ -71,11 +70,10 @@ public class ViolationTest {
     @Test
     public void testCountryIsValid() {
         final String country = DEFAULT_LOCALE.getCountry();
-        if (!country.isEmpty()) {
-            assertWithMessage("Invalid country")
-                    .that(Arrays.asList(Locale.getISOCountries()))
-                    .contains(country);
-        }
+        assumeFalse(country.isEmpty(), "Locale not set");
+        assertWithMessage("Invalid country")
+                .that(Locale.getISOCountries()).asList()
+                .contains(country);
     }
 
     /**
@@ -85,12 +83,12 @@ public class ViolationTest {
     @Test
     public void testLocaleIsSupported() {
         final String language = DEFAULT_LOCALE.getLanguage();
-        if (!language.isEmpty() && !Locale.ENGLISH.getLanguage().equals(language)) {
-            final Violation violation = createSampleViolation();
-            assertWithMessage("Unsupported language: " + DEFAULT_LOCALE)
-                    .that(violation.getViolation())
-                    .isNotEqualTo("Empty statement.");
-        }
+        assumeFalse(language.isEmpty() || Locale.ENGLISH.getLanguage().equals(language),
+                "Custom locale not set");
+        final Violation violation = createSampleViolation();
+        assertWithMessage("Unsupported language: {}", DEFAULT_LOCALE)
+                .that(violation.getViolation())
+                .isNotEqualTo("Empty statement.");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -2963,10 +2963,11 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
             final int line = event.getLine();
             final String message = event.getMessage();
 
-            if (position >= comments.length) {
-                assertWithMessage("found a warning when none was expected for #" + position
-                        + " at line " + line + " with message " + message).fail();
-            }
+            assertWithMessage(
+                    "found a warning when none was expected for #%s at line %s with message %s",
+                    position, line, message)
+                .that(position)
+                .isLessThan(comments.length);
 
             final IndentComment comment = comments[position];
             position++;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.filters;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -192,37 +193,31 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
             }
         }
 
-        // Run the test only if connection is available and url is reachable.
-        // We must use an if statement over junit's rule or assume because
-        // powermock disrupts the assume exception and turns into a failure
-        // instead of a skip when it doesn't pass
-        if (urlForTest != null) {
-            final DefaultConfiguration firstFilterConfig =
-                createModuleConfig(SuppressionFilter.class);
-            // -@cs[CheckstyleTestMakeup] need to test dynamic property
-            firstFilterConfig.addProperty("file", urlForTest);
+        assumeTrue(urlForTest != null, "No Internet connection.");
+        final DefaultConfiguration firstFilterConfig = createModuleConfig(SuppressionFilter.class);
+        // -@cs[CheckstyleTestMakeup] need to test dynamic property
+        firstFilterConfig.addProperty("file", urlForTest);
 
-            final DefaultConfiguration firstCheckerConfig = createRootConfig(firstFilterConfig);
-            final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
-            firstCheckerConfig.addProperty("cacheFile", cacheFile.getPath());
+        final DefaultConfiguration firstCheckerConfig = createRootConfig(firstFilterConfig);
+        final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
+        firstCheckerConfig.addProperty("cacheFile", cacheFile.getPath());
 
-            final String pathToEmptyFile =
-                    File.createTempFile("file", ".java", temporaryFolder).getPath();
-            final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        final String pathToEmptyFile =
+                File.createTempFile("file", ".java", temporaryFolder).getPath();
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
-            verify(firstCheckerConfig, pathToEmptyFile, expected);
+        verify(firstCheckerConfig, pathToEmptyFile, expected);
 
-            // One more time to use cache.
-            final DefaultConfiguration secondFilterConfig =
-                createModuleConfig(SuppressionFilter.class);
-            // -@cs[CheckstyleTestMakeup] need to test dynamic property
-            secondFilterConfig.addProperty("file", urlForTest);
+        // One more time to use cache.
+        final DefaultConfiguration secondFilterConfig =
+            createModuleConfig(SuppressionFilter.class);
+        // -@cs[CheckstyleTestMakeup] need to test dynamic property
+        secondFilterConfig.addProperty("file", urlForTest);
 
-            final DefaultConfiguration secondCheckerConfig = createRootConfig(secondFilterConfig);
-            secondCheckerConfig.addProperty("cacheFile", cacheFile.getPath());
+        final DefaultConfiguration secondCheckerConfig = createRootConfig(secondFilterConfig);
+        secondCheckerConfig.addProperty("cacheFile", cacheFile.getPath());
 
-            verify(secondCheckerConfig, pathToEmptyFile, expected);
-        }
+        verify(secondCheckerConfig, pathToEmptyFile, expected);
     }
 
     private static boolean isConnectionAvailableAndStable(String url) throws Exception {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.filters;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -74,14 +75,12 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
                 break;
             }
         }
-        // Use Assume.assumeNotNull(actualFilterSet) instead of the if-condition
-        // when https://github.com/jayway/powermock/issues/428 will be fixed
-        if (actualFilterSet != null) {
-            final FilterSet expectedFilterSet = new FilterSet();
-            assertWithMessage("Failed to load from url")
-                .that(actualFilterSet.getFilters())
-                .isEqualTo(expectedFilterSet.getFilters());
-        }
+
+        assumeTrue(actualFilterSet != null, "No Internet connection.");
+        final FilterSet expectedFilterSet = new FilterSet();
+        assertWithMessage("Failed to load from url")
+            .that(actualFilterSet.getFilters())
+            .isEqualTo(expectedFilterSet.getFilters());
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammar/comments/AllBlockCommentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammar/comments/AllBlockCommentsTest.java
@@ -97,9 +97,9 @@ public class AllBlockCommentsTest extends AbstractModuleTestSupport {
         @Override
         public void visitToken(DetailAST ast) {
             final String commentContent = ast.getFirstChild().getText();
-            if (!ALL_COMMENTS.remove(commentContent)) {
-                assertWithMessage("Unexpected comment: " + commentContent).fail();
-            }
+            assertWithMessage("Unexpected comment: %s", commentContent)
+                    .that(ALL_COMMENTS.remove(commentContent))
+                    .isTrue();
         }
 
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammar/comments/AllSinglelineCommentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammar/comments/AllSinglelineCommentsTest.java
@@ -92,9 +92,9 @@ public class AllSinglelineCommentsTest extends AbstractModuleTestSupport {
         @Override
         public void visitToken(DetailAST ast) {
             final String commentContent = ast.getFirstChild().getText();
-            if (!ALL_COMMENTS.remove(commentContent)) {
-                assertWithMessage("Unexpected comment: " + commentContent).fail();
-            }
+            assertWithMessage("Unexpected comment: %s", commentContent)
+                    .that(ALL_COMMENTS.remove(commentContent))
+                    .isTrue();
         }
 
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -295,12 +295,10 @@ public class AllChecksTest extends AbstractModuleTestSupport {
                 final int[] defaultTokens = testedCheck.getDefaultTokens();
                 final int[] acceptableTokens = testedCheck.getAcceptableTokens();
 
-                if (!isSubset(defaultTokens, acceptableTokens)) {
-                    final String errorMessage = String.format(Locale.ROOT,
-                            "%s's default tokens must be a subset"
-                            + " of acceptable tokens.", check.getName());
-                    assertWithMessage(errorMessage).fail();
-                }
+                assertWithMessage("%s's default tokens must be a subset of acceptable tokens.",
+                            check.getName())
+                        .that(isSubset(defaultTokens, acceptableTokens))
+                        .isTrue();
             }
         }
     }
@@ -314,12 +312,10 @@ public class AllChecksTest extends AbstractModuleTestSupport {
                 final int[] requiredTokens = testedCheck.getRequiredTokens();
                 final int[] acceptableTokens = testedCheck.getAcceptableTokens();
 
-                if (!isSubset(requiredTokens, acceptableTokens)) {
-                    final String errorMessage = String.format(Locale.ROOT,
-                            "%s's required tokens must be a subset"
-                            + " of acceptable tokens.", check.getName());
-                    assertWithMessage(errorMessage).fail();
-                }
+                assertWithMessage("%s's required tokens must be a subset of acceptable tokens.",
+                            check.getName())
+                        .that(isSubset(requiredTokens, acceptableTokens))
+                        .isTrue();
             }
         }
     }
@@ -333,12 +329,10 @@ public class AllChecksTest extends AbstractModuleTestSupport {
                 final int[] defaultTokens = testedCheck.getDefaultTokens();
                 final int[] requiredTokens = testedCheck.getRequiredTokens();
 
-                if (!isSubset(requiredTokens, defaultTokens)) {
-                    final String errorMessage = String.format(Locale.ROOT,
-                            "%s's required tokens must be a subset"
-                            + " of default tokens.", check.getName());
-                    assertWithMessage(errorMessage).fail();
-                }
+                assertWithMessage("%s's required tokens must be a subset of default tokens.",
+                            check.getName())
+                        .that(isSubset(requiredTokens, defaultTokens))
+                        .isTrue();
             }
         }
     }


### PR DESCRIPTION
Fixes #11131

This is leftover of #10932 

There were some `if` in the tests due to the  incompatibility of Powermock with `assumeXXX`.

Detected by @rnveach at https://github.com/checkstyle/checkstyle/issues/10932#issuecomment-1001087308