### PR TITLE
infra: use master branch for no-error-xwiki execution

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -295,7 +295,6 @@ no-error-xwiki)
   cd ..
   checkout_from https://github.com/xwiki/xwiki-platform.git
   cd .ci-temp/xwiki-platform
-  git checkout "92f6c0d52e99f61d65a5962e1b258b""a1e535b""a6e"
   # Validate xwiki-platform
   mvn -e --no-transfer-progress checkstyle:check@default -Dcheckstyle.version=${CS_POM_VERSION}
   cd ..


### PR DESCRIPTION
Not sure if I should reference https://github.com/checkstyle/checkstyle/issues/10885 or not, only time will tell if this will be a permanent fix.

Failure noted at https://circleci.com/gh/checkstyle/checkstyle/112560?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link