### PR TITLE
Issue #10933: Checkstyle should force logging of AST in checks that require it

### DIFF
--- a/config/signatures.txt
+++ b/config/signatures.txt
@@ -1,3 +1,5 @@
 com.puppycrawl.tools.checkstyle.DefaultConfiguration#getAttributeNames() @ Usage of deprecated API is forbidden. Please use DefaultConfiguration.getPropertyNames() instead.
 com.puppycrawl.tools.checkstyle.DefaultConfiguration#getAttribute(java.lang.String) @ Usage of deprecated API is forbidden. Please use DefaultConfiguration.getProperty(String name) instead.
 com.puppycrawl.tools.checkstyle.DefaultConfiguration#addAttribute(java.lang.String,java.lang.String) @ Usage of deprecated API is forbidden. Please use DefaultConfiguration.addProperty(String name, String value) instead.
+com.puppycrawl.tools.checkstyle.api.AbstractCheck#log(int,int,java.lang.String,java.lang.Object[]) @ Use of this log method is forbidden, please use AbstractCheck#log(DetailAST ast, String key, Object... args)
+com.puppycrawl.tools.checkstyle.api.AbstractCheck#log(int,java.lang.String,java.lang.Object[]) @ Use of this log method is forbidden, please use AbstractCheck#log(DetailAST ast, String key, Object... args)

--- a/pom.xml
+++ b/pom.xml
@@ -1498,6 +1498,28 @@
                 <exclude>**/JavadocPropertiesGenerator.class</exclude>
                 <!-- generated classes, unfortunately use problematic api -->
                 <exclude>**/JavadocParser.class</exclude>
+                <!-- reason at https://github.com/checkstyle/checkstyle/issues/7759 -->
+                <exclude>**/RegexpCheck.class</exclude>
+                <!-- no code in file, no AST to log -->
+                <exclude>**/NoCodeInFileCheck.class</exclude>
+                <!-- until https://github.com/checkstyle/checkstyle/issues/5770 -->
+                <exclude>**/AbstractJavadocCheck.class</exclude>
+                <exclude>**/AtclauseOrderCheck.class</exclude>
+                <exclude>**/JavadocBlockTagLocationCheck.class</exclude>
+                <exclude>**/JavadocMethodCheck.class</exclude>
+                <exclude>**/JavadocMissingLeadingAsteriskCheck.class</exclude>
+                <exclude>**/JavadocMissingWhitespaceAfterAsteriskCheck.class</exclude>
+                <exclude>**/JavadocParagraphCheck.class</exclude>
+                <exclude>**/JavadocStyleCheck.class</exclude>
+                <exclude>**/JavadocTagContinuationIndentationCheck.class</exclude>
+                <exclude>**/JavadocTypeCheck.class</exclude>
+                <exclude>**/MissingDeprecatedCheck.class</exclude>
+                <exclude>**/NonEmptyAtclauseDescriptionCheck.class</exclude>
+                <exclude>**/RequireEmptyLineBeforeBlockTagGroupCheck.class</exclude>
+                <exclude>**/SingleLineJavadocCheck.class</exclude>
+                <exclude>**/SummaryJavadocCheck.class</exclude>
+                <exclude>**/WriteTagCheck.class</exclude>
+                <exclude>**/JavadocMetadataScraper.class</exclude>
               </excludes>
             </configuration>
           </execution>


### PR DESCRIPTION
Closes #10933 .

Example of error message:

```
[ERROR] Forbidden method invocation: com.puppycrawl.tools.checkstyle.api.AbstractCheck#log(int,java.lang.String,java.lang.Object[]) [Use of this log method is forbidden, please use AbstractCheck#log(DetailAST ast, String key, Object... args)]


```