### PR TITLE
infra: use stable commit for gcp

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -699,6 +699,7 @@ no-error-spring-cloud-gcp)
   echo CS_version: ${CS_POM_VERSION}
   checkout_from https://github.com/googlecloudplatform/spring-cloud-gcp
   cd .ci-temp/spring-cloud-gcp
+  git checkout "7c99f37087ac8f""eb""db""f7e185375a217b744895a4"
   mvn -e --no-transfer-progress checkstyle:check@checkstyle-validation \
    -Dmaven-checkstyle-plugin.version=3.1.1 \
    -Dpuppycrawl-tools-checkstyle.version=${CS_POM_VERSION}


### PR DESCRIPTION
Noticed at https://app.travis-ci.com/github/checkstyle/checkstyle/jobs/555202878, gcp core checkstyle execution is failing with 87 violations

Passing build at https://app.travis-ci.com/github/checkstyle/checkstyle/jobs/555207079