### PR TITLE
Issue #11203: Update bump-license-year.sh to use g4 file extension

### DIFF
--- a/.ci/bump-license-year.sh
+++ b/.ci/bump-license-year.sh
@@ -9,7 +9,7 @@ DIR=$3
 OLD_VALUE="// Copyright (C) 2001-$PREV_YEAR the original author or authors."
 NEW_VALUE="// Copyright (C) 2001-$CURR_YEAR the original author or authors."
 
-find $DIR -type f \( -name *.java -o -name *.header -o -name *.g \) \
+find $DIR -type f \( -name *.java -o -name *.header -o -name *.g4 \) \
   -exec sed -i "s|$OLD_VALUE|$NEW_VALUE|g" {} +
 
 BASEDIR=$(pwd)


### PR DESCRIPTION
Closes #11203