### PR TITLE
Issue #10924: Update WhitespaceAroundCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
@@ -687,21 +687,17 @@ public class WhitespaceAroundCheck extends AbstractCheck {
     public void visitToken(DetailAST ast) {
         final int currentType = ast.getType();
         if (!isNotRelevantSituation(ast, currentType)) {
-            final String line = getLine(ast.getLineNo() - 1);
+            final int[] line = getLineCodePoints(ast.getLineNo() - 1);
             final int before = ast.getColumnNo() - 1;
             final int after = ast.getColumnNo() + ast.getText().length();
-            final int[] codePoints = line.codePoints().toArray();
 
-            if (before >= 0) {
-                final char prevChar = Character.toChars(codePoints[before])[0];
-                if (shouldCheckSeparationFromPreviousToken(ast)
-                        && !Character.isWhitespace(prevChar)) {
-                    log(ast, MSG_WS_NOT_PRECEDED, ast.getText());
-                }
+            if (before >= 0 && shouldCheckSeparationFromPreviousToken(ast)
+                        && !CommonUtil.isCodePointWhitespace(line, before)) {
+                log(ast, MSG_WS_NOT_PRECEDED, ast.getText());
             }
 
-            if (after < codePoints.length) {
-                final char nextChar = Character.toChars(codePoints[after])[0];
+            if (after < line.length) {
+                final char nextChar = Character.toChars(line[after])[0];
                 if (shouldCheckSeparationFromNextToken(ast, nextChar)
                         && !Character.isWhitespace(nextChar)) {
                     log(ast, MSG_WS_NOT_FOLLOWED, ast.getText());


### PR DESCRIPTION
Issue #10924: `WhitespaceAroundCheck` already uses `codepoint`. Updated this check to use `CodePointUtil` methods.

Diff Regression config: https://gist.githubusercontent.com/MUzairS15/d4bef73243734249b18a2f5fa01ef190/raw/ecbfc3ab7e81187983b6f8ae78547254421f9e1d/config.xml