### PR TITLE
Issue #11370: use naive implementation for isOfType

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java
@@ -281,7 +281,14 @@ public final class TokenUtil {
      * @return true if type matches one of the given types.
      */
     public static boolean isOfType(int type, int... types) {
-        return Arrays.stream(types).anyMatch(tokenType -> tokenType == type);
+        boolean matching = false;
+        for (int tokenType : types) {
+            if (tokenType == type) {
+                matching = true;
+                break;
+            }
+        }
+        return matching;
     }
 
     /**


### PR DESCRIPTION
This PR proposed to use a naive implementation for `TokenUtil.isOfType`, as discussed in #11370. This yields a significant speedup of Checkstyle run-time.