### PR TITLE
infra: add `--list` to .ci/pitest.sh

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -151,8 +151,18 @@ pitest-javadoc)
 #   # post validation is skipped, we do not test gui throughly
 #   ;;
 
+--list)
+  echo "Supported profiles:"
+  pomXmlPath="$(dirname "${0}")/../pom.xml"
+  sed -n -e 's/<id>\(pitest-\w\+\)<\/id>/\1/p' < "${pomXmlPath}" | sort
+  ;;
+
 *)
-  echo "Unexpected argument: $1"
+  if [[ -n "$1" ]]; then
+    echo "Unexpected argument: $*"
+  fi
+  echo "Usage $0 <profile>"
+  echo "To see the full list of supported profiles run '$0 --list'"
   sleep 5s
   false
   ;;


### PR DESCRIPTION
Outputs:

```bash
$ .ci/pitest.sh --list
Supported profiles:
      pitest-annotation
      pitest-ant
      pitest-api
      pitest-blocks
      pitest-coding
      pitest-common
      pitest-design
      pitest-filters
      pitest-gui
      pitest-header
      pitest-imports
      pitest-indentation
      pitest-javadoc
      pitest-main
      pitest-metrics
      pitest-misc
      pitest-modifier
      pitest-naming
      pitest-packagenamesloader
      pitest-regexp
      pitest-sizes
      pitest-utils
      pitest-whitespace
      pitest-xpath


$ .ci/pitest.sh nosuchoption
Unexpected argument: nosuchoption
Usage .ci/pitest.sh <profile>
To see the full list of supported profiles run '.ci/pitest.sh --list'
```