### PR TITLE
Issue #11651: splits xpath it to be based on test tier

### DIFF
--- a/src/it/java/org/checkstyle/suppressionxpathfilter/AbstractXpathTestSupport.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/AbstractXpathTestSupport.java
@@ -22,6 +22,7 @@ package org.checkstyle.suppressionxpathfilter;
 import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -31,9 +32,9 @@ import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.checkstyle.base.AbstractCheckstyleModuleTestSupport;
 import org.junit.jupiter.api.io.TempDir;
 
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.JavaParser;
 import com.puppycrawl.tools.checkstyle.TreeWalker;
@@ -43,7 +44,7 @@ import com.puppycrawl.tools.checkstyle.filters.SuppressionXpathFilter;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import com.puppycrawl.tools.checkstyle.xpath.XpathQueryGenerator;
 
-public abstract class AbstractXpathTestSupport extends AbstractCheckstyleModuleTestSupport {
+public abstract class AbstractXpathTestSupport extends AbstractModuleTestSupport {
 
     private static final int DEFAULT_TAB_WIDTH = 4;
 
@@ -70,6 +71,32 @@ public abstract class AbstractXpathTestSupport extends AbstractCheckstyleModuleT
         final String subpackage = getCheckName().toLowerCase(Locale.ENGLISH)
                 .replace("check", "");
         return "org/checkstyle/suppressionxpathfilter/" + subpackage;
+    }
+
+    /**
+     * Returns canonical path for the file with the given file name.
+     * The path is formed base on the non-compilable resources location.
+     *
+     * @param filename file name.
+     * @return canonical path for the file with the given file name.
+     * @throws IOException if I/O exception occurs while forming the path.
+     */
+    protected final String getXpathPath(String filename) throws IOException {
+        return new File("src/it/resources/" + getPackageLocation() + "/"
+                + filename).getCanonicalPath();
+    }
+
+    /**
+     * Returns canonical path for the file with the given file name.
+     * The path is formed base on the non-compilable resources location.
+     *
+     * @param filename file name.
+     * @return canonical path for the file with the given file name.
+     * @throws IOException if I/O exception occurs while forming the path.
+     */
+    protected final String getXpathNonCompilablePath(String filename) throws IOException {
+        return new File("src/it/resources-noncompilable/" + getPackageLocation() + "/"
+                + filename).getCanonicalPath();
     }
 
     /**
@@ -210,8 +237,7 @@ public abstract class AbstractXpathTestSupport extends AbstractCheckstyleModuleT
         treeWalkerConfigWithXpath.addChild(createSuppressionXpathFilter(moduleConfig.getName(),
                 generatedXpathQueries));
 
-        final Integer[] warnList = getLinesWithWarn(fileToProcess.getPath());
-        verify(moduleConfig, fileToProcess.getPath(), expectedViolations, warnList);
+        verify(moduleConfig, fileToProcess.getPath(), expectedViolations);
         verifyXpathQueries(generatedXpathQueries, expectedXpathQueries);
         verify(treeWalkerConfigWithXpath, fileToProcess.getPath(), CommonUtil.EMPTY_STRING_ARRAY);
     }

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAbbreviationAsWordInNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAbbreviationAsWordInNameTest.java
@@ -39,7 +39,7 @@ public class XpathRegressionAbbreviationAsWordInNameTest extends AbstractXpathTe
 
     @Test
     public void testAnnotation() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionAbbreviationAsWordInNameAnnotation.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -62,7 +62,7 @@ public class XpathRegressionAbbreviationAsWordInNameTest extends AbstractXpathTe
 
     @Test
     public void testAnnotationField() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionAbbreviationAsWordInNameAnnotationField.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -85,7 +85,7 @@ public class XpathRegressionAbbreviationAsWordInNameTest extends AbstractXpathTe
 
     @Test
     public void testClass() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionAbbreviationAsWordInNameClass.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -108,7 +108,7 @@ public class XpathRegressionAbbreviationAsWordInNameTest extends AbstractXpathTe
 
     @Test
     public void testEnum() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionAbbreviationAsWordInNameEnum.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -131,7 +131,7 @@ public class XpathRegressionAbbreviationAsWordInNameTest extends AbstractXpathTe
 
     @Test
     public void testField() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionAbbreviationAsWordInNameField.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -154,7 +154,7 @@ public class XpathRegressionAbbreviationAsWordInNameTest extends AbstractXpathTe
 
     @Test
     public void testInterface() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionAbbreviationAsWordInNameInterface.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -177,7 +177,7 @@ public class XpathRegressionAbbreviationAsWordInNameTest extends AbstractXpathTe
 
     @Test
     public void testMethod() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionAbbreviationAsWordInNameMethod.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -200,7 +200,7 @@ public class XpathRegressionAbbreviationAsWordInNameTest extends AbstractXpathTe
 
     @Test
     public void testParameter() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionAbbreviationAsWordInNameParameter.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -224,7 +224,7 @@ public class XpathRegressionAbbreviationAsWordInNameTest extends AbstractXpathTe
 
     @Test
     public void testVariable() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionAbbreviationAsWordInNameVariable.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAbstractClassNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAbstractClassNameTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionAbstractClassNameTest extends AbstractXpathTestSuppo
     @Test
     public void testClassNameTop() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionAbstractClassNameTop.java"));
+                new File(getXpathPath("SuppressionXpathRegressionAbstractClassNameTop.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(AbstractClassNameCheck.class);
@@ -69,7 +69,7 @@ public class XpathRegressionAbstractClassNameTest extends AbstractXpathTestSuppo
     @Test
     public void testClassNameInner() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionAbstractClassNameInner.java"));
+                new File(getXpathPath("SuppressionXpathRegressionAbstractClassNameInner.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(AbstractClassNameCheck.class);
@@ -98,8 +98,8 @@ public class XpathRegressionAbstractClassNameTest extends AbstractXpathTestSuppo
 
     @Test
     public void testClassNameNoModifier() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionAbstractClassNameNoModifier.java"));
+        final File fileToProcess = new File(
+                getXpathPath("SuppressionXpathRegressionAbstractClassNameNoModifier.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(AbstractClassNameCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAnnotationLocationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAnnotationLocationTest.java
@@ -39,7 +39,7 @@ public class XpathRegressionAnnotationLocationTest extends AbstractXpathTestSupp
 
     @Test
     public void testClass() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionAnnotationLocationClass.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -70,7 +70,7 @@ public class XpathRegressionAnnotationLocationTest extends AbstractXpathTestSupp
 
     @Test
     public void testInterface() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionAnnotationLocationInterface.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -103,7 +103,7 @@ public class XpathRegressionAnnotationLocationTest extends AbstractXpathTestSupp
 
     @Test
     public void testEnum() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionAnnotationLocationEnum.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -136,7 +136,7 @@ public class XpathRegressionAnnotationLocationTest extends AbstractXpathTestSupp
 
     @Test
     public void testMethod() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionAnnotationLocationMethod.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -173,7 +173,7 @@ public class XpathRegressionAnnotationLocationTest extends AbstractXpathTestSupp
 
     @Test
     public void testVariable() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionAnnotationLocationVariable.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -210,7 +210,7 @@ public class XpathRegressionAnnotationLocationTest extends AbstractXpathTestSupp
 
     @Test
     public void testConstructor() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionAnnotationLocationCTOR.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAnnotationOnSameLineTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAnnotationOnSameLineTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionAnnotationOnSameLineTest extends AbstractXpathTestSu
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath(
+                new File(getXpathPath(
                         "SuppressionXpathRegressionAnnotationOnSameLineOne.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -82,7 +82,7 @@ public class XpathRegressionAnnotationOnSameLineTest extends AbstractXpathTestSu
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath(
+                new File(getXpathPath(
                         "SuppressionXpathRegressionAnnotationOnSameLineTwo.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -118,7 +118,7 @@ public class XpathRegressionAnnotationOnSameLineTest extends AbstractXpathTestSu
     @Test
     public void testThree() throws Exception {
         final File fileToProcess =
-                new File(getPath(
+                new File(getXpathPath(
                         "SuppressionXpathRegressionAnnotationOnSameLineThree.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAnnotationUseStyleTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAnnotationUseStyleTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionAnnotationUseStyleTest extends AbstractXpathTestSupp
 
     @Test
     public void testOne() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionAnnotationUseStyleOne.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -67,7 +67,7 @@ public class XpathRegressionAnnotationUseStyleTest extends AbstractXpathTestSupp
 
     @Test
     public void testTwo() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionAnnotationUseStyleTwo.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -102,7 +102,7 @@ public class XpathRegressionAnnotationUseStyleTest extends AbstractXpathTestSupp
 
     @Test
     public void testThree() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionAnnotationUseStyleThree.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -139,7 +139,7 @@ public class XpathRegressionAnnotationUseStyleTest extends AbstractXpathTestSupp
 
     @Test
     public void testFour() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionAnnotationUseStyleFour.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -167,7 +167,7 @@ public class XpathRegressionAnnotationUseStyleTest extends AbstractXpathTestSupp
 
     @Test
     public void testFive() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionAnnotationUseStyleFive.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -203,7 +203,7 @@ public class XpathRegressionAnnotationUseStyleTest extends AbstractXpathTestSupp
 
     @Test
     public void testSix() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionAnnotationUseStyleSix.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -239,7 +239,7 @@ public class XpathRegressionAnnotationUseStyleTest extends AbstractXpathTestSupp
 
     @Test
     public void testSeven() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionAnnotationUseStyleSeven.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -266,7 +266,7 @@ public class XpathRegressionAnnotationUseStyleTest extends AbstractXpathTestSupp
 
     @Test
     public void testEight() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionAnnotationUseStyleEight.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAnonInnerLengthTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAnonInnerLengthTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionAnonInnerLengthTest extends AbstractXpathTestSupport
     @Test
     public void testDefault() throws Exception {
         final File fileToProcess =
-            new File(getPath("SuppressionXpathRegressionAnonInnerLengthDefault.java"));
+            new File(getXpathPath("SuppressionXpathRegressionAnonInnerLengthDefault.java"));
 
         final DefaultConfiguration moduleConfig =
             createModuleConfig(AnonInnerLengthCheck.class);
@@ -71,7 +71,7 @@ public class XpathRegressionAnonInnerLengthTest extends AbstractXpathTestSupport
     public void testMaxLength() throws Exception {
         final int maxLen = 5;
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionAnonInnerLength.java"));
+                new File(getXpathPath("SuppressionXpathRegressionAnonInnerLength.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(AnonInnerLengthCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionArrayTrailingCommaTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionArrayTrailingCommaTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionArrayTrailingCommaTest extends AbstractXpathTestSupp
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionArrayTrailingCommaOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionArrayTrailingCommaOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ArrayTrailingCommaCheck.class);
@@ -69,7 +69,7 @@ public class XpathRegressionArrayTrailingCommaTest extends AbstractXpathTestSupp
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionArrayTrailingCommaTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionArrayTrailingCommaTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ArrayTrailingCommaCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionArrayTypeStyleTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionArrayTypeStyleTest.java
@@ -38,7 +38,7 @@ public class XpathRegressionArrayTypeStyleTest extends AbstractXpathTestSupport 
     @Test
     public void testVariable() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionArrayTypeStyleVariable.java"));
+                new File(getXpathPath("SuppressionXpathRegressionArrayTypeStyleVariable.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ArrayTypeStyleCheck.class);
@@ -61,7 +61,7 @@ public class XpathRegressionArrayTypeStyleTest extends AbstractXpathTestSupport 
     @Test
     public void testMethodDef() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionArrayTypeStyleMethodDef.java"));
+                new File(getXpathPath("SuppressionXpathRegressionArrayTypeStyleMethodDef.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ArrayTypeStyleCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidDoubleBraceInitializationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidDoubleBraceInitializationTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionAvoidDoubleBraceInitializationTest extends AbstractX
     @Test
     public void testOne() throws Exception {
         final File fileToProcess = new File(
-            getPath("SuppressionXpathRegressionAvoidDoubleBraceInitialization.java"));
+            getXpathPath("SuppressionXpathRegressionAvoidDoubleBraceInitialization.java"));
 
         final DefaultConfiguration moduleConfig = createModuleConfig(clazz);
 
@@ -66,7 +66,7 @@ public class XpathRegressionAvoidDoubleBraceInitializationTest extends AbstractX
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess = new File(
-            getPath("SuppressionXpathRegressionAvoidDoubleBraceInitializationTwo.java"));
+            getXpathPath("SuppressionXpathRegressionAvoidDoubleBraceInitializationTwo.java"));
 
         final DefaultConfiguration moduleConfig = createModuleConfig(clazz);
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidEscapedUnicodeCharactersTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidEscapedUnicodeCharactersTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionAvoidEscapedUnicodeCharactersTest extends AbstractXp
 
     @Test
     public void testDefault() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
             "SuppressionXpathRegressionAvoidEscapedUnicodeCharactersDefault.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -67,7 +67,7 @@ public class XpathRegressionAvoidEscapedUnicodeCharactersTest extends AbstractXp
 
     @Test
     public void testControlCharacters() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
             "SuppressionXpathRegressionAvoidEscapedUnicodeCharactersControlCharacters.java")
         );
 
@@ -98,7 +98,7 @@ public class XpathRegressionAvoidEscapedUnicodeCharactersTest extends AbstractXp
 
     @Test
     public void testTailComment() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
             "SuppressionXpathRegressionAvoidEscapedUnicodeCharactersTailComment.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -128,7 +128,7 @@ public class XpathRegressionAvoidEscapedUnicodeCharactersTest extends AbstractXp
 
     @Test
     public void testAllCharactersEscaped() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
             "SuppressionXpathRegressionAvoidEscapedUnicodeCharactersAllEscaped.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -158,7 +158,7 @@ public class XpathRegressionAvoidEscapedUnicodeCharactersTest extends AbstractXp
 
     @Test
     public void testNonPrintableCharacters() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
             "SuppressionXpathRegressionAvoidEscapedUnicodeCharactersNonPrintable.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidInlineConditionalsTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidInlineConditionalsTest.java
@@ -39,7 +39,7 @@ public class XpathRegressionAvoidInlineConditionalsTest extends AbstractXpathTes
     @Test
     public void testInlineConditionalsVariableDef() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionAvoidInlineConditionalsVariableDef.java"));
+                getXpathPath("SuppressionXpathRegressionAvoidInlineConditionalsVariableDef.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(AvoidInlineConditionalsCheck.class);
@@ -67,7 +67,7 @@ public class XpathRegressionAvoidInlineConditionalsTest extends AbstractXpathTes
     @Test
     public void testInlineConditionalsAssign() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionAvoidInlineConditionalsAssign.java"));
+                getXpathPath("SuppressionXpathRegressionAvoidInlineConditionalsAssign.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(AvoidInlineConditionalsCheck.class);
@@ -91,7 +91,7 @@ public class XpathRegressionAvoidInlineConditionalsTest extends AbstractXpathTes
     @Test
     public void testInlineConditionalsAssert() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionAvoidInlineConditionalsAssert.java"));
+                getXpathPath("SuppressionXpathRegressionAvoidInlineConditionalsAssert.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(AvoidInlineConditionalsCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidNestedBlocksTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidNestedBlocksTest.java
@@ -39,7 +39,7 @@ public class XpathRegressionAvoidNestedBlocksTest extends AbstractXpathTestSuppo
     @Test
     public void testEmpty() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionAvoidNestedBlocksEmpty.java"));
+                getXpathPath("SuppressionXpathRegressionAvoidNestedBlocksEmpty.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(AvoidNestedBlocksCheck.class);
@@ -62,7 +62,7 @@ public class XpathRegressionAvoidNestedBlocksTest extends AbstractXpathTestSuppo
     @Test
     public void testVariableAssignment() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionAvoidNestedBlocksVariable.java"));
+                getXpathPath("SuppressionXpathRegressionAvoidNestedBlocksVariable.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(AvoidNestedBlocksCheck.class);
@@ -85,7 +85,7 @@ public class XpathRegressionAvoidNestedBlocksTest extends AbstractXpathTestSuppo
     @Test
     public void testSwitchAllowInSwitchCaseFalse() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionAvoidNestedBlocksSwitch1.java"));
+                getXpathPath("SuppressionXpathRegressionAvoidNestedBlocksSwitch1.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(AvoidNestedBlocksCheck.class);
@@ -117,7 +117,7 @@ public class XpathRegressionAvoidNestedBlocksTest extends AbstractXpathTestSuppo
     @Test
     public void testSwitchAllowInSwitchCaseTrue() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionAvoidNestedBlocksSwitch2.java"));
+                getXpathPath("SuppressionXpathRegressionAvoidNestedBlocksSwitch2.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(AvoidNestedBlocksCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidNoArgumentSuperConstructorCallTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidNoArgumentSuperConstructorCallTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionAvoidNoArgumentSuperConstructorCallTest
 
     @Test
     public void testDefault() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
             "SuppressionXpathRegressionAvoidNoArgumentSuperConstructorCall.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -65,7 +65,7 @@ public class XpathRegressionAvoidNoArgumentSuperConstructorCallTest
 
     @Test
     public void testInnerClass() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
             "SuppressionXpathRegressionAvoidNoArgumentSuperConstructorCallInnerClass.java"
         ));
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidStarImportTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidStarImportTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionAvoidStarImportTest
 
     @Test
     public void testOne() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
             "SuppressionXpathRegressionAvoidStarImport1.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -61,7 +61,7 @@ public class XpathRegressionAvoidStarImportTest
 
     @Test
     public void testTwo() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
             "SuppressionXpathRegressionAvoidStarImport2.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidStaticImportTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionAvoidStaticImportTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionAvoidStaticImportTest
 
     @Test
     public void testOne() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
             "SuppressionXpathRegressionAvoidStaticImport1.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -61,7 +61,7 @@ public class XpathRegressionAvoidStaticImportTest
 
     @Test
     public void testTwo() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
             "SuppressionXpathRegressionAvoidStaticImport2.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionClassMemberImpliedModifierTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionClassMemberImpliedModifierTest.java
@@ -39,8 +39,8 @@ public class XpathRegressionClassMemberImpliedModifierTest extends AbstractXpath
 
     @Test
     public void testOne() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionClassMemberImpliedModifierOne.java"));
+        final File fileToProcess = new File(
+                getXpathPath("SuppressionXpathRegressionClassMemberImpliedModifierOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ClassMemberImpliedModifierCheck.class);
@@ -68,8 +68,8 @@ public class XpathRegressionClassMemberImpliedModifierTest extends AbstractXpath
 
     @Test
     public void testTwo() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionClassMemberImpliedModifierTwo.java"));
+        final File fileToProcess = new File(
+                getXpathPath("SuppressionXpathRegressionClassMemberImpliedModifierTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ClassMemberImpliedModifierCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionCommentsIndentationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionCommentsIndentationTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
     @Test
     public void testSingleLine() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionCommentsIndentation"
+                new File(getXpathPath("SuppressionXpathRegressionCommentsIndentation"
                                         + "SingleLine.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -64,7 +64,7 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
     @Test
     public void testBlock() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionCommentsIndentation"
+                new File(getXpathPath("SuppressionXpathRegressionCommentsIndentation"
                                         + "Block.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -89,7 +89,7 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
     @Test
     public void testSeparator() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionCommentsIndentation"
+                new File(getXpathPath("SuppressionXpathRegressionCommentsIndentation"
                                         + "Separator.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -114,7 +114,7 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
     @Test
     public void testDistributedStatement() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionCommentsIndentation"
+                new File(getXpathPath("SuppressionXpathRegressionCommentsIndentation"
                                         + "DistributedStatement.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -139,7 +139,7 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
     @Test
     public void testSingleLineBlock() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionCommentsIndentation"
+                new File(getXpathPath("SuppressionXpathRegressionCommentsIndentation"
                                         + "SingleLineBlock.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -164,7 +164,7 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
     @Test
     public void testNonEmptyCase() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionCommentsIndentation"
+                new File(getXpathPath("SuppressionXpathRegressionCommentsIndentation"
                                         + "NonEmptyCase.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -189,7 +189,7 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
     @Test
     public void testEmptyCase() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionCommentsIndentation"
+                new File(getXpathPath("SuppressionXpathRegressionCommentsIndentation"
                                         + "EmptyCase.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -214,7 +214,7 @@ public class XpathRegressionCommentsIndentationTest extends AbstractXpathTestSup
     @Test
     public void testWithinBlockStatement() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionCommentsIndentation"
+                new File(getXpathPath("SuppressionXpathRegressionCommentsIndentation"
                                         + "WithinBlockStatement.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionCovariantEqualsTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionCovariantEqualsTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionCovariantEqualsTest extends AbstractXpathTestSupport
     @Test
     public void testCovariantEqualsInClass() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionCovariantEqualsInClass.java"));
+                new File(getXpathPath("SuppressionXpathRegressionCovariantEqualsInClass.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(CovariantEqualsCheck.class);
@@ -63,7 +63,7 @@ public class XpathRegressionCovariantEqualsTest extends AbstractXpathTestSupport
     @Test
     public void testCovariantEqualsInEnum() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionCovariantEqualsInEnum.java"));
+                new File(getXpathPath("SuppressionXpathRegressionCovariantEqualsInEnum.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(CovariantEqualsCheck.class);
@@ -85,7 +85,7 @@ public class XpathRegressionCovariantEqualsTest extends AbstractXpathTestSupport
     @Test
     public void testCovariantEqualsInRecord() throws Exception {
         final File fileToProcess =
-                new File(getNonCompilablePath(
+                new File(getXpathNonCompilablePath(
                         "SuppressionXpathRegressionCovariantEqualsInRecord.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionCustomImportOrderTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionCustomImportOrderTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionCustomImportOrderTest extends AbstractXpathTestSuppo
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionCustomImportOrderOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionCustomImportOrderOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(CustomImportOrderCheck.class);
@@ -64,7 +64,7 @@ public class XpathRegressionCustomImportOrderTest extends AbstractXpathTestSuppo
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionCustomImportOrderTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionCustomImportOrderTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(CustomImportOrderCheck.class);
@@ -86,7 +86,7 @@ public class XpathRegressionCustomImportOrderTest extends AbstractXpathTestSuppo
     @Test
     public void testThree() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionCustomImportOrderThree.java"));
+                new File(getXpathPath("SuppressionXpathRegressionCustomImportOrderThree.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(CustomImportOrderCheck.class);
@@ -108,7 +108,7 @@ public class XpathRegressionCustomImportOrderTest extends AbstractXpathTestSuppo
     @Test
     public void testFour() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionCustomImportOrderFour.java"));
+                new File(getXpathPath("SuppressionXpathRegressionCustomImportOrderFour.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(CustomImportOrderCheck.class);
@@ -131,7 +131,7 @@ public class XpathRegressionCustomImportOrderTest extends AbstractXpathTestSuppo
     @Test
     public void testFive() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionCustomImportOrderFive.java"));
+                new File(getXpathPath("SuppressionXpathRegressionCustomImportOrderFive.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(CustomImportOrderCheck.class);
@@ -154,7 +154,7 @@ public class XpathRegressionCustomImportOrderTest extends AbstractXpathTestSuppo
     @Test
     public void testSix() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionCustomImportOrderSix.java"));
+                new File(getXpathPath("SuppressionXpathRegressionCustomImportOrderSix.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(CustomImportOrderCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionCyclomaticComplexityTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionCyclomaticComplexityTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionCyclomaticComplexityTest extends AbstractXpathTestSu
     public void testOne() throws Exception {
 
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionCyclomaticComplexityOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionCyclomaticComplexityOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(CyclomaticComplexityCheck.class);
@@ -71,7 +71,7 @@ public class XpathRegressionCyclomaticComplexityTest extends AbstractXpathTestSu
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionCyclomaticComplexityTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionCyclomaticComplexityTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(CyclomaticComplexityCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionDeclarationOrderTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionDeclarationOrderTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionDeclarationOrderTest extends AbstractXpathTestSuppor
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionDeclarationOrderOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionDeclarationOrderOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(DeclarationOrderCheck.class);
@@ -69,7 +69,7 @@ public class XpathRegressionDeclarationOrderTest extends AbstractXpathTestSuppor
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionDeclarationOrderTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionDeclarationOrderTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(DeclarationOrderCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionDefaultComesLastTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionDefaultComesLastTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionDefaultComesLastTest extends AbstractXpathTestSuppor
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionDefaultComesLastOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionDefaultComesLastOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(DefaultComesLastCheck.class);
@@ -69,7 +69,7 @@ public class XpathRegressionDefaultComesLastTest extends AbstractXpathTestSuppor
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionDefaultComesLastTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionDefaultComesLastTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(DefaultComesLastCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionEmptyBlockTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionEmptyBlockTest.java
@@ -39,7 +39,7 @@ public class XpathRegressionEmptyBlockTest extends AbstractXpathTestSupport {
     @Test
     public void testEmptyForLoopEmptyBlock() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionEmptyBlockEmpty.java"));
+                new File(getXpathPath("SuppressionXpathRegressionEmptyBlockEmpty.java"));
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(EmptyBlockCheck.class);
         moduleConfig.addAttribute("option", "TEXT");
@@ -60,7 +60,7 @@ public class XpathRegressionEmptyBlockTest extends AbstractXpathTestSupport {
     @Test
     public void testEmptyForLoopEmptyStatement() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionEmptyBlockEmpty.java"));
+                new File(getXpathPath("SuppressionXpathRegressionEmptyBlockEmpty.java"));
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(EmptyBlockCheck.class);
         final String[] expectedViolation = {

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionEmptyCatchBlockTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionEmptyCatchBlockTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionEmptyCatchBlockTest extends AbstractXpathTestSupport
     @Test
     public void testOne() throws Exception {
         final File fileToProcess = new File(
-            getPath("SuppressionXpathRegressionEmptyCatchBlock1.java"));
+            getXpathPath("SuppressionXpathRegressionEmptyCatchBlock1.java"));
 
         final DefaultConfiguration moduleConfig = createModuleConfig(clazz);
 
@@ -62,7 +62,7 @@ public class XpathRegressionEmptyCatchBlockTest extends AbstractXpathTestSupport
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess = new File(
-            getPath("SuppressionXpathRegressionEmptyCatchBlock2.java"));
+            getXpathPath("SuppressionXpathRegressionEmptyCatchBlock2.java"));
 
         final DefaultConfiguration moduleConfig = createModuleConfig(clazz);
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionEmptyForInitializerPadTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionEmptyForInitializerPadTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionEmptyForInitializerPadTest extends AbstractXpathTest
     @Test
     public void testPreceded() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionEmptyForInitializerPadPreceded.java"));
+                getXpathPath("SuppressionXpathRegressionEmptyForInitializerPadPreceded.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(EmptyForInitializerPadCheck.class);
@@ -67,7 +67,7 @@ public class XpathRegressionEmptyForInitializerPadTest extends AbstractXpathTest
     @Test
     public void testNotPreceded() throws Exception {
         final File fileToProcess = new File(
-            getPath("SuppressionXpathRegressionEmptyForInitializerPadNotPreceded.java"));
+            getXpathPath("SuppressionXpathRegressionEmptyForInitializerPadNotPreceded.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(EmptyForInitializerPadCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionEmptyForIteratorPadTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionEmptyForIteratorPadTest.java
@@ -40,8 +40,8 @@ public class XpathRegressionEmptyForIteratorPadTest extends AbstractXpathTestSup
 
     @Test
     public void testFollowed() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionEmptyForIteratorPadFollowed.java"));
+        final File fileToProcess = new File(
+                getXpathPath("SuppressionXpathRegressionEmptyForIteratorPadFollowed.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(EmptyForIteratorPadCheck.class);
@@ -66,8 +66,8 @@ public class XpathRegressionEmptyForIteratorPadTest extends AbstractXpathTestSup
 
     @Test
     public void testNotFollowed() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionEmptyForIteratorPadNotFollowed.java"));
+        final File fileToProcess = new File(
+                getXpathPath("SuppressionXpathRegressionEmptyForIteratorPadNotFollowed.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(EmptyForIteratorPadCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionEmptyLineSeparatorTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionEmptyLineSeparatorTest.java
@@ -39,7 +39,7 @@ public class XpathRegressionEmptyLineSeparatorTest extends AbstractXpathTestSupp
     @Test
     public void testOne() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionEmptyLineSeparator1.java")
+                getXpathPath("SuppressionXpathRegressionEmptyLineSeparator1.java")
         );
 
         final DefaultConfiguration moduleConfig =
@@ -61,7 +61,7 @@ public class XpathRegressionEmptyLineSeparatorTest extends AbstractXpathTestSupp
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionEmptyLineSeparator2.java")
+                getXpathPath("SuppressionXpathRegressionEmptyLineSeparator2.java")
         );
 
         final DefaultConfiguration moduleConfig =
@@ -83,7 +83,7 @@ public class XpathRegressionEmptyLineSeparatorTest extends AbstractXpathTestSupp
     @Test
     public void testThree() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionEmptyLineSeparator3.java")
+                getXpathPath("SuppressionXpathRegressionEmptyLineSeparator3.java")
         );
 
         final DefaultConfiguration moduleConfig =
@@ -117,7 +117,7 @@ public class XpathRegressionEmptyLineSeparatorTest extends AbstractXpathTestSupp
     @Test
     public void testFour() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionEmptyLineSeparator4.java")
+                getXpathPath("SuppressionXpathRegressionEmptyLineSeparator4.java")
         );
 
         final DefaultConfiguration moduleConfig =
@@ -141,7 +141,7 @@ public class XpathRegressionEmptyLineSeparatorTest extends AbstractXpathTestSupp
     @Test
     public void testFive() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionEmptyLineSeparator5.java")
+                getXpathPath("SuppressionXpathRegressionEmptyLineSeparator5.java")
         );
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionEmptyStatementTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionEmptyStatementTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionEmptyStatementTest extends AbstractXpathTestSupport 
     @Test
     public void testForLoopEmptyStatement() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionEmptyStatement1.java"));
+                new File(getXpathPath("SuppressionXpathRegressionEmptyStatement1.java"));
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(EmptyStatementCheck.class);
         final String[] expectedViolation = {
@@ -59,7 +59,7 @@ public class XpathRegressionEmptyStatementTest extends AbstractXpathTestSupport 
     @Test
     public void testIfBlockEmptyStatement() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionEmptyStatement2.java"));
+                new File(getXpathPath("SuppressionXpathRegressionEmptyStatement2.java"));
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(EmptyStatementCheck.class);
         final String[] expectedViolation = {

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionExplicitInitializationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionExplicitInitializationTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionExplicitInitializationTest extends AbstractXpathTest
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionExplicitInitializationOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionExplicitInitializationOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ExplicitInitializationCheck.class);
@@ -63,7 +63,7 @@ public class XpathRegressionExplicitInitializationTest extends AbstractXpathTest
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionExplicitInitializationTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionExplicitInitializationTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ExplicitInitializationCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionFallThroughTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionFallThroughTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionFallThroughTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionFallThroughOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionFallThroughOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(FallThroughCheck.class);
@@ -67,7 +67,7 @@ public class XpathRegressionFallThroughTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionFallThroughTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionFallThroughTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(FallThroughCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionFinalClassTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionFinalClassTest.java
@@ -38,7 +38,7 @@ public class XpathRegressionFinalClassTest extends AbstractXpathTestSupport {
 
     @Test
     public void testOne() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionFinalClass1.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -64,7 +64,7 @@ public class XpathRegressionFinalClassTest extends AbstractXpathTestSupport {
 
     @Test
     public void testTwo() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionFinalClass2.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionGenericWhitespaceTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionGenericWhitespaceTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
     @Test
     public void testProcessEnd() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionGenericWhitespaceEnd.java"));
+                getXpathPath("SuppressionXpathRegressionGenericWhitespaceEnd.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(GenericWhitespaceCheck.class);
@@ -66,7 +66,7 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
     @Test
     public void testProcessNestedGenericsOne() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionGenericWhitespaceNestedGenericsOne.java"));
+                getXpathPath("SuppressionXpathRegressionGenericWhitespaceNestedGenericsOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(GenericWhitespaceCheck.class);
@@ -91,7 +91,7 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
     @Test
     public void testProcessNestedGenericsTwo() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionGenericWhitespaceNestedGenericsTwo.java"));
+                getXpathPath("SuppressionXpathRegressionGenericWhitespaceNestedGenericsTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(GenericWhitespaceCheck.class);
@@ -115,8 +115,8 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
 
     @Test
     public void testProcessNestedGenericsThree() throws Exception {
-        final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionGenericWhitespaceNestedGenericsThree.java"));
+        final File fileToProcess = new File(getXpathPath(
+                "SuppressionXpathRegressionGenericWhitespaceNestedGenericsThree.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(GenericWhitespaceCheck.class);
@@ -141,7 +141,7 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
     @Test
     public void testProcessSingleGenericOne() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionGenericWhitespaceSingleGenericOne.java"));
+                getXpathPath("SuppressionXpathRegressionGenericWhitespaceSingleGenericOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(GenericWhitespaceCheck.class);
@@ -166,7 +166,7 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
     @Test
     public void testProcessSingleGenericTwo() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionGenericWhitespaceSingleGenericTwo.java"));
+                getXpathPath("SuppressionXpathRegressionGenericWhitespaceSingleGenericTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(GenericWhitespaceCheck.class);
@@ -189,7 +189,7 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
     @Test
     public void testProcessStartOne() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionGenericWhitespaceStartOne.java"));
+                getXpathPath("SuppressionXpathRegressionGenericWhitespaceStartOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(GenericWhitespaceCheck.class);
@@ -215,7 +215,7 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
     @Test
     public void testProcessStartTwo() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionGenericWhitespaceStartTwo.java"));
+                getXpathPath("SuppressionXpathRegressionGenericWhitespaceStartTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(GenericWhitespaceCheck.class);
@@ -245,7 +245,7 @@ public class XpathRegressionGenericWhitespaceTest extends AbstractXpathTestSuppo
     @Test
     public void testProcessStartThree() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionGenericWhitespaceStartThree.java"));
+                getXpathPath("SuppressionXpathRegressionGenericWhitespaceStartThree.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(GenericWhitespaceCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionHiddenFieldTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionHiddenFieldTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionHiddenFieldTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionHiddenFieldOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionHiddenFieldOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(HiddenFieldCheck.class);
@@ -64,7 +64,7 @@ public class XpathRegressionHiddenFieldTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionHiddenFieldTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionHiddenFieldTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(HiddenFieldCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionIllegalCatchTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionIllegalCatchTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionIllegalCatchTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionIllegalCatchOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionIllegalCatchOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IllegalCatchCheck.class);
@@ -64,7 +64,7 @@ public class XpathRegressionIllegalCatchTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionIllegalCatchTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionIllegalCatchTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IllegalCatchCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionIllegalIdentifierNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionIllegalIdentifierNameTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionIllegalIdentifierNameTest extends AbstractXpathTestS
 
     @Test
     public void testOne() throws Exception {
-        final File fileToProcess = new File(getNonCompilablePath(
+        final File fileToProcess = new File(getXpathNonCompilablePath(
             "SuppressionXpathRegressionIllegalIdentifierNameTestOne.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -65,7 +65,7 @@ public class XpathRegressionIllegalIdentifierNameTest extends AbstractXpathTestS
 
     @Test
     public void testTwo() throws Exception {
-        final File fileToProcess = new File(getNonCompilablePath(
+        final File fileToProcess = new File(getXpathNonCompilablePath(
             "SuppressionXpathRegressionIllegalIdentifierNameTestTwo.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionIllegalImportTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionIllegalImportTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionIllegalImportTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionIllegalImportOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionIllegalImportOne.java"));
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IllegalImportCheck.class);
         moduleConfig.addProperty("illegalPkgs", "java.util");
@@ -59,7 +59,7 @@ public class XpathRegressionIllegalImportTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionIllegalImportTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionIllegalImportTwo.java"));
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IllegalImportCheck.class);
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionIllegalThrowsTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionIllegalThrowsTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionIllegalThrowsTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionIllegalThrowsOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionIllegalThrowsOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IllegalThrowsCheck.class);
@@ -64,7 +64,7 @@ public class XpathRegressionIllegalThrowsTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionIllegalThrowsTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionIllegalThrowsTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IllegalThrowsCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionIllegalTokenTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionIllegalTokenTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionIllegalTokenTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionIllegalToken1.java"));
+                new File(getXpathPath("SuppressionXpathRegressionIllegalToken1.java"));
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IllegalTokenCheck.class);
         final String[] expectedViolation = {
@@ -61,7 +61,7 @@ public class XpathRegressionIllegalTokenTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionIllegalToken2.java"));
+                new File(getXpathPath("SuppressionXpathRegressionIllegalToken2.java"));
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IllegalTokenCheck.class);
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionIllegalTypeTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionIllegalTypeTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionIllegalTypeTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-            new File(getPath("SuppressionXpathRegressionIllegalTypeOne.java"));
+            new File(getXpathPath("SuppressionXpathRegressionIllegalTypeOne.java"));
         final DefaultConfiguration moduleConfig =
             createModuleConfig(IllegalTypeCheck.class);
         moduleConfig.addProperty("tokens", "METHOD_DEF");
@@ -63,7 +63,7 @@ public class XpathRegressionIllegalTypeTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-            new File(getPath("SuppressionXpathRegressionIllegalTypeTwo.java"));
+            new File(getXpathPath("SuppressionXpathRegressionIllegalTypeTwo.java"));
         final DefaultConfiguration moduleConfig =
             createModuleConfig(IllegalTypeCheck.class);
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionImportControlTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionImportControlTest.java
@@ -41,11 +41,11 @@ public class XpathRegressionImportControlTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionImportControlOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionImportControlOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ImportControlCheck.class);
-        moduleConfig.addProperty("file", getPath(
+        moduleConfig.addProperty("file", getXpathPath(
                 "SuppressionXpathRegressionImportControlOne.xml"));
 
         final String[] expectedViolation = {
@@ -64,11 +64,11 @@ public class XpathRegressionImportControlTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionImportControlTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionImportControlTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ImportControlCheck.class);
-        moduleConfig.addProperty("file", getPath(
+        moduleConfig.addProperty("file", getXpathPath(
                 "SuppressionXpathRegressionImportControlTwo.xml"));
 
         final String[] expectedViolation = {
@@ -87,7 +87,7 @@ public class XpathRegressionImportControlTest extends AbstractXpathTestSupport {
     @Test
     public void testThree() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionImportControlThree.java"));
+                new File(getXpathPath("SuppressionXpathRegressionImportControlThree.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ImportControlCheck.class);
@@ -108,12 +108,12 @@ public class XpathRegressionImportControlTest extends AbstractXpathTestSupport {
     @Test
     public void testFour() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionImportControlFour.java"));
+                new File(getXpathPath("SuppressionXpathRegressionImportControlFour.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ImportControlCheck.class);
         moduleConfig.addProperty("file",
-                getPath("SuppressionXpathRegressionImportControlFour.xml"));
+                getXpathPath("SuppressionXpathRegressionImportControlFour.xml"));
 
         final String[] expectedViolation = {
             "4:1: " + getCheckMessage(ImportControlCheck.class,

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionImportOrderTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionImportOrderTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionImportOrderTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionImportOrderOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionImportOrderOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ImportOrderCheck.class);
@@ -61,7 +61,7 @@ public class XpathRegressionImportOrderTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionImportOrderTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionImportOrderTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ImportOrderCheck.class);
@@ -82,7 +82,7 @@ public class XpathRegressionImportOrderTest extends AbstractXpathTestSupport {
     @Test
     public void testThree() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionImportOrderThree.java"));
+                new File(getXpathPath("SuppressionXpathRegressionImportOrderThree.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ImportOrderCheck.class);
@@ -105,7 +105,7 @@ public class XpathRegressionImportOrderTest extends AbstractXpathTestSupport {
     @Test
     public void testFour() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionImportOrderFour.java"));
+                new File(getXpathPath("SuppressionXpathRegressionImportOrderFour.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ImportOrderCheck.class);
@@ -127,7 +127,7 @@ public class XpathRegressionImportOrderTest extends AbstractXpathTestSupport {
     @Test
     public void testFive() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionImportOrderFive.java"));
+                new File(getXpathPath("SuppressionXpathRegressionImportOrderFive.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ImportOrderCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionIndentationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionIndentationTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionIndentationTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionIndentationTestOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionIndentationTestOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IndentationCheck.class);
@@ -75,7 +75,7 @@ public class XpathRegressionIndentationTest extends AbstractXpathTestSupport {
     @Test
     public void testBasicOffset() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionIndentationTestTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionIndentationTestTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IndentationCheck.class);
@@ -118,7 +118,7 @@ public class XpathRegressionIndentationTest extends AbstractXpathTestSupport {
     @Test
     public void testCaseIndent() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionIndentationTestThree.java"));
+                new File(getXpathPath("SuppressionXpathRegressionIndentationTestThree.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IndentationCheck.class);
@@ -155,7 +155,7 @@ public class XpathRegressionIndentationTest extends AbstractXpathTestSupport {
     @Test
     public void testLambda() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionIndentationLambdaTest1.java"));
+                new File(getXpathPath("SuppressionXpathRegressionIndentationLambdaTest1.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IndentationCheck.class);
@@ -187,7 +187,7 @@ public class XpathRegressionIndentationTest extends AbstractXpathTestSupport {
     @Test
     public void testLambda2() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionIndentationLambdaTest2.java"));
+                new File(getXpathPath("SuppressionXpathRegressionIndentationLambdaTest2.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IndentationCheck.class);
@@ -219,7 +219,7 @@ public class XpathRegressionIndentationTest extends AbstractXpathTestSupport {
     @Test
     public void testIfWithNoCurlies() throws Exception {
         final File fileToProcess =
-            new File(getPath("SuppressionXpathRegressionIndentationIfWithoutCurly.java"));
+            new File(getXpathPath("SuppressionXpathRegressionIndentationIfWithoutCurly.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IndentationCheck.class);
@@ -251,8 +251,8 @@ public class XpathRegressionIndentationTest extends AbstractXpathTestSupport {
 
     @Test
     public void testElseWithNoCurlies() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionIndentationElseWithoutCurly.java"));
+        final File fileToProcess = new File(
+                getXpathPath("SuppressionXpathRegressionIndentationElseWithoutCurly.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IndentationCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionInterfaceIsTypeTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionInterfaceIsTypeTest.java
@@ -39,7 +39,7 @@ public class XpathRegressionInterfaceIsTypeTest extends AbstractXpathTestSupport
 
     @Test
     public void testOne() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionInterfaceIsType1.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -66,7 +66,7 @@ public class XpathRegressionInterfaceIsTypeTest extends AbstractXpathTestSupport
 
     @Test
     public void testTwo() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionInterfaceIsType2.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionInterfaceMemberImpliedModifierTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionInterfaceMemberImpliedModifierTest.java
@@ -38,7 +38,7 @@ public class XpathRegressionInterfaceMemberImpliedModifierTest extends AbstractX
     @Test
     public void testOne() throws Exception {
         final File fileToProcess = new File(
-            getPath("SuppressionXpathRegressionInterfaceMemberImpliedModifier1.java")
+            getXpathPath("SuppressionXpathRegressionInterfaceMemberImpliedModifier1.java")
         );
 
         final DefaultConfiguration moduleConfig =
@@ -71,7 +71,7 @@ public class XpathRegressionInterfaceMemberImpliedModifierTest extends AbstractX
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess = new File(
-            getPath("SuppressionXpathRegressionInterfaceMemberImpliedModifier2.java")
+            getXpathPath("SuppressionXpathRegressionInterfaceMemberImpliedModifier2.java")
         );
 
         final DefaultConfiguration moduleConfig =
@@ -104,7 +104,7 @@ public class XpathRegressionInterfaceMemberImpliedModifierTest extends AbstractX
     @Test
     public void testThree() throws Exception {
         final File fileToProcess = new File(
-            getPath("SuppressionXpathRegressionInterfaceMemberImpliedModifier3.java")
+            getXpathPath("SuppressionXpathRegressionInterfaceMemberImpliedModifier3.java")
         );
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionInvalidJavadocPositionTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionInvalidJavadocPositionTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionInvalidJavadocPositionTest extends AbstractXpathTest
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionInvalidJavadocPositionOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionInvalidJavadocPositionOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(InvalidJavadocPositionCheck.class);
@@ -64,7 +64,7 @@ public class XpathRegressionInvalidJavadocPositionTest extends AbstractXpathTest
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionInvalidJavadocPositionTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionInvalidJavadocPositionTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(InvalidJavadocPositionCheck.class);
@@ -87,8 +87,8 @@ public class XpathRegressionInvalidJavadocPositionTest extends AbstractXpathTest
 
     @Test
     public void testThree() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionInvalidJavadocPositionThree.java"));
+        final File fileToProcess = new File(
+                getXpathPath("SuppressionXpathRegressionInvalidJavadocPositionThree.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(InvalidJavadocPositionCheck.class);
@@ -112,7 +112,7 @@ public class XpathRegressionInvalidJavadocPositionTest extends AbstractXpathTest
     @Test
     public void testFour() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionInvalidJavadocPositionFour.java"));
+                new File(getXpathPath("SuppressionXpathRegressionInvalidJavadocPositionFour.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(InvalidJavadocPositionCheck.class);
@@ -136,7 +136,7 @@ public class XpathRegressionInvalidJavadocPositionTest extends AbstractXpathTest
     @Test
     public void testFive() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionInvalidJavadocPositionFive.java"));
+                new File(getXpathPath("SuppressionXpathRegressionInvalidJavadocPositionFive.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(InvalidJavadocPositionCheck.class);
@@ -161,7 +161,7 @@ public class XpathRegressionInvalidJavadocPositionTest extends AbstractXpathTest
     @Test
     public void testSix() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionInvalidJavadocPositionSix.java"));
+                new File(getXpathPath("SuppressionXpathRegressionInvalidJavadocPositionSix.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(InvalidJavadocPositionCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionJavadocContentLocationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionJavadocContentLocationTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionJavadocContentLocationTest extends AbstractXpathTest
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionJavadocContentLocationOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionJavadocContentLocationOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(JavadocContentLocationCheck.class);
@@ -64,7 +64,7 @@ public class XpathRegressionJavadocContentLocationTest extends AbstractXpathTest
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionJavadocContentLocationTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionJavadocContentLocationTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(JavadocContentLocationCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionJavadocMethodTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionJavadocMethodTest.java
@@ -44,7 +44,7 @@ public class XpathRegressionJavadocMethodTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionJavadocMethodOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionJavadocMethodOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(JavadocMethodCheck.class);
@@ -72,7 +72,7 @@ public class XpathRegressionJavadocMethodTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionJavadocMethodTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionJavadocMethodTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(JavadocMethodCheck.class);
@@ -95,7 +95,7 @@ public class XpathRegressionJavadocMethodTest extends AbstractXpathTestSupport {
     @Test
     public void testThree() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionJavadocMethodThree.java"));
+                new File(getXpathPath("SuppressionXpathRegressionJavadocMethodThree.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(JavadocMethodCheck.class);
@@ -122,7 +122,7 @@ public class XpathRegressionJavadocMethodTest extends AbstractXpathTestSupport {
     @Test
     public void testFour() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionJavadocMethodFour.java"));
+                new File(getXpathPath("SuppressionXpathRegressionJavadocMethodFour.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(JavadocMethodCheck.class);
@@ -147,7 +147,7 @@ public class XpathRegressionJavadocMethodTest extends AbstractXpathTestSupport {
     @Test
     public void testFive() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionJavadocMethodFive.java"));
+                new File(getXpathPath("SuppressionXpathRegressionJavadocMethodFive.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(JavadocMethodCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionJavadocStyleTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionJavadocStyleTest.java
@@ -39,7 +39,7 @@ public class XpathRegressionJavadocStyleTest extends AbstractXpathTestSupport {
 
     @Test
     public void testOne() throws Exception {
-        final File fileToProcess = new File(getPath("SuppressionXpathRegression"
+        final File fileToProcess = new File(getXpathPath("SuppressionXpathRegression"
                 + File.separator + "package-info.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionJavadocTypeTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionJavadocTypeTest.java
@@ -44,7 +44,7 @@ public class XpathRegressionJavadocTypeTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionJavadocTypeOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionJavadocTypeOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(JavadocTypeCheck.class);
@@ -73,7 +73,7 @@ public class XpathRegressionJavadocTypeTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionJavadocTypeTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionJavadocTypeTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(JavadocTypeCheck.class);
@@ -101,7 +101,7 @@ public class XpathRegressionJavadocTypeTest extends AbstractXpathTestSupport {
     @Test
     public void testThree() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionJavadocTypeThree.java"));
+                new File(getXpathPath("SuppressionXpathRegressionJavadocTypeThree.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(JavadocTypeCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionJavadocVariableTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionJavadocVariableTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionJavadocVariableTest extends AbstractXpathTestSupport
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionJavadocVariableOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionJavadocVariableOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(JavadocVariableCheck.class);
@@ -69,7 +69,7 @@ public class XpathRegressionJavadocVariableTest extends AbstractXpathTestSupport
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionJavadocVariableTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionJavadocVariableTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(JavadocVariableCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionLambdaBodyLengthTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionLambdaBodyLengthTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionLambdaBodyLengthTest
 
     @Test
     public void testDefault() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
             "SuppressionXpathRegressionLambdaBodyLength1.java"));
         final DefaultConfiguration moduleConfig = createModuleConfig(CLASS);
         final String[] expectedViolation = {
@@ -59,7 +59,7 @@ public class XpathRegressionLambdaBodyLengthTest
 
     @Test
     public void testMaxIsNotDefault() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
             "SuppressionXpathRegressionLambdaBodyLength2.java"));
         final DefaultConfiguration moduleConfig = createModuleConfig(CLASS);
         moduleConfig.addProperty("max", "5");

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionLambdaParameterNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionLambdaParameterNameTest.java
@@ -42,7 +42,7 @@ public class XpathRegressionLambdaParameterNameTest extends AbstractXpathTestSup
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionLambdaParameterName1.java"));
+                new File(getXpathPath("SuppressionXpathRegressionLambdaParameterName1.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(LambdaParameterNameCheck.class);
@@ -67,7 +67,7 @@ public class XpathRegressionLambdaParameterNameTest extends AbstractXpathTestSup
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionLambdaParameterName2.java"));
+                new File(getXpathPath("SuppressionXpathRegressionLambdaParameterName2.java"));
 
         final String nonDefaultPattern = "^_[a-zA-Z0-9]*$";
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionLeftCurlyTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionLeftCurlyTest.java
@@ -42,7 +42,7 @@ public class XpathRegressionLeftCurlyTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionLeftCurlyOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionLeftCurlyOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(LeftCurlyCheck.class);
@@ -66,7 +66,7 @@ public class XpathRegressionLeftCurlyTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionLeftCurlyTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionLeftCurlyTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(LeftCurlyCheck.class);
@@ -91,7 +91,7 @@ public class XpathRegressionLeftCurlyTest extends AbstractXpathTestSupport {
     @Test
     public void testThree() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionLeftCurlyThree.java"));
+                new File(getXpathPath("SuppressionXpathRegressionLeftCurlyThree.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(LeftCurlyCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMatchXpathTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMatchXpathTest.java
@@ -42,7 +42,7 @@ public class XpathRegressionMatchXpathTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMatchXpathOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionMatchXpathOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(MatchXpathCheck.class);
@@ -68,7 +68,7 @@ public class XpathRegressionMatchXpathTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMatchXpathTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionMatchXpathTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(MatchXpathCheck.class);
@@ -92,8 +92,8 @@ public class XpathRegressionMatchXpathTest extends AbstractXpathTestSupport {
 
     @Test
     public void testEncodedQuoteString() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMatchXpathEncodedQuoteString.java"));
+        final File fileToProcess = new File(
+                getXpathPath("SuppressionXpathRegressionMatchXpathEncodedQuoteString.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IllegalTokenCheck.class);
@@ -121,8 +121,8 @@ public class XpathRegressionMatchXpathTest extends AbstractXpathTestSupport {
 
     @Test
     public void testEncodedLessString() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMatchXpathEncodedLessString.java"));
+        final File fileToProcess = new File(
+                getXpathPath("SuppressionXpathRegressionMatchXpathEncodedLessString.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IllegalTokenCheck.class);
@@ -150,8 +150,8 @@ public class XpathRegressionMatchXpathTest extends AbstractXpathTestSupport {
 
     @Test
     public void testEncodedNewLineString() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMatchXpathEncodedNewLineString.java"));
+        final File fileToProcess = new File(
+                getXpathPath("SuppressionXpathRegressionMatchXpathEncodedNewLineString.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IllegalTokenCheck.class);
@@ -179,8 +179,8 @@ public class XpathRegressionMatchXpathTest extends AbstractXpathTestSupport {
 
     @Test
     public void testGreaterString() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMatchXpathEncodedGreaterString.java"));
+        final File fileToProcess = new File(
+                getXpathPath("SuppressionXpathRegressionMatchXpathEncodedGreaterString.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IllegalTokenCheck.class);
@@ -209,7 +209,7 @@ public class XpathRegressionMatchXpathTest extends AbstractXpathTestSupport {
     @Test
     public void testEncodedAmpString() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMatchXpathEncodedAmpString.java"));
+                new File(getXpathPath("SuppressionXpathRegressionMatchXpathEncodedAmpString.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IllegalTokenCheck.class);
@@ -237,8 +237,8 @@ public class XpathRegressionMatchXpathTest extends AbstractXpathTestSupport {
 
     @Test
     public void testEncodedAposString() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMatchXpathEncodedAposString.java"));
+        final File fileToProcess = new File(
+                getXpathPath("SuppressionXpathRegressionMatchXpathEncodedAposString.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IllegalTokenCheck.class);
@@ -266,8 +266,8 @@ public class XpathRegressionMatchXpathTest extends AbstractXpathTestSupport {
 
     @Test
     public void testEncodedCarriageString() throws Exception {
-        final File fileToProcess =
-            new File(getPath("SuppressionXpathRegressionMatchXpathEncodedCarriageString.java"));
+        final File fileToProcess = new File(
+                getXpathPath("SuppressionXpathRegressionMatchXpathEncodedCarriageString.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IllegalTokenCheck.class);
@@ -296,7 +296,7 @@ public class XpathRegressionMatchXpathTest extends AbstractXpathTestSupport {
     @Test
     public void testEncodedAmpersandChars() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMatchXpathEncodedAmpChar.java"));
+                new File(getXpathPath("SuppressionXpathRegressionMatchXpathEncodedAmpChar.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IllegalTokenCheck.class);
@@ -325,7 +325,7 @@ public class XpathRegressionMatchXpathTest extends AbstractXpathTestSupport {
     @Test
     public void testEncodedQuoteChar() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMatchXpathEncodedQuotChar.java"));
+                new File(getXpathPath("SuppressionXpathRegressionMatchXpathEncodedQuotChar.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IllegalTokenCheck.class);
@@ -354,7 +354,7 @@ public class XpathRegressionMatchXpathTest extends AbstractXpathTestSupport {
     @Test
     public void testEncodedLessChar() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMatchXpathEncodedLessChar.java"));
+                new File(getXpathPath("SuppressionXpathRegressionMatchXpathEncodedLessChar.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IllegalTokenCheck.class);
@@ -383,7 +383,7 @@ public class XpathRegressionMatchXpathTest extends AbstractXpathTestSupport {
     @Test
     public void testEncodedAposChar() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMatchXpathEncodedAposChar.java"));
+                new File(getXpathPath("SuppressionXpathRegressionMatchXpathEncodedAposChar.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IllegalTokenCheck.class);
@@ -411,8 +411,8 @@ public class XpathRegressionMatchXpathTest extends AbstractXpathTestSupport {
 
     @Test
     public void testEncodedGreaterChar() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMatchXpathEncodedGreaterChar.java"));
+        final File fileToProcess = new File(
+                getXpathPath("SuppressionXpathRegressionMatchXpathEncodedGreaterChar.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(IllegalTokenCheck.class);
@@ -443,7 +443,7 @@ public class XpathRegressionMatchXpathTest extends AbstractXpathTestSupport {
     @Test
     public void testFollowing() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMatchXpathThree.java"));
+                new File(getXpathPath("SuppressionXpathRegressionMatchXpathThree.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(MatchXpathCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMemberNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMemberNameTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionMemberNameTest extends AbstractXpathTestSupport {
     @Test
     public void test1() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMemberName1.java"));
+                new File(getXpathPath("SuppressionXpathRegressionMemberName1.java"));
 
         final String pattern = "^[a-z][a-zA-Z0-9]*$";
         final DefaultConfiguration moduleConfig =
@@ -65,7 +65,7 @@ public class XpathRegressionMemberNameTest extends AbstractXpathTestSupport {
     @Test
     public void test2() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMemberName2.java"));
+                new File(getXpathPath("SuppressionXpathRegressionMemberName2.java"));
 
         final String pattern = "^m[A-Z][a-zA-Z0-9]*$";
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMethodCountTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMethodCountTest.java
@@ -38,7 +38,7 @@ public class XpathRegressionMethodCountTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess = new File(
-            getPath("SuppressionXpathRegressionMethodCount1.java")
+            getXpathPath("SuppressionXpathRegressionMethodCount1.java")
         );
 
         final DefaultConfiguration moduleConfig =
@@ -69,7 +69,7 @@ public class XpathRegressionMethodCountTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess = new File(
-            getPath("SuppressionXpathRegressionMethodCount2.java")
+            getXpathPath("SuppressionXpathRegressionMethodCount2.java")
         );
 
         final DefaultConfiguration moduleConfig =
@@ -100,7 +100,7 @@ public class XpathRegressionMethodCountTest extends AbstractXpathTestSupport {
     @Test
     public void testThree() throws Exception {
         final File fileToProcess = new File(
-            getPath("SuppressionXpathRegressionMethodCount1.java")
+            getXpathPath("SuppressionXpathRegressionMethodCount1.java")
         );
 
         final DefaultConfiguration moduleConfig =
@@ -131,7 +131,7 @@ public class XpathRegressionMethodCountTest extends AbstractXpathTestSupport {
     @Test
     public void testFour() throws Exception {
         final File fileToProcess = new File(
-            getPath("SuppressionXpathRegressionMethodCount3.java")
+            getXpathPath("SuppressionXpathRegressionMethodCount3.java")
         );
 
         final DefaultConfiguration moduleConfig =
@@ -162,7 +162,7 @@ public class XpathRegressionMethodCountTest extends AbstractXpathTestSupport {
     @Test
     public void testFive() throws Exception {
         final File fileToProcess = new File(
-            getPath("SuppressionXpathRegressionMethodCount4.java")
+            getXpathPath("SuppressionXpathRegressionMethodCount4.java")
         );
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMethodNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMethodNameTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionMethodNameTest extends AbstractXpathTestSupport {
     @Test
     public void test1() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMethodName1.java"));
+                new File(getXpathPath("SuppressionXpathRegressionMethodName1.java"));
 
         final String pattern = "^[a-z][a-zA-Z0-9]*$";
         final DefaultConfiguration moduleConfig =
@@ -65,7 +65,7 @@ public class XpathRegressionMethodNameTest extends AbstractXpathTestSupport {
     @Test
     public void test2() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMethodName2.java"));
+                new File(getXpathPath("SuppressionXpathRegressionMethodName2.java"));
 
         final String pattern = "^[a-z](_?[a-zA-Z0-9]+)*$";
         final DefaultConfiguration moduleConfig =
@@ -91,7 +91,7 @@ public class XpathRegressionMethodNameTest extends AbstractXpathTestSupport {
     @Test
     public void test3() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMethodName3.java"));
+                new File(getXpathPath("SuppressionXpathRegressionMethodName3.java"));
 
         final String pattern = "^[a-z](_?[a-zA-Z0-9]+)*$";
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMethodParamPadTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMethodParamPadTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionMethodParamPadTest extends AbstractXpathTestSupport 
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMethodParamPadOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionMethodParamPadOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(MethodParamPadCheck.class);
@@ -63,7 +63,7 @@ public class XpathRegressionMethodParamPadTest extends AbstractXpathTestSupport 
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMethodParamPadTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionMethodParamPadTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(MethodParamPadCheck.class);
@@ -86,7 +86,7 @@ public class XpathRegressionMethodParamPadTest extends AbstractXpathTestSupport 
     @Test
     public void testThree() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMethodParamPadThree.java"));
+                new File(getXpathPath("SuppressionXpathRegressionMethodParamPadThree.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(MethodParamPadCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMissingCtorTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMissingCtorTest.java
@@ -39,7 +39,7 @@ public class XpathRegressionMissingCtorTest extends AbstractXpathTestSupport {
 
     @Test
     public void testOne() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionMissingCtor1.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -65,7 +65,7 @@ public class XpathRegressionMissingCtorTest extends AbstractXpathTestSupport {
 
     @Test
     public void testTwo() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionMissingCtor2.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMissingJavadocMethodTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMissingJavadocMethodTest.java
@@ -38,7 +38,7 @@ public class XpathRegressionMissingJavadocMethodTest extends AbstractXpathTestSu
     @Test
     public void testOne() throws Exception {
         final File fileToProcess = new File(
-            getPath("SuppressionXpathRegressionMissingJavadocMethod1.java")
+            getXpathPath("SuppressionXpathRegressionMissingJavadocMethod1.java")
         );
 
         final DefaultConfiguration moduleConfig =
@@ -75,7 +75,7 @@ public class XpathRegressionMissingJavadocMethodTest extends AbstractXpathTestSu
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess = new File(
-            getPath("SuppressionXpathRegressionMissingJavadocMethod2.java")
+            getXpathPath("SuppressionXpathRegressionMissingJavadocMethod2.java")
         );
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMissingJavadocPackageTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMissingJavadocPackageTest.java
@@ -39,7 +39,7 @@ public class XpathRegressionMissingJavadocPackageTest extends AbstractXpathTestS
 
     @Test
     public void testBlockComment() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "blockcomment/package-info.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -59,7 +59,7 @@ public class XpathRegressionMissingJavadocPackageTest extends AbstractXpathTestS
 
     @Test
     public void testNoJavadoc() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "nojavadoc/package-info.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMissingJavadocTypeTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMissingJavadocTypeTest.java
@@ -39,7 +39,7 @@ public class XpathRegressionMissingJavadocTypeTest extends AbstractXpathTestSupp
 
     @Test
     public void testClass() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionMissingJavadocTypeClass.java"
         ));
 
@@ -68,7 +68,7 @@ public class XpathRegressionMissingJavadocTypeTest extends AbstractXpathTestSupp
 
     @Test
     public void testScope() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionMissingJavadocTypeScope.java"
         ));
 
@@ -99,7 +99,7 @@ public class XpathRegressionMissingJavadocTypeTest extends AbstractXpathTestSupp
 
     @Test
     public void testExcluded() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionMissingJavadocTypeExcluded.java"
         ));
 
@@ -131,7 +131,7 @@ public class XpathRegressionMissingJavadocTypeTest extends AbstractXpathTestSupp
 
     @Test
     public void testAnnotation() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionMissingJavadocTypeAnnotation.java"
         ));
 
@@ -167,7 +167,7 @@ public class XpathRegressionMissingJavadocTypeTest extends AbstractXpathTestSupp
 
     @Test
     public void testToken() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionMissingJavadocTypeToken.java"
         ));
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMissingOverrideTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMissingOverrideTest.java
@@ -39,7 +39,7 @@ public class XpathRegressionMissingOverrideTest extends AbstractXpathTestSupport
 
     @Test
     public void testClass() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionMissingOverrideClass.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -70,7 +70,7 @@ public class XpathRegressionMissingOverrideTest extends AbstractXpathTestSupport
 
     @Test
     public void testInterface() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionMissingOverrideInterface.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -104,7 +104,7 @@ public class XpathRegressionMissingOverrideTest extends AbstractXpathTestSupport
 
     @Test
     public void testAnonymous() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionMissingOverrideAnonymous.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -141,7 +141,7 @@ public class XpathRegressionMissingOverrideTest extends AbstractXpathTestSupport
 
     @Test
     public void testInheritDocInvalid1() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionMissingOverrideInheritDocInvalid1.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -172,7 +172,7 @@ public class XpathRegressionMissingOverrideTest extends AbstractXpathTestSupport
 
     @Test
     public void testInheritDocInvalid2() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionMissingOverrideInheritDocInvalid2.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -203,7 +203,7 @@ public class XpathRegressionMissingOverrideTest extends AbstractXpathTestSupport
 
     @Test
     public void testJavaFiveCompatibility1() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionMissingOverrideClass.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -235,7 +235,7 @@ public class XpathRegressionMissingOverrideTest extends AbstractXpathTestSupport
 
     @Test
     public void testJavaFiveCompatibility2() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionMissingOverrideInterface.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMissingSwitchDefaultTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMissingSwitchDefaultTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionMissingSwitchDefaultTest extends AbstractXpathTestSu
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMissingSwitchDefaultOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionMissingSwitchDefaultOne.java"));
 
         final DefaultConfiguration moduleConfig = createModuleConfig(clss);
         final String[] expectedViolation = {
@@ -61,7 +61,7 @@ public class XpathRegressionMissingSwitchDefaultTest extends AbstractXpathTestSu
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionMissingSwitchDefaultTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionMissingSwitchDefaultTwo.java"));
 
         final DefaultConfiguration moduleConfig = createModuleConfig(clss);
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMultipleVariableDeclarationsTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionMultipleVariableDeclarationsTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionMultipleVariableDeclarationsTest extends AbstractXpa
     @Test
     public void testOne() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionMultipleVariableDeclarationsOne.java"));
+                getXpathPath("SuppressionXpathRegressionMultipleVariableDeclarationsOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(MultipleVariableDeclarationsCheck.class);
@@ -84,7 +84,7 @@ public class XpathRegressionMultipleVariableDeclarationsTest extends AbstractXpa
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionMultipleVariableDeclarationsTwo.java"));
+                getXpathPath("SuppressionXpathRegressionMultipleVariableDeclarationsTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(MultipleVariableDeclarationsCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNPathComplexityTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNPathComplexityTest.java
@@ -42,7 +42,7 @@ public class XpathRegressionNPathComplexityTest extends AbstractXpathTestSupport
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionNPathComplexityOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionNPathComplexityOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(NPathComplexityCheck.class);
@@ -72,7 +72,7 @@ public class XpathRegressionNPathComplexityTest extends AbstractXpathTestSupport
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionNPathComplexityTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionNPathComplexityTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(NPathComplexityCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNeedBracesTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNeedBracesTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionNeedBracesTest extends AbstractXpathTestSupport {
 
     @Test
     public void testDo() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionNeedBracesDo.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -62,7 +62,7 @@ public class XpathRegressionNeedBracesTest extends AbstractXpathTestSupport {
 
     @Test
     public void testSingleLine() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionNeedBracesSingleLine.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -85,7 +85,7 @@ public class XpathRegressionNeedBracesTest extends AbstractXpathTestSupport {
 
     @Test
     public void testSingleLineLambda() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionNeedBracesSingleLineLambda.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -109,7 +109,7 @@ public class XpathRegressionNeedBracesTest extends AbstractXpathTestSupport {
 
     @Test
     public void testEmptyLoopBody() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionNeedBracesEmptyLoopBody.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNestedForDepthTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNestedForDepthTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionNestedForDepthTest extends AbstractXpathTestSupport 
     @Test
     public void testCorrect() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionNestedForDepth.java"));
+                new File(getXpathPath("SuppressionXpathRegressionNestedForDepth.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(NestedForDepthCheck.class);
@@ -64,7 +64,7 @@ public class XpathRegressionNestedForDepthTest extends AbstractXpathTestSupport 
     @Test
     public void testMax() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionNestedForDepthMax.java"));
+                new File(getXpathPath("SuppressionXpathRegressionNestedForDepthMax.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(NestedForDepthCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNestedIfDepthTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNestedIfDepthTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionNestedIfDepthTest extends AbstractXpathTestSupport {
     @Test
     public void testCorrect() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionNestedIfDepth.java"));
+                new File(getXpathPath("SuppressionXpathRegressionNestedIfDepth.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(NestedIfDepthCheck.class);
@@ -64,7 +64,7 @@ public class XpathRegressionNestedIfDepthTest extends AbstractXpathTestSupport {
     @Test
     public void testMax() throws Exception {
         final File fileToProcess =
-            new File(getPath("SuppressionXpathRegressionNestedIfDepthMax.java"));
+            new File(getXpathPath("SuppressionXpathRegressionNestedIfDepthMax.java"));
 
         final DefaultConfiguration moduleConfig =
             createModuleConfig(NestedIfDepthCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNestedTryDepthTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNestedTryDepthTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionNestedTryDepthTest extends AbstractXpathTestSupport 
     @Test
     public void testCorrect() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionNestedTryDepth.java"));
+                new File(getXpathPath("SuppressionXpathRegressionNestedTryDepth.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(NestedTryDepthCheck.class);
@@ -64,7 +64,7 @@ public class XpathRegressionNestedTryDepthTest extends AbstractXpathTestSupport 
     @Test
     public void testMax() throws Exception {
         final File fileToProcess =
-            new File(getPath("SuppressionXpathRegressionNestedTryDepthMax.java"));
+            new File(getXpathPath("SuppressionXpathRegressionNestedTryDepthMax.java"));
 
         final DefaultConfiguration moduleConfig =
             createModuleConfig(NestedTryDepthCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNoArrayTrailingCommaTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNoArrayTrailingCommaTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionNoArrayTrailingCommaTest extends AbstractXpathTestSu
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionNoArrayTrailingCommaOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionNoArrayTrailingCommaOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(NoArrayTrailingCommaCheck.class);
@@ -64,7 +64,7 @@ public class XpathRegressionNoArrayTrailingCommaTest extends AbstractXpathTestSu
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionNoArrayTrailingCommaTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionNoArrayTrailingCommaTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(NoArrayTrailingCommaCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNoCloneTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNoCloneTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionNoCloneTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionNoCloneOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionNoCloneOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(NoCloneCheck.class);
@@ -68,7 +68,7 @@ public class XpathRegressionNoCloneTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionNoCloneTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionNoCloneTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(NoCloneCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNoEnumTrailingCommaTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNoEnumTrailingCommaTest.java
@@ -39,7 +39,7 @@ public class XpathRegressionNoEnumTrailingCommaTest extends AbstractXpathTestSup
 
     @Test
     public void testOne() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionNoEnumTrailingCommaOne.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -61,7 +61,7 @@ public class XpathRegressionNoEnumTrailingCommaTest extends AbstractXpathTestSup
 
     @Test
     public void testTwo() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionNoEnumTrailingCommaTwo.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNoFinalizerTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNoFinalizerTest.java
@@ -38,7 +38,7 @@ public class XpathRegressionNoFinalizerTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionNoFinalizer1.java"));
+                getXpathPath("SuppressionXpathRegressionNoFinalizer1.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(NoFinalizerCheck.class);
@@ -67,7 +67,7 @@ public class XpathRegressionNoFinalizerTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionNoFinalizer2.java"));
+                getXpathPath("SuppressionXpathRegressionNoFinalizer2.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(NoFinalizerCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNoLineWrapTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNoLineWrapTest.java
@@ -38,7 +38,7 @@ public class XpathRegressionNoLineWrapTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionNoLineWrap1.java")
+                getXpathPath("SuppressionXpathRegressionNoLineWrap1.java")
         );
 
         final DefaultConfiguration moduleConfig =
@@ -59,7 +59,7 @@ public class XpathRegressionNoLineWrapTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionNoLineWrap2.java")
+                getXpathPath("SuppressionXpathRegressionNoLineWrap2.java")
         );
 
         final DefaultConfiguration moduleConfig =
@@ -94,7 +94,7 @@ public class XpathRegressionNoLineWrapTest extends AbstractXpathTestSupport {
     @Test
     public void testThree() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionNoLineWrap3.java")
+                getXpathPath("SuppressionXpathRegressionNoLineWrap3.java")
         );
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNoWhitespaceAfterTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNoWhitespaceAfterTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionNoWhitespaceAfterTest extends AbstractXpathTestSuppo
     @Test
     public void testNoWhitespaceAfter() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionNoWhitespaceAfter.java"));
+                new File(getXpathPath("SuppressionXpathRegressionNoWhitespaceAfter.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(NoWhitespaceAfterCheck.class);
@@ -68,7 +68,7 @@ public class XpathRegressionNoWhitespaceAfterTest extends AbstractXpathTestSuppo
     @Test
     public void testTokens() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionNoWhitespaceAfterTokens.java"));
+                new File(getXpathPath("SuppressionXpathRegressionNoWhitespaceAfterTokens.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(NoWhitespaceAfterCheck.class);
@@ -94,7 +94,7 @@ public class XpathRegressionNoWhitespaceAfterTest extends AbstractXpathTestSuppo
     @Test
     public void testAllowLineBreaks() throws Exception {
         final File fileToProcess =
-            new File(getPath("SuppressionXpathRegressionNoWhitespaceAfterLineBreaks.java"));
+            new File(getXpathPath("SuppressionXpathRegressionNoWhitespaceAfterLineBreaks.java"));
 
         final DefaultConfiguration moduleConfig =
             createModuleConfig(NoWhitespaceAfterCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNoWhitespaceBeforeCaseDefaultColonTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNoWhitespaceBeforeCaseDefaultColonTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionNoWhitespaceBeforeCaseDefaultColonTest
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath(
+                new File(getXpathPath(
                         "SuppressionXpathRegressionNoWhitespaceBeforeCaseDefaultColonOne.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -65,7 +65,7 @@ public class XpathRegressionNoWhitespaceBeforeCaseDefaultColonTest
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath(
+                new File(getXpathPath(
                         "SuppressionXpathRegressionNoWhitespaceBeforeCaseDefaultColonTwo.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -90,7 +90,7 @@ public class XpathRegressionNoWhitespaceBeforeCaseDefaultColonTest
     @Test
     public void testThree() throws Exception {
         final File fileToProcess =
-                new File(getPath(
+                new File(getXpathPath(
                         "SuppressionXpathRegressionNoWhitespaceBeforeCaseDefaultColonThree.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -115,7 +115,7 @@ public class XpathRegressionNoWhitespaceBeforeCaseDefaultColonTest
     @Test
     public void testFour() throws Exception {
         final File fileToProcess =
-                new File(getPath(
+                new File(getXpathPath(
                         "SuppressionXpathRegressionNoWhitespaceBeforeCaseDefaultColonFour.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNoWhitespaceBeforeTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionNoWhitespaceBeforeTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionNoWhitespaceBeforeTest extends AbstractXpathTestSupp
     @Test
     public void testNoWhitespaceBefore() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionNoWhitespaceBefore.java"));
+                new File(getXpathPath("SuppressionXpathRegressionNoWhitespaceBefore.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(NoWhitespaceBeforeCheck.class);
@@ -63,7 +63,7 @@ public class XpathRegressionNoWhitespaceBeforeTest extends AbstractXpathTestSupp
     @Test
     public void testTokens() throws Exception {
         final File fileToProcess =
-            new File(getPath("SuppressionXpathRegressionNoWhitespaceBeforeTokens.java"));
+            new File(getXpathPath("SuppressionXpathRegressionNoWhitespaceBeforeTokens.java"));
 
         final DefaultConfiguration moduleConfig =
             createModuleConfig(NoWhitespaceBeforeCheck.class);
@@ -89,7 +89,7 @@ public class XpathRegressionNoWhitespaceBeforeTest extends AbstractXpathTestSupp
     @Test
     public void testAllowLineBreaks() throws Exception {
         final File fileToProcess =
-            new File(getPath("SuppressionXpathRegressionNoWhitespaceBeforeLineBreaks.java"));
+            new File(getXpathPath("SuppressionXpathRegressionNoWhitespaceBeforeLineBreaks.java"));
 
         final DefaultConfiguration moduleConfig =
             createModuleConfig(NoWhitespaceBeforeCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOneStatementPerLineTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOneStatementPerLineTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionOneStatementPerLineTest extends AbstractXpathTestSup
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionOneStatementPerLineOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionOneStatementPerLineOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(OneStatementPerLineCheck.class);
@@ -63,7 +63,7 @@ public class XpathRegressionOneStatementPerLineTest extends AbstractXpathTestSup
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionOneStatementPerLineTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionOneStatementPerLineTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(OneStatementPerLineCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOneTopLevelClassTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOneTopLevelClassTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionOneTopLevelClassTest extends AbstractXpathTestSuppor
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionOneTopLevelClassFirst.java"));
+                new File(getXpathPath("SuppressionXpathRegressionOneTopLevelClassFirst.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(OneTopLevelClassCheck.class);
@@ -63,7 +63,7 @@ public class XpathRegressionOneTopLevelClassTest extends AbstractXpathTestSuppor
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-            new File(getPath("SuppressionXpathRegressionOneTopLevelClassSecond.java"));
+            new File(getXpathPath("SuppressionXpathRegressionOneTopLevelClassSecond.java"));
 
         final DefaultConfiguration moduleConfig =
             createModuleConfig(OneTopLevelClassCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOperatorWrapTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOperatorWrapTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionOperatorWrapTest extends AbstractXpathTestSupport {
     @Test
     public void testOperatorWrapNewLine() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionOperatorWrapNewLine.java"));
+                new File(getXpathPath("SuppressionXpathRegressionOperatorWrapNewLine.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(OperatorWrapCheck.class);
@@ -67,7 +67,7 @@ public class XpathRegressionOperatorWrapTest extends AbstractXpathTestSupport {
     @Test
     public void testOperatorWrapPreviousLine() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionOperatorWrapPreviousLine.java"));
+                new File(getXpathPath("SuppressionXpathRegressionOperatorWrapPreviousLine.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(OperatorWrapCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOuterTypeFilenameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOuterTypeFilenameTest.java
@@ -39,7 +39,7 @@ public class XpathRegressionOuterTypeFilenameTest extends AbstractXpathTestSuppo
 
     @Test
     public void testNoPublic() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionOuterTypeFilename1.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -62,7 +62,7 @@ public class XpathRegressionOuterTypeFilenameTest extends AbstractXpathTestSuppo
 
     @Test
     public void testNested() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionOuterTypeFilename2.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOuterTypeNumberTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOuterTypeNumberTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionOuterTypeNumberTest extends AbstractXpathTestSupport
     @Test
     public void testDefault() throws Exception {
         final File fileToProcess =
-            new File(getPath("SuppressionXpathRegressionOuterTypeNumberDefault.java"));
+            new File(getXpathPath("SuppressionXpathRegressionOuterTypeNumberDefault.java"));
 
         final DefaultConfiguration moduleConfig =
             createModuleConfig(OuterTypeNumberCheck.class);
@@ -61,7 +61,7 @@ public class XpathRegressionOuterTypeNumberTest extends AbstractXpathTestSupport
     @Test
     public void testMax() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionOuterTypeNumber.java"));
+                new File(getXpathPath("SuppressionXpathRegressionOuterTypeNumber.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(OuterTypeNumberCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOverloadMethodsDeclarationOrderTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionOverloadMethodsDeclarationOrderTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionOverloadMethodsDeclarationOrderTest extends Abstract
     @Test
     public void testOne() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionOverloadMethodsDeclarationOrder1.java"));
+                getXpathPath("SuppressionXpathRegressionOverloadMethodsDeclarationOrder1.java"));
 
         final DefaultConfiguration moduleConfig = createModuleConfig(clazz);
 
@@ -69,7 +69,7 @@ public class XpathRegressionOverloadMethodsDeclarationOrderTest extends Abstract
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionOverloadMethodsDeclarationOrder2.java"));
+                getXpathPath("SuppressionXpathRegressionOverloadMethodsDeclarationOrder2.java"));
 
         final DefaultConfiguration moduleConfig = createModuleConfig(clazz);
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionPackageAnnotationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionPackageAnnotationTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionPackageAnnotationTest extends AbstractXpathTestSuppo
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getNonCompilablePath(
+                new File(getXpathNonCompilablePath(
                         "SuppressionXpathRegressionPackageAnnotationOne.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -61,7 +61,7 @@ public class XpathRegressionPackageAnnotationTest extends AbstractXpathTestSuppo
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getNonCompilablePath(
+                new File(getXpathNonCompilablePath(
                         "SuppressionXpathRegressionPackageAnnotationTwo.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionPackageDeclarationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionPackageDeclarationTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionPackageDeclarationTest extends AbstractXpathTestSupp
     @Test
     public void test1() throws Exception {
         final File fileToProcess =
-                new File(getNonCompilablePath("SuppressionXpathRegression1.java"));
+                new File(getXpathNonCompilablePath("SuppressionXpathRegression1.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(PackageDeclarationCheck.class);
@@ -61,7 +61,7 @@ public class XpathRegressionPackageDeclarationTest extends AbstractXpathTestSupp
     @Test
     public void test2() throws Exception {
         final File fileToProcess =
-                new File(getNonCompilablePath("SuppressionXpathRegression2.java"));
+                new File(getXpathNonCompilablePath("SuppressionXpathRegression2.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(PackageDeclarationCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionParenPadTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionParenPadTest.java
@@ -42,7 +42,7 @@ public class XpathRegressionParenPadTest extends AbstractXpathTestSupport {
     @Test
     public void testLeftFollowed() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionParenPadLeftFollowed.java"));
+                new File(getXpathPath("SuppressionXpathRegressionParenPadLeftFollowed.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ParenPadCheck.class);
@@ -65,7 +65,7 @@ public class XpathRegressionParenPadTest extends AbstractXpathTestSupport {
     @Test
     public void testLeftNotFollowed() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionParenPadLeftNotFollowed.java"));
+                new File(getXpathPath("SuppressionXpathRegressionParenPadLeftNotFollowed.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ParenPadCheck.class);
@@ -89,7 +89,7 @@ public class XpathRegressionParenPadTest extends AbstractXpathTestSupport {
     @Test
     public void testRightPreceded() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionParenPadRightPreceded.java"));
+                new File(getXpathPath("SuppressionXpathRegressionParenPadRightPreceded.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ParenPadCheck.class);
@@ -112,7 +112,7 @@ public class XpathRegressionParenPadTest extends AbstractXpathTestSupport {
     @Test
     public void testRightNotPreceded() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionParenPadRightNotPreceded.java"));
+                new File(getXpathPath("SuppressionXpathRegressionParenPadRightNotPreceded.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ParenPadCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionPatternVariableNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionPatternVariableNameTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionPatternVariableNameTest extends AbstractXpathTestSup
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getNonCompilablePath(
+                new File(getXpathNonCompilablePath(
                         "SuppressionXpathRegressionPatternVariableName1.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -69,7 +69,7 @@ public class XpathRegressionPatternVariableNameTest extends AbstractXpathTestSup
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getNonCompilablePath(
+                new File(getXpathNonCompilablePath(
                         "SuppressionXpathRegressionPatternVariableName2.java"));
 
         final String nonDefaultPattern = "^_[a-zA-Z0-9]*$";
@@ -98,7 +98,7 @@ public class XpathRegressionPatternVariableNameTest extends AbstractXpathTestSup
     @Test
     public void testThree() throws Exception {
         final File fileToProcess =
-                new File(getNonCompilablePath(
+                new File(getXpathNonCompilablePath(
                         "SuppressionXpathRegressionPatternVariableName3.java"));
 
         final String nonDefaultPattern = "^[a-z](_?[a-zA-Z0-9]+)*$";
@@ -127,7 +127,7 @@ public class XpathRegressionPatternVariableNameTest extends AbstractXpathTestSup
     @Test
     public void testFour() throws Exception {
         final File fileToProcess =
-                new File(getNonCompilablePath(
+                new File(getXpathNonCompilablePath(
                         "SuppressionXpathRegressionPatternVariableName4.java"));
 
         final String nonDefaultPattern = "^[a-z][_a-zA-Z0-9]{2,}$";

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionRecordComponentNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionRecordComponentNameTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionRecordComponentNameTest extends AbstractXpathTestSup
 
     @Test
     public void testOne() throws Exception {
-        final File fileToProcess = new File(getNonCompilablePath(
+        final File fileToProcess = new File(getXpathNonCompilablePath(
                 "SuppressionXpathRecordComponentName1.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -63,7 +63,7 @@ public class XpathRegressionRecordComponentNameTest extends AbstractXpathTestSup
 
     @Test
     public void testTwo() throws Exception {
-        final File fileToProcess = new File(getNonCompilablePath(
+        final File fileToProcess = new File(getXpathNonCompilablePath(
                 "SuppressionXpathRecordComponentName2.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionRecordComponentNumberTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionRecordComponentNumberTest.java
@@ -39,7 +39,7 @@ public class XpathRegressionRecordComponentNumberTest extends AbstractXpathTestS
 
     @Test
     public void testOne() throws Exception {
-        final File fileToProcess = new File(getNonCompilablePath(
+        final File fileToProcess = new File(getXpathNonCompilablePath(
                 "SuppressionXpathRecordComponentNumber1.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -65,7 +65,7 @@ public class XpathRegressionRecordComponentNumberTest extends AbstractXpathTestS
 
     @Test
     public void testTwo() throws Exception {
-        final File fileToProcess = new File(getNonCompilablePath(
+        final File fileToProcess = new File(getXpathNonCompilablePath(
                 "SuppressionXpathRecordComponentNumber2.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionRecordTypeParameterNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionRecordTypeParameterNameTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionRecordTypeParameterNameTest extends AbstractXpathTes
 
     @Test
     public void testOne() throws Exception {
-        final File fileToProcess = new File(getNonCompilablePath(
+        final File fileToProcess = new File(getXpathNonCompilablePath(
                 "SuppressionXpathRegressionRecordTypeParameterName1.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -66,7 +66,7 @@ public class XpathRegressionRecordTypeParameterNameTest extends AbstractXpathTes
 
     @Test
     public void testTwo() throws Exception {
-        final File fileToProcess = new File(getNonCompilablePath(
+        final File fileToProcess = new File(getXpathNonCompilablePath(
                 "SuppressionXpathRegressionRecordTypeParameterName2.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionRedundantImportTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionRedundantImportTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionRedundantImportTest extends AbstractXpathTestSupport
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionRedundantImport1.java"));
+                new File(getXpathPath("SuppressionXpathRegressionRedundantImport1.java"));
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(RedundantImportCheck.class);
         final String[] expectedViolation = {
@@ -58,7 +58,7 @@ public class XpathRegressionRedundantImportTest extends AbstractXpathTestSupport
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionRedundantImport2.java"));
+                new File(getXpathPath("SuppressionXpathRegressionRedundantImport2.java"));
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(RedundantImportCheck.class);
         final String[] expectedViolation = {
@@ -75,7 +75,7 @@ public class XpathRegressionRedundantImportTest extends AbstractXpathTestSupport
     @Test
     public void testThree() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionRedundantImport3.java"));
+                new File(getXpathPath("SuppressionXpathRegressionRedundantImport3.java"));
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(RedundantImportCheck.class);
         final String[] expectedViolation = {

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionRequireThisTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionRequireThisTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionRequireThisTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionRequireThisOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionRequireThisOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(RequireThisCheck.class);
@@ -65,7 +65,7 @@ public class XpathRegressionRequireThisTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionRequireThisTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionRequireThisTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(RequireThisCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionRightCurlyTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionRightCurlyTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionRightCurlyTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionRightCurlyOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionRightCurlyOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(RightCurlyCheck.class);
@@ -64,7 +64,7 @@ public class XpathRegressionRightCurlyTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionRightCurlyTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionRightCurlyTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(RightCurlyCheck.class);
@@ -88,7 +88,7 @@ public class XpathRegressionRightCurlyTest extends AbstractXpathTestSupport {
     @Test
     public void testThree() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionRightCurlyThree.java"));
+                new File(getXpathPath("SuppressionXpathRegressionRightCurlyThree.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(RightCurlyCheck.class);
@@ -112,7 +112,7 @@ public class XpathRegressionRightCurlyTest extends AbstractXpathTestSupport {
     @Test
     public void testFour() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionRightCurlyFour.java"));
+                new File(getXpathPath("SuppressionXpathRegressionRightCurlyFour.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(RightCurlyCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionSingleSpaceSeparatorTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionSingleSpaceSeparatorTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionSingleSpaceSeparatorTest extends AbstractXpathTestSu
     @Test
     public void testSingleSpaceSeparator() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionSingleSpaceSeparator.java"));
+                new File(getXpathPath("SuppressionXpathRegressionSingleSpaceSeparator.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(SingleSpaceSeparatorCheck.class);
@@ -62,7 +62,7 @@ public class XpathRegressionSingleSpaceSeparatorTest extends AbstractXpathTestSu
 
     @Test
     public void testValidateComments() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
             "SuppressionXpathRegressionSingleSpaceSeparatorValidateComments.java"
         ));
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionStringLiteralEqualityTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionStringLiteralEqualityTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionStringLiteralEqualityTest extends AbstractXpathTestS
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionStringLiteralEquality.java"));
+                new File(getXpathPath("SuppressionXpathRegressionStringLiteralEquality.java"));
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(StringLiteralEqualityCheck.class);
         final String[] expectedViolation = {
@@ -67,7 +67,7 @@ public class XpathRegressionStringLiteralEqualityTest extends AbstractXpathTestS
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionStringLiteralEquality1.java"));
+                new File(getXpathPath("SuppressionXpathRegressionStringLiteralEquality1.java"));
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(StringLiteralEqualityCheck.class);
         final String[] expectedViolation = {
@@ -93,7 +93,7 @@ public class XpathRegressionStringLiteralEqualityTest extends AbstractXpathTestS
     @Test
     public void testThree() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionStringLiteralEquality2.java"));
+                new File(getXpathPath("SuppressionXpathRegressionStringLiteralEquality2.java"));
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(StringLiteralEqualityCheck.class);
         final String[] expectedViolation = {

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionThrowsCountTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionThrowsCountTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionThrowsCountTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionThrowsCount1.java"));
+                new File(getXpathPath("SuppressionXpathRegressionThrowsCount1.java"));
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ThrowsCountCheck.class);
         final String[] expectedViolation = {
@@ -62,7 +62,7 @@ public class XpathRegressionThrowsCountTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionThrowsCount2.java"));
+                new File(getXpathPath("SuppressionXpathRegressionThrowsCount2.java"));
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ThrowsCountCheck.class);
 
@@ -87,7 +87,7 @@ public class XpathRegressionThrowsCountTest extends AbstractXpathTestSupport {
     @Test
     public void testThree() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionThrowsCount3.java"));
+                new File(getXpathPath("SuppressionXpathRegressionThrowsCount3.java"));
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(ThrowsCountCheck.class);
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionTodoCommentTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionTodoCommentTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionTodoCommentTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionTodoCommentOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionTodoCommentOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(TodoCommentCheck.class);
@@ -63,7 +63,7 @@ public class XpathRegressionTodoCommentTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionTodoCommentTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionTodoCommentTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(TodoCommentCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionTrailingCommentTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionTrailingCommentTest.java
@@ -38,7 +38,7 @@ public class XpathRegressionTrailingCommentTest extends AbstractXpathTestSupport
 
     @Test
     public void testOne() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionTrailingComment1.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -62,7 +62,7 @@ public class XpathRegressionTrailingCommentTest extends AbstractXpathTestSupport
 
     @Test
     public void testTwo() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionTrailingComment2.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionTypeNameTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionTypeNameTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionTypeNameTest extends AbstractXpathTestSupport {
     @Test
     public void test1() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionTypeName1.java"));
+                new File(getXpathPath("SuppressionXpathRegressionTypeName1.java"));
 
         final String pattern = "^[A-Z][a-zA-Z0-9]*$";
         final DefaultConfiguration moduleConfig =
@@ -65,7 +65,7 @@ public class XpathRegressionTypeNameTest extends AbstractXpathTestSupport {
     @Test
     public void test2() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionTypeName2.java"));
+                new File(getXpathPath("SuppressionXpathRegressionTypeName2.java"));
 
         final String pattern = "^I_[a-zA-Z0-9]*$";
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionTypecastParenPadTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionTypecastParenPadTest.java
@@ -42,8 +42,8 @@ public class XpathRegressionTypecastParenPadTest extends AbstractXpathTestSuppor
 
     @Test
     public void testLeftFollowed() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionTypecastParenPadLeftFollowed.java"));
+        final File fileToProcess = new File(
+                getXpathPath("SuppressionXpathRegressionTypecastParenPadLeftFollowed.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(TypecastParenPadCheck.class);
@@ -68,8 +68,8 @@ public class XpathRegressionTypecastParenPadTest extends AbstractXpathTestSuppor
 
     @Test
     public void testLeftNotFollowed() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionTypecastParenPadLeftNotFollowed.java"));
+        final File fileToProcess = new File(
+                getXpathPath("SuppressionXpathRegressionTypecastParenPadLeftNotFollowed.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(TypecastParenPadCheck.class);
@@ -95,8 +95,8 @@ public class XpathRegressionTypecastParenPadTest extends AbstractXpathTestSuppor
 
     @Test
     public void testRightPreceded() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionTypecastParenPadRightPreceded.java"));
+        final File fileToProcess = new File(
+                getXpathPath("SuppressionXpathRegressionTypecastParenPadRightPreceded.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(TypecastParenPadCheck.class);
@@ -119,7 +119,7 @@ public class XpathRegressionTypecastParenPadTest extends AbstractXpathTestSuppor
     @Test
     public void testRightNotPreceded() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionTypecastParenPadRightNotPreceded.java"));
+                getXpathPath("SuppressionXpathRegressionTypecastParenPadRightNotPreceded.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(TypecastParenPadCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUncommentedMainTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUncommentedMainTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionUncommentedMainTest extends AbstractXpathTestSupport
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionUncommentedMain.java"));
+                new File(getXpathPath("SuppressionXpathRegressionUncommentedMain.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(UncommentedMainCheck.class);
@@ -70,7 +70,7 @@ public class XpathRegressionUncommentedMainTest extends AbstractXpathTestSupport
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionUncommentedMainTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionUncommentedMainTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(UncommentedMainCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUnnecessaryParenthesesTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUnnecessaryParenthesesTest.java
@@ -39,7 +39,7 @@ public class XpathRegressionUnnecessaryParenthesesTest extends AbstractXpathTest
     @Test
     public void testOne() throws Exception {
         final File fileToProcess = new File(
-            getPath("SuppressionXpathRegressionUnnecessaryParentheses1.java")
+            getXpathPath("SuppressionXpathRegressionUnnecessaryParentheses1.java")
         );
 
         final DefaultConfiguration moduleConfig =
@@ -68,7 +68,7 @@ public class XpathRegressionUnnecessaryParenthesesTest extends AbstractXpathTest
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess = new File(
-            getPath("SuppressionXpathRegressionUnnecessaryParentheses2.java")
+            getXpathPath("SuppressionXpathRegressionUnnecessaryParentheses2.java")
         );
 
         final DefaultConfiguration moduleConfig =
@@ -97,7 +97,7 @@ public class XpathRegressionUnnecessaryParenthesesTest extends AbstractXpathTest
     @Test
     public void testThree() throws Exception {
         final File fileToProcess = new File(
-            getPath("SuppressionXpathRegressionUnnecessaryParentheses3.java")
+            getXpathPath("SuppressionXpathRegressionUnnecessaryParentheses3.java")
         );
 
         final DefaultConfiguration moduleConfig =
@@ -121,7 +121,7 @@ public class XpathRegressionUnnecessaryParenthesesTest extends AbstractXpathTest
     @Test
     public void testFour() throws Exception {
         final File fileToProcess = new File(
-            getPath("SuppressionXpathRegressionUnnecessaryParentheses4.java")
+            getXpathPath("SuppressionXpathRegressionUnnecessaryParentheses4.java")
         );
 
         final DefaultConfiguration moduleConfig =
@@ -146,7 +146,7 @@ public class XpathRegressionUnnecessaryParenthesesTest extends AbstractXpathTest
     @Test
     public void testFive() throws Exception {
         final File fileToProcess = new File(
-            getPath("SuppressionXpathRegressionUnnecessaryParentheses5.java")
+            getXpathPath("SuppressionXpathRegressionUnnecessaryParentheses5.java")
         );
 
         final DefaultConfiguration moduleConfig =
@@ -171,7 +171,7 @@ public class XpathRegressionUnnecessaryParenthesesTest extends AbstractXpathTest
     @Test
     public void testSix() throws Exception {
         final File fileToProcess = new File(
-            getPath("SuppressionXpathRegressionUnnecessaryParentheses6.java")
+            getXpathPath("SuppressionXpathRegressionUnnecessaryParentheses6.java")
         );
 
         final DefaultConfiguration moduleConfig =
@@ -196,7 +196,7 @@ public class XpathRegressionUnnecessaryParenthesesTest extends AbstractXpathTest
     @Test
     public void testSeven() throws Exception {
         final File fileToProcess = new File(
-            getPath("SuppressionXpathRegressionUnnecessaryParentheses7.java")
+            getXpathPath("SuppressionXpathRegressionUnnecessaryParentheses7.java")
         );
 
         final DefaultConfiguration moduleConfig =
@@ -225,7 +225,7 @@ public class XpathRegressionUnnecessaryParenthesesTest extends AbstractXpathTest
     @Test
     public void testEight() throws Exception {
         final File fileToProcess = new File(
-            getPath("SuppressionXpathRegressionUnnecessaryParentheses8.java")
+            getXpathPath("SuppressionXpathRegressionUnnecessaryParentheses8.java")
         );
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUnnecessarySemicolonAfterOuterTypeDeclarationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUnnecessarySemicolonAfterOuterTypeDeclarationTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionUnnecessarySemicolonAfterOuterTypeDeclarationTest
 
     @Test
     public void testOne() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
             "SuppressionXpathRegressionUnnecessarySemicolonAfterOuterTypeDeclaration.java"));
         final DefaultConfiguration moduleConfig = createModuleConfig(CLASS);
         final String[] expectedViolation = {
@@ -57,7 +57,7 @@ public class XpathRegressionUnnecessarySemicolonAfterOuterTypeDeclarationTest
 
     @Test
     public void testTwo() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
             "SuppressionXpathRegressionUnnecessarySemicolonAfterOuterTypeDeclarationInnerTypes"
                     + ".java"));
         final DefaultConfiguration moduleConfig = createModuleConfig(CLASS);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest.java
@@ -41,7 +41,7 @@ public class XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest
 
     @Test
     public void testDefault() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
             "SuppressionXpathRegressionUnnecessarySemicolonAfterTypeMemberDeclaration.java"));
         final DefaultConfiguration moduleConfig = createModuleConfig(CLASS);
         final String[] expectedViolation = {
@@ -61,7 +61,7 @@ public class XpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTest
 
     @Test
     public void testTokens() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
             "SuppressionXpathRegressionUnnecessarySemicolonAfterTypeMemberDeclarationTokens"
                 + ".java"));
         final DefaultConfiguration moduleConfig = createModuleConfig(CLASS);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUnnecessarySemicolonInEnumerationTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUnnecessarySemicolonInEnumerationTest.java
@@ -42,7 +42,7 @@ public class XpathRegressionUnnecessarySemicolonInEnumerationTest
     @Test
     public void testOne() throws Exception {
         final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionUnnecessarySemicolonInEnumeration.java"));
+                getXpathPath("SuppressionXpathRegressionUnnecessarySemicolonInEnumeration.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(UnnecessarySemicolonInEnumerationCheck.class);
@@ -61,7 +61,7 @@ public class XpathRegressionUnnecessarySemicolonInEnumerationTest
 
     @Test
     public void testTwo() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
             "SuppressionXpathRegressionUnnecessarySemicolonInEnumerationAll.java"
         ));
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUnnecessarySemicolonInTryWithResourcesTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUnnecessarySemicolonInTryWithResourcesTest.java
@@ -41,8 +41,8 @@ public class XpathRegressionUnnecessarySemicolonInTryWithResourcesTest
 
     @Test
     public void testDefault() throws Exception {
-        final File fileToProcess = new File(
-                getPath("SuppressionXpathRegressionUnnecessarySemicolonInTryWithResources.java"));
+        final File fileToProcess = new File(getXpathPath(
+                "SuppressionXpathRegressionUnnecessarySemicolonInTryWithResources.java"));
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(UnnecessarySemicolonInTryWithResourcesCheck.class);
         final String[] expectedViolation = {
@@ -62,7 +62,7 @@ public class XpathRegressionUnnecessarySemicolonInTryWithResourcesTest
 
     @Test
     public void testAllowWhenNoBraceAfterSemicolon() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
             "SuppressionXpathRegressionUnnecessarySemicolonInTryWithResourcesNoBrace.java"
         ));
 

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUnusedImportsTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUnusedImportsTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionUnusedImportsTest extends AbstractXpathTestSupport {
     @Test
     public void testOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionUnusedImportsOne.java"));
+                new File(getXpathPath("SuppressionXpathRegressionUnusedImportsOne.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(UnusedImportsCheck.class);
@@ -60,7 +60,7 @@ public class XpathRegressionUnusedImportsTest extends AbstractXpathTestSupport {
     @Test
     public void testTwo() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionUnusedImportsTwo.java"));
+                new File(getXpathPath("SuppressionXpathRegressionUnusedImportsTwo.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(UnusedImportsCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUnusedLocalVariableTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUnusedLocalVariableTest.java
@@ -38,7 +38,7 @@ public class XpathRegressionUnusedLocalVariableTest extends AbstractXpathTestSup
 
     @Test
     public void testOne() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionUnusedLocalVariableOne.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -73,7 +73,7 @@ public class XpathRegressionUnusedLocalVariableTest extends AbstractXpathTestSup
 
     @Test
     public void testTwo() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionUnusedLocalVariableTwo.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUpperEllTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionUpperEllTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionUpperEllTest extends AbstractXpathTestSupport {
     @Test
     public void testUpperEllOne() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionUpperEllFirst.java"));
+                new File(getXpathPath("SuppressionXpathRegressionUpperEllFirst.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(UpperEllCheck.class);
@@ -67,7 +67,7 @@ public class XpathRegressionUpperEllTest extends AbstractXpathTestSupport {
     @Test
     public void testUpperEllTwo() throws Exception {
         final File fileToProcess =
-            new File(getPath("SuppressionXpathRegressionUpperEllSecond.java"));
+            new File(getXpathPath("SuppressionXpathRegressionUpperEllSecond.java"));
 
         final DefaultConfiguration moduleConfig =
             createModuleConfig(UpperEllCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionVariableDeclarationUsageDistanceTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionVariableDeclarationUsageDistanceTest.java
@@ -38,7 +38,7 @@ public class XpathRegressionVariableDeclarationUsageDistanceTest extends Abstrac
 
     @Test
     public void testOne() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionVariableDeclarationUsageDistance1.java"));
 
         final DefaultConfiguration moduleConfig =
@@ -78,7 +78,7 @@ public class XpathRegressionVariableDeclarationUsageDistanceTest extends Abstrac
 
     @Test
     public void testTwo() throws Exception {
-        final File fileToProcess = new File(getPath(
+        final File fileToProcess = new File(getXpathPath(
                 "SuppressionXpathRegressionVariableDeclarationUsageDistance2.java"));
 
         final DefaultConfiguration moduleConfig =

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionWhitespaceAfterTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionWhitespaceAfterTest.java
@@ -40,7 +40,7 @@ public class XpathRegressionWhitespaceAfterTest extends AbstractXpathTestSupport
     @Test
     public void testWhitespaceAfterTypecast() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionWhitespaceAfterTypecast.java"));
+                new File(getXpathPath("SuppressionXpathRegressionWhitespaceAfterTypecast.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(WhitespaceAfterCheck.class);
@@ -63,7 +63,7 @@ public class XpathRegressionWhitespaceAfterTest extends AbstractXpathTestSupport
     @Test
     public void testWhitespaceAfterNotFollowed() throws Exception {
         final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionWhitespaceAfterNotFollowed.java"));
+                new File(getXpathPath("SuppressionXpathRegressionWhitespaceAfterNotFollowed.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(WhitespaceAfterCheck.class);

--- a/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionWhitespaceAroundTest.java
+++ b/src/it/java/org/checkstyle/suppressionxpathfilter/XpathRegressionWhitespaceAroundTest.java
@@ -39,8 +39,8 @@ public class XpathRegressionWhitespaceAroundTest extends AbstractXpathTestSuppor
 
     @Test
     public void testWhitespaceAroundNotPreceded() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionWhitespaceAroundNotPreceded.java"));
+        final File fileToProcess = new File(
+                getXpathPath("SuppressionXpathRegressionWhitespaceAroundNotPreceded.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(WhitespaceAroundCheck.class);
@@ -62,8 +62,8 @@ public class XpathRegressionWhitespaceAroundTest extends AbstractXpathTestSuppor
 
     @Test
     public void testWhitespaceAroundNotFollowed() throws Exception {
-        final File fileToProcess =
-                new File(getPath("SuppressionXpathRegressionWhitespaceAroundNotFollowed.java"));
+        final File fileToProcess = new File(
+                getXpathPath("SuppressionXpathRegressionWhitespaceAroundNotFollowed.java"));
 
         final DefaultConfiguration moduleConfig =
                 createModuleConfig(WhitespaceAroundCheck.class);


### PR DESCRIPTION
Issue #11651

This starts the split, that IT xpath and checkstyle are different form of tests that will be for google/sun's tests as the latter relies on configurations and these won't. This is needed for a future change which will split google/sun's tests more apart from these.

Since IT xpath and checkstyle have different abstract classes, I am keeping them separate. Test's paths are fully focused on `test` folder path, so IT's version need their own paths.