### PR TITLE
minor: removes complicated uses of test tier that are not needed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1735,6 +1735,7 @@
                 <exclude>**/MainTest.class</exclude>
                 <!-- tests need forbidden apis to test the main code fully -->
                 <exclude>**/XpathFileGeneratorAuditListenerTest.class</exclude>
+                <exclude>**/AllChecksTest.class</exclude>
                 <!-- Needed for testing deprecated API. -->
                 <exclude>**/DefaultConfigurationTest.class</exclude>
                 <!-- is not Check or Filter, it is internal module -->
@@ -1750,6 +1751,7 @@
 
                 <!-- input files are not java files, bdd need support for other comment types -->
                 <exclude>**/SuppressWithPlainTextCommentFilterTest.class</exclude>
+                <exclude>**/NewlineAtEndOfFileCheckTest.class</exclude>
 
                 <!-- stay in old way as format of input files is very special -->
                 <exclude>**/IndentationCheckTest.class</exclude>
@@ -1811,6 +1813,9 @@
 
                 <!-- tests should be updated -->
                 <exclude>**/AbstractJavadocCheckTest.class</exclude>
+
+                <!-- tests should be updated -->
+                <exclude>**/JavadocPackageCheckTest.class</exclude>
 
               </excludes>
             </configuration>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -501,8 +501,6 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         treeWalkerConfig.addChild(createModuleConfig(MemberNameCheck.class));
         treeWalkerConfig.addChild(filterConfig);
 
-        final DefaultConfiguration checkerConfig = createRootConfig(treeWalkerConfig);
-
         final String[] expected = {
             "9:17: " + getCheckMessage(MemberNameCheck.class, "name.invalidPattern", "P",
                     "^[a-z][a-zA-Z0-9]*$"),
@@ -510,7 +508,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
                     "^[a-z][a-zA-Z0-9]*$"),
         };
 
-        verify(checkerConfig,
+        verify(treeWalkerConfig,
                 getPath("InputTreeWalkerSuppressionCommentFilter.java"),
                 expected);
     }
@@ -521,13 +519,11 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         treeWalkerConfig.addChild(createModuleConfig(WhitespaceAroundCheck.class));
         treeWalkerConfig.addChild(createModuleConfig(WhitespaceAfterCheck.class));
 
-        final DefaultConfiguration checkerConfig = createRootConfig(treeWalkerConfig);
-
         final String[] expected = {
             "6:9: " + getCheckMessage(WhitespaceAfterCheck.class, "ws.notFollowed", "if"),
         };
 
-        verify(checkerConfig,
+        verify(treeWalkerConfig,
                 getPath("InputTreeWalkerMultiCheckOrder.java"),
                 expected);
     }
@@ -620,14 +616,12 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         treeWalkerConfig.addChild(filterConfig);
         treeWalkerConfig.addChild(checkConfig);
 
-        final DefaultConfiguration checkerConfig = createRootConfig(treeWalkerConfig);
-
         // test is only valid when relative paths are given
         final String filePath = "src/test/resources/" + getPackageLocation()
                 + "/InputTreeWalkerSuppressionXpathFilterAbsolute.java";
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
-        verify(checkerConfig, filePath, expected);
+        verify(treeWalkerConfig, filePath, expected);
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
@@ -146,7 +146,7 @@ public class NewlineAtEndOfFileCheckTest
             "1: " + getCheckMessage(MSG_KEY_NO_NEWLINE_EOF),
         };
         verify(
-            createChecker(checkConfig),
+            checkConfig,
             getPath("InputNewlineAtEndOfFileEmptyFile.txt"),
             expected);
     }
@@ -158,7 +158,7 @@ public class NewlineAtEndOfFileCheckTest
         checkConfig.addProperty("lineSeparator", LineSeparatorOption.LF.toString());
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(
-                createChecker(checkConfig),
+                checkConfig,
                 getPath("InputNewlineAtEndOfFileNewlineAtEnd.txt"),
                 expected);
     }
