### PR TITLE
Issue #11442: Check no closed issue references workflow is now triggered on pull requests

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -604,7 +604,7 @@ invalidinherit
 invalidjavadocposition
 ioe
 ioffset
-IPohr
+IPonr
 IPv
 isindex
 isrutf
@@ -830,6 +830,7 @@ modifierorder
 Mohnen
 mojohaus
 moks
+mondeja
 moradan
 mozilla
 MRELEASE

--- a/.ci/no_old_refs.sh
+++ b/.ci/no_old_refs.sh
@@ -3,29 +3,73 @@
 set -e
 
 # Script requires GITHUB_TOKEN env variable
-MENTIONED_ISSUES=/tmp/mentioned_issues
+MENTIONED_ISSUES_GREP_OUTPUT=/tmp/mentioned_issues_grep_output
 CLOSED_ISSUES=/tmp/failed_issues
+
+# Linked issues that are mentioned in the code
+LINKED_ISSUES_MENTIONED=/tmp/linked_issues_mentioned
 API_GITHUB_PREFIX="https://api.github.com/repos"
 GITHUB_HOST="https://github.com"
+MAIN_REPO="checkstyle/checkstyle"
+DEFAULT_BRANCH="master"
+
+# These are modified when event is of type pull_request
+if [ ! -z "$PR_HEAD_REPO_NAME" ]; then
+  MAIN_REPO=$PR_HEAD_REPO_NAME
+  DEFAULT_BRANCH=$GITHUB_HEAD_REF
+fi
 
 # collect issues where full link is used
-grep -IPohr "(after|[Tt]il[l]?) $GITHUB_HOST/[\w.-]+/[\w.-]+/issues/\d{1,5}" . \
-  | sed -e 's/.*github.com\///' >> $MENTIONED_ISSUES
+grep -IPonr "(after|[Tt]il[l]?) $GITHUB_HOST/[\w.-]+/[\w.-]+/issues/\d{1,5}" . \
+  | sed -e 's/:[a-zA-Z].*github.com\//:/' >> $MENTIONED_ISSUES_GREP_OUTPUT
 
 # collect checkstyle issues where only hash sign is used
-grep -IPohr "[Tt]il[l]? #\d{1,5}" . \
-  | sed -e 's/.*#/checkstyle\/checkstyle\/issues\//' >> $MENTIONED_ISSUES
+grep -IPonr "[Tt]il[l]? #\d{1,5}" . \
+  | sed -e 's/:[a-zA-Z].*#/:checkstyle\/checkstyle\/issues\//' >> $MENTIONED_ISSUES_GREP_OUTPUT
 
