### PR TITLE
Issue #11214: Remove DeclarationOrderCheck from InlineConfigParser

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -108,7 +108,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck",
             "com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck",
-            "com.puppycrawl.tools.checkstyle.checks.coding.DeclarationOrderCheck",
             "com.puppycrawl.tools.checkstyle.checks.annotation.MissingOverrideCheck",
             "com.puppycrawl.tools.checkstyle.checks.naming.AbstractClassNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.PackageDeclarationCheck",


### PR DESCRIPTION
Issue number: #11214

In DeclarationOrderCheck all violation messages are specified correctly and testing passed correctly so and should be remove from the InlineConfigParser list

https://github.com/checkstyle/checkstyle/tree/master/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/declarationorder