### PR TITLE
Issue #11730: ci/pitest.sh --list doesn't show all pitest profiles

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -227,7 +227,7 @@ pitest-coding-require-this-check)
 --list)
   echo "Supported profiles:"
   pomXmlPath="$(dirname "${0}")/../pom.xml"
-  sed -n -e 's/<id>\(pitest-\w\+\)<\/id>/\1/p' < "${pomXmlPath}" | sort
+  sed -n -e 's/^.*<id>\(pitest-[^<]\+\)<\/id>.*$/\1/p' < "${pomXmlPath}" | sort
   ;;
 
 *)


### PR DESCRIPTION
Resolves #11730 

Result:-
```
Supported profiles:
pitest-annotation
pitest-ant
pitest-api
pitest-blocks
pitest-coding-1
pitest-coding-2
pitest-coding-require-this-check
pitest-common
pitest-common-2
pitest-design
pitest-filters
pitest-gui
pitest-header
pitest-imports
pitest-indentation
pitest-java-ast-visitor
pitest-javadoc
pitest-main
pitest-metrics
pitest-misc
pitest-modifier
pitest-naming
pitest-packagenamesloader
pitest-regexp
pitest-sizes
pitest-tree-walker
pitest-utils
pitest-whitespace
pitest-xpath
```