### PR TITLE
Issue #7624: Updated doc for NoWhitespaceAfter

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
@@ -99,6 +99,19 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  *   &lt;property name=&quot;allowLineBreaks&quot; value=&quot;false&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>To Configure the check to restrict the use of whitespace after TYPECAST:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;NoWhitespaceAfter&quot;&gt;
+ *   &lt;property name=&quot;tokens&quot; value=&quot;TYPECAST&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * int test6;
+ * long test8 = (long) test6;// violation,whitespace after '(long)' is not allowed
+ * long test9 = (long)test6;//OK
+ * </pre>
  * <p>
  * If the annotation is between the type and the array, the check will skip validation for spaces:
  * </p>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheckTest.java
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// checkstyle: Checks Java source code for adherence to a set of rules.
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
 // Copyright (C) 2001-2022 the original author or authors.
 //
 // This library is free software; you can redistribute it and/or
@@ -80,6 +80,7 @@ public class NoWhitespaceAfterCheckTest
             "87:20: " + getCheckMessage(MSG_KEY, ")"),
             "89:13: " + getCheckMessage(MSG_KEY, ")"),
             "241:17: " + getCheckMessage(MSG_KEY, ")"),
+            "311:18 : " + getCheckMessage(MSG_KEY, ")"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputNoWhitespaceAfterTestTypecast.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterTestTypecast.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/nowhitespaceafter/InputNoWhitespaceAfterTestTypecast.java
@@ -306,4 +306,10 @@ class SpecialCasesInForLoopTestTypecast
 
     int someStuff8
     []; // ok
+
+    int test6;
+    long test8 = (long ) test6; // violation
+    long test9 = (long)test6; // ok
+
+
 }

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -1426,6 +1426,20 @@ import static java.math.BigInteger.ZERO;
 &lt;/module&gt;
         </source>
         <p>
+          To Configure the check to restrict the use of whitespace after TYPECAST:
+        </p>
+        <source>
+&lt;module name=&quot;NoWhitespaceAfter&quot;&gt;
+  &lt;property name=&quot;tokens&quot; value=&quot;TYPECAST&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+int test6;
+long test8 = (long) test6;// violation,whitespace after '(long)' is not allowed
+long test9 = (long)test6;//OK
+        </source>
+        <p>
          If the annotation is between the type and the array, the check will skip validation for
          spaces:
         </p>


### PR DESCRIPTION
Issue #7624 Updated
![image](https://user-images.githubusercontent.com/84538746/164992705-60a6095d-c895-4046-83af-0399c20ebcde.png)
````
$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
    "https://checkstyle.org/dtds/configuration_1_3.dtd">

    <module name = "Checker">
        <property name="charset" value="UTF-8"/>
        <module name="TreeWalker">
          <module name="NoWhitespaceAfter">
            <property name="tokens" value="TYPECAST" />
          </module>
        </module>
    </module>
    
$ cat TYPECASTTest.java
class TYPECASTTest {
  int test6;
  long test8 = (long) test6;// violation,whitespace after '(long)' is not allowed
  long test9 = (long)test6;//OK
}

$ java -jar checkstyle-10.1-all.jar -c config.xml TYPECASTTest.java
Starting audit...
[ERROR] /home/izumi-kanata/checkstyle/TYPECASTTest.java:5:16: ')' is followed by whitespace. [NoWhitespaceAfter]
Audit done.
Checkstyle ends with 1 errors.
````