### PR TITLE
Issue #6320: added test case for EqualsAvoidNullCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheckTest.java
@@ -222,6 +222,7 @@ public class EqualsAvoidNullCheckTest extends AbstractModuleTestSupport {
             "22:34: " + getCheckMessage(MSG_EQUALS_AVOID_NULL),
             "34:33: " + getCheckMessage(MSG_EQUALS_IGNORE_CASE_AVOID_NULL),
             "41:33: " + getCheckMessage(MSG_EQUALS_IGNORE_CASE_AVOID_NULL),
+            "49:33: " + getCheckMessage(MSG_EQUALS_IGNORE_CASE_AVOID_NULL),
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputEqualsAvoidNullRecordsAndCompactCtors.java"),

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/InputEqualsAvoidNullRecordsAndCompactCtors.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/equalsavoidnull/InputEqualsAvoidNullRecordsAndCompactCtors.java
@@ -43,4 +43,12 @@ public class InputEqualsAvoidNullRecordsAndCompactCtors {
         }
     }
 
+    record TestRecord5() {
+        TestRecord5 (int num) {
+            this();
+            str.equalsIgnoreCase("my string"); // violation 'left .* of .* equalsIgnoreCase'
+            "my string".equals(str); // ok
+        }
+        private static String str;
+    }
 }


### PR DESCRIPTION
Issue #6320
Identified at #11157 .

Field needs to come at end of record definition instead of before.

Latest run at https://github.com/checkstyle/checkstyle/runs/4733793364 shows mutations gone with this.