### PR TITLE
Issue #11569: Fixed the false negative in the rule ClassMemberImplied…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3772,6 +3772,9 @@
                 <param>
                   com.puppycrawl.tools.checkstyle.checks.design.FinalClassCheckTest
                 </param>
+                <param>
+                  com.puppycrawl.tools.checkstyle.checks.modifier.ClassMemberImpliedModifierCheckTest
+                </param>
               </targetTests>
               <excludedTestClasses>
                 <param>*.Input*</param>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheck.java
@@ -243,9 +243,33 @@ public class ClassMemberImpliedModifierCheck
      * @return true if ast is in a class, enum, or record
      */
     private static boolean isInTypeBlock(DetailAST ast) {
-        return ScopeUtil.isInClassBlock(ast)
+        return isInObjBlock(ast)
+                || ScopeUtil.isInClassBlock(ast)
                 || ScopeUtil.isInEnumBlock(ast)
                 || ScopeUtil.isInRecordBlock(ast);
+    }
+
+    /**
+     * Returns whether a node is directly contained within an anonymous object block.
+     *
+     * @param node the node to check if directly contained within an anonymous object block.
+     * @return a {@code boolean} value
+     */
+    public static boolean isInObjBlock(DetailAST node) {
+        boolean returnValue = false;
+
+        // Loop up looking for a containing interface block
+        for (DetailAST token = node.getParent();
+             token != null;
+             token = token.getParent()) {
+            if (token.getType() == TokenTypes.OBJBLOCK
+                && token.getParent().getType() == TokenTypes.LITERAL_NEW) {
+                returnValue = true;
+                break;
+            }
+        }
+
+        return returnValue;
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheckTest.java
@@ -143,6 +143,26 @@ public class ClassMemberImpliedModifierCheckTest
     }
 
     @Test
+    public void testClassMemberImpliedModifierObjNestedRecord() throws Exception {
+        final String[] expected = {
+            "15:9: " + getCheckMessage(MSG_KEY, "static"),
+        };
+        verifyWithInlineConfigParser(
+            getNonCompilablePath(
+                "InputClassMemberImpliedModifierObjNestedRecord.java"),
+            expected);
+    }
+
+    @Test
+    public void testClassMemberImpliedModifierObjNestedRecordNoViolation() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+            getNonCompilablePath(
+                "InputClassMemberImpliedModifierObjNestedRecordNoViolation.java"),
+            expected);
+    }
+
+    @Test
     public void testIllegalState() {
         final DetailAstImpl init = new DetailAstImpl();
         init.setType(TokenTypes.STATIC_INIT);

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/InputClassMemberImpliedModifierObjNestedRecord.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/InputClassMemberImpliedModifierObjNestedRecord.java
@@ -1,0 +1,17 @@
+/*
+ClassMemberImpliedModifier
+violateImpliedStaticOnNestedEnum = (default)true
+violateImpliedStaticOnNestedInterface = (default)true
+violateImpliedStaticOnNestedRecord = (default)true
+
+
+*/
+
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.modifier.classmemberimpliedmodifier;
+
+public class InputClassMemberImpliedModifierObjNestedRecord {
+    Object obj = new Object() {
+        public record BadRecord() {} // violation
+    };
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/InputClassMemberImpliedModifierObjNestedRecordNoViolation.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/modifier/classmemberimpliedmodifier/InputClassMemberImpliedModifierObjNestedRecordNoViolation.java
@@ -1,0 +1,17 @@
+/*
+ClassMemberImpliedModifier
+violateImpliedStaticOnNestedEnum = (default)true
+violateImpliedStaticOnNestedInterface = (default)true
+violateImpliedStaticOnNestedRecord = (default)true
+
+
+*/
+
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.modifier.classmemberimpliedmodifier;
+
+public class InputClassMemberImpliedModifierObjNestedRecordNoViolation {
+    Object obj = new Object() {
+        public static record BadRecord() {} // ok
+    };
+}


### PR DESCRIPTION
Fixed #11569 
The problem was due to the original implementation didn't consider the case that the declaration of record could be nested in an anonymous object, and ``ScopeUtil.isInBlockOf`` will break the loop once it encounters a ``new`` keyword. I fixed this issue by adding a method to dertermine whether the node is in an anonymous object.
Diff Regression config: https://gist.githubusercontent.com/as23415672/b6efc853253765e2c3ff2ae12f77b6a5/raw/2610c9ad3fe1b3c1213896f23816169f81d11755/my_check_ClassMemberImpliedModifier.xml