### PR TITLE
Issue #11643 Solved UnnecessaryParentheses: false negative on unnecessary parenthesis

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
@@ -555,8 +555,16 @@ public class UnnecessaryParenthesesCheck extends AbstractCheck {
     private static boolean isSurrounded(DetailAST ast) {
         // if previous sibling is left parenthesis,
         // next sibling can't be other than right parenthesis
+        // if the parent's tokentype is METHOD_CALL,
+        // check whether the parent's previous sibling is left parenthesis.
+
         final DetailAST prev = ast.getPreviousSibling();
-        return prev != null && prev.getType() == TokenTypes.LPAREN;
+        // assume parent should not be null
+        final DetailAST parent = ast.getParent();
+        return prev != null && prev.getType() == TokenTypes.LPAREN
+                || parent.getType() == TokenTypes.METHOD_CALL
+                    && parent.getPreviousSibling() != null
+                        && parent.getPreviousSibling().getType() == TokenTypes.LPAREN;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheckTest.java
@@ -257,4 +257,22 @@ public class UnnecessaryParenthesesCheckTest extends AbstractModuleTestSupport {
                 getPath("InputUnnecessaryParenthesesIfStatement2.java"), expected);
     }
 
+    @Test
+    public void testIssue11643() throws Exception {
+        final String[] expected =
+        {
+            "25:11: " + getCheckMessage(MSG_ASSIGN),
+            "25:14: " + getCheckMessage(MSG_IDENT, "test"),
+            "27:18: " + getCheckMessage(MSG_IDENT, "test"),
+            "31:17: " + getCheckMessage(MSG_IDENT, "test"),
+            "38:11: " + getCheckMessage(MSG_ASSIGN),
+            "50:10: " + getCheckMessage(MSG_ASSIGN),
+            "51:11: " + getCheckMessage(MSG_ASSIGN),
+            "52:11: " + getCheckMessage(MSG_ASSIGN),
+            "52:19: " + getCheckMessage(MSG_IDENT, "getOne"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputUnnecessaryParenthesesIssue11643.java"), expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesIssue11643.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesIssue11643.java
@@ -1,0 +1,55 @@
+/*
+UnnecessaryParentheses
+tokens = (default)EXPR, IDENT, NUM_DOUBLE, NUM_FLOAT, NUM_INT, NUM_LONG, \
+         STRING_LITERAL, LITERAL_NULL, LITERAL_FALSE, LITERAL_TRUE, ASSIGN, \
+         BAND_ASSIGN, BOR_ASSIGN, BSR_ASSIGN, BXOR_ASSIGN, DIV_ASSIGN, \
+         MINUS_ASSIGN, MOD_ASSIGN, PLUS_ASSIGN, SL_ASSIGN, SR_ASSIGN, STAR_ASSIGN, \
+         LAMBDA, TEXT_BLOCK_LITERAL_BEGIN, LAND, LITERAL_INSTANCEOF, GT, LT, GE, \
+         LE, EQUAL, NOT_EQUAL, UNARY_MINUS, UNARY_PLUS, INC, DEC, LNOT, BNOT, \
+         POST_INC, POST_DEC
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.unnecessaryparentheses;
+public class InputUnnecessaryParenthesesIssue11643 {
+    public static boolean is(Class<?> clazz) {
+
+        boolean a = true;
+        boolean b = false;
+        boolean c;
+        boolean d;
+
+        test(clazz);
+        c = test(clazz);
+        d = (test(clazz)); // 2 violations
+
+        if(a && (test(clazz)) ){ // violation 'Unnecessary parentheses around identifier 'test''
+
+        };
+        return true
+            && (test(clazz)); // violation 'Unnecessary parentheses around identifier 'test''
+    }
+
+    public static boolean test(Class<?> clazz) {
+        int a, b, c;
+        a = 0;
+        b = 0;
+        c = (a + 1); // violation 'Unnecessary parentheses around assignment right.*side'
+        return true;
+    }
+
+    public static int getOne() {
+        return 1;
+    }
+
+    public static void testOne() {
+        int a = 1;
+        int b, c, d, f;
+        b = a + getOne();
+        c=(getOne()+getOne());// violation 'Unnecessary parentheses around assignment right.*side'
+        d = (a + getOne()); // violation 'Unnecessary parentheses around assignment right.*side'
+        f = (1 + (getOne())); // 2 violations
+    }
+
+}


### PR DESCRIPTION
[Issue: #11643 ](https://github.com/checkstyle/checkstyle/issues/11643)
I found that the keyword of METHOD_CALL is not considered when the UnnecessaryParentheses checker processes keywords.
I add lines to solve this problem. Please check and provide advice.
Thank you.