### PR TITLE
minor: fix broken links

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2031,6 +2031,7 @@
             <excludedLink>https://paypal.com/</excludedLink>
             <!-- temporal suppress till plugin update link in his source -->
             <excludedLink>http://www.mojohaus.org/exec-maven-plugin</excludedLink>
+            <excludedLink>http://www.mojohaus.org/versions-maven-plugin</excludedLink>
             <!-- SSL -->
             <excludedLink>https://travis-ci.org/</excludedLink>
             <excludedLink>https://travis-ci.org/checkstyle/checkstyle</excludedLink>
@@ -2132,6 +2133,8 @@
             <excludedLink>https://travis-ci.com/</excludedLink>
             <!-- permanent 403 -->
             <excludedLink>https://docs.github.com/en/rest/checks</excludedLink>
+            <!-- until https://github.com/checkstyle/checkstyle/issues/11754 -->
+            <excludedLink>https://checkstyle.sourceforge.io/version/6.18</excludedLink>
           </excludedLinks>
         </configuration>
       </plugin>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java
@@ -51,7 +51,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * javadoc tag and annotation to deprecate.  It is not clear if the javadoc
  * tool will support it or not as newer versions keep flip-flopping on if
  * it is supported or will cause an error. See
- * <a href="https://bugs.openjdk.java.net/browse/JDK-8160601">JDK-8160601</a>.
+ * <a href="https://bugs.openjdk.org/browse/JDK-8160601">JDK-8160601</a>.
  * The deprecated javadoc tag is currently the only way to say why the package
  * is deprecated and what to use instead.  Until this is resolved, if you don't
  * want to print violations on package-info, you can use a
@@ -60,7 +60,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * using SuppressionSingleFilter is:
  * </p>
  * <pre>
- * &lt;!-- required till https://bugs.openjdk.java.net/browse/JDK-8160601 --&gt;
+ * &lt;!-- required till https://bugs.openjdk.org/browse/JDK-8160601 --&gt;
  * &lt;module name="SuppressionSingleFilter"&gt;
  *     &lt;property name="checks" value="MissingDeprecatedCheck"/&gt;
  *     &lt;property name="files" value="package-info\.java"/&gt;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheck.java
@@ -99,7 +99,7 @@ import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
  * </pre>
  * <p>
  * To configure the check to verify tags from
- * <a href="https://openjdk.java.net/jeps/8068562">JEP 8068562</a> only:
+ * <a href="https://openjdk.org/jeps/8068562">JEP 8068562</a> only:
  * </p>
  * <pre>
  * &lt;module name="JavadocBlockTagLocation"&gt;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/RedundantModifierCheck.java
@@ -81,7 +81,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * that the API of a record class is defined solely by its state description, and
  * cannot be enhanced later by another class. Nested records are implicitly static. This avoids an
  * immediately enclosing instance which would silently add state to the record class.
- * See <a href="https://openjdk.java.net/jeps/395">JEP 395</a> for more info.</p>
+ * See <a href="https://openjdk.org/jeps/395">JEP 395</a> for more info.</p>
  *
  * <p>Enums by definition are static implicit subclasses of java.lang.Enum&#60;E&#62;.
  * So, the {@code static} modifier on the enums is redundant. In addition,

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/annotation/MissingDeprecatedCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/annotation/MissingDeprecatedCheck.xml
@@ -23,7 +23,7 @@
  javadoc tag and annotation to deprecate.  It is not clear if the javadoc
  tool will support it or not as newer versions keep flip-flopping on if
  it is supported or will cause an error. See
- &lt;a href="https://bugs.openjdk.java.net/browse/JDK-8160601"&gt;JDK-8160601&lt;/a&gt;.
+ &lt;a href="https://bugs.openjdk.org/browse/JDK-8160601"&gt;JDK-8160601&lt;/a&gt;.
  The deprecated javadoc tag is currently the only way to say why the package
  is deprecated and what to use instead.  Until this is resolved, if you don't
  want to print violations on package-info, you can use a
@@ -32,7 +32,7 @@
  using SuppressionSingleFilter is:
  &lt;/p&gt;
  &lt;pre&gt;
- &amp;lt;!-- required till https://bugs.openjdk.java.net/browse/JDK-8160601 --&amp;gt;
+ &amp;lt;!-- required till https://bugs.openjdk.org/browse/JDK-8160601 --&amp;gt;
  &amp;lt;module name="SuppressionSingleFilter"&amp;gt;
      &amp;lt;property name="checks" value="MissingDeprecatedCheck"/&amp;gt;
      &amp;lt;property name="files" value="package-info\.java"/&amp;gt;

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/modifier/RedundantModifierCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/modifier/RedundantModifierCheck.xml
@@ -54,7 +54,7 @@
  that the API of a record class is defined solely by its state description, and
  cannot be enhanced later by another class. Nested records are implicitly static. This avoids an
  immediately enclosing instance which would silently add state to the record class.
