### PR TITLE
Issue #11214: Specified violation message in RightCurlyCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -97,7 +97,6 @@ public final class InlineConfigParser {
      * Until <a>https://github.com/checkstyle/checkstyle/issues/11214</a>
      */
     private static final Set<String> SUPPRESSED_CHECKS = new HashSet<>(Arrays.asList(
-            "com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCheck",
             "com.puppycrawl.tools.checkstyle.checks.DescendantTokenCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
@@ -97,7 +97,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "57:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
             "94:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 27),
-            "98:72: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 72),
+            "98:41: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 41),
             "174:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "176:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "178:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
@@ -121,7 +121,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "136:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "136:6: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 6),
             "144:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
-            "149:50: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 50),
+            "149:41: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 41),
             "152:31: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 31),
             "154:39: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 39),
             "197:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
@@ -223,13 +223,13 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "162:58: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 58),
             "162:74: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 74),
             "163:58: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 58),
-            "164:58: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 58),
-            "164:74: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 74),
-            "170:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
-            "177:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
-            "192:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
-            "199:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
-            "199:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "165:58: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 58),
+            "165:74: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 74),
+            "171:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
+            "178:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
+            "193:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "200:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "200:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
             "208:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "208:10: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 10),
             "212:54: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 54),
@@ -245,7 +245,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "239:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
             "242:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
             "245:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
-            "248:38: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 38),
+            "248:39: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 39),
             "250:56: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 56),
             "253:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
             "263:29: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 29),
@@ -296,7 +296,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "212:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "217:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
             "222:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
-            "223:53: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 53),
+            "223:39: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 39),
             "231:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
             "243:30: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 30),
         };
@@ -307,7 +307,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testCatchWithoutFinally() throws Exception {
         final String[] expected = {
-            "19:13: " + getCheckMessage(MSG_KEY_LINE_SAME, "}", 13),
+            "19:9: " + getCheckMessage(MSG_KEY_LINE_SAME, "}", 9),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRightCurlyTestWithoutFinally.java"), expected);
@@ -357,9 +357,9 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
     public void testTryWithResourceSame() throws Exception {
         final String[] expected = {
             "19:9: " + getCheckMessage(MSG_KEY_LINE_SAME, "}", 9),
-            "32:67: " + getCheckMessage(MSG_KEY_LINE_SAME, "}", 67),
-            "43:15: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 15),
-            "45:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "33:67: " + getCheckMessage(MSG_KEY_LINE_SAME, "}", 67),
+            "44:15: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 15),
+            "46:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRightCurlyTestTryWithResourceSame.java"), expected);
@@ -369,13 +369,13 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
     public void testTryWithResourceAlone() throws Exception {
         final String[] expected = {
             "27:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
-            "32:67: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 67),
-            "33:35: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 35),
-            "36:64: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 64),
-            "36:92: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 92),
-            "42:67: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 67),
-            "44:15: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 15),
-            "46:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "33:67: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 67),
+            "34:35: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 35),
+            "37:64: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 64),
+            "37:92: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 92),
+            "44:67: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 67),
+            "46:15: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 15),
+            "48:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
         };
         verifyWithInlineConfigParser(
                 getPath("InputRightCurlyTestTryWithResourceAlone.java"), expected);
@@ -606,7 +606,7 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
             "23:11: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 11),
             "27:21: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 21),
             "32:23: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 23),
-            "34:43: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 43),
+            "34:37: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 37),
             "41:68: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 68),
         };
         verifyWithInlineConfigParser(

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestRecordsAndCompactCtors.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestRecordsAndCompactCtors.java
@@ -24,22 +24,22 @@ public class InputRightCurlyTestRecordsAndCompactCtors {
 
     record MyTestRecord2() {
         MyTestRecord2(String one, String two, String three) {
-            this(); } // violation
+            this(); } // violation ''}' at column 21 should have line break before'
     }
 
     record MyTestRecord3(Integer i, Node node) {
         public MyTestRecord3{
-            int x = 5;} // violation
+            int x = 5;} // violation ''}' at column 23 should have line break before'
         public static void main(String... args) {
-            System.out.println("works!"); } // violation
+            System.out.print("ok"); } // violation ''}' at column 37 should have line break before'
     }
 
     record MyTestRecord4() {} // ok, same line
 
     record MyTestRecord5() {
         static MyTestRecord mtr =
-                new MyTestRecord("my string", new MyTestRecord4());} // violation
-
+                new MyTestRecord("my string", new MyTestRecord4());}
+                // violation above ''}' at column 68 should be alone on a line'
     class MyTestClass {
         private MyTestRecord mtr =
                 new MyTestRecord("my string", new MyTestRecord4());} // ok

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeftTestAlone.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeftTestAlone.java
@@ -54,7 +54,7 @@ class InputRightCurlyLeftTestAlone
             do
             {
                 x = 2;
-            } while (x == 2); // violation
+            } while (x == 2); // violation ''}' at column 13 should be alone on a line'
         }
 
         this.wait(666
@@ -91,11 +91,11 @@ class InputRightCurlyLeftTestAlone
         boolean flag = true;
         if (flag) {
             System.identityHashCode("heh");
-            flag = !flag; } String.CASE_INSENSITIVE_ORDER. // violation
-              equals("Xe-xe");
+            flag = !flag; } String. // violation ''}' at column 27 should be alone on a line'
+                CASE_INSENSITIVE_ORDER.equals("Xe-xe");
         // it is ok to have rcurly on the same line as previous
         // statement if lcurly on the same line.
-        if (flag) { String.CASE_INSENSITIVE_ORDER.equals("it is ok."); } // violation
+        if (flag) { String.valueOf(""); } // violation ''}' at column 41 should be alone on a line'
     }
 }
 
@@ -171,23 +171,24 @@ class ClassWithStaticInitializersTestAlone
     public void emptyBlocks() {
         try {
             // comment
-        } catch (RuntimeException e) { // violation
+        } catch (RuntimeException e) { // violation ''}' at column 9 should be alone on a line'
             new Object();
-        } catch (Exception e) { // violation
+        } catch (Exception e) { // violation ''}' at column 9 should be alone on a line'
             // comment
-        } catch (Throwable e) { // violation
-        } finally { // violation
+        } catch (Throwable e) { // violation ''}' at column 9 should be alone on a line'
+        } finally { // violation ''}' at column 9 should be alone on a line'
             // comment
         }
 
         do {
-        } while (true); // violation
+        } while (true); // violation ''}' at column 9 should be alone on a line'
     }
 
     public void codeAfterLastRightCurly() {
         while (new Object().equals(new Object())) {
-        }; // violation
-        for (int i = 0; i < 1; i++) { new Object(); }; // violation
+        }; // violation ''}' at column 9 should be alone on a line'
+        for (int i = 0; i < 1; i++) { new Object(); };
+        // violation above ''}' at column 53 should be alone on a line'
     }
 
     static final java.util.concurrent.ThreadFactory threadFactory

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeftTestDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeftTestDefault.java
@@ -22,10 +22,10 @@ class InputRightCurlyLeftTestDefault
                 if (x > 0)
                 {
                     break;
-                } // violation
+                } // violation ''}' at column 17 should be on the same line with else if'
                 else if (x < 0) {
                     ;
-                } // violation
+                } // violation ''}' at column 17 should be on the same line with else'
                 else
                 {
                     break;
@@ -37,11 +37,11 @@ class InputRightCurlyLeftTestDefault
                 default:
                     break;
                 }
