### PR TITLE
minor: remove testLocaleIsSupported tests

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
@@ -241,26 +241,6 @@ public class DefaultLoggerTest {
                 .contains(country);
     }
 
-    /**
-     * Verifies that if the language is specified explicitly (and it is not English),
-     * the message does not use the default value.
-     */
-    @Test
-    public void testLocaleIsSupported() throws Exception {
-        final String language = DEFAULT_LOCALE.getLanguage();
-        assumeFalse(language.isEmpty() || Locale.ENGLISH.getLanguage().equals(language),
-                "Custom locale not set");
-        final Class<?> localizedMessage = getDefaultLoggerClass().getDeclaredClasses()[0];
-        final Object messageCon = localizedMessage.getConstructor(String.class, String[].class)
-                .newInstance(DefaultLogger.ADD_EXCEPTION_MESSAGE, null);
-        final Method message = messageCon.getClass().getDeclaredMethod("getMessage");
-        final Object constructor = localizedMessage.getConstructor(String.class)
-                .newInstance(DefaultLogger.ADD_EXCEPTION_MESSAGE);
-        assertWithMessage("Unsupported language: " + DEFAULT_LOCALE)
-                .that(message.invoke(constructor))
-                .isEqualTo("Error auditing {0}");
-    }
-
     @DefaultLocale("fr")
     @Test
     public void testCleatBundleCache() throws Exception {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/ViolationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/ViolationTest.java
@@ -78,21 +78,6 @@ public class ViolationTest {
                 .contains(country);
     }
 
-    /**
-     * Verifies that if the language is specified explicitly (and it is not English),
-     * the violation does not use the default value.
-     */
-    @Test
-    public void testLocaleIsSupported() {
-        final String language = DEFAULT_LOCALE.getLanguage();
-        assumeFalse(language.isEmpty() || Locale.ENGLISH.getLanguage().equals(language),
-                "Custom locale not set");
-        final Violation violation = createSampleViolation();
-        assertWithMessage("Unsupported language: %s", DEFAULT_LOCALE)
-                .that(violation.getViolation())
-                .isNotEqualTo("Empty statement.");
-    }
-
     @Test
     public void testEqualsAndHashCode() {
         final EqualsVerifierReport ev = EqualsVerifier.forClass(Violation.class)


### PR DESCRIPTION
These tests are useless. If the **user.language** property is set to anything else but English, 200+ tests will fail.
So we need a dedicated test suite to validate all supported languages.