### PR TITLE
config: bump hibernate search to jdk 17

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -18,6 +18,7 @@ Aconfig
 adb
 addons
 adf
+adoptium
 adoptopenjdk
 adr
 AFBR
@@ -60,6 +61,7 @@ arraycopy
 arraytrailingcomma
 arraytypestyle
 artifactory
+asc
 asda
 ASF
 ASingle
@@ -235,6 +237,7 @@ codeclimate
 codeconventions
 codecov
 codehaus
+codename
 codeql
 codeselectorpresentation
 codeship
@@ -504,6 +507,7 @@ googleecommon
 googlegroups
 googlesource
 govstrangefolder
+gpg
 gradle
 gradlew
 Grenner
@@ -732,6 +736,7 @@ kbd
 kclee
 KDoc
 keygen
+keyrings
 Kochurkin
 konstantinos
 Kordas
@@ -777,6 +782,7 @@ Loughran
 lparen
 lpb
 lpl
+lsb
 lucene
 lui
 luiframework
@@ -1278,6 +1284,7 @@ td
 teamcity
 technotes
 tected
+temurin
 Testik
 testmodules
 textlevel

--- a/.ci/travis.sh
+++ b/.ci/travis.sh
@@ -28,12 +28,31 @@ init-m2-repo)
   fi
   ;;
 
+install-adoptium-jdk)
+  if [[ -n "${CUSTOM_ADOPTIUM_JDK}" ]]; then
+    echo "Installing ${CUSTOM_ADOPTIUM_JDK}...";
+    curl -s https://packages.adoptium.net/artifactory/api/gpg/key/public |
+      sudo tee /usr/share/keyrings/adoptium.asc
+    echo "deb [signed-by=/usr/share/keyrings/adoptium.asc] \
+      https://packages.adoptium.net/artifactory/deb $(lsb_release --short --codename) main" |
+      sudo tee /etc/apt/sources.list.d/adoptium.list
+    sudo apt-get update
+    sudo apt-get install "${CUSTOM_ADOPTIUM_JDK}"
+  fi
+  ;;
+
+remove-adoptium-jdk)
+  if [[ -n "${CUSTOM_ADOPTIUM_JDK}" ]]; then
+    sudo apt-get remove "${CUSTOM_ADOPTIUM_JDK}"
+  fi
+  ;;
+
 install-custom-mvn)
   if [[ -n "${CUSTOM_MVN_VERSION}" ]]; then
     echo "Download Maven ${CUSTOM_MVN_VERSION}....";
     URL="https://archive.apache.org/dist/maven/maven-3/"
     URL=$URL"${CUSTOM_MVN_VERSION}/binaries/apache-maven-${CUSTOM_MVN_VERSION}-bin.zip"
-    wget $URL
+    wget --progress=dot:giga $URL
     unzip -q apache-maven-${CUSTOM_MVN_VERSION}-bin.zip
     export M2_HOME=$PWD/apache-maven-${CUSTOM_MVN_VERSION};
     export PATH=$M2_HOME/bin:$PATH;

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ branches:
     - master
 
 install:
+  - ./.ci/travis.sh install-adoptium-jdk
   - ./.ci/travis.sh install-custom-mvn
 
 jobs:
@@ -59,9 +60,9 @@ jobs:
         - CMD="$CMD1 && $CMD2"
         - USE_MAVEN_REPO="true"
 
-    - jdk: openjdk17
-      env:
+    - env:
         - DESC="NoErrorTest - Hibernate Search"
+        - CUSTOM_ADOPTIUM_JDK="temurin-17-jdk"
         - CUSTOM_MVN_VERSION="3.8.4"
         - M2_HOME="$PWD/apache-maven-${CUSTOM_MVN_VERSION}"
         - PATH="$M2_HOME/bin:$PATH"
@@ -122,6 +123,7 @@ script:
   - ./.ci/travis.sh init-m2-repo
   - ./.ci/travis.sh run-command "$CMD"
   - ./.ci/travis.sh remove-custom-mvn
+  - ./.ci/travis.sh remove-adoptium-jdk
   - ./.ci/travis.sh git-diff
   - ./.ci/travis.sh ci-temp-check
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ jobs:
         - CMD="$CMD1 && $CMD2"
         - USE_MAVEN_REPO="true"
 
-    - jdk: openjdk11
+    - jdk: openjdk17
       env:
         - DESC="NoErrorTest - Hibernate Search"
         - CUSTOM_MVN_VERSION="3.8.4"


### PR DESCRIPTION
Master build is failing 

They migrated https://github.com/hibernate/hibernate-search/commit/81a280863aab3e42a8f9eb52d3c277b5c7731373