### PR TITLE
Issue #11352: Update AvoidStarImport documentation with example for mix of properties

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
@@ -127,6 +127,43 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * import java.net.*;                // violation
  * </pre>
  * <p>
+ * To configure the check so that star imports from packages
+ * {@code java.io and java.net} are allowed:
+ * </p>
+ * <pre>
+ * &lt;module name="AvoidStarImport"&gt;
+ *   &lt;property name="allowClassImports" value="true"/&gt;
+ *   &lt;property name="excludes" value="java.io,java.net"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * import java.util.Scanner;         // OK
+ * import java.io.*;                 // OK
+ * import static java.lang.Math.*;   // violation
+ * import java.util.*;               // OK
+ * import java.net.*;                // OK
+ * </pre>
+ * <p>
+ * To configure the check so that star imports from packages
+ * {@code java.io and java.net} as well as static members imports
+ * from all packages are allowed:
+ * </p>
+ * <pre>
+ * &lt;module name="AvoidStarImport"&gt;
+ *   &lt;property name="allowStaticMemberImports" value="true"/&gt;
+ *   &lt;property name="excludes" value="java.io,java.net"/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * import java.util.Scanner;         // OK
+ * import java.io.*;                 // OK
+ * import static java.lang.Math.*;   // OK
+ * import java.util.*;               // violation
+ * import java.net.*;                // OK
+ * </pre>
+ * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
  * </p>
  * <p>

--- a/src/xdocs/config_imports.xml
+++ b/src/xdocs/config_imports.xml
@@ -158,6 +158,47 @@ import static java.lang.Math.*;   // OK
 import java.util.*;               // violation
 import java.net.*;                // violation
         </source>
+        <p>
+          To configure the check so that star imports from packages
+          <code>java.io and java.net</code> are allowed:
+        </p>
+        <source>
+&lt;module name="AvoidStarImport"&gt;
+  &lt;property name="allowClassImports" value="true"/&gt;
+  &lt;property name="excludes" value="java.io,java.net"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+import java.util.Scanner;         // OK
+import java.io.*;                 // OK
+import static java.lang.Math.*;   // violation
+import java.util.*;               // OK
+import java.net.*;                // OK
+        </source>
+        <p>
+          To configure the check so that star imports from packages
+          <code>java.io and java.net</code> as well as static members imports
+          from all packages are allowed:
+        </p>
+        <source>
+&lt;module name="AvoidStarImport"&gt;
+  &lt;property name="allowStaticMemberImports" value="true"/&gt;
+  &lt;property name="excludes" value="java.io,java.net"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+import java.util.Scanner;         // OK
+import java.io.*;                 // OK
+import static java.lang.Math.*;   // OK
+import java.util.*;               // violation
+import java.net.*;                // OK
+        </source>
       </subsection>
 
       <subsection name="Example of Usage" id="AvoidStarImport_Example_of_Usage">


### PR DESCRIPTION
Issue #11352

![avoid_star](https://user-images.githubusercontent.com/23631699/156165957-46c91096-862f-4c04-8611-6a14b0e0f55a.png)

Example 1

```
amrdeveloper@machine:~/Downloads$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
        "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
       <module name="AvoidStarImport">
          <property name="allowClassImports" value="true"/>
          <property name="excludes" value="java.io,java.net"/>
       </module>
    </module>
</module>
amrdeveloper@machine:~/Downloads$ cat Test.java
import java.util.Scanner;         // OK
import java.io.*;                 // OK
import static java.lang.Math.*;   // violation
import java.util.*;               // OK
import java.net.*;                // OK
amrdeveloper@machine:~/Downloads$ java -jar checkstyle.jar -c config.xml Test.java
Starting audit...
[ERROR] /home/amrdeveloper/Downloads/Test.java:3:29: Using the '.*' form of import should be avoided - java.lang.Math.*. [AvoidStarImport]
Audit done.
Checkstyle ends with 1 errors.
amrdeveloper@machine:~/Downloads$ 

```

Example 2

```
amrdeveloper@machine:~/Downloads$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
        "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
       <module name="AvoidStarImport">
          <property name="allowStaticMemberImports" value="true"/>
          <property name="excludes" value="java.io,java.net"/>
       </module>
    </module>
</module>
amrdeveloper@machine:~/Downloads$ cat Test.java
import java.util.Scanner;         // OK
import java.io.*;                 // OK
import static java.lang.Math.*;   // OK
import java.util.*;               // violation
import java.net.*;                // OK
amrdeveloper@machine:~/Downloads$ java -jar checkstyle.jar -c config.xml Test.java
Starting audit...
[ERROR] /home/amrdeveloper/Downloads/Test.java:4:17: Using the '.*' form of import should be avoided - java.util.*. [AvoidStarImport]
Audit done.
Checkstyle ends with 1 errors.

```
