### PR TITLE
Issue #11309: Replace usages of deprecated method AccessibleObject.is…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1517,10 +1517,6 @@
                 <exclude>**/MainTest.class</exclude>
                 <!-- tests need forbidden apis to test the main code fully -->
                 <exclude>**/XpathFileGeneratorAuditListenerTest.class</exclude>
-                <!-- These tests uses java.lang.reflect.AccessibleObject.isAccessible
-                  which has no Java 8 compatible workaround. -->
-                <exclude>**/AllChecksTest.class</exclude>
-                <exclude>**/XdocsPagesTest.class</exclude>
                 <!-- Needed for testing deprecated API. -->
                 <exclude>**/DefaultConfigurationTest.class</exclude>
                 <!-- Inline Config cannot be supported. -->

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -552,9 +552,7 @@ public class AllChecksTest extends AbstractModuleTestSupport {
                     .isEqualTo(Modifier.PUBLIC | Modifier.STATIC | Modifier.FINAL);
 
                 // below is required for package/private classes
-                if (!message.isAccessible()) {
-                    message.setAccessible(true);
-                }
+                message.trySetAccessible();
 
                 if (!INTERNAL_MODULES.contains(module.getSimpleName())) {
                     verifyCheckstyleMessage(usedMessages, module, message);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -1283,7 +1283,7 @@ public class XdocsPagesTest {
         while (!Object.class.equals(currentClass)) {
             try {
                 result = currentClass.getDeclaredField(propertyName);
-                result.setAccessible(true);
+                result.trySetAccessible();
                 break;
             }
             catch (NoSuchFieldException ignored) {
@@ -1359,9 +1359,7 @@ public class XdocsPagesTest {
 
         for (Field field : fields) {
             // below is required for package/private classes
-            if (!field.isAccessible()) {
-                field.setAccessible(true);
-            }
+            field.trySetAccessible();
 
             list.add(field.get(null).toString());
         }


### PR DESCRIPTION
Closes #11309.

From https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/reflect/AccessibleObject.html#trySetAccessible():

> Set the accessible flag for this reflected object to true if possible. This method sets the accessible flag, as if by invoking [setAccessible(true)](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/reflect/AccessibleObject.html#setAccessible(boolean)), and returns the possibly-updated value for the accessible flag. If access cannot be enabled, i.e. the checks or Java language access control cannot be suppressed, this method returns false (as opposed to setAccessible(true) throwing InaccessibleObjectException when it fails).