- See &lt;a href="https://openjdk.java.net/jeps/395"&gt;JEP 395&lt;/a&gt; for more info.&lt;/p&gt;
+ See &lt;a href="https://openjdk.org/jeps/395"&gt;JEP 395&lt;/a&gt; for more info.&lt;/p&gt;
 
  &lt;p&gt;Enums by definition are static implicit subclasses of java.lang.Enum&amp;#60;E&amp;#62;.
  So, the {@code static} modifier on the enums is redundant. In addition,

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -725,7 +725,7 @@ class TestTwo {
           javadoc tag and annotation to deprecate.  It is not clear if the
           javadoc tool will support it or not as newer versions keep flip-flopping
           on if it is supported or will cause an error.
-          See <a href="https://bugs.openjdk.java.net/browse/JDK-8160601">
+          See <a href="https://bugs.openjdk.org/browse/JDK-8160601">
           JDK-8160601</a>.
           The deprecated javadoc tag is currently the only way to say why the package
           is deprecated and what to use instead.  Until this is resolved, if you
@@ -735,7 +735,7 @@ class TestTwo {
           SuppressionSingleFilter is:
         </p>
         <source>
-&lt;!-- required till https://bugs.openjdk.java.net/browse/JDK-8160601 --&gt;
+&lt;!-- required till https://bugs.openjdk.org/browse/JDK-8160601 --&gt;
 &lt;module name=&quot;SuppressionSingleFilter&quot;&gt;
     &lt;property name=&quot;checks&quot; value=&quot;MissingDeprecatedCheck&quot;/&gt;
     &lt;property name=&quot;files&quot; value=&quot;package-info\.java&quot;/&gt;

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -363,7 +363,7 @@ public int field;
         </source>
         <p>
           To configure the check to verify tags from
-          <a href="https://openjdk.java.net/jeps/8068562">JEP 8068562</a> only:
+          <a href="https://openjdk.org/jeps/8068562">JEP 8068562</a> only:
         </p>
         <source>
 &lt;module name=&quot;JavadocBlockTagLocation&quot;&gt;

--- a/src/xdocs/config_modifier.xml
+++ b/src/xdocs/config_modifier.xml
@@ -591,7 +591,7 @@ public interface RoadFeature {
           that the API of a record class is defined solely by its state description, and cannot be
           enhanced later by another class. Nested records are implicitly static. This avoids an
           immediately enclosing instance which would silently add state to the record class.
-          See <a href="https://openjdk.java.net/jeps/395">JEP 395</a> for more info.
+          See <a href="https://openjdk.org/jeps/395">JEP 395</a> for more info.
         </p>
 
         <p>

--- a/src/xdocs/index.xml.vm
+++ b/src/xdocs/index.xml.vm
@@ -554,9 +554,9 @@
               <td>Supports tracking Checkstyle statistics over time.</td>
             </tr>
             <tr>
-              <td><a href="https://vim.sourceforge.io/">Vim editor</a></td>
+              <td><a href="https://www.vim.org/">Vim editor</a></td>
               <td>Xandy Johnson</td>
-              <td><a href="https://vim.sourceforge.io/scripts/script.php?script_id=448">
+              <td><a href="https://www.vim.org/scripts/script.php?script_id=448">
                   Plugin Homepage</a></td>
               <td>Vim file-type plug-in</td>
             </tr>


### PR DESCRIPTION
Noticed at https://github.com/checkstyle/checkstyle/runs/6930711012?check_suite_focus=true

Two remaining "broken" links:

One (mojohaus) has been suppressed, since the plugin needs to update the link on their end.
I can't figure out what is going on with the other, I have no problem accessing the site:

```
➜  checkstyle git:(fix-broken-links) curl https://checkstyle.sourceforge.io/version/6.18/ -I 
HTTP/2 200 
date: Fri, 17 Jun 2022 15:43:47 GMT


```

Remaining "broken" links:
```
------------ grep of linkcheck.html--BEGIN
<td><i><a class="externalLink" href="https://checkstyle.sourceforge.io/version/6.18/">https://checkstyle.sourceforge.io/version/6.18/</a>: 403 Forbidden</i></td></tr></table></td></tr>
<td><i><a class="externalLink" href="http://www.mojohaus.org/versions-maven-plugin/">http://www.mojohaus.org/versions-maven-plugin/</a>: 301 Moved Permanently</i></td></tr></table></td></tr>
------------ grep of linkcheck.html--END
Exit code:2

```

Edit: failing sourceforge links have been removed