### PR TITLE
Issue #11294: fix NPE in gui.MainFrameModel#getLastDirectory

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModel.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModel.java
@@ -163,7 +163,7 @@ public class MainFrameModel {
     public File getLastDirectory() {
         File lastDirectory = null;
         if (currentFile != null) {
-            lastDirectory = new File(currentFile.getParent());
+            lastDirectory = currentFile.getParentFile();
         }
         return lastDirectory;
     }


### PR DESCRIPTION
Fixes #11294 

`File#getParentFile` is actually `new File(file.getParent())` with null check.