### PR TITLE
Issue #11194: Automate bumping license year

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -915,6 +915,7 @@ nonrequiredjavadoc
 nonvalidating
 noparentfile
 NOPMD
+noreply
 noscript
 NOSONAR
 nospace

--- a/.github/workflows/bump_license_year.yml
+++ b/.github/workflows/bump_license_year.yml
@@ -1,0 +1,42 @@
+#############################################################################
+# Github Action to bump license year
+#
+# Workflow starts every new year.
+#
+#############################################################################
+name: "Bump license year"
+on:
+  schedule:
+    - cron: "0 0 1 1 *"
+  # So we can manually trigger if required
+  workflow_dispatch:
+jobs:
+  bump:
+    name: Bump license year
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the latest code
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set Current Year
+        id: CURRENT_YEAR
+        run: |
+          echo "::set-output name=year::$(date +'%Y')"
+      - name: Modify File
+        run: |
+          ./.ci/bump-license-year.sh $(expr ${{ env.YEAR }} - 1) ${{ env.YEAR }} .
+        env:
+          YEAR: ${{ steps.CURRENT_YEAR.outputs.year }}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        env:
+          YEAR: ${{ steps.CURRENT_YEAR.outputs.year }}
+        with:
+          commit-message: "minor: Bump year to ${{ env.YEAR }}"
+          committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          branch: bump-year
+          delete-branch: true
+          body: "minor: Bump year to ${{ env.YEAR }}"
+          title: "minor: Bump year to ${{ env.YEAR }}"


### PR DESCRIPTION
Resolves #11194: Automate bumping license year

https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule

After merge:
manually run it from the actions tab to see it in action.