-for issue in $(sort -u $MENTIONED_ISSUES); do
-  STATE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$API_GITHUB_PREFIX/$issue" \
+for MENTIONED_ISSUES_GREP_OUTPUT_LINE in $(cat $MENTIONED_ISSUES_GREP_OUTPUT); do
+  ISSUE=${MENTIONED_ISSUES_GREP_OUTPUT_LINE#*[0-9]:}
+
+  FILE_PATH=${MENTIONED_ISSUES_GREP_OUTPUT_LINE%:[0-9]*}
+  FILE_PATH=${FILE_PATH:2}
+
+  LINE_NUMBER=${MENTIONED_ISSUES_GREP_OUTPUT_LINE#*:}
+  LINE_NUMBER=${LINE_NUMBER%:*}
+
+  LINK="$GITHUB_HOST/$MAIN_REPO/blob/$DEFAULT_BRANCH/$FILE_PATH#L$LINE_NUMBER"
+
+  STATE=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$API_GITHUB_PREFIX/$ISSUE" \
    | jq '.state' | xargs)
   if [ "$STATE" = "closed" ]; then
-    echo "$GITHUB_HOST/$issue" >> $CLOSED_ISSUES
+    echo "$LINK" >> $CLOSED_ISSUES
+  fi
+  if [ ! -z "$LINKED_ISSUES" ]; then
+    for LINKED_ISSUE in $(cat $LINKED_ISSUES); do
+      if [ "$LINKED_ISSUE" = "$GITHUB_HOST/$ISSUE" ]; then
+        echo "$LINK" >> $LINKED_ISSUES_MENTIONED
+      fi
+    done
   fi
 done
 
+EXIT_CODE=0
+
 if [ -f "$CLOSED_ISSUES" ]; then
-    echo "Following issues are mentioned in code to do something after they are closed:"
+    echo
+    echo "Following lines are referencing closed issues."
+    echo "Such lines should be removed or the issue should be examined:"
+    echo
     cat $CLOSED_ISSUES
-    exit 1
+    EXIT_CODE=1
 fi
+
+if [ -f "$LINKED_ISSUES_MENTIONED" ]; then
+    echo
+    echo "Following lines are referencing to issues linked to this PR."
+    echo "Such lines should be removed or the issue should be examined:"
+    echo
+    cat $LINKED_ISSUES_MENTIONED
+    EXIT_CODE=1
+fi
+
+exit $EXIT_CODE

--- a/.github/workflows/no_old_refs.yml
+++ b/.github/workflows/no_old_refs.yml
@@ -3,6 +3,7 @@
 #
 # Workflow starts when:
 # 1) push on master branch
+# 2) pull request is opened or synchronized or reopened
 #
 #####################################################################################
 name: "Check no closed issue references"
@@ -10,6 +11,7 @@ name: "Check no closed issue references"
 on:
   push:
     branches: [ master ]
+  pull_request:
 
 jobs:
   check_issues:
@@ -17,14 +19,36 @@ jobs:
     steps:
       - name: Download checkstyle
         uses: actions/checkout@v2
-        with:
-          repository: checkstyle/checkstyle
-          ref: master
-          path: checkstyle
-
+      - name: PR linked issues
+        id: links
+        uses: mondeja/pr-linked-issues-action@v2
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #######################################################################
+      # Linked issues, if present, are received in the following format:
+      # 37,38
+      # We convert it into:
+      # https://github.com/checkstyle/checkstyle/issues/37
+      # https://github.com/checkstyle/checkstyle/issues/38
+      #######################################################################
+      - name: Format linked issues
+        id: format-linked-issues
+        if: github.event_name == 'pull_request'
+        run: |
+          LINKED_ISSUES=${{ steps.links.outputs.issues }}
+          LINKED_ISSUES_FORMATTED=/tmp/linked_issues
+          CHECKSTYLE_ISSUE_URL="https:\/\/github.com\/checkstyle\/checkstyle\/issues\/"
+          if [ ! -z "$LINKED_ISSUES" ]; then
+            echo $LINKED_ISSUES | sed -e 's/,/\n/g' >> $LINKED_ISSUES_FORMATTED
+            sed -i "s/^/$CHECKSTYLE_ISSUE_URL/" $LINKED_ISSUES_FORMATTED
+          fi
+          echo "::set-output name=linked-issues-formatted::$LINKED_ISSUES_FORMATTED"
       - name: Check Issues
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          LINKED_ISSUES: '${{ steps.format-linked-issues.outputs.linked-issues-formatted }}'
+          PR_HEAD_REPO_NAME: "${{ github.event.pull_request.head.repo.full_name }}"
+          GITHUB_HEAD_REF: "${{ github.head.ref }}"
         run: |
-          cd checkstyle
           ./.ci/no_old_refs.sh


### PR DESCRIPTION
Resolves #11442
Tested at - https://github.com/Vyom-Yadav/actions-test/pull/39
https://github.com/Vyom-Yadav/actions-test/pull/40

Direct push to master - https://github.com/Vyom-Yadav/actions-test/runs/5655841079?check_suite_focus=true

Push to PR (not from fork) - https://github.com/Vyom-Yadav/actions-test/runs/5655783382?check_suite_focus=true

Push to PR (from fork) - https://github.com/Vyom-Yadav/actions-test/runs/5655810498?check_suite_focus=true

---

What this PR does-

1. **Improved reporting:-** A clickable link is now given to the user which redirects it to the line where the closed issue is referenced. 
2. **Runs on a PR:-** The job now runs on a PR too.
3. **Issues linked to PR are mentioned:-** If the developer has linked some issue to the PR and that issue is referenced somewhere in the code then a violation will be given out to user. Rationale behind this is that if you [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) an issue to a PR then when that PR is merged, then that issue would be automatically closed, linking issue is different than just mentioning it.
