### PR TITLE
Issue #10043: Fixed SuppressWarnings not working on local variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
     <maven.site.plugin.version>3.12.0</maven.site.plugin.version>
     <maven.spotbugs.plugin.version>4.6.0.0</maven.spotbugs.plugin.version>
     <maven.pmd.plugin.version>3.16.0</maven.pmd.plugin.version>
-    <pmd.version>6.44.0</pmd.version>
+    <pmd.version>6.45.0</pmd.version>
     <maven.jacoco.plugin.version>0.8.8</maven.jacoco.plugin.version>
     <mockito.version>4.5.1</mockito.version>
     <saxon.version>11.3</saxon.version>

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
     <mockito.version>4.5.1</mockito.version>
     <saxon.version>11.3</saxon.version>
     <maven.checkstyle.plugin.version>3.1.2</maven.checkstyle.plugin.version>
-    <maven.sevntu.checkstyle.plugin.version>1.41.0</maven.sevntu.checkstyle.plugin.version>
+    <maven.sevntu.checkstyle.plugin.version>1.42.0</maven.sevntu.checkstyle.plugin.version>
     <maven.sevntu-checkstyle-check.checkstyle.version>
       9.1
     </maven.sevntu-checkstyle-check.checkstyle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
     <maven.checkstyle.plugin.version>3.1.2</maven.checkstyle.plugin.version>
     <maven.sevntu.checkstyle.plugin.version>1.42.0</maven.sevntu.checkstyle.plugin.version>
     <maven.sevntu-checkstyle-check.checkstyle.version>
-      9.1
+      10.0
     </maven.sevntu-checkstyle-check.checkstyle.version>
     <maven.versions.plugin.version>2.10.0</maven.versions.plugin.version>
     <java.version>11</java.version>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -335,7 +335,7 @@ public class SuppressWarningsHolder
         }
         else {
             lastLine = nextAST.getLineNo();
-            lastColumn = nextAST.getColumnNo() - 1;
+            lastColumn = nextAST.getColumnNo();
         }
 
         final List<Entry> entries = ENTRIES.get();

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheckTest.java
@@ -46,7 +46,7 @@ public class MagicNumberCheckTest
     public void testLocalVariables2()
             throws Exception {
         final String[] expected = {
-            "25:17: " + getCheckMessage(MSG_KEY, "8"),
+                "25:17: " + getCheckMessage(MSG_KEY, "8"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMagicNumber_9.java"), expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheckTest.java
@@ -46,7 +46,7 @@ public class MagicNumberCheckTest
     public void testLocalVariables2()
             throws Exception {
         final String[] expected = {
-                "25:17: " + getCheckMessage(MSG_KEY, "8"),
+            "25:17: " + getCheckMessage(MSG_KEY, "8"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputMagicNumber_9.java"), expected);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheckTest.java
@@ -24,6 +24,7 @@ import static com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck.MSG
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class MagicNumberCheckTest
     extends AbstractModuleTestSupport {
@@ -31,6 +32,24 @@ public class MagicNumberCheckTest
     @Override
     protected String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/checks/coding/magicnumber";
+    }
+
+    @Test
+    public void testLocalVariables()
+            throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputMagicNumber_8.java"), expected);
+    }
+
+    @Test
+    public void testLocalVariables2()
+            throws Exception {
+        final String[] expected = {
+            "25:17: " + getCheckMessage(MSG_KEY, "8"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputMagicNumber_9.java"), expected);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumber_8.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumber_8.java
@@ -1,0 +1,33 @@
+/*
+MagicNumber
+ignoreNumbers = (default)-1, 0, 1, 2
+ignoreHashCodeMethod = (default)false
+ignoreAnnotation = (default)false
+ignoreFieldDeclaration = (default)false
+ignoreAnnotationElementDefaults = (default)true
+constantWaiverParentToken = (default)TYPECAST, METHOD_CALL, EXPR, ARRAY_INIT, UNARY_MINUS, \
+                            UNARY_PLUS, ELIST, STAR, ASSIGN, PLUS, MINUS, DIV, LITERAL_NEW
+tokens = (default)NUM_DOUBLE, NUM_FLOAT, NUM_INT, NUM_LONG
+
+com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter
+
+com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.magicnumber;
+
+public class InputMagicNumber_8 {
+    @SuppressWarnings("MagicNumber")
+    private int A = 8; // ok
+
+    @SuppressWarnings("MagicNumber")
+    void method() {
+        int b = 8; // ok
+    }
+
+    void method2() {
+        @SuppressWarnings("MagicNumber")
+        int c = 8; // ok
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumber_9.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/magicnumber/InputMagicNumber_9.java
@@ -1,0 +1,32 @@
+/*
+MagicNumber
+ignoreNumbers = (default)-1, 0, 1, 2
+ignoreHashCodeMethod = (default)false
+ignoreAnnotation = (default)false
+ignoreFieldDeclaration = (default)false
+ignoreAnnotationElementDefaults = (default)true
+constantWaiverParentToken = (default)TYPECAST, METHOD_CALL, EXPR, ARRAY_INIT, UNARY_MINUS, \
+                            UNARY_PLUS, ELIST, STAR, ASSIGN, PLUS, MINUS, DIV, LITERAL_NEW
+tokens = (default)NUM_DOUBLE, NUM_FLOAT, NUM_INT, NUM_LONG
+
+com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter
+
+com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.magicnumber;
+
+public class InputMagicNumber_9 {
+    @SuppressWarnings("MagicNumber")
+    private int A = 8; // ok
+
+    void method() {
+        int b = 8; // violation
+    }
+
+    void method2() {
+        @SuppressWarnings("MagicNumber")
+        int c = 8; // ok
+    }
+}


### PR DESCRIPTION
Issue #10043

The bug in line 12 is caused by the following line [lastColumn = nextAST.getColumnNo() - 1;](https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java#L338)
It will lead to the 8 of the method2() be out of the range of the SuppressWarnings and will not be suppressed. The end position of the SuppressWarnings will be located to the ";" at the end of the code line. If it minus one, it will not cover the "8", which is just before the ";" .
