### PR TITLE
Some reworking for test structures

### DIFF
--- a/src/it/java/com/google/checkstyle/test/base/AbstractGoogleModuleTestSupport.java
+++ b/src/it/java/com/google/checkstyle/test/base/AbstractGoogleModuleTestSupport.java
@@ -20,14 +20,11 @@
 package com.google.checkstyle.test.base;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 
 import org.checkstyle.base.AbstractItModuleTestSupport;
 
 import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.PropertiesExpander;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
@@ -76,11 +73,6 @@ public abstract class AbstractGoogleModuleTestSupport extends AbstractItModuleTe
         return moduleCreationOption;
     }
 
-    @Override
-    protected DefaultConfiguration createModuleConfig(Class<?> clazz) {
-        return new DefaultConfiguration(clazz.getName());
-    }
-
     /**
      * Returns {@link Configuration} instance for the given module name.
      * This implementation uses {@link #getModuleConfig(String, String)} method inside.
@@ -102,54 +94,7 @@ public abstract class AbstractGoogleModuleTestSupport extends AbstractItModuleTe
      * @throws IllegalStateException if there is a problem retrieving the module or config.
      */
     protected static Configuration getModuleConfig(String moduleName, String moduleId) {
-        final Configuration result;
-        final List<Configuration> configs = getModuleConfigs(moduleName);
-        if (configs.size() == 1) {
-            result = configs.get(0);
-        }
-        else if (configs.isEmpty()) {
-            throw new IllegalStateException("no instances of the Module was found: " + moduleName);
-        }
-        else if (moduleId == null) {
-            throw new IllegalStateException("multiple instances of the same Module are detected");
-        }
-        else {
-            result = configs.stream().filter(conf -> {
-                try {
-                    return conf.getProperty("id").equals(moduleId);
-                }
-                catch (CheckstyleException ex) {
-                    throw new IllegalStateException("problem to get ID attribute from " + conf, ex);
-                }
-            })
-            .findFirst()
-            .orElseThrow(() -> new IllegalStateException("problem with module config"));
-        }
-
-        return result;
-    }
-
-    /**
-     * Returns a list of all {@link Configuration} instances for the given module name.
-     *
-     * @param moduleName module name.
-     * @return {@link Configuration} instance for the given module name.
-     */
-    protected static List<Configuration> getModuleConfigs(String moduleName) {
-        final List<Configuration> result = new ArrayList<>();
-        for (Configuration currentConfig : CONFIGURATION.getChildren()) {
-            if ("TreeWalker".equals(currentConfig.getName())) {
-                for (Configuration moduleConfig : currentConfig.getChildren()) {
-                    if (moduleName.equals(moduleConfig.getName())) {
-                        result.add(moduleConfig);
-                    }
-                }
-            }
-            else if (moduleName.equals(currentConfig.getName())) {
-                result.add(currentConfig);
-            }
-        }
-        return result;
+        return getModuleConfig(CONFIGURATION, moduleName, moduleId);
     }
 
 }

--- a/src/it/java/com/sun/checkstyle/test/base/AbstractSunModuleTestSupport.java
+++ b/src/it/java/com/sun/checkstyle/test/base/AbstractSunModuleTestSupport.java
@@ -20,14 +20,11 @@
 package com.sun.checkstyle.test.base;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 
 import org.checkstyle.base.AbstractItModuleTestSupport;
 
 import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.PropertiesExpander;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
@@ -76,11 +73,6 @@ public abstract class AbstractSunModuleTestSupport extends AbstractItModuleTestS
         return moduleCreationOption;
     }
 
