### PR TITLE
Issue #11220: False positive in MissingSwitchDefault with pattern in switch label

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheck.java
@@ -23,6 +23,7 @@ import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
  * <p>
@@ -35,10 +36,23 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * cases are covered, this should be expressed in the
  * default branch, e.g. by using an assertion. This way
  * the code is protected against later changes, e.g.
- * introduction of new types in an enumeration type. Note that
- * the compiler requires switch expressions to be exhaustive,
- * so this check does not enforce default branches on
- * such expressions.
+ * introduction of new types in an enumeration type.
+ * </p>
+ * <p>
+ * This check does not validate any switch expressions. Rationale:
+ * The compiler requires switch expressions to be exhaustive. This means
+ * that all possible inputs must be covered.
+ * </p>
+ * <p>
+ * This check does not validate switch statements that use pattern or null
+ * labels. Rationale: Switch statements that use pattern or null labels are
+ * checked by the compiler for exhaustiveness. This means that all possible
+ * inputs must be covered.
+ * </p>
+ * <p>
+ * See the <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-15.html#jls-15.28">
+ *     Java Language Specification</a> for more information about switch statements
+ *     and expressions.
  * </p>
  * <p>
  * To configure the check:
@@ -65,14 +79,80 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *  default: // OK
  *    break;
  * }
