### PR TITLE
doc: mention that excludes can be class names

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
@@ -44,7 +44,8 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </p>
  * <ul>
  * <li>
- * Property {@code excludes} - Specify packages where star imports are allowed.
+ * Property {@code excludes} - Specify packages where starred class imports are
+ * allowed and classes where starred static member imports are allowed.
  * Type is {@code java.lang.String[]}.
  * Default value is {@code ""}.
  * </li>
@@ -152,7 +153,10 @@ public class AvoidStarImportCheck
     /** Suffix for the star import. */
     private static final String STAR_IMPORT_SUFFIX = ".*";
 
-    /** Specify packages where star imports are allowed. */
+    /**
+     * Specify packages where starred class imports are
+     * allowed and classes where starred static member imports are allowed.
+     */
     private final List<String> excludes = new ArrayList<>();
 
     /**
@@ -192,7 +196,8 @@ public class AvoidStarImportCheck
     }
 
     /**
-     * Setter to specify packages where star imports are allowed.
+     * Setter to specify packages where starred class imports are
+     * allowed and classes where starred static member imports are allowed.
      *
      * @param excludesParam a list of package names/fully-qualifies class names
      *     where star imports are ok.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/imports/AvoidStarImportCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/imports/AvoidStarImportCheck.xml
@@ -19,7 +19,8 @@
  &lt;/p&gt;</description>
          <properties>
             <property default-value="" name="excludes" type="java.lang.String[]">
-               <description>Specify packages where star imports are allowed.</description>
+               <description>Specify packages where starred class imports are
+ allowed and classes where starred static member imports are allowed.</description>
             </property>
             <property default-value="false" name="allowClassImports" type="boolean">
                <description>Control whether to allow starred class

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -51,7 +51,9 @@
             <tr>
               <td>excludes</td>
               <td>
-                Specify packages where star imports are allowed.
+                Specify packages where starred class imports are
+                allowed and classes where starred static member imports are
+                allowed.
               </td>
               <td><a href="property_types.html#String.5B.5D">String[]</a></td>
               <td><code>{}</code></td>


### PR DESCRIPTION
I found it confusing that the `excludes` property only mentioned packages, yet when I specified a package, starred static member imports within that package were not excluded. This change clarifies that the `excludes` property uses packages for starred class imports and class names for starred static member imports.

https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html is a class
https://checkstyle.org/config_imports.html#AvoidStarImport we already have example where `exclude` uses not only package (2nd example).

---

Edit: the requested CLI demonstration of the existing behavior that is merely being documented in this PR:

```
tniessen@ubuntuserver:~/dev/checkstyle$ javac Test.java 
tniessen@ubuntuserver:~/dev/checkstyle$ cat Test.java 
import static java.lang.Math.*; // okay, class exclude applies
import static java.lang.System.*; // violation, package excludes do not apply
import java.io.*; // okay, package exclude applies
tniessen@ubuntuserver:~/dev/checkstyle$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="AvoidStarImport">
      <property name="excludes" value="java.io,java.lang.Math"/>
    </module>
  </module>
</module>
tniessen@ubuntuserver:~/dev/checkstyle$ RUN_LOCALE="-Duser.language=en -Duser.country=US"
tniessen@ubuntuserver:~/dev/checkstyle$ java $RUN_LOCALE -jar checkstyle-9.2.1-all.jar -c config.xml Test.java 
Starting audit...
[ERROR] /home/tniessen/dev/checkstyle/Test.java:2:31: Using the '.*' form of import should be avoided - java.lang.System.*. [AvoidStarImport]
Audit done.
Checkstyle ends with 1 errors.
```