### PR TITLE
minor: add comment with explanation of manual setting of JAVA_HOME in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,6 +126,8 @@ jobs:
         - USE_MAVEN_REPO="true"
 
 script:
+  # manually set JAVA_HOME to overcome issue with travis ci noted at
+  # https://github.com/checkstyle/checkstyle/pull/11699#issue-1261272652
   - JAVA_HOME='/usr/lib/jvm/adoptopenjdk-11-hotspot-ppc64el'
   - ./.ci/travis.sh init-m2-repo
   - ./.ci/travis.sh run-command "$CMD"


### PR DESCRIPTION
We forgot to link to explanation of manual JAVA_HOME assignment in travis.yml config, this PR adds quick explanation and link to investigation.