### PR TITLE
minor: use iterator instead of enumeration

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 import java.util.regex.Matcher;
@@ -123,7 +124,6 @@ public class OrderedPropertiesCheck extends AbstractFileSetCheck {
      *
      * @param file the file to be processed
      * @param fileText the contents of the file.
-     * @noinspection EnumerationCanBeIteration
      */
     @Override
     protected void processFiltered(File file, FileText fileText) {
@@ -138,11 +138,11 @@ public class OrderedPropertiesCheck extends AbstractFileSetCheck {
         String previousProp = "";
         int startLineNo = 0;
 
-        final Enumeration<Object> keys = properties.keys();
+        final Iterator<Object> propertyIterator = properties.keys().asIterator();
 
-        while (keys.hasMoreElements()) {
+        while (propertyIterator.hasNext()) {
 
-            final String propKey = (String) keys.nextElement();
+            final String propKey = (String) propertyIterator.next();
 
             if (String.CASE_INSENSITIVE_ORDER.compare(previousProp, propKey) > 0) {
 


### PR DESCRIPTION
Noticed during work on https://github.com/checkstyle/checkstyle/pull/11691, it is better to fix a simple violation like this, than to put a comment on it and let it live in the code base.

Diff Regression config: https://gist.githubusercontent.com/nick-mancuso/e46a3d11fe985fac1c4468c6b0f7fa4e/raw/98085c1a02a72fdf3419e35c5cbfe23cd9aa111c/config.xml