### PR TITLE
Issue #11528: Split pitest coding into 3 to improve execution time

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -155,42 +155,9 @@ pitest-javadoc)
   checkPitestReport ignoredItems
   ;;
 
-pitest-coding)
+pitest-coding-1)
   mvn --no-transfer-progress -e -P"$1" clean test-compile org.pitest:pitest-maven:mutationCoverage;
   declare -a ignoredItems=(
-  "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>                            &#38;&#38; isSameVariables(storedVariable, variable)</span></pre></td></tr>"
-  "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>                        == ast.getParent()) {</span></pre></td></tr>"
-  "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>                if (ast.getParent().getType() == TokenTypes.SWITCH_RULE</span></pre></td></tr>"
-  "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (astIterator.getType() == childType</span></pre></td></tr>"
-  "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (storedVariable != null &#38;&#38; isSameVariables(storedVariable, ast)) {</span></pre></td></tr>"
-  "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>            result = findLastChildWhichContainsSpecifiedToken(</span></pre></td></tr>"
-  "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>        return ast.getType() == TokenTypes.LITERAL_IF</span></pre></td></tr>"
-  "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>        return loop1 != null &#38;&#38; loop1 == loop2;</span></pre></td></tr>"
-  "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>                &#38;&#38; ast.getType() == TokenTypes.PARAMETER_DEF) {</span></pre></td></tr>"
-  "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>                &#38;&#38; firstChild.getType() == TokenTypes.IDENT) {</span></pre></td></tr>"
-  "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>                &#38;&#38; methodAST.getType() == TokenTypes.METHOD_DEF</span></pre></td></tr>"
-  "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (method.getType() == TokenTypes.METHOD_DEF) {</span></pre></td></tr>"
-  "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>            return instanceFields.contains(field)</span></pre></td></tr>"
-  "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (ignoreSetter &#38;&#38; ast.getType() == TokenTypes.PARAMETER_DEF) {</span></pre></td></tr>"
-  "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (type == TokenTypes.CLASS_DEF</span></pre></td></tr>"
-  "IllegalInstantiationCheck.java.html:<td class='covered'><pre><span  class='survived'>            &#38;&#38; illegal.startsWith(JAVA_LANG)) {</span></pre></td></tr>"
-  "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>                        &#38;&#38; currentStatement.getPreviousSibling().getType() == TokenTypes.RESOURCES;</span></pre></td></tr>"
-  "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>                currentStatement.getPreviousSibling() != null</span></pre></td></tr>"
-  "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>                if (countOfSemiInLambda.isEmpty()) {</span></pre></td></tr>"
-  "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>            multiline = !TokenUtil.areOnSameLine(prevSibling, ast)</span></pre></td></tr>"
-  "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (!hasResourcesPrevSibling &#38;&#38; isMultilineStatement(currentStatement)) {</span></pre></td></tr>"
-  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>                        &#38;&#38; ast.getParent().getType() != TokenTypes.LITERAL_CATCH) {</span></pre></td></tr>"
-  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>                if (isAnonymousClassDef(ast)) {</span></pre></td></tr>"
-  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>                if (toVisit == null) {</span></pre></td></tr>"
-  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>               &#38;&#38; parent.getType() != TokenTypes.CTOR_DEF</span></pre></td></tr>"
-  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>            &#38;&#38; lastChild.getType() == TokenTypes.OBJBLOCK;</span></pre></td></tr>"
-  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (definitionToken.getType() == TokenTypes.STATIC_INIT) {</span></pre></td></tr>"
-  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (elistToken != null &#38;&#38; ident.getText().equals(ast.getText())) {</span></pre></td></tr>"
-  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (lookForMethod &#38;&#38; containsMethod(nameToFind)</span></pre></td></tr>"
-  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (variableDeclarationFrame.getType() == FrameType.CLASS_FRAME) {</span></pre></td></tr>"
-  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (fieldUsageFrame.getType() == FrameType.BLOCK_FRAME) {</span></pre></td></tr>"
-  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (sibling != null &#38;&#38; isAssignToken(parent.getType())) {</span></pre></td></tr>"
-  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>        return left.getType() == right.getType() &#38;&#38; left.getText().equals(right.getText());</span></pre></td></tr>"
   "UnnecessaryParenthesesCheck.java.html:<td class='covered'><pre><span  class='survived'>            || parent.getType() != TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR) {</span></pre></td></tr>"
   "UnnecessaryParenthesesCheck.java.html:<td class='covered'><pre><span  class='survived'>        else if (type != TokenTypes.ASSIGN</span></pre></td></tr>"
   "UnnecessaryParenthesesCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (firstChild != null &#38;&#38; firstChild.getType() == TokenTypes.LPAREN) {</span></pre></td></tr>"
@@ -206,6 +173,49 @@ pitest-coding)
   "VariableDeclarationUsageDistanceCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (!firstUsageFound) {</span></pre></td></tr>"
   "VariableDeclarationUsageDistanceCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (!isVarInOperatorDeclaration &#38;&#38; operator.getType() == TokenTypes.LITERAL_IF) {</span></pre></td></tr>"
   "VariableDeclarationUsageDistanceCheck.java.html:<td class='covered'><pre><span  class='survived'>        while (result</span></pre></td></tr>"
+  );
+  checkPitestReport ignoredItems
+  ;;
+
+pitest-coding-2)
+  mvn --no-transfer-progress -e -P"$1" clean test-compile org.pitest:pitest-maven:mutationCoverage;
+  declare -a ignoredItems=(
+  "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>                            &#38;&#38; isSameVariables(storedVariable, variable)</span></pre></td></tr>"
+  "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>                        == ast.getParent()) {</span></pre></td></tr>"
+  "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>                if (ast.getParent().getType() == TokenTypes.SWITCH_RULE</span></pre></td></tr>"
+  "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (astIterator.getType() == childType</span></pre></td></tr>"
+  "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>            result = findLastChildWhichContainsSpecifiedToken(</span></pre></td></tr>"
+  "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>        return ast.getType() == TokenTypes.LITERAL_IF</span></pre></td></tr>"
+  "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>        return loop1 != null &#38;&#38; loop1 == loop2;</span></pre></td></tr>"
+  "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>                &#38;&#38; ast.getType() == TokenTypes.PARAMETER_DEF) {</span></pre></td></tr>"
+  "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>                &#38;&#38; firstChild.getType() == TokenTypes.IDENT) {</span></pre></td></tr>"
+  "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>                &#38;&#38; methodAST.getType() == TokenTypes.METHOD_DEF</span></pre></td></tr>"
+  "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (method.getType() == TokenTypes.METHOD_DEF) {</span></pre></td></tr>"
+  "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (ignoreSetter &#38;&#38; ast.getType() == TokenTypes.PARAMETER_DEF) {</span></pre></td></tr>"
+  "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (type == TokenTypes.CLASS_DEF</span></pre></td></tr>"
+  "IllegalInstantiationCheck.java.html:<td class='covered'><pre><span  class='survived'>            &#38;&#38; illegal.startsWith(JAVA_LANG)) {</span></pre></td></tr>"
+  "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>                        &#38;&#38; currentStatement.getPreviousSibling().getType() == TokenTypes.RESOURCES;</span></pre></td></tr>"
+  "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>                currentStatement.getPreviousSibling() != null</span></pre></td></tr>"
+  "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>                if (countOfSemiInLambda.isEmpty()) {</span></pre></td></tr>"
+  "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>            multiline = !TokenUtil.areOnSameLine(prevSibling, ast)</span></pre></td></tr>"
+  "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (!hasResourcesPrevSibling &#38;&#38; isMultilineStatement(currentStatement)) {</span></pre></td></tr>"
+  );
+  checkPitestReport ignoredItems
+  ;;
+
+pitest-coding-require-this-check)
+  mvn --no-transfer-progress -e -P"$1" clean test-compile org.pitest:pitest-maven:mutationCoverage;
+  declare -a ignoredItems=(
+  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>                        &#38;&#38; ast.getParent().getType() != TokenTypes.LITERAL_CATCH) {</span></pre></td></tr>"
+  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>                if (isAnonymousClassDef(ast)) {</span></pre></td></tr>"
+  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>                if (toVisit == null) {</span></pre></td></tr>"
+  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>               &#38;&#38; parent.getType() != TokenTypes.CTOR_DEF</span></pre></td></tr>"
+  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>            &#38;&#38; lastChild.getType() == TokenTypes.OBJBLOCK;</span></pre></td></tr>"
+  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (definitionToken.getType() == TokenTypes.STATIC_INIT) {</span></pre></td></tr>"
+  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (variableDeclarationFrame.getType() == FrameType.CLASS_FRAME) {</span></pre></td></tr>"
+  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (fieldUsageFrame.getType() == FrameType.BLOCK_FRAME) {</span></pre></td></tr>"
+  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (sibling != null &#38;&#38; isAssignToken(parent.getType())) {</span></pre></td></tr>"
+  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>        return left.getType() == right.getType() &#38;&#38; left.getText().equals(right.getText());</span></pre></td></tr>"
   );
   checkPitestReport ignoredItems
   ;;

--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -107,7 +107,7 @@ jobs:
           path: staging
           retention-days: 7
 
-  pitest-coding:
+  pitest-coding-1:
     runs-on: ubuntu-latest
     steps:
       - name: Setup local maven cache
@@ -117,9 +117,9 @@ jobs:
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}
       - name: Checkout
         uses: actions/checkout@v2
-      - name: pitest-Coding
+      - name: pitest-Coding-1
         run: |
-          ./.ci/pitest.sh pitest-coding
+          ./.ci/pitest.sh pitest-coding-1
       - name: Stage results
         if: failure() || github.ref == 'refs/heads/master'
         run: |
@@ -128,7 +128,57 @@ jobs:
         if: failure() || github.ref == 'refs/heads/master'
         uses: actions/upload-artifact@v2
         with:
-          name: pitest-coding-coverage-report
+          name: pitest-coding-1-coverage-report
+          path: staging
+          retention-days: 7
+
+  pitest-coding-2:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup local maven cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: pitest-Coding-2
+        run: |
+          ./.ci/pitest.sh pitest-coding-2
+      - name: Stage results
+        if: failure() || github.ref == 'refs/heads/master'
+        run: |
+          mkdir staging && cp -r target/pit-reports/ staging
+      - name: Archive code coverage results
+        if: failure() || github.ref == 'refs/heads/master'
+        uses: actions/upload-artifact@v2
+        with:
+          name: pitest-coding-2-coverage-report
+          path: staging
+          retention-days: 7
+
+  pitest-coding-require-this-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup local maven cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: pitest-Coding-require-this-check
+        run: |
+          ./.ci/pitest.sh pitest-coding-require-this-check
+      - name: Stage results
+        if: failure() || github.ref == 'refs/heads/master'
+        run: |
+          mkdir staging && cp -r target/pit-reports/ staging
+      - name: Archive code coverage results
+        if: failure() || github.ref == 'refs/heads/master'
+        uses: actions/upload-artifact@v2
+        with:
+          name: pitest-coding-require-this-check-coverage-report
           path: staging
           retention-days: 7
 

--- a/pom.xml
+++ b/pom.xml
@@ -2474,7 +2474,7 @@
       </build>
     </profile>
     <profile>
-      <id>pitest-coding</id>
+      <id>pitest-coding-1</id>
       <properties>
         <jacoco.skip>true</jacoco.skip>
       </properties>
@@ -2499,16 +2499,207 @@
                 <mutator>VOID_METHOD_CALLS</mutator>
               </mutators>
               <targetClasses>
-                <param>com.puppycrawl.tools.checkstyle.checks.coding.*</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.AbstractSuperCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.ArrayTrailingCommaCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.AvoidDoubleBraceInitializationCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.AvoidInlineConditionalsCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.AvoidNoArgumentSuperConstructorCallCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.CovariantEqualsCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.DeclarationOrderCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.DefaultComesLastCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.EmptyStatementCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.EqualsHashCodeCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.IllegalCatchCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.IllegalThrowsCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessaryParenthesesCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.SuperCloneCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.SuperFinalizeCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.PackageDeclarationCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.ParameterAssignmentCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.ReturnCountCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.SimplifyBooleanExpressionCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.SimplifyBooleanReturnCheck</param>
               </targetClasses>
               <targetTests>
-                <param>com.puppycrawl.tools.checkstyle.checks.coding.*</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.ArrayTrailingCommaCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.AvoidDoubleBraceInitializationCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.AvoidInlineConditionalsCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.AvoidNoArgumentSuperConstructorCallCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.CovariantEqualsCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.DeclarationOrderCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.DefaultComesLastCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.EmptyStatementCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.EqualsHashCodeCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.ExplicitInitializationCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.FallThroughCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.IllegalCatchCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.IllegalThrowsCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessaryParenthesesCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.SuperCloneCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.SuperFinalizeCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.PackageDeclarationCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.ParameterAssignmentCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.ReturnCountCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.SimplifyBooleanExpressionCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.SimplifyBooleanReturnCheckTest</param>
               </targetTests>
               <excludedTestClasses>
                 <param>*.Input*</param>
               </excludedTestClasses>
               <coverageThreshold>100</coverageThreshold>
               <mutationThreshold>99</mutationThreshold>
+              <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
+              <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
+              <threads>${pitest.plugin.threads}</threads>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>pitest-coding-2</id>
+      <properties>
+        <jacoco.skip>true</jacoco.skip>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest-maven</artifactId>
+            <version>${pitest.plugin.version}</version>
+            <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>CONSTRUCTOR_CALLS</mutator>
+                <mutator>FALSE_RETURNS</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>REMOVE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>TRUE_RETURNS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
+              <targetClasses>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.IllegalInstantiationCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.InnerAssignmentCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.MatchXpathCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.MissingCtorCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.MissingSwitchDefaultCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.ModifiedControlVariableCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.MultipleVariableDeclarationsCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.NestedForDepthCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.NestedIfDepthCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.NestedTryDepthCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.IllegalTypeCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonInTryWithResourcesCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.FallThroughCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.NoArrayTrailingCommaCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.NoCloneCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.NoEnumTrailingCommaCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.NoFinalizerCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.OverloadMethodsDeclarationOrderCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.StringLiteralEqualityCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.ExplicitInitializationCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonAfterOuterTypeDeclarationCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonAfterTypeMemberDeclarationCheck</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonInEnumerationCheck</param>
+              </targetClasses>
+              <targetTests>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.IllegalInstantiationCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.InnerAssignmentCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.MatchXpathCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.MissingCtorCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.MissingSwitchDefaultCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.ModifiedControlVariableCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.MultipleVariableDeclarationsCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.NestedForDepthCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.NestedIfDepthCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.NestedTryDepthCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.IllegalTypeCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonInTryWithResourcesCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.FallThroughCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.NoArrayTrailingCommaCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.NoCloneCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.NoEnumTrailingCommaCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.NoFinalizerCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.OverloadMethodsDeclarationOrderCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.StringLiteralEqualityCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.ExplicitInitializationCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonAfterOuterTypeDeclarationCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonAfterTypeMemberDeclarationCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessarySemicolonInEnumerationCheckTest</param>
+              </targetTests>
+              <excludedTestClasses>
+                <param>*.Input*</param>
+              </excludedTestClasses>
+              <coverageThreshold>100</coverageThreshold>
+              <mutationThreshold>99</mutationThreshold>
+              <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
+              <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
+              <threads>${pitest.plugin.threads}</threads>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>pitest-coding-require-this-check</id>
+      <properties>
+        <jacoco.skip>true</jacoco.skip>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest-maven</artifactId>
+            <version>${pitest.plugin.version}</version>
+            <configuration>
+              <mutators>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>CONSTRUCTOR_CALLS</mutator>
+                <mutator>FALSE_RETURNS</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>MATH</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>REMOVE_CONDITIONALS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>TRUE_RETURNS</mutator>
+                <mutator>VOID_METHOD_CALLS</mutator>
+              </mutators>
+              <targetClasses>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck</param>
+              </targetClasses>
+              <targetTests>
+                <param>com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheckTest</param>
+              </targetTests>
+              <excludedTestClasses>
+                <param>*.Input*</param>
+              </excludedTestClasses>
+              <coverageThreshold>100</coverageThreshold>
+              <mutationThreshold>98</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>


### PR DESCRIPTION
Resolves #11528 

No Checks are left for migration.
One check was left in the initial commit, semaphore failed - https://checkstyle.semaphoreci.com/jobs/7b20f037-132b-4ddd-ab3b-089fa7a1c702

Bash script mentioned below governs it.
https://github.com/checkstyle/checkstyle/blob/cffefba904f8d47f7bf9a9d9b053f5d33ea2afff/.ci/validation.sh#L39

---

`pitest-coding-1` -> `6 minutes`
`pitest-coding-2` -> `4 minutes`
`pitest-require-this-check` -> `18 minutes`

There is a separate instance for `RequireThis` as it consumes a lot of time. 

---

ATTENTION: Update https://github.com/checkstyle/checkstyle/wiki/How-to-run-certain-phases-and-validations#how-to-generate-pitest-report after merging this PR.