-            } // violation
+            } // violation ''}' at column 13 should be on the same line with catch'
             catch (Exception e)
             {
                 break;
-            } // violation
+            } // violation ''}' at column 13 should be on the same line with finally'
             finally
             {
                 break;
@@ -90,8 +90,8 @@ class InputRightCurlyLeftTestDefault
         boolean flag = true;
         if (flag) {
             System.identityHashCode("heh");
-            flag = !flag; } String.CASE_INSENSITIVE_ORDER. // violation
-              equals("Xe-xe");
+            flag = !flag; } String. // violation ''}' at column 17 should have line break before'
+                CASE_INSENSITIVE_ORDER.equals("Xe-xe");
         // it is ok to have rcurly on the same line as previous
         // statement if lcurly on the same line.
         if (flag) { String.CASE_INSENSITIVE_ORDER.equals("it is ok."); } // ok

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeftTestNewLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeftTestNewLine.java
@@ -83,7 +83,7 @@ class InputRightCurlyLeftTestNewLine
     {
         HELLO,
         GOODBYE
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
     void method2()
     {
@@ -141,17 +141,17 @@ class FooInnerTestNewLine
  */
 class Absent_CustomFieldSerializer3TestNewLine {
 
-    public static void serialize() {} // violation
+    public static void serialize() {} // violation ''}' at column 37 should be alone on a line'
 }
 
 class Absent_CustomFieldSerializer4TestNewLine
 {
-    public void Absent_CustomFieldSerializer4() {} // violation
+  void Absent_CustomFieldSerializer4() {} // violation ''}' at column 41 should be alone on a line'
 }
 
-class EmptyClass2TestNewLine {} // violation
+class EmptyClass2TestNewLine {} // violation ''}' at column 31 should be alone on a line'
 
-interface EmptyInterface3TestNewLine {} // violation
+interface EmptyInterface3TestNewLine {} // violation ''}' at column 39 should be alone on a line'
 
 class ClassWithStaticInitializersTestNewLine
 {
@@ -194,15 +194,15 @@ class ClassWithStaticInitializersTestNewLine
         @Override
         public Thread newThread(final Runnable r) {
             return new Thread(r);
-        }}; // violation
+        }}; // violation ''}' at column 9 should be alone on a line'
 
     interface Interface1
     {
         int i = 1;
-        public void meth1(); } // violation
+        public void meth1(); } // violation ''}' at column 30 should be alone on a line'
 
     interface Interface2
-    { int i = 1; public void meth1(); } // violation
+    { int i = 1; public void meth1(); } // violation ''}' at column 39 should be alone on a line'
 
     interface Interface3 {
         void display();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeftTestSame.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeftTestSame.java
@@ -23,10 +23,10 @@ class InputRightCurlyLeftTestSame
                 if (x > 0)
                 {
                     break;
-                } // violation
+                } // violation ''}' at column 17 should be on the same line with else if'
                 else if (x < 0) {
                     ;
-                } // violation
+                } // violation ''}' at column 17 should be on the same line with else'
                 else
                 {
                     break;
@@ -38,11 +38,11 @@ class InputRightCurlyLeftTestSame
                 default:
                     break;
                 }
