### PR TITLE
Minor: remove suppression for spotbugs-maven-plugin version check

### DIFF
--- a/config/version-number-rules.xml
+++ b/config/version-number-rules.xml
@@ -26,11 +26,5 @@
         <ignoreVersion type="regex">.*</ignoreVersion>
       </ignoreVersions>
     </rule>
-    <rule groupId="com.github.spotbugs" artifactId="spotbugs-maven-plugin">
-      <ignoreVersions>
-        <!-- until https://github.com/spotbugs/spotbugs/issues/1601 -->
-        <ignoreVersion type="regex">.*</ignoreVersion>
-      </ignoreVersions>
-    </rule>
   </rules>
 </ruleset>


### PR DESCRIPTION
Patterns  **EI_EXPOSE_REP, EI_EXPOSE_REP2** were suppressed in 5e618459068dbd6d64a8f3518e4fce38b26b5a6f
And we have already updated spotbugs-maven-plugin to the latest version. There is no longer any reason for this suppression.
