### PR TITLE
Issue #9146: switch to jdk 11

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -469,7 +469,7 @@ check-since-version)
   fi
   ;;
 
-javac8)
+javac11)
   # InputCustomImportOrderNoPackage2 - nothing is required in front of first import
   # InputIllegalTypePackageClassName - bad import for testing
   # InputVisibilityModifierPackageClassName - bad import for testing
@@ -482,22 +482,8 @@ javac8)
   mkdir -p target
   for file in "${files[@]}"
   do
-    javac --release 8 -d target "${file}"
+    javac -d target "${file}"
   done
-  ;;
-
-javac9)
-  files=($(grep -Rl --include='*.java' ': Compilable with Java9' \
-        src/test/resources-noncompilable || true))
-  if [[  ${#files[@]} -eq 0 ]]; then
-    echo "No Java9 files to process"
-  else
-      mkdir -p target
-      for file in "${files[@]}"
-      do
-        javac --release 9 -d target "${file}"
-      done
-  fi
   ;;
 
 javac14)

--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -85,16 +85,6 @@ eclipse-static-analysis)
   mvn -e --no-transfer-progress clean compile exec:exec -Peclipse-compiler
   ;;
 
-eclipse-static-analysis-java11)
-  # Ensure that project sources can be compiled by eclipse with Java11 language features.
-  mvn -e --no-transfer-progress clean compile exec:exec -Peclipse-compiler -D java.version=11
-  ;;
-
-java11-verify)
-  # Ensure that project sources can be compiled by jdk with Java11 language features.
-  mvn -e --no-transfer-progress clean verify -D java.version=11
-  ;;
-
 nondex)
   # Below we exclude test that fails due to picocli library usage
   mvn -e --no-transfer-progress --fail-never clean nondex:nondex -DargLine='-Xms1024m -Xmx2048m' \
@@ -492,7 +482,7 @@ javac8)
   mkdir -p target
   for file in "${files[@]}"
   do
-    javac -d target "${file}"
+    javac --release 8 -d target "${file}"
   done
   ;;
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
 
   no-exception-lucene-and-others-javadoc:
     docker:
-      - image: checkstyle/jdk-8-groovy-git-mvn:1.8.0_282-3.0.8-2.25.1-3.6.3
+      - image: &default-image checkstyle/jdk-11-groovy-git-mvn:11.0.13__3.0.9__2.25.1__3.6.3
     steps:
       - checkout
       - run:
@@ -11,7 +11,7 @@ jobs:
             ./.ci/no-exception-test.sh no-exception-lucene-and-others-javadoc
   no-exception-cassandra-storm-tapestry-javadoc:
     docker:
-      - image: checkstyle/jdk-8-groovy-git-mvn:1.8.0_282-3.0.8-2.25.1-3.6.3
+      - image: *default-image
     steps:
       - checkout
       - run:
@@ -19,7 +19,7 @@ jobs:
             ./.ci/no-exception-test.sh no-exception-cassandra-storm-tapestry-javadoc
   no-exception-hadoop-apache-groovy-scouter-javadoc:
     docker:
-      - image: checkstyle/jdk-8-groovy-git-mvn:1.8.0_282-3.0.8-2.25.1-3.6.3
+      - image: *default-image
     steps:
       - checkout
       - run:
@@ -27,7 +27,7 @@ jobs:
             ./.ci/no-exception-test.sh no-exception-hadoop-apache-groovy-scouter-javadoc
   no-exception-only-javadoc:
     docker:
-      - image: checkstyle/jdk-8-groovy-git-mvn:1.8.0_282-3.0.8-2.25.1-3.6.3
+      - image: *default-image
     steps:
       - checkout
       - run:
@@ -35,7 +35,7 @@ jobs:
             ./.ci/no-exception-test.sh no-exception-only-javadoc
   no-error-xwiki:
     docker:
-      - image: checkstyle/jdk-11-groovy-git-mvn:11.0.13__3.0.9__2.25.1__3.6.3
+      - image: *default-image
     steps:
       - checkout
       - run:

--- a/.drone.yml
+++ b/.drone.yml
@@ -148,16 +148,10 @@ steps:
   commands:
   - ./.ci/validation.sh check-since-version
 
-- name: javac8
+- name: javac11
   image: *default-image
   commands:
-  - ./.ci/validation.sh javac8
-
-
-- name: javac9
-  image: *default-image
-  commands:
-  - ./.ci/validation.sh javac9
+  - ./.ci/validation.sh javac11
 
 - name: javac14
   image: maven:3.6.3-adoptopenjdk-14

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ volumes:
 
 steps:
 - name: restore-cache
-  image: maven:3.6.3-adoptopenjdk-8
+  image: &default-image maven:3.8.4-openjdk-11
   failure: ignore
   volumes:
   - name: m2-cache
@@ -17,7 +17,7 @@ steps:
   - ./.ci/drone-io.sh restore-maven-cache
 
 - name: checkstyle-and-sevntu
-  image: maven:3.6.3-adoptopenjdk-8
+  image: *default-image
   environment:
     MAVEN_OPTS: "-Dmaven.repo.local=/.m2"
   volumes:
@@ -27,7 +27,7 @@ steps:
   - ./.ci/validation.sh checkstyle-and-sevntu
 
 - name: spotbugs-and-pmd
-  image: maven:3.6.3-adoptopenjdk-8
+  image: *default-image
   environment:
     MAVEN_OPTS: "-Dmaven.repo.local=/.m2"
   volumes:
@@ -46,7 +46,7 @@ volumes:
 
 steps:
 - name: restore-cache
-  image: maven:3.6.3-adoptopenjdk-8
+  image: &default-image maven:3.8.4-openjdk-11
   failure: ignore
   volumes:
   - name: m2-cache
@@ -55,7 +55,7 @@ steps:
   - ./.ci/drone-io.sh restore-maven-cache
 
 - name: site
-  image: maven:3.6.3-adoptopenjdk-8
+  image: *default-image
   environment:
     MAVEN_OPTS: "-Dmaven.repo.local=/.m2"
   volumes:
@@ -75,7 +75,7 @@ volumes:
 
 steps:
 - name: restore-cache
-  image: maven:3.6.3-adoptopenjdk-8
+  image: &default-image maven:3.8.4-openjdk-11
   failure: ignore
   volumes:
   - name: m2-cache
@@ -84,7 +84,7 @@ steps:
   - ./.ci/drone-io.sh restore-maven-cache
 
 - name: release-dry-run
-  image: maven:3.6.3-adoptopenjdk-8
+  image: *default-image
   environment:
     MAVEN_OPTS: "-Dmaven.repo.local=/.m2"
   volumes:
@@ -94,7 +94,7 @@ steps:
   - ./.ci/validation.sh release-dry-run
 
 - name: assembly-run-all-jar
-  image: maven:3.6.3-adoptopenjdk-8
+  image: *default-image
   environment:
     MAVEN_OPTS: "-Dmaven.repo.local=/.m2"
   volumes:
@@ -113,7 +113,7 @@ volumes:
 
 steps:
 - name: restore-cache
-  image: maven:3.6.3-adoptopenjdk-8
+  image: &default-image maven:3.8.4-openjdk-11
   failure: ignore
   volumes:
   - name: m2-cache
@@ -122,7 +122,7 @@ steps:
   - ./.ci/drone-io.sh restore-maven-cache
 
 - name: releasenotes-gen
-  image: maven:3.6.3-adoptopenjdk-8
+  image: *default-image
   environment:
     READ_ONLY_TOKEN:
       from_secret: READ_ONLY_TOKEN
@@ -139,23 +139,23 @@ name: non-mvn_javac
 
 steps:
 - name: check-chmod
-  image: maven:3.6.3-adoptopenjdk-8
+  image: &default-image maven:3.8.4-openjdk-11
   commands:
   - ./.ci/checkchmod.sh
 
 - name: check-since-version
-  image: maven:3.6.3-adoptopenjdk-8
+  image: *default-image
   commands:
   - ./.ci/validation.sh check-since-version
 
 - name: javac8
-  image: maven:3.6.3-adoptopenjdk-8
+  image: *default-image
   commands:
   - ./.ci/validation.sh javac8
 
 
 - name: javac9
-  image: maven:3.6.3-jdk-11
+  image: *default-image
   commands:
   - ./.ci/validation.sh javac9
 
@@ -189,7 +189,7 @@ volumes:
 
 steps:
 - name: restore-cache
