### PR TITLE
Issue #11140: resolve COM_COPIED_OVERRIDDEN_METHOD

### DIFF
--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -138,6 +138,12 @@
     <Bug pattern="FCBL_FIELD_COULD_BE_LOCAL"/>
   </Match>
   <Match>
+    <!-- False positive as we override and enforce final so no more overrides. -->
+    <Bug pattern="COM_COPIED_OVERRIDDEN_METHOD"/>
+    <Class name="com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck"/>
+    <Method name="finishTree"/>
+  </Match>
+  <Match>
     <!-- Check is broken and does not clearly report where the fault is.
          Suppressed until https://github.com/mebigfatguy/fb-contrib/issues/408 -->
     <Bug pattern="WOC_WRITE_ONLY_COLLECTION_FIELD"/>
@@ -152,7 +158,6 @@
       CC_CYCLOMATIC_COMPLEXITY,
       CE_CLASS_ENVY,
       CLI_CONSTANT_LIST_INDEX,
-      COM_COPIED_OVERRIDDEN_METHOD,
       CVAA_CONTRAVARIANT_ELEMENT_ASSIGNMENT,
       DLC_DUBIOUS_LIST_COLLECTION,
       EXS_EXCEPTION_SOFTENING_NO_CHECKED,


### PR DESCRIPTION
Issue #11140

`[ERROR] Medium: Method com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck.finishTree(DetailAST) is implemented with an exact copy of its superclass' method [com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck] At AbstractJavadocCheck.java:[line 293] COM_COPIED_OVERRIDDEN_METHOD`

>COM_COPIED_OVERRIDDEN_METHOD This method is implemented using an exact copy of its superclass method's implementation, which usually means that this method can just be removed.