### PR TITLE
Issue #11340: Add ignoreMethodAnnotatedBy property to ParameterNumberCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheck.java
@@ -19,6 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.sizes;
 
+import java.util.Arrays;
+
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -41,6 +43,12 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * methods with {@code @Override} annotation.
  * Type is {@code boolean}.
  * Default value is {@code false}.
+ * </li>
+ * <li>
+ * Property {@code ignoreMethodsAnnotatedBy} - Ignore number of parameters for
+ * method with any of given annotation.
+ * Type is {@code java.lang.String[]}.
+ * Default value is {@code ""}.
  * </li>
  * <li>
  * Property {@code tokens} - tokens to check
@@ -130,6 +138,9 @@ public class ParameterNumberCheck
     /** Ignore number of parameters for methods with {@code @Override} annotation. */
     private boolean ignoreOverriddenMethods;
 
+    /** Ignore number of parameters for method with any of given annotation. */
+    private String[] ignoreMethodsAnnotatedBy = {};
+
     /**
      * Setter to specify the maximum number of parameters allowed.
      *
@@ -146,6 +157,15 @@ public class ParameterNumberCheck
      */
     public void setIgnoreOverriddenMethods(boolean ignoreOverriddenMethods) {
         this.ignoreOverriddenMethods = ignoreOverriddenMethods;
+    }
+
+    /**
+     * Setter to ignore number of parameters for method with any of given annotation.
+     *
+     * @param annotations set annotation names
+     */
+    public void setIgnoreMethodsAnnotatedBy(String... annotations) {
+        ignoreMethodsAnnotatedBy = annotations.clone();
     }
 
     @Override
@@ -181,10 +201,36 @@ public class ParameterNumberCheck
      *         false otherwise
      */
     private boolean shouldIgnoreNumberOfParameters(DetailAST ast) {
+        return shouldIgnoreOverriddenMethods(ast) || shouldIgnoreAnnotatedMethods(ast);
+    }
+
+    /**
+     * Determine whether to ignore the check for the method because it is annotated by @Override.
+     *
+     * @param ast the token to process
+     * @return true if this is overridden method and number of parameters should be ignored
+     *         false otherwise
+     */
+    private boolean shouldIgnoreOverriddenMethods(DetailAST ast) {
         // if you override a method, you have no power over the number of parameters
         return ignoreOverriddenMethods
                 && (AnnotationUtil.containsAnnotation(ast, OVERRIDE)
                 || AnnotationUtil.containsAnnotation(ast, CANONICAL_OVERRIDE));
+    }
+
+    /**
+     * Determine whether to ignore the check for the method because of its annotation.
+     *
+     * @param ast the token to process
+     * @return true if this is a method with annotation specify in ignoreMethodsAnnotatedBy list
+     *         and number of parameters should be ignored, otherwise false otherwise
+     */
+    private boolean shouldIgnoreAnnotatedMethods(DetailAST ast) {
+        // if you implement external API, you have no power over the number of parameters,
+        // e.g. when create a class for REST API and convert JSON to object by constructor
+        // annotated by `@JsonCreator`.
+        return Arrays.stream(ignoreMethodsAnnotatedBy)
+                .anyMatch(annotation -> AnnotationUtil.containsAnnotation(ast, annotation));
     }
 
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/sizes/ParameterNumberCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/sizes/ParameterNumberCheck.xml
@@ -15,6 +15,12 @@
                <description>Ignore number of parameters for
  methods with {@code @Override} annotation.</description>
             </property>
+            <property default-value=""
+                      name="ignoreMethodsAnnotatedBy"
+                      type="java.lang.String[]">
+               <description>Ignore number of parameters for
+ method with any of given annotation.</description>
+            </property>
             <property default-value="METHOD_DEF,CTOR_DEF"
                       name="tokens"
                       type="java.lang.String[]"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheckTest.java
@@ -123,4 +123,26 @@ public class ParameterNumberCheckTest
                 getPath("InputParameterNumber2.java"), expected);
     }
 
