### PR TITLE
Issue #7592: Update doc for TrailingComment

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
@@ -102,23 +102,34 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * &lt;module name=&quot;TrailingComment&quot;/&gt;
  * </pre>
  * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * // OK
+ * if (&#47;&#42; OK &#42;&#47; x &#62; 5) {}
+ * int a = 5; // violation
+ * doSomething(
+ *   param1
+ * ); // OK, by default such trailing of method/code-block ending is allowed
+ * </pre>
+ * <p>
  * To configure the check to enforce only comment on a line:
  * </p>
  * <pre>
  * &lt;module name=&quot;TrailingComment&quot;&gt;
- *   &lt;property name=&quot;format&quot; value=&quot;^\\s*$&quot;/&gt;
+ *   &lt;property name=&quot;format&quot; value=&quot;^\s*$&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
  * <p>
- * Example for trailing comments check to suppress specific trailing comment:
+ * Example:
  * </p>
  * <pre>
- * public class Test {
- *   int a; // SUPPRESS CHECKSTYLE
- *   int b; // NOPMD
- *   int c; // NOSONAR
- *   int d; // violation, not suppressed
- * }
+ * // OK
+ * if (&#47;&#42; OK, this comment does not end the line &#42;&#47; x &#62; 5) {}
+ * int a = 5; // violation, line content before comment should match pattern "^\s*$"
+ * doSomething(
+ *   param1
+ * ); // violation, line content before comment should match pattern "^\s*$"
  * </pre>
  * <p>
  * To configure check so that trailing comment with exact comments like "SUPPRESS CHECKSTYLE",
@@ -134,6 +145,17 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * &lt;/module&gt;
  * </pre>
  * <p>
+ * Example for trailing comments check to suppress specific trailing comment:
+ * </p>
+ * <pre>
+ * public class Test {
+ *   int a; // SUPPRESS CHECKSTYLE
+ *   int b; // NOPMD
+ *   int c; // NOSONAR
+ *   int d; // violation, not suppressed
+ * }
+ * </pre>
+ * <p>
  * To configure check so that trailing comment starting with "SUPPRESS CHECKSTYLE", "NOPMD",
  * "NOSONAR" are suppressed:
  * </p>
@@ -147,6 +169,17 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *   &lt;property name="query" value="//SINGLE_LINE_COMMENT
  *       [./COMMENT_CONTENT[starts-with(@text, ' NOSONAR')]]"/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * public class Test {
+ *   int a; // SUPPRESS CHECKSTYLE - OK, comment starts with " SUPPRESS CHECKSTYLE"
+ *   int b; // NOPMD - OK, comment starts with " NOPMD"
+ *   int c; // NOSONAR - OK, comment starts with " NOSONAR"
+ *   int d; // violation, not suppressed
+ * }
  * </pre>
  * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -2107,25 +2107,36 @@ d = e / f;        // Another comment for this line
         </source>
 
         <p>
+          Example:
+        </p>
+        <source>
+// OK
+if (/* OK */ x > 5) {}
+int a = 5; // violation
+doSomething(
+  param1
+); // OK, by default such trailing of method/code-block ending is allowed
+        </source>
+
+        <p>
           To configure the check to enforce only comment on a line:
         </p>
         <source>
 &lt;module name=&quot;TrailingComment&quot;&gt;
-  &lt;property name=&quot;format&quot; value=&quot;^\\s*$&quot;/&gt;
+  &lt;property name=&quot;format&quot; value=&quot;^\s*$&quot;/&gt;
 &lt;/module&gt;
         </source>
 
         <p>
-          Example for trailing comments check to suppress specific trailing comment:
+          Example:
         </p>
-
         <source>
-public class Test {
-int a; // SUPPRESS CHECKSTYLE
-int b; // NOPMD
-int c; // NOSONAR
-int d; // violation, not suppressed
-}
+// OK
+if (&#47;&#42; OK, this comment does not end the line &#42;&#47; x > 5) {}
+int a = 5; // violation, line content before comment should match pattern "^\s*$"
+doSomething(
+  param1
+); // violation, line content before comment should match pattern "^\s*$"
         </source>
 
         <p>
@@ -2133,33 +2144,55 @@ int d; // violation, not suppressed
           &quot;SUPPRESS CHECKSTYLE&quot;, &quot;NOPMD&quot;, &quot;NOSONAR&quot;
           are suppressed:
         </p>
-
         <source>
 &lt;module name=&quot;TrailingComment&quot;/&gt;
 &lt;module name=&quot;SuppressionXpathSingleFilter&quot;&gt;
-&lt;property name=&quot;checks&quot; value=&quot;TrailingCommentCheck&quot;/&gt;
-&lt;property name=&quot;query&quot; value=&quot;//SINGLE_LINE_COMMENT
-[./COMMENT_CONTENT[@text=&apos; NOSONAR\n&apos; or @text=&apos; NOPMD\n&apos;
-or @text=&apos; SUPPRESS CHECKSTYLE\n&apos;]]&quot;/&gt;
+  &lt;property name=&quot;checks&quot; value=&quot;TrailingCommentCheck&quot;/&gt;
+  &lt;property name=&quot;query&quot; value=&quot;//SINGLE_LINE_COMMENT
+    [./COMMENT_CONTENT[@text=&apos; NOSONAR\n&apos; or @text=&apos; NOPMD\n&apos;
+    or @text=&apos; SUPPRESS CHECKSTYLE\n&apos;]]&quot;/&gt;
 &lt;/module&gt;
+        </source>
+
+        <p>
+          Example for trailing comments check to suppress specific trailing comment:
+        </p>
+        <source>
+public class Test {
+  int a; // SUPPRESS CHECKSTYLE
+  int b; // NOPMD
+  int c; // NOSONAR
+  int d; // violation, not suppressed
+}
         </source>
 
         <p>
           To configure check so that trailing comment starting with &quot;SUPPRESS CHECKSTYLE&quot;,
           &quot;NOPMD&quot;, &quot;NOSONAR&quot; are suppressed:
         </p>
-
         <source>
 &lt;module name=&quot;TrailingComment&quot;/&gt;
 &lt;module name=&quot;SuppressionXpathSingleFilter&quot;&gt;
-&lt;property name=&quot;checks&quot; value=&quot;TrailingCommentCheck&quot;/&gt;
-&lt;property name=&quot;query&quot; value=&quot;//SINGLE_LINE_COMMENT
-[./COMMENT_CONTENT[starts-with(@text, &apos; NOPMD&apos;)]]&quot;/&gt;
-&lt;property name=&quot;query&quot; value=&quot;//SINGLE_LINE_COMMENT
-[./COMMENT_CONTENT[starts-with(@text, &apos; SUPPRESS CHECKSTYLE&apos;)]]&quot;/&gt;
-&lt;property name=&quot;query&quot; value=&quot;//SINGLE_LINE_COMMENT
-[./COMMENT_CONTENT[starts-with(@text, &apos; NOSONAR&apos;)]]&quot;/&gt;
+  &lt;property name=&quot;checks&quot; value=&quot;TrailingCommentCheck&quot;/&gt;
+  &lt;property name=&quot;query&quot; value=&quot;//SINGLE_LINE_COMMENT
+    [./COMMENT_CONTENT[starts-with(@text, &apos; NOPMD&apos;)]]&quot;/&gt;
+  &lt;property name=&quot;query&quot; value=&quot;//SINGLE_LINE_COMMENT
+    [./COMMENT_CONTENT[starts-with(@text, &apos; SUPPRESS CHECKSTYLE&apos;)]]&quot;/&gt;
+  &lt;property name=&quot;query&quot; value=&quot;//SINGLE_LINE_COMMENT
+    [./COMMENT_CONTENT[starts-with(@text, &apos; NOSONAR&apos;)]]&quot;/&gt;
 &lt;/module&gt;
+        </source>
+
+        <p>
+          Example:
+        </p>
+        <source>
+public class Test {
+  int a; // SUPPRESS CHECKSTYLE - OK, comment starts with " SUPPRESS CHECKSTYLE"
+  int b; // NOPMD - OK, comment starts with " NOPMD"
+  int c; // NOSONAR - OK, comment starts with " NOSONAR"
+  int d; // violation, not suppressed
+}
         </source>
 
       </subsection>


### PR DESCRIPTION
Issue #7592: Update examples for TrailingComment
# Changes
[Link to official doc if you need to compare](https://checkstyle.org/config_misc.html#TrailingComment_Examples)
* Added example for first and second configuration.
* Switched third example with third configuration since the proper order is `first configuration -> then example`.
* Added indentation to third and fourth configuration and third example.
* Fixed wrong configuration(I explain down below why I think it is wrong).
# How examples look after changes
![screenshott](https://user-images.githubusercontent.com/23459549/174550217-5ebe5d26-9369-499d-9099-b1b39e44e68f.png)
# Outputs of examples
## First one
```console
stoyank@zenbook:~/Desktop/checkstyle$ cat configuration.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="TrailingComment" />
    </module>
</module>

stoyank@zenbook:~/Desktop/checkstyle$ cat Example.java 
class Example {
    public static void main() {
        // OK
        if (/* OK */ x > 5) {}
        int a = 5; // violation, string before comment should match pattern "^[\s});]*$"
        doSomething(
        param1
        ); // OK
    }
}

stoyank@zenbook:~/Desktop/checkstyle$ RUN_LOCALE="-Duser.language=en -Duser.country=US"

stoyank@zenbook:~/Desktop/checkstyle$ java $RUN_LOCALE -jar checkstyle-10.3-all.jar -c configuration.xml Example.java 
Starting audit...
[ERROR] /home/stoyank/Desktop/checkstyle/Example.java:5:20: Don't use trailing comments. [TrailingComment]
Audit done.
Checkstyle ends with 1 errors.

```
## Second one
```console
stoyank@zenbook:~/Desktop/checkstyle$ cat configuration.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="TrailingComment">
            <property name="format" value="^\s*$" />
        </module>
    </module>
</module>

stoyank@zenbook:~/Desktop/checkstyle$ cat Example.java 
class Example {
    public static void main() {
        // OK
        if (/* OK */ x > 5) {}
        int a = 5; // violation, string before comment should match pattern "^\s*$"
        doSomething(
        param1
        ); // violation, string before comment should match pattern "^\s*$"
    }
}

stoyank@zenbook:~/Desktop/checkstyle$ RUN_LOCALE="-Duser.language=en -Duser.country=US"

stoyank@zenbook:~/Desktop/checkstyle$ java RUN_LOCALE -jar checkstyle-10.3-all.jar -c configuration.xml Example.java 
Starting audit...
[ERROR] /home/stoyank/Desktop/checkstyle/Example.java:5:20: Don't use trailing comments. [TrailingComment]
[ERROR] /home/stoyank/Desktop/checkstyle/Example.java:8:12: Don't use trailing comments. [TrailingComment]
Audit done.
Checkstyle ends with 2 errors.

```
## Third one
```console
stoyank@zenbook:~/Desktop/checkstyle$ cat configuration.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="TrailingComment" />
        <module name="SuppressionXpathSingleFilter">
            <property name="checks" value="TrailingCommentCheck" />
            <property name="query" value="//SINGLE_LINE_COMMENT
                [./COMMENT_CONTENT[@text=' NOSONAR\n' or @text=' NOPMD\n'
                or @text=' SUPPRESS CHECKSTYLE\n']]" />
        </module>
    </module>
</module>

stoyank@zenbook:~/Desktop/checkstyle$ cat Example.java 
public class Test {
    int a; // SUPPRESS CHECKSTYLE
    int b; // NOPMD
    int c; // NOSONAR
    int d; // violation, not suppressed
}

stoyank@zenbook:~/Desktop/checkstyle$ RUN_LOCALE="-Duser.language=en -Duser.country=US"

stoyank@zenbook:~/Desktop/checkstyle$ java $RUN_LOCALE -jar checkstyle-10.3-all.jar -c configuration.xml Example.java 
Starting audit...
[ERROR] /home/stoyank/Desktop/checkstyle/Example.java:5:12: Don't use trailing comments. [TrailingComment]
Audit done.
Checkstyle ends with 1 errors.

```
## Fourth one
```console
stoyank@zenbook:~/Desktop/checkstyle$ cat configuration.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="TrailingComment" />
        <module name="SuppressionXpathSingleFilter">
            <property name="checks" value="TrailingCommentCheck" />
            <property name="query" value="//SINGLE_LINE_COMMENT
                [./COMMENT_CONTENT[starts-with(@text, ' NOPMD')]]" />
            <property name="query" value="//SINGLE_LINE_COMMENT
                [./COMMENT_CONTENT[starts-with(@text, ' SUPPRESS CHECKSTYLE')]]" />
            <property name="query" value="//SINGLE_LINE_COMMENT
                [./COMMENT_CONTENT[starts-with(@text, ' NOSONAR')]]" />
        </module>
    </module>
</module>

stoyank@zenbook:~/Desktop/checkstyle$ cat Example.java 
public class Test {
  int a; // SUPPRESS CHECKSTYLE - OK, comment starts with " SUPPRESS CHECKSTYLE"
  int b; // NOPMD - OK, comment starts with " NOPMD"
  int c; // NOSONAR - OK, comment starts with " NOSONAR"
  int d; // violation, not suppressed
}

stoyank@zenbook:~/Desktop/checkstyle$ RUN_LOCALE="-Duser.language=en -Duser.country=US"

stoyank@zenbook:~/Desktop/checkstyle$ java $RUN_LOCALE -jar checkstyle-10.3-all.jar -c configuration.xml Example.java 
Starting audit...
[ERROR] /home/stoyank/Desktop/checkstyle/Example.java:5:10: Don't use trailing comments. [TrailingComment]
Audit done.
Checkstyle ends with 1 errors.

```
# Wrong configuration found
The second configuration on the website that enforces only comment on a line is wrong. I don't know if it is a typo or somebody thought there is a need for string escaping.
![Screenshot from 2022-06-19 15-58-15](https://user-images.githubusercontent.com/23459549/174484872-cf3b29e1-15e6-45e3-863f-80176616c95c.png)
I believe it should be:
```xml
<module name="TrailingComment">
    <property name="format" value="^\s*$"/>
</module>  
```
The difference is in the value of the `format` property. `^\\s*$` -> `^\s*$`. 

For the below comparison I used [regexr.com](https://regexr.com/)
* The first one(that is on the website) is interpreted like this:
  * `^` - **Beginning** Matches beginning of the string.
  * `\\` - **Escaped character** Matches a `\` character (char code 92).
  * `s` - **Character**. Matches a `s` character (char code 115).
    * `*` - **Quantifier** Match 0 or more of the preceding token.
  * `$` - **End** Matches the end of the string.
* The second one(which I believe is correct) is interpreted like this:
  * `^` - **Beginning** Matches beginning of the string.
  * `\s` - **Whitespace** Matches any whitespace character (spaces, tabs, line breaks).
    * `*` - **Quantifier** Match 0 or more of the preceding token.
  * `$` - **End** Matches the end of the string.
## Output of second example if first configuration is used
```console
stoyank@zenbook:~/Desktop/checkstyle$ cat configuration.xml 
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
    <module name="TreeWalker">
        <module name="TrailingComment">
            <property name="format" value="^\\s*$" />
        </module>
    </module>
</module>

stoyank@zenbook:~/Desktop/checkstyle$ cat Example.java 
class Example {
    public static void main() {
        // OK
        if (/* OK */ x > 5) {}
        int a = 5; // violation, string before comment should match pattern "^\s*$"
        doSomething(
        param1
        ); // violation, string before comment should match pattern "^\s*$"
    }
}

stoyank@zenbook:~/Desktop/checkstyle$ RUN_LOCALE="-Duser.language=en -Duser.country=US"

stoyank@zenbook:~/Desktop/checkstyle$ java $RUN_LOCALE -jar checkstyle-10.3-all.jar -c configuration.xml Example.java 
Starting audit...
[ERROR] /home/stoyank/Desktop/checkstyle/Example.java:3:9: Don't use trailing comments. [TrailingComment]
[ERROR] /home/stoyank/Desktop/checkstyle/Example.java:5:20: Don't use trailing comments. [TrailingComment]
[ERROR] /home/stoyank/Desktop/checkstyle/Example.java:8:12: Don't use trailing comments. [TrailingComment]
Audit done.
Checkstyle ends with 3 errors.

```
Notice how checkstyle complains for row 3 even though it should be valid since the comment is alone on the line.