- * return switch (option) { // OK, the compiler requires switch expression to be exhaustive
- *  case ONE:
- *    yield 1;
- *  case TWO:
- *    yield 2;
- *  case THREE:
- *    yield 3;
+ * switch (o) {
+ *     case String s: // type pattern
+ *         System.out.println(s);
+ *         break;
+ *     case Integer i: // type pattern
+ *         System.out.println("Integer");
+ *         break;
+ *     default:    // will not compile without default label, thanks to type pattern label usage
+ *         break;
  * }
+ * </pre>
+ * <p>Example of correct code which does not require default labels:</p>
+ * <pre>
+ *    sealed interface S permits A, B, C {}
+ *    final class A implements S {}
+ *    final class B implements S {}
+ *    record C(int i) implements S {}  // Implicitly final
+ *
+ *    /**
+ *     * The completeness of a switch statement can be
+ *     * determined by the contents of the permits clause
+ *     * of interface S. No default label or default case
+ *     * label is allowed by the compiler in this situation, so
+ *     * this check does not enforce a default label in such
+ *     * statements.
+ *     *&#47;
+ *    static void showSealedCompleteness(S s) {
+ *        switch (s) {
+ *            case A a: System.out.println("A"); break;
+ *            case B b: System.out.println("B"); break;
+ *            case C c: System.out.println("C"); break;
+ *        }
+ *    }
+ *
+ *    /**
+ *     * A total type pattern matches all possible inputs,
+ *     * including null. A default label or
+ *     * default case is not allowed by the compiler in this
+ *     * situation. Accordingly, check does not enforce a
+ *     * default label in this case.
+ *     *&#47;
+ *    static void showTotality(String s) {
+ *        switch (s) {
+ *            case Object o: // total type pattern
+ *                System.out.println("o!");
+ *        }
+ *    }
+ *
+ *    enum Color { RED, GREEN, BLUE }
+ *
+ *    static int showSwitchExpressionExhaustiveness(Color color) {
+ *        switch (color) {
+ *            case RED: System.out.println("RED"); break;
+ *            case BLUE: System.out.println("BLUE"); break;
+ *            case GREEN: System.out.println("GREEN"); break;
+ *            // Check will require default label below, compiler
+ *            // does not enforce a switch statement with constants
+ *            // to be complete.
+ *            default: System.out.println("Something else");
+ *        }
+ *
+ *        // Check will not require default label in switch
+ *        // expression below, because code will not compile
+ *        // if all possible values are not handled. If the
+ *        // 'Color' enum is extended, code will fail to compile.
+ *        return switch (color) {
+ *            case RED:
+ *                yield 1;
+ *            case GREEN:
+ *                yield 2;
+ *            case BLUE:
+ *                yield 3;
+ *        };
+ *    }
  * </pre>
  * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
@@ -114,9 +194,10 @@ public class MissingSwitchDefaultCheck extends AbstractCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
-        final DetailAST firstSwitchMemberAst = findFirstSwitchMember(ast);
-
-        if (!containsDefaultSwitch(firstSwitchMemberAst) && !isSwitchExpression(ast)) {
+        if (!containsDefaultLabel(ast)
+                && !containsPatternCaseLabelElement(ast)
+                && !containsDefaultCaseLabelElement(ast)
+                && !isSwitchExpression(ast)) {
             log(ast, MSG_KEY);
         }
     }
@@ -124,37 +205,41 @@ public class MissingSwitchDefaultCheck extends AbstractCheck {
     /**
      * Checks if the case group or its sibling contain the 'default' switch.
      *
-     * @param caseGroupAst first case group to check.
+     * @param detailAst first case group to check.
      * @return true if 'default' switch found.
      */
-    private static boolean containsDefaultSwitch(DetailAST caseGroupAst) {
-        DetailAST nextAst = caseGroupAst;
-        boolean found = false;
-
-        while (nextAst != null) {
-            if (nextAst.findFirstToken(TokenTypes.LITERAL_DEFAULT) != null) {
-                found = true;
-                break;
-            }
-
-            nextAst = nextAst.getNextSibling();
-        }
-
-        return found;
+    private static boolean containsDefaultLabel(DetailAST detailAst) {
+        return TokenUtil.findFirstTokenByPredicate(detailAst,
+                ast -> ast.findFirstToken(TokenTypes.LITERAL_DEFAULT) != null
+        ).isPresent();
     }
 
     /**
-     * Returns first CASE_GROUP or SWITCH_RULE ast.
+     * Checks if a switch block contains a case label with a pattern variable definition.
+     * In this situation, the compiler enforces the given switch block to cover
+     * all possible inputs, and we do not need a default label.
      *
-     * @param parent the switch statement we are checking
-     * @return ast of first switch member.
+     * @param detailAst first case group to check.
+     * @return true if switch block contains a pattern case label element
      */
-    private static DetailAST findFirstSwitchMember(DetailAST parent) {
-        DetailAST switchMember = parent.findFirstToken(TokenTypes.CASE_GROUP);
-        if (switchMember == null) {
-            switchMember = parent.findFirstToken(TokenTypes.SWITCH_RULE);
-        }
-        return switchMember;
+    private static boolean containsPatternCaseLabelElement(DetailAST detailAst) {
+        return TokenUtil.findFirstTokenByPredicate(detailAst, ast -> {
+            return ast.getFirstChild() != null
+                    && ast.getFirstChild().findFirstToken(TokenTypes.PATTERN_VARIABLE_DEF) != null;
+        }).isPresent();
+    }
+
+    /**
+     * Checks if a switch block contains a default case label.
+     *
+     * @param detailAst first case group to check.
+     * @return true if switch block contains default case label
+     */
+    private static boolean containsDefaultCaseLabelElement(DetailAST detailAst) {
+        return TokenUtil.findFirstTokenByPredicate(detailAst, ast -> {
+            return ast.getFirstChild() != null
+                    && ast.getFirstChild().findFirstToken(TokenTypes.LITERAL_DEFAULT) != null;
+        }).isPresent();
     }
 
     /**
@@ -167,5 +252,4 @@ public class MissingSwitchDefaultCheck extends AbstractCheck {
         return ast.getParent().getType() == TokenTypes.EXPR
                 || ast.getParent().getParent().getType() == TokenTypes.EXPR;
     }
-
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/MissingSwitchDefaultCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/MissingSwitchDefaultCheck.xml
@@ -14,10 +14,23 @@
  cases are covered, this should be expressed in the
  default branch, e.g. by using an assertion. This way
  the code is protected against later changes, e.g.
- introduction of new types in an enumeration type. Note that
- the compiler requires switch expressions to be exhaustive,
- so this check does not enforce default branches on
- such expressions.
+ introduction of new types in an enumeration type.
+ &lt;/p&gt;
+ &lt;p&gt;
+ This check does not validate any switch expressions. Rationale:
+ The compiler requires switch expressions to be exhaustive. This means
+ that all possible inputs must be covered.
+ &lt;/p&gt;
+ &lt;p&gt;
+ This check does not validate switch statements that use pattern or null
+ labels. Rationale: Switch statements that use pattern or null labels are
+ checked by the compiler for exhaustiveness. This means that all possible
+ inputs must be covered.
+ &lt;/p&gt;
+ &lt;p&gt;
+ See the &lt;a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-15.html#jls-15.28"&gt;
+     Java Language Specification&lt;/a&gt; for more information about switch statements
+     and expressions.
  &lt;/p&gt;</description>
          <message-keys>
             <message-key key="missing.switch.default"/>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheckTest.java
@@ -41,6 +41,7 @@ public class MissingSwitchDefaultCheckTest
             "23:9: " + getCheckMessage(MSG_KEY, "default"),
             "35:17: " + getCheckMessage(MSG_KEY, "default"),
             "46:17: " + getCheckMessage(MSG_KEY, "default"),
+            "53:9: " + getCheckMessage(MSG_KEY, "default"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMissingSwitchDefault.java"),
@@ -87,6 +88,14 @@ public class MissingSwitchDefaultCheckTest
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputMissingSwitchDefaultCheckSwitchExpressionsThree.java"),
+                expected);
+    }
+
+    @Test
+    public void testMissingSwitchDefaultCaseLabelElements() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputMissingSwitchDefaultCaseLabelElements.java"),
                 expected);
     }
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefaultCaseLabelElements.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefaultCaseLabelElements.java
@@ -1,0 +1,91 @@
+/*
+MissingSwitchDefault
+
+
+*/
+
+//non-compiled with javac: Compilable with Java17
+package com.puppycrawl.tools.checkstyle.checks.coding.missingswitchdefault;
+
+public class InputMissingSwitchDefaultCaseLabelElements {
+    static void m(Object o) {
+        switch (o) { // ok
+            case null, String s -> System.out.println("String, including null");
+            default -> System.out.println("something else");
+        }
+
+        switch (o) { // ok
+            case null, String s: System.out.println("String, including null"); break;
+            default: System.out.println("something else");
+        }
+
+        switch(o) {
+            case null: default: // ok
+                System.out.println("The rest (including null)");
+        }
+
+        switch(o) { // ok, pattern totality enforced by compiler
+            case Object o1:
+                System.out.println("object");
+        }
+
+        switch(o) { // ok, pattern totality enforced by compiler
+            case Object o1 && o1.toString().length() > 2:
+                System.out.println("object");
+                break;
+            case Object o1 && o1.toString().length() <= 2:
+                System.out.println("object");
+                break;
+            case null, Object o1:
+                break;
+        }
+
+        switch(o) { // ok
+            case String str, null ->
+                System.out.println("null");
+            default -> System.out.println("default");
+        }
+
+        switch(o) { // ok
+            case null, default ->
+                System.out.println("The rest (including null)");
+        }
+
+        switch(o) { // ok
+            case String s && s.length() > 2 ->
+                System.out.println("The string longer than 2 chars");
+            default -> System.out.println("default!");
+        }
+
+        switch(o) { // ok
+            case default, null ->
+                System.out.println("The rest (including null)");
+        }
+
+        switch(o) { // ok
+            case default, null:
+                System.out.println("The rest (including null)");
+        }
+
+        switch(o) { // ok
+            case null, default:
+                System.out.println("The rest (including null)");
+        }
+
+        switch(o) { // ok
+            case null, default:
+                throw new UnsupportedOperationException("not supported!");
+        }
+    }
+
+    void m2(String s) {
+        switch (s) { // ok
+            case "a": throw new AssertionError("Wrong branch.");
+            case default: break;
+        }
+        switch (s) { // ok
+            case "a" -> throw new AssertionError("Wrong branch.");
+            case default -> {}
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/missingswitchdefault/InputMissingSwitchDefault.java
@@ -49,5 +49,9 @@ class bad_test {
             }
             default: break;
         }
+
+        switch(i) { // violation
+
+        }
     }
 }

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -4231,9 +4231,24 @@ abstract class AbstractExample { // OK
           currently possible cases are covered, this should be expressed in
           the default branch, e.g. by using an assertion. This way the code is
           protected against later changes, e.g. introduction of new types in an
-          enumeration type. Note that the compiler requires switch expressions
-          to be exhaustive, so this check does not enforce default branches on
-          such expressions.
+          enumeration type.
+        </p>
+        <p>
+          This check does not validate any switch expressions. Rationale:
+          The compiler requires switch expressions to be exhaustive. This means
+          that all possible inputs must be covered.
+        </p>
+        <p>
+          This check does not validate switch statements that use pattern or null
+          labels. Rationale: Switch statements that use pattern or null labels are
+          checked by the compiler for exhaustiveness. This means that all possible
+          inputs must be covered.
+        </p>
+        <p>
+          See the
+          <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-15.html#jls-15.28">
+          Java Language Specification</a> for more information about switch statements
+          and expressions.
         </p>
       </subsection>
 
@@ -4267,13 +4282,81 @@ switch (i) {
   default: // OK
     break;
 }
-return switch (option) { // OK, the compiler requires switch expression to be exhaustive
-  case ONE:
-    yield 1;
-  case TWO:
-    yield 2;
-  case THREE:
-    yield 3;
+switch (o) {
+    case String s: // type pattern
+        System.out.println(s);
+        break;
+    case Integer i: // type pattern
+        System.out.println("Integer");
+        break;
+    default:    // will not compile without default label, thanks to type pattern label usage
+        break;
+}
+        </source>
+        <p>
+          Example of correct code which does not require default labels:
+        </p>
+        <source>
+sealed interface S permits A, B, C {}
+final class A implements S {}
+final class B implements S {}
+record C(int i) implements S {}  // Implicitly final
+
+/**
+ * The completeness of a switch statement can be
+ * determined by the contents of the permits clause
+ * of interface S. No default label or default case
+ * label is allowed by the compiler in this situation, so
+ * this check does not enforce a default label in such
+ * statements.
+ */
+static void showSealedCompleteness(S s) {
+    switch (s) {
+        case A a: System.out.println("A"); break;
+        case B b: System.out.println("B"); break;
+        case C c: System.out.println("C"); break;
+    }
+}
+
+/**
+ * A total type pattern matches all possible inputs,
+ * including null. A default label or
+ * default case is not allowed by the compiler in this
+ * situation. Accordingly, check does not enforce a
+ * default label in this case.
+ */
+static void showTotality(String s) {
+    switch (s) {
+        case Object o: // total type pattern
+            System.out.println("o!");
+    }
+}
+
+enum Color { RED, GREEN, BLUE }
+
+static int showSwitchExpressionExhaustiveness(Color color) {
+    switch (color) {
+        case RED: System.out.println("RED"); break;
+        case BLUE: System.out.println("BLUE"); break;
+        case GREEN: System.out.println("GREEN"); break;
+        // Check will require default label below, compiler
+        // does not enforce a switch statement with constants
+        // to be complete.
+        default: System.out.println("Something else");
+    }
+
+    // Check will not require default label in switch
+    // expression below, because code will not compile
+    // if all possible values are not handled. If the
+    // 'Color' enum is extended, code will fail to compile.
+    return switch (color) {
+        case RED:
+            yield 1;
+        case GREEN:
+            yield 2;
+        case BLUE:
+            yield 3;
+    };
 }
         </source>
       </subsection>


### PR DESCRIPTION
Closes #11220 

Report label: all projects

Diff Regression config: https://gist.githubusercontent.com/nmancus1/3db3e23a5063857160d7d92cbdfa1bfe/raw/b8fc9b284c6604bf0862f237f030794bfb0a7800/config.xml

Diff Regression projects: https://raw.githubusercontent.com/checkstyle/contribution/e34312d61da0b073f31339cfbf385f289b721fed/checkstyle-tester/projects-to-test-on-for-github-action.properties

Final report: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/f5590ec_2022232703/reports/diff/index.html

Only diffs are in openjdk17, in noncompilable files. I am not sure if we should add files filters for these files, though, since they are how I confirmed logic of check update. I think that they might be valuable in the future for similar reasons.

Blocked until https://github.com/checkstyle/checkstyle/pull/11100

Only last commit is under review.

Example of compile error on new enum value:
```
$ cat Test.java 
public class Test {
enum Color { RED, GREEN, BLUE, MY_COLOR }

/**
 * In the case of switch expressions, the compiler requires
 * that they are exhaustive, so this check does not enforce
 * a default label. This code would still compile with a
 * default label, but it is unnecessary so this check does
 * not enforce it.
 */
static int showSwitchExpressionExhaustiveness(Color color) {
    switch (color) {
        case RED: System.out.println("RED"); break;
        case BLUE: System.out.println("BLUE"); break;
        case GREEN: System.out.println("GREEN"); break;
        // Check will require default label below, compiler
        // does not enforce a switch statement with constants
        // to be complete.
        //default: System.out.println("Something else");
    }

    // Check will not require default label in switch
    // expression below, because code will not compile
    // if all possible values are not handled. If the
    // 'Color' enum is extended, code will fail to compile.
    return switch (color) {
        case RED:
            yield 1;
        case GREEN:
            yield 2;
        case BLUE:
            yield 3;
    };
}

  }

$ javac --enable-preview --release 17 Test.java 
Test.java:26: error: the switch expression does not cover all possible input values
    return switch (color) {
           ^
1 error

```