### PR TITLE
spelling: Fix double word in TreeWalker

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java
@@ -48,7 +48,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
  * Responsible for walking an abstract syntax tree and notifying interested
- * checks at each each node.
+ * checks at each node.
  *
  */
 @FileStatefulCheck


### PR DESCRIPTION
The comment said "each each" instead of just "each"