### PR TITLE
Issue #11215: add file filters for non-compilable files in openjdk16

### DIFF
--- a/.ci/openjdk16-excluded.files
+++ b/.ci/openjdk16-excluded.files
@@ -597,3 +597,9 @@
 <module name="BeforeExecutionExclusionFileFilter">
   <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]generics[\\/]6413682[\\/]T6413682.java$"/>
 </module>
+<module name="BeforeExecutionExclusionFileFilter">
+  <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]annotations[\\/]neg[\\/]pkg[\\/]package-info.java$"/>
+</module>
+<module name="BeforeExecutionExclusionFileFilter">
+  <property name="fileNamePattern" value="[\\/]test[\\/]langtools[\\/]tools[\\/]javac[\\/]annotations[\\/]neg[\\/]AnonSubclass.java$"/>
+</module>


### PR DESCRIPTION
Resolves #11215: add file filters for non-compilable files in openjdk16 