### PR TITLE
infra: clear cache

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -13,7 +13,7 @@ blocks:
       prologue:
         commands:
           - checkout
-          - cache restore m2
+          - cache delete m2
           - eval "export M2_CACHE_SIZE=$(du -s $HOME/.m2 | cut -f1)"
           - sudo apt-get update
           - sudo apt-get install -y ant groovy xsltproc xmlstarlet


### PR DESCRIPTION
Just trying to clear cache, builds are failing with the same error again: https://checkstyle.semaphoreci.com/jobs/dde21618-4a6b-4ee3-9b37-993ba00d14ca
`A required class was missing while executing org.antlr:antlr4-maven-plugin:4.9.3:antlr4: org/stringtemplate/v4/STGroup`