### PR TITLE
Issue #7797: Kill two surviving mutations in pitest-javadoc

### DIFF
--- a/.ci/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -1,24 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
-    <sourceFile>AbstractJavadocCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck</mutatedClass>
-    <mutatedMethod>processTree</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck::beginJavadocTree</description>
-    <lineContent>beginJavadocTree(root);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>AbstractJavadocCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck</mutatedClass>
-    <mutatedMethod>processTree</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck::finishJavadocTree</description>
-    <lineContent>finishJavadocTree(root);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>TagParser.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.TagParser</mutatedClass>
     <mutatedMethod>getNextCharPos</mutatedMethod>

--- a/pom.xml
+++ b/pom.xml
@@ -2934,6 +2934,8 @@
               </targetClasses>
               <targetTests>
                 <param>com.puppycrawl.tools.checkstyle.checks.javadoc.*</param>
+                <!-- JavadocMetadataScraper extends AbstractJavadocCheck -->
+                <param>com.puppycrawl.tools.checkstyle.meta.JavadocMetadataScraperTest</param>
               </targetTests>
               <excludedTestClasses>
                 <param>*.Input*</param>


### PR DESCRIPTION
#7797 
Kill 2 surviving mutations in `pitest-javadoc`.

Both the mutations were removing the call to `beginJavadocTree(..)` and `finishJavadocTree(..)`, both these methods-
https://github.com/checkstyle/checkstyle/blob/da2237a0f86d6590673dafefb6d5995c60b5eb89/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java#L234-L248

Have no implementation by default. Only `JavadocMetadataScraper` overrides these methods.

Adding its test to the profile resulted in the mutations being killed. I didn't follow SOP as this case is different.