### PR TITLE
Issue #11140: resolve PMB_POSSIBLE_MEMORY_BLOAT

### DIFF
--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -74,6 +74,14 @@
     </Or>
   </Match>
   <Match>
+    <!-- These fields are restricted caches which must remain populated until the process ends. -->
+    <Bug pattern="PMB_POSSIBLE_MEMORY_BLOAT"/>
+    <Or>
+      <Class name="com.puppycrawl.tools.checkstyle.PackageObjectFactory"/>
+      <Class name="com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder"/>
+    </Or>
+  </Match>
+  <Match>
     <!-- false positive, beginTree is a kind of constructor for Checks -->
     <Or>
       <Class name="com.puppycrawl.tools.checkstyle.checks.AvoidEscapedUnicodeCharactersCheck" />
@@ -160,7 +168,6 @@
       OI_OPTIONAL_ISSUES_USES_ORELSEGET_WITH_NULL,
       OPM_OVERLY_PERMISSIVE_METHOD,
       PMB_INSTANCE_BASED_THREAD_LOCAL,
-      PMB_POSSIBLE_MEMORY_BLOAT,
       PRMC_POSSIBLY_REDUNDANT_METHOD_CALLS,
       PSC_PRESIZE_COLLECTIONS,
       PSC_SUBOPTIMAL_COLLECTION_SIZING,


### PR DESCRIPTION
Issue #11140

`[ERROR] Medium: Class com.puppycrawl.tools.checkstyle.PackageObjectFactory defines static field "com.puppycrawl.tools.checkstyle.PackageObjectFactory.NAME_TO_FULL_MODULE_NAME" which appears to allow memory bloat [com.puppycrawl.tools.checkstyle.PackageObjectFactory] In PackageObjectFactory.java PMB_POSSIBLE_MEMORY_BLOAT`
`[ERROR] Medium: Class com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder defines static field "com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder.CHECK_ALIAS_MAP" which appears to allow memory bloat [com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder] In SuppressWarningsHolder.java PMB_POSSIBLE_MEMORY_BLOAT`

http://fb-contrib.sourceforge.net/bugdescriptions.html

>PMB_POSSIBLE_MEMORY_BLOAT
This class defines static fields that are Collections, StringBuffers, or StringBuilders that do not appear to have any way to clear or reduce their size. That is, a collection is defined and has method calls like
{add(), append(), offer(), put(), ...}
with no method calls to removal methods like
{clear(), delete(), pop(), remove(), ...}
This means that the collection in question can only ever increase in size, which is a potential cause of memory bloat.
If this collection is a list, set or otherwise of static things (e.g. a List>String> for month names), consider adding all of the elements in a static initializer, which can only be called once:
 private static List<String> monthNames = new ArrayList<String>(); static { monthNames.add("January"); monthNames.add("February"); monthNames.add("March"); ... } 
