### PR TITLE
Issue #11651: removes it reliance on the configuration file

### DIFF
--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/GenericWhitespaceTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/GenericWhitespaceTest.java
@@ -19,8 +19,6 @@
 
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
-import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 
 import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
@@ -29,6 +27,15 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class GenericWhitespaceTest extends AbstractGoogleModuleTestSupport {
 
+    public static final String MSG_PRECEDED =
+            "GenericWhitespace ''{0}'' is preceded with whitespace.";
+    public static final String MSG_FOLLOWED =
+            "GenericWhitespace ''{0}'' is followed by whitespace.";
+    public static final String MSG_ILLEGAL_FOLLOW =
+            "GenericWhitespace ''{0}'' should followed by whitespace.";
+    public static final String MSG_NOT_PRECEDED =
+            "GenericWhitespace ''{0}'' is not preceded with whitespace.";
+
     @Override
     protected String getPackageLocation() {
         return "com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace";
@@ -36,28 +43,25 @@ public class GenericWhitespaceTest extends AbstractGoogleModuleTestSupport {
 
     @Test
     public void testWhitespaceAroundGenerics() throws Exception {
-        final String msgPreceded = "ws.preceded";
-        final String msgFollowed = "ws.followed";
         final Configuration checkConfig = getModuleConfig("GenericWhitespace");
-        final Map<String, String> messages = checkConfig.getMessages();
 
         final String[] expected = {
-            "12:17: " + getCheckMessage(messages, msgFollowed, "<"),
-            "12:17: " + getCheckMessage(messages, msgPreceded, "<"),
-            "12:37: " + getCheckMessage(messages, msgFollowed, "<"),
-            "12:37: " + getCheckMessage(messages, msgPreceded, "<"),
-            "12:48: " + getCheckMessage(messages, msgFollowed, ">"),
-            "12:48: " + getCheckMessage(messages, msgPreceded, ">"),
-            "12:50: " + getCheckMessage(messages, msgPreceded, ">"),
-            "14:33: " + getCheckMessage(messages, msgFollowed, "<"),
-            "14:33: " + getCheckMessage(messages, msgPreceded, "<"),
-            "14:46: " + getCheckMessage(messages, msgPreceded, ">"),
-            "15:33: " + getCheckMessage(messages, msgFollowed, "<"),
-            "15:33: " + getCheckMessage(messages, msgPreceded, "<"),
-            "15:46: " + getCheckMessage(messages, msgPreceded, ">"),
-            "20:39: " + getCheckMessage(messages, msgFollowed, "<"),
-            "20:39: " + getCheckMessage(messages, msgPreceded, "<"),
-            "20:62: " + getCheckMessage(messages, msgPreceded, ">"),
+            "12:17: " + getCheckMessage(MSG_FOLLOWED, "<"),
+            "12:17: " + getCheckMessage(MSG_PRECEDED, "<"),
+            "12:37: " + getCheckMessage(MSG_FOLLOWED, "<"),
+            "12:37: " + getCheckMessage(MSG_PRECEDED, "<"),
+            "12:48: " + getCheckMessage(MSG_FOLLOWED, ">"),
+            "12:48: " + getCheckMessage(MSG_PRECEDED, ">"),
+            "12:50: " + getCheckMessage(MSG_PRECEDED, ">"),
+            "14:33: " + getCheckMessage(MSG_FOLLOWED, "<"),
+            "14:33: " + getCheckMessage(MSG_PRECEDED, "<"),
+            "14:46: " + getCheckMessage(MSG_PRECEDED, ">"),
+            "15:33: " + getCheckMessage(MSG_FOLLOWED, "<"),
+            "15:33: " + getCheckMessage(MSG_PRECEDED, "<"),
+            "15:46: " + getCheckMessage(MSG_PRECEDED, ">"),
+            "20:39: " + getCheckMessage(MSG_FOLLOWED, "<"),
+            "20:39: " + getCheckMessage(MSG_PRECEDED, "<"),
+            "20:62: " + getCheckMessage(MSG_PRECEDED, ">"),
         };
 
         final String filePath = getPath("InputWhitespaceAroundGenerics.java");
@@ -68,40 +72,35 @@ public class GenericWhitespaceTest extends AbstractGoogleModuleTestSupport {
 
     @Test
     public void testGenericWhitespace() throws Exception {
-        final String msgPreceded = "ws.preceded";
-        final String msgFollowed = "ws.followed";
-        final String msgNotPreceded = "ws.notPreceded";
-        final String msgIllegalFollow = "ws.illegalFollow";
         final Configuration checkConfig = getModuleConfig("GenericWhitespace");
-        final Map<String, String> messages = checkConfig.getMessages();
 
         final String[] expected = {
-            "16:14: " + getCheckMessage(messages, msgFollowed, "<"),
-            "16:14: " + getCheckMessage(messages, msgPreceded, "<"),
-            "16:24: " + getCheckMessage(messages, msgPreceded, ">"),
-            "16:44: " + getCheckMessage(messages, msgFollowed, "<"),
-            "16:44: " + getCheckMessage(messages, msgPreceded, "<"),
-            "16:54: " + getCheckMessage(messages, msgPreceded, ">"),
-            "17:14: " + getCheckMessage(messages, msgFollowed, "<"),
-            "17:14: " + getCheckMessage(messages, msgPreceded, "<"),
-            "17:21: " + getCheckMessage(messages, msgFollowed, "<"),
-            "17:21: " + getCheckMessage(messages, msgPreceded, "<"),
-            "17:31: " + getCheckMessage(messages, msgFollowed, ">"),
-            "17:31: " + getCheckMessage(messages, msgPreceded, ">"),
-            "17:33: " + getCheckMessage(messages, msgPreceded, ">"),
-            "17:53: " + getCheckMessage(messages, msgFollowed, "<"),
-            "17:53: " + getCheckMessage(messages, msgPreceded, "<"),
-            "17:60: " + getCheckMessage(messages, msgFollowed, "<"),
-            "17:60: " + getCheckMessage(messages, msgPreceded, "<"),
-            "17:70: " + getCheckMessage(messages, msgFollowed, ">"),
-            "17:70: " + getCheckMessage(messages, msgPreceded, ">"),
-            "17:72: " + getCheckMessage(messages, msgPreceded, ">"),
-            "30:18: " + getCheckMessage(messages, msgNotPreceded, "<"),
-            "30:20: " + getCheckMessage(messages, msgIllegalFollow, ">"),
-            "42:22: " + getCheckMessage(messages, msgPreceded, "<"),
-            "42:29: " + getCheckMessage(messages, msgFollowed, ">"),
-            "60:59: " + getCheckMessage(messages, msgNotPreceded, "&"),
-            "63:59: " + getCheckMessage(messages, msgFollowed, ">"),
+            "16:14: " + getCheckMessage(MSG_FOLLOWED, "<"),
+            "16:14: " + getCheckMessage(MSG_PRECEDED, "<"),
+            "16:24: " + getCheckMessage(MSG_PRECEDED, ">"),
+            "16:44: " + getCheckMessage(MSG_FOLLOWED, "<"),
+            "16:44: " + getCheckMessage(MSG_PRECEDED, "<"),
+            "16:54: " + getCheckMessage(MSG_PRECEDED, ">"),
+            "17:14: " + getCheckMessage(MSG_FOLLOWED, "<"),
+            "17:14: " + getCheckMessage(MSG_PRECEDED, "<"),
+            "17:21: " + getCheckMessage(MSG_FOLLOWED, "<"),
+            "17:21: " + getCheckMessage(MSG_PRECEDED, "<"),
+            "17:31: " + getCheckMessage(MSG_FOLLOWED, ">"),
+            "17:31: " + getCheckMessage(MSG_PRECEDED, ">"),
+            "17:33: " + getCheckMessage(MSG_PRECEDED, ">"),
+            "17:53: " + getCheckMessage(MSG_FOLLOWED, "<"),
+            "17:53: " + getCheckMessage(MSG_PRECEDED, "<"),
+            "17:60: " + getCheckMessage(MSG_FOLLOWED, "<"),
+            "17:60: " + getCheckMessage(MSG_PRECEDED, "<"),
+            "17:70: " + getCheckMessage(MSG_FOLLOWED, ">"),
+            "17:70: " + getCheckMessage(MSG_PRECEDED, ">"),
+            "17:72: " + getCheckMessage(MSG_PRECEDED, ">"),
+            "30:18: " + getCheckMessage(MSG_NOT_PRECEDED, "<"),
+            "30:20: " + getCheckMessage(MSG_ILLEGAL_FOLLOW, ">"),
+            "42:22: " + getCheckMessage(MSG_PRECEDED, "<"),
+            "42:29: " + getCheckMessage(MSG_FOLLOWED, ">"),
+            "60:59: " + getCheckMessage(MSG_NOT_PRECEDED, "&"),
+            "63:59: " + getCheckMessage(MSG_FOLLOWED, ">"),
         };
 
         final String filePath = getPath("InputGenericWhitespace.java");

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/WhitespaceAroundTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule462horizontalwhitespace/WhitespaceAroundTest.java
@@ -19,8 +19,6 @@
 
 package com.google.checkstyle.test.chapter4formatting.rule462horizontalwhitespace;
 
-import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 
 import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
@@ -28,6 +26,13 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class WhitespaceAroundTest extends AbstractGoogleModuleTestSupport {
+
+    public static final String MSG_NOT_FOLLOWED =
+            "WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks"
+                + "                may only be represented as '{}' when not part of a "
+                + "multi-block statement (4.1.3)";
+    public static final String MSG_NOT_PRECEDED =
+            "WhitespaceAround: ''{0}'' is not preceded with whitespace.";
 
     @Override
     protected String getPackageLocation() {
@@ -37,37 +42,34 @@ public class WhitespaceAroundTest extends AbstractGoogleModuleTestSupport {
     @Test
     public void testWhitespaceAroundBasic() throws Exception {
         final Configuration checkConfig = getModuleConfig("WhitespaceAround");
-        final String msgPreceded = "ws.notPreceded";
-        final String msgFollowed = "ws.notFollowed";
-        final Map<String, String> messages = checkConfig.getMessages();
 
         final String[] expected = {
-            "10:22: " + getCheckMessage(messages, msgPreceded, "="),
-            "12:23: " + getCheckMessage(messages, msgFollowed, "="),
-            "20:14: " + getCheckMessage(messages, msgPreceded, "="),
-            "21:10: " + getCheckMessage(messages, msgPreceded, "="),
-            "22:11: " + getCheckMessage(messages, msgFollowed, "+="),
-            "23:11: " + getCheckMessage(messages, msgFollowed, "-="),
-            "31:9: " + getCheckMessage(messages, msgFollowed, "synchronized"),
-            "33:13: " + getCheckMessage(messages, msgFollowed, "{"),
-            "35:36: " + getCheckMessage(messages, msgFollowed, "{"),
-            "52:9: " + getCheckMessage(messages, msgFollowed, "if"),
-            "70:13: " + getCheckMessage(messages, msgFollowed, "return"),
-            "92:24: " + getCheckMessage(messages, msgFollowed, "=="),
-            "98:22: " + getCheckMessage(messages, msgPreceded, "*"),
-            "113:18: " + getCheckMessage(messages, msgPreceded, "%"),
-            "114:19: " + getCheckMessage(messages, msgFollowed, "%"),
-            "115:18: " + getCheckMessage(messages, msgPreceded, "%"),
-            "117:18: " + getCheckMessage(messages, msgPreceded, "/"),
-            "118:19: " + getCheckMessage(messages, msgFollowed, "/"),
-            "147:9: " + getCheckMessage(messages, msgFollowed, "assert"),
-            "150:20: " + getCheckMessage(messages, msgPreceded, ":"),
-            "241:19: " + getCheckMessage(messages, msgFollowed, ":"),
-            "241:19: " + getCheckMessage(messages, msgPreceded, ":"),
-            "242:20: " + getCheckMessage(messages, msgFollowed, ":"),
-            "243:19: " + getCheckMessage(messages, msgPreceded, ":"),
-            "257:14: " + getCheckMessage(messages, msgPreceded, "->"),
-            "258:15: " + getCheckMessage(messages, msgFollowed, "->"),
+            "10:22: " + getCheckMessage(MSG_NOT_PRECEDED, "="),
+            "12:23: " + getCheckMessage(MSG_NOT_FOLLOWED, "="),
+            "20:14: " + getCheckMessage(MSG_NOT_PRECEDED, "="),
+            "21:10: " + getCheckMessage(MSG_NOT_PRECEDED, "="),
+            "22:11: " + getCheckMessage(MSG_NOT_FOLLOWED, "+="),
+            "23:11: " + getCheckMessage(MSG_NOT_FOLLOWED, "-="),
+            "31:9: " + getCheckMessage(MSG_NOT_FOLLOWED, "synchronized"),
+            "33:13: " + getCheckMessage(MSG_NOT_FOLLOWED, "{"),
+            "35:36: " + getCheckMessage(MSG_NOT_FOLLOWED, "{"),
+            "52:9: " + getCheckMessage(MSG_NOT_FOLLOWED, "if"),
+            "70:13: " + getCheckMessage(MSG_NOT_FOLLOWED, "return"),
+            "92:24: " + getCheckMessage(MSG_NOT_FOLLOWED, "=="),
+            "98:22: " + getCheckMessage(MSG_NOT_PRECEDED, "*"),
+            "113:18: " + getCheckMessage(MSG_NOT_PRECEDED, "%"),
+            "114:19: " + getCheckMessage(MSG_NOT_FOLLOWED, "%"),
+            "115:18: " + getCheckMessage(MSG_NOT_PRECEDED, "%"),
+            "117:18: " + getCheckMessage(MSG_NOT_PRECEDED, "/"),
+            "118:19: " + getCheckMessage(MSG_NOT_FOLLOWED, "/"),
+            "147:9: " + getCheckMessage(MSG_NOT_FOLLOWED, "assert"),
+            "150:20: " + getCheckMessage(MSG_NOT_PRECEDED, ":"),
+            "241:19: " + getCheckMessage(MSG_NOT_FOLLOWED, ":"),
+            "241:19: " + getCheckMessage(MSG_NOT_PRECEDED, ":"),
+            "242:20: " + getCheckMessage(MSG_NOT_FOLLOWED, ":"),
+            "243:19: " + getCheckMessage(MSG_NOT_PRECEDED, ":"),
+            "257:14: " + getCheckMessage(MSG_NOT_PRECEDED, "->"),
+            "258:15: " + getCheckMessage(MSG_NOT_FOLLOWED, "->"),
         };
 
         final String filePath = getPath("InputWhitespaceAroundBasic.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule51identifiernames/CatchParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule51identifiernames/CatchParameterNameTest.java
@@ -19,14 +19,14 @@
 
 package com.google.checkstyle.test.chapter5naming.rule51identifiernames;
 
-import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 
 import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public class CatchParameterNameTest extends AbstractGoogleModuleTestSupport {
+
+    private static final String MSG = "Catch parameter name ''{0}'' must match pattern ''{1}''.";
 
     @Override
     protected String getPackageLocation() {
@@ -35,18 +35,16 @@ public class CatchParameterNameTest extends AbstractGoogleModuleTestSupport {
 
     @Test
     public void testCatchParameterName() throws Exception {
-        final String msgKey = "name.invalidPattern";
         final Configuration checkConfig = getModuleConfig("CatchParameterName");
-        final String format = checkConfig.getProperty("format");
-        final Map<String, String> messages = checkConfig.getMessages();
+        final String format = "^[a-z]([a-z0-9][a-zA-Z0-9]*)?$";
 
         final String[] expected = {
-            "47:28: " + getCheckMessage(messages, msgKey, "iException", format),
-            "50:28: " + getCheckMessage(messages, msgKey, "ex_1", format),
-            "53:28: " + getCheckMessage(messages, msgKey, "eX", format),
-            "56:28: " + getCheckMessage(messages, msgKey, "eXX", format),
-            "59:28: " + getCheckMessage(messages, msgKey, "x_y_z", format),
-            "62:28: " + getCheckMessage(messages, msgKey, "Ex", format),
+            "47:28: " + getCheckMessage(MSG, "iException", format),
+            "50:28: " + getCheckMessage(MSG, "ex_1", format),
+            "53:28: " + getCheckMessage(MSG, "eX", format),
+            "56:28: " + getCheckMessage(MSG, "eXX", format),
+            "59:28: " + getCheckMessage(MSG, "x_y_z", format),
+            "62:28: " + getCheckMessage(MSG, "Ex", format),
         };
 
         final String filePath = getPath("InputCatchParameterName.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule521packagenames/PackageNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule521packagenames/PackageNameTest.java
@@ -30,7 +30,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class PackageNameTest extends AbstractGoogleModuleTestSupport {
 
-    private static final String MSG_KEY = "name.invalidPattern";
+    private static final String MSG = "Package name ''{0}'' must match pattern ''{1}''.";
 
     @Override
     protected String getPackageLocation() {
@@ -57,8 +57,8 @@ public class PackageNameTest extends AbstractGoogleModuleTestSupport {
         final String packagePath =
                 "com.google.checkstyle.test.chapter5naming.rule521packageNamesCamelCase";
         final Configuration checkConfig = getModuleConfig("PackageName");
-        final String format = checkConfig.getProperty("format");
-        final String msg = getCheckMessage(checkConfig.getMessages(), MSG_KEY, packagePath, format);
+        final String format = "^[a-z]+(\\.[a-z][a-z0-9]*)*$";
+        final String msg = getCheckMessage(MSG, packagePath, format);
 
         final String[] expected = {
             "1:9: " + msg,
@@ -74,8 +74,8 @@ public class PackageNameTest extends AbstractGoogleModuleTestSupport {
     public void testBadPackageName2() throws Exception {
         final String packagePath = "com.google.checkstyle.test.chapter5naming.rule521_packagenames";
         final Configuration checkConfig = getModuleConfig("PackageName");
-        final String format = checkConfig.getProperty("format");
-        final String msg = getCheckMessage(checkConfig.getMessages(), MSG_KEY, packagePath, format);
+        final String format = "^[a-z]+(\\.[a-z][a-z0-9]*)*$";
+        final String msg = getCheckMessage(MSG, packagePath, format);
 
         final String[] expected = {
             "1:9: " + msg,
@@ -91,8 +91,8 @@ public class PackageNameTest extends AbstractGoogleModuleTestSupport {
     public void testBadPackageName3() throws Exception {
         final String packagePath = "com.google.checkstyle.test.chapter5naming.rule521$packagenames";
         final Configuration checkConfig = getModuleConfig("PackageName");
-        final String format = checkConfig.getProperty("format");
-        final String msg = getCheckMessage(checkConfig.getMessages(), MSG_KEY, packagePath, format);
+        final String format = "^[a-z]+(\\.[a-z][a-z0-9]*)*$";
+        final String msg = getCheckMessage(MSG, packagePath, format);
 
         final String[] expected = {
             "1:9: " + msg,

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule522typenames/TypeNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule522typenames/TypeNameTest.java
@@ -19,14 +19,14 @@
 
 package com.google.checkstyle.test.chapter5naming.rule522typenames;
 
-import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 
 import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public class TypeNameTest extends AbstractGoogleModuleTestSupport {
+
+    public static final String MSG = "Type name ''{0}'' must match pattern ''{1}''.";
 
     @Override
     protected String getPackageLocation() {
@@ -36,41 +36,39 @@ public class TypeNameTest extends AbstractGoogleModuleTestSupport {
     @Test
     public void testTypeName() throws Exception {
         final Configuration checkConfig = getModuleConfig("TypeName");
-        final String msgKey = "name.invalidPattern";
         final String format = "^[A-Z][a-zA-Z0-9]*$";
-        final Map<String, String> messages = checkConfig.getMessages();
 
         final String[] expected = {
-            "3:7: " + getCheckMessage(messages, msgKey, "inputHeaderClass", format),
-            "5:22: " + getCheckMessage(messages, msgKey, "InputHeader___Interface", format),
-            "7:17: " + getCheckMessage(messages, msgKey, "inputHeaderEnum", format),
-            "9:11: " + getCheckMessage(messages, msgKey, "NoValid$Name", format),
-            "11:11: " + getCheckMessage(messages, msgKey, "$NoValidName", format),
-            "13:11: " + getCheckMessage(messages, msgKey, "NoValidName$", format),
-            "19:7: " + getCheckMessage(messages, msgKey, "_ValidName", format),
-            "21:7: " + getCheckMessage(messages, msgKey, "Valid_Name", format),
-            "23:7: " + getCheckMessage(messages, msgKey, "ValidName_", format),
-            "27:11: " + getCheckMessage(messages, msgKey, "_Foo", format),
-            "29:11: " + getCheckMessage(messages, msgKey, "Fo_o", format),
-            "31:11: " + getCheckMessage(messages, msgKey, "Foo_", format),
-            "33:11: " + getCheckMessage(messages, msgKey, "$Foo", format),
-            "35:11: " + getCheckMessage(messages, msgKey, "Fo$o", format),
-            "37:11: " + getCheckMessage(messages, msgKey, "Foo$", format),
-            "41:6: " + getCheckMessage(messages, msgKey, "_FooEnum", format),
-            "43:6: " + getCheckMessage(messages, msgKey, "Foo_Enum", format),
-            "45:6: " + getCheckMessage(messages, msgKey, "FooEnum_", format),
-            "47:6: " + getCheckMessage(messages, msgKey, "$FooEnum", format),
-            "49:6: " + getCheckMessage(messages, msgKey, "Foo$Enum", format),
-            "51:6: " + getCheckMessage(messages, msgKey, "FooEnum$", format),
-            "53:7: " + getCheckMessage(messages, msgKey, "aaa", format),
-            "55:11: " + getCheckMessage(messages, msgKey, "bbb", format),
-            "57:6: " + getCheckMessage(messages, msgKey, "ccc", format),
-            "61:12: " + getCheckMessage(messages, msgKey, "_Annotation", format),
-            "63:12: " + getCheckMessage(messages, msgKey, "Annot_ation", format),
-            "65:12: " + getCheckMessage(messages, msgKey, "Annotation_", format),
-            "67:12: " + getCheckMessage(messages, msgKey, "$Annotation", format),
-            "69:12: " + getCheckMessage(messages, msgKey, "Annot$ation", format),
-            "71:12: " + getCheckMessage(messages, msgKey, "Annotation$", format),
+            "3:7: " + getCheckMessage(MSG, "inputHeaderClass", format),
+            "5:22: " + getCheckMessage(MSG, "InputHeader___Interface", format),
+            "7:17: " + getCheckMessage(MSG, "inputHeaderEnum", format),
+            "9:11: " + getCheckMessage(MSG, "NoValid$Name", format),
+            "11:11: " + getCheckMessage(MSG, "$NoValidName", format),
+            "13:11: " + getCheckMessage(MSG, "NoValidName$", format),
+            "19:7: " + getCheckMessage(MSG, "_ValidName", format),
+            "21:7: " + getCheckMessage(MSG, "Valid_Name", format),
+            "23:7: " + getCheckMessage(MSG, "ValidName_", format),
+            "27:11: " + getCheckMessage(MSG, "_Foo", format),
+            "29:11: " + getCheckMessage(MSG, "Fo_o", format),
+            "31:11: " + getCheckMessage(MSG, "Foo_", format),
+            "33:11: " + getCheckMessage(MSG, "$Foo", format),
+            "35:11: " + getCheckMessage(MSG, "Fo$o", format),
+            "37:11: " + getCheckMessage(MSG, "Foo$", format),
+            "41:6: " + getCheckMessage(MSG, "_FooEnum", format),
+            "43:6: " + getCheckMessage(MSG, "Foo_Enum", format),
+            "45:6: " + getCheckMessage(MSG, "FooEnum_", format),
+            "47:6: " + getCheckMessage(MSG, "$FooEnum", format),
+            "49:6: " + getCheckMessage(MSG, "Foo$Enum", format),
+            "51:6: " + getCheckMessage(MSG, "FooEnum$", format),
+            "53:7: " + getCheckMessage(MSG, "aaa", format),
+            "55:11: " + getCheckMessage(MSG, "bbb", format),
+            "57:6: " + getCheckMessage(MSG, "ccc", format),
+            "61:12: " + getCheckMessage(MSG, "_Annotation", format),
+            "63:12: " + getCheckMessage(MSG, "Annot_ation", format),
+            "65:12: " + getCheckMessage(MSG, "Annotation_", format),
+            "67:12: " + getCheckMessage(MSG, "$Annotation", format),
+            "69:12: " + getCheckMessage(MSG, "Annot$ation", format),
+            "71:12: " + getCheckMessage(MSG, "Annotation$", format),
         };
 
         final String filePath = getPath("InputTypeName.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule523methodnames/MethodNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule523methodnames/MethodNameTest.java
@@ -19,14 +19,14 @@
 
 package com.google.checkstyle.test.chapter5naming.rule523methodnames;
 
-import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 
 import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public class MethodNameTest extends AbstractGoogleModuleTestSupport {
+
+    private static final String MSG = "Method name ''{0}'' must match pattern ''{1}''.";
 
     @Override
     protected String getPackageLocation() {
@@ -36,35 +36,33 @@ public class MethodNameTest extends AbstractGoogleModuleTestSupport {
     @Test
     public void testMethodName() throws Exception {
         final Configuration checkConfig = getModuleConfig("MethodName");
-        final String msgKey = "name.invalidPattern";
         final String format = "^[a-z][a-z0-9][a-zA-Z0-9_]*$";
-        final Map<String, String> messages = checkConfig.getMessages();
 
         final String[] expected = {
-            "11:10: " + getCheckMessage(messages, msgKey, "Foo", format),
-            "12:10: " + getCheckMessage(messages, msgKey, "fOo", format),
-            "14:10: " + getCheckMessage(messages, msgKey, "f$o", format),
-            "15:10: " + getCheckMessage(messages, msgKey, "f_oo", format),
-            "16:10: " + getCheckMessage(messages, msgKey, "f", format),
-            "17:10: " + getCheckMessage(messages, msgKey, "fO", format),
-            "21:14: " + getCheckMessage(messages, msgKey, "Foo", format),
-            "22:14: " + getCheckMessage(messages, msgKey, "fOo", format),
-            "24:14: " + getCheckMessage(messages, msgKey, "f$o", format),
-            "25:14: " + getCheckMessage(messages, msgKey, "f_oo", format),
-            "26:14: " + getCheckMessage(messages, msgKey, "f", format),
-            "27:14: " + getCheckMessage(messages, msgKey, "fO", format),
-            "32:14: " + getCheckMessage(messages, msgKey, "Foo", format),
-            "33:14: " + getCheckMessage(messages, msgKey, "fOo", format),
-            "35:14: " + getCheckMessage(messages, msgKey, "f$o", format),
-            "36:14: " + getCheckMessage(messages, msgKey, "f_oo", format),
-            "37:14: " + getCheckMessage(messages, msgKey, "f", format),
-            "38:14: " + getCheckMessage(messages, msgKey, "fO", format),
-            "44:10: " + getCheckMessage(messages, msgKey, "Foo", format),
-            "45:10: " + getCheckMessage(messages, msgKey, "fOo", format),
-            "47:10: " + getCheckMessage(messages, msgKey, "f$o", format),
-            "48:10: " + getCheckMessage(messages, msgKey, "f_oo", format),
-            "49:10: " + getCheckMessage(messages, msgKey, "f", format),
-            "50:10: " + getCheckMessage(messages, msgKey, "fO", format),
+            "11:10: " + getCheckMessage(MSG, "Foo", format),
+            "12:10: " + getCheckMessage(MSG, "fOo", format),
+            "14:10: " + getCheckMessage(MSG, "f$o", format),
+            "15:10: " + getCheckMessage(MSG, "f_oo", format),
+            "16:10: " + getCheckMessage(MSG, "f", format),
+            "17:10: " + getCheckMessage(MSG, "fO", format),
+            "21:14: " + getCheckMessage(MSG, "Foo", format),
+            "22:14: " + getCheckMessage(MSG, "fOo", format),
+            "24:14: " + getCheckMessage(MSG, "f$o", format),
+            "25:14: " + getCheckMessage(MSG, "f_oo", format),
+            "26:14: " + getCheckMessage(MSG, "f", format),
+            "27:14: " + getCheckMessage(MSG, "fO", format),
+            "32:14: " + getCheckMessage(MSG, "Foo", format),
+            "33:14: " + getCheckMessage(MSG, "fOo", format),
+            "35:14: " + getCheckMessage(MSG, "f$o", format),
+            "36:14: " + getCheckMessage(MSG, "f_oo", format),
+            "37:14: " + getCheckMessage(MSG, "f", format),
+            "38:14: " + getCheckMessage(MSG, "fO", format),
+            "44:10: " + getCheckMessage(MSG, "Foo", format),
+            "45:10: " + getCheckMessage(MSG, "fOo", format),
+            "47:10: " + getCheckMessage(MSG, "f$o", format),
+            "48:10: " + getCheckMessage(MSG, "f_oo", format),
+            "49:10: " + getCheckMessage(MSG, "f", format),
+            "50:10: " + getCheckMessage(MSG, "fO", format),
         };
 
         final String filePath = getPath("InputMethodName.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/MemberNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule525nonconstantfieldnames/MemberNameTest.java
@@ -19,8 +19,6 @@
 
 package com.google.checkstyle.test.chapter5naming.rule525nonconstantfieldnames;
 
-import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 
 import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
@@ -28,7 +26,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public class MemberNameTest extends AbstractGoogleModuleTestSupport {
 
-    private static final String MSG_KEY = "name.invalidPattern";
+    private static final String MSG = "Member name ''{0}'' must match pattern ''{1}''.";
 
     @Override
     protected String getPackageLocation() {
@@ -38,22 +36,21 @@ public class MemberNameTest extends AbstractGoogleModuleTestSupport {
     @Test
     public void testMemberName() throws Exception {
         final Configuration checkConfig = getModuleConfig("MemberName");
-        final String format = checkConfig.getProperty("format");
-        final Map<String, String> messages = checkConfig.getMessages();
+        final String format = "^[a-z][a-z0-9][a-zA-Z0-9]*$";
         final String[] expected = {
-            "5:16: " + getCheckMessage(messages, MSG_KEY, "mPublic", format),
-            "6:19: " + getCheckMessage(messages, MSG_KEY, "mProtected", format),
-            "7:9: " + getCheckMessage(messages, MSG_KEY, "mPackage", format),
-            "8:17: " + getCheckMessage(messages, MSG_KEY, "mPrivate", format),
-            "10:16: " + getCheckMessage(messages, MSG_KEY, "_public", format),
-            "11:19: " + getCheckMessage(messages, MSG_KEY, "prot_ected", format),
-            "12:9: " + getCheckMessage(messages, MSG_KEY, "package_", format),
-            "13:17: " + getCheckMessage(messages, MSG_KEY, "priva$te", format),
-            "20:9: " + getCheckMessage(messages, MSG_KEY, "ABC", format),
-            "21:15: " + getCheckMessage(messages, MSG_KEY, "C_D_E", format),
-            "23:16: " + getCheckMessage(messages, MSG_KEY, "$mPublic", format),
-            "24:19: " + getCheckMessage(messages, MSG_KEY, "mPro$tected", format),
-            "25:9: " + getCheckMessage(messages, MSG_KEY, "mPackage$", format),
+            "5:16: " + getCheckMessage(MSG, "mPublic", format),
+            "6:19: " + getCheckMessage(MSG, "mProtected", format),
+            "7:9: " + getCheckMessage(MSG, "mPackage", format),
+            "8:17: " + getCheckMessage(MSG, "mPrivate", format),
+            "10:16: " + getCheckMessage(MSG, "_public", format),
+            "11:19: " + getCheckMessage(MSG, "prot_ected", format),
+            "12:9: " + getCheckMessage(MSG, "package_", format),
+            "13:17: " + getCheckMessage(MSG, "priva$te", format),
+            "20:9: " + getCheckMessage(MSG, "ABC", format),
+            "21:15: " + getCheckMessage(MSG, "C_D_E", format),
+            "23:16: " + getCheckMessage(MSG, "$mPublic", format),
+            "24:19: " + getCheckMessage(MSG, "mPro$tected", format),
+            "25:9: " + getCheckMessage(MSG, "mPackage$", format),
         };
 
         final String filePath = getPath("InputMemberNameBasic.java");
@@ -65,41 +62,40 @@ public class MemberNameTest extends AbstractGoogleModuleTestSupport {
     @Test
     public void testSimple() throws Exception {
         final Configuration checkConfig = getModuleConfig("MemberName");
-        final String format = checkConfig.getProperty("format");
-        final Map<String, String> messages = checkConfig.getMessages();
+        final String format = "^[a-z][a-z0-9][a-zA-Z0-9]*$";
         final String[] expected = {
-            "12:17: " + getCheckMessage(messages, MSG_KEY, "bad$Static", format),
-            "17:17: " + getCheckMessage(messages, MSG_KEY, "bad_Member", format),
-            "19:17: " + getCheckMessage(messages, MSG_KEY, "m", format),
-            "21:19: " + getCheckMessage(messages, MSG_KEY, "m_M", format),
-            "24:19: " + getCheckMessage(messages, MSG_KEY, "m$nts", format),
-            "35:9: " + getCheckMessage(messages, MSG_KEY, "mTest1", format),
-            "37:16: " + getCheckMessage(messages, MSG_KEY, "mTest2", format),
-            "39:16: " + getCheckMessage(messages, MSG_KEY, "$mTest2", format),
-            "41:16: " + getCheckMessage(messages, MSG_KEY, "mTes$t2", format),
-            "43:16: " + getCheckMessage(messages, MSG_KEY, "mTest2$", format),
-            "77:21: " + getCheckMessage(messages, MSG_KEY, "bad$Static", format),
-            "79:22: " + getCheckMessage(messages, MSG_KEY, "sum_Created", format),
-            "82:21: " + getCheckMessage(messages, MSG_KEY, "bad_Member", format),
-            "84:21: " + getCheckMessage(messages, MSG_KEY, "m", format),
-            "86:23: " + getCheckMessage(messages, MSG_KEY, "m_M", format),
-            "89:23: " + getCheckMessage(messages, MSG_KEY, "m$nts", format),
-            "93:13: " + getCheckMessage(messages, MSG_KEY, "mTest1", format),
-            "95:20: " + getCheckMessage(messages, MSG_KEY, "mTest2", format),
-            "97:20: " + getCheckMessage(messages, MSG_KEY, "$mTest2", format),
-            "99:20: " + getCheckMessage(messages, MSG_KEY, "mTes$t2", format),
-            "101:20: " + getCheckMessage(messages, MSG_KEY, "mTest2$", format),
-            "107:25: " + getCheckMessage(messages, MSG_KEY, "bad$Static", format),
-            "109:25: " + getCheckMessage(messages, MSG_KEY, "sum_Created", format),
-            "112:25: " + getCheckMessage(messages, MSG_KEY, "bad_Member", format),
-            "114:25: " + getCheckMessage(messages, MSG_KEY, "m", format),
-            "116:25: " + getCheckMessage(messages, MSG_KEY, "m_M", format),
-            "119:27: " + getCheckMessage(messages, MSG_KEY, "m$nts", format),
-            "123:25: " + getCheckMessage(messages, MSG_KEY, "mTest1", format),
-            "125:25: " + getCheckMessage(messages, MSG_KEY, "mTest2", format),
-            "127:25: " + getCheckMessage(messages, MSG_KEY, "$mTest2", format),
-            "129:25: " + getCheckMessage(messages, MSG_KEY, "mTes$t2", format),
-            "131:25: " + getCheckMessage(messages, MSG_KEY, "mTest2$", format),
+            "12:17: " + getCheckMessage(MSG, "bad$Static", format),
+            "17:17: " + getCheckMessage(MSG, "bad_Member", format),
+            "19:17: " + getCheckMessage(MSG, "m", format),
+            "21:19: " + getCheckMessage(MSG, "m_M", format),
+            "24:19: " + getCheckMessage(MSG, "m$nts", format),
+            "35:9: " + getCheckMessage(MSG, "mTest1", format),
+            "37:16: " + getCheckMessage(MSG, "mTest2", format),
+            "39:16: " + getCheckMessage(MSG, "$mTest2", format),
+            "41:16: " + getCheckMessage(MSG, "mTes$t2", format),
+            "43:16: " + getCheckMessage(MSG, "mTest2$", format),
+            "77:21: " + getCheckMessage(MSG, "bad$Static", format),
+            "79:22: " + getCheckMessage(MSG, "sum_Created", format),
+            "82:21: " + getCheckMessage(MSG, "bad_Member", format),
+            "84:21: " + getCheckMessage(MSG, "m", format),
+            "86:23: " + getCheckMessage(MSG, "m_M", format),
+            "89:23: " + getCheckMessage(MSG, "m$nts", format),
+            "93:13: " + getCheckMessage(MSG, "mTest1", format),
+            "95:20: " + getCheckMessage(MSG, "mTest2", format),
+            "97:20: " + getCheckMessage(MSG, "$mTest2", format),
+            "99:20: " + getCheckMessage(MSG, "mTes$t2", format),
+            "101:20: " + getCheckMessage(MSG, "mTest2$", format),
+            "107:25: " + getCheckMessage(MSG, "bad$Static", format),
+            "109:25: " + getCheckMessage(MSG, "sum_Created", format),
+            "112:25: " + getCheckMessage(MSG, "bad_Member", format),
+            "114:25: " + getCheckMessage(MSG, "m", format),
+            "116:25: " + getCheckMessage(MSG, "m_M", format),
+            "119:27: " + getCheckMessage(MSG, "m$nts", format),
+            "123:25: " + getCheckMessage(MSG, "mTest1", format),
+            "125:25: " + getCheckMessage(MSG, "mTest2", format),
+            "127:25: " + getCheckMessage(MSG, "$mTest2", format),
+            "129:25: " + getCheckMessage(MSG, "mTes$t2", format),
+            "131:25: " + getCheckMessage(MSG, "mTest2$", format),
         };
 
         final String filePath = getPath("InputMemberNameSimple.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/LambdaParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/LambdaParameterNameTest.java
@@ -19,8 +19,6 @@
 
 package com.google.checkstyle.test.chapter5naming.rule526parameternames;
 
-import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 
 import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
@@ -28,7 +26,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public class LambdaParameterNameTest extends AbstractGoogleModuleTestSupport {
 
-    public static final String MSG_INVALID_PATTERN = "name.invalidPattern";
+    public static final String MSG = "Lambda parameter name ''{0}'' must match pattern ''{1}''.";
 
     @Override
     protected String getPackageLocation() {
@@ -38,15 +36,14 @@ public class LambdaParameterNameTest extends AbstractGoogleModuleTestSupport {
     @Test
     public void testLambdaParameterName() throws Exception {
         final Configuration config = getModuleConfig("LambdaParameterName");
-        final String format = config.getProperty("format");
-        final Map<String, String> messages = config.getMessages();
+        final String format = "^[a-z]([a-z0-9][a-zA-Z0-9]*)?$";
 
         final String[] expected = {
-            "9:13: " + getCheckMessage(messages, MSG_INVALID_PATTERN, "S", format),
-            "12:14: " + getCheckMessage(messages, MSG_INVALID_PATTERN, "sT", format),
-            "14:65: " + getCheckMessage(messages, MSG_INVALID_PATTERN, "sT1", format),
-            "14:70: " + getCheckMessage(messages, MSG_INVALID_PATTERN, "sT2", format),
-            "17:21: " + getCheckMessage(messages, MSG_INVALID_PATTERN, "_s", format),
+            "9:13: " + getCheckMessage(MSG, "S", format),
+            "12:14: " + getCheckMessage(MSG, "sT", format),
+            "14:65: " + getCheckMessage(MSG, "sT1", format),
+            "14:70: " + getCheckMessage(MSG, "sT2", format),
+            "17:21: " + getCheckMessage(MSG, "_s", format),
         };
 
         final String filePath = getPath("InputLambdaParameterName.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/ParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/ParameterNameTest.java
@@ -19,8 +19,6 @@
 
 package com.google.checkstyle.test.chapter5naming.rule526parameternames;
 
-import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 
 import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
@@ -28,7 +26,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public class ParameterNameTest extends AbstractGoogleModuleTestSupport {
 
-    private static final String MSG_KEY = "name.invalidPattern";
+    private static final String MSG = "Parameter name ''{0}'' must match pattern ''{1}''.";
 
     @Override
     protected String getPackageLocation() {
@@ -38,21 +36,20 @@ public class ParameterNameTest extends AbstractGoogleModuleTestSupport {
     @Test
     public void testGeneralParameterName() throws Exception {
         final Configuration config = getModuleConfig("ParameterName");
-        final String format = config.getProperty("format");
-        final Map<String, String> messages = config.getMessages();
+        final String format = "^[a-z]([a-z0-9][a-zA-Z0-9]*)?$";
         final String[] expected = {
-            "10:21: " + getCheckMessage(messages, MSG_KEY, "bB", format),
-            "33:18: " + getCheckMessage(messages, MSG_KEY, "llll_llll", format),
-            "34:21: " + getCheckMessage(messages, MSG_KEY, "bB", format),
-            "64:13: " + getCheckMessage(messages, MSG_KEY, "$arg1", format),
-            "65:13: " + getCheckMessage(messages, MSG_KEY, "ar$g2", format),
-            "66:13: " + getCheckMessage(messages, MSG_KEY, "arg3$", format),
-            "67:13: " + getCheckMessage(messages, MSG_KEY, "a_rg4", format),
-            "68:13: " + getCheckMessage(messages, MSG_KEY, "_arg5", format),
-            "69:13: " + getCheckMessage(messages, MSG_KEY, "arg6_", format),
-            "70:13: " + getCheckMessage(messages, MSG_KEY, "aArg7", format),
-            "71:13: " + getCheckMessage(messages, MSG_KEY, "aArg8", format),
-            "72:13: " + getCheckMessage(messages, MSG_KEY, "aar_g", format),
+            "10:21: " + getCheckMessage(MSG, "bB", format),
+            "33:18: " + getCheckMessage(MSG, "llll_llll", format),
+            "34:21: " + getCheckMessage(MSG, "bB", format),
+            "64:13: " + getCheckMessage(MSG, "$arg1", format),
+            "65:13: " + getCheckMessage(MSG, "ar$g2", format),
+            "66:13: " + getCheckMessage(MSG, "arg3$", format),
+            "67:13: " + getCheckMessage(MSG, "a_rg4", format),
+            "68:13: " + getCheckMessage(MSG, "_arg5", format),
+            "69:13: " + getCheckMessage(MSG, "arg6_", format),
+            "70:13: " + getCheckMessage(MSG, "aArg7", format),
+            "71:13: " + getCheckMessage(MSG, "aArg8", format),
+            "72:13: " + getCheckMessage(MSG, "aar_g", format),
         };
 
         final String filePath = getPath("InputParameterName.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/RecordComponentNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule526parameternames/RecordComponentNameTest.java
@@ -19,8 +19,6 @@
 
 package com.google.checkstyle.test.chapter5naming.rule526parameternames;
 
-import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 
 import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
@@ -28,7 +26,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public class RecordComponentNameTest extends AbstractGoogleModuleTestSupport {
 
-    private static final String MSG_KEY = "name.invalidPattern";
+    private static final String MSG = "Record component name ''{0}'' must match pattern ''{1}''.";
 
     @Override
     protected String getPackageLocation() {
@@ -38,11 +36,10 @@ public class RecordComponentNameTest extends AbstractGoogleModuleTestSupport {
     @Test
     public void testGeneralParameterName() throws Exception {
         final Configuration config = getModuleConfig("RecordComponentName");
-        final String format = config.getProperty("format");
-        final Map<String, String> messages = config.getMessages();
+        final String format = "^[a-z]([a-z0-9][a-zA-Z0-9]*)?$";
         final String[] expected = {
-            "8:47: " + getCheckMessage(messages, MSG_KEY, "_componentName", format),
-            "12:40: " + getCheckMessage(messages, MSG_KEY, "Capital", format),
+            "8:47: " + getCheckMessage(MSG, "_componentName", format),
+            "12:40: " + getCheckMessage(MSG, "Capital", format),
         };
 
         final String filePath = getNonCompilablePath("InputRecordComponentName.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/LocalVariableNameTest.java
@@ -19,8 +19,6 @@
 
 package com.google.checkstyle.test.chapter5naming.rule527localvariablenames;
 
-import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 
 import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
@@ -28,7 +26,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public class LocalVariableNameTest extends AbstractGoogleModuleTestSupport {
 
-    private static final String MSG_KEY = "name.invalidPattern";
+    private static final String MSG = "Local variable name ''{0}'' must match pattern ''{1}''.";
 
     @Override
     protected String getPackageLocation() {
@@ -38,19 +36,18 @@ public class LocalVariableNameTest extends AbstractGoogleModuleTestSupport {
     @Test
     public void testLocalVariableName() throws Exception {
         final Configuration checkConfig = getModuleConfig("LocalVariableName");
-        final String format = checkConfig.getProperty("format");
-        final Map<String, String> messages = checkConfig.getMessages();
+        final String format = "^[a-z]([a-z0-9][a-zA-Z0-9]*)?$";
         final String[] expected = {
-            "27:13: " + getCheckMessage(messages, MSG_KEY, "aA", format),
-            "28:13: " + getCheckMessage(messages, MSG_KEY, "a1_a", format),
-            "29:13: " + getCheckMessage(messages, MSG_KEY, "A_A", format),
-            "30:13: " + getCheckMessage(messages, MSG_KEY, "aa2_a", format),
-            "31:13: " + getCheckMessage(messages, MSG_KEY, "_a", format),
-            "32:13: " + getCheckMessage(messages, MSG_KEY, "_aa", format),
-            "33:13: " + getCheckMessage(messages, MSG_KEY, "aa_", format),
-            "34:13: " + getCheckMessage(messages, MSG_KEY, "aaa$aaa", format),
-            "35:13: " + getCheckMessage(messages, MSG_KEY, "$aaaaaa", format),
-            "36:13: " + getCheckMessage(messages, MSG_KEY, "aaaaaa$", format),
+            "27:13: " + getCheckMessage(MSG, "aA", format),
+            "28:13: " + getCheckMessage(MSG, "a1_a", format),
+            "29:13: " + getCheckMessage(MSG, "A_A", format),
+            "30:13: " + getCheckMessage(MSG, "aa2_a", format),
+            "31:13: " + getCheckMessage(MSG, "_a", format),
+            "32:13: " + getCheckMessage(MSG, "_aa", format),
+            "33:13: " + getCheckMessage(MSG, "aa_", format),
+            "34:13: " + getCheckMessage(MSG, "aaa$aaa", format),
+            "35:13: " + getCheckMessage(MSG, "$aaaaaa", format),
+            "36:13: " + getCheckMessage(MSG, "aaaaaa$", format),
         };
 
         final String filePath = getPath("InputLocalVariableNameSimple.java");
@@ -62,15 +59,14 @@ public class LocalVariableNameTest extends AbstractGoogleModuleTestSupport {
     @Test
     public void testOneChar() throws Exception {
         final Configuration checkConfig = getModuleConfig("LocalVariableName");
-        final String format = checkConfig.getProperty("format");
-        final Map<String, String> messages = checkConfig.getMessages();
+        final String format = "^[a-z]([a-z0-9][a-zA-Z0-9]*)?$";
         final String[] expected = {
-            "21:17: " + getCheckMessage(messages, MSG_KEY, "I_ndex", format),
-            "45:17: " + getCheckMessage(messages, MSG_KEY, "i_ndex", format),
-            "49:17: " + getCheckMessage(messages, MSG_KEY, "ii_i1", format),
-            "53:17: " + getCheckMessage(messages, MSG_KEY, "$index", format),
-            "57:17: " + getCheckMessage(messages, MSG_KEY, "in$dex", format),
-            "61:17: " + getCheckMessage(messages, MSG_KEY, "index$", format),
+            "21:17: " + getCheckMessage(MSG, "I_ndex", format),
+            "45:17: " + getCheckMessage(MSG, "i_ndex", format),
+            "49:17: " + getCheckMessage(MSG, "ii_i1", format),
+            "53:17: " + getCheckMessage(MSG, "$index", format),
+            "57:17: " + getCheckMessage(MSG, "in$dex", format),
+            "61:17: " + getCheckMessage(MSG, "index$", format),
         };
 
         final String filePath = getPath("InputLocalVariableNameOneCharVarName.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/PatternVariableNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule527localvariablenames/PatternVariableNameTest.java
@@ -19,8 +19,6 @@
 
 package com.google.checkstyle.test.chapter5naming.rule527localvariablenames;
 
-import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 
 import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
@@ -28,7 +26,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public class PatternVariableNameTest extends AbstractGoogleModuleTestSupport {
 
-    private static final String MSG_KEY = "name.invalidPattern";
+    private static final String MSG = "Pattern variable name ''{0}'' must match pattern ''{1}''.";
 
     @Override
     protected String getPackageLocation() {
@@ -38,22 +36,21 @@ public class PatternVariableNameTest extends AbstractGoogleModuleTestSupport {
     @Test
     public void testPatternVariableName() throws Exception {
         final Configuration checkConfig = getModuleConfig("PatternVariableName");
-        final String format = checkConfig.getProperty("format");
-        final Map<String, String> messages = checkConfig.getMessages();
+        final String format = "^[a-z]([a-z0-9][a-zA-Z0-9]*)?$";
         final String[] expected = {
-            "11:39: " + getCheckMessage(messages, MSG_KEY, "OTHER", format),
-            "21:34: " + getCheckMessage(messages, MSG_KEY, "Count", format),
-            "36:36: " + getCheckMessage(messages, MSG_KEY, "aA", format),
-            "37:42: " + getCheckMessage(messages, MSG_KEY, "a1_a", format),
-            "40:34: " + getCheckMessage(messages, MSG_KEY, "A_A", format),
-            "41:43: " + getCheckMessage(messages, MSG_KEY, "aa2_a", format),
-            "53:37: " + getCheckMessage(messages, MSG_KEY, "_a", format),
-            "59:43: " + getCheckMessage(messages, MSG_KEY, "_aa", format),
-            "63:41: " + getCheckMessage(messages, MSG_KEY, "aa_", format),
-            "68:38: " + getCheckMessage(messages, MSG_KEY, "aaa$aaa", format),
-            "69:36: " + getCheckMessage(messages, MSG_KEY, "$aaaaaa", format),
-            "70:37: " + getCheckMessage(messages, MSG_KEY, "aaaaaa$", format),
-            "77:41: " + getCheckMessage(messages, MSG_KEY, "_A_aa_B", format),
+            "11:39: " + getCheckMessage(MSG, "OTHER", format),
+            "21:34: " + getCheckMessage(MSG, "Count", format),
+            "36:36: " + getCheckMessage(MSG, "aA", format),
+            "37:42: " + getCheckMessage(MSG, "a1_a", format),
+            "40:34: " + getCheckMessage(MSG, "A_A", format),
+            "41:43: " + getCheckMessage(MSG, "aa2_a", format),
+            "53:37: " + getCheckMessage(MSG, "_a", format),
+            "59:43: " + getCheckMessage(MSG, "_aa", format),
+            "63:41: " + getCheckMessage(MSG, "aa_", format),
+            "68:38: " + getCheckMessage(MSG, "aaa$aaa", format),
+            "69:36: " + getCheckMessage(MSG, "$aaaaaa", format),
+            "70:37: " + getCheckMessage(MSG, "aaaaaa$", format),
+            "77:41: " + getCheckMessage(MSG, "_A_aa_B", format),
 
         };
 

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassTypeParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/ClassTypeParameterNameTest.java
@@ -19,8 +19,6 @@
 
 package com.google.checkstyle.test.chapter5naming.rule528typevariablenames;
 
-import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 
 import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
@@ -28,7 +26,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public class ClassTypeParameterNameTest extends AbstractGoogleModuleTestSupport {
 
-    private static final String MSG_KEY = "name.invalidPattern";
+    private static final String MSG = "Class type name ''{0}'' must match pattern ''{1}''.";
 
     @Override
     protected String getPackageLocation() {
@@ -38,13 +36,12 @@ public class ClassTypeParameterNameTest extends AbstractGoogleModuleTestSupport 
     @Test
     public void testClassDefault() throws Exception {
         final Configuration configuration = getModuleConfig("ClassTypeParameterName");
-        final String format = configuration.getProperty("format");
-        final Map<String, String> messages = configuration.getMessages();
+        final String format = "(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)";
 
         final String[] expected = {
-            "5:36: " + getCheckMessage(messages, MSG_KEY, "t", format),
-            "13:14: " + getCheckMessage(messages, MSG_KEY, "foo", format),
-            "27:24: " + getCheckMessage(messages, MSG_KEY, "$foo", format),
+            "5:36: " + getCheckMessage(MSG, "t", format),
+            "13:14: " + getCheckMessage(MSG, "foo", format),
+            "27:24: " + getCheckMessage(MSG, "$foo", format),
         };
 
         final String filePath = getPath("InputClassTypeParameterName.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/InterfaceTypeParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/InterfaceTypeParameterNameTest.java
@@ -19,8 +19,6 @@
 
 package com.google.checkstyle.test.chapter5naming.rule528typevariablenames;
 
-import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 
 import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
@@ -28,7 +26,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public class InterfaceTypeParameterNameTest extends AbstractGoogleModuleTestSupport {
 
-    private static final String MSG_KEY = "name.invalidPattern";
+    private static final String MSG = "Interface type name ''{0}'' must match pattern ''{1}''.";
 
     @Override
     protected String getPackageLocation() {
@@ -38,13 +36,12 @@ public class InterfaceTypeParameterNameTest extends AbstractGoogleModuleTestSupp
     @Test
     public void testInterfaceDefault() throws Exception {
         final Configuration configuration = getModuleConfig("InterfaceTypeParameterName");
-        final String format = configuration.getProperty("format");
-        final Map<String, String> messages = configuration.getMessages();
+        final String format = "(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)";
 
         final String[] expected = {
-            "48:15: " + getCheckMessage(messages, MSG_KEY, "Input", format),
-            "76:25: " + getCheckMessage(messages, MSG_KEY, "Request", format),
-            "80:25: " + getCheckMessage(messages, MSG_KEY, "TRequest", format),
+            "48:15: " + getCheckMessage(MSG, "Input", format),
+            "76:25: " + getCheckMessage(MSG, "Request", format),
+            "80:25: " + getCheckMessage(MSG, "TRequest", format),
         };
 
         final String filePath = getPath("InputInterfaceTypeParameterName.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/MethodTypeParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/MethodTypeParameterNameTest.java
@@ -19,42 +19,32 @@
 
 package com.google.checkstyle.test.chapter5naming.rule528typevariablenames;
 
-import java.util.Map;
-
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
-import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public class MethodTypeParameterNameTest extends AbstractGoogleModuleTestSupport {
 
-    private static final String MSG_KEY = "name.invalidPattern";
-    private static String format;
+    private static final String MSG = "Method type name ''{0}'' must match pattern ''{1}''.";
 
     @Override
     protected String getPackageLocation() {
         return "com/google/checkstyle/test/chapter5naming/rule528typevariablenames";
     }
 
-    @BeforeAll
-    public static void setConfigurationBuilder() throws CheckstyleException {
-        format = getModuleConfig("ClassTypeParameterName").getProperty("format");
-    }
-
     @Test
     public void testMethodDefault() throws Exception {
         final Configuration checkConfig = getModuleConfig("MethodTypeParameterName");
-        final Map<String, String> messages = checkConfig.getMessages();
+        final String format = "(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)";
 
         final String[] expected = {
-            "9:6: " + getCheckMessage(messages, MSG_KEY, "e_e", format),
-            "19:6: " + getCheckMessage(messages, MSG_KEY, "Tfo$o2T", format),
-            "23:6: " + getCheckMessage(messages, MSG_KEY, "foo_", format),
-            "28:10: " + getCheckMessage(messages, MSG_KEY, "_abc", format),
-            "37:14: " + getCheckMessage(messages, MSG_KEY, "T$", format),
-            "42:14: " + getCheckMessage(messages, MSG_KEY, "EE", format),
+            "9:6: " + getCheckMessage(MSG, "e_e", format),
+            "19:6: " + getCheckMessage(MSG, "Tfo$o2T", format),
+            "23:6: " + getCheckMessage(MSG, "foo_", format),
+            "28:10: " + getCheckMessage(MSG, "_abc", format),
+            "37:14: " + getCheckMessage(MSG, "T$", format),
+            "42:14: " + getCheckMessage(MSG, "EE", format),
         };
 
         final String filePath = getPath("InputMethodTypeParameterName.java");

--- a/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/RecordTypeParameterNameTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter5naming/rule528typevariablenames/RecordTypeParameterNameTest.java
@@ -19,8 +19,6 @@
 
 package com.google.checkstyle.test.chapter5naming.rule528typevariablenames;
 
-import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 
 import com.google.checkstyle.test.base.AbstractGoogleModuleTestSupport;
@@ -28,7 +26,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 public class RecordTypeParameterNameTest extends AbstractGoogleModuleTestSupport {
 
-    private static final String MSG_KEY = "name.invalidPattern";
+    private static final String MSG = "Record type name ''{0}'' must match pattern ''{1}''.";
 
     @Override
     protected String getPackageLocation() {
@@ -38,13 +36,12 @@ public class RecordTypeParameterNameTest extends AbstractGoogleModuleTestSupport
     @Test
     public void testRecordDefault() throws Exception {
         final Configuration configuration = getModuleConfig("RecordTypeParameterName");
-        final String format = configuration.getProperty("format");
-        final Map<String, String> messages = configuration.getMessages();
+        final String format = "(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)";
 
         final String[] expected = {
-            "13:44: " + getCheckMessage(messages, MSG_KEY, "t", format),
-            "20:15: " + getCheckMessage(messages, MSG_KEY, "foo", format),
-            "35:25: " + getCheckMessage(messages, MSG_KEY, "foo", format),
+            "13:44: " + getCheckMessage(MSG, "t", format),
+            "20:15: " + getCheckMessage(MSG, "foo", format),
+            "35:25: " + getCheckMessage(MSG, "foo", format),
         };
 
         final String filePath = getNonCompilablePath("InputRecordTypeParameterName.java");

--- a/src/it/java/org/checkstyle/base/AbstractItModuleTestSupport.java
+++ b/src/it/java/org/checkstyle/base/AbstractItModuleTestSupport.java
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
@@ -473,22 +472,14 @@ public abstract class AbstractItModuleTestSupport extends AbstractPathTestSuppor
     /**
      * Gets the check message 'as is' from appropriate 'messages.properties' file.
      *
-     * @param messages the map of messages to scan.
-     * @param messageKey the key of message in 'messages.properties' file.
+     * @param message the message.
      * @param arguments the arguments of message in 'messages.properties' file.
      * @return The message of the check with the arguments applied.
      */
-    protected static String getCheckMessage(Map<String, String> messages, String messageKey,
+    protected static String getCheckMessage(String message,
             Object... arguments) {
-        String checkMessage = null;
-        for (Map.Entry<String, String> entry : messages.entrySet()) {
-            if (messageKey.equals(entry.getKey())) {
-                final MessageFormat formatter = new MessageFormat(entry.getValue(), Locale.ROOT);
-                checkMessage = formatter.format(arguments);
-                break;
-            }
-        }
-        return checkMessage;
+        final MessageFormat formatter = new MessageFormat(message, Locale.ROOT);
+        return formatter.format(arguments);
     }
 
     /**


### PR DESCRIPTION
Issue #11651 

As the title suggests, we will no longer pull values from the configuration, allowing us to change the precise configuration returned from our methods.

Messages must be in English since the configuration forces English for these.