### PR TITLE
Resolve IDEA violations from Teamcity 2022.04 part 2

### DIFF
--- a/config/intellij-idea-inspections.properties
+++ b/config/intellij-idea-inspections.properties
@@ -1,6 +1,7 @@
 # this file is used by .ci/idea_inspection.sh and .ci/idea_inspection.bat
 # Content should be the same as in TeamCity "Include / exclude patterns:"
 idea.exclude.patterns=.idea/**;\
+              .ci/*.config\
               target/**;\
               src/test/resources/**;\
               src/it/resources/**;\

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
@@ -153,12 +153,14 @@ public final class DefaultConfiguration implements Configuration {
      */
     public void addProperty(String propertyName, String value) {
         final String current = propertyMap.get(propertyName);
+        final String newValue;
         if (current == null) {
-            propertyMap.put(propertyName, value);
+            newValue = value;
         }
         else {
-            propertyMap.put(propertyName, current + "," + value);
+            newValue = current + "," + value;
         }
+        propertyMap.put(propertyName, newValue);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java
@@ -229,7 +229,7 @@ public class OrderedPropertiesCheck extends AbstractFileSetCheck {
          * Returns a copy of the keys.
          */
         @Override
-        public synchronized Enumeration<Object> keys() {
+        public Enumeration<Object> keys() {
             return Collections.enumeration(keyList);
         }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.annotation;
 
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -214,15 +215,10 @@ public class SuppressWarningsCheck extends AbstractCheck {
 
             final DetailAST token =
                     warningHolder.findFirstToken(TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR);
-            DetailAST warning;
 
-            if (token == null) {
-                warning = warningHolder.findFirstToken(TokenTypes.EXPR);
-            }
-            else {
-                // case like '@SuppressWarnings(value = UNUSED)'
-                warning = token.findFirstToken(TokenTypes.EXPR);
-            }
+            // case like '@SuppressWarnings(value = UNUSED)'
+            final DetailAST parent = Objects.requireNonNullElse(token, warningHolder);
+            DetailAST warning = parent.findFirstToken(TokenTypes.EXPR);
 
             // rare case with empty array ex: @SuppressWarnings({})
             if (warning == null) {
@@ -307,23 +303,11 @@ public class SuppressWarningsCheck extends AbstractCheck {
     private static DetailAST findWarningsHolder(final DetailAST annotation) {
         final DetailAST annValuePair =
             annotation.findFirstToken(TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR);
-        final DetailAST annArrayInit;
 
-        if (annValuePair == null) {
-            annArrayInit =
-                    annotation.findFirstToken(TokenTypes.ANNOTATION_ARRAY_INIT);
-        }
-        else {
-            annArrayInit =
-                    annValuePair.findFirstToken(TokenTypes.ANNOTATION_ARRAY_INIT);
-        }
-
-        DetailAST warningsHolder = annotation;
-        if (annArrayInit != null) {
-            warningsHolder = annArrayInit;
-        }
-
-        return warningsHolder;
+        final DetailAST annArrayInitParent = Objects.requireNonNullElse(annValuePair, annotation);
+        final DetailAST annArrayInit = annArrayInitParent
+                .findFirstToken(TokenTypes.ANNOTATION_ARRAY_INIT);
+        return Objects.requireNonNullElse(annArrayInit, annotation);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.design;
 
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -509,14 +510,8 @@ public class DesignForExtensionCheck extends AbstractCheck {
      */
     private static String getAnnotationName(DetailAST annotation) {
         final DetailAST dotAst = annotation.findFirstToken(TokenTypes.DOT);
-        final String name;
-        if (dotAst == null) {
-            name = annotation.findFirstToken(TokenTypes.IDENT).getText();
-        }
-        else {
-            name = dotAst.findFirstToken(TokenTypes.IDENT).getText();
-        }
-        return name;
+        final DetailAST parent = Objects.requireNonNullElse(dotAst, annotation);
+        return parent.findFirstToken(TokenTypes.IDENT).getText();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java
@@ -19,6 +19,8 @@
 
 package com.puppycrawl.tools.checkstyle.checks.design;
 
+import java.util.Objects;
+
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -299,14 +301,8 @@ public final class ThrowsCountCheck extends AbstractCheck {
      */
     private static String getAnnotationName(DetailAST annotation) {
         final DetailAST dotAst = annotation.findFirstToken(TokenTypes.DOT);
-        final String name;
-        if (dotAst == null) {
-            name = annotation.findFirstToken(TokenTypes.IDENT).getText();
-        }
-        else {
-            name = dotAst.findFirstToken(TokenTypes.IDENT).getText();
-        }
-        return name;
+        final DetailAST parent = Objects.requireNonNullElse(dotAst, annotation);
+        return parent.findFirstToken(TokenTypes.IDENT).getText();
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -493,13 +493,9 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
                 final String actualViolationFileName = actualViolation[0];
                 final String actualViolationMessage = actualViolation[1];
 
-                List<String> actualViolationsPerFile =
-                        actualViolations.get(actualViolationFileName);
-                if (actualViolationsPerFile == null) {
-                    actualViolationsPerFile = new ArrayList<>();
-                    actualViolations.put(actualViolationFileName, actualViolationsPerFile);
-                }
-                actualViolationsPerFile.add(actualViolationMessage);
+                actualViolations
+                        .computeIfAbsent(actualViolationFileName, key -> new ArrayList<>())
+                        .add(actualViolationMessage);
             }
 
             return actualViolations;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractXmlTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractXmlTestSupport.java
@@ -46,7 +46,7 @@ public abstract class AbstractXmlTestSupport extends AbstractModuleTestSupport {
      */
     protected static Document getOutputStreamXml(ByteArrayOutputStream outputStream)
             throws ParserConfigurationException {
-        final String xml = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
+        final String xml = outputStream.toString(StandardCharsets.UTF_8);
 
         return XmlUtil.getRawXml("audit output", xml, xml);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
@@ -286,8 +286,8 @@ public class SarifLoggerTest extends AbstractModuleTestSupport {
             String expectedOutputFile,
             ByteArrayOutputStream actualOutputStream) throws IOException {
         final String expectedContent = readFile(expectedOutputFile);
-        final String actualContent = toLfLineEnding(new String(actualOutputStream.toByteArray(),
-                StandardCharsets.UTF_8));
+        final String actualContent =
+                toLfLineEnding(actualOutputStream.toString(StandardCharsets.UTF_8));
         assertWithMessage("sarif content should match")
             .that(actualContent)
             .isEqualTo(expectedContent);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheckTest.java
@@ -76,6 +76,14 @@ public class FallThroughCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testStringSwitch() throws Exception {
+        final String[] expected = {
+            "21:9: " + getCheckMessage(MSG_FALL_THROUGH),
+        };
+        verifyWithInlineConfigParser(getPath("InputFallThroughStringSwitch.java"), expected);
+    }
+
+    @Test
     public void testLastCaseGroup() throws Exception {
         final String[] expected = {
             "22:13: " + getCheckMessage(MSG_FALL_THROUGH),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheckTest.java
@@ -70,6 +70,16 @@ public class InnerAssignmentCheckTest
     }
 
     @Test
+    public void testInnerAssignmentNotInLoopContext() throws Exception {
+        final String[] expected = {
+            "12:28: " + getCheckMessage(MSG_KEY),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputInnerAssignmentNotInLoopContext.java"),
+                expected);
+    }
+
+    @Test
     public void testTokensNotNull() {
         final InnerAssignmentCheck check = new InnerAssignmentCheck();
         assertWithMessage("Acceptable tokens should not be null")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtilTest.java
@@ -27,7 +27,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -45,7 +44,7 @@ import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
 @ExtendWith(SystemOutGuard.class)
 public final class MetadataGeneratorUtilTest extends AbstractModuleTestSupport {
 
-    private final List<String> modulesContainingNoMetadataFile = Arrays.asList(
+    private final Set<String> modulesContainingNoMetadataFile = Set.of(
             "Checker",
             "TreeWalker",
             "JavadocMetadataScraper"

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThroughStringSwitch.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThroughStringSwitch.java
@@ -1,0 +1,25 @@
+/*
+FallThrough
+checkLastCaseGroup = (default)false
+reliefPattern = (default)falls?[ -]?thr(u|ough)
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.fallthrough;
+
+public class InputFallThroughStringSwitch
+{
+    int method(String arg) {
+        int i = 0;
+        switch (arg) {
+        case "ok": // ok
+        case "break":
+            break;
+        case "violation":
+            i++;
+        case "fallthru": // violation 'Fall through from previous branch of the switch statement.'
+      }
+      return i;
+   }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/innerassignment/InputInnerAssignmentNotInLoopContext.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/innerassignment/InputInnerAssignmentNotInLoopContext.java
@@ -1,0 +1,13 @@
+/*
+InnerAssignment
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.innerassignment;
+
+
+public class InputInnerAssignmentNotInLoopContext {
+    int value = 3;
+    boolean b = 1 > (value = 2); // violation
+}


### PR DESCRIPTION
Issue #11566 

* syntax error in `.config` files
* ~~'if' statement can be replaced with conditional or boolean expression~~
* null check can be replaced with method
* call to set.removeAll may work slowly
* redundant string operation
* synchronized method

Two new test inputs added: for an assignment not within a loop and for "fallthru" outside of a comment.