-    @Override
-    protected DefaultConfiguration createModuleConfig(Class<?> clazz) {
-        return new DefaultConfiguration(clazz.getName());
-    }
-
     /**
      * Returns {@link Configuration} instance for the given module name.
      * This implementation uses {@link #getModuleConfig(String, String)} method inside.
@@ -102,54 +94,7 @@ public abstract class AbstractSunModuleTestSupport extends AbstractItModuleTestS
      * @throws IllegalStateException if there is a problem retrieving the module or config.
      */
     protected static Configuration getModuleConfig(String moduleName, String moduleId) {
-        final Configuration result;
-        final List<Configuration> configs = getModuleConfigs(moduleName);
-        if (configs.size() == 1) {
-            result = configs.get(0);
-        }
-        else if (configs.isEmpty()) {
-            throw new IllegalStateException("no instances of the Module was found: " + moduleName);
-        }
-        else if (moduleId == null) {
-            throw new IllegalStateException("multiple instances of the same Module are detected");
-        }
-        else {
-            result = configs.stream().filter(conf -> {
-                try {
-                    return conf.getProperty("id").equals(moduleId);
-                }
-                catch (CheckstyleException ex) {
-                    throw new IllegalStateException("problem to get ID attribute from " + conf, ex);
-                }
-            })
-            .findFirst()
-            .orElseThrow(() -> new IllegalStateException("problem with module config"));
-        }
-
-        return result;
-    }
-
-    /**
-     * Returns a list of all {@link Configuration} instances for the given module name.
-     *
-     * @param moduleName module name.
-     * @return {@link Configuration} instance for the given module name.
-     */
-    protected static List<Configuration> getModuleConfigs(String moduleName) {
-        final List<Configuration> result = new ArrayList<>();
-        for (Configuration currentConfig : CONFIGURATION.getChildren()) {
-            if ("TreeWalker".equals(currentConfig.getName())) {
-                for (Configuration moduleConfig : currentConfig.getChildren()) {
-                    if (moduleName.equals(moduleConfig.getName())) {
-                        result.add(moduleConfig);
-                    }
-                }
-            }
-            else if (moduleName.equals(currentConfig.getName())) {
-                result.add(currentConfig);
-            }
-        }
-        return result;
+        return getModuleConfig(CONFIGURATION, moduleName, moduleId);
     }
 
 }

--- a/src/it/java/org/checkstyle/base/AbstractCheckstyleModuleTestSupport.java
+++ b/src/it/java/org/checkstyle/base/AbstractCheckstyleModuleTestSupport.java
@@ -19,7 +19,6 @@
 
 package org.checkstyle.base;
 
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.utils.ModuleReflectionUtil;
 
 public abstract class AbstractCheckstyleModuleTestSupport extends AbstractItModuleTestSupport {
@@ -42,11 +41,6 @@ public abstract class AbstractCheckstyleModuleTestSupport extends AbstractItModu
         }
 
         return moduleCreationOption;
-    }
-
-    @Override
-    protected DefaultConfiguration createModuleConfig(Class<?> clazz) {
-        return new DefaultConfiguration(clazz.getName());
     }
 
 }

--- a/src/it/java/org/checkstyle/base/AbstractItModuleTestSupport.java
+++ b/src/it/java/org/checkstyle/base/AbstractItModuleTestSupport.java
@@ -45,6 +45,7 @@ import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.TreeWalker;
 import com.puppycrawl.tools.checkstyle.api.AbstractViolationReporter;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.internal.utils.BriefUtLogger;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
