### PR TITLE
Issue #8239: Report expression violation message for symmetric and contiguous parentheses in expression in UnnecessaryParenthesesCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheckTest.java
@@ -61,11 +61,13 @@ public class UnnecessaryParenthesesCheckTest extends AbstractModuleTestSupport {
             "25:22: " + getCheckMessage(MSG_ASSIGN),
             "25:30: " + getCheckMessage(MSG_IDENT, "i"),
             "25:46: " + getCheckMessage(MSG_ASSIGN),
+            "25:33: " + getCheckMessage(MSG_EXPR),
             "29:17: " + getCheckMessage(MSG_LITERAL, "0"),
             "39:11: " + getCheckMessage(MSG_ASSIGN),
             "43:11: " + getCheckMessage(MSG_ASSIGN),
             "45:11: " + getCheckMessage(MSG_ASSIGN),
             "47:11: " + getCheckMessage(MSG_ASSIGN),
+            "47:11: " + getCheckMessage(MSG_EXPR),
             "48:16: " + getCheckMessage(MSG_IDENT, "a"),
             "49:14: " + getCheckMessage(MSG_IDENT, "a"),
             "49:20: " + getCheckMessage(MSG_IDENT, "b"),
@@ -257,4 +259,24 @@ public class UnnecessaryParenthesesCheckTest extends AbstractModuleTestSupport {
                 getPath("InputUnnecessaryParenthesesIfStatement2.java"), expected);
     }
 
+    @Test
+    public void testNestedCondition() throws Exception {
+        final String[] expected = {
+                "27:11: " + getCheckMessage(MSG_ASSIGN),
+                "30:11: " + getCheckMessage(MSG_ASSIGN),
+                "30:11: " + getCheckMessage(MSG_EXPR),
+                "32:11: " + getCheckMessage(MSG_ASSIGN),
+                "46:23: " + getCheckMessage(MSG_EXPR),
+                "50:27: " + getCheckMessage(MSG_EXPR),
+                "54:13: " + getCheckMessage(MSG_EXPR),
+                "58:16: " + getCheckMessage(MSG_ASSIGN),
+                "58:26: " + getCheckMessage(MSG_IDENT, "i"),
+                "58:29: " + getCheckMessage(MSG_EXPR),
+                "58:42: " + getCheckMessage(MSG_ASSIGN),
+                "62:11: " + getCheckMessage(MSG_ASSIGN),
+                "62:11: " + getCheckMessage(MSG_EXPR),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputUnnecessaryParenthesesNestedCondition.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesNestedCondition.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesNestedCondition.java
@@ -1,0 +1,64 @@
+/*
+UnnecessaryParentheses
+tokens = (default)EXPR, IDENT, NUM_DOUBLE, NUM_FLOAT, NUM_INT, NUM_LONG, \
+         STRING_LITERAL, LITERAL_NULL, LITERAL_FALSE, LITERAL_TRUE, ASSIGN, \
+         BAND_ASSIGN, BOR_ASSIGN, BSR_ASSIGN, BXOR_ASSIGN, DIV_ASSIGN, \
+         MINUS_ASSIGN, MOD_ASSIGN, PLUS_ASSIGN, SL_ASSIGN, SR_ASSIGN, STAR_ASSIGN, \
+         LAMBDA, TEXT_BLOCK_LITERAL_BEGIN, LAND, LITERAL_INSTANCEOF, GT, LT, GE, \
+         LE, EQUAL, NOT_EQUAL, UNARY_MINUS, UNARY_PLUS, INC, DEC, LNOT, BNOT, \
+         POST_INC, POST_DEC
+*/
+
+
+
+package com.puppycrawl.tools.checkstyle.checks.coding.unnecessaryparentheses;
+
+public class InputUnnecessaryParenthesesNestedCondition {
+    public void foo() {
+        int a, b, c, d;
+        int i = 0;
+        int x = 0;
+        int y = 0;
+
+        a = 0;
+        b = 0;
+        c = 0;
+        d = c - 1;
+        c = (a + b); // violation 'Unnecessary parentheses around assignment right-hand side'
+        d = c - 1;
+
+        b = ((((a + b) * (c + d)))); // 2 violations
+
+        i = ((a + b) * (c + d)); // violation 'parentheses around assignment right.*side'
+        i = (a + b) * (c + d);
+
+        int n = 10;
+        if ((n = n % 2) == 0) {
+            System.out.println("correct 1");
+        }
+
+        if (n % 2 == 0) {
+            System.out.println("correct 2");
+        }
+
+        n = (1 + 2) * 3;
+
+        if (((n % 2)) == 0) { // violation 'Unnecessary parentheses around expression'
+            System.out.println("violation 1");
+        }
+
+        if (((n = n % 2)) == 0) { // violation 'Unnecessary parentheses around expression'
+            System.out.println("violation 3");
+        }
+
+        if ((x > y)) { // violation 'Unnecessary parentheses around expression'
+            x += y;
+        }
+
+        for (i = (0+1); (i) < ((6+6)); i += (1+0)) { // 4 violations
+            System.identityHashCode("hi");
+        }
+
+        n = ((((a + b) * (c + d)))); // 2 violations
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesOperatorsAndCasts.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesOperatorsAndCasts.java
@@ -22,7 +22,7 @@ public class InputUnnecessaryParenthesesOperatorsAndCasts {
             (x) = (x + i + 100); // 2 violations
         }
 
-        for (int i = (0+1); (i) < ((6+6)); i += (1+0)) { // 3 violations
+        for (int i = (0+1); (i) < ((6+6)); i += (1+0)) { // 4 violations
             System.identityHashCode("hi");
         }
 
@@ -44,7 +44,7 @@ public class InputUnnecessaryParenthesesOperatorsAndCasts {
 
         x += (i + 100 + arg1); // violation 'Unnecessary parentheses around assignment right.*side'
         a = (a + b) * (c + d);
-        b = ((((a + b) * (c + d)))); // violation 'parentheses around assignment right.*side'
+        b = ((((a + b) * (c + d)))); // 2 violations
         c = (((a) <= b)) ? 0 : 1; // violation 'Unnecessary parentheses around identifier 'a''
         d = (a) + (b) * (600) / (int) (12.5f) + (int) (arg2); // 5 violations
         e = ("this") + ("that") + ("is" + "other"); // 2 violations


### PR DESCRIPTION
[Issue #8239](https://github.com/checkstyle/checkstyle/issues/8239)

This is part of the fix for Issue #8239. Missing violation related to the method call mentioned in Issue #8239 has already been implemented in issue #11643. I extended the current isExprSurrounded method to check whether an expression contains symmetric and contiguous parentheses in it.