@@ -170,7 +170,7 @@ public class NewlineAtEndOfFileCheckTest
         checkConfig.addProperty("lineSeparator", LineSeparatorOption.LF_CR_CRLF.toString());
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(
-                createChecker(checkConfig),
+                checkConfig,
                 getPath("InputNewlineAtEndOfFileNewlineAtEndLf.txt"),
                 expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheckTest.java
@@ -1334,11 +1334,10 @@ public class IndentationCheckTest extends AbstractModuleTestSupport {
         checkConfig.addProperty("throwsIndent", "4");
         final String fileName = getPath("InputIndentationChainedMethodCalls.java");
         final String[] expected = {
-            "32:5: " + getCheckMessage(IndentationCheck.class,
-                MSG_CHILD_ERROR, "method call", 4, 8),
-            "37:5: " + getCheckMessage(IndentationCheck.class, MSG_ERROR, ".", 4, 8),
-            "38:5: " + getCheckMessage(IndentationCheck.class, MSG_ERROR, ".", 4, 8),
-            "41:5: " + getCheckMessage(IndentationCheck.class, MSG_ERROR, "new", 4, 8),
+            "32:5: " + getCheckMessage(MSG_CHILD_ERROR, "method call", 4, 8),
+            "37:5: " + getCheckMessage(MSG_ERROR, ".", 4, 8),
+            "38:5: " + getCheckMessage(MSG_ERROR, ".", 4, 8),
+            "41:5: " + getCheckMessage(MSG_ERROR, "new", 4, 8),
         };
         verifyWarns(checkConfig, fileName, expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheckTest.java
@@ -50,8 +50,7 @@ public class JavadocPackageCheckTest
             "1: " + getCheckMessage(MSG_PACKAGE_INFO),
         };
         verify(
-            createChecker(checkConfig),
-            getPath("InputJavadocPackageBadCls.java"),
+            checkConfig,
             getPath("InputJavadocPackageBadCls.java"),
             expected);
     }
@@ -64,8 +63,7 @@ public class JavadocPackageCheckTest
             "1: " + getCheckMessage(MSG_PACKAGE_INFO),
         };
         verify(
-            createChecker(checkConfig),
-            getPath("InputJavadocPackageBadCls2.java"),
+            checkConfig,
             getPath("InputJavadocPackageBadCls2.java"),
             expected);
     }
@@ -91,8 +89,7 @@ public class JavadocPackageCheckTest
         final String[] expected = {
             "1: " + getCheckMessage(MSG_LEGACY_PACKAGE_HTML),
         };
-        verify(createChecker(checkConfig),
-            getPath("bothfiles" + File.separator + "InputJavadocPackageBothIgnored.java"),
+        verify(checkConfig,
             getPath("bothfiles" + File.separator + "InputJavadocPackageBothIgnored.java"),
             expected);
     }
@@ -103,8 +100,7 @@ public class JavadocPackageCheckTest
         final String[] expected = {
             "1: " + getCheckMessage(MSG_PACKAGE_INFO),
         };
-        verify(createChecker(checkConfig),
-            getPath("pkghtml" + File.separator + "InputJavadocPackageHtmlIgnored.java"),
+        verify(checkConfig,
             getPath("pkghtml" + File.separator + "InputJavadocPackageHtmlIgnored.java"), expected);
     }
 
