### PR TITLE
infra: update docker image for no-error-xwiki

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
             ./.ci/no-exception-test.sh no-exception-only-javadoc
   no-error-xwiki:
     docker:
-      - image: checkstyle/jdk-8-groovy-git-mvn:1.8.0_282-3.0.8-2.25.1-3.6.3
+      - image: checkstyle/jdk-11-groovy-git-mvn:11.0.13__3.0.9__2.25.1__3.6.3
     steps:
       - checkout
       - run:


### PR DESCRIPTION
noticed at https://app.circleci.com/pipelines/github/checkstyle/checkstyle/11304/workflows/de04ced3-7f8c-4b13-9f08-c47d6cd3f641/jobs/111882

`Caused by: java.lang.IllegalArgumentException: invalid target release: 11`

Successful run: https://app.circleci.com/pipelines/github/checkstyle/checkstyle/11305/workflows/fde9c587-dc2b-4a6c-8899-b194fb8cb779/jobs/111887