### PR TITLE
minor: do-while loop in VisibilityModifierCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -882,17 +882,14 @@ public class VisibilityModifierCheck
     private static List<String> getTypeArgsClassNames(DetailAST typeArgs) {
         final List<String> typeClassNames = new ArrayList<>();
         DetailAST type = typeArgs.findFirstToken(TokenTypes.TYPE_ARGUMENT);
-        boolean isCanonicalName = isCanonicalName(type);
-        String typeName = getTypeName(type, isCanonicalName);
-        typeClassNames.add(typeName);
-        DetailAST sibling = type.getNextSibling();
-        while (sibling.getType() == TokenTypes.COMMA) {
-            type = sibling.getNextSibling();
-            isCanonicalName = isCanonicalName(type);
-            typeName = getTypeName(type, isCanonicalName);
+        DetailAST sibling;
+        do {
+            final boolean isCanonicalName = isCanonicalName(type);
+            final String typeName = getTypeName(type, isCanonicalName);
             typeClassNames.add(typeName);
             sibling = type.getNextSibling();
-        }
+            type = sibling.getNextSibling();
+        } while (sibling.getType() == TokenTypes.COMMA);
         return typeClassNames;
     }
 


### PR DESCRIPTION
Discovered in #11621

The method `getTypeArgsClassNames` is a `do-while` loop written as `while` loop.

Diff Regression config: https://gist.githubusercontent.com/pbludov/3a8be5da26a64e2be80b26217d052eb6/raw/a4f71fbe46c69ee580723a11be2690478433b987/config.xml