### PR TITLE
Issue #10924: Update NoWhitespaceAfterCheck to use codepoints

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
@@ -276,9 +276,9 @@ public class NoWhitespaceAfterCheck extends AbstractCheck {
         int whitespaceColumnNo, int whitespaceLineNo) {
         final boolean result;
         final int astLineNo = ast.getLineNo();
-        final String line = getLine(astLineNo - 1);
-        if (astLineNo == whitespaceLineNo && whitespaceColumnNo < line.length()) {
-            result = Character.isWhitespace(line.charAt(whitespaceColumnNo));
+        final int[] line = getLineCodePoints(astLineNo - 1);
+        if (astLineNo == whitespaceLineNo && whitespaceColumnNo < line.length) {
+            result = CommonUtil.isCodePointWhitespace(line, whitespaceColumnNo);
         }
         else {
             result = !allowLineBreaks;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
@@ -330,6 +330,23 @@ public class NoWhitespaceAfterCheckTest
                 getPath("InputNoWhitespaceAfterNewGenericTypeArgument.java"), expected);
     }
 
+    @Test
+    public void testNoWhitespaceAfterWithEmoji() throws Exception {
+
+        final String[] expected = {
+            "16:16: " + getCheckMessage(MSG_KEY, "String"),
+            "16:26: " + getCheckMessage(MSG_KEY, "{"),
+            "23:24: " + getCheckMessage(MSG_KEY, "char"),
+            "28:22: " + getCheckMessage(MSG_KEY, ")"),
+            "28:23: " + getCheckMessage(MSG_KEY, "@"),
+            "35:17: " + getCheckMessage(MSG_KEY, "!"),
+            "35:22: " + getCheckMessage(MSG_KEY, "."),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputNoWhitespaceAfterWithEmoji.java"), expected);
+    }
+
     /**
      * Creates MOCK lexical token and returns AST node for this token.
      *

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterWithEmoji.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterWithEmoji.java
@@ -1,0 +1,45 @@
+/*
+NoWhitespaceAfter
+allowLineBreaks = (default)true
+tokens = ARRAY_INIT, AT, INC, DEC, UNARY_MINUS, UNARY_PLUS, BNOT, LNOT, DOT, TYPECAST, \
+         ARRAY_DECLARATOR, INDEX_OP, LITERAL_SYNCHRONIZED, METHOD_REF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.nowhitespaceafter;
+
+public class InputNoWhitespaceAfterWithEmoji {
+
+    String txt = new String ("sd🤩🎄😂 " );
+    public String foo() {
+        String []   s =  { "🎄😂", // 2 violations
+                        "🎄😂12wq"
+        };
+
+        for (int i = 0; i < s.length; i++) {
+            char[]c = "🤩🎄".toCharArray();
+
+        /* 👉🏻😆*/ char  []c2= "🤩🎄".toCharArray(); // violation ''char' is followed by whitespace.'
+        }
+        return "😅🧐 dsad "; // ok
+    }
+    public String foo2() {
+        String str = (@ MyAnnotation String) "🤩dsa😂adsad"; // 2 violations
+        String str3 = str + "😂" + "sadsa" +"😅🧐" +    " " ;
+        return("  🎄😂  ");
+    }
+
+    public String foo3() {
+
+        return  ! "🎄". isEmpty() ?"dsa😂a":  "😂..😅" ; // 2 violations
+    }
+
+    public String[] foo4 () {
+        return new String[] {
+          "sd😂"+  "😅🧐",
+                "👉🏻"
+        };
+    }
+
+}


### PR DESCRIPTION
Issue #10924: Updated NoWhitespaceAfterCheck to use codepoints

Diff Regression config: https://gist.githubusercontent.com/MUzairS15/ee7bdfb2a7f3238291d8fd09eb24a752/raw/21d54b97bef2a9883661ab84140125af7f877c27/config.xml

```
src % cat config.xml Test.java 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name = "Checker">
    <property name="charset" value="UTF-8"/>

    <property name="severity" value="warning"/>

    <property name="fileExtensions" value="java, properties, xml"/>

    <module name="TreeWalker">
        <module name="NoWhitespaceAfter"/>
    </module>

</module>

public class Test {

    /* a🎄🎄a*/ char  []c2= "🤩🎄".toCharArray(); // violation but not reported
    /* trees*/ char  []c3= "haha".toCharArray(); // violation and reported

    public String foo1() {
      return "🎄". isEmpty() ?"haha":"a..a"; // violation
    }

    public String foo2() {
        return "tree". isEmpty() ?"haha":"a..a"; 
    }

}
src % java -jar checkstyle-10.0-all.jar -c config.xml Test.java
Starting audit...
[WARN] /Users/shabana/Documents/OpenSource/CheckStyleTest/src/src/Test.java:4:22: 'char' is followed by whitespace. [NoWhitespaceAfter]
[WARN] /Users/shabana/Documents/OpenSource/CheckStyleTest/src/src/Test.java:11:22: '.' is followed by whitespace. [NoWhitespaceAfter]
Audit done.
