### PR TITLE
infra: set JAVA_HOME in travis ci

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -549,6 +549,7 @@ hne
 homepage
 horizontalwhitespace
 Hostname
+hotspot
 href
 htaccess
 htag

--- a/.travis.yml
+++ b/.travis.yml
@@ -126,6 +126,7 @@ jobs:
         - USE_MAVEN_REPO="true"
 
 script:
+  - JAVA_HOME='/usr/lib/jvm/adoptopenjdk-11-hotspot-ppc64el'
   - ./.ci/travis.sh init-m2-repo
   - ./.ci/travis.sh run-command "$CMD"
   - ./.ci/travis.sh remove-custom-mvn


### PR DESCRIPTION
Attempt to fix failure to find `JAVA_HOME` env varible noted at https://app.travis-ci.com/github/checkstyle/checkstyle/jobs/572463219 and elsewhere

Upon starting container, openjdk is already installed:
```
Java version: 11.0.11, vendor: AdoptOpenJDK, runtime: /usr/lib/jvm/adoptopenjdk-11-hotspot-ppc64el

```
But later, travis ci tries to install coretto, which fails to download:
```
install_jdk
Installing openjdk11
--2022-06-06 03:58:06--  https://apt.corretto.aws/corretto.key
Resolving apt.corretto.aws (apt.corretto.aws)... 65.8.214.8, 65.8.214.107, 65.8.214.114, ...
Connecting to apt.corretto.aws (apt.corretto.aws)|65.8.214.8|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 1695 (1.7K) [binary/octet-stream]
Saving to: ‘STDOUT’
     0K .                                                     100% 29.8M=0s
2022-06-06 03:58:06 (29.8 MB/s) - written to stdout [1695/1695]
OK
Get:1 https://apt.corretto.aws stable InRelease [10.7 kB]
Hit:2 http://ports.ubuntu.com/ubuntu-ports focal InRelease
Hit:3 https://adoptopenjdk.jfrog.io/adoptopenjdk/deb focal InRelease
Hit:4 http://ports.ubuntu.com/ubuntu-ports focal-updates InRelease
Hit:5 http://ports.ubuntu.com/ubuntu-ports focal-backports InRelease
Hit:6 https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu focal InRelease
Hit:7 http://ports.ubuntu.com/ubuntu-ports focal-security InRelease
Fetched 10.7 kB in 1s (7436 B/s)
Reading package lists...
E: Unable to locate package java-11-amazon-corretto-jdk
```
But, even though installation fails, travis still sets corretto as `JAVA_HOME`:

```
$ export JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto
$ export PATH="$JAVA_HOME/bin:$PATH"
update-java-alternatives: directory does not exist: /usr/lib/jvm/java-11-amazon-corretto-jdk*

```

This is why travis has been failing lately.

-----------------------------

Possibly related: https://travis-ci.community/t/update-install-jdk-sh-with-the-new-revision/12761/6
