### PR TITLE
Issue #11720: Kill surviving mutation in RequireThisCheck

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-require-this-check-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-require-this-check-suppressions.xml
@@ -3,15 +3,6 @@
   <mutation unstable="false">
     <sourceFile>RequireThisCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck</mutatedClass>
-    <mutatedMethod>beginTree</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (toVisit == null) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>RequireThisCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck</mutatedClass>
     <mutatedMethod>canBeReferencedFromStaticContext</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
     <description>removed conditional - replaced equality check with false</description>

--- a/.ci/pitest-survival-check-html.sh
+++ b/.ci/pitest-survival-check-html.sh
@@ -200,7 +200,6 @@ pitest-coding-require-this-check)
   declare -a ignoredItems=(
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>                        &#38;&#38; ast.getParent().getType() != TokenTypes.LITERAL_CATCH) {</span></pre></td></tr>"
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>                if (isAnonymousClassDef(ast)) {</span></pre></td></tr>"
-  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>                if (toVisit == null) {</span></pre></td></tr>"
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>               &#38;&#38; parent.getType() != TokenTypes.CTOR_DEF</span></pre></td></tr>"
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>            &#38;&#38; lastChild.getType() == TokenTypes.OBJBLOCK;</span></pre></td></tr>"
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (definitionToken.getType() == TokenTypes.STATIC_INIT) {</span></pre></td></tr>"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -383,9 +383,7 @@ public class RequireThisCheck extends AbstractCheck {
             while (curNode != null && toVisit == null) {
                 endCollectingDeclarations(frameStack, curNode);
                 toVisit = curNode.getNextSibling();
-                if (toVisit == null) {
-                    curNode = curNode.getParent();
-                }
+                curNode = curNode.getParent();
             }
             curNode = toVisit;
         }


### PR DESCRIPTION
#11720
Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11771

### Reports with hardcoded mutation (clean):

- DefaultConfig: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/d1202e8_2022093015/reports/diff/index.html

### This mutation falls in the category:

- Safely (no regressions) remove code to be covered

### Rationale:

Without the condition `if (toVisit == null)`, `curNode = curNode.getParent();` will be executed even when `toVisit != null`, if `toVisit != null`, we will break from the loop
`while (curNode != null && toVisit == null)` and on the very next line after while loop, `curNode` gets updated `curNode = toVisit;`, so the previous assignment of
`curNode = curNode.getParent();`does not make a difference.