### PR TITLE
Issue #11241: fix empty line separator for enum and interface fields

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -586,7 +586,7 @@ no-error-pgjdbc)
   checkout_from https://github.com/pgjdbc/pgjdbc.git
   cd .ci-temp/pgjdbc
   # pgjdbc easily damage build, we should use stable versions
-  git checkout "3a2bb""d77969903f8a4ce721d45905c72bd1688d6"
+  git checkout "417c9a2354ad""c3d2c80f84b0a5059ce""ad92e7c2b"
   ./gradlew --no-parallel --no-daemon checkstyleAll \
             -PenableMavenLocal -Pcheckstyle.version=${CS_POM_VERSION}
   cd ../

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -935,8 +935,7 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
      * @return true variable definition is a type field.
      */
     private static boolean isTypeField(DetailAST variableDef) {
-        return TokenUtil.isOfType(variableDef.getParent().getParent(),
-             TokenTypes.CLASS_DEF, TokenTypes.RECORD_DEF);
+        return TokenUtil.isTypeDeclaration(variableDef.getParent().getParent().getType());
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -249,6 +249,35 @@ public class EmptyLineSeparatorCheckTest
     }
 
     @Test
+    public void testEnumMembers() throws Exception {
+        final String[] expected = {
+            "22:5: " + getCheckMessage(MSG_MULTIPLE_LINES, "VARIABLE_DEF"),
+            "27:5: " + getCheckMessage(MSG_MULTIPLE_LINES, "VARIABLE_DEF"),
+            "28:5: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "VARIABLE_DEF"),
+            "31:5: " + getCheckMessage(MSG_MULTIPLE_LINES, "CTOR_DEF"),
+            "36:5: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "STATIC_INIT"),
+            "40:5: " + getCheckMessage(MSG_MULTIPLE_LINES, "STATIC_INIT"),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputEmptyLineSeparatorEnumMembers.java"), expected
+        );
+    }
+
+    @Test
+    public void testInterfaceFields() throws Exception {
+        final String[] expected = {
+            "21:5: " + getCheckMessage(MSG_MULTIPLE_LINES, "VARIABLE_DEF"),
+            "25:5: " + getCheckMessage(MSG_MULTIPLE_LINES, "VARIABLE_DEF"),
+            "34:5: " + getCheckMessage(MSG_MULTIPLE_LINES, "VARIABLE_DEF"),
+            "38:5: " + getCheckMessage(MSG_MULTIPLE_LINES, "VARIABLE_DEF"),
+            "45:5: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "VARIABLE_DEF"),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputEmptyLineSeparatorInterfaceFields.java"), expected
+        );
+    }
+
+    @Test
     public void testGetAcceptableTokens() {
         final EmptyLineSeparatorCheck emptyLineSeparatorCheckObj = new EmptyLineSeparatorCheck();
         final int[] actual = emptyLineSeparatorCheckObj.getAcceptableTokens();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorEnumMembers.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorEnumMembers.java
@@ -1,0 +1,47 @@
+/*
+EmptyLineSeparator
+allowNoEmptyLineBetweenFields = (default)false
+allowMultipleEmptyLines = false
+allowMultipleEmptyLinesInsideClassMembers = false
+tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF, \
+         STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, RECORD_DEF, \
+         COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
+
+public class InputEmptyLineSeparatorEnumMembers {}
+
+enum A {
+    ONE("one"),
+    TWO("two");
+
+
+    private final String str; // violation ''VARIABLE_DEF' has more than 1 empty lines before.'
+
+    private String otherString; // ok
+
+
+    private String thirdString; // violation ''VARIABLE_DEF' has more than 1 empty lines before.'
+    private String fourth; // violation ''VARIABLE_DEF' should be separated from previous line.'
+
+
+    A(String s) { // violation ''CTOR_DEF' has more than 1 empty lines before.'
+        this.str = s;
+    }
+
+    private String fifth;
+    static { // violation ''STATIC_INIT' should be separated from previous line.'
+    }
+
+
+    static { // violation ''STATIC_INIT' has more than 1 empty lines before.'
+
+    }
+
+    public String getStr() {
+        return str;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorInterfaceFields.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorInterfaceFields.java
@@ -1,0 +1,46 @@
+/*
+EmptyLineSeparator
+allowNoEmptyLineBetweenFields = (default)false
+allowMultipleEmptyLines = false
+allowMultipleEmptyLinesInsideClassMembers = false
+tokens = (default)PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF, \
+         STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, RECORD_DEF, \
+         COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
+
+public interface InputEmptyLineSeparatorInterfaceFields {
+    int a = 45; // ok
+
+    int b = 45; // ok
+
+
+    int c = 45; // violation ''VARIABLE_DEF' has more than 1 empty lines before.'
+
+
+
+    int d = 45; // violation ''VARIABLE_DEF' has more than 1 empty lines before.'
+}
+
+@interface Ann {
+    int a = 45; // ok
+
+    int b = 45; // ok
+
+
+    int c = 45; // violation ''VARIABLE_DEF' has more than 1 empty lines before.'
+
+
+
+    int d = 45; // violation ''VARIABLE_DEF' has more than 1 empty lines before.'
+}
+
+interface Abc {
+    Object apply(Object array, int index);
+
+    Abc A = (o, i) -> new Object();
+    Abc B = (o, i) -> o; // violation ''VARIABLE_DEF' should be separated from previous line.'
+}


### PR DESCRIPTION
Closes #11241 

for some reason, check was not aware that enums can have fields

Diff Regression config: https://gist.githubusercontent.com/strkkk/31749e0743553a606f69fdfc6670d780/raw/332b1574376419f7ea927be6902398aedec8e3bf/confg.xml