### PR TITLE
Issue #11120: switch from fb-contrib to sb-contrib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -495,8 +495,8 @@
             <spotbugsXmlOutputDirectory>target/spotbugsreports</spotbugsXmlOutputDirectory>
             <plugins>
               <plugin>
-                <groupId>com.mebigfatguy.fb-contrib</groupId>
-                <artifactId>fb-contrib</artifactId>
+                <groupId>com.mebigfatguy.sb-contrib</groupId>
+                <artifactId>sb-contrib</artifactId>
                 <version>7.4.7</version>
               </plugin>
             </plugins>


### PR DESCRIPTION
Fixes #11120 

fb-contrib works with Spotbugs, but with some exceptions thrown at runtime:

```
Exception analyzing...using detector com.mebigfatguy.fbcontrib.detect.OverlyPermissiveMethod
[java] java.lang.RuntimeException: Incompatible bcel version, apparently bcel has been upgraded to not use 'Unknown' for 'BootstrapMethods', but uses: BootstrapMethods
```
This is due to fb-contrib shoud be used only with Findbugs. For Spotbugs there is a dedicated build named sb-contrib.