### PR TITLE
Issue #11228: Let 'site' Github action to generate javadoc

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -92,7 +92,7 @@ jobs:
         run: |
           cd checkstyle
           bash
-          mvn -e --no-transfer-progress clean site -Pno-validations
+          mvn -e --no-transfer-progress clean site -Pno-validations -Dmaven.javadoc.skip=false
 
       - name: Copy site to AWS S3 Bucket
         run: |


### PR DESCRIPTION
Closes #11228

Javadocs are generated successfully:

![image](https://user-images.githubusercontent.com/31252532/150658952-b8ceda1e-9499-4fa3-9d10-7af7aab25e65.png)

```bash
➜  checkstyle git:(issue-11228) mvn -e --no-transfer-progress clean site -Pno-validations -Dmaven.javadoc.skip=false
...
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.7:report (default-report) @ checkstyle ---
[INFO] Skipping JaCoCo execution because property jacoco.skip is set.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:16 min
[INFO] Finished at: 2022-01-22T18:37:35-05:00
[INFO] ------------------------------------------------------------------------

```