+    @Test
+    public void testIgnoreMethodsAnnotatedByEmpty() throws Exception {
+        final String[] expected = {
+            "15:10: " + getCheckMessage(MSG_KEY, 7, 8),
+            "20:10: " + getCheckMessage(MSG_KEY, 7, 8),
+            "25:10: " + getCheckMessage(MSG_KEY, 7, 8),
+            "30:10: " + getCheckMessage(MSG_KEY, 7, 8),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputParameterNumberAnnotations.java"), expected);
+    }
+
+    @Test
+    public void testIgnoreMethodsAnnotatedBy() throws Exception {
+        final String[] expected = {
+            "15:10: " + getCheckMessage(MSG_KEY, 7, 8),
+            "30:10: " + getCheckMessage(MSG_KEY, 7, 8),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputParameterNumberAnnotations2.java"), expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberAnnotations.java
@@ -1,0 +1,44 @@
+/*
+ParameterNumber
+max = (default)7
+ignoreOverriddenMethods = (default)false
+ignoreMethodsAnnotatedBy = (default)
+tokens = (default)METHOD_DEF, CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.sizes.parameternumber;
+
+public class InputParameterNumberAnnotations
+{
+    void myMethod1(int a, int b, int c, int d, int e, int f, int g, int h) {// violation
+
+    }
+
+    @TestAnnotation1
+    void myMethod2(int a, int b, int c, int d, int e, int f, int g, int h) {// violation
+
+    }
+
+    @TestAnnotation2(someValue = "any value")
+    void myMethod3(int a, int b, int c, int d, int e, int f, int g, int h) {// violation
+
+    }
+
+    @TestAnnotation3(someValue = "some value")
+    void myMethod4(int a, int b, int c, int d, int e, int f, int g, int h) {// violation
+
+    }
+
+    @interface TestAnnotation1 {
+    }
+
+    @interface TestAnnotation2 {
+        String someValue();
+    }
+
+    @interface TestAnnotation3 {
+        String someValue();
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberAnnotations2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberAnnotations2.java
@@ -1,0 +1,56 @@
+/*
+ParameterNumber
+max = (default)7
+ignoreOverriddenMethods = (default)false
+ignoreMethodsAnnotatedBy = TestAnnotation1, TestAnnotation2
+tokens = (default)METHOD_DEF, CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.sizes.parameternumber;
+
+public class InputParameterNumberAnnotations2
+{
+    void myMethod1(int a, int b, int c, int d, int e, int f, int g, int h) {// violation
+
+    }
+
+    @TestAnnotation1
+    void myMethod2(int a, int b, int c, int d, int e, int f, int g, int h) {
+
+    }
+
+    @TestAnnotation2(someValue = "any value")
+    void myMethod3(int a, int b, int c, int d, int e, int f, int g, int h) {
+
+    }
+
+    @TestAnnotation3(someValue = "some value")
+    void myMethod4(int a, int b, int c, int d, int e, int f, int g, int h) {// violation
+
+    }
+
+    @TestAnnotation1
+    @TestAnnotation2(someValue = "some value")
+    void myMethod5(int a, int b, int c, int d, int e, int f, int g, int h) {
+
+    }
+
+    @TestAnnotation1
+    @TestAnnotation3(someValue = "some value")
+    void myMethod6(int a, int b, int c, int d, int e, int f, int g, int h) {
+
+    }
+
+    @interface TestAnnotation1 {
+    }
+
+    @interface TestAnnotation2 {
+        String someValue();
+    }
+
+    @interface TestAnnotation3 {
+        String someValue();
+    }
+}

--- a/src/xdocs/config_sizes.xml
+++ b/src/xdocs/config_sizes.xml
@@ -1118,6 +1118,15 @@ public class ExampleClass {
               <td>6.2</td>
             </tr>
             <tr>
+              <td>ignoreMethodsAnnotatedBy</td>
+              <td>
+                  Ignore number of parameters for method with any of given annotation.
+              </td>
+              <td><a href="property_types.html#String[]">String[]</a></td>
+              <td><code>{}</code></td>
+              <td>9.4</td>
+            </tr>
+            <tr>
               <td>tokens</td>
               <td>tokens to check</td>
 


### PR DESCRIPTION
Issue #11340

If you implement external API, you have no power over the number of parameters, e.g. when creating a DTO class for REST API and deserializing JSON to an object by constructor annotated by `@JsonCreator`

```
class MyDto {
  private final String a1;
  private final String a2;
  private final String a3;
  private final String a4;
  private final String a5;
  private final String a6;
  private final String a7;
  private final String a8;
  private final String a9;

  @JsonCreator
  MyDto(String a1, String a2, String a3, String a4, String a5, String a6, String a7, String a8, String a9) {
    this.a1 = a1;
    this.a2 = a2;
    this.a3 = a3;
    this.a4 = a4;
    this.a5 = a5;
    this.a6 = a6;
    this.a7 = a7;
    this.a8 = a8;
    this.a9 = a9;
  }
}
```

By this change, you can ignore ParameterNumberCheck for this constructor.