### PR TITLE
Issue #11729: Automate update of releasenotes.xml by content for new …

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -478,6 +478,7 @@ Foreach
 Fpuppycrawl
 fq
 freedomsponsors
+freemarker
 Fregexp
 Fresources
 Frob

--- a/.ci/releasenotes-gen-xdoc-push.sh
+++ b/.ci/releasenotes-gen-xdoc-push.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -e
+
+source ./.ci/util.sh
+
+checkForVariable() {
+  VAR_NAME=$1
+  if [ -v "${!VAR_NAME}" ]; then
+    echo "Error: Define $1 environment variable"
+    exit 1
+  fi
+}
+
+checkForVariable "READ_ONLY_TOKEN"
+
+checkout_from https://github.com/checkstyle/contribution
+
+cd .ci-temp/contribution/releasenotes-builder
+mvn -e --no-transfer-progress clean compile package
+cd ../../../
+
+if [ -d .ci-temp/checkstyle ]; then
+  cd .ci-temp/checkstyle/
+  git reset --hard origin/master
+  git pull origin master
+  git fetch --tags
+  cd ../../
+else
+  cd .ci-temp/
+  git clone https://github.com/checkstyle/checkstyle
+  cd ../
+fi
+
+CS_RELEASE_VERSION="$(getCheckstylePomVersion)"
+echo CS_RELEASE_VERSION="$CS_RELEASE_VERSION"
+
+cd .ci-temp/checkstyle
+LATEST_RELEASE_TAG=$(curl -s https://api.github.com/repos/checkstyle/checkstyle/releases/latest \
+                       | jq ".tag_name")
+echo LATEST_RELEASE_TAG="$LATEST_RELEASE_TAG"
+
+cd ../
+
+BUILDER_RESOURCE_DIR="contribution/releasenotes-builder/src/main/resources/com/github/checkstyle"
+
+java -jar contribution/releasenotes-builder/target/releasenotes-builder-1.0-all.jar \
+     -localRepoPath checkstyle \
+     -remoteRepoPath checkstyle/checkstyle \
+     -startRef "$LATEST_RELEASE_TAG" \
+     -releaseNumber "$CS_RELEASE_VERSION" \
+     -githubAuthToken "$READ_ONLY_TOKEN" \
+     -generateXdoc \
+     -xdocTemplate $BUILDER_RESOURCE_DIR/templates/xdoc_freemarker.template \
+     -publishXdoc -publishXdocWithPush
+
+echo "releasenotes.xml after commit:"
+head "checkstyle/src/xdocs/releasenotes.xml" -n 100


### PR DESCRIPTION
Resolves #11729 

File: `releasenotes-gen-auto.sh` to test the updates.

xdocs.xml:
  
```
    <section name="Release 10.4">
      <div class="releaseDate">17.06.2022</div>
      <p>Bug fixes:</p>
        <ul>
          <li>
            FallThrough should recognize yield also.
            Author: Hyeonmin Park
            <a href="https://github.com/checkstyle/checkstyle/issues/11712">#11712</a>
          </li>
          <li>
            FinalClassCheck: False positive with anonymous classes.
            Author: Vyom-Yadav
            <a href="https://github.com/checkstyle/checkstyle/issues/11365">#11365</a>
          </li>
        </ul>
      <p>Notes:</p>
        <ul>
          <li>
            Move Backport section on index page to be update JRE_and_JDK .
            Author: Roman Ivanov
            <a href="https://github.com/checkstyle/checkstyle/issues/11735">#11735</a>
          </li>
          <li>
            .ci/pitest.sh --list doesn&#39;t show all pitest profiles.
            Author: Vyom-Yadav
            <a href="https://github.com/checkstyle/checkstyle/issues/11730">#11730</a>
          </li>
          <li>
            update code base to have javadoc tag to explain noinspection tag
content.
            Author: Nick Mancuso
            <a href="https://github.com/checkstyle/checkstyle/issues/11277">#11277</a>
          </li>
          <li>
            Split pitest-coding execution into 3 executions and investigate
instability.
            Author: Vyom-Yadav
            <a href="https://github.com/checkstyle/checkstyle/issues/11528">#11528</a>
          </li>
          <li>
            Use Shellcheck to resolve violations code in Shell Script.
            Author: Rahul Khinchi
            <a href="https://github.com/checkstyle/checkstyle/issues/11637">#11637</a>
          </li>
          <li>
            Add &#39;git diff&#39; validation after execution of verify phase to
Azure.
            Author: Rahul Khinchi
            <a href="https://github.com/checkstyle/checkstyle/issues/11554">#11554</a>
          </li>
          <li>
            Solve fb-contrib errors.
            Author: pbludov
            <a href="https://github.com/checkstyle/checkstyle/issues/11140">#11140</a>
          </li>
          <li>
            Checkstyle doesn&#39;t publish test source code.
            Author: rnveach
            <a href="https://github.com/checkstyle/checkstyle/issues/11681">#11681</a>
          </li>
        </ul>
    </section>
```
