### PR TITLE
Issue #11531: Fixed methods for package-info file check

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java
@@ -334,6 +334,6 @@ public final class FileContents implements CommentListener {
      */
     @Deprecated(since = "10.2")
     public boolean inPackageInfo() {
-        return getFileName().endsWith("package-info.java");
+        return "package-info.java".equals(text.getFile().getName());
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.utils;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -688,6 +689,6 @@ public final class CheckUtil {
      * @return true if the package file.
      */
     public static boolean isPackageInfo(String filePath) {
-        return filePath.endsWith("package-info.java");
+        return "package-info.java".equals(new File(filePath).getName());
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
@@ -258,7 +258,7 @@ public class FileContentsTest {
     @Test
     public void testInPackageInfo() {
         final FileContents fileContents = new FileContents(new FileText(
-                new File("filename.package-info.java"),
+                new File("package-info.java"),
                 Collections.singletonList("  //   ")));
 
         assertWithMessage("Should return true when in package info")
@@ -269,7 +269,7 @@ public class FileContentsTest {
     @Test
     public void testNotInPackageInfo() {
         final FileContents fileContents = new FileContents(new FileText(
-                new File("filename.java"),
+                new File("some-package-info.java"),
                 Collections.singletonList("  //   ")));
 
         assertWithMessage("Should return false when not in package info")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocPackageCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocPackageCheckTest.java
@@ -137,6 +137,13 @@ public class MissingJavadocPackageCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testNotPackageInfo() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyFilterWithInlineConfigParser(
+                getPath("InputMissingJavadocPackageNotPackageInfo-package-info.java"), expected);
+    }
+
+    @Test
     public void testTokensAreCorrect() {
         final MissingJavadocPackageCheck check = new MissingJavadocPackageCheck();
         final int[] expected = {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/InputMissingJavadocPackageNotPackageInfo-package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocpackage/InputMissingJavadocPackageNotPackageInfo-package-info.java
@@ -1,0 +1,7 @@
+/*
+MissingJavadocPackage
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocpackage; // ok


### PR DESCRIPTION
Fixed the issue #11531 by checking if the file name is equal to "package-info.java".