### PR TITLE
infra: Update commands used for validation with Hibernate Search

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -352,6 +352,7 @@ Dstrict
 Dtest
 Dubinin
 Duser
+Dversion
 Dxml
 eb
 ecj

--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -645,10 +645,12 @@ no-error-hibernate-search)
   echo CS_version: ${CS_POM_VERSION}
   checkout_from https://github.com/hibernate/hibernate-search.git
   cd .ci-temp/hibernate-search
-  mvn -e --no-transfer-progress clean install -DskipTests=true -Dtest.elasticsearch.run.skip=true \
+  mvn -e --no-transfer-progress clean install -pl build/config -am \
+     -DskipTests=true -Dmaven.compiler.failOnWarning=false \
      -Dcheckstyle.skip=true -Dforbiddenapis.skip=true \
-     -Dpuppycrawl.checkstyle.version=${CS_POM_VERSION}
-  mvn -e --no-transfer-progress checkstyle:check  -Dpuppycrawl.checkstyle.version=${CS_POM_VERSION}
+     -Dversion.com.puppycrawl.tools.checkstyle=${CS_POM_VERSION}
+  mvn -e --no-transfer-progress checkstyle:check \
+     -Dversion.com.puppycrawl.tools.checkstyle=${CS_POM_VERSION}
   cd ../
   removeFolderWithProtectedFiles hibernate-search
   ;;


### PR DESCRIPTION
Hibernate Search changed the name of its Maven property controlling the version of checkstyle, so the previous commands did not actually override the version of checkstyle.

Fortunately we upgrade checkstyle regularly in Hibernate Search (e.g. https://github.com/hibernate/hibernate-search/pull/2874), so we know it still works.