-            } // violation
+            } // violation ''}' at column 13 should be on the same line with catch'
             catch (Exception e)
             {
                 break;
-            } // violation
+            } // violation ''}' at column 13 should be on the same line with finally'
             finally
             {
                 break;
@@ -84,15 +84,15 @@ class InputRightCurlyLeftTestSame
     {
         HELLO,
         GOODBYE
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
     void method2()
     {
         boolean flag = true;
         if (flag) {
             System.identityHashCode("heh");
-            flag = !flag; } String.CASE_INSENSITIVE_ORDER. // violation
-              equals("Xe-xe");
+            flag = !flag; } String. // violation ''}' at column 27 should have line break before'
+                CASE_INSENSITIVE_ORDER.equals("Xe-xe");
         // it is ok to have rcurly on the same line as previous
         // statement if lcurly on the same line.
         if (flag) { String.CASE_INSENSITIVE_ORDER.equals("it is ok."); } // ok
@@ -186,8 +186,8 @@ class ClassWithStaticInitializersTestSame
 
     public void codeAfterLastRightCurly() {
         while (new Object().equals(new Object())) {
-        }; // violation
-        for (int i = 0; i < 1; i++) { new Object(); }; // violation
+        }; // violation ''}' at column 9 should be alone on a line'
+        for (int i = 0; i < 1; i++) { ; }; // violation ''}' at column 53 should be alone on a line'
     }
 
     static final java.util.concurrent.ThreadFactory threadFactory

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeftTestShouldStartLine2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyLeftTestShouldStartLine2.java
@@ -83,7 +83,7 @@ class InputRightCurlyLeftTestShouldStartLine2
     {
         HELLO,
         GOODBYE
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
     void method2()
     {
@@ -194,12 +194,12 @@ class ClassWithStaticInitializersTestShouldStartLine2
         @Override
         public Thread newThread(final Runnable r) {
             return new Thread(r);
-        }}; // violation
+        }}; // violation ''}' at column 9 should be alone on a line'
 
     interface Interface1
     {
         int i = 1;
-        public void meth1(); } // violation
+        public void meth1(); } // violation ''}' at column 30 should be alone on a line'
 
     interface Interface2
     { int i = 1; public void meth1(); } // ok

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyNewTokensAloneOrSingleLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyNewTokensAloneOrSingleLine.java
@@ -13,7 +13,7 @@ public class InputRightCurlyNewTokensAloneOrSingleLine {
     enum TestEnum{} // ok
 
     enum TestEnum1{
-        SOME_VALUE;} // violation
+        SOME_VALUE;} // violation ''}' at column 20 should be alone on a line'
 
     enum TestEnum2 { SOME_VALUE; } // ok
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestAloneOrSingleline.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestAloneOrSingleline.java
@@ -67,7 +67,7 @@ public class InputRightCurlyTestAloneOrSingleline {
     }
 
     private void foo15() {
-        class A { int a; } var1++; // violation
+        class A { int a; } var1++; // violation ''}' at column 26 should be alone on a line'
         class B {  }
         if(true) {
 
@@ -80,23 +80,23 @@ public class InputRightCurlyTestAloneOrSingleline {
         if (false) {
         }
     }
-    // violation below
+    // violation below ''}' at column 42 should be alone on a line'
     void f17() { int var1 = 5; var2 = 6; } private void f18() {int var1 = 5; var2 = 6; }
 
     private void foo19() {int var1 = 5;
-        var2 = 6;} // violation
+        var2 = 6;} // violation ''}' at column 18 should be alone on a line'
 
     private String foo20() {
         do { var2 ++; }
         while (var2 < 15);
 
         while (var1 < 10) { var1++; }
-
-        do { var2++; var1++; } while (var2 < 15); return ""+0xCAFEBABE; // violation
+        // violation below ''}' at column 30 should be alone on a line'
+        do { var2++; var1++; } while (var2 < 15); return ""+0xCAFEBABE;
     }
 
-    private void foo21() {
-        new Object() { @Override protected void finalize() { "".toString(); }}; // violation
+    private void foo21() { // violation below ''}' at column 77 should be alone on a line'
+        new Object() { @Override protected void finalize() { "".toString(); }};
     }
 
     void foo22() {
@@ -104,9 +104,9 @@ public class InputRightCurlyTestAloneOrSingleline {
         try {
             int a = 5;
             toString();
-        } catch (Exception e) { // violation
+        } catch (Exception e) { // violation ''}' at column 9 should be alone on a line'
             throw new RuntimeException(e);
-        } finally { toString(); } // violation
+        } finally { toString(); } // violation ''}' at column 9 should be alone on a line'
     }
 
     void doDoubleBraceInitialization() {
@@ -116,11 +116,11 @@ public class InputRightCurlyTestAloneOrSingleline {
             put("polygene", "lubricants");
             put("alpha", "betical");
         }}; //NO violation
-
-        Thread t = new Thread() {@Override public void run() {super.run();}}; // violation
+        // violation below ''}' at column 75 should be alone on a line'
+        Thread t = new Thread() {@Override public void run() {super.run();}};
         // 2 violations below
         new Object() { @Override protected void finalize() { "".toString(); }  { int a = 5; }};
-        // violation below
+        // violation below ''}' at column 77 should be alone on a line'
         new Object() { @Override protected void finalize() { "".toString(); }  int b = 10; };
         // 2 violations below
         new Object() { protected void finalize() { hashCode(); }  { int c = 5; } int d = 8; };
@@ -129,14 +129,14 @@ public class InputRightCurlyTestAloneOrSingleline {
             put("Hello", "World");
             put("first", "second");
             put("polygene", "lubricants");
-            put("alpha", "betical");}  // violation
+            put("alpha", "betical");}  // violation ''}' at column 37 should be alone on a line'
         };
 
         java.util.Map<String, String> map3 = new java.util.LinkedHashMap<String, String>() {{
             put("Hello", "World");
             put("first", "second");
             put("polygene", "lubricants");
-            put("alpha", "betical");}}; // violation
+            put("alpha", "betical");}}; // violation ''}' at column 37 should be alone on a line'
 
         java.util.Map<String, String> map4 = new java.util.LinkedHashMap<String, String>() {{
             put("Hello", "World");
@@ -151,7 +151,7 @@ public class InputRightCurlyTestAloneOrSingleline {
             add("AB21/X");
             add("YYLEX");
             add("AR5E");
-        }});  // violation
+        }});  // violation ''}' at column 9 should be alone on a line'
 
         foo23(new java.util.HashSet<String>() {{
             add("XZ13s");
@@ -186,41 +186,41 @@ public class InputRightCurlyTestAloneOrSingleline {
         boolean flag = true;
         if (flag) {
             System.identityHashCode("heh");
-            flag = !flag; } String.CASE_INSENSITIVE_ORDER. // violation
-            equals("Xe-xe");
+            flag = !flag; } String. // violation ''}' at column 27 should be alone on a line'
+                CASE_INSENSITIVE_ORDER.equals("Xe-xe");
     }
 
     void foo30() {
         if (true) {
-            getClass();} // violation
+            getClass();} // violation ''}' at column 24 should be alone on a line'
 
         for (int i = 0; i == 0; i++) {
-            getClass();} // violation
+            getClass();} // violation ''}' at column 24 should be alone on a line'
 
         while (true) {
-            getClass();} // violation
+            getClass();} // violation ''}' at column 24 should be alone on a line'
     }
 
     public void emptyBlocks() {
         try {
             // comment
-        } catch (RuntimeException e) { // violation
+        } catch (RuntimeException e) { // violation ''}' at column 9 should be alone on a line'
             new Object();
-        } catch (Exception e) { // violation
+        } catch (Exception e) { // violation ''}' at column 9 should be alone on a line'
             // comment
-        } catch (Throwable e) { // violation
-        } finally { // violation
+        } catch (Throwable e) { // violation ''}' at column 9 should be alone on a line'
+        } finally { // violation ''}' at column 9 should be alone on a line'
             // comment
         }
 
         do {
-        } while (true); // violation
+        } while (true); // violation ''}' at column 9 should be alone on a line'
     }
 
     public void codeAfterLastRightCurly() {
         while (new Object().equals(new Object())) {
-        }; // violation
-        for (int i = 0; i < 1; i++) { new Object(); }; // violation
+        }; // violation ''}' at column 9 should be alone on a line'
+        for (int i = 0; i < 1; i++) { }; // violation ''}' at column 39 should be alone on a line'
     }
 
     public @interface TestAnnotation {}
@@ -228,7 +228,7 @@ public class InputRightCurlyTestAloneOrSingleline {
     public @interface TestAnnotation1{ String value(); }
 
     public @interface TestAnnotation2 {
-        String value();} // violation
+        String value();} // violation ''}' at column 24 should be alone on a line'
 
     public @interface TestAnnotation3 {
         String value();
@@ -240,7 +240,7 @@ public class InputRightCurlyTestAloneOrSingleline {
     interface Interface1
     {
         int i = 1;
-        public void meth1(); } // violation
+        public void meth1(); } // violation ''}' at column 30 should be alone on a line'
 
     interface Interface2
     { int i = 1; public void meth1(); }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestForceLineBreakBefore.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestForceLineBreakBefore.java
@@ -34,20 +34,20 @@ class InputRightCurlyTestForceLineBreakBefore
                 }
             } catch (Exception e) { break; } finally { break; }
         }
