### PR TITLE
minor: compare tokens by type in ScopeUtil

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java
@@ -44,16 +44,20 @@ public final class ScopeUtil {
      */
     public static Scope getDeclaredScopeFromMods(DetailAST aMods) {
         Scope result = null;
-        for (DetailAST token = aMods.getFirstChild(); token != null;
+        for (DetailAST token = aMods.getFirstChild(); token != null && result == null;
                 token = token.getNextSibling()) {
-            if ("public".equals(token.getText())) {
-                result = Scope.PUBLIC;
-            }
-            else if ("protected".equals(token.getText())) {
-                result = Scope.PROTECTED;
-            }
-            else if ("private".equals(token.getText())) {
-                result = Scope.PRIVATE;
+            switch (token.getType()) {
+                case TokenTypes.LITERAL_PUBLIC:
+                    result = Scope.PUBLIC;
+                    break;
+                case TokenTypes.LITERAL_PROTECTED:
+                    result = Scope.PROTECTED;
+                    break;
+                case TokenTypes.LITERAL_PRIVATE:
+                    result = Scope.PRIVATE;
+                    break;
+                default:
+                    break;
             }
         }
         return result;


### PR DESCRIPTION
For some reason, the modifiers in `ScopeUtil` are compared by text.
Maybe it comes from very ancient code.

Diff Regression config: https://gist.githubusercontent.com/pbludov/3a8be5da26a64e2be80b26217d052eb6/raw/343dd6f3ef6e8c8d3ae5c06821cc4a4f59fb4101/config.xml