### PR TITLE
11166 remove get file contents method length

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheck.java
@@ -19,10 +19,17 @@
 
 package com.puppycrawl.tools.checkstyle.checks.sizes;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
-import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
@@ -42,8 +49,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * Default value is {@code 150}.
  * </li>
  * <li>
- * Property {@code countEmpty} - Control whether to count empty lines and single
- * line comments of the form {@code //}.
+ * Property {@code countEmpty} - Control whether to count empty lines and comments.
  * Type is {@code boolean}.
  * Default value is {@code true}.
  * </li>
@@ -77,7 +83,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </pre>
  * <p>
  * To configure the check so that it accepts methods with at most 60 lines,
- * not counting empty lines and single line comments:
+ * not counting empty lines and comments:
  * </p>
  * <pre>
  * &lt;module name="MethodLength"&gt;
@@ -112,7 +118,7 @@ public class MethodLengthCheck extends AbstractCheck {
     /** Default maximum number of lines. */
     private static final int DEFAULT_MAX_LINES = 150;
 
-    /** Control whether to count empty lines and single line comments of the form {@code //}. */
+    /** Control whether to count empty lines and comments. */
     private boolean countEmpty = true;
 
     /** Specify the maximum number of lines allowed. */
@@ -141,9 +147,14 @@ public class MethodLengthCheck extends AbstractCheck {
     public void visitToken(DetailAST ast) {
         final DetailAST openingBrace = ast.findFirstToken(TokenTypes.SLIST);
         if (openingBrace != null) {
-            final DetailAST closingBrace =
-                openingBrace.findFirstToken(TokenTypes.RCURLY);
-            final int length = getLengthOfBlock(openingBrace, closingBrace);
+            final int length;
+            if (countEmpty) {
+                final DetailAST closingBrace = openingBrace.findFirstToken(TokenTypes.RCURLY);
+                length = getLengthOfBlock(openingBrace, closingBrace);
+            }
+            else {
+                length = countUsedLines(openingBrace);
+            }
             if (length > max) {
                 final String methodName = ast.findFirstToken(TokenTypes.IDENT).getText();
                 log(ast, MSG_KEY, length, max, methodName);
@@ -152,30 +163,45 @@ public class MethodLengthCheck extends AbstractCheck {
     }
 
     /**
-     * Returns length of code only without comments and blank lines.
+     * Returns length of code.
      *
      * @param openingBrace block opening brace
      * @param closingBrace block closing brace
      * @return number of lines with code for current block
      */
-    // suppress deprecation until https://github.com/checkstyle/checkstyle/issues/11166
-    @SuppressWarnings("deprecation")
-    private int getLengthOfBlock(DetailAST openingBrace, DetailAST closingBrace) {
-        int length = closingBrace.getLineNo() - openingBrace.getLineNo() + 1;
+    private static int getLengthOfBlock(DetailAST openingBrace, DetailAST closingBrace) {
+        final int startLineNo = openingBrace.getLineNo();
+        final int endLineNo = closingBrace.getLineNo();
+        return endLineNo - startLineNo + 1;
+    }
 
-        if (!countEmpty) {
-            final FileContents contents = getFileContents();
-            final int lastLine = closingBrace.getLineNo();
-            // lastLine - 1 is actual last line index. Last line is line with curly brace,
-            // which is always not empty. So, we make it lastLine - 2 to cover last line that
-            // actually may be empty.
-            for (int i = openingBrace.getLineNo() - 1; i <= lastLine - 2; i++) {
-                if (contents.lineIsBlank(i) || contents.lineIsComment(i)) {
-                    length--;
-                }
+    /**
+     * Count number of used code lines without comments.
+     *
+     * @param ast start ast
+     * @return number of used lines of code
+     */
+    private static int countUsedLines(DetailAST ast) {
+        final Deque<DetailAST> nodes = new ArrayDeque<>();
+        nodes.add(ast);
+        final Set<Integer> usedLines = new HashSet<>();
+        while (!nodes.isEmpty()) {
+            final DetailAST node = nodes.removeFirst();
+            final int lineNo = node.getLineNo();
+            // text block requires special treatment,
+            // since it is the only non-comment token that can span more than one line
+            if (node.getType() == TokenTypes.TEXT_BLOCK_LITERAL_BEGIN) {
+                IntStream.rangeClosed(lineNo, node.getLastChild().getLineNo())
+                    .forEach(usedLines::add);
+            }
+            else {
+                usedLines.add(lineNo);
+                Stream.iterate(
+                    node.getLastChild(), Objects::nonNull, DetailAST::getPreviousSibling
+                ).forEach(nodes::addFirst);
             }
         }
-        return length;
+        return usedLines.size();
     }
 
     /**
@@ -188,11 +214,9 @@ public class MethodLengthCheck extends AbstractCheck {
     }
 
     /**
-     * Setter to control whether to count empty lines and single line comments
-     * of the form {@code //}.
+     * Setter to control whether to count empty lines and comments.
      *
-     * @param countEmpty whether to count empty and single line comments
-     *     of the form //.
+     * @param countEmpty whether to count empty and comments.
      */
     public void setCountEmpty(boolean countEmpty) {
         this.countEmpty = countEmpty;

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/sizes/MethodLengthCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/sizes/MethodLengthCheck.xml
@@ -17,8 +17,7 @@
                <description>Specify the maximum number of lines allowed.</description>
             </property>
             <property default-value="true" name="countEmpty" type="boolean">
-               <description>Control whether to count empty lines and single
- line comments of the form {@code //}.</description>
+               <description>Control whether to count empty lines and comments.</description>
             </property>
             <property default-value="METHOD_DEF,CTOR_DEF,COMPACT_CTOR_DEF"
                       name="tokens"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheckTest.java
@@ -86,10 +86,40 @@ public class MethodLengthCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testCountEmpty() throws Exception {
+        final int max = 2;
+        final String[] expected = {
+            "24:5: " + getCheckMessage(MSG_KEY, 3, max, "AA"),
+            "41:5: " + getCheckMessage(MSG_KEY, 3, max, "threeLines"),
+            "45:5: " + getCheckMessage(MSG_KEY, 3, max, "threeLinesAndComments"),
+            "53:5: " + getCheckMessage(MSG_KEY, 3, max, "threeLinesWrap"),
+            "63:5: " + getCheckMessage(MSG_KEY, 10, max, "m2"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputMethodLengthCountEmptySmallSize.java"), expected);
+    }
+
+    @Test
     public void testAbstract() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(
                 getPath("InputMethodLengthModifier.java"), expected);
+    }
+
+    @Test
+    public void testTextBlocks() throws Exception {
+        final int max = 2;
+
+        final String[] expected = {
+            "14:5: " + getCheckMessage(MSG_KEY, 21, max, "longEmptyTextBlock"),
+            "43:5: " + getCheckMessage(MSG_KEY, 10, max, "textBlock2"),
+            "57:5: " + getCheckMessage(MSG_KEY, 8, max, "textBlockWithIndent"),
+            "66:5: " + getCheckMessage(MSG_KEY, 12, max, "textBlockNoIndent"),
+        };
+
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputMethodLengthTextBlocksCountEmpty.java"),
+                expected);
     }
 
     @Test
@@ -107,6 +137,23 @@ public class MethodLengthCheckTest extends AbstractModuleTestSupport {
 
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputMethodLengthRecordsAndCompactCtors.java"),
+                expected);
+    }
+
+    @Test
+    public void testRecordsAndCompactCtorsCountEmpty() throws Exception {
+        final int max = 2;
+
+        final String[] expected = {
+            "25:9: " + getCheckMessage(MSG_KEY, 3, max, "MyTestRecord2"),
+            "32:9: " + getCheckMessage(MSG_KEY, 3, max, "foo"),
+            "38:9: " + getCheckMessage(MSG_KEY, 3, max, "MyTestRecord4"),
+            "55:9: " + getCheckMessage(MSG_KEY, 13, max, "m"),
+            "58:17: " + getCheckMessage(MSG_KEY, 8, max, "R76"),
+        };
+
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputMethodLengthCompactCtorsCountEmpty.java"),
                 expected);
     }
 

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthCompactCtorsCountEmpty.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthCompactCtorsCountEmpty.java
@@ -1,0 +1,71 @@
+/*
+MethodLength
+max = 2
+countEmpty = false
+tokens = (default)METHOD_DEF, CTOR_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.sizes.methodlength;
+
+public class InputMethodLengthCompactCtorsCountEmpty {
+
+    record MyTestRecord() {
+        static { // ok
+            System.out.println("test");
+            System.out.println("test");
+            System.out.println("test");
+        }
+    }
+
+    //compact ctor
+    record MyTestRecord2() {
+        public MyTestRecord2 { // violation 'Method .* length is 3 lines (max allowed is 2).'
+            System.out.println("test");
+
+        }
+    }
+
+    record MyTestRecord3(String str) {
+        void foo() { // violation 'Method .* length is 3 lines (max allowed is 2).'
+            System.out.println("test");
+        }
+    }
+
+    record MyTestRecord4(int x, int y) {
+        public MyTestRecord4() { // violation 'Method .* length is 3 lines (max allowed is 2).'
+            this(4, 5);
+
+        }
+    }
+
+    record MyTestRecord5() {
+        public MyTestRecord5() { // ok
+            // some comment
+            /*
+            block comment
+             */
+
+        }
+    }
+
+    class LocalRecordHelper {
+        Class<?> m(int x) { // violation 'Method .* length is 13 lines (max allowed is 2).'
+            record R76(int x) {
+
+                public R76 { // violation 'Method .* length is 8 lines (max allowed is 2).'
+                    int y = 5;
+                    int z = 10;
+                    String newString = String.valueOf(y);
+                    System.out.println(newString);
+                    System.out.println("Value of y: " + newString);
+                    System.out.println(y + z);
+                }
+
+            }
+            return R76.class;
+        }
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthTextBlocksCountEmpty.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthTextBlocksCountEmpty.java
@@ -1,0 +1,83 @@
+/*
+MethodLength
+max = 2
+countEmpty = false
+tokens = (default)METHOD_DEF, CTOR_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.sizes.methodlength;
+
+public class InputMethodLengthTextBlocksCountEmpty {
+    void longEmptyTextBlock() { // violation 'Method .* length is 21 lines (max allowed is 2).'
+
+
+
+
+
+
+
+        String a = """
+                      3
+                      4
+                      5
+                      6
+                      7
+                      8
+                      9
+                      10
+                      11
+                      12
+                      13
+                      14
+                      15
+                      16
+                      17
+                      18
+                      19
+                      20
+""";}
+
+    void textBlock2() { // violation 'Method .* length is 10 lines (max allowed is 2).'
+    String a = """
+        3
+        4
+        5
+        6
+
+""";
+    // comment
+    int b = 1;
+    /* block comment */
+
+    }
+
+    void textBlockWithIndent() { // violation 'Method .* length is 8 lines (max allowed is 2).'
+        String a = """
+        3
+        4
+        5
+        6
+        7
+         """;}
+
+    void textBlockNoIndent() { // violation 'Method .* length is 12 lines (max allowed is 2).'
+        String a =
+"""
+        3
+        4
+        5
+        6
+        7
+
+"""
+
+            ;
+
+    }
+
+    void text2Lines() {String a = """
+    """;}
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthCountEmptySmallSize.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/methodlength/InputMethodLengthCountEmptySmallSize.java
@@ -1,0 +1,73 @@
+/*
+MethodLength
+max = 2
+countEmpty = false
+tokens = (default)METHOD_DEF, CTOR_DEF, COMPACT_CTOR_DEF
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.sizes.methodlength;
+
+public class InputMethodLengthCountEmptySmallSize {}
+class AA {
+    AA() { // ok, 2 lines
+
+    }
+
+    AA(int a) { // ok, 2 lines
+        /*
+        my comment
+         */
+        // other comment
+    }
+
+    AA(String a) {  // violation 'Method .* length is 3 lines (max allowed is 2).'
+        oneLine();
+    }
+
+    void twoLines() { // ok
+
+    }
+
+    void twoLines2() { // ok
+        oneLine();}
+
+    void twoLinesAndComment() { // ok
+        // some comment
+    }
+
+    void oneLine() { oneLine();/* ok */ }
+
+    void threeLines() { // violation 'Method threeLines length is 3 lines (max allowed is 2).'
+        oneLine();
+    }
+
+    void threeLinesAndComments() { // violation 'Method .* length is 3 lines (max allowed is 2).'
+        // comment above
+        oneLine();
+        /*
+        block comment below
+         */
+    }
+
+    void threeLinesWrap() // violation 'Method .* length is 3 lines (max allowed is 2).'
+
+    {
+        // comment above
+        oneLine();
+        /*
+        block comment below
+         */
+    }
+
+    void m2() { // violation 'Method .* length is 10 lines (max allowed is 2).'
+        String a = "1";
+        a.concat("")
+            .concat("")
+            .concat("")
+            .concat("")
+            .concat("")
+            .concat("")
+            .concat("");
+    }
+}

--- a/src/xdocs/config_sizes.xml
+++ b/src/xdocs/config_sizes.xml
@@ -917,8 +917,7 @@ public class ExampleClass {
             <tr>
               <td>countEmpty</td>
               <td>
-                Control whether to count empty lines and single line comments of the
-                form <code>//</code>.
+                Control whether to count empty lines and comments.
               </td>
               <td><a href="property_types.html#boolean">boolean</a></td>
               <td><code>true</code></td>
@@ -975,7 +974,7 @@ public class ExampleClass {
 
         <p>
           To configure the check so that it accepts methods with at most 60
-          lines, not counting empty lines and single line comments:
+          lines, not counting empty lines and comments:
         </p>
         <source>
 &lt;module name="MethodLength"&gt;


### PR DESCRIPTION
Issue #11166 
Remove usage of getFileContents for method length check.

Note - count is changed because now check ignores block comments as well.

Report - https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/80b7f57_2022070929/reports/diff/index.html

Diff Regression config: https://gist.githubusercontent.com/strkkk/31749e0743553a606f69fdfc6670d780/raw/4d8840dce7f80febf98199fab58575402d503fec/confg.xml