### PR TITLE
doc: update requirements to jdk 11

### DIFF
--- a/src/xdocs/beginning_development.xml
+++ b/src/xdocs/beginning_development.xml
@@ -17,7 +17,7 @@
     </section>
     <section name="Before development">
       <p>
-        1. Ensure that Git, Java JDK >= 8 until JDK 17, maven >= 3.0.1 are installed.<br/>
+        1. Ensure that Git, Java JDK >= 11 until JDK 17, maven >= 3.0.1 are installed.<br/>
         You can find information about development environment preparation here:
         <a href="https://github.com/sevntu-checkstyle/sevntu.checkstyle/wiki/Prepare-Development-Environment-in-Ubuntu-12.04">
         Prepare development environment in Ubuntu</a>.<br/>

--- a/src/xdocs/index.xml.vm
+++ b/src/xdocs/index.xml.vm
@@ -131,6 +131,14 @@
           </tr>
           <tr>
             <td>
+              10.x
+            </td>
+            <td>
+              11 and above
+            </td>
+          </tr>
+          <tr>
+            <td>
               7.x, 8.x, 9.x
             </td>
             <td>


### PR DESCRIPTION
Missed in #9146 

We need to update Index.html and beginning_development.html to specify the minimum JDK version.