### PR TITLE
Issue #11214: Specify violation messages for AbstractClassNameCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -104,7 +104,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck",
-            "com.puppycrawl.tools.checkstyle.checks.naming.AbstractClassNameCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.PackageDeclarationCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheckTest.java
@@ -41,11 +41,11 @@ public class AbstractClassNameCheckTest extends AbstractModuleTestSupport {
         final String pattern = "^Abstract.+$";
 
         final String[] expected = {
-            "12:1: " + getCheckMessage(MSG_ILLEGAL_ABSTRACT_CLASS_NAME, "InputAbstractClassName",
+            "13:1: " + getCheckMessage(MSG_ILLEGAL_ABSTRACT_CLASS_NAME, "InputAbstractClassName",
                 pattern),
-            "15:1: " + getCheckMessage(MSG_ILLEGAL_ABSTRACT_CLASS_NAME, "NonAbstractClassName",
+            "17:1: " + getCheckMessage(MSG_ILLEGAL_ABSTRACT_CLASS_NAME, "NonAbstractClassName",
                 pattern),
-            "19:5: " + getCheckMessage(MSG_ILLEGAL_ABSTRACT_CLASS_NAME, "NonAbstractInnerClass",
+            "22:5: " + getCheckMessage(MSG_ILLEGAL_ABSTRACT_CLASS_NAME, "NonAbstractInnerClass",
                 pattern),
         };
 
@@ -57,12 +57,12 @@ public class AbstractClassNameCheckTest extends AbstractModuleTestSupport {
     public void testCustomFormat() throws Exception {
 
         final String[] expected = {
-            "12:1: "
+            "13:1: "
                 + getCheckMessage(MSG_ILLEGAL_ABSTRACT_CLASS_NAME, "InputAbstractClassNameCustom",
                 "^NonAbstract.+$"),
-            "18:1: " + getCheckMessage(MSG_ILLEGAL_ABSTRACT_CLASS_NAME, "AbstractClassOtherCustom",
+            "20:1: " + getCheckMessage(MSG_ILLEGAL_ABSTRACT_CLASS_NAME, "AbstractClassOtherCustom",
                 "^NonAbstract.+$"),
-            "30:1: " + getCheckMessage(MSG_ILLEGAL_ABSTRACT_CLASS_NAME, "AbstractClassName2Custom",
+            "32:1: " + getCheckMessage(MSG_ILLEGAL_ABSTRACT_CLASS_NAME, "AbstractClassName2Custom",
                 "^NonAbstract.+$"),
         };
 
@@ -88,15 +88,15 @@ public class AbstractClassNameCheckTest extends AbstractModuleTestSupport {
         final String pattern = "^Abstract.+$";
 
         final String[] expected = {
-            "12:1: "
+            "13:1: "
                 + getCheckMessage(MSG_ILLEGAL_ABSTRACT_CLASS_NAME, "InputAbstractClassNameVariants",
                 pattern),
-            "15:1: " + getCheckMessage(MSG_ILLEGAL_ABSTRACT_CLASS_NAME, "NonAbstractClassNameVa",
+            "17:1: " + getCheckMessage(MSG_ILLEGAL_ABSTRACT_CLASS_NAME, "NonAbstractClassNameVa",
                 pattern),
-            "19:5: " + getCheckMessage(MSG_ILLEGAL_ABSTRACT_CLASS_NAME, "NonAbstractInnerClassVa",
+            "22:5: " + getCheckMessage(MSG_ILLEGAL_ABSTRACT_CLASS_NAME, "NonAbstractInnerClassVa",
                 pattern),
-            "27:1: " + getCheckMessage(MSG_NO_ABSTRACT_CLASS_MODIFIER, "AbstractClassVa"),
-            "31:5: " + getCheckMessage(MSG_NO_ABSTRACT_CLASS_MODIFIER, "AbstractInnerClassVa"),
+            "30:1: " + getCheckMessage(MSG_NO_ABSTRACT_CLASS_MODIFIER, "AbstractClassVa"),
+            "35:5: " + getCheckMessage(MSG_NO_ABSTRACT_CLASS_MODIFIER, "AbstractInnerClassVa"),
         };
 
         verifyWithInlineConfigParser(
@@ -107,14 +107,14 @@ public class AbstractClassNameCheckTest extends AbstractModuleTestSupport {
     public void testFalsePositive() throws Exception {
         final String pattern = "^Abstract.+$";
         final String[] expected = {
-            "12:1: "
+            "13:1: "
                 + getCheckMessage(MSG_ILLEGAL_ABSTRACT_CLASS_NAME,
                         "InputAbstractClassNameFormerFalsePositive",
                 pattern),
-            "19:5: " + getCheckMessage(MSG_ILLEGAL_ABSTRACT_CLASS_NAME, "NonAbstractInnerClassFP",
+            "21:5: " + getCheckMessage(MSG_ILLEGAL_ABSTRACT_CLASS_NAME, "NonAbstractInnerClassFP",
                 pattern),
-            "27:1: " + getCheckMessage(MSG_NO_ABSTRACT_CLASS_MODIFIER, "AbstractClassNameFP"),
-            "31:5: " + getCheckMessage(MSG_NO_ABSTRACT_CLASS_MODIFIER, "AbstractInnerClassFP"),
+            "29:1: " + getCheckMessage(MSG_NO_ABSTRACT_CLASS_MODIFIER, "AbstractClassNameFP"),
+            "34:5: " + getCheckMessage(MSG_NO_ABSTRACT_CLASS_MODIFIER, "AbstractInnerClassFP"),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abstractclassname/InputAbstractClassName.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abstractclassname/InputAbstractClassName.java
@@ -9,14 +9,17 @@ ignoreName = (default)false
 
 package com.puppycrawl.tools.checkstyle.checks.naming.abstractclassname;
 
-abstract public class InputAbstractClassName { // violation
+// violation below 'Name 'InputAbstractClassName' must match pattern '\^Abstract\.\+\$'.'
+abstract public class InputAbstractClassName {
 }
 
-abstract class NonAbstractClassName { // violation
+// violation below 'Name 'NonAbstractClassName' must match pattern '\^Abstract\.\+\$'.'
+abstract class NonAbstractClassName {
 }
 
 abstract class AbstractClassOther { // ok
-    abstract class NonAbstractInnerClass { // violation
+    // violation below 'Name 'NonAbstractInnerClass' must match pattern '\^Abstract\.\+\$'.'
+    abstract class NonAbstractInnerClass {
     }
 }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abstractclassname/InputAbstractClassNameCustom.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abstractclassname/InputAbstractClassNameCustom.java
@@ -9,13 +9,15 @@ ignoreName = (default)false
 
 package com.puppycrawl.tools.checkstyle.checks.naming.abstractclassname;
 
-abstract public class InputAbstractClassNameCustom { // violation
+// violation below 'Name 'InputAbstractClassNameCustom' must match pattern '\^NonAbstract\.\+\$'.'
+abstract public class InputAbstractClassNameCustom {
 }
 
 abstract class NonAbstractClassNameCustom { // ok
 }
 
-abstract class AbstractClassOtherCustom { // violation
+// violation below 'Name 'AbstractClassOtherCustom' must match pattern '\^NonAbstract\.\+\$'.'
+abstract class AbstractClassOtherCustom {
     abstract class NonAbstractInnerClass { // ok
     }
 }
@@ -26,8 +28,8 @@ class NonAbstractClassCustom { // ok
 class AbstractClassCustom {
 }
 
-
-abstract class AbstractClassName2Custom { // violation
+// violation below 'Name 'AbstractClassName2Custom' must match pattern '\^NonAbstract\.\+\$'.'
+abstract class AbstractClassName2Custom {
     class AbstractInnerClass {
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abstractclassname/InputAbstractClassNameFormerFalsePositive.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abstractclassname/InputAbstractClassNameFormerFalsePositive.java
@@ -9,25 +9,28 @@ ignoreName = (default)false
 
 package com.puppycrawl.tools.checkstyle.checks.naming.abstractclassname;
 
-abstract public class InputAbstractClassNameFormerFalsePositive { // violation
+// violation below '.*'InputAbstractClassNameFormerFalsePositive' .* match .* '\^Abstract\.\+\$'.'
+abstract public class InputAbstractClassNameFormerFalsePositive {
 }
 
 abstract class AbstractClassFP {
 }
 
 abstract class AbstractClassOtherFP { // ok
-    abstract class NonAbstractInnerClassFP { // violation
+    // violation below 'Name 'NonAbstractInnerClassFP' must match pattern '\^Abstract\.\+\$'.'
+    abstract class NonAbstractInnerClassFP {
     }
 }
 
 class NonAbstractClassFP {
 }
 
-
-class AbstractClassNameFP { // violation
+// violation below 'Class 'AbstractClassNameFP' must be declared as 'abstract'.'
+class AbstractClassNameFP {
 }
 
 abstract class AbstractClassName2FP { // ok
-    class AbstractInnerClassFP { // violation
+    // violation below 'Class 'AbstractInnerClassFP' must be declared as 'abstract'.'
+    class AbstractInnerClassFP {
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abstractclassname/InputAbstractClassNameType.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abstractclassname/InputAbstractClassNameType.java
@@ -15,7 +15,7 @@ abstract public class InputAbstractClassNameType { // ok
 abstract class NonAbstractClassNameType { // ok
 }
 
-class AbstractClassType { // violation
+class AbstractClassType { // violation 'Class 'AbstractClassType' must be declared as 'abstract'.'
     abstract class NonAbstractInnerClass { // ok
     }
 }
@@ -24,7 +24,7 @@ abstract class NonAbstractClassType { // ok
 }
 
 
-class AbstractClassTypes { // violation
+class AbstractClassTypes { // violation 'Class 'AbstractClassTypes' must be declared as 'abstract'.'
 }
 
 abstract class AbstractClassName2Type { // ok

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abstractclassname/InputAbstractClassNameVariants.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/abstractclassname/InputAbstractClassNameVariants.java
@@ -9,14 +9,17 @@ ignoreName = (default)false
 
 package com.puppycrawl.tools.checkstyle.checks.naming.abstractclassname;
 
-abstract public class InputAbstractClassNameVariants { // violation
+// violation below 'Name 'InputAbstractClassNameVariants' must match pattern '\^Abstract\.\+\$'.'
+abstract public class InputAbstractClassNameVariants {
 }
 
-abstract class NonAbstractClassNameVa { // violation
+// violation below 'Name 'NonAbstractClassNameVa' must match pattern '\^Abstract\.\+\$'.'
+abstract class NonAbstractClassNameVa {
 }
 
 abstract class AbstractClassOtherVa { // ok
-    abstract class NonAbstractInnerClassVa { // violation
+    // violation below 'Name 'NonAbstractInnerClassVa' must match pattern '\^Abstract\.\+\$'.'
+    abstract class NonAbstractInnerClassVa {
     }
 }
 
@@ -24,10 +27,11 @@ class NonAbstractClassVa {
 }
 
 
-class AbstractClassVa { // violation
+class AbstractClassVa { // violation 'Class 'AbstractClassVa' must be declared as 'abstract'.'
 }
 
 abstract class AbstractClassName2Va { // ok
-    class AbstractInnerClassVa { // violation
+    // violation below 'Class 'AbstractInnerClassVa' must be declared as 'abstract'.'
+    class AbstractInnerClassVa {
     }
 }


### PR DESCRIPTION
Addresses issue #11214
Specifies the violation messages for `AbstractClassNameCheck` in all relevant `Input..` files.
## Changes
* Specified violation messages for `AbstractClassNameCheck` in 5 files
	* Escaped RegEx special characters in the message. For instance, 
		`^Abstract.+$` -> `\^Abstract\.\+\$`
	* I got `Line should not be longer than 100 symbols [lineLength]` when  	running `mvn clean verify` so I moved the problematic `// violation '..'` 	comments above the violation line and changed them to `// violation below '..'`. This is what I noticed other people did.
* Changed the row numbers in `expected` variables in `AbstractClassNameCheckTest` due to the moved `// violation` comments.
* Removed the check from the suppresion list in `InlineConfigParser`.
## ~~Pull request is not ready to merge yet~~
The biggest outlier is in the `InputAbstractClassNameFormerFalsePositive` file where the first comment(around line 12) **itself** was too long(more than 100 characters) for one row so I tried to split it in 2 rows. The comment should be
`// violation below 'Name 'InputAbstractClassNameFormerFalsePositive' must match pattern '\^Abstract\.\+\$'.'`, not what is in the commit right now(without the pattern):
![Screenshot from 2022-06-21 23-17-16](https://user-images.githubusercontent.com/23459549/174898890-9447534d-d320-49a6-ad39-cfee4ed9a18b.png)

I tried both stuff like 
```java
abstract public class InputAbstractClassNameFormerFalsePositive {
// violation above
// 'Name 'InputAbstractClassNameFormerFalsePositive' must match pattern '\^Abstract\.\+\$'.'
```
or
```java
// violation below
// 'Name 'InputAbstractClassNameFormerFalsePositive' must match pattern '\^Abstract\.\+\$'.'
abstract public class InputAbstractClassNameFormerFalsePositive {
```
but no success there. On the second one I believe if I put `// violation below` directly above the class declaration, it might work but then the readability is sacrifised.

What options are there? Changing the class name? Leaving it as I did it without mentioning the pattern?