### PR TITLE
Issue #10924: Update SeparatorWrapCheck to use code points

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3308,6 +3308,10 @@
                 <param>
                   com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheckTest
                 </param>
+                <!-- 35% coverage, 29% mutation in CodePointUtil -->
+                <param>
+                  com.puppycrawl.tools.checkstyle.checks.whitespace.SeparatorWrapCheckTest
+                </param>
                 <!-- 2% mutation in ScopeUtil -->
                 <param>
                   com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocStyleCheckTest

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheck.java
@@ -19,12 +19,14 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
+import java.util.Arrays;
 import java.util.Locale;
 
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CodePointUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
@@ -220,18 +222,20 @@ public class SeparatorWrapCheck
         final String text = ast.getText();
         final int colNo = ast.getColumnNo();
         final int lineNo = ast.getLineNo();
-        final String currentLine = getLines()[lineNo - 1];
-        final String substringAfterToken =
-                currentLine.substring(colNo + text.length()).trim();
-        final String substringBeforeToken =
-                currentLine.substring(0, colNo).trim();
+        final int[] currentLine = getLineCodePoints(lineNo - 1);
+        final int[] substringAfterToken = CodePointUtil.trim(
+                Arrays.copyOfRange(currentLine, colNo + text.length(), currentLine.length)
+        );
+        final int[] substringBeforeToken = CodePointUtil.trim(
+                Arrays.copyOfRange(currentLine, 0, colNo)
+        );
 
         if (option == WrapOption.EOL
-                && substringBeforeToken.isEmpty()) {
+                && substringBeforeToken.length == 0) {
             log(ast, MSG_LINE_PREVIOUS, text);
         }
         else if (option == WrapOption.NL
-                 && substringAfterToken.isEmpty()) {
+                 && substringAfterToken.length == 0) {
             log(ast, MSG_LINE_NEW, text);
         }
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CodePointUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CodePointUtil.java
@@ -63,10 +63,36 @@ public final class CodePointUtil {
      */
     public static int[] stripTrailing(int... codePoints) {
         int lastIndex = codePoints.length;
-        while (CommonUtil.isCodePointWhitespace(codePoints, lastIndex - 1)) {
+        while (lastIndex > 0 && CommonUtil.isCodePointWhitespace(codePoints, lastIndex - 1)) {
             lastIndex--;
         }
         return Arrays.copyOfRange(codePoints, 0, lastIndex);
+    }
+
+    /**
+     * Removes leading whitespaces.
+     *
+     * @param codePoints array of unicode code points
+     * @return unicode code points array with leading whitespaces removed
+     */
+    public static int[] stripLeading(int... codePoints) {
+        int startIndex = 0;
+        while (startIndex < codePoints.length
+            && CommonUtil.isCodePointWhitespace(codePoints, startIndex)) {
+            startIndex++;
+        }
+        return Arrays.copyOfRange(codePoints, startIndex, codePoints.length);
+    }
+
+    /**
+     * Removes leading and trailing whitespaces.
+     *
+     * @param codePoints array of unicode code points
+     * @return unicode code points array with leading and trailing whitespaces removed
+     */
+    public static int[] trim(int... codePoints) {
+        final int[] strippedCodePoints = stripTrailing(codePoints);
+        return stripLeading(strippedCodePoints);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheckTest.java
@@ -117,4 +117,18 @@ public class SeparatorWrapCheckTest
                 getPath("InputSeparatorWrapForArrayDeclarator.java"), expected);
     }
 
+    @Test
+    public void testWithEmoji() throws Exception {
+        final String[] expected = {
+            "13:39: " + getCheckMessage(MSG_LINE_NEW, '['),
+            "16:57: " + getCheckMessage(MSG_LINE_NEW, '['),
+            "19:39: " + getCheckMessage(MSG_LINE_NEW, "..."),
+            "26:19: " + getCheckMessage(MSG_LINE_NEW, '.'),
+            "39:50: " + getCheckMessage(MSG_LINE_NEW, ','),
+            "41:50: " + getCheckMessage(MSG_LINE_NEW, "::"),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputSeparatorWrapWithEmoji.java"), expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/separatorwrap/InputSeparatorWrapWithEmoji.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/separatorwrap/InputSeparatorWrapWithEmoji.java
@@ -1,0 +1,44 @@
+/*
+SeparatorWrap
+option = NL
+tokens = DOT, COMMA,ELLIPSIS, ARRAY_DECLARATOR, METHOD_REF
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.separatorwrap;
+
+import java.util.Arrays;
+
+public class InputSeparatorWrapWithEmoji {
+    protected String[] s1 = new String[
+        /*🎄 with text */    ] {"aab🎄", "a🎄a👍ba"}; // violation above ''\[' should be on a new line'
+
+    /* emoji👍array */ protected String[] s2 = new String[
+        ] {"🥳", "😠", "😨"}; // violation above''\[' should be on a new line'
+
+    /*👆🏻 👇🏻*/ public void test1(String...
+                        parameters) { // violation above ''...' should be on a new line'
+    }
+
+    public void test2(String
+                          /* 👌🏻👌🏻 */    ...parameters) { // ok
+        String s = "ffffooooString";
+        /* 🧐🥳 */ s.
+            isEmpty(); // violation above ''.' should be on a new line'
+        try {
+            test2("2", s);
+        } catch (Exception e) {}
+
+        test1("1"
+            /*🧐 sda 🥳 */   ,s); // ok
+
+    }
+    void goodCase() {
+        String[] stringArray =
+            {
+                "🌏", "🌔🌟", "QWERTY", "🧛🏻", "John",
+                /*🤞🏻*/ }; // violation above '',' should be on a new line'
+        /*🤞🏻 🤞🏻*/ Arrays.sort(stringArray, String::
+            compareToIgnoreCase); // violation above ''::' should be on a new line'
+    }
+}


### PR DESCRIPTION
Issue #10924: Updated SeparatorWrapCheck to use code points
```
src % cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
        "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="SeparatorWrap">
            <property name="option" value="NL"/>
        </module>
    </module>
</module>

src % cat src/main/java/Test.java 
public class Test {
        void test() {
                String s = "sda";
                /* 🎄🎄 */ s.
                        isEmpty(); // violation but not reported
                /* sda */ s.
                        isEmpty(); // violation and reported
        }

}      
                                                                                                                                                                  
src % java -jar checkstyle-10.0-all.jar -c config.xml src/main/java/Test.java
Starting audit...
[ERROR] Test.java:6:28: '.' should be on a new line. [SeparatorWrap]
Audit done.
Checkstyle ends with 1 errors.
```

Diff Regression config: https://gist.githubusercontent.com/MUzairS15/7241576ae68289631f7560ece75b4f2a/raw/ea1dac19a8541caa225ec90c881b81fc11f4411e/config.xml