@@ -85,20 +86,89 @@ public abstract class AbstractItModuleTestSupport extends AbstractPathTestSuppor
     protected abstract ModuleCreationOption findModuleCreationOption(String moduleName);
 
     /**
-     * Creates {@link DefaultConfiguration} instance for the given module class.
-     *
-     * @param clazz module class.
-     * @return {@link DefaultConfiguration} instance.
-     */
-    protected abstract DefaultConfiguration createModuleConfig(Class<?> clazz);
-
-    /**
      * Returns test logger.
      *
      * @return logger for tests
      */
     protected final BriefUtLogger getBriefUtLogger() {
         return new BriefUtLogger(stream);
+    }
+
+    /**
+     * Creates a default module configuration {@link DefaultConfiguration} for a given object
+     * of type {@link Class}.
+     *
+     * @param clazz a {@link Class} type object.
+     * @return default module configuration for the given {@link Class} instance.
+     */
+    protected static DefaultConfiguration createModuleConfig(Class<?> clazz) {
+        return new DefaultConfiguration(clazz.getName());
+    }
+
+    /**
+     * Returns {@link Configuration} instance for the given module name pulled
+     * from the {@code masterConfig}.
+     *
+     * @param masterConfig The master configuration to examine.
+     * @param moduleName module name.
+     * @param moduleId module id.
+     * @return {@link Configuration} instance for the given module name.
+     * @throws IllegalStateException if there is a problem retrieving the module
+     *         or config.
+     */
+    protected static Configuration getModuleConfig(Configuration masterConfig, String moduleName,
+            String moduleId) {
+        final Configuration result;
+        final List<Configuration> configs = getModuleConfigs(masterConfig, moduleName);
+        if (configs.size() == 1) {
+            result = configs.get(0);
+        }
+        else if (configs.isEmpty()) {
+            throw new IllegalStateException("no instances of the Module was found: " + moduleName);
+        }
+        else if (moduleId == null) {
+            throw new IllegalStateException("multiple instances of the same Module are detected");
+        }
+        else {
+            result = configs.stream().filter(conf -> {
+                try {
+                    return conf.getProperty("id").equals(moduleId);
+                }
+                catch (CheckstyleException ex) {
+                    throw new IllegalStateException("problem to get ID attribute from " + conf, ex);
+                }
+            })
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("problem with module config"));
+        }
+
+        return result;
+    }
+
+    /**
+     * Returns a list of all {@link Configuration} instances for the given
+     * module name pulled from the {@code masterConfig}.
+     *
+     * @param masterConfig The master configuration to examine.
+     * @param moduleName module name.
+     * @return {@link Configuration} instance for the given module name.
+     */
+    protected static List<Configuration> getModuleConfigs(Configuration masterConfig,
+            String moduleName) {
+        final List<Configuration> result = new ArrayList<>();
+        for (Configuration currentConfig : masterConfig.getChildren()) {
+            if ("TreeWalker".equals(currentConfig.getName())) {
+                for (Configuration moduleConfig : currentConfig.getChildren()) {
+                    if (moduleName.equals(moduleConfig.getName())) {
+                        result.add(moduleConfig);
+                    }
+                }
+            }
+            else if (moduleName.equals(currentConfig.getName())) {
+                result.add(currentConfig);
+            }
+        }
+        return result;
     }
 
     /**
@@ -158,9 +228,9 @@ public abstract class AbstractItModuleTestSupport extends AbstractPathTestSuppor
      * @return {@link DefaultConfiguration} for the {@link TreeWalker}
      *     based on the given {@link Configuration} instance.
      */
