### PR TITLE
minor: includes skipping tidy on no-validations profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2134,6 +2134,7 @@
         <linkcheck.skip>true</linkcheck.skip>
         <jdepend.skip>true</jdepend.skip>
         <modernizer.skip>true</modernizer.skip>
+        <tidy.skip>true</tidy.skip>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
Added tidy skip to no validation profile.

Identified at https://github.com/checkstyle/checkstyle/pull/11686 and https://github.com/rnveach/checkstyle-backport-jre8/commit/7032abdb5ec9d48e9e61079625bd8c7f547f4dd5 .