### PR TITLE
minor: extract maven execution from pitest

### DIFF
--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -51,6 +51,10 @@ jobs:
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Generate ${{ matrix.profile }} report
+        run: |
+          mvn -e --no-transfer-progress -P"${{ matrix.profile }}" clean test-compile \
+          org.pitest:pitest-maven:mutationCoverage
       - name: ${{ matrix.profile }}
         run: |
           ./.ci/pitest.sh ${{ matrix.profile }}


### PR DESCRIPTION
From discussion at https://github.com/checkstyle/checkstyle/pull/11731#discussion_r903910867 and https://github.com/checkstyle/checkstyle/issues/11720#issuecomment-1164365831:

Extract maven execution from `pitest.sh` script.

Failed pitest run (for proof): https://github.com/checkstyle/checkstyle/actions/runs/2555422670