### PR TITLE
Issue #11277: update code base to have javadoc tag to explain noinspe…

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -920,6 +920,7 @@ noenumtrailingcomma
 nofinalizer
 NOI
 noinspection
+noinspectionreason
 nojavadoc
 nolinewrap
 nonascii

--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -2804,7 +2804,7 @@
     <option name="IGNORE_JAVADOC_PERIOD" value="true"/>
     <option name="IGNORE_DUPLICATED_THROWS" value="false"/>
     <option name="IGNORE_POINT_TO_ITSELF" value="false"/>
-    <option name="myAdditionalJavadocTags" value=""/>
+    <option name="myAdditionalJavadocTags" value="noinspectionreason"/>
   </inspection_tool>
   <inspection_tool class="JavaFxColorRgb" enabled="false" level="WARNING"
                    enabled_by_default="false"/>
@@ -3966,7 +3966,10 @@
                         ,com.puppycrawl.tools.checkstyle.gui.ParseTreeTablePresentation,
                         ,com.puppycrawl.tools.checkstyle.gui.TreeTableCellRenderer,
                         ,com.puppycrawl.tools.checkstyle.gui.TreeTableModelAdapter,
-                        ,com.puppycrawl.tools.checkstyle.gui.TreeTable"/>
+                        ,com.puppycrawl.tools.checkstyle.gui.TreeTable,
+                        ,com.puppycrawl.tools.checkstyle.api.Configuration,
+                        ,java.util.EventObject,
+                        ,java.util.Properties,"/>
     <option name="ignoreClassWithoutFields" value="true"/>
   </inspection_tool>
   <inspection_tool class="SerializableInnerClassHasSerialVersionUIDField" enabled="true"

--- a/pom.xml
+++ b/pom.xml
@@ -457,6 +457,10 @@
                 <name>noinspection</name>
                 <placement>X</placement>
               </tag>
+              <tag>
+                <name>noinspectionreason</name>
+                <placement>X</placement>
+              </tag>
             </tags>
           </configuration>
         </plugin>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java
@@ -31,8 +31,6 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
  * Default implementation of the Configuration interface.
- *
- * @noinspection SerializableHasSerializationMethods
  */
 public final class DefaultConfiguration implements Configuration {
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ThreadModeSettings.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ThreadModeSettings.java
@@ -25,6 +25,8 @@ import java.io.Serializable;
  * Thread mode settings for the checkstyle modules.
  *
  * @noinspection SerializableHasSerializationMethods
+ * @noinspectionreason SerializableHasSerializationMethods - we only need serialVersionUID
+ *      to differentiate between threads
  */
 public class ThreadModeSettings implements Serializable {
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AuditEvent.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AuditEvent.java
@@ -36,7 +36,6 @@ import java.util.EventObject;
  * </p>
  *
  * @see AuditListener
- * @noinspection SerializableHasSerializationMethods
  */
 public final class AuditEvent
     extends EventObject {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java
@@ -44,6 +44,9 @@ import java.util.ResourceBundle.Control;
  * java.text.MessageFormat.
  *
  * @noinspection SerializableHasSerializationMethods, ClassWithTooManyConstructors
+ * @noinspectionreason SerializableHasSerializationMethods - we do not serialize this class
+ * @noinspectionreason ClassWithTooManyConstructors - immutable nature of class requires a
+ *      bunch of constructors
  */
 public final class Violation
     implements Comparable<Violation>, Serializable {
@@ -86,6 +89,10 @@ public final class Violation
      * Arguments for MessageFormat.
      *
      * @noinspection NonSerializableFieldInSerializableClass
+     * @noinspectionreason NonSerializableFieldInSerializableClass - usage of
+     *      'Serializable' for this api class
+     *      is considered as mistake now, but we do not break api without
+     *      good reason
      */
     private final Object[] args;
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java
@@ -213,7 +213,9 @@ public class OrderedPropertiesCheck extends AbstractFileSetCheck {
     /**
      * Private property implementation that keeps order of properties like in file.
      *
-     * @noinspection ClassExtendsConcreteCollection, SerializableHasSerializationMethods
+     * @noinspection ClassExtendsConcreteCollection
+     * @noinspectionreason ClassExtendsConcreteCollection - we require order from
+     *      file to be maintained by {@code put} method
      */
     private static class SequencedProperties extends Properties {
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java
@@ -197,7 +197,9 @@ public class UniquePropertiesCheck extends AbstractFileSetCheck {
     /**
      * Properties subclass to store duplicated property keys in a separate map.
      *
-     * @noinspection ClassExtendsConcreteCollection, SerializableHasSerializationMethods
+     * @noinspection ClassExtendsConcreteCollection
+     * @noinspectionreason ClassExtendsConcreteCollection - we require custom
+     *      {@code put} method to find duplicate keys
      */
     private static class UniqueProperties extends Properties {
 


### PR DESCRIPTION
Does not close #11277, but puts in place suppressions for spelling and javadoc tag, and adds comments for SerializableHasSerializationMethods, ClassWithTooManyConstructors, and ClassExtendsConcreteCollection