-
-        synchronized (this) { do { x = 2; } while (x == 2); } // violation
+        // violation below ''}' at column 43 should be alone on a line'
+        synchronized (this) { do { x = 2; } while (x == 2); }
 
         synchronized (this) {
-            do {} while (x == 2); // violation
+            do {} while (x == 2); // violation ''}' at column 17 should be alone on a line'
         }
+        // violation below ''}' at column 71 should be alone on a line'
+        for (int k = 0; k < 1; k++) { String innerBlockVariable = ""; }
 
-        for (int k = 0; k < 1; k++) { String innerBlockVariable = ""; } // violation
-
-        for (int k = 0; k < 1; k++) {} // violation
+        for (int k = 0; k < 1; k++) {} // violation ''}' at column 38 should be alone on a line'
                 return a;
     }
 
-    static { int x = 1; } // violation
+    static { int x = 1; } // violation ''}' at column 25 should be alone on a line'
 
     void method2()
     {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestNewTokensAlone.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestNewTokensAlone.java
@@ -10,12 +10,12 @@ package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
 
 public class InputRightCurlyTestNewTokensAlone {
 
-    enum TestEnum{} // violation
+    enum TestEnum{} // violation ''}' at column 19 should be alone on a line'
 
     enum TestEnum1{
-        SOME_VALUE;} // violation
+        SOME_VALUE;} // violation ''}' at column 20 should be alone on a line'
 
-    enum TestEnum2 { SOME_VALUE; } // violation
+    enum TestEnum2 { SOME_VALUE; } // violation ''}' at column 34 should be alone on a line'
 
     enum TestEnum3{
         SOME_VALUE;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptAloneBlocksWithSemi.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptAloneBlocksWithSemi.java
@@ -10,21 +10,21 @@ package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
 
 public class InputRightCurlyTestOptAloneBlocksWithSemi {
 
-    public void testMethod() {}; // violation
+    public void testMethod() {}; // violation ''}' at column 31 should be alone on a line'
 
     public void testMethod1() {
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
-    public class TestClass {}; // violation
+    public class TestClass {}; // violation ''}' at column 29 should be alone on a line'
 
     public class TestClass1 {
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
     public class TestClass2 {
-        public TestClass2() {}; // violation
+        public TestClass2() {}; // violation ''}' at column 30 should be alone on a line'
 
         public TestClass2(String someValue) {
-        }; // violation
+        }; // violation ''}' at column 9 should be alone on a line'
     }
 
     public void testMethod11() {
@@ -32,37 +32,37 @@ public class InputRightCurlyTestOptAloneBlocksWithSemi {
     ;
 
     public @interface TestAnnnotation5 {
-        String someValue(); }; // violation
+        String someValue(); }; // violation ''}' at column 29 should be alone on a line'
 
-    public @interface TestAnnotation6 {}; // violation
+    public @interface TestAnnotation6 {}; // violation ''}' at column 40 should be alone on a line'
 
     public @interface TestAnnotation7 {
         String someValue();
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
     public @interface TestAnnotation8 { String someValue();
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
+    // violation below ''}' at column 61 should be alone on a line'
+    public @interface TestAnnotation9 { String someValue(); };
 
-    public @interface TestAnnotation9 { String someValue(); }; // violation
-
-    enum TestEnum{}; // violation
+    enum TestEnum{}; // violation ''}' at column 19 should be alone on a line'
 
     enum TestEnum1{
-        SOME_VALUE;}; // violation
+        SOME_VALUE;}; // violation ''}' at column 20 should be alone on a line'
 
-    enum TestEnum2 { SOME_VALUE; }; // violation
+    enum TestEnum2 { SOME_VALUE; }; // violation ''}' at column 34 should be alone on a line'
 
     enum TestEnum3{
         SOME_VALUE;
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
     enum TestEnum4{ SOME_VALUE;
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
     interface Interface1
     {
         int i = 1;
-        public void meth1(); }; // violation
+        public void meth1(); }; // violation ''}' at column 30 should be alone on a line'
 
     interface Interface3 {
         void display();
@@ -72,5 +72,5 @@ public class InputRightCurlyTestOptAloneBlocksWithSemi {
 
     interface InterfaceEndingWithSemiColon2 {
         public void fooEmpty();
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptAloneOrSingleLineBlocksWithSemi.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptAloneOrSingleLineBlocksWithSemi.java
@@ -13,18 +13,18 @@ public class InputRightCurlyTestOptAloneOrSingleLineBlocksWithSemi {
     public void testMethod() {}; // ok
 
     public void testMethod1() {
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
     public class TestClass {}; // ok
 
     public class TestClass1 {
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
     public class TestClass2 {
         public TestClass2() {}; // ok
 
         public TestClass2(String someValue) {
-        }; // violation
+        }; // violation ''}' at column 9 should be alone on a line'
     }
 
     public void testMethod11() {
@@ -32,37 +32,37 @@ public class InputRightCurlyTestOptAloneOrSingleLineBlocksWithSemi {
     ;
 
     public @interface TestAnnnotation5 {
-        String someValue(); }; // violation
+        String someValue(); }; // violation ''}' at column 29 should be alone on a line'
 
     public @interface TestAnnotation6 {}; // ok
 
     public @interface TestAnnotation7 {
         String someValue();
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
     public @interface TestAnnotation8 { String someValue();
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
     public @interface TestAnnotation9 { String someValue(); }; // ok
 
     enum TestEnum{}; // ok
 
     enum TestEnum1{
-        SOME_VALUE;}; // violation
+        SOME_VALUE;}; // violation ''}' at column 20 should be alone on a line'
 
     enum TestEnum2 { SOME_VALUE; }; // ok
 
     enum TestEnum3{
         SOME_VALUE;
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
     enum TestEnum4{ SOME_VALUE;
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
     interface Interface1
     {
         int i = 1;
-        public void meth1(); }; // violation
+        public void meth1(); }; // violation ''}' at column 30 should be alone on a line'
 
     interface Interface2
     { int i = 1; public void meth1(); };
@@ -75,5 +75,5 @@ public class InputRightCurlyTestOptAloneOrSingleLineBlocksWithSemi {
 
     interface InterfaceEndingWithSemiColon2 {
         public void fooEmpty();
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptSameBlocksWithSemi.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptSameBlocksWithSemi.java
@@ -13,18 +13,18 @@ public class InputRightCurlyTestOptSameBlocksWithSemi {
     public void testMethod() {}; // ok
 
     public void testMethod1() {
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
     public class TestClass {}; // ok
 
     public class TestClass1 {
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
     public class TestClass2 {
         public TestClass2() {}; // ok
 
         public TestClass2(String someValue) {
-        }; // violation
+        }; // violation ''}' at column 9 should be alone on a line'
     }
 
     public void testMethod11() {
@@ -32,37 +32,37 @@ public class InputRightCurlyTestOptSameBlocksWithSemi {
     ;
 
     public @interface TestAnnnotation5 {
-        String someValue(); }; // violation
+        String someValue(); }; // violation ''}' at column 29 should have line break before'
 
     public @interface TestAnnotation6 {}; // ok
 
     public @interface TestAnnotation7 {
         String someValue();
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
     public @interface TestAnnotation8 { String someValue();
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
     public @interface TestAnnotation9 { String someValue(); }; // ok
 
     enum TestEnum{}; // ok
 
     enum TestEnum1{
-        SOME_VALUE;}; // violation
+        SOME_VALUE;}; // violation ''}' at column 20 should have line break before'
 
     enum TestEnum2 { SOME_VALUE; }; // ok
 
     enum TestEnum3{
         SOME_VALUE;
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
     enum TestEnum4{ SOME_VALUE;
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
     interface Interface1
     {
         int i = 1;
-        public void meth1(); }; // violation
+        public void meth1(); }; // violation ''}' at column 30 should have line break before'
 
     interface Interface2
     { int i = 1; public void meth1(); };
@@ -75,5 +75,5 @@ public class InputRightCurlyTestOptSameBlocksWithSemi {
 
     interface InterfaceEndingWithSemiColon2 {
         public void fooEmpty();
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptionAlone.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptionAlone.java
@@ -13,12 +13,12 @@ public class InputRightCurlyTestOptionAlone {
 
     private int a;
     private static int b;
-    {  a = 2; } // violation
-    static { b = 3; } // violation
+    {  a = 2; } // violation ''}' at column 15 should be alone on a line'
+    static { b = 3; } // violation ''}' at column 21 should be alone on a line'
 
     void method1() {
         Thread t = new Thread() {@Override public void run() {
-            int a; int b;} // violation
+            int a; int b;} // violation ''}' at column 26 should be alone on a line'
         };
     }
 
@@ -27,7 +27,7 @@ public class InputRightCurlyTestOptionAlone {
             put("Hello", "World");
             put("first", "second");
             put("polygene", "lubricants");
-            put("alpha", "betical");} // violation
+            put("alpha", "betical");} // violation ''}' at column 37 should be alone on a line'
         };
 
         java.util.Map<String, String> map2 = new java.util.LinkedHashMap<String, String>() {{
@@ -44,20 +44,20 @@ public class InputRightCurlyTestOptionAlone {
             add("AB21/X");
             add("YYLEX");
             add("AR5E");
-        }}); // violation
+        }}); // violation ''}' at column 9 should be alone on a line'
     }
 
     int method4(int a) {
-        if (a>2) a*=10; return ++a; } // violation
+        if (a>2) a*=10; return ++a; } // violation ''}' at column 37 should be alone on a line'
 
     void method5(int a) {
-        while (a > 5) { a--; } // violation
+        while (a > 5) { a--; } // violation ''}' at column 30 should be alone on a line'
 
-        if (a > 4) { a++; } // violation
+        if (a > 4) { a++; } // violation ''}' at column 27 should be alone on a line'
 
-        do {a--;} while (a > 3); // violation
-
-        for (int i = 1; i < 10; i++) { byte b = 10; } // violation
+        do {a--;} while (a > 3); // violation ''}' at column 17 should be alone on a line'
+        // violation below ''}' at column 53 should be alone on a line'
+        for (int i = 1; i < 10; i++) { byte b = 10; }
 
         if (a < 2) { --a; } else if (a > 3) { a++; } // 2 violations
 
@@ -76,12 +76,12 @@ public class InputRightCurlyTestOptionAlone {
         };
     }
 
-    public @interface TestAnnotation {} // violation
-
-    public @interface TestAnnotation1{ String value(); } // violation
+    public @interface TestAnnotation {} // violation ''}' at column 39 should be alone on a line'
+    // violation below ''}' at column 56 should be alone on a line'
+    public @interface TestAnnotation1{ String value(); }
 
     public @interface TestAnnotation2 {
-        String value();} // violation
+        String value();} // violation ''}' at column 24 should be alone on a line'
 
     public @interface TestAnnotation3 {
         String value();
@@ -93,10 +93,10 @@ public class InputRightCurlyTestOptionAlone {
     interface Interface1
     {
         int i = 1;
-        public void meth1(); } // violation
+        public void meth1(); } // violation ''}' at column 30 should be alone on a line'
 
     interface Interface2
-    { int i = 1; public void meth1(); } // violation
+    { int i = 1; public void meth1(); } // violation ''}' at column 39 should be alone on a line'
 
     interface Interface3 {
         void display();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptionAloneOrSingleLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestOptionAloneOrSingleLine.java
@@ -18,7 +18,7 @@ public class InputRightCurlyTestOptionAloneOrSingleLine {
 
     void method1() {
         Thread t = new Thread() {@Override public void run() {
-            int a; int b;} // violation
+            int a; int b;} // violation ''}' at column 26 should be alone on a line'
         };
     }
 
@@ -27,7 +27,7 @@ public class InputRightCurlyTestOptionAloneOrSingleLine {
             put("Hello", "World");
             put("first", "second");
             put("polygene", "lubricants");
-            put("alpha", "betical");} // violation
+            put("alpha", "betical");} // violation ''}' at column 37 should be alone on a line'
         };
 
         java.util.Map<String, String> map2 = new java.util.LinkedHashMap<String, String>() {{
@@ -35,7 +35,7 @@ public class InputRightCurlyTestOptionAloneOrSingleLine {
             put("first", "second");
             put("polygene", "lubricants");
             put("alpha", "betical");
-        }};; // violation
+        }};; // violation ''}' at column 9 should be alone on a line'
     }
 
     void method3() {
@@ -44,11 +44,11 @@ public class InputRightCurlyTestOptionAloneOrSingleLine {
             add("AB21/X");
             add("YYLEX");
             add("AR5E");
-        }}); // violation
+        }}); // violation ''}' at column 9 should be alone on a line'
     }
 
     int method4(int a) {
-        if (a>2) a*=10; return ++a; } // violation
+        if (a>2) a*=10; return ++a; } // violation ''}' at column 37 should be alone on a line'
 
     void method5(int a) {
         while (a > 5) { a--; } // ok
@@ -69,12 +69,12 @@ public class InputRightCurlyTestOptionAloneOrSingleLine {
 
     class TestClass4 { }
 
-    class TestClass5 { } { } // violation
+    class TestClass5 { } { } // violation ''}' at column 24 should be alone on a line'
 
     interface Interface1
     {
         int i = 1;
-        public void meth1(); } // violation
+        public void meth1(); } // violation ''}' at column 30 should be alone on a line'
 
     interface Interface2
     { int i = 1; public void meth1(); } // ok

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSameAndLiteralDo.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSameAndLiteralDo.java
@@ -67,12 +67,12 @@ public class InputRightCurlyTestSameAndLiteralDo {
 
     public void foo5() {
         do {
-        } // violation
+        } // violation ''}' at column 17 should be on the same line with while'
         while (true);
     }
 
     public void foo6() {
-        do {} // violation
+        do {} // violation ''}' at column 17 should be on the same line with while'
         while (true);
     }
 
@@ -88,7 +88,7 @@ public class InputRightCurlyTestSameAndLiteralDo {
 
         {
 
-        } // violation
+        } // violation ''}' at column 9 should be on the same line with else if'
 
         while
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSameNewTokens.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSameNewTokens.java
@@ -13,7 +13,7 @@ public class InputRightCurlyTestSameNewTokens {
     enum TestEnum{} // ok
 
     enum TestEnum1{
-        SOME_VALUE;} // violation
+        SOME_VALUE;} // violation ''}' at column 20 should have line break before'
 
     enum TestEnum2 { SOME_VALUE; } // ok
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSingleLineClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSingleLineClass.java
@@ -25,5 +25,5 @@ class InputRightCurlyTestSingleLineClass
         }
 
     }
-
-class UniqEmptyClassTestSingleLineClass {private int a;} // violation
+// violation below ''}' at column 56 should be alone on a line'
+class UniqEmptyClassTestSingleLineClass {private int a;}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSinglelineIfBlocks.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSinglelineIfBlocks.java
@@ -10,7 +10,7 @@ package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
 
 public class InputRightCurlyTestSinglelineIfBlocks {
     void foo1() {
-        if (true) { int a = 5; } // violation
+        if (true) { int a = 5; } // violation ''}' at column 32 should be alone on a line'
 
         if (true) { if (false) { int b = 6; } } // 2 violations
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestTryWithResourceAlone.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestTryWithResourceAlone.java
@@ -24,13 +24,14 @@ class InputRightCurlyTestTryWithResourceAlone {
                 BufferedReader br2 = new BufferedReader(br1))
         {
             ;
-        } catch (IOException e) // violation
+        } catch (IOException e) // violation ''}' at column 9 should be alone on a line'
         {
             ;
         }
         try (BufferedReader br1 = new BufferedReader(null);
-                BufferedReader br2 = new BufferedReader(br1)) { ; } // violation
-        catch (IOException e) { ; } // violation
+                // violation below ''}' at column 67 should be alone on a line'
+                BufferedReader br2 = new BufferedReader(br1)) { ; }
+        catch (IOException e) { ; } // violation ''}' at column 35 should be alone on a line'
         try (BufferedReader br1 = new BufferedReader(null);
 
                 BufferedReader br2 = new BufferedReader(br1)) {} catch (IOException e) { ; }
@@ -39,10 +40,11 @@ class InputRightCurlyTestTryWithResourceAlone {
             ;
         }
         try (BufferedReader br1 = new BufferedReader(null);
-                BufferedReader br2 = new BufferedReader(br1)) { ; } // violation
+                // violation below ''}' at column 67 should be alone on a line'
+                BufferedReader br2 = new BufferedReader(br1)) { ; }
         try (BufferedReader br1 = new BufferedReader(null)) {
-            ; } // violation
+            ; } // violation ''}' at column 15 should be alone on a line'
         try (BufferedReader br1 = new BufferedReader(null)) {
-            } int i; // violation
+            } int i; // violation ''}' at column 13 should be alone on a line'
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestTryWithResourceSame.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestTryWithResourceSame.java
@@ -16,7 +16,7 @@ class InputRightCurlyTestTryWithResourceSame {
         try (BufferedReader br1 = new BufferedReader(null);
                 BufferedReader br2 = new BufferedReader(br1)) {
             ;
-        } // violation
+        } // violation ''}' at column 9 should be on the same line with catch'
         catch (IOException e) {
             ;
         }
@@ -29,7 +29,8 @@ class InputRightCurlyTestTryWithResourceSame {
             ;
         }
         try (BufferedReader br1 = new BufferedReader(null);
-                BufferedReader br2 = new BufferedReader(br1)) { ; } // violation
+                // violation below ''}' at column 67 should be on the same line with catch'
+                BufferedReader br2 = new BufferedReader(br1)) { ; }
         catch (IOException e) { ; } // ok
         try (BufferedReader br1 = new BufferedReader(null);
                 BufferedReader br2 = new BufferedReader(br1)) {} catch (IOException e) { ; } // ok
@@ -40,8 +41,8 @@ class InputRightCurlyTestTryWithResourceSame {
         try (BufferedReader br1 = new BufferedReader(null);
                 BufferedReader br2 = new BufferedReader(br1)) { ; } // ok
         try (BufferedReader br1 = new BufferedReader(null)) {
-            ; } // violation
+            ; } // violation ''}' at column 15 should have line break before'
         try (BufferedReader br1 = new BufferedReader(null)) {
-            } int i; // violation
+            } int i; // violation ''}' at column 13 should be alone on a line'
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestWithAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestWithAnnotations.java
@@ -15,11 +15,11 @@ class InputRightCurlyTestWithAnnotations
 
     @Deprecated
     @Override
-    public boolean equals(Object other) { boolean flag = true; return flag; } // violation
-
+    public boolean equals(Object other) { boolean flag = true; return flag; }
+    // violation above ''}' at column 77 should be alone on a line'
     @Override
-    public String toString() { String s = "toString"; return s; } // violation
-
+    public String toString() { String s = "toString"; return s; }
+    // violation above ''}' at column 65 should be alone on a line'
     @Override
     @SuppressWarnings("unused")
     public int hashCode()
@@ -29,54 +29,54 @@ class InputRightCurlyTestWithAnnotations
     }
 
     @SuppressWarnings("unused")
-    private void foo2() { int a = 9; return; } // violation
-
+    private void foo2() { int a = 9; return; }
+    // violation above ''}' at column 46 should be alone on a line'
     @SuppressWarnings("unused")
     private void foo3()
-    { int var1 = 5; var2 = 6; } // violation
+    { int var1 = 5; var2 = 6; } // violation ''}' at column 31 should be alone on a line'
 
     @Deprecated
-    private void foo4() { return; } // violation
+    private void foo4() { return; } // violation ''}' at column 35 should be alone on a line'
 
     @SuppressWarnings("unused")
-    private int foo5() { return 1; } // violation
+    private int foo5() { return 1; } // violation ''}' at column 36 should be alone on a line'
 
     @SuppressWarnings("unused")
     private String foo6() { return toString();
     }
+    // violation below ''}' at column 73 should be alone on a line'
+    private String foo7() { String s = toString(); return s.toString(); }
 
-    private String foo7() { String s = toString(); return s.toString(); } // violation
-
-    private void foo8() { ; return; } // violation
+    private void foo8() { ; return; } // violation ''}' at column 37 should be alone on a line'
 
     private int var1; private int v1;
     private int var2; private int v2;
     @SuppressWarnings("unused")
-    public InputRightCurlyTestWithAnnotations() { this.var1 = 1; } // violation
+    public InputRightCurlyTestWithAnnotations() { this.var1 = 1; }
+    // violation above ''}' at column 66 should be alone on a line'
     @SuppressWarnings("unused")
-
     public InputRightCurlyTestWithAnnotations(int v1, int v2) {this.var1 = v1; this.var2 = v2; }
-    // violation above
+    // violation above ''}' at column 96 should be alone on a line'
     @SuppressWarnings("unused")
-    private void foo9() { ;; } // violation
+    private void foo9() { ;; } // violation ''}' at column 30 should be alone on a line'
 
     @SuppressWarnings("unused")
-    private void foo10() { ; } // violation
+    private void foo10() { ; } // violation ''}' at column 30 should be alone on a line'
 
     @SuppressWarnings("unused")
-    private void foo11() {  } // violation
+    private void foo11() {  } // violation ''}' at column 29 should be alone on a line'
 
     @SuppressWarnings("unused")
     private void foo12() {
-        try { int i = 5; int b = 10; } // violation
-        catch (Exception e) { } // violation
+        try { int i = 5; int b = 10; } // violation ''}' at column 38 should be alone on a line'
+        catch (Exception e) { } // violation ''}' at column 31 should be alone on a line'
     }
 
     @Deprecated
     @SuppressWarnings("unused")
     private void foo13() {
-        for (int i = 0; i < 10; i++) { int a = 5; int b = 6; } // violation
-
+        for (int i = 0; i < 10; i++) { int a = 5; int b = 6; }
+        // violation above ''}' at column 62 should be alone on a line'
         do
         {
             var1 = 2;
@@ -84,13 +84,13 @@ class InputRightCurlyTestWithAnnotations
         while (var2 == 2);
     }
 
-    static { int a; int b; } // violation
+    static { int a; int b; } // violation ''}' at column 28 should be alone on a line'
 
-    static { int a; } // violation
+    static { int a; } // violation ''}' at column 21 should be alone on a line'
 
-    { int c; int d;} // violation
+    { int c; int d;} // violation ''}' at column 20 should be alone on a line'
 
-    { int c; } // violation
+    { int c; } // violation ''}' at column 14 should be alone on a line'
 
     @Deprecated
     private void foo14() {
@@ -101,8 +101,8 @@ class InputRightCurlyTestWithAnnotations
 
     @Deprecated
     private void foo15() {
-        class A { int a; } var1++; // violation
-        class B {  } // violation
+        class A { int a; } var1++; // violation ''}' at column 26 should be alone on a line'
+        class B {  } // violation ''}' at column 20 should be alone on a line'
         if(true) {
 
         }
@@ -122,20 +122,20 @@ class InputRightCurlyTestWithAnnotations
     void foo17() { int v1 = 5; v2 = 6; } @Deprecated void foo18() {int v1 = 5; v2 = 6; }
     // 2 violations above
     private void foo19() {int var1 = 5;
-        var2 = 6;} // violation
+        var2 = 6;} // violation ''}' at column 18 should be alone on a line'
 
     @SuppressWarnings("Hello, world!")
     private String foo20() {
-        do { var2 ++; } // violation
+        do { var2 ++; } // violation ''}' at column 23 should be alone on a line'
         while (var2 < 15);
 
-        while (var1 < 10) { var1++; } // violation
-
-        do { var2++; var1++; } while (var2 < 15); return ""+0xCAFEBABE; // violation
+        while (var1 < 10) { var1++; } // violation ''}' at column 37 should be alone on a line'
+        // violation below ''}' at column 30 should be alone on a line'
+        do { var2++; var1++; } while (var2 < 15); return ""+0xCAFEBABE;
     }
 
-    private void foo21() {
-        new Object() { @Override protected void finalize() { "".toString(); }}; // violation
+    private void foo21() { // violation below ''}' at column 77 should be alone on a line'
+        new Object() { @Override protected void finalize() { "".toString(); }};
     }
 
     @SuppressWarnings("All")
@@ -144,7 +144,7 @@ class InputRightCurlyTestWithAnnotations
         try {
             int a = 5;
             toString();
-        } catch (Exception e) { // violation
+        } catch (Exception e) { // violation ''}' at column 9 should be alone on a line'
             throw new RuntimeException(e);
         } finally { toString(); } // 2 violations
     }
@@ -157,24 +157,25 @@ class InputRightCurlyTestWithAnnotations
             put("polygene", "lubricants");
             put("alpha", "betical");
         }}; //NO violation
-
-        Thread t = new Thread() {@Override public void run() {super.run();}}; // violation
+        // violation below ''}' at col.* 75 should be alone on a line'
+        Thread t = new Thread() {@Override public void run() {super.run();}};
         new Object() { public int hashCode() { return 1; }  { int a = 5; }}; // 2 violations
-        new Object() { public int hashCode() { return 1; }  int b = 10; }; // violation
-        new Object() { public int hashCode() { return 1; }  { int c = 5; } int d = 8; };
+        new Object() { public int hashCode() { return 1; }  int b = 10; };
+        // violation above ''}' at column 58 should be alone on a line'
+        new Object() { public int hashCode() { return 1; } { int c = 5; } int d = 8; };
         // 2 violations above
         java.util.Map<String, String> map2 = new java.util.LinkedHashMap<String, String>() {{
             put("Hello", "World");
             put("first", "second");
             put("polygene", "lubricants");
-            put("alpha", "betical");}  // violation
+            put("alpha", "betical");}  // violation ''}' at column 37 should be alone on a line'
         };
 
         java.util.Map<String, String> map3 = new java.util.LinkedHashMap<String, String>() {{
             put("Hello", "World");
             put("first", "second");
             put("polygene", "lubricants");
-            put("alpha", "betical");}};  // violation
+            put("alpha", "betical");}};  // violation ''}' at column 37 should be alone on a line'
 
         java.util.Map<String, String> map4 = new java.util.LinkedHashMap<String, String>() {{
             put("Hello", "World");
@@ -189,7 +190,7 @@ class InputRightCurlyTestWithAnnotations
             add("AB21/X");
             add("YYLEX");
             add("AR5E");
-        }}); // violation
+        }}); // violation ''}' at column 9 should be alone on a line'
 
         foo23(new java.util.HashSet<String>() {{
             add("XZ13s");
@@ -197,7 +198,6 @@ class InputRightCurlyTestWithAnnotations
             add("YYLEX");
             add("AR5E");
         }});} // 2 violations
