### PR TITLE
minor: fixes off pom indentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2991,7 +2991,7 @@
         </plugins>
       </build>
     </profile>
-   <!-- Non-checks code profiles -->
+    <!-- Non-checks code profiles -->
     <profile>
       <id>pitest-ant</id>
       <properties>


### PR DESCRIPTION
Identified at https://github.com/rnveach/checkstyle-extras/issues/3

Very minor. Only thing found.