### PR TITLE
Issue #7582: Update doc for LeftCurly

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -177,6 +177,35 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * }
  * </pre>
  * <p>
+ * To configure the check to apply the {@code nlow} policy
+ *</p>
+ * <pre>
+ * &lt;module name=&quot;LeftCurly&quot;&gt;
+ *   &lt;property name=&quot;option&quot; value=&quot;nlow&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <pre>
+ * public class InputLeftCurlyTestOptionNlow { // OK
+ *
+ *   public void foo1() {// OK
+ *   }
+ *
+ *   public void foo2()
+ *   { // Violation - '{' should be on the previous line
+ *   }
+ *
+ *   public void foo3(int value1, int value2,
+ *                    int value3, int value4)
+ *   { // OK
+ *   }
+ *
+ *   public void foo4(int value1, int value2,
+ *                    int value3, int value4) { // Violation - '{' should be on a new line
+ *   }
+ *
+ * }
+ * </pre>
+ * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
  * </p>
  * <p>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheckTest.java
@@ -512,4 +512,15 @@ public class LeftCurlyCheckTest extends AbstractModuleTestSupport {
         }
     }
 
+    @Test
+    public void testOptionNlow() throws Exception {
+        final String[] expected = {
+            "22:3: " + getCheckMessage(MSG_KEY_LINE_PREVIOUS, "{", 3),
+            "31:44: " + getCheckMessage(MSG_KEY_LINE_NEW, "{", 44),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputLeftCurlyTestOptionNlow.java"), expected);
+    }
+
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestOptionNlow.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/leftcurly/InputLeftCurlyTestOptionNlow.java
@@ -1,0 +1,34 @@
+/*
+LeftCurly
+option = NLOW
+ignoreEnums = (default)true
+tokens = (default)ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, \
+         ENUM_DEF, INTERFACE_DEF, LAMBDA, LITERAL_CASE, LITERAL_CATCH, \
+         LITERAL_DEFAULT, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, \
+         LITERAL_IF, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, \
+         METHOD_DEF, OBJBLOCK, STATIC_INIT, RECORD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.leftcurly;
+
+public class InputLeftCurlyTestOptionNlow { // OK
+
+  public void foo1() {// OK
+  }
+  
+  public void foo2()
+  { // violation ''{' at column 3 should be on the previous line'
+  }
+  
+  public void foo3(int value1, int value2,
+                   int value3, int value4)
+  { // OK
+  }
+  
+  public void foo4(int value1, int value2,
+                   int value3, int value4) { // violation ''{' at column 44 should be on a new line'
+  }
+  
+}


### PR DESCRIPTION
![page](https://user-images.githubusercontent.com/84538746/170854843-98bed1f3-9fc3-4e06-8e91-500d1f30a9f9.png)
```
$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
    "https://checkstyle.org/dtds/configuration_1_3.dtd">

    <module name = "Checker">
        <property name="charset" value="UTF-8"/>
        <module name="TreeWalker">
          <module name="LeftCurly">
               <property name="option" value="nlow"/>
           </module>
        </module>
    </module>
    
$ cat InputLeftCurlyTestOptionNlow.java
public class InputLeftCurlyTestOptionNlow { // OK

  public void foo1() {// OK
  }
  
  public void foo2() 
  { // Violation - '{' should be on the previous line
  }
  
  public void foo3(int value1, int value2, 
                   int value3, int value4)
  { // OK
  }
  
  public void foo4(int value1, int value2, 
                   int value3, int value4) { // Violation - '{' should be on a new line
  }
  
}

$ java -jar checkstyle-10.2-all.jar -c config.xml InputLeftCurlyTestOptionNlow.java
Starting audit...
[ERROR] /home/InputLeftCurlyTestOptionNlow.java:7:3: '{' at column 3 should be on the previous line. [LeftCurly]
[ERROR] /home/InputLeftCurlyTestOptionNlow.java:16:44: '{' at column 44 should be on a new line. [LeftCurly]
Audit done.
Checkstyle ends with 2 errors.
```