### PR TITLE
Issue #6320: resolution for AbstractSuperCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AbstractSuperCheck.java
@@ -98,8 +98,7 @@ public abstract class AbstractSuperCheck
     private boolean isSuperCall(DetailAST literalSuperAst) {
         boolean superCall = false;
 
-        if (literalSuperAst.getType() == TokenTypes.LITERAL_SUPER
-            && !isSameNameMethod(literalSuperAst)) {
+        if (!isSameNameMethod(literalSuperAst)) {
             final DetailAST parent = literalSuperAst.getParent();
             if (parent.getType() == TokenTypes.METHOD_REF
                 || !hasArguments(parent)) {


### PR DESCRIPTION
Issue #6320

Identified at https://github.com/checkstyle/checkstyle/pull/11157 .
http://rveach.no-ip.org/checkstyle/pitest/40/pitest-coding/com.puppycrawl.tools.checkstyle.checks.coding/AbstractSuperCheck.java.html#org.pitest.mutationtest.report.html.SourceFile@4c20892b_101

We limit this check to very specific tokens. METHOD_DEF and LITERAL_SUPER.

The area in question in this code relies directly on the tokens brought forward to the visit check. So we can't show super is needed, regression showed nothing anyways. METHOD_DEF is not an issue and cannot be contributed to show such because we already have a specific section in the visit for METHOD_DEF and any that get to this section, we enough checks in `isSameNameMethod` that it basically has to be the super literal because we are looking for specific tokens with specific text that prevents us from matching something random.

I tried re-writting the code in addition to removing the existing code so it made more sense and satisfy pitest, Ex:
````
        if (ast.getType() == TokenTypes.METHOD_DEF) {
            if (isOverridingMethod(ast)) {
                methodStack.add(new MethodNode(ast));
            }
        }
        else if (isSuperCall(ast)) {
````
but this increased the number of surviving mutations beyond the original report.

With this code removed, this class has 100% mutation covered from testing locally.