### PR TITLE
Issue #11277: update code base to have javadoc tag to explain noinspection content(JUnitTestMethodWithNoAssertions, ClassIndependentOfModule, unchecked, ProhibitedExceptionThrown)

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -273,6 +273,8 @@ public class Checker extends AutomaticBean implements MessageDispatcher, RootMod
      * @throws CheckstyleException if error condition within Checkstyle occurs.
      * @throws Error wraps any java.lang.Error happened during execution
      * @noinspection ProhibitedExceptionThrown
+     * @noinspectionreason ProhibitedExceptionThrown - There is no other way to
+     *      deliver filename that was under processing.
      */
     // -@cs[CyclomaticComplexity] no easy way to split this logic of processing the file
     private void processFiles(List<File> files) throws CheckstyleException {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/GlobalStatefulCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/GlobalStatefulCheck.java
@@ -38,7 +38,10 @@ import java.lang.annotation.Target;
  * This is similar to multi-file validation, which checkstyle does not support fully yet.
  * Please refer to https://github.com/checkstyle/checkstyle/issues/3540 for details.
  *
- * @noinspection AnnotationClass, ClassIndependentOfModule, unused, ClassOnlyUsedInOnePackage
+ * @noinspection AnnotationClass, ClassIndependentOfModule, ClassOnlyUsedInOnePackage
+ * @noinspectionreason AnnotationClass - we support only Java 11+
+ * @noinspectionreason ClassIndependentOfModule - we keep this annotation at top level by design
+ * @noinspectionreason ClassOnlyUsedInOnePackage - checks live in one package by design
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGenerator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGenerator.java
@@ -49,6 +49,9 @@ import picocli.CommandLine.ParseResult;
  * so they can use them in their configuration gui.
  *
  * @noinspection UseOfSystemOutOrSystemErr, unused, ClassIndependentOfModule
+ * @noinspectionreason UseOfSystemOutOrSystemErr - used for CLI output
+ * @noinspectionreason unused - main method is "unused" in code since it is driver method
+ * @noinspectionreason ClassIndependentOfModule - architecture of package requires this
  */
 public final class JavadocPropertiesGenerator {
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/StatelessCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/StatelessCheck.java
@@ -34,6 +34,8 @@ import java.lang.annotation.Target;
  * This also means, that all files will be processed by the same check instance.
  *
  * @noinspection AnnotationClass, ClassIndependentOfModule
+ * @noinspectionreason AnnotationClass - we support only Java 11+
+ * @noinspectionreason ClassIndependentOfModule - we keep this annotation at top level by design
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractGuiTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractGuiTestSupport.java
@@ -49,6 +49,7 @@ public abstract class AbstractGuiTestSupport extends AbstractPathTestSupport {
      * @param <T> the type of component to find
      * @return the component if found, {@code null} otherwise
      * @noinspection unchecked
+     * @noinspectionreason unchecked - we know that any component is OK to typecast to T
      */
     protected static <T extends Component> T findComponentByName(Component root, String name) {
         Component result = null;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammar/GeneratedJavaTokenTypesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammar/GeneratedJavaTokenTypesTest.java
@@ -33,6 +33,8 @@ import com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageLexer;
  * GeneratedJavaTokenTypesTest.
  *
  * @noinspection ClassIndependentOfModule
+ * @noinspectionreason ClassIndependentOfModule - architecture of test modules
+ *      requires this structure
  */
 public class GeneratedJavaTokenTypesTest {
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammar/javadoc/GeneratedJavadocTokenTypesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammar/javadoc/GeneratedJavadocTokenTypesTest.java
@@ -31,6 +31,8 @@ import org.junit.jupiter.api.Test;
  * GeneratedJavadocTokenTypesTest.
  *
  * @noinspection ClassIndependentOfModule
+ * @noinspectionreason ClassIndependentOfModule - architecture of test modules
+ *      requires this structure
  */
 public class GeneratedJavadocTokenTypesTest {
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllTestsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllTestsTest.java
@@ -40,6 +40,8 @@ import org.junit.jupiter.api.Test;
  * AllTestsTest.
  *
  * @noinspection ClassIndependentOfModule
+ * @noinspectionreason ClassIndependentOfModule - architecture of
+ *      test modules requires this structure
  */
 public class AllTestsTest {
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/ArchUnitTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/ArchUnitTest.java
@@ -43,9 +43,10 @@ public class ArchUnitTest {
      * except for those which are annotated with {@code Override}. In the bytecode there is no
      * trace anymore if this method was annotated with {@code Override} or not (limitation of
      * Archunit), eventually we need to make checkstyle's Check on this.
-     * Test contains assertions in the callstack, but TeamCity inspection does not see them.
      *
      * @noinspection JUnitTestMethodWithNoAssertions
+     * @noinspectionreason JUnitTestMethodWithNoAssertions - asserts in callstack,
+     *      but not in this method
      */
     @Test
     public void nonProtectedCheckMethodsTest() {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -133,9 +133,11 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
     }
 
     /**
-     * Test contains asserts in callstack, but idea does not see them.
+     * Validates check javadocs and xdocs for consistency.
      *
      * @noinspection JUnitTestMethodWithNoAssertions
+     * @noinspectionreason JUnitTestMethodWithNoAssertions - asserts in callstack,
+     *      but not in this method
      */
     @Test
     public void testAllCheckSectionJavaDocs() throws Exception {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -505,9 +505,11 @@ public class XdocsPagesTest {
     }
 
     /**
-     * Test contains asserts in callstack, but idea does not see them.
+     * Validates xml check documentation section.
      *
      * @noinspection JUnitTestMethodWithNoAssertions
+     * @noinspectionreason JUnitTestMethodWithNoAssertions -asserts in callstack,
+     *      but not in this method
      */
     @Test
     public void testAllCheckSectionsEx() throws Exception {


### PR DESCRIPTION
Issue #11277: update code base to have javadoc tag to explain noinspection content(JUnitTestMethodWithNoAssertions, ClassIndependentOfModule, unchecked, ProhibitedExceptionThrown)

Only the last commit is under review