-  image: maven:3.6.3-adoptopenjdk-8
+  image: &default-image maven:3.8.4-openjdk-11
   failure: ignore
   volumes:
   - name: m2-cache
@@ -208,7 +208,7 @@ steps:
   - ./.ci/validation.sh jdk14-assembly-site
 
 - name: assembly/site with OpenJDK11
-  image: maven:3.6.3-adoptopenjdk-11
+  image: *default-image
   environment:
     MAVEN_OPTS: "-Dmaven.repo.local=/.m2"
   volumes:
@@ -219,7 +219,7 @@ steps:
      mvn -e --no-transfer-progress site -Dlinkcheck.skip=true"
 
 - name: no-error-test-sbe
-  image: maven:3.6.3-adoptopenjdk-8
+  image: *default-image
   environment:
     MAVEN_OPTS: "-Dmaven.repo.local=/.m2"
   volumes:

--- a/.github/workflows/no-exception-workflow.yml
+++ b/.github/workflows/no-exception-workflow.yml
@@ -9,10 +9,10 @@ jobs:
   no-exception-openjdk17:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up JDK 8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 8
+        java-version: 11
 
     - name: Install dependencies
       run: sudo apt install groovy

--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -335,10 +335,10 @@ jobs:
   pitest-main:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
       - name: Setup local maven cache
         uses: actions/cache@v2
         with:
@@ -642,10 +642,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
 
       - name: Generate pitest report
         run: ./.ci/pitest.sh pitest-java-ast-visitor

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,7 +3,7 @@ name: "Checkstyle CI pipeline on Semaphore"
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
+    os_image: ubuntu2004
 auto_cancel:
   running:
     when: "branch != 'master'"
@@ -28,20 +28,20 @@ blocks:
             fi
       jobs:
         # NonDex supports only Java 8 till https://github.com/TestingResearchIllinois/NonDex/pull/155
-        #        - name: NonDex (openjdk11)
-        #          priority:
-        #            - value: 90
-        #              when: true
-        #          matrix:
-        #            - env_var: CMD
-        #              values:
-        #                - .ci/validation.sh nondex
-        #          commands:
-        #            - sem-version java 11
-        #            - echo "eval of CMD is starting";
-        #            - echo "CMD=$CMD";
-        #            - eval $CMD;
-        #            - echo "eval of CMD is completed";
+        # - name: NonDex (openjdk11)
+        #   priority:
+        #     - value: 90
+        #       when: true
+        #   matrix:
+        #     - env_var: CMD
+        #       values:
+        #         - .ci/validation.sh nondex
+        #   commands:
+        #     - sem-version java 11
+        #     - echo "eval of CMD is starting";
+        #     - echo "CMD=$CMD";
+        #     - eval $CMD;
+        #     - echo "eval of CMD is completed";
 
         - name: Validation (openjdk11, fast pool)
           matrix:
@@ -50,13 +50,9 @@ blocks:
                 - .ci/validation.sh all-sevntu-checks
                 - .ci/validation.sh check-missing-pitests
                 - .ci/validation.sh eclipse-static-analysis
-                - .ci/validation.sh eclipse-static-analysis-java11
-                - .ci/validation.sh java11-verify
                 - .ci/validation.sh verify-regexp-id
-                - mvn -e --no-transfer-progress clean install -Pno-validations
-                    && .ci/no-exception-test.sh guava-with-google-checks
-                - mvn -e --no-transfer-progress clean install -Pno-validations
-                    && .ci/no-exception-test.sh guava-with-sun-checks
+                - .ci/no-exception-test.sh guava-with-google-checks
+                - .ci/no-exception-test.sh guava-with-sun-checks
                 # until https://github.com/checkstyle/checkstyle/issues/9807
                 # - mvn -e --no-transfer-progress clean package -Passembly
                 #    && .ci/validation.sh no-violation-test-josm

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ jobs:
   include:
 
     # this job do deploy maven repository
-    # unit tests (openjdk8)
-    - jdk: openjdk8
+    # unit tests (openjdk11)
+    - jdk: openjdk11
       env:
         - DESC="tests and deploy"
         - CMD="mvn -e --no-transfer-progress clean integration-test failsafe:verify
@@ -43,7 +43,7 @@ jobs:
     #    - CMD2="./.ci/validation.sh verify-no-exception-configs"
     #    - CMD="$CMD1 && $CMD2"
 
-    - jdk: openjdk8
+    - jdk: openjdk11
       env:
         - DESC="NoErrorTest - Postgresql JDBC Driver"
         - CMD1="mvn -e --no-transfer-progress clean install -Pno-validations"
@@ -51,7 +51,7 @@ jobs:
         - CMD="$CMD1 && $CMD2"
         - USE_MAVEN_REPO="true"
 
-    - jdk: openjdk8
+    - jdk: openjdk11
       env:
         - DESC="NoErrorTest - Orekit"
         - CMD1="mvn -e --no-transfer-progress clean install -Pno-validations"
@@ -62,7 +62,7 @@ jobs:
     - jdk: openjdk11
       env:
         - DESC="NoErrorTest - Hibernate Search"
-        - CUSTOM_MVN_VERSION="3.8.1"
+        - CUSTOM_MVN_VERSION="3.8.4"
         - M2_HOME="$PWD/apache-maven-${CUSTOM_MVN_VERSION}"
         - PATH="$M2_HOME/bin:$PATH"
         - CMD1="mvn -e --no-transfer-progress clean install -Pno-validations"
@@ -70,7 +70,7 @@ jobs:
         - CMD="$CMD1 && $CMD2"
         - USE_MAVEN_REPO="true"
 
-    - jdk: openjdk8
+    - jdk: openjdk11
       env:
         - DESC="NoErrorTest - checkstyle's sevntu"
         - CMD1="mvn -e --no-transfer-progress clean install -Pno-validations"
@@ -78,7 +78,7 @@ jobs:
         - CMD="$CMD1 && $CMD2"
         - USE_MAVEN_REPO="true"
 
-    - jdk: openjdk8
+    - jdk: openjdk11
       env:
         - DESC="NoErrorTest - sevntu-checks"
         - CMD1="mvn -e --no-transfer-progress clean install -Pno-validations"
@@ -86,7 +86,7 @@ jobs:
         - CMD="$CMD1 && $CMD2"
         - USE_MAVEN_REPO="true"
 
-    - jdk: openjdk8
+    - jdk: openjdk11
       env:
         - DESC="NoErrorTest - contribution"
         - CMD1="mvn -e --no-transfer-progress clean install -Pno-validations"
@@ -94,7 +94,7 @@ jobs:
         - CMD="$CMD1 && $CMD2"
         - USE_MAVEN_REPO="true"
 
-    - jdk: openjdk8
+    - jdk: openjdk11
       env:
         - DESC="NoErrorTest - methods distance"
         - CMD1="mvn -e --no-transfer-progress clean install -Pno-validations"
@@ -102,7 +102,7 @@ jobs:
         - CMD="$CMD1 && $CMD2"
         - USE_MAVEN_REPO="true"
 
-    - jdk: openjdk8
+    - jdk: openjdk11
       env:
         - DESC="NoErrorTest - Spring Cloud GCP"
         - CMD1="mvn -e --no-transfer-progress clean install -Pno-validations"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,21 +11,21 @@ branches:
 install:
   - ps: |
       Add-Type -AssemblyName System.IO.Compression.FileSystem