-
 
     void foo23(java.util.HashSet<String> set) {
     }
@@ -216,41 +216,41 @@ class InputRightCurlyTestWithAnnotations
 
     private java.util.ArrayList<Integer> foo28(int delta) {
         return new java.util.ArrayList<Integer>() {
-        @Override public int size() { return Math.max(0, super.size() + 1);}; // violation
-        };
+        @Override public int size() { return Math.max(0, super.size() + 1);};
+        }; // violation above ''}' at column 76 should be alone on a line'
     }
 
     private void foo29() {
         boolean flag = true;
         if (flag) {
             System.identityHashCode("heh");
-            flag = !flag; } String.CASE_INSENSITIVE_ORDER. // violation
-            equals("Xe-xe");
+            flag = !flag; } String. // violation ''}' at column 27 should be alone on a line'
+                CASE_INSENSITIVE_ORDER.equals("Xe-xe");
     }
 
-    public void testMethod() {}; // violation
+    public void testMethod() {}; // violation ''}' at column 31 should be alone on a line'
 
     public void testMethod1() {
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
-    public class TestClass {}; // violation
+    public class TestClass {}; // violation ''}' at column 29 should be alone on a line'
 
     public class TestClass1 {
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
     public class TestClass2 {
-        public TestClass2() {}; // violation
+        public TestClass2() {}; // violation ''}' at column 30 should be alone on a line'
 
         public TestClass2(String someValue) {
-        }; // violation
+        }; // violation ''}' at column 9 should be alone on a line'
     }
 
-   public @interface TestAnnotation {} // violation
-
-    public @interface TestAnnotation1{ String value(); } // violation
+    public @interface TestAnnotation {} // violation ''}' at column 39 should be alone on a line'
+    // violation below ''}' at column 56 should be alone on a line'
+    public @interface TestAnnotation1{ String value(); }
 
     public @interface TestAnnotation2 {
-        String value();} // violation
+        String value();} // violation ''}' at column 24 should be alone on a line'
 
     public @interface TestAnnotation3 {
         String value();
@@ -260,16 +260,17 @@ class InputRightCurlyTestWithAnnotations
     }
 
     public @interface TestAnnnotation5 {
-        String someValue(); }; // violation
+        String someValue(); }; // violation ''}' at column 29 should be alone on a line'
 
