### PR TITLE
Issue #11289: add since and forRemoval properties to Deprecated annotation

### DIFF
--- a/config/checkstyle_checks.xml
+++ b/config/checkstyle_checks.xml
@@ -462,6 +462,14 @@
       <message key="matchxpath.match"
                value="Block comment text should start with space after asterisk."/>
     </module>
+    <module name="MatchXpath">
+      <property name="id" value="deprecatedWithoutSince"/>
+      <property name="query"
+               value="//ANNOTATION[./IDENT[@text='Deprecated']
+                      and not(./ANNOTATION_MEMBER_VALUE_PAIR/IDENT[@text='since'])]"/>
+      <message key="matchxpath.match"
+             value="@Deprecated annotation should contain 'since' property."/>
+    </module>
     <module name="MissingCtor">
       <!--
         we will not use that fanatic validation, extra code is not good

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
@@ -140,7 +140,7 @@ public final class DefaultConfiguration implements Configuration {
      * @deprecated This shall be removed in future releases. Please use
      *      {@code addProperty(String propertyName, String value)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "8.45")
     public void addAttribute(String attributeName, String value) {
         addProperty(attributeName, value);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java
@@ -192,7 +192,7 @@ public abstract class AbstractCheck extends AbstractViolationReporter {
      *      Please use AST based methods instead.
      * @noinspection WeakerAccess
      */
-    @Deprecated
+    @Deprecated(since = "9.3")
     public final FileContents getFileContents() {
         return context.get().fileContents;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Configuration.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Configuration.java
@@ -36,7 +36,7 @@ public interface Configuration extends Serializable {
      * @deprecated This shall be removed in future releases. Please use
      *      {@code getPropertyNames()} instead.
      */
-    @Deprecated
+    @Deprecated(since = "8.45")
     String[] getAttributeNames();
 
     /**
@@ -48,7 +48,7 @@ public interface Configuration extends Serializable {
      * @deprecated This shall be removed in future releases. Please use
      *      {@code getProperty(String name)} instead.
      */
-    @Deprecated
+    @Deprecated(since = "8.45")
     String getAttribute(String name) throws CheckstyleException;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -98,7 +98,7 @@ public interface DetailAST {
      *      traversal of subtrees to be written per the needs of each check
      *      to avoid unintended side effects.
      */
-    @Deprecated
+    @Deprecated(since = "8.43")
     boolean branchContains(int type);
 
     /**
@@ -137,7 +137,7 @@ public interface DetailAST {
      * @deprecated This method will be removed in a future release.
      *             Use {@link #getChildCount()} instead.
      */
-    @Deprecated
+    @Deprecated(since = "8.30")
     int getNumberOfChildren();
 
     /**


### PR DESCRIPTION
Issue #11289

Java 9 introduces two attributes for `@Deprecated` annotation: `since` and `forRemoval`.
The first one should be mandatory. New XPath check added to validate this.