-      if (!(Test-Path -Path "C:\maven\apache-maven-3.8.1" )) {
+      if (!(Test-Path -Path "C:\maven\apache-maven-3.8.4" )) {
         (new-object System.Net.WebClient).DownloadFile(
-          'https://downloads.apache.org/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.zip',
+          'https://downloads.apache.org/maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.zip',
           'C:\maven-bin.zip'
         )
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
       }
-  - cmd: SET M2_HOME=C:\maven\apache-maven-3.8.1
+  - cmd: SET M2_HOME=C:\maven\apache-maven-3.8.4
   - cmd: SET PATH=%M2_HOME%\bin;%JAVA_HOME%\bin;%PATH%
   - cmd: git config core.autocrlf
   - cmd: mvn --version
   - cmd: java -version
 
 cache:
-  - C:\maven\apache-maven-3.8.1
+  - C:\maven\apache-maven-3.8.4
   - C:\Users\appveyor\.m2
 
 matrix:
@@ -39,26 +39,14 @@ environment:
   # We do matrix as AppVeyor could fail to finish simple "mvn -e verify"
   #    if he loose maven cache (happens from time to time)
   matrix:
-    # checkstyle and sevntu.checkstyle (JDK8)
-    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-      DESC: "checkstyle and sevntu.checkstyle (JDK8)"
-      CMD: "./.ci/validation.cmd sevntu"
     # checkstyle and sevntu.checkstyle (JDK11)
     - JAVA_HOME: C:\Program Files\Java\jdk11
       DESC: "checkstyle and sevntu.checkstyle (JDK11)"
       CMD: "./.ci/validation.cmd sevntu"
-    # verify without checkstyle (JDK8)
-    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-      DESC: "verify without checkstyle (JDK8)"
-      CMD: "./.ci/validation.cmd verify_without_checkstyle"
     # verify without checkstyle (JDK11)
     - JAVA_HOME: C:\Program Files\Java\jdk11
       DESC: "verify without checkstyle (JDK11)"
       CMD: "./.ci/validation.cmd verify_without_checkstyle"
-    # site, without verify (JDK8)
-    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-      DESC: "site, without verify (JDK8)"
-      CMD: "./.ci/validation.cmd site_without_verify"
     # site, without verify (JDK11)
     - JAVA_HOME: C:\Program Files\Java\jdk11
       DESC: "site, without verify (JDK11)"
@@ -79,5 +67,5 @@ build_script:
         Write-Host "build is skipped ..."
       }
   - ps: echo "Size of caches (bytes):"
-  - ps: Get-ChildItem -Recurse 'C:\maven\apache-maven-3.8.1' | Measure-Object -Property Length -Sum
+  - ps: Get-ChildItem -Recurse 'C:\maven\apache-maven-3.8.4' | Measure-Object -Property Length -Sum
   - ps: Get-ChildItem -Recurse 'C:\Users\appveyor\.m2' | Measure-Object -Property Length -Sum

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,47 +30,47 @@ strategy:
       cmd: "./.ci/test-spelling-unknown-words.sh"
       skipCache: true
 
-    # unit tests (openjdk8)
+    # unit tests (openjdk11)
     'test':
       image: 'ubuntu-20.04'
       cmd: "./.ci/validation.sh test"
 
-    # unit tests in German locale (openjdk8)
+    # unit tests in German locale (openjdk11)
     'test-de':
       image: 'ubuntu-20.04'
       cmd: "./.ci/validation.sh test-de"
 
-    # unit tests in Spanish locale (openjdk8)
+    # unit tests in Spanish locale (openjdk11)
     'test-es':
       image: 'ubuntu-20.04'
       cmd: "./.ci/validation.sh test-es"
 
-    # unit tests in Finnish locale (openjdk8)
+    # unit tests in Finnish locale (openjdk11)
     'test-fi':
       image: 'ubuntu-20.04'
       cmd: "./.ci/validation.sh test-fi"
 
-    # unit tests in French locale (openjdk8)
+    # unit tests in French locale (openjdk11)
     'test-fr':
       image: 'ubuntu-20.04'
       cmd: "./.ci/validation.sh test-fr"
 
-    # unit tests in Chinese locale (openjdk8)
+    # unit tests in Chinese locale (openjdk11)
     'test-zh':
       image: 'ubuntu-20.04'
       cmd: "./.ci/validation.sh test-zh"
 
-    # unit tests in Japanese locale (openjdk8)
+    # unit tests in Japanese locale (openjdk11)
     'test-ja':
       image: 'ubuntu-20.04'
       cmd: "./.ci/validation.sh test-ja"
 
-    # unit tests in Portuguese locale (openjdk8)
+    # unit tests in Portuguese locale (openjdk11)
     'test-pt':
       image: 'ubuntu-20.04'
       cmd: "./.ci/validation.sh test-pt"
 
-    # unit tests in Turkish locale (openjdk8)
+    # unit tests in Turkish locale (openjdk11)
     'test-tr':
       image: 'ubuntu-20.04'
       cmd: "./.ci/validation.sh test-tr"
@@ -80,25 +80,15 @@ strategy:
       image: 'ubuntu-20.04'
       cmd: "mvn -e --no-transfer-progress verify"
 
-    # MacOS JDK8 verify
-    'MacOS JDK8 verify':
-      image: 'macOS-10.15'
-      cmd: "export JAVA_HOME=$JAVA_HOME_8_X64 && mvn -e --no-transfer-progress verify"
-
     # MacOS JDK11 verify
     'MacOS JDK11 verify':
       image: 'macOS-10.15'
-      cmd: "export JAVA_HOME=$JAVA_HOME_11_X64 && mvn -e --no-transfer-progress verify"
+      cmd: "JAVA_HOME=$JAVA_HOME_11_X64 mvn -e --no-transfer-progress verify"
 
-    # MacOS JDK13 verify
-    'MacOS JDK13 verify':
-      image: 'macOS-10.15'
-      cmd: "export JAVA_HOME=$JAVA_HOME_13_X64 && mvn -e --no-transfer-progress verify"
-
-    # MacOS JDK14 verify
+    # MacOS JDK17 verify
     'MacOS JDK14 verify':
-      image: 'macOS-10.15'
-      cmd: "export JAVA_HOME=$JAVA_HOME_14_X64 && mvn -e --no-transfer-progress verify"
+      image: 'macOS-11'
+      cmd: "JAVA_HOME=$JAVA_HOME_17_X64 mvn -e --no-transfer-progress verify"
 
     # moved back to Travis till we find a way to keep secrets in azure
     # ensure that all modules are used in no exception configs
@@ -126,7 +116,7 @@ pool:
 
 variables:
   MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository
-  MAVEN_OPTS: '-Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
+  MAVEN_OPTS: '--show-version -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
   SKIP_CACHE: $(skipCache)
   IMAGE: $(image)
   ON_CRON_ONLY: $(onCronOnly)
@@ -146,6 +136,12 @@ steps:
 - bash: |
     gem install mdl
   condition: eq(variables.NEED_MDL, 'true')
+
+- task: JavaToolInstaller@0
+  inputs:
+    versionSpec: 11
+    jdkArchitectureOption: 'X64'
+    jdkSourceOption: 'PreInstalled'
 
 - task: Cache@2
   inputs:

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
       9.1
     </maven.sevntu-checkstyle-check.checkstyle.version>
     <maven.versions.plugin.version>2.9.0</maven.versions.plugin.version>
-    <java.version>1.8</java.version>
+    <java.version>11</java.version>
     <pitest.plugin.version>1.7.3</pitest.plugin.version>
     <pitest.plugin.timeout.factor>10</pitest.plugin.timeout.factor>
     <pitest.plugin.timeout.constant>50000</pitest.plugin.timeout.constant>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Definitions.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Definitions.java