-    protected final DefaultConfiguration createTreeWalkerConfig(Configuration config) {
+    protected static DefaultConfiguration createTreeWalkerConfig(Configuration config) {
         final DefaultConfiguration dc =
-                new DefaultConfiguration("configuration");
+                new DefaultConfiguration(ROOT_MODULE_NAME);
         final DefaultConfiguration twConf = createModuleConfig(TreeWalker.class);
         // make sure that the tests always run with this charset
         dc.addProperty("charset", StandardCharsets.UTF_8.name());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -52,25 +52,7 @@ import com.puppycrawl.tools.checkstyle.utils.ModuleReflectionUtil;
 
 public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport {
 
-    /**
-     * Enum to specify options for checker creation.
-     */
-    public enum ModuleCreationOption {
-
-        /**
-         * Points that the module configurations
-         * has to be added under {@link TreeWalker}.
-         */
-        IN_TREEWALKER,
-        /**
-         * Points that checker will be created as
-         * a root of default configuration.
-         */
-        IN_CHECKER,
-
-    }
-
-    private static final String ROOT_MODULE_NAME = "root";
+    protected static final String ROOT_MODULE_NAME = Checker.class.getSimpleName();
 
     private final ByteArrayOutputStream stream = new ByteArrayOutputStream();
 
@@ -104,31 +86,6 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
     }
 
     /**
-     * Find the module creation option to use for the module name.
-     *
-     * @param moduleName the module name.
-     * @return the module creation option.
-     */
-    protected ModuleCreationOption findModuleCreationOption(String moduleName) {
-        ModuleCreationOption moduleCreationOption = ModuleCreationOption.IN_CHECKER;
-
-        if (!ROOT_MODULE_NAME.equals(moduleName)) {
-            try {
-                final Class<?> moduleClass = Class.forName(moduleName);
-                if (ModuleReflectionUtil.isCheckstyleTreeWalkerCheck(moduleClass)
-                        || ModuleReflectionUtil.isTreeWalkerFilterModule(moduleClass)) {
-                    moduleCreationOption = ModuleCreationOption.IN_TREEWALKER;
-                }
-            }
-            catch (ClassNotFoundException ignore) {
-                // ignore exception, assume it is not part of TreeWalker
-            }
-        }
-
-        return moduleCreationOption;
-    }
-
-    /**
      * Creates {@link Checker} instance based on the given {@link Configuration} instance.
      *
      * @param moduleConfig {@link Configuration} instance.
@@ -137,39 +94,42 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      */
     protected final Checker createChecker(Configuration moduleConfig)
             throws Exception {
-        final String name = moduleConfig.getName();
-
-        return createChecker(moduleConfig, findModuleCreationOption(name));
-    }
-
-    /**
-     * Creates {@link Checker} instance based on the given {@link Configuration} instance.
-     *
-     * @param moduleConfig {@link Configuration} instance.
-     * @param moduleCreationOption {@code IN_TREEWALKER} if the {@code moduleConfig} should be added
-     *                                                  under {@link TreeWalker}.
-     * @return {@link Checker} instance based on the given {@link Configuration} instance.
-     * @throws Exception if an exception occurs during checker configuration.
-     */
-    protected final Checker createChecker(Configuration moduleConfig,
-                                 ModuleCreationOption moduleCreationOption)
-            throws Exception {
+        final String moduleName = moduleConfig.getName();
         final Checker checker = new Checker();
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
 
-        if (moduleCreationOption == ModuleCreationOption.IN_TREEWALKER) {
+        if (ROOT_MODULE_NAME.equals(moduleName)) {
+            checker.configure(moduleConfig);
+        }
+        else {
+            final Class<?> moduleClass = Class.forName(moduleName);
+
+            configureChecker(checker, moduleClass, moduleConfig);
+        }
+
+        checker.addListener(getBriefUtLogger());
+        return checker;
+    }
+
+    /**
+     * Configures the {@code checker} instance with {@code moduleConfig}.
+     *
+     * @param checker {@link Checker} instance.
+     * @param moduleClass {@link Class} of the module involved.
+     * @param moduleConfig {@link Configuration} instance.
+     * @throws Exception if an exception occurs during configuration.
+     */
+    protected void configureChecker(Checker checker, Class<?> moduleClass,
+            Configuration moduleConfig) throws Exception {
+        if (ModuleReflectionUtil.isCheckstyleTreeWalkerCheck(moduleClass)
+                || ModuleReflectionUtil.isTreeWalkerFilterModule(moduleClass)) {
             final Configuration dc = createTreeWalkerConfig(moduleConfig);
             checker.configure(dc);
-        }
-        else if (ROOT_MODULE_NAME.equals(moduleConfig.getName())) {
-            checker.configure(moduleConfig);
         }
         else {
             final Configuration dc = createRootConfig(moduleConfig);
             checker.configure(dc);
         }
-        checker.addListener(getBriefUtLogger());
-        return checker;
     }
 
     /**
@@ -182,7 +142,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      */
     protected static DefaultConfiguration createTreeWalkerConfig(Configuration config) {
         final DefaultConfiguration dc =
-                new DefaultConfiguration("configuration");
+                new DefaultConfiguration(ROOT_MODULE_NAME);
         final DefaultConfiguration twConf = createModuleConfig(TreeWalker.class);
         // make sure that the tests always run with this charset
         dc.addProperty("charset", StandardCharsets.UTF_8.name());

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -79,7 +79,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      *
      * @return stream with log
      */
-    public ByteArrayOutputStream getStream() {
+    protected final ByteArrayOutputStream getStream() {
         return stream;
     }
 
@@ -88,7 +88,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      *
      * @return logger for tests
      */
-    public final BriefUtLogger getBriefUtLogger() {
+    protected final BriefUtLogger getBriefUtLogger() {
         return new BriefUtLogger(stream);
     }
 
@@ -104,17 +104,14 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
     }
 
     /**
-     * Creates {@link Checker} instance based on the given {@link Configuration} instance.
+     * Find the module creation option to use for the module name.
      *
-     * @param moduleConfig {@link Configuration} instance.
-     * @return {@link Checker} instance based on the given {@link Configuration} instance.
-     * @throws Exception if an exception occurs during checker configuration.
+     * @param moduleName the module name.
+     * @return the module creation option.
      */
-    public final Checker createChecker(Configuration moduleConfig)
-            throws Exception {
+    protected ModuleCreationOption findModuleCreationOption(String moduleName) {
         ModuleCreationOption moduleCreationOption = ModuleCreationOption.IN_CHECKER;
 
-        final String moduleName = moduleConfig.getName();
         if (!ROOT_MODULE_NAME.equals(moduleName)) {
             try {
                 final Class<?> moduleClass = Class.forName(moduleName);
@@ -128,7 +125,21 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
             }
         }
 
-        return createChecker(moduleConfig, moduleCreationOption);
+        return moduleCreationOption;
+    }
+
+    /**
+     * Creates {@link Checker} instance based on the given {@link Configuration} instance.
+     *
+     * @param moduleConfig {@link Configuration} instance.
+     * @return {@link Checker} instance based on the given {@link Configuration} instance.
+     * @throws Exception if an exception occurs during checker configuration.
+     */
+    protected final Checker createChecker(Configuration moduleConfig)
+            throws Exception {
+        final String name = moduleConfig.getName();
+
+        return createChecker(moduleConfig, findModuleCreationOption(name));
     }
 
     /**
@@ -136,11 +147,11 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      *
      * @param moduleConfig {@link Configuration} instance.
      * @param moduleCreationOption {@code IN_TREEWALKER} if the {@code moduleConfig} should be added
-*                                              under {@link TreeWalker}.
+     *                                                  under {@link TreeWalker}.
      * @return {@link Checker} instance based on the given {@link Configuration} instance.
      * @throws Exception if an exception occurs during checker configuration.
      */
-    public final Checker createChecker(Configuration moduleConfig,
+    protected final Checker createChecker(Configuration moduleConfig,
                                  ModuleCreationOption moduleCreationOption)
             throws Exception {
         final Checker checker = new Checker();
@@ -157,7 +168,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
             final Configuration dc = createRootConfig(moduleConfig);
             checker.configure(dc);
         }
-        checker.addListener(new BriefUtLogger(stream));
+        checker.addListener(getBriefUtLogger());
         return checker;
     }
 
@@ -197,8 +208,6 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
     /**
      * Returns canonical path for the file with the given file name.
      * The path is formed base on the non-compilable resources location.
-     * This implementation uses 'src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/'
-     * as a non-compilable resource location.
      *
      * @param filename file name.
      * @return canonical path for the file with the given file name.
@@ -212,8 +221,6 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
     /**
      * Returns URI-representation of the path for the given file name.
      * The path is formed base on the root location.
-     * This implementation uses 'src/test/resources/com/puppycrawl/tools/checkstyle/'
-     * as a root location.
      *
      * @param filename file name.
      * @return URI-representation of the path for the file with the given file name.
@@ -278,14 +285,14 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * This implementation uses overloaded
      * {@link AbstractModuleTestSupport#verify(Checker, File[], String, String...)} method inside.
      *
-     * @param aConfig configuration.
+     * @param config configuration.
      * @param fileName file name to verify.
      * @param expected an array of expected messages.
      * @throws Exception if exception occurs during verification process.
      */
-    protected final void verify(Configuration aConfig, String fileName, String... expected)
+    protected final void verify(Configuration config, String fileName, String... expected)
             throws Exception {
-        verify(createChecker(aConfig), fileName, fileName, expected);
+        verify(createChecker(config), fileName, fileName, expected);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -102,9 +102,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
             checker.configure(moduleConfig);
         }
         else {
-            final Class<?> moduleClass = Class.forName(moduleName);
-
-            configureChecker(checker, moduleClass, moduleConfig);
+            configureChecker(checker, moduleConfig);
         }
 
         checker.addListener(getBriefUtLogger());
@@ -115,20 +113,20 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * Configures the {@code checker} instance with {@code moduleConfig}.
      *
      * @param checker {@link Checker} instance.
-     * @param moduleClass {@link Class} of the module involved.
      * @param moduleConfig {@link Configuration} instance.
      * @throws Exception if an exception occurs during configuration.
      */
-    protected void configureChecker(Checker checker, Class<?> moduleClass,
-            Configuration moduleConfig) throws Exception {
+    protected void configureChecker(Checker checker, Configuration moduleConfig) throws Exception {
+        final Class<?> moduleClass = Class.forName(moduleConfig.getName());
+
         if (ModuleReflectionUtil.isCheckstyleTreeWalkerCheck(moduleClass)
                 || ModuleReflectionUtil.isTreeWalkerFilterModule(moduleClass)) {
-            final Configuration dc = createTreeWalkerConfig(moduleConfig);
-            checker.configure(dc);
+            final Configuration config = createTreeWalkerConfig(moduleConfig);
+            checker.configure(config);
         }
         else {
-            final Configuration dc = createRootConfig(moduleConfig);
-            checker.configure(dc);
+            final Configuration config = createRootConfig(moduleConfig);
+            checker.configure(config);
         }
     }
 
@@ -141,14 +139,14 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      *     based on the given {@link Configuration} instance.
      */
     protected static DefaultConfiguration createTreeWalkerConfig(Configuration config) {
-        final DefaultConfiguration dc =
+        final DefaultConfiguration rootConfig =
                 new DefaultConfiguration(ROOT_MODULE_NAME);
         final DefaultConfiguration twConf = createModuleConfig(TreeWalker.class);
         // make sure that the tests always run with this charset
-        dc.addProperty("charset", StandardCharsets.UTF_8.name());
-        dc.addChild(twConf);
+        rootConfig.addProperty("charset", StandardCharsets.UTF_8.name());
+        rootConfig.addChild(twConf);
         twConf.addChild(config);
-        return dc;
+        return rootConfig;
     }
 
     /**
@@ -158,11 +156,11 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @return {@link DefaultConfiguration} for the given {@link Configuration} instance.
      */
     protected static DefaultConfiguration createRootConfig(Configuration config) {
-        final DefaultConfiguration dc = new DefaultConfiguration(ROOT_MODULE_NAME);
+        final DefaultConfiguration rootConfig = new DefaultConfiguration(ROOT_MODULE_NAME);
         if (config != null) {
-            dc.addChild(config);
+            rootConfig.addChild(config);
         }
-        return dc;
+        return rootConfig;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -243,7 +243,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
 
         try {
             final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-            verify(createChecker(checkConfig, ModuleCreationOption.IN_TREEWALKER),
+            verify(createChecker(createTreeWalkerConfig(checkConfig)),
                     File.createTempFile("junit", null, temporaryFolder).getPath(), expected);
             assertWithMessage("CheckstyleException is expected").fail();
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputConfiguration.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputConfiguration.java
@@ -27,12 +27,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.TreeWalker;
 
 public final class TestInputConfiguration {
 
-    private static final String ROOT_MODULE_NAME = "root";
+    private static final String ROOT_MODULE_NAME = Checker.class.getSimpleName();
 
     private static final Set<String> CHECKER_CHILDREN = new HashSet<>(Arrays.asList(
             "com.puppycrawl.tools.checkstyle.filefilters.BeforeExecutionExclusionFileFilter",


### PR DESCRIPTION
#11604

First commit is a simple synchronize between Test and IT where similar code is.

Second commit is the bigger change. I reworked how we build the Checker tree so it is more streamlined and not passing around the enumeration. `createChecker` will now handle the current given module and identify if it needs a TreeWalker or other similar intermediary between it and the module. It also removed random config names and more closely used the ones they represent.

I could not make similar changes to the IT side as the IT side has some weird complexities that need to be dealt with. We pass the name of the check and not the full class. We have to pull things from an existing config, and we only do partial pulls, still rebuild the missing pieces. There are also some tests that pull in more information from the config to not duplicate it making it all very complicated and needing its own rewrite.

I at least removed and centralized the code for `getModuleConfig` and `getModuleConfigs` for IT.