### PR TITLE
minor: replace Collections.unmodifiable* with static factory methods

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheck.java
@@ -19,10 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
@@ -152,17 +149,16 @@ public class FinalParametersCheck extends AbstractCheck {
      * <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html">
      * primitive datatypes</a>.
      */
-    private final Set<Integer> primitiveDataTypes = Collections.unmodifiableSet(
-        Arrays.stream(new Integer[] {
-            TokenTypes.LITERAL_BYTE,
-            TokenTypes.LITERAL_SHORT,
-            TokenTypes.LITERAL_INT,
-            TokenTypes.LITERAL_LONG,
-            TokenTypes.LITERAL_FLOAT,
-            TokenTypes.LITERAL_DOUBLE,
-            TokenTypes.LITERAL_BOOLEAN,
-            TokenTypes.LITERAL_CHAR, })
-        .collect(Collectors.toSet()));
+    private final Set<Integer> primitiveDataTypes = Set.of(
+        TokenTypes.LITERAL_BYTE,
+        TokenTypes.LITERAL_SHORT,
+        TokenTypes.LITERAL_INT,
+        TokenTypes.LITERAL_LONG,
+        TokenTypes.LITERAL_FLOAT,
+        TokenTypes.LITERAL_DOUBLE,
+        TokenTypes.LITERAL_BOOLEAN,
+        TokenTypes.LITERAL_CHAR
+    );
 
     /**
      * Ignore primitive types as parameters.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
@@ -22,8 +22,6 @@ package com.puppycrawl.tools.checkstyle.checks;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
@@ -139,12 +137,12 @@ public class UncommentedMainCheck
     public static final String MSG_KEY = "uncommented.main";
 
     /** Set of possible String array types. */
-    private static final Set<String> STRING_PARAMETER_NAMES = Stream.of(
+    private static final Set<String> STRING_PARAMETER_NAMES = Set.of(
         String[].class.getCanonicalName(),
         String.class.getCanonicalName(),
         String[].class.getSimpleName(),
         String.class.getSimpleName()
-    ).collect(Collectors.toSet());
+    );
 
     /**
      * Specify pattern for qualified names of classes which are allowed to

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -20,8 +20,6 @@
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.util.ArrayDeque;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -29,7 +27,6 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
@@ -266,47 +263,44 @@ public class RequireThisCheck extends AbstractCheck {
     public static final String MSG_VARIABLE = "require.this.variable";
 
     /** Set of all declaration tokens. */
-    private static final Set<Integer> DECLARATION_TOKENS = Collections.unmodifiableSet(
-        Arrays.stream(new Integer[] {
-            TokenTypes.VARIABLE_DEF,
-            TokenTypes.CTOR_DEF,
-            TokenTypes.METHOD_DEF,
-            TokenTypes.CLASS_DEF,
-            TokenTypes.ENUM_DEF,
-            TokenTypes.ANNOTATION_DEF,
-            TokenTypes.INTERFACE_DEF,
-            TokenTypes.PARAMETER_DEF,
-            TokenTypes.TYPE_ARGUMENT,
-            TokenTypes.RECORD_DEF,
-            TokenTypes.RECORD_COMPONENT_DEF,
-        }).collect(Collectors.toSet()));
+    private static final Set<Integer> DECLARATION_TOKENS = Set.of(
+        TokenTypes.VARIABLE_DEF,
+        TokenTypes.CTOR_DEF,
+        TokenTypes.METHOD_DEF,
+        TokenTypes.CLASS_DEF,
+        TokenTypes.ENUM_DEF,
+        TokenTypes.ANNOTATION_DEF,
+        TokenTypes.INTERFACE_DEF,
+        TokenTypes.PARAMETER_DEF,
+        TokenTypes.TYPE_ARGUMENT,
+        TokenTypes.RECORD_DEF,
+        TokenTypes.RECORD_COMPONENT_DEF
+    );
     /** Set of all assign tokens. */
-    private static final Set<Integer> ASSIGN_TOKENS = Collections.unmodifiableSet(
-        Arrays.stream(new Integer[] {
-            TokenTypes.ASSIGN,
-            TokenTypes.PLUS_ASSIGN,
-            TokenTypes.STAR_ASSIGN,
-            TokenTypes.DIV_ASSIGN,
-            TokenTypes.MOD_ASSIGN,
-            TokenTypes.SR_ASSIGN,
-            TokenTypes.BSR_ASSIGN,
-            TokenTypes.SL_ASSIGN,
-            TokenTypes.BAND_ASSIGN,
-            TokenTypes.BXOR_ASSIGN,
-        }).collect(Collectors.toSet()));
+    private static final Set<Integer> ASSIGN_TOKENS = Set.of(
+        TokenTypes.ASSIGN,
+        TokenTypes.PLUS_ASSIGN,
+        TokenTypes.STAR_ASSIGN,
+        TokenTypes.DIV_ASSIGN,
+        TokenTypes.MOD_ASSIGN,
+        TokenTypes.SR_ASSIGN,
+        TokenTypes.BSR_ASSIGN,
+        TokenTypes.SL_ASSIGN,
+        TokenTypes.BAND_ASSIGN,
+        TokenTypes.BXOR_ASSIGN
+    );
     /** Set of all compound assign tokens. */
-    private static final Set<Integer> COMPOUND_ASSIGN_TOKENS = Collections.unmodifiableSet(
-        Arrays.stream(new Integer[] {
-            TokenTypes.PLUS_ASSIGN,
-            TokenTypes.STAR_ASSIGN,
-            TokenTypes.DIV_ASSIGN,
-            TokenTypes.MOD_ASSIGN,
-            TokenTypes.SR_ASSIGN,
-            TokenTypes.BSR_ASSIGN,
-            TokenTypes.SL_ASSIGN,
-            TokenTypes.BAND_ASSIGN,
-            TokenTypes.BXOR_ASSIGN,
-        }).collect(Collectors.toSet()));
+    private static final Set<Integer> COMPOUND_ASSIGN_TOKENS = Set.of(
+        TokenTypes.PLUS_ASSIGN,
+        TokenTypes.STAR_ASSIGN,
+        TokenTypes.DIV_ASSIGN,
+        TokenTypes.MOD_ASSIGN,
+        TokenTypes.SR_ASSIGN,
+        TokenTypes.BSR_ASSIGN,
+        TokenTypes.SL_ASSIGN,
+        TokenTypes.BAND_ASSIGN,
+        TokenTypes.BXOR_ASSIGN
+    );
 
     /** Frame for the currently processed AST. */
     private final Deque<AbstractFrame> current = new ArrayDeque<>();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -21,12 +21,10 @@ package com.puppycrawl.tools.checkstyle.checks.design;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
@@ -415,37 +413,35 @@ public class VisibilityModifierCheck
     public static final String MSG_KEY = "variable.notPrivate";
 
     /** Default immutable types canonical names. */
-    private static final List<String> DEFAULT_IMMUTABLE_TYPES = Collections.unmodifiableList(
-        Arrays.stream(new String[] {
-            "java.lang.String",
-            "java.lang.Integer",
-            "java.lang.Byte",
-            "java.lang.Character",
-            "java.lang.Short",
-            "java.lang.Boolean",
-            "java.lang.Long",
-            "java.lang.Double",
-            "java.lang.Float",
-            "java.lang.StackTraceElement",
-            "java.math.BigInteger",
-            "java.math.BigDecimal",
-            "java.io.File",
-            "java.util.Locale",
-            "java.util.UUID",
-            "java.net.URL",
-            "java.net.URI",
-            "java.net.Inet4Address",
-            "java.net.Inet6Address",
-            "java.net.InetSocketAddress",
-        }).collect(Collectors.toList()));
+    private static final List<String> DEFAULT_IMMUTABLE_TYPES = List.of(
+        "java.lang.String",
+        "java.lang.Integer",
+        "java.lang.Byte",
+        "java.lang.Character",
+        "java.lang.Short",
+        "java.lang.Boolean",
+        "java.lang.Long",
+        "java.lang.Double",
+        "java.lang.Float",
+        "java.lang.StackTraceElement",
+        "java.math.BigInteger",
+        "java.math.BigDecimal",
+        "java.io.File",
+        "java.util.Locale",
+        "java.util.UUID",
+        "java.net.URL",
+        "java.net.URI",
+        "java.net.Inet4Address",
+        "java.net.Inet6Address",
+        "java.net.InetSocketAddress"
+    );
 
     /** Default ignore annotations canonical names. */
-    private static final List<String> DEFAULT_IGNORE_ANNOTATIONS = Collections.unmodifiableList(
-        Arrays.stream(new String[] {
-            "org.junit.Rule",
-            "org.junit.ClassRule",
-            "com.google.common.annotations.VisibleForTesting",
-        }).collect(Collectors.toList()));
+    private static final List<String> DEFAULT_IGNORE_ANNOTATIONS = List.of(
+        "org.junit.Rule",
+        "org.junit.ClassRule",
+        "com.google.common.annotations.VisibleForTesting"
+    );
 
     /** Name for 'public' access modifier. */
     private static final String PUBLIC_ACCESS_MODIFIER = "public";

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java
@@ -75,8 +75,7 @@ public abstract class AbstractHeaderCheck extends AbstractFileSetCheck
      * @return the header lines to check against.
      */
     protected List<String> getHeaderLines() {
-        final List<String> copy = new ArrayList<>(readerLines);
-        return Collections.unmodifiableList(copy);
+        return List.copyOf(readerLines);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -20,15 +20,11 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import java.util.ArrayDeque;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
@@ -327,25 +323,24 @@ public class JavadocStyleCheck
     public static final String MSG_EXTRA_HTML = "javadoc.extraHtml";
 
     /** HTML tags that do not require a close tag. */
-    private static final Set<String> SINGLE_TAGS = Collections.unmodifiableSortedSet(
-        Arrays.stream(new String[] {"br", "li", "dt", "dd", "hr", "img", "p", "td", "tr", "th", })
-            .collect(Collectors.toCollection(TreeSet::new)));
+    private static final Set<String> SINGLE_TAGS = Set.of(
+        "br", "li", "dt", "dd", "hr", "img", "p", "td", "tr", "th"
+    );
 
     /**
      * HTML tags that are allowed in java docs.
      * From https://www.w3schools.com/tags/default.asp
      * The forms and structure tags are not allowed
      */
-    private static final Set<String> ALLOWED_TAGS = Collections.unmodifiableSortedSet(
-        Arrays.stream(new String[] {
-            "a", "abbr", "acronym", "address", "area", "b", "bdo", "big",
-            "blockquote", "br", "caption", "cite", "code", "colgroup", "dd",
-            "del", "dfn", "div", "dl", "dt", "em", "fieldset", "font", "h1",
-            "h2", "h3", "h4", "h5", "h6", "hr", "i", "img", "ins", "kbd",
-            "li", "ol", "p", "pre", "q", "samp", "small", "span", "strong",
-            "sub", "sup", "table", "tbody", "td", "tfoot", "th", "thead",
-            "tr", "tt", "u", "ul", "var", })
-        .collect(Collectors.toCollection(TreeSet::new)));
+    private static final Set<String> ALLOWED_TAGS = Set.of(
+        "a", "abbr", "acronym", "address", "area", "b", "bdo", "big",
+        "blockquote", "br", "caption", "cite", "code", "colgroup", "dd",
+        "del", "dfn", "div", "dl", "dt", "em", "fieldset", "font", "h1",
+        "h2", "h3", "h4", "h5", "h6", "hr", "i", "img", "ins", "kbd",
+        "li", "ol", "p", "pre", "q", "samp", "small", "span", "strong",
+        "sub", "sup", "table", "tbody", "td", "tfoot", "th", "thead",
+        "tr", "tt", "u", "ul", "var"
+    );
 
     /** Specify the visibility scope where Javadoc comments are checked. */
     private Scope scope = Scope.PRIVATE;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfo.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfo.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -383,10 +382,11 @@ public enum JavadocTagInfo {
     private static final Map<String, JavadocTagInfo> NAME_TO_TAG;
 
     static {
-        TEXT_TO_TAG = Collections.unmodifiableMap(Arrays.stream(values())
-            .collect(Collectors.toMap(JavadocTagInfo::getText, Function.identity())));
-        NAME_TO_TAG = Collections.unmodifiableMap(Arrays.stream(values())
-            .collect(Collectors.toMap(JavadocTagInfo::getName, Function.identity())));
+        final JavadocTagInfo[] values = values();
+        TEXT_TO_TAG = Arrays.stream(values)
+            .collect(Collectors.toUnmodifiableMap(JavadocTagInfo::getText, Function.identity()));
+        NAME_TO_TAG = Arrays.stream(values)
+            .collect(Collectors.toUnmodifiableMap(JavadocTagInfo::getName, Function.identity()));
 
         // Arrays sorting for binary search
         Arrays.sort(DEF_TOKEN_TYPES);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTags.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTags.java
@@ -19,7 +19,6 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -41,10 +40,8 @@ public final class JavadocTags {
      * @param invalidTags the list of invalid tags
      */
     public JavadocTags(List<JavadocTag> tags, List<InvalidJavadocTag> invalidTags) {
-        final List<JavadocTag> validTagsCopy = new ArrayList<>(tags);
-        validTags = Collections.unmodifiableList(validTagsCopy);
-        final List<InvalidJavadocTag> invalidTagsCopy = new ArrayList<>(invalidTags);
-        this.invalidTags = Collections.unmodifiableList(invalidTagsCopy);
+        validTags = List.copyOf(tags);
+        this.invalidTags = List.copyOf(invalidTags);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java
@@ -53,35 +53,34 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
     private static final String DOT = ".";
 
     /** Class names to ignore. */
-    private static final Set<String> DEFAULT_EXCLUDED_CLASSES = Collections.unmodifiableSet(
-        Arrays.stream(new String[] {
-            // reserved type name
-            "var",
-            // primitives
-            "boolean", "byte", "char", "double", "float", "int",
-            "long", "short", "void",
-            // wrappers
-            "Boolean", "Byte", "Character", "Double", "Float",
-            "Integer", "Long", "Short", "Void",
-            // java.lang.*
-            "Object", "Class",
-            "String", "StringBuffer", "StringBuilder",
-            // Exceptions
-            "ArrayIndexOutOfBoundsException", "Exception",
-            "RuntimeException", "IllegalArgumentException",
-            "IllegalStateException", "IndexOutOfBoundsException",
-            "NullPointerException", "Throwable", "SecurityException",
-            "UnsupportedOperationException",
-            // java.util.*
-            "List", "ArrayList", "Deque", "Queue", "LinkedList",
-            "Set", "HashSet", "SortedSet", "TreeSet",
-            "Map", "HashMap", "SortedMap", "TreeMap",
-            "Override", "Deprecated", "SafeVarargs", "SuppressWarnings", "FunctionalInterface",
-            "Collection", "EnumSet", "LinkedHashMap", "LinkedHashSet", "Optional",
-            "OptionalDouble", "OptionalInt", "OptionalLong",
-            // java.util.stream.*
-            "DoubleStream", "IntStream", "LongStream", "Stream",
-        }).collect(Collectors.toSet()));
+    private static final Set<String> DEFAULT_EXCLUDED_CLASSES = Set.of(
+        // reserved type name
+        "var",
+        // primitives
+        "boolean", "byte", "char", "double", "float", "int",
+        "long", "short", "void",
+        // wrappers
+        "Boolean", "Byte", "Character", "Double", "Float",
+        "Integer", "Long", "Short", "Void",
+        // java.lang.*
+        "Object", "Class",
+        "String", "StringBuffer", "StringBuilder",
+        // Exceptions
+        "ArrayIndexOutOfBoundsException", "Exception",
+        "RuntimeException", "IllegalArgumentException",
+        "IllegalStateException", "IndexOutOfBoundsException",
+        "NullPointerException", "Throwable", "SecurityException",
+        "UnsupportedOperationException",
+        // java.util.*
+        "List", "ArrayList", "Deque", "Queue", "LinkedList",
+        "Set", "HashSet", "SortedSet", "TreeSet",
+        "Map", "HashMap", "SortedMap", "TreeMap",
+        "Override", "Deprecated", "SafeVarargs", "SuppressWarnings", "FunctionalInterface",
+        "Collection", "EnumSet", "LinkedHashMap", "LinkedHashSet", "Optional",
+        "OptionalDouble", "OptionalInt", "OptionalLong",
+        // java.util.stream.*
+        "DoubleStream", "IntStream", "LongStream", "Stream"
+    );
 
     /** Package names to ignore. */
     private static final Set<String> DEFAULT_EXCLUDED_PACKAGES = Collections.emptySet();
@@ -150,8 +149,7 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
      * @param excludedClasses the list of classes to ignore.
      */
     public final void setExcludedClasses(String... excludedClasses) {
-        this.excludedClasses =
-            Arrays.stream(excludedClasses).collect(Collectors.toUnmodifiableSet());
+        this.excludedClasses = Set.of(excludedClasses);
     }
 
     /**
@@ -182,8 +180,7 @@ public abstract class AbstractClassCouplingCheck extends AbstractCheck {
                 "the following values are not valid identifiers: " + invalidIdentifiers);
         }
 
-        this.excludedPackages =
-            Arrays.stream(excludedPackages).collect(Collectors.toUnmodifiableSet());
+        this.excludedPackages = Set.of(excludedPackages);
     }
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java
@@ -22,7 +22,6 @@ package com.puppycrawl.tools.checkstyle.utils;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -93,10 +92,11 @@ public final class TokenUtil {
      * @return unmodifiable name to value map
      */
     public static Map<String, Integer> nameToValueMapFromPublicIntFields(Class<?> cls) {
-        final Map<String, Integer> map = Arrays.stream(cls.getDeclaredFields())
+        return Arrays.stream(cls.getDeclaredFields())
             .filter(fld -> Modifier.isPublic(fld.getModifiers()) && fld.getType() == Integer.TYPE)
-            .collect(Collectors.toMap(Field::getName, fld -> getIntFromField(fld, fld.getName())));
-        return Collections.unmodifiableMap(map);
+            .collect(Collectors.toUnmodifiableMap(
+                Field::getName, fld -> getIntFromField(fld, fld.getName()))
+            );
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/XpathUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/XpathUtil.java
@@ -27,7 +27,6 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.puppycrawl.tools.checkstyle.AstTreeStringPrinter;
 import com.puppycrawl.tools.checkstyle.JavaParser;
@@ -103,12 +102,11 @@ public final class XpathUtil {
      * Only these tokens support text attribute because they make our xpath queries more accurate.
      * These token types are listed below.
      * */
-    private static final Set<Integer> TOKEN_TYPES_WITH_TEXT_ATTRIBUTE =
-        Stream.of(
+    private static final Set<Integer> TOKEN_TYPES_WITH_TEXT_ATTRIBUTE = Set.of(
             TokenTypes.IDENT, TokenTypes.STRING_LITERAL, TokenTypes.CHAR_LITERAL,
             TokenTypes.NUM_LONG, TokenTypes.NUM_INT, TokenTypes.NUM_DOUBLE, TokenTypes.NUM_FLOAT,
-            TokenTypes.TEXT_BLOCK_CONTENT, TokenTypes.COMMENT_CONTENT)
-        .collect(Collectors.toSet());
+            TokenTypes.TEXT_BLOCK_CONTENT, TokenTypes.COMMENT_CONTENT
+        );
 
     /**
      * This regexp is used to convert new line to newline tag.


### PR DESCRIPTION
1. Replace some usages, where static factory method can be used
2. Simplify some places, where new java11 Collectors methods can be used

Note: some static fields sets where mutable, but now they are immutable.