@@ -122,9 +118,7 @@ public class JavadocPackageCheckTest
     public void testAnnotation() throws Exception {
         final DefaultConfiguration checkConfig = createModuleConfig(JavadocPackageCheck.class);
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-        verify(createChecker(checkConfig),
-            getPath("annotation"
-                    + File.separator + "package-info.java"),
+        verify(checkConfig,
             getPath("annotation"
                     + File.separator + "package-info.java"), expected);
     }
@@ -156,7 +150,7 @@ public class JavadocPackageCheckTest
         final Configuration checkConfig = createModuleConfig(JavadocPackageCheck.class);
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(
-            createChecker(checkConfig),
+            checkConfig,
             getPath("InputJavadocPackageNotJava.txt"),
             expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheckTest.java
@@ -122,7 +122,7 @@ public class EmptyForInitializerPadCheckTest
         try {
             final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
-            verify(createChecker(checkConfig),
+            verifyWithInlineConfigParser(
                     getPath("InputEmptyForInitializerPad2.java"), expected);
             assertWithMessage("exception expected").fail();
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheckTest.java
@@ -26,7 +26,6 @@ import static com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIterator
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
@@ -92,14 +91,10 @@ public class EmptyForIteratorPadCheckTest
 
     @Test
     public void testInvalidOption() throws Exception {
-        final DefaultConfiguration checkConfig = createModuleConfig(EmptyForIteratorPadCheck.class);
-        checkConfig.addProperty("option", "invalid_option");
-
         try {
             final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
-            verify(createChecker(checkConfig),
-                    getPath("InputEmptyForIteratorPad2.java"), expected);
+            verifyWithInlineConfigParser(getPath("InputEmptyForIteratorPad2.java"), expected);
             assertWithMessage("exception expected").fail();
         }
         catch (CheckstyleException ex) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterCheckTest.java
@@ -25,9 +25,6 @@ import static com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacter
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.Definitions;
-import com.puppycrawl.tools.checkstyle.api.Violation;
 
 public class FileTabCharacterCheckTest
     extends AbstractModuleTestSupport {
@@ -62,23 +59,6 @@ public class FileTabCharacterCheckTest
         verifyWithInlineConfigParser(
                 getPath("InputFileTabCharacterSimple1.java"),
             expected);
-    }
-
-    @Test
-    public void testBadFile() throws Exception {
-        final DefaultConfiguration checkConfig =
-                createModuleConfig(FileTabCharacterCheck.class);
-        checkConfig.addProperty("eachLine", "false");
-        final String path = getPath("Claira");
-        final String exceptionMessage = " (No such file or directory)";
-        final Violation violation = new Violation(1,
-                Definitions.CHECKSTYLE_BUNDLE, "general.exception",
-                new String[] {path + exceptionMessage}, null, getClass(), null);
-
-        final String[] expected = {
-            "1: " + violation.getViolation(),
-        };
-        verify(createChecker(checkConfig), path, expected);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheckTest.java
@@ -27,7 +27,6 @@ import static com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCh
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
@@ -185,13 +184,10 @@ public class MethodParamPadCheckTest
 
     @Test
     public void testInvalidOption() throws Exception {
-        final DefaultConfiguration checkConfig = createModuleConfig(MethodParamPadCheck.class);
-        checkConfig.addProperty("option", "invalid_option");
-
         try {
             final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
-            verify(createChecker(checkConfig), getPath("InputMethodParamPad4.java"), expected);
+            verifyWithInlineConfigParser(getPath("InputMethodParamPad4.java"), expected);
             assertWithMessage("exception expected").fail();
         }
         catch (CheckstyleException ex) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -41,7 +41,6 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
-import com.puppycrawl.tools.checkstyle.Checker;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.Definitions;
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
@@ -281,8 +280,7 @@ public class AllChecksTest extends AbstractModuleTestSupport {
                 moduleConfig.addProperty("file", getPath(
                         "InputAllChecksImportControl.xml"));
             }
-            final Checker checker = createChecker(moduleConfig);
-            verify(checker, inputFilePath, expected);
+            verify(moduleConfig, inputFilePath, expected);
         }
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforiteratorpad/InputEmptyForIteratorPad2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforiteratorpad/InputEmptyForIteratorPad2.java
@@ -1,11 +1,11 @@
 /*
 EmptyForIteratorPad
-option = (default)nospace
+option = invalid_option
 
 
 */
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace.emptyforiteratorpad;
 
-class InputEmptyForIteratorPad2 // violation
+class InputEmptyForIteratorPad2 // ok
 { }


### PR DESCRIPTION
Went through the test tier to see why certain methods are still protected and not final. Found some instances were the methods were used in complex ways that weren't needed. Like manually creating the Checker when the verify method will do this for us, etc...