### PR TITLE
minor: Set default locale for unit test execution to "en"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <surefire.options />
+    <surefire.options>-Duser.language=en</surefire.options>
     <projectVersion>${project.version}</projectVersion>
     <antlr4.version>4.9.3</antlr4.version>
     <maven.site.plugin.version>3.11.0</maven.site.plugin.version>


### PR DESCRIPTION
There are a few unit tests that rely on the default locale language being set to english because they make assertions about localized messages. On systems where the default locale language is not "en", these tests fail.

This change sets the default language for test execution to "en" as surefire argument.

Other than that, I couldn't help but fixing some assertions in `DefaultLoggerTest` to improve the failure messages.
