### PR TITLE
Issue #11641 Solved SuppressWarningsHolder should allow usage of simple name of Checks in aliasList

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -168,6 +168,24 @@ public class SuppressWarningsHolder
     }
 
     /**
+     * Returns the default name for the source name of a check, which is the
+     * source name with any dotted prefix or "Check" suffix
+     * romoved.
+     *
+     * @param sourceName the source name of the check (generally the class
+     *        name)
+     * @return the default name for the given check
+     */
+    public static String getDefaultName(String sourceName) {
+        int endIndex = sourceName.length();
+        if (sourceName.endsWith(CHECK_SUFFIX)) {
+            endIndex -= CHECK_SUFFIX.length();
+        }
+        final int startIndex = sourceName.lastIndexOf('.') + 1;
+        return sourceName.substring(startIndex, endIndex);
+    }
+
+    /**
      * Returns the alias for the source name of a check. If an alias has been
      * explicitly registered via {@link #setAliasList(String...)}, that
      * alias is returned; otherwise, the default alias is used.
@@ -179,7 +197,10 @@ public class SuppressWarningsHolder
     public static String getAlias(String sourceName) {
         String checkAlias = CHECK_ALIAS_MAP.get(sourceName);
         if (checkAlias == null) {
-            checkAlias = getDefaultAlias(sourceName);
+            checkAlias = CHECK_ALIAS_MAP.get(getDefaultName(sourceName));
+        }
+        if (checkAlias == null) {
+            checkAlias = "";
         }
         return checkAlias;
     }
@@ -227,6 +248,7 @@ public class SuppressWarningsHolder
     public static boolean isSuppressed(AuditEvent event) {
         final List<Entry> entries = ENTRIES.get();
         final String sourceName = event.getSourceName();
+        final String defaultName = getDefaultName(sourceName);
         final String checkAlias = getAlias(sourceName);
         final int line = event.getLine();
         final int column = event.getColumn();
@@ -237,7 +259,8 @@ public class SuppressWarningsHolder
             final String checkName = entry.getCheckName();
             final boolean nameMatches =
                 ALL_WARNING_MATCHING_ID.equals(checkName)
-                    || checkName.equalsIgnoreCase(checkAlias);
+                    || checkName.equalsIgnoreCase(checkAlias)
+                    || checkName.equalsIgnoreCase(defaultName);
             if (afterStart && beforeEnd
                     && (nameMatches || checkName.equals(event.getModuleId()))) {
                 suppressed = true;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -142,6 +142,16 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testGetDefaultName() {
+        assertWithMessage("Default name differs from expected")
+            .that(SuppressWarningsHolder.getDefaultName("SomeName"))
+            .isEqualTo("SomeName");
+        assertWithMessage("Default name differs from expected")
+            .that(SuppressWarningsHolder.getDefaultName("SomeNameCheck"))
+            .isEqualTo("SomeName");
+    }
+
+    @Test
     public void testSetAliasListEmpty() {
         final SuppressWarningsHolder holder = new SuppressWarningsHolder();
         holder.setAliasList("");

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheckTest.java
@@ -123,4 +123,25 @@ public class ParameterNumberCheckTest
                 getPath("InputParameterNumber2.java"), expected);
     }
 
+    @Test
+    public void testIssue11641() throws Exception {
+        final String[] expected = {
+            "50:17: " + getCheckMessage(MSG_KEY, 7, 8),
+            "56:17: " + getCheckMessage(MSG_KEY, 7, 8),
+            "61:17: " + getCheckMessage(MSG_KEY, 7, 8),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputParameterNumberIssue11641.java"), expected);
+    }
+
+    @Test
+    public void testIssue11641fullCheckName() throws Exception {
+        final String[] expected = {
+            "50:17: " + getCheckMessage(MSG_KEY, 7, 8),
+            "56:17: " + getCheckMessage(MSG_KEY, 7, 8),
+            "61:17: " + getCheckMessage(MSG_KEY, 7, 8),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputParameterNumberIssue11641fullCheckName.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberIssue11641.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberIssue11641.java
@@ -1,0 +1,67 @@
+/*
+ParameterNumber
+max = (default)7
+ignoreOverriddenMethods = true
+tokens = (default)METHOD_DEF, CTOR_DEF
+
+com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter
+
+com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder
+aliasList = ParameterNumber=paramnum
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.sizes.parameternumber;
+
+public class InputParameterNumberIssue11641 {
+
+    @SuppressWarnings("paramnum") // OK
+    public void needsLotsOfParameters( int a, // OK
+    int b, int c, int d, int e, int f, int g, int h) {
+        // ...
+    }
+
+    @SuppressWarnings("pAramNUM") // OK
+    public void needsLotsOfParameters2( int a, // OK
+    int b, int c, int d, int e, int f, int g, int h) {
+        // ...
+    }
+
+
+    @SuppressWarnings("ParameterNumber") // OK
+    public void needsLotsOfParameters3( int a, // OK
+    int b, int c, int d, int e, int f, int g, int h) {
+        // ...
+    }
+
+    @SuppressWarnings("parameternumber") // OK
+    public void needsLotsOfParameters4( int a, // OK
+    int b, int c, int d, int e, int f, int g, int h) {
+        // ...
+    }
+
+    @SuppressWarnings("ParaMETERnumber") // OK
+    public void needsLotsOfParameters5( int a, // OK
+    int b, int c, int d, int e, int f, int g, int h) {
+        // ...
+    }
+
+    @SuppressWarnings("Parameter")
+    public void needsLotsOfParameters6( int a, // violation
+    int b, int c, int d, int e, int f, int g, int h) {
+        // ...
+    }
+
+    @SuppressWarnings("error")
+    public void needsLotsOfParameters7( int a, // violation
+    int b, int c, int d, int e, int f, int g, int h) {
+        // ...
+    }
+
+    public void needsLotsOfParameters8( int a, // violation
+    int b, int c, int d, int e, int f, int g, int h) {
+        // ...
+    }
+}
+
+

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberIssue11641fullCheckName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/sizes/parameternumber/InputParameterNumberIssue11641fullCheckName.java
@@ -1,0 +1,65 @@
+/*
+ParameterNumber
+max = (default)7
+ignoreOverriddenMethods = true
+tokens = (default)METHOD_DEF, CTOR_DEF
+
+com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter
+
+com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder
+aliasList = com.puppycrawl.tools.checkstyle.checks.sizes.ParameterNumberCheck=paramnum
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.sizes.parameternumber;
+
+public class InputParameterNumberIssue11641fullCheckName {
+
+    @SuppressWarnings("paramnum") // OK
+    public void needsLotsOfParameters( int a, // OK
+    int b, int c, int d, int e, int f, int g, int h) {
+        // ...
+    }
+
+    @SuppressWarnings("pAramNUM") // OK
+    public void needsLotsOfParameters2( int a, // OK
+    int b, int c, int d, int e, int f, int g, int h) {
+        // ...
+    }
+
+
+    @SuppressWarnings("ParameterNumber") // OK
+    public void needsLotsOfParameters3( int a, // OK
+    int b, int c, int d, int e, int f, int g, int h) {
+        // ...
+    }
+
+    @SuppressWarnings("parameternumber") // OK
+    public void needsLotsOfParameters4( int a, // OK
+    int b, int c, int d, int e, int f, int g, int h) {
+        // ...
+    }
+
+    @SuppressWarnings("ParaMETERnumber") // OK
+    public void needsLotsOfParameters5( int a, // OK
+    int b, int c, int d, int e, int f, int g, int h) {
+        // ...
+    }
+
+    @SuppressWarnings("Parameter")
+    public void needsLotsOfParameters6( int a, // violation
+    int b, int c, int d, int e, int f, int g, int h) {
+        // ...
+    }
+
+    @SuppressWarnings("error")
+    public void needsLotsOfParameters7( int a, // violation
+    int b, int c, int d, int e, int f, int g, int h) {
+        // ...
+    }
+
+    public void needsLotsOfParameters8( int a, // violation
+    int b, int c, int d, int e, int f, int g, int h) {
+        // ...
+    }
+}


### PR DESCRIPTION
#11641 
Added a method `getDefaultName` which is similar with `getDefaultAlias` except the last line.
I think we can just modify the last line of `getDefaultAlias` since it seems that it's just use for `nameMatches` at: 
https://github.com/checkstyle/checkstyle/blob/51408f83b03311e2c4a86cb28410d4bd7b3388be/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java#L238
However, it needs to change the Javadoc of `getDefaultName`, so I want to ask for your advice. 
Thank you.
