### PR TITLE
Issue #9142: finalize

### DIFF
--- a/config/import-control-test.xml
+++ b/config/import-control-test.xml
@@ -17,7 +17,9 @@
   <!-- Disallow hamcrest and only allow Truth -->
   <disallow pkg="org.hamcrest.CoreMatchers"/>
   <disallow pkg="org.hamcrest.MatcherAssert"/>
-  <!-- until https://github.com/checkstyle/checkstyle/issues/9142 -->
+  <!-- Disallow Junit assert in favor of Truth asserts in few exceptions -->
+  <allow class="org.junit.jupiter.api.Assertions.assertThrows"/>
+  <allow class="org.junit.jupiter.api.Assertions.assertDoesNotThrow"/>
   <disallow pkg="org.junit.jupiter.api.Assertions"/>
 
   <!-- Reflection shouldn't be used in tests. -->

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -101,30 +101,6 @@
   <!-- until https://github.com/checkstyle/checkstyle/issues/5234 -->
   <suppress id="MatchXPathBranchContains" files="[\\/]DetailAstImplTest.java"/>
 
-  <!-- until https://github.com/checkstyle/checkstyle/issues/9142 -->
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]base[\\/]AbstractItModuleTestSupport.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]it[\\/]java[\\/]org[\\/]checkstyle[\\/]suppressionxpathfilter[\\/]AbstractXpathTestSupport.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]PropertyCacheFileTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]ant[\\/]CheckstyleAntTaskTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]header[\\/]HeaderCheckTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]javadoc[\\/]AbstractJavadocCheckTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]checks[\\/]regexp[\\/]RegexpOnFilenameCheckTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]filters[\\/]SuppressionsLoaderTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]utils[\\/]ChainedPropertyUtilTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]utils[\\/]CheckUtilTest.java"/>
-  <suppress id="ImportControlTest"
-            files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]xpath[\\/]AttributeNodeTest.java"/>
-
   <!-- until https://github.com/checkstyle/checkstyle/issues/11123 -->
   <suppress id="ImportControlTest"
             files="[\\/]src[\\/]test[\\/]java[\\/]com[\\/]puppycrawl[\\/]tools[\\/]checkstyle[\\/]api[\\/]JavadocTokenTypesTest.java"/>

--- a/src/it/java/org/checkstyle/base/AbstractItModuleTestSupport.java
+++ b/src/it/java/org/checkstyle/base/AbstractItModuleTestSupport.java
@@ -19,8 +19,7 @@
 
 package org.checkstyle.base;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -251,22 +250,29 @@ public abstract class AbstractItModuleTestSupport extends AbstractPathTestSuppor
             for (int i = 0; i < expected.length; i++) {
                 final String expectedResult = messageFileName + ":" + expected[i];
                 final String actual = lnr.readLine();
-                assertEquals(expectedResult, actual, "error message " + i);
+                assertWithMessage("error message %s", i)
+                    .that(actual)
+                    .isEqualTo(expectedResult);
 
                 String parseInt = removeDeviceFromPathOnWindows(actual);
                 parseInt = parseInt.substring(parseInt.indexOf(':') + 1);
                 parseInt = parseInt.substring(0, parseInt.indexOf(':'));
                 final int lineNumber = Integer.parseInt(parseInt);
-                assertTrue(previousLineNumber == lineNumber
-                                || theWarnings.remove((Integer) lineNumber),
-                        "input file is expected to have a warning comment on line number "
-                                        + lineNumber);
+                assertWithMessage(
+                        "input file is expected to have a warning comment on line number %s",
+                        lineNumber)
+                    .that(previousLineNumber == lineNumber
+                            || theWarnings.remove((Integer) lineNumber))
+                    .isTrue();
                 previousLineNumber = lineNumber;
             }
 
-            assertEquals(expected.length,
-                    errs, "unexpected output: " + lnr.readLine());
-            assertEquals(0, theWarnings.size(), "unexpected warnings " + theWarnings);
+            assertWithMessage("unexpected output: %s", lnr.readLine())
+                .that(errs)
+                .isEqualTo(expected.length);
+            assertWithMessage("unexpected warnings %s", theWarnings)
+                .that(theWarnings)
+                .isEmpty();
         }
 
         checker.destroy();

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/AbstractXpathTestSupport.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/AbstractXpathTestSupport.java
@@ -19,7 +19,7 @@
 
 package org.checkstyle.suppressionxpathfilter;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.io.File;
 import java.io.Writer;
