### PR TITLE
Issue #10924: Refactored AbstractParenPadCheck to use CodePointUtil methods.

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/AbstractParenPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/AbstractParenPadCheck.java
@@ -24,6 +24,7 @@ import java.util.Locale;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.utils.CodePointUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
@@ -85,18 +86,17 @@ public abstract class AbstractParenPadCheck
      * @param ast the token representing a left parentheses
      */
     protected void processLeft(DetailAST ast) {
-        final String line = getLines()[ast.getLineNo() - 1];
-        final int[] codePoints = line.codePoints().toArray();
+        final int[] line = getLineCodePoints(ast.getLineNo() - 1);
         final int after = ast.getColumnNo() + 1;
 
-        if (after < codePoints.length) {
+        if (after < line.length) {
             final boolean hasWhitespaceAfter =
-                    CommonUtil.isCodePointWhitespace(codePoints, after);
+                    CommonUtil.isCodePointWhitespace(line, after);
             if (option == PadOption.NOSPACE && hasWhitespaceAfter) {
                 log(ast, MSG_WS_FOLLOWED, OPEN_PARENTHESIS);
             }
             else if (option == PadOption.SPACE && !hasWhitespaceAfter
-                     && line.charAt(after) != CLOSE_PARENTHESIS) {
+                     && line[after] != CLOSE_PARENTHESIS) {
                 log(ast, MSG_WS_NOT_FOLLOWED, OPEN_PARENTHESIS);
             }
         }
@@ -110,17 +110,16 @@ public abstract class AbstractParenPadCheck
     protected void processRight(DetailAST ast) {
         final int before = ast.getColumnNo() - 1;
         if (before >= 0) {
-            final String line = getLines()[ast.getLineNo() - 1];
-            final int[] codePoints = line.codePoints().toArray();
+            final int[] line = getLineCodePoints(ast.getLineNo() - 1);
             final boolean hasPrecedingWhitespace =
-                    CommonUtil.isCodePointWhitespace(codePoints, before);
+                    CommonUtil.isCodePointWhitespace(line, before);
 
             if (option == PadOption.NOSPACE && hasPrecedingWhitespace
-                && !CommonUtil.hasWhitespaceBefore(before, line)) {
+                && !CodePointUtil.hasWhitespaceBefore(before, line)) {
                 log(ast, MSG_WS_PRECEDED, CLOSE_PARENTHESIS);
             }
             else if (option == PadOption.SPACE && !hasPrecedingWhitespace
-                && line.charAt(before) != OPEN_PARENTHESIS) {
+                && line[before] != OPEN_PARENTHESIS) {
                 log(ast, MSG_WS_NOT_PRECEDED, CLOSE_PARENTHESIS);
             }
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtilTest.java
@@ -82,7 +82,7 @@ public final class MetadataGeneratorUtilTest extends AbstractModuleTestSupport {
             "45: " + getCheckMessage(MSG_DESC_MISSING, "AbstractClassCouplingCheck"),
             "26: " + getCheckMessage(MSG_DESC_MISSING, "AbstractAccessControlNameCheck"),
             "30: " + getCheckMessage(MSG_DESC_MISSING, "AbstractNameCheck"),
-            "29: " + getCheckMessage(MSG_DESC_MISSING, "AbstractParenPadCheck"),
+            "30: " + getCheckMessage(MSG_DESC_MISSING, "AbstractParenPadCheck"),
         };
 
         final String[] actualViolations = systemOut.getCapturedData().split("\\n");


### PR DESCRIPTION
Issue #10924: AbstractParenPadCheck already uses code points. Updated this check to use CodePointUtil methods.

Diff Regression config: https://gist.githubusercontent.com/MUzairS15/327da1e283758cd4593c483c91f7ff76/raw/a4ce66842137ae5e853df3e40d28ddc7f6833840/config.xml

```
checkstyle % git grep "extends AbstractParenPadCheck" 
src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheck.java:public class ParenPadCheck extends AbstractParenPadCheck {
src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadCheck.java:public class TypecastParenPadCheck extends AbstractParenPadCheck {
```