### PR TITLE
Issue #6320: added test case for IllegalInstantiationCheck

### DIFF
--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalinstantiation/InputIllegalInstantiationNoPackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegalinstantiation/InputIllegalInstantiationNoPackage.java
@@ -1,6 +1,6 @@
 /*
 IllegalInstantiation
-classes = java.lang.Boolean
+classes = java.lang.Boolean, .BadExample
 tokens = (default)CLASS_DEF
 
 
@@ -9,4 +9,7 @@ tokens = (default)CLASS_DEF
 public class InputIllegalInstantiationNoPackage {
     Boolean obj1 = new Boolean(true); // violation
     String obj2 = new String();
+    BadExample obj3 = new BadExample();
+
+    private static class BadExample {}
 }


### PR DESCRIPTION
Issue #6320

Identified at #11157 .

This needs a very specific case to kill the mutation. We need an input file with no package definition, and we need the class we are forbidding to match the current package plus the dot and the name of the class to forbid. Since the package doesn't exist, it is an empty string. This makes the class we need to forbid be `.<ClassName>` hence this test case. I went with `BadExample` to specially denote it. With the mutation in place, this causes an NPE to kill it.

Latest run at https://github.com/checkstyle/checkstyle/runs/4734268330 shows mutations gone with this.