### PR TITLE
Issue #11662: Fixed NoSuchFileException during maven-compiler-plugin:3.10.1:testCompile

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -1487,6 +1487,7 @@ xpathfilegeneratorauditlistener
 xpathfilterelement
 xpathmapper
 xpathquerygenerator
+Xpkginfo
 xright
 xsd
 xsi

--- a/pom.xml
+++ b/pom.xml
@@ -729,6 +729,9 @@
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>
+          <compilerArgs>
+            <arg>-Xpkginfo:always</arg>
+          </compilerArgs>
         </configuration>
         <!-- till https://github.com/checkstyle/checkstyle/issues/2160
         <executions>


### PR DESCRIPTION
Resolves #11662 
Related documentation: https://docs.oracle.com/en/java/javase/11/tools/javac.html#GUID-AEEC9F07-CB49-4E96-8BC7-BCC2C7F725C9

>always - Generates a package-info.class file for every package-info.java file. This option may be useful if you use a build system such as Ant, which checks that each .java file has a corresponding .class file.