### PR TITLE
minor: removes checkstyle specific class in ReverseListIterator

### DIFF
--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -233,6 +233,11 @@
     <allow class="com.puppycrawl.tools.checkstyle.xpath.AbstractNode"/>
     <allow pkg="com.puppycrawl.tools.checkstyle.xpath.iterators" local-only="true"/>
     <allow class="com.puppycrawl.tools.checkstyle.TreeWalkerAuditEvent" local-only="true"/>
+
+    <subpackage name="iterators">
+      <!-- These are more saxon utilities, and should not have anything checkstyle specific -->
+      <disallow pkg="com\.puppycrawl.*" regex="true"/>
+    </subpackage>
   </subpackage>
 
   <subpackage name="grammar">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseListIterator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseListIterator.java
@@ -22,7 +22,6 @@ package com.puppycrawl.tools.checkstyle.xpath.iterators;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.puppycrawl.tools.checkstyle.xpath.AbstractNode;
 import net.sf.saxon.om.NodeInfo;
 import net.sf.saxon.tree.iter.AxisIterator;
 
@@ -33,7 +32,7 @@ public class ReverseListIterator implements AxisIterator {
     /**
      * List of nodes.
      */
-    private final List<AbstractNode> items;
+    private final List<? extends NodeInfo> items;
     /**
      * Current index.
      */
@@ -44,7 +43,7 @@ public class ReverseListIterator implements AxisIterator {
      *
      * @param items the list of nodes.
      */
-    public ReverseListIterator(List<AbstractNode> items) {
+    public ReverseListIterator(List<? extends NodeInfo> items) {
         if (items == null) {
             this.items = null;
             index = -1;


### PR DESCRIPTION
`ReverseListIterator` is basically a utility class. It shouldn't have anything specific to checkstyle similar to `ReverseDescendantIterator` and the others...