### PR TITLE
minor: fix mnemonic for open file button

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java
@@ -125,7 +125,7 @@ public class MainFrame extends JFrame {
      */
     private JPanel createButtonsPanel() {
         final JButton openFileButton = new JButton(new FileSelectionAction());
-        openFileButton.setMnemonic(KeyEvent.VK_S);
+        openFileButton.setMnemonic(KeyEvent.VK_O);
         openFileButton.setText("Open File");
 
         reloadAction.setEnabled(false);


### PR DESCRIPTION
It is strange that the hotkey for Open file dialog is `Alt+S`. It looks like a mistype.
Should be `Alt+O`.

Maybe it was "Select file" originally, but later the label was changed.