@@ -19,8 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle;
 
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -33,10 +31,8 @@ public final class Definitions {
             "com.puppycrawl.tools.checkstyle.messages";
 
     /** Name of modules which are not checks, but are internal modules. */
-    public static final Set<String> INTERNAL_MODULES = Collections.unmodifiableSet(
-            new HashSet<>(Collections.singletonList(
-                    "com.puppycrawl.tools.checkstyle.meta.JavadocMetadataScraper"
-    )));
+    public static final Set<String> INTERNAL_MODULES = Set.of(
+                    "com.puppycrawl.tools.checkstyle.meta.JavadocMetadataScraper");
 
     /**
      * Do no allow {@code Definitions} instances to be created.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/SarifLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/SarifLogger.java
@@ -137,12 +137,6 @@ public class SarifLogger extends AutomaticBean implements AuditListener {
         // No code by default
     }
 
-    /**
-     * {@inheritDoc}
-     * Following idea suppressions are false positives
-     *
-     * @noinspection DynamicRegexReplaceableByCompiledPattern
-     */
     @Override
     public void auditFinished(AuditEvent event) {
         final String version = SarifLogger.class.getPackage().getImplementationVersion();
@@ -158,12 +152,6 @@ public class SarifLogger extends AutomaticBean implements AuditListener {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     * Following idea suppressions are false positives
-     *
-     * @noinspection DynamicRegexReplaceableByCompiledPattern
-     */
     @Override
     public void addError(AuditEvent event) {
         if (event.getColumn() > 0) {
@@ -187,12 +175,6 @@ public class SarifLogger extends AutomaticBean implements AuditListener {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     * Following idea suppressions are false positives
-     *
-     * @noinspection DynamicRegexReplaceableByCompiledPattern
-     */
     @Override
     public void addException(AuditEvent event, Throwable throwable) {
         final StringWriter stringWriter = new StringWriter();
@@ -305,14 +287,10 @@ public class SarifLogger extends AutomaticBean implements AuditListener {
      * @return the escaped string.
      */
     private static String escapeUnicode1F(char chr) {
-        final StringBuilder stringBuilder = new StringBuilder(UNICODE_LENGTH + 1);
-        stringBuilder.append("\\u");
         final String hexString = Integer.toHexString(chr);
-        for (int i = 0; i < UNICODE_LENGTH - hexString.length(); i++) {
-            stringBuilder.append('0');
-        }
-        stringBuilder.append(hexString.toUpperCase(Locale.US));
-        return stringBuilder.toString();
+        return "\\u"
+                + "0".repeat(UNICODE_LENGTH - hexString.length())
+                + hexString.toUpperCase(Locale.US);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidDoubleBraceInitializationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidDoubleBraceInitializationCheck.java
@@ -162,6 +162,6 @@ public class AvoidDoubleBraceInitializationCheck extends AbstractCheck {
     private static boolean hasOnlyInitialization(DetailAST objBlock) {
         final boolean hasInitBlock = objBlock.findFirstToken(TokenTypes.INSTANCE_INIT) != null;
         return hasInitBlock
-                  && !TokenUtil.findFirstTokenByPredicate(objBlock, HAS_MEMBERS).isPresent();
+                  && TokenUtil.findFirstTokenByPredicate(objBlock, HAS_MEMBERS).isEmpty();
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -440,7 +440,7 @@ public class FinalLocalVariableCheck extends AbstractCheck {
     private Optional<FinalVariableCandidate> getFinalCandidate(DetailAST ast) {
         Optional<FinalVariableCandidate> result = Optional.empty();
         final Iterator<ScopeData> iterator = scopeStack.descendingIterator();
-        while (iterator.hasNext() && !result.isPresent()) {
+        while (iterator.hasNext() && result.isEmpty()) {
             final ScopeData scopeData = iterator.next();
             result = scopeData.findFinalVariableCandidateForAst(ast);
         }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
@@ -220,12 +221,7 @@ public class IllegalTokenTextCheck
      *                 to report about violations.
      */
     public void setMessage(String message) {
-        if (message == null) {
-            this.message = "";
-        }
-        else {
-            this.message = message;
-        }
+        this.message = Objects.requireNonNullElse(message, "");
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
@@ -832,12 +832,12 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
      */
     public static boolean shouldCheckIdentTokenNestedUnderDot(DetailAST dotAst) {
 
-        return !TokenUtil.findFirstTokenByPredicate(dotAst,
+        return TokenUtil.findFirstTokenByPredicate(dotAst,
                         childAst -> {
                             return TokenUtil.isOfType(childAst,
                                     UNACCEPTABLE_CHILD_OF_DOT);
                         })
-                .isPresent();
+                .isEmpty();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -23,6 +23,7 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -659,12 +660,8 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
                         exprWithVariableUsage = blockWithVariableUsage.getFirstChild();
                 }
                 currentScopeAst = exprWithVariableUsage;
-                if (exprWithVariableUsage == null) {
-                    variableUsageAst = blockWithVariableUsage;
-                }
-                else {
-                    variableUsageAst = exprWithVariableUsage;
-                }
+                variableUsageAst =
+                        Objects.requireNonNullElse(exprWithVariableUsage, blockWithVariableUsage);
             }
 
             // If there's no any variable usage, then distance = 0.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
@@ -20,8 +20,6 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -264,12 +262,10 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
     private static final String SUMMARY_TEXT = "@summary";
 
     /** Set of allowed Tokens tags in summary java doc. */
-    private static final Set<Integer> ALLOWED_TYPES = Collections.unmodifiableSet(
-            new HashSet<>(Arrays.asList(
+    private static final Set<Integer> ALLOWED_TYPES = Set.of(
                     JavadocTokenTypes.WS,
                     JavadocTokenTypes.DESCRIPTION,
-                    JavadocTokenTypes.TEXT))
-    );
+                    JavadocTokenTypes.TEXT);
 
     /**
      * Specify the regexp for forbidden summary fragments.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -150,7 +151,7 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
      */
     public final void setExcludedClasses(String... excludedClasses) {
         this.excludedClasses =
-            Collections.unmodifiableSet(Arrays.stream(excludedClasses).collect(Collectors.toSet()));
+            Arrays.stream(excludedClasses).collect(Collectors.toUnmodifiableSet());
     }
 
     /**
@@ -159,9 +160,10 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
      * @param from array representing regular expressions of classes to ignore.
      */
     public void setExcludeClassesRegexps(String... from) {
-        excludeClassesRegexps.addAll(Arrays.stream(from.clone())
+        Arrays.stream(from)
                 .map(CommonUtil::createPattern)
-                .collect(Collectors.toSet()));
+                .distinct()
+                .forEach(excludeClassesRegexps::add);
     }
 
     /**
@@ -173,16 +175,15 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
      */
     public final void setExcludedPackages(String... excludedPackages) {
         final List<String> invalidIdentifiers = Arrays.stream(excludedPackages)
-            .filter(excludedPackageName -> !CommonUtil.isName(excludedPackageName))
+            .filter(Predicate.not(CommonUtil::isName))
             .collect(Collectors.toList());
         if (!invalidIdentifiers.isEmpty()) {
             throw new IllegalArgumentException(
-                "the following values are not valid identifiers: "
-                    + invalidIdentifiers.stream().collect(Collectors.joining(", ", "[", "]")));
+                "the following values are not valid identifiers: " + invalidIdentifiers);
         }
 
-        this.excludedPackages = Collections.unmodifiableSet(
-            Arrays.stream(excludedPackages).collect(Collectors.toSet()));
+        this.excludedPackages =
+            Arrays.stream(excludedPackages).collect(Collectors.toUnmodifiableSet());
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java
@@ -106,12 +106,10 @@ public class JavadocMetadataScraper extends AbstractJavadocCheck {
      * This set contains faulty property default value which should not be written to the XML
      * metadata files.
      */
-    private static final Set<String> PROPERTIES_TO_NOT_WRITE = Collections.unmodifiableSet(
-            new HashSet<>(Arrays.asList(
+    private static final Set<String> PROPERTIES_TO_NOT_WRITE = Set.of(
                     "null",
                     "the charset property of the parent <a href=https://checkstyle.org/"
-                        + "config.html#Checker>Checker</a> module"
-    )));
+                        + "config.html#Checker>Checker</a> module");
 
     /**
      * Format for exception message for missing type for check property.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractPathTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractPathTestSupport.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.stream.Collectors;
@@ -79,14 +78,15 @@ public abstract class AbstractPathTestSupport {
 
     /**
      * Reads the contents of a file.
+     * IDEA inspection RedundantThrows suppressed as a false positive.
      *
      * @param filename the name of the file whose contents are to be read
      * @return contents of the file with all {@code \r\n} replaced by {@code \n}
      * @throws IOException if I/O exception occurs while reading
+     * @noinspection RedundantThrows
      */
     protected static String readFile(String filename) throws IOException {
-        return toLfLineEnding(new String(Files.readAllBytes(
-                Paths.get(filename)), StandardCharsets.UTF_8));
+        return toLfLineEnding(Files.readString(Paths.get(filename)));
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
@@ -97,8 +97,8 @@ public class AstTreeStringPrinterTest extends AbstractTreeTestSupport {
                 System.getProperty("file.encoding", StandardCharsets.UTF_8.name()));
         final String actual = toLfLineEnding(AstTreeStringPrinter.printAst(text,
                 JavaParser.Options.WITHOUT_COMMENTS));
-        final String expected = toLfLineEnding(new String(Files.readAllBytes(Paths.get(
-                getPath("ExpectedAstTreeStringPrinter.txt"))), StandardCharsets.UTF_8));
+        final String expected = toLfLineEnding(Files.readString(Paths.get(
+                getPath("ExpectedAstTreeStringPrinter.txt"))));
 
         assertWithMessage("Print AST output is invalid")
             .that(actual)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailAstImplTest.java
@@ -30,8 +30,6 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -53,8 +51,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 public class DetailAstImplTest extends AbstractModuleTestSupport {
 
     // Ignores file which are not meant to have root node intentionally.
-    public static final Set<String> NO_ROOT_FILES =
-        Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+    public static final Set<String> NO_ROOT_FILES = Set.of(
                  // fails with unexpected character
                  "InputGrammar.java",
                  // comment only files, no root
@@ -64,7 +61,7 @@ public class DetailAstImplTest extends AbstractModuleTestSupport {
                  "InputNoCodeInFile2.java",
                  "InputNoCodeInFile3.java",
                  "InputNoCodeInFile5.java"
-        )));
+        );
 
     @TempDir
     public File temporaryFolder;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParserTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParserTest.java
@@ -22,7 +22,6 @@ package com.puppycrawl.tools.checkstyle;
 import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -47,9 +46,8 @@ public class JavadocDetailNodeParserTest extends AbstractModuleTestSupport {
         final JavadocDetailNodeParser.ParseStatus status = parser.parseJavadocAsDetailNode(ast);
         final String actual = toLfLineEnding(DetailNodeTreeStringPrinter.printTree(status.getTree(),
                 "", ""));
-        final String expected = toLfLineEnding(new String(Files.readAllBytes(Paths.get(
-                getPath("ExpectedJavadocDetailNodeParser.txt"))),
-                StandardCharsets.UTF_8));
+        final String expected = toLfLineEnding(Files.readString(Paths.get(
+                getPath("ExpectedJavadocDetailNodeParser.txt"))));
         assertWithMessage("Invalid parse result")
                 .that(actual)
                 .isEqualTo(expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -1151,11 +1151,20 @@ public class MainTest {
             .isEqualTo("");
     }
 
+    /**
+     * Verifies the output of the command line parameter "-j".
+     * IDEA inspection RedundantThrows suppressed as a false positive.
+     *
+     * @param systemErr wrapper for {@code System.err}
+     * @param systemOut wrapper for {@code System.out}
+     * @throws IOException if I/O exception occurs while reading the test input.
+     * @noinspection RedundantThrows
+     */
     @Test
     public void testPrintTreeJavadocOption(@SysErr Capturable systemErr,
-            @SysOut Capturable systemOut) throws Exception {
-        final String expected = new String(Files.readAllBytes(Paths.get(
-            getPath("InputMainExpectedInputJavadocComment.txt"))), StandardCharsets.UTF_8)
+            @SysOut Capturable systemOut) throws IOException {
+        final String expected = Files.readString(Paths.get(
+            getPath("InputMainExpectedInputJavadocComment.txt")))
             .replaceAll("\\\\r\\\\n", "\\\\n").replaceAll("\r\n", "\n");
 
         assertMainReturnCode(0, "-j", getPath("InputMainJavadocComment.javadoc"));
@@ -1535,12 +1544,21 @@ public class MainTest {
             .isEqualTo("");
     }
 
+    /**
+     * Verifies the output of the command line parameter "-J".
+     * IDEA inspection RedundantThrows suppressed as a false positive.
+     *
+     * @param systemErr wrapper for {@code System.err}
+     * @param systemOut wrapper for {@code System.out}
+     * @throws IOException if I/O exception occurs while reading the test input.
+     * @noinspection RedundantThrows
+     */
     @Test
     public void testPrintFullTreeOption(@SysErr Capturable systemErr, @SysOut Capturable systemOut)
             throws IOException {
-        final String expected = new String(Files.readAllBytes(Paths.get(
-            getPath("InputMainExpectedInputAstTreeStringPrinterJavadoc.txt"))),
-            StandardCharsets.UTF_8).replaceAll("\\\\r\\\\n", "\\\\n")
+        final String expected = Files.readString(Paths.get(
+            getPath("InputMainExpectedInputAstTreeStringPrinterJavadoc.txt")))
+                .replaceAll("\\\\r\\\\n", "\\\\n")
                 .replaceAll("\r\n", "\n");
 
         assertMainReturnCode(0, "-J", getPath("InputMainAstTreeStringPrinterJavadoc.java"));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -603,9 +603,8 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         verify(checkerConfig, filePath, expected);
 
         assertWithMessage("External resource is not present in cache")
-                .that(new String(Files.readAllBytes(cacheFile.toPath()), StandardCharsets.UTF_8)
-                        .contains("InputTreeWalkerSuppressionXpathFilter.xml"))
-                .isTrue();
+                .that(Files.readString(cacheFile.toPath()))
+                .contains("InputTreeWalkerSuppressionXpathFilter.xml");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheckTest.java
@@ -170,7 +170,7 @@ public class MatchXpathCheckTest
             "13:9: " + getCheckMessage(MatchXpathCheck.MSG_KEY),
         };
         verifyWithInlineConfigParser(
-                getNonCompilablePath("InputMatchXpathAvoidInstanceCreationWithoutVar.java"),
+                getPath("InputMatchXpathAvoidInstanceCreationWithoutVar.java"),
                 expected);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheckTest.java
@@ -108,7 +108,7 @@ public class OneStatementPerLineCheckTest extends AbstractModuleTestSupport {
         };
 
         verifyWithInlineConfigParser(
-                getNonCompilablePath("InputOneStatementPerLineTryWithResources.java"),
+                getPath("InputOneStatementPerLineTryWithResources.java"),
                 expected);
     }
 
@@ -116,7 +116,7 @@ public class OneStatementPerLineCheckTest extends AbstractModuleTestSupport {
     public void testResourcesIgnored() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(
-                getNonCompilablePath("InputOneStatementPerLineTryWithResourcesIgnore.java"),
+                getPath("InputOneStatementPerLineTryWithResourcesIgnore.java"),
                 expected);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
@@ -25,7 +25,6 @@ import static com.puppycrawl.tools.checkstyle.checks.imports.ImportControlCheck.
 import static com.puppycrawl.tools.checkstyle.checks.imports.ImportControlCheck.MSG_UNKNOWN_PKG;
 
 import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
 import org.junit.jupiter.api.Test;
@@ -344,8 +343,7 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
         // One more time to use cache.
         verify(checkerConfig, filePath, expected);
 
-        final String contents = new String(Files.readAllBytes(cacheFile.toPath()),
-                StandardCharsets.UTF_8);
+        final String contents = Files.readString(cacheFile.toPath());
         assertWithMessage("External resource is not present in cache")
                 .that(contents.contains("InputImportControlOneRegExp.xml"))
                 .isTrue();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
@@ -403,8 +403,7 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
     public void testNotPublicInterfaceMethods() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(
-                getNonCompilablePath(
-            "InputMissingJavadocMethodInterfacePrivateMethod.java"), expected);
+                getPath("InputMissingJavadocMethodInterfacePrivateMethod.java"), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/metrics/ClassFanOutComplexityCheckTest.java
@@ -255,7 +255,7 @@ public class ClassFanOutComplexityCheckTest extends AbstractModuleTestSupport {
     public void testClassFanOutComplexityIgnoreVar() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(
-                getNonCompilablePath("InputClassFanOutComplexityVar.java"), expected);
+                getPath("InputClassFanOutComplexityVar.java"), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheckTest.java
@@ -358,7 +358,7 @@ public class InterfaceMemberImpliedModifierCheckTest
     public void testPrivateMethodsOnInterface() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(
-                getNonCompilablePath("InputInterfaceMemberImpliedModifierPrivateMethods.java"),
+                getPath("InputInterfaceMemberImpliedModifierPrivateMethods.java"),
             expected);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheckTest.java
@@ -259,7 +259,7 @@ public class RedundantModifierCheckTest
             "18:19: " + getCheckMessage(MSG_KEY, "final"),
         };
         verifyWithInlineConfigParser(
-                getNonCompilablePath("InputRedundantModifierTryWithResources.java"),
+                getPath("InputRedundantModifierTryWithResources.java"),
                 expected);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalFinalVariableNameCheckTest.java
@@ -116,8 +116,7 @@ public class LocalFinalVariableNameCheckTest
 
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(
-                getNonCompilablePath(
-            "InputLocalFinalVariableNameTryResourcesJava9.java"), expected);
+                getPath("InputLocalFinalVariableNameTryResourcesJava9.java"), expected);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheckTest.java
@@ -162,7 +162,7 @@ public class MethodNameCheckTest
         };
 
         verifyWithInlineConfigParser(
-                getNonCompilablePath("InputMethodNamePublicMethodsInInterfaces.java"),
+                getPath("InputMethodNamePublicMethodsInInterfaces.java"),
             expected);
     }
 
@@ -178,7 +178,7 @@ public class MethodNameCheckTest
         };
 
         verifyWithInlineConfigParser(
-                getNonCompilablePath("InputMethodNamePrivateMethodsInInterfaces.java"),
+                getPath("InputMethodNamePrivateMethodsInInterfaces.java"),
             expected);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheckTest.java
@@ -229,12 +229,8 @@ public class RegexpMultilineCheckTest extends AbstractModuleTestSupport {
     private static CharSequence makeLargeXyString() {
         // now needs 10'000 or 100'000, as just 1000 is no longer enough today to provoke the
         // StackOverflowError
-        final int size = 100000;
-        final StringBuilder largeString = new StringBuilder(size);
-        for (int i = 0; i < size / 2; i++) {
-            largeString.append("xy");
-        }
-        return largeString;
+        final int size = 100_000;
+        return "xy".repeat(size / 2);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheckTest.java
@@ -160,7 +160,7 @@ public class OperatorWrapCheckTest
     public void testTryWithResources() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(
-                getNonCompilablePath("InputOperatorWrapTryWithResources.java"), expected);
+                getPath("InputOperatorWrapTryWithResources.java"), expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammar/AstRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammar/AstRegressionTest.java
@@ -66,13 +66,13 @@ public class AstRegressionTest extends AbstractTreeTestSupport {
     @Test
     public void testJava9TryWithResourcesAstTree() throws Exception {
         verifyAst(getPath("ExpectedJava9TryWithResources.txt"),
-                getNonCompilablePath("/java9/InputJava9TryWithResources.java"));
+                getPath("/java9/InputJava9TryWithResources.java"));
     }
 
     @Test
     public void testAdvanceJava9TryWithResourcesAstTree() throws Exception {
         verifyAst(getPath("ExpectedAdvanceJava9TryWithResources.txt"),
-                getNonCompilablePath("/java9/InputAdvanceJava9TryWithResources.java"));
+                getPath("/java9/InputAdvanceJava9TryWithResources.java"));
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammar/Java9TryWithResourcesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammar/Java9TryWithResourcesTest.java
@@ -38,7 +38,7 @@ public class Java9TryWithResourcesTest extends AbstractModuleTestSupport {
     public void testCanParse() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(
-                getNonCompilablePath("InputJava9TryWithResources.java"), expected);
+                getPath("InputJava9TryWithResources.java"), expected);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CliOptionsXdocsSyncTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CliOptionsXdocsSyncTest.java
@@ -20,8 +20,6 @@
 package com.puppycrawl.tools.checkstyle.internal;
 
 import static com.google.common.truth.Truth.assertWithMessage;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -79,8 +77,10 @@ public class CliOptionsXdocsSyncTest {
                 .isEqualTo(descXdoc);
             cmdDesc.remove(option);
         }
-        assertTrue("CLI Options: " + cmdDesc + " present in "
-                + "cmdline.xml.vm, not documented in Main.java", cmdDesc.isEmpty());
+        assertWithMessage("CLI Options: %s present in cmdline.xml.vm, not documented in Main.java",
+                    cmdDesc)
+                .that(cmdDesc)
+                .isEmpty();
     }
 
     @Test
@@ -127,7 +127,7 @@ public class CliOptionsXdocsSyncTest {
 
     private static NodeList getSectionsFromXdoc(String xdocPath) throws Exception {
         final Path path = Paths.get(xdocPath);
-        final String input = new String(Files.readAllBytes(path), UTF_8);
+        final String input = Files.readString(path);
         final Document document = XmlUtil.getRawXml(path.getFileName().toString(), input, input);
         return document.getElementsByTagName("section");
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle.internal;
 
 import static com.google.common.truth.Truth.assertWithMessage;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.File;
 import java.net.URI;
@@ -150,7 +149,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
                 continue;
             }
 
-            final String input = new String(Files.readAllBytes(path), UTF_8);
+            final String input = Files.readString(path);
             final Document document = XmlUtil.getRawXml(fileName, input, input);
             final NodeList sources = document.getElementsByTagName("section");
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsMobileWrapperTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsMobileWrapperTest.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle.internal;
 
 import static com.google.common.truth.Truth.assertWithMessage;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -55,7 +54,7 @@ public class XdocsMobileWrapperTest {
             final File file = path.toFile();
             final String fileName = file.getName();
 
-            final String input = new String(Files.readAllBytes(path), UTF_8);
+            final String input = Files.readString(path);
             assertWithMessage(fileName + ": input file cannot be empty")
                     .that(input)
                     .isNotEmpty();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -21,7 +21,6 @@ package com.puppycrawl.tools.checkstyle.internal;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static java.lang.Integer.parseInt;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.beans.PropertyDescriptor;
 import java.io.File;
@@ -93,7 +92,7 @@ public class XdocsPagesTest {
     private static final Pattern DESCRIPTION_VERSION = Pattern
             .compile("^Since Checkstyle \\d+\\.\\d+(\\.\\d+)?");
 
-    private static final List<String> XML_FILESET_LIST = Arrays.asList(
+    private static final List<String> XML_FILESET_LIST = List.of(
             "TreeWalker",
             "name=\"Checker\"",
             "name=\"Header\"",
@@ -122,7 +121,7 @@ public class XdocsPagesTest {
             getProperties(AbstractJavadocCheck.class);
     private static final Set<String> FILESET_PROPERTIES = getProperties(AbstractFileSetCheck.class);
 
-    private static final List<String> UNDOCUMENTED_PROPERTIES = Arrays.asList(
+    private static final List<String> UNDOCUMENTED_PROPERTIES = List.of(
             "Checker.classLoader",
             "Checker.classloader",
             "Checker.moduleClassLoader",
@@ -135,7 +134,7 @@ public class XdocsPagesTest {
             "SuppressionCommentFilter.fileContents"
     );
 
-    private static final List<String> PROPERTIES_ALLOWED_GET_TYPES_FROM_METHOD = Arrays.asList(
+    private static final List<String> PROPERTIES_ALLOWED_GET_TYPES_FROM_METHOD = List.of(
             // static field (all upper case)
             "SuppressWarningsHolder.aliasList",
             // loads string into memory similar to file
@@ -152,11 +151,11 @@ public class XdocsPagesTest {
     );
 
     private static final Set<String> SUN_MODULES = Collections.unmodifiableSet(
-        new HashSet<>(CheckUtil.getConfigSunStyleModules()));
+        CheckUtil.getConfigSunStyleModules());
     // ignore the not yet properly covered modules while testing newly added ones
     // add proper sections to the coverage report and integration tests
     // and then remove this list eventually
-    private static final List<String> IGNORED_SUN_MODULES = Arrays.asList(
+    private static final List<String> IGNORED_SUN_MODULES = List.of(
             "ArrayTypeStyle",
             "AvoidNestedBlocks",
             "AvoidStarImport",
@@ -221,11 +220,11 @@ public class XdocsPagesTest {
             "WhitespaceAround"
     );
     private static final Set<String> GOOGLE_MODULES = Collections.unmodifiableSet(
-        new HashSet<>(CheckUtil.getConfigGoogleStyleModules()));
+        CheckUtil.getConfigGoogleStyleModules());
 
     @Test
     public void testAllChecksPresentOnAvailableChecksPage() throws Exception {
-        final String availableChecks = new String(Files.readAllBytes(AVAILABLE_CHECKS_PATH), UTF_8);
+        final String availableChecks = Files.readString(AVAILABLE_CHECKS_PATH);
 
         CheckUtil.getSimpleNames(CheckUtil.getCheckstyleChecks())
             .stream()
@@ -257,7 +256,7 @@ public class XdocsPagesTest {
                 continue;
             }
 
-            final String input = new String(Files.readAllBytes(path), UTF_8);
+            final String input = Files.readString(path);
             final Document document = XmlUtil.getRawXml(fileName, input, input);
             final NodeList sources = document.getElementsByTagName("subsection");
 
@@ -288,7 +287,7 @@ public class XdocsPagesTest {
 
     private static Map<String, String> readSummaries() throws Exception {
         final String fileName = AVAILABLE_CHECKS_PATH.getFileName().toString();
-        final String input = new String(Files.readAllBytes(AVAILABLE_CHECKS_PATH), UTF_8);
+        final String input = Files.readString(AVAILABLE_CHECKS_PATH);
         final Document document = XmlUtil.getRawXml(fileName, input, input);
         final NodeList rows = document.getElementsByTagName("tr");
         final Map<String, String> result = new HashMap<>();
@@ -308,7 +307,7 @@ public class XdocsPagesTest {
     @Test
     public void testAllSubSections() throws Exception {
         for (Path path : XdocUtil.getXdocsFilePaths()) {
-            final String input = new String(Files.readAllBytes(path), UTF_8);
+            final String input = Files.readString(path);
             final String fileName = path.getFileName().toString();
 
             final Document document = XmlUtil.getRawXml(fileName, input, input);
@@ -354,7 +353,7 @@ public class XdocsPagesTest {
     @Test
     public void testAllXmlExamples() throws Exception {
         for (Path path : XdocUtil.getXdocsFilePaths()) {
-            final String input = new String(Files.readAllBytes(path), UTF_8);
+            final String input = Files.readString(path);
             final String fileName = path.getFileName().toString();
 
             final Document document = XmlUtil.getRawXml(fileName, input, input);
@@ -471,7 +470,7 @@ public class XdocsPagesTest {
                 continue;
             }
 
-            final String input = new String(Files.readAllBytes(path), UTF_8);
+            final String input = Files.readString(path);
             final Document document = XmlUtil.getRawXml(fileName, input, input);
             final NodeList sources = document.getElementsByTagName("section");
             String lastSectionName = null;
@@ -518,7 +517,7 @@ public class XdocsPagesTest {
         final Path path = Paths.get(XdocUtil.DIRECTORY_PATH + "/config.xml");
         final String fileName = path.getFileName().toString();
 
-        final String input = new String(Files.readAllBytes(path), UTF_8);
+        final String input = Files.readString(path);
         final Document document = XmlUtil.getRawXml(fileName, input, input);
         final NodeList sources = document.getElementsByTagName("section");
 
@@ -1539,7 +1538,7 @@ public class XdocsPagesTest {
         for (Path path : XdocUtil.getXdocsStyleFilePaths(XdocUtil.getXdocsFilePaths())) {
             final String fileName = path.getFileName().toString();
             final String styleName = fileName.substring(0, fileName.lastIndexOf('_'));
-            final String input = new String(Files.readAllBytes(path), UTF_8);
+            final String input = Files.readString(path);
             final Document document = XmlUtil.getRawXml(fileName, input, input);
             final NodeList sources = document.getElementsByTagName("tr");
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -26,8 +26,6 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
@@ -52,19 +50,17 @@ import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
 public class XpathRegressionTest extends AbstractModuleTestSupport {
 
     // Checks that not compatible with SuppressionXpathFilter
-    public static final Set<String> INCOMPATIBLE_CHECK_NAMES =
-        Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+    public static final Set<String> INCOMPATIBLE_CHECK_NAMES = Set.of(
             "NoCodeInFile (reason is that AST is not generated for a file not containing code)",
             "Regexp (reason is at  #7759)",
             "RegexpSinglelineJava (reason is at  #7759)"
-    )));
+    );
 
     // Javadoc checks are not compatible with SuppressionXpathFilter
     // till https://github.com/checkstyle/checkstyle/issues/5770
     // then all of them should be added to the list of incompatible checks
     // and this field should be removed
-    public static final Set<String> INCOMPATIBLE_JAVADOC_CHECK_NAMES =
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+    public static final Set<String> INCOMPATIBLE_JAVADOC_CHECK_NAMES = Set.of(
                     "AtclauseOrder",
                     "JavadocBlockTagLocation",
                     "JavadocMethod",
@@ -80,21 +76,20 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
                     "SingleLineJavadoc",
                     "SummaryJavadoc",
                     "WriteTag"
-    )));
+    );
 
     // Older regex-based checks that are under INCOMPATIBLE_JAVADOC_CHECK_NAMES
     // but not subclasses of AbstractJavadocCheck.
-    private static final Set<Class<?>> REGEXP_JAVADOC_CHECKS =
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+    private static final Set<Class<?>> REGEXP_JAVADOC_CHECKS = Set.of(
                     JavadocStyleCheck.class,
                     JavadocMethodCheck.class,
                     JavadocTypeCheck.class,
                     WriteTagCheck.class
-    )));
+    );
 
     // Checks that allowed to have no XPath IT Regression Testing
     // till https://github.com/checkstyle/checkstyle/issues/6207
-    private static final Set<String> MISSING_CHECK_NAMES = new HashSet<>(Arrays.asList(
+    private static final Set<String> MISSING_CHECK_NAMES = Set.of(
             "BooleanExpressionComplexity",
             "CatchParameterName",
             "ClassDataAbstractionCoupling",
@@ -148,12 +143,12 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
             "ThrowsCount",
             "TypeName",
             "VisibilityModifier"
-    ));
+    );
 
     // Modules that will never have xpath support ever because they not report violations
-    private static final Set<String> NO_VIOLATION_MODULES = new HashSet<>(Collections.singletonList(
+    private static final Set<String> NO_VIOLATION_MODULES = Set.of(
             "SuppressWarningsHolder"
-    ));
+    );
 
     private static Set<String> simpleCheckNames;
     private static Map<String, String> allowedDirectoryAndChecks;
@@ -256,7 +251,7 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
         final Set<String> allChecks = new HashSet<>(simpleCheckNames);
         allChecks.removeAll(INCOMPATIBLE_JAVADOC_CHECK_NAMES);
         allChecks.removeAll(INCOMPATIBLE_CHECK_NAMES);
-        allChecks.removeAll(Arrays.asList("Regexp", "RegexpSinglelineJava", "NoCodeInFile"));
+        allChecks.removeAll(Set.of("Regexp", "RegexpSinglelineJava", "NoCodeInFile"));
         allChecks.removeAll(MISSING_CHECK_NAMES);
         allChecks.removeAll(NO_VIOLATION_MODULES);
         allChecks.removeAll(compatibleChecks);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/InputMatchXpathAvoidInstanceCreationWithoutVar.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/InputMatchXpathAvoidInstanceCreationWithoutVar.java
@@ -5,7 +5,7 @@ query = //VARIABLE_DEF[./ASSIGN/EXPR/LITERAL_NEW and not(./TYPE/IDENT[@text='var
 
 */
 
-//non-compiled with javac: Compilable with Java10
+
 package com.puppycrawl.tools.checkstyle.checks.coding.matchxpath;
 
 public class InputMatchXpathAvoidInstanceCreationWithoutVar {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineTryWithResources.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineTryWithResources.java
@@ -1,46 +1,49 @@
 /*
 OneStatementPerLine
-treatTryResourcesAsStatement = (default)false
+treatTryResourcesAsStatement = true
 
 
 */
 
-//non-compiled with javac: Compilable with Java9
+
 package com.puppycrawl.tools.checkstyle.checks.coding.onestatementperline;
 
 import java.io.IOException;
 import java.io.PipedOutputStream;
 import java.io.OutputStream;
 
-public class InputOneStatementPerLineTryWithResourcesIgnore {
+/**
+ * Config treatTryResourcesAsStatement = true
+ */
+public class InputOneStatementPerLineTryWithResources {
 
     void method() throws IOException {
         OutputStream s1 = new PipedOutputStream();
         OutputStream s2 = new PipedOutputStream();
-        try (s1; s2; OutputStream s3 = new PipedOutputStream();) { // ok
+        try (s1; s2; OutputStream s3 = new PipedOutputStream();) {
         }
-        try (s1; OutputStream s4 = new PipedOutputStream(); s2;) { // ok
+        try (s1; OutputStream s4 = new PipedOutputStream(); s2;) {
         }
-        try (s1; s2; OutputStream s5 = new PipedOutputStream()) { // ok
+        try (s1; s2; OutputStream s5 = new PipedOutputStream()) {
         }
-        try (s1; OutputStream s6 = new PipedOutputStream(); s2) { // ok
+        try (s1; OutputStream s6 = new PipedOutputStream(); s2) {
         }
         try (
-OutputStream s7 = new PipedOutputStream();OutputStream s8 = new PipedOutputStream();
+OutputStream s7 = new PipedOutputStream();OutputStream s8 = new PipedOutputStream(); // violation
            s2;
         ) {}
         try (
-OutputStream s9=new PipedOutputStream();s2;OutputStream s10 = new PipedOutputStream())
+OutputStream s9=new PipedOutputStream();s2;OutputStream s10 = new PipedOutputStream()) // violation
         {}
         try (s1; OutputStream s11 = new PipedOutputStream();
              s2;) {
         }
         try (OutputStream
-             s12 = new PipedOutputStream();s1;OutputStream s3 = new PipedOutputStream()
+             s12 = new PipedOutputStream();s1;OutputStream s3 = new PipedOutputStream() // violation
              ;s2;) {
         }
         try (OutputStream
-             s12 = new PipedOutputStream();s1;OutputStream s3 // ok
+             s12 = new PipedOutputStream();s1;OutputStream s3 // violation
                 = new PipedOutputStream()) {}
         try (s1; s2; OutputStream stream3 =
              new PipedOutputStream()) {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineTryWithResourcesIgnore.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineTryWithResourcesIgnore.java
@@ -1,49 +1,46 @@
 /*
 OneStatementPerLine
-treatTryResourcesAsStatement = true
+treatTryResourcesAsStatement = (default)false
 
 
 */
 
-//non-compiled with javac: Compilable with Java9
+
 package com.puppycrawl.tools.checkstyle.checks.coding.onestatementperline;
 
 import java.io.IOException;
 import java.io.PipedOutputStream;
 import java.io.OutputStream;
 
-/**
- * Config treatTryResourcesAsStatement = true
- */
-public class InputOneStatementPerLineTryWithResources {
+public class InputOneStatementPerLineTryWithResourcesIgnore {
 
     void method() throws IOException {
         OutputStream s1 = new PipedOutputStream();
         OutputStream s2 = new PipedOutputStream();
-        try (s1; s2; OutputStream s3 = new PipedOutputStream();) {
+        try (s1; s2; OutputStream s3 = new PipedOutputStream();) { // ok
         }
-        try (s1; OutputStream s4 = new PipedOutputStream(); s2;) {
+        try (s1; OutputStream s4 = new PipedOutputStream(); s2;) { // ok
         }
-        try (s1; s2; OutputStream s5 = new PipedOutputStream()) {
+        try (s1; s2; OutputStream s5 = new PipedOutputStream()) { // ok
         }
-        try (s1; OutputStream s6 = new PipedOutputStream(); s2) {
+        try (s1; OutputStream s6 = new PipedOutputStream(); s2) { // ok
         }
         try (
-OutputStream s7 = new PipedOutputStream();OutputStream s8 = new PipedOutputStream(); // violation
+OutputStream s7 = new PipedOutputStream();OutputStream s8 = new PipedOutputStream();
            s2;
         ) {}
         try (
-OutputStream s9=new PipedOutputStream();s2;OutputStream s10 = new PipedOutputStream()) // violation
+OutputStream s9=new PipedOutputStream();s2;OutputStream s10 = new PipedOutputStream())
         {}
         try (s1; OutputStream s11 = new PipedOutputStream();
              s2;) {
         }
         try (OutputStream
-             s12 = new PipedOutputStream();s1;OutputStream s3 = new PipedOutputStream() // violation
+             s12 = new PipedOutputStream();s1;OutputStream s3 = new PipedOutputStream()
              ;s2;) {
         }
         try (OutputStream
-             s12 = new PipedOutputStream();s1;OutputStream s3 // violation
+             s12 = new PipedOutputStream();s1;OutputStream s3 // ok
                 = new PipedOutputStream()) {}
         try (s1; s2; OutputStream stream3 =
              new PipedOutputStream()) {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodInterfacePrivateMethod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodInterfacePrivateMethod.java
@@ -11,7 +11,6 @@ tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
 
 */
 
-//non-compiled with javac: Compilable with Java9
 // private method in interface
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocmethod;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityVar.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/metrics/classfanoutcomplexity/InputClassFanOutComplexityVar.java
@@ -18,7 +18,6 @@ excludedPackages = (default)
 
 */
 
-//non-compiled with javac: Compilable with Java10
 package com.puppycrawl.tools.checkstyle.checks.metrics.classfanoutcomplexity;
 
 import javax.naming.NamingException;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierPrivateMethods.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/interfacememberimpliedmodifier/InputInterfaceMemberImpliedModifierPrivateMethods.java
@@ -11,7 +11,6 @@ violateImpliedStaticNested = (default)true
 
 */
 
-//non-compiled with javac: Compilable with Java9
 package com.puppycrawl.tools.checkstyle.checks.modifier.interfacememberimpliedmodifier;
 
 /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierTryWithResources.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/modifier/redundantmodifier/InputRedundantModifierTryWithResources.java
@@ -6,7 +6,7 @@ tokens = (default)METHOD_DEF, VARIABLE_DEF, ANNOTATION_FIELD_DEF, INTERFACE_DEF,
 
 */
 
-//non-compiled with javac: Compilable with Java9
+
 package com.puppycrawl.tools.checkstyle.checks.modifier.redundantmodifier;
 
 import java.io.IOException;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/InputLocalFinalVariableNameTryResourcesJava9.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/localfinalvariablename/InputLocalFinalVariableNameTryResourcesJava9.java
@@ -6,7 +6,6 @@ tokens = (default)VARIABLE_DEF, PARAMETER_DEF, RESOURCE
 
 */
 
-//non-compiled with javac: Compilable with Java9
 package com.puppycrawl.tools.checkstyle.checks.naming.localfinalvariablename;
 
 public class InputLocalFinalVariableNameTryResourcesJava9 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNamePrivateMethodsInInterfaces.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNamePrivateMethodsInInterfaces.java
@@ -10,7 +10,7 @@ applyToPrivate = false
 
 */
 
-//non-compiled with javac: Compilable with Java9
+
 package com.puppycrawl.tools.checkstyle.checks.naming.methodname;
 
 public interface InputMethodNamePrivateMethodsInInterfaces {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNamePublicMethodsInInterfaces.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/methodname/InputMethodNamePublicMethodsInInterfaces.java
@@ -10,7 +10,7 @@ applyToPrivate = (default)true
 
 */
 
-//non-compiled with javac: Compilable with Java9
+
 package com.puppycrawl.tools.checkstyle.checks.naming.methodname;
 
 public interface InputMethodNamePublicMethodsInInterfaces {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/operatorwrap/InputOperatorWrapTryWithResources.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/operatorwrap/InputOperatorWrapTryWithResources.java
@@ -7,7 +7,6 @@ tokens = (default)QUESTION, COLON, EQUAL, NOT_EQUAL, DIV, PLUS, MINUS, STAR, MOD
 
 
 */
-//non-compiled with javac: Compilable with Java9
 package com.puppycrawl.tools.checkstyle.checks.whitespace.operatorwrap;
 
 public class InputOperatorWrapTryWithResources implements AutoCloseable

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java9/InputAdvanceJava9TryWithResources.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java9/InputAdvanceJava9TryWithResources.java
@@ -1,4 +1,4 @@
-//non-compiled with javac: Compilable with Java9
+
 package com.puppycrawl.tools.checkstyle.grammar.java9;
 
 /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java9/InputJava9TryWithResources.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/grammar/java9/InputJava9TryWithResources.java
@@ -9,7 +9,7 @@ applyToPrivate = (default)true
 
 */
 
-//non-compiled with javac: Compilable with Java9
+
 package com.puppycrawl.tools.checkstyle.grammar.java9;
 
 /**

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,5 +1,5 @@
 box:
-  id: maven:3.8.1-jdk-11
+  id: maven:3.8.4-jdk-11
   username: $DOCKERHUB_USER
   password: $DOCKERHUB_TOKEN
 


### PR DESCRIPTION
Issue #9146

### First commit
* explicit release version for validation.sh javac8
* javafx-tests-for-jdk11 profile of equalsverifier disabled
* docker image jdk-8-groovy-git-mvn -> jdk-11-groovy-git-mvn for circleci
* docker image maven:3.6.3-adoptopenjdk-8 -> maven:3.8.4-adoptopenjdk-11 for drone
*  java-version: 8 ->  java-version: 11 for github workflows
* maven 3.8.4 for appveyor, JDK8 builds removed
* JDK13, JDK14 builds in azure pipelines removed, JDK17 added
* Set minimal required version to Java 11

### Second commit
* Move all Java{9-11} inputs to compilable resources folder

### Third commit
* Fixes for IDEA inspections triggered for Java 11 build