-    public @interface TestAnnotation6 {}; // violation
+    public @interface TestAnnotation6 {}; // violation ''}' at column 40 should be alone on a line'
 
     public @interface TestAnnotation7 {
         String someValue();
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
     public @interface TestAnnotation8 { String someValue();
-    }; // violation
+    }; // violation ''}' at column 5 should be alone on a line'
 
-    public @interface TestAnnotation9 { String someValue(); }; // violation
+    public @interface TestAnnotation9 { String someValue(); };
+    // violation above ''}' at column 61 should be alone on a line'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestWithoutFinally.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestWithoutFinally.java
@@ -13,14 +13,14 @@ class InputRightCurlyTestWithoutFinally
     void foo() throws InterruptedException
     {
 
-            try
-            {
+        try
+        {
 
-            } // violation
-            catch (Exception e)
-            {
-                return;
-            }
+        } // violation ''}' at col.* 9 should be on the same line as the next part of a multi-block statement'
+        catch (Exception e)
+        {
+            return;
+        }
 
         }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTryWithResourceAloneSingle.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTryWithResourceAloneSingle.java
@@ -24,7 +24,7 @@ class InputRightCurlyTryWithResourceAloneSingle {
                 BufferedReader br2 = new BufferedReader(br1))
         {
             ;
-        } catch (IOException e) // violation
+        } catch (IOException e) // violation ''}' at column 9 should be alone on a line'
         {
             ;
         }
