### PR TITLE
minor: removes inputs and expecteds from test jar to reduce size

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1528,6 +1528,10 @@
               <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
             </manifest>
           </archive>
+          <excludes>
+            <exclude>**/Input*.*</exclude>
+            <exclude>**/Expected*.*</exclude>
+          </excludes>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
Identified at https://github.com/checkstyle/checkstyle/pull/11686 and it's issue.

This removes inputs and expecteds from the test jar to reduce its size.

> -rw-r--r--  1 www-data www-data 10299902 May 31 21:54 checkstyle-10.4-SNAPSHOT-tests.jar

On Windows, new file size is: 3,576,922. Reduced by ~6.7 megs.