### PR TITLE
minor: Remove outdated comment from UnusedLocalVariable

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
@@ -287,9 +287,6 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
 
     @Override
     public void beginTree(DetailAST root) {
-        // No need to set blockContainingLocalAnonInnerClass to null, if
-        // its value gets changed during the check then it is changed back to null
-        // inside the check only.
         variables.clear();
         typeDeclarations.clear();
         typeDeclAstToTypeDeclDesc.clear();


### PR DESCRIPTION
This field was removed in 0f3d9d4709f929d57310ff5505bbcfa4f93f1037 but I forgot to remove the comment related to it.