@@ -32,17 +32,17 @@ class InputRightCurlyTryWithResourceAloneSingle {
                 BufferedReader br2 = new BufferedReader(br1)) { ; } // ok
         catch (IOException e) { ; } // ok
         try (BufferedReader br1 = new BufferedReader(null);
-
+                // violation below ''}' at column 64 should be alone on a line'
                 BufferedReader br2 = new BufferedReader(br1)) {} catch (IOException e) { ; }
-        try (BufferedReader br1 = new BufferedReader(null); // violation above
+        try (BufferedReader br1 = new BufferedReader(null);
                 BufferedReader br2 = new BufferedReader(br1)) {
             ;
         }
         try (BufferedReader br1 = new BufferedReader(null);
                 BufferedReader br2 = new BufferedReader(br1)) { ; } // ok
         try (BufferedReader br1 = new BufferedReader(null)) {
-            ; } // violation
+            ; } // violation ''}' at column 15 should be alone on a line'
         try (BufferedReader br1 = new BufferedReader(null)) {
-            } int i; // violation
+            } int i; // violation ''}' at column 13 should be alone on a line'
     }
 }


### PR DESCRIPTION
Issue #11214: Specified violation message in RightCurlyCheck


I am having trouble with this error. 
I have shorten the long violation message but I am getting an error that the violation message does not match with the message in properties file.
I don't want to change the violation message in `messages.properties`. I try to use regex but it does not match.
Can you give me some guidelines to solve this error?
```
[ERROR] Failures: 
[ERROR]   RightCurlyCheckTest.testDefault:61->AbstractModuleTestSupport.verifyWithInlineConfigParser:271->AbstractModuleTestSupport.verifyViolations:448 Actual and expected violations differ.
expected to match: 25:(?:\d+:)?\s.*'}' at column 17 should be on the same line with else if.*
but was          : 25:17: '}' at column 17 should be on the same line as the next part of a multi-block statement (one that directly contains multiple blocks: if/else-if/else, do/while or try/catch/finally).
[ERROR]   RightCurlyCheckTest.testRightCurlySameAndLiteralDo:352->AbstractModuleTestSupport.verifyWithInlineConfigParser:271->AbstractModuleTestSupport.verifyViolations:448 Actual and expected violations differ.
expected to match: 70:(?:\d+:)?\s.*'}' at column 17 should be on the same line with while.*
but was          : 70:9: '}' at column 9 should be on the same line as the next part of a multi-block statement (one that directly contains multiple blocks: if/else-if/else, do/while or try/catch/finally).
```