@@ -102,8 +102,9 @@ public abstract class AbstractXpathTestSupport extends AbstractCheckstyleModuleT
      */
     private static void verifyXpathQueries(List<String> generatedXpathQueries,
                                            List<String> expectedXpathQueries) {
-        assertEquals(expectedXpathQueries,
-                generatedXpathQueries, "Generated queries do not match expected ones");
+        assertWithMessage("Generated queries do not match expected ones")
+            .that(generatedXpathQueries)
+            .isEqualTo(expectedXpathQueries);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle.filters;
 
 import static com.google.common.truth.Truth.assertWithMessage;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
@@ -184,8 +183,9 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
             assertWithMessage("Exception is expected").fail();
         }
         catch (CheckstyleException ex) {
-            assertTrue(ex.getMessage().startsWith("Number format exception " + fn + " - "),
-                    ex.getMessage());
+            assertWithMessage(ex.getMessage())
+                .that(ex.getMessage())
+                .startsWith("Number format exception " + fn + " - ");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
@@ -22,7 +22,6 @@ package com.puppycrawl.tools.checkstyle.utils;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.findTokenInAstByPredicate;
 import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.util.Arrays;
@@ -154,7 +153,8 @@ public class CheckUtilTest extends AbstractPathTestSupport {
 
         try {
             CheckUtil.getAccessModifierFromModifiersToken(modifiers);
-            fail(IllegalArgumentException.class.getSimpleName() + " was expected.");
+            assertWithMessage("%s was expected.", IllegalArgumentException.class.getSimpleName())
+                .fail();
         }
         catch (IllegalArgumentException exc) {
             final String expectedExceptionMsg = "expected non-null AST-token with type 'MODIFIERS'";
@@ -452,9 +452,9 @@ public class CheckUtilTest extends AbstractPathTestSupport {
         final Optional<DetailAST> node = findTokenInAstByPredicate(root,
             ast -> ast.getType() == type);
 
-        if (!node.isPresent()) {
-            fail("Cannot find node of specified type: " + type);
-        }
+        assertWithMessage("Cannot find node of specified type: %s", type)
+            .that(node.isPresent())
+            .isTrue();
 
         return node.get();
     }


### PR DESCRIPTION
Closes #9142

Doing a search on `org.junit.jupiter.api.Assertions` only provides the following results:
````
M:\checkstyleWorkspace\checkstyle\src\test\java\com\puppycrawl\tools\checkstyle\ant\CheckstyleAntTaskTest.java (1 hit)
	Line 23: import static org.junit.jupiter.api.Assertions.assertThrows;
  M:\checkstyleWorkspace\checkstyle\src\test\java\com\puppycrawl\tools\checkstyle\checks\header\HeaderCheckTest.java (1 hit)
	Line 25: import static org.junit.jupiter.api.Assertions.assertThrows;
  M:\checkstyleWorkspace\checkstyle\src\test\java\com\puppycrawl\tools\checkstyle\checks\imports\ImportControlLoaderTest.java (1 hit)
	Line 23: import static org.junit.jupiter.api.Assertions.assertThrows;
  M:\checkstyleWorkspace\checkstyle\src\test\java\com\puppycrawl\tools\checkstyle\checks\javadoc\AbstractJavadocCheckTest.java (1 hit)
	Line 30: import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
  M:\checkstyleWorkspace\checkstyle\src\test\java\com\puppycrawl\tools\checkstyle\checks\regexp\RegexpOnFilenameCheckTest.java (1 hit)
	Line 25: import static org.junit.jupiter.api.Assertions.assertThrows;
  M:\checkstyleWorkspace\checkstyle\src\test\java\com\puppycrawl\tools\checkstyle\ConfigurationLoaderTest.java (1 hit)
	Line 23: import static org.junit.jupiter.api.Assertions.assertThrows;
  M:\checkstyleWorkspace\checkstyle\src\test\java\com\puppycrawl\tools\checkstyle\DefaultLoggerTest.java (1 hit)
	Line 23: import static org.junit.jupiter.api.Assertions.assertThrows;
  M:\checkstyleWorkspace\checkstyle\src\test\java\com\puppycrawl\tools\checkstyle\PropertyCacheFileTest.java (1 hit)
	Line 23: import static org.junit.jupiter.api.Assertions.assertThrows;
  M:\checkstyleWorkspace\checkstyle\src\test\java\com\puppycrawl\tools\checkstyle\utils\ChainedPropertyUtilTest.java (1 hit)
	Line 24: import static org.junit.jupiter.api.Assertions.assertThrows;
  M:\checkstyleWorkspace\checkstyle\src\test\java\com\puppycrawl\tools\checkstyle\utils\CommonUtilTest.java (1 hit)
	Line 25: import static org.junit.jupiter.api.Assertions.assertThrows;
  M:\checkstyleWorkspace\checkstyle\src\test\java\com\puppycrawl\tools\checkstyle\xpath\AttributeNodeTest.java (1 hit)
	Line 23: import static org.junit.jupiter.api.Assertions.assertThrows;
````