### PR TITLE
Issue #11214: Specify violation messages for AnnotationLocationCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -116,7 +116,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.javadoc.WriteTagCheck",
             "com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck",
-            "com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocationCheck",
             "com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck"));
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheckTest.java
@@ -56,30 +56,30 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testIncorrect() throws Exception {
         final String[] expected = {
-            "14:11: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnn"),
-            "19:15: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation1"),
-            "22:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation1"),
-            "25:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation1", 8, 4),
-            "33:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation1", 8, 4),
-            "37:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation1"),
-            "37:27: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnn_21"),
-            "40:8: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_21", 7, 4),
-            "44:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_21", 8, 4),
-            "45:7: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation3", 6, 4),
-            "46:11: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation4", 10, 4),
-            "49:19: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation1"),
-            "53:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation1"),
-            "56:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation1", 12, 8),
-            "64:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation1"),
-            "69:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_21", 12, 8),
-            "73:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_21", 12, 8),
-            "78:8: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_21", 7, 4),
-            "81:19: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation1"),
-            "83:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation1"),
-            "93:12: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_21", 11, 8),
-            "96:11: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_21", 10, 8),
+            "15:11: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnn"),
+            "20:15: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation1"),
+            "24:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation1"),
+            "28:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation1", 8, 4),
+            "37:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation1", 8, 4),
+            "41:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation1"),
+            "41:27: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnn_21"),
+            "45:8: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_21", 7, 4),
+            "50:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_21", 8, 4),
+            "52:7: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation3", 6, 4),
+            "54:11: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation4", 10, 4),
+            "57:19: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation1"),
+            "62:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation1"),
+            "66:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation1", 12, 8),
+            "75:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation1"),
+            "81:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_21", 12, 8),
+            "86:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_21", 12, 8),
+            "92:8: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_21", 7, 4),
+            "96:19: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation1"),
             "99:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation1"),
-            "106:1: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_21", 0, 3),
+            "110:12: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_21", 11, 8),
+            "114:11: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_21", 10, 8),
+            "117:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation1"),
+            "125:1: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_21", 0, 3),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAnnotationLocationIncorrect.java"), expected);
@@ -88,30 +88,30 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testIncorrectAllTokens() throws Exception {
         final String[] expected = {
-            "14:11: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnn3"),
-            "19:15: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation_13"),
-            "22:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation_13"),
-            "25:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation_13", 8, 4),
-            "33:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation_13", 8, 4),
-            "37:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation_13"),
-            "37:29: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnn_23"),
-            "40:8: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_23", 7, 4),
-            "44:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_23", 8, 4),
-            "45:7: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation_33", 6, 4),
-            "46:11: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation_43", 10, 4),
-            "49:19: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation_13"),
-            "53:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation_13"),
-            "56:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation_13", 12, 8),
-            "64:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation_13"),
-            "69:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_23", 12, 8),
-            "73:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_23", 12, 8),
-            "78:8: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_23", 7, 4),
-            "81:19: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation_13"),
-            "83:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation_13"),
-            "93:12: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_23", 11, 8),
-            "96:11: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_23", 10, 8),
-            "99:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation_13"),
-            "106:1: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_23", 0, 3),
+            "15:11: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnn3"),
+            "21:15: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation_13"),
+            "25:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation_13"),
+            "29:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation_13", 8, 4),
+            "38:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation_13", 8, 4),
+            "42:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation_13"),
+            "42:29: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnn_23"),
+            "46:8: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_23", 7, 4),
+            "51:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_23", 8, 4),
+            "53:7: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation_33", 6, 4),
+            "55:11: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation_43", 10, 4),
+            "58:19: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation_13"),
+            "63:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation_13"),
+            "67:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation_13", 12, 8),
+            "76:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation_13"),
+            "82:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_23", 12, 8),
+            "86:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_23", 12, 8),
+            "91:8: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_23", 7, 4),
+            "95:19: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation_13"),
+            "98:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation_13"),
+            "109:12: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_23", 11, 8),
+            "113:11: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_23", 10, 8),
+            "117:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "MyAnnotation_13"),
+            "124:1: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_23", 0, 3),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAnnotationLocationIncorrect3.java"), expected);
@@ -150,19 +150,19 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testWithParameters() throws Exception {
         final String[] expected = {
-            "25:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation_12", 8, 4),
-            "33:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation_12", 8, 4),
-            "40:8: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_22", 7, 4),
-            "44:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_22", 8, 4),
-            "45:7: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation_32", 6, 4),
-            "46:11: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation_42", 10, 4),
-            "56:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation_12", 12, 8),
-            "69:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_22", 12, 8),
-            "73:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_22", 12, 8),
-            "78:8: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_22", 7, 4),
-            "93:12: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_22", 11, 8),
-            "96:11: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_22", 10, 8),
-            "106:1: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_22", 0, 3),
+            "26:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation_12", 8, 4),
+            "35:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation_12", 8, 4),
+            "42:8: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_22", 7, 4),
+            "46:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_22", 8, 4),
+            "48:7: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation_32", 6, 4),
+            "50:11: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation_42", 10, 4),
+            "61:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnnotation_12", 12, 8),
+            "75:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_22", 12, 8),
+            "80:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_22", 12, 8),
+            "86:8: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_22", 7, 4),
+            "102:12: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_22", 11, 8),
+            "106:11: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_22", 10, 8),
+            "116:1: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "MyAnn_22", 0, 3),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAnnotationLocationIncorrect2.java"), expected);
@@ -190,10 +190,10 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testAnnotation() throws Exception {
         final String[] expected = {
-            "18:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "AnnotationAnnotation", 2, 0),
-            "19:1: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "AnnotationAnnotation"),
-            "22:7: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "AnnotationAnnotation", 6, 4),
-            "23:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "AnnotationAnnotation"),
+            "19:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "AnnotationAnnotation", 2, 0),
+            "21:1: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "AnnotationAnnotation"),
+            "25:7: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "AnnotationAnnotation", 6, 4),
+            "27:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "AnnotationAnnotation"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAnnotationLocationAnnotation.java"), expected);
@@ -202,12 +202,12 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testClass() throws Exception {
         final String[] expected = {
-            "18:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "ClassAnnotation", 2, 0),
-            "19:1: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "ClassAnnotation"),
-            "22:7: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "ClassAnnotation", 6, 4),
-            "23:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "ClassAnnotation"),
-            "26:7: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "ClassAnnotation", 6, 4),
+            "19:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "ClassAnnotation", 2, 0),
+            "21:1: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "ClassAnnotation"),
+            "25:7: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "ClassAnnotation", 6, 4),
             "27:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "ClassAnnotation"),
+            "31:7: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "ClassAnnotation", 6, 4),
+            "33:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "ClassAnnotation"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAnnotationLocationClass.java"), expected);
@@ -216,10 +216,10 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testEnum() throws Exception {
         final String[] expected = {
-            "18:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "EnumAnnotation", 2, 0),
-            "19:1: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "EnumAnnotation"),
-            "22:7: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "EnumAnnotation", 6, 4),
-            "23:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "EnumAnnotation"),
+            "19:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "EnumAnnotation", 2, 0),
+            "21:1: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "EnumAnnotation"),
+            "25:7: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "EnumAnnotation", 6, 4),
+            "27:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "EnumAnnotation"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAnnotationLocationEnum.java"), expected);
@@ -228,10 +228,10 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testInterface() throws Exception {
         final String[] expected = {
-            "18:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "InterfaceAnnotation", 2, 0),
-            "19:1: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "InterfaceAnnotation"),
-            "22:7: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "InterfaceAnnotation", 6, 4),
-            "23:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "InterfaceAnnotation"),
+            "19:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "InterfaceAnnotation", 2, 0),
+            "21:1: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "InterfaceAnnotation"),
+            "25:7: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "InterfaceAnnotation", 6, 4),
+            "27:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "InterfaceAnnotation"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAnnotationLocationInterface.java"), expected);
@@ -240,8 +240,8 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testPackage() throws Exception {
         final String[] expected = {
-            "12:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "PackageAnnotation", 2, 0),
-            "13:1: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "PackageAnnotation"),
+            "13:3: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION, "PackageAnnotation", 2, 0),
+            "15:1: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "PackageAnnotation"),
         };
         verifyWithInlineConfigParser(
                 getPath("inputs/package-info.java"), expected);
@@ -264,13 +264,13 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testAnnotationParameterized() throws Exception {
         final String[] expected = {
-            "18:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
-            "20:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
-            "20:17: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
-            "26:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
-            "26:17: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
-            "26:33: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
-            "28:21: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
+            "19:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
+            "21:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
+            "21:17: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
+            "27:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
+            "27:17: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
+            "27:33: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
+            "30:21: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAnnotationLocationParameterized.java"), expected);
@@ -279,13 +279,13 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testAnnotationSingleParameterless() throws Exception {
         final String[] expected = {
-            "22:17: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
-            "24:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
+            "23:17: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
             "26:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
-            "28:17: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
-            "28:33: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
-            "30:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
-            "30:21: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
+            "29:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
+            "31:17: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
+            "31:33: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
+            "33:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
+            "33:21: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "Annotation"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputAnnotationLocationSingleParameterless.java"), expected);
@@ -294,13 +294,13 @@ public class AnnotationLocationCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testAnnotationLocationRecordsAndCompactCtors() throws Exception {
         final String[] expected = {
-            "19:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
-            "22:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
-            "25:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
-            "26:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
-            "32:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
-            "43:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
-            "53:34: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
+            "20:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
+            "24:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
+            "28:5: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
+            "30:9: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
+            "37:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
+            "49:13: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
+            "59:34: " + getCheckMessage(MSG_KEY_ANNOTATION_LOCATION_ALONE, "SuppressWarnings"),
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputAnnotationLocationRecordsAndCompactCtors.java"),

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationRecordsAndCompactCtors.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationRecordsAndCompactCtors.java
@@ -16,20 +16,25 @@ public class InputAnnotationLocationRecordsAndCompactCtors {
     @NonNull1 public record MyRecord1() { // ok, no param
     }
 
-    @SuppressWarnings("deprecation") public record MyRecord2() { // violation
+    // violation below 'Annotation 'SuppressWarnings' should be alone on line.'
+    @SuppressWarnings("deprecation") public record MyRecord2() {
     }
 
-    @SuppressWarnings("deprecation") record MyRecord3() { // violation
+    // violation below 'Annotation 'SuppressWarnings' should be alone on line.'
+    @SuppressWarnings("deprecation") record MyRecord3() {
     }
 
-    @SuppressWarnings("deprecation") public record MyRecord4() { // violation
-        @SuppressWarnings("deprecation")public MyRecord4{} // violation
+    // violation below 'Annotation 'SuppressWarnings' should be alone on line.'
+    @SuppressWarnings("deprecation") public record MyRecord4() {
+        // violation below 'Annotation 'SuppressWarnings' should be alone on line.'
+        @SuppressWarnings("deprecation")public MyRecord4{}
     }
 
     @SuppressWarnings("deprecation")
     public record MyRecord5() {
         record MyInnerRecord(){
-            @SuppressWarnings("Annotation")public MyInnerRecord{} // violation
+            // violation below 'Annotation 'SuppressWarnings' should be alone on line.'
+            @SuppressWarnings("Annotation")public MyInnerRecord{}
         }
     }
 
@@ -40,7 +45,8 @@ public class InputAnnotationLocationRecordsAndCompactCtors {
     @SuppressWarnings("deprecation") // ok
     public record MyRecord6() {
         record MyInnerRecord () {
-            @SuppressWarnings("Annotation")public MyInnerRecord { // violation
+            // violation below 'Annotation 'SuppressWarnings' should be alone on line.'
+            @SuppressWarnings("Annotation")public MyInnerRecord {
             }
         }
     }
@@ -51,7 +57,7 @@ public class InputAnnotationLocationRecordsAndCompactCtors {
      */
     public record MyRecord7() {
         record MyInnerRecord () {@SuppressWarnings("Annotation")public MyInnerRecord {
-            } // violation above
+            } // violation above 'Annotation 'SuppressWarnings' should be alone on line.'
         }
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationAnnotation.java
@@ -15,12 +15,16 @@ import java.lang.annotation.Repeatable;
 import java.lang.annotation.Target;
 
 @AnnotationAnnotation(value = "foo")
-  @AnnotationAnnotation // violation
-@AnnotationAnnotation("bar") @interface InputAnnotationLocationAnnotation { // violation
+  // violation below '.*'AnnotationAnnotation' have incorrect indentation level 2, .*should be 0.'
+  @AnnotationAnnotation
+// violation below 'Annotation 'AnnotationAnnotation' should be alone on line.'
+@AnnotationAnnotation("bar") @interface InputAnnotationLocationAnnotation {
 
     @AnnotationAnnotation(value = "foo")
-      @AnnotationAnnotation // violation
-    @AnnotationAnnotation("bar") String value(); // violation
+      // violation below '.*'AnnotationAnnotation' .* incorrect indentation level 6, .*should be 4.'
+      @AnnotationAnnotation
+    // violation below 'Annotation 'AnnotationAnnotation' should be alone on line.'
+    @AnnotationAnnotation("bar") String value();
 
 }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationClass.java
@@ -15,16 +15,22 @@ import java.lang.annotation.Repeatable;
 import java.lang.annotation.Target;
 
 @ClassAnnotation(value = "foo")
-  @ClassAnnotation // violation
-@ClassAnnotation("bar") class InputAnnotationLocationClass { // violation
+  // violation below '.*'ClassAnnotation' have incorrect indentation level 2, .* should be 0.'
+  @ClassAnnotation
+// violation below 'Annotation 'ClassAnnotation' should be alone on line.'
+@ClassAnnotation("bar") class InputAnnotationLocationClass {
 
     @ClassAnnotation(value = "foo")
-      @ClassAnnotation // violation
-    @ClassAnnotation("bar") Object field; // violation
+      // violation below '.*'ClassAnnotation' have incorrect indentation level 6, .* should be 4.'
+      @ClassAnnotation
+    // violation below 'Annotation 'ClassAnnotation' should be alone on line.'
+    @ClassAnnotation("bar") Object field;
 
     @ClassAnnotation(value = "foo")
-      @ClassAnnotation // violation
-    @ClassAnnotation("bar") InputAnnotationLocationClass() { // violation
+    // violation below '.*'ClassAnnotation' have incorrect indentation level 6, .* should be 4.'
+      @ClassAnnotation
+    // violation below 'Annotation 'ClassAnnotation' should be alone on line.'
+    @ClassAnnotation("bar") InputAnnotationLocationClass() {
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationEnum.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationEnum.java
@@ -15,12 +15,16 @@ import java.lang.annotation.Repeatable;
 import java.lang.annotation.Target;
 
 @EnumAnnotation(value = "foo")
-  @EnumAnnotation // violation
-@EnumAnnotation("bar") enum InputAnnotationLocationEnum { // violation
+  // violation below '.* 'EnumAnnotation' have incorrect indentation level 2, .* should be 0.'
+  @EnumAnnotation
+// violation below 'Annotation 'EnumAnnotation' should be alone on line.'
+@EnumAnnotation("bar") enum InputAnnotationLocationEnum {
 
     @EnumAnnotation(value = "foo")
-      @EnumAnnotation // violation
-    @EnumAnnotation("bar") ENUM_VALUE(); // violation
+      // violation below '.* 'EnumAnnotation' have incorrect indentation level 6, .* should be 4.'
+      @EnumAnnotation
+    // violation below 'Annotation 'EnumAnnotation' should be alone on line.'
+    @EnumAnnotation("bar") ENUM_VALUE();
 
     InputAnnotationLocationEnum() {
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationIncorrect.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationIncorrect.java
@@ -11,18 +11,21 @@ tokens = (default)CLASS_DEF, INTERFACE_DEF, PACKAGE_DEF, ENUM_CONSTANT_DEF, \
 
 package com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation;
 
-@MyAnn_21 @com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation.MyAnn // violation
+// violation below 'Annotation 'MyAnn' should be alone on line.'
+@MyAnn_21 @com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation.MyAnn
 (value = "")
 class InputAnnotationLocationIncorrect
 {
 
-    @MyAnn_21 @MyAnnotation1(value = "") // violation
+    @MyAnn_21 @MyAnnotation1(value = "") // violation '.*'MyAnnotation1' should be alone on line.'
     public int a;
 
-    @MyAnnotation1(value = "") public int b; // violation
+    // violation below 'Annotation 'MyAnnotation1' should be alone on line.'
+    @MyAnnotation1(value = "") public int b;
 
     @MyAnn_21 // ok
-        @MyAnnotation1 // violation
+        // violation below '.* 'MyAnnotation1' have incorrect indentation level 8, .* should be 4.'
+        @MyAnnotation1
 (value = "")
     public int c;
 
@@ -30,30 +33,37 @@ class InputAnnotationLocationIncorrect
     public int d;
 
     @MyAnn_21 // ok
-        @MyAnnotation1 // violation
+        // violation below '.* 'MyAnnotation1' have incorrect indentation level 8, .* should be 4.'
+        @MyAnnotation1
 (value = "")
     public InputAnnotationLocationIncorrect() {}
 
     @MyAnnotation1("foo") @MyAnn_21 void foo1() {} // 2 violations
 
     @MyAnnotation1(value = "") // ok
-       @MyAnn_21 // violation
+       // violation below 'Annotation 'MyAnn_21' have incorrect indentation level 7, .*should be 4.'
+       @MyAnn_21
     void foo2() {}
 
     @MyAnnotation1(value = "") // ok
-        @MyAnn_21 // violation
-      @MyAnnotation3 // violation
-          @MyAnnotation4 // violation
+        // violation below 'Annotation 'MyAnn_21' have incorrect indentation level 8,.*should be 4.'
+        @MyAnn_21
+      // violation below '.* 'MyAnnotation3' have incorrect indentation level 6, .* should be 4.'
+      @MyAnnotation3
+          // violation below '.*'MyAnnotation4' have incorrect indentation level 10, .*should be 4.'
+          @MyAnnotation4
     class InnerClass
     {
-        @MyAnn_21 @MyAnnotation1 // violation
+        @MyAnn_21 @MyAnnotation1 // violation 'Annotation 'MyAnnotation1' should be alone on line.'
 (value = "")
         public int a;
 
-        @MyAnnotation1(value = "") public int b; // violation
+        // violation below 'Annotation 'MyAnnotation1' should be alone on line.'
+        @MyAnnotation1(value = "") public int b;
 
         @MyAnn_21 // ok
-            @MyAnnotation1 // violation
+            // violation below '.*'MyAnnotation1' .* incorrect indentation level 12,.*should be 8.'
+            @MyAnnotation1
 (value = "")
         public int c;
 
@@ -61,26 +71,32 @@ class InputAnnotationLocationIncorrect
         public int d;
 
         @MyAnn_21 // ok
-        @MyAnnotation1(value = "") public InnerClass() // violation
+        // violation below 'Annotation 'MyAnnotation1' should be alone on line.'
+        @MyAnnotation1(value = "") public InnerClass()
         {
             // comment
         }
         @MyAnnotation1(value = "")
-            @MyAnn_21 // violation
+            // violation below '.*'MyAnn_21' have incorrect indentation level 12, .* should be 8.'
+            @MyAnn_21
         void foo1() {}
 
         @MyAnnotation1(value = "")
-            @MyAnn_21 // violation
+            // violation below '.*'MyAnn_21' have incorrect indentation level 12, .* should be 8.'
+            @MyAnn_21
         void foo2() {}
     }
 
     @MyAnnotation1(value = "")
-       @MyAnn_21 // violation
+       // violation below 'Annotation 'MyAnn_21' have incorrect indentation level 7,.*should be 4.'
+       @MyAnn_21
     InnerClass anon = new InnerClass()
     {
-        @MyAnn_21 @MyAnnotation1(value = "") public int a; // violation
+        // violation below 'Annotation 'MyAnnotation1' should be alone on line.'
+        @MyAnn_21 @MyAnnotation1(value = "") public int a;
 
-        @MyAnnotation1(value = "") public int b; // violation
+        // violation below 'Annotation 'MyAnnotation1' should be alone on line.'
+        @MyAnnotation1(value = "") public int b;
 
         @MyAnn_21 // ok
         @MyAnnotation1(value = "") // ok
@@ -90,20 +106,23 @@ class InputAnnotationLocationIncorrect
         public int d;
 
         @MyAnnotation1(value = "") // ok
-           @MyAnn_21 void foo1() {} // violation
+           // violation below '.*'MyAnn_21' have incorrect indentation level 11, .* should be 8.'
+           @MyAnn_21 void foo1() {}
 
         @MyAnnotation1(value = "") // ok
-          @MyAnn_21 // violation
+          // violation below '.* 'MyAnn_21' have incorrect indentation level 10, .* should be 8.'
+          @MyAnn_21
         void foo2() {}
-
-        @MyAnnotation1(value = "") void foo42() {} // violation
+        // violation below 'Annotation 'MyAnnotation1' should be alone on line.'
+        @MyAnnotation1(value = "") void foo42() {}
     };
 
 }
 
    @MyAnnotation1 // ok
 (value = "")
-@MyAnn_21 // violation
+// violation below 'Annotation 'MyAnn_21' have incorrect indentation level 0, .* should be 3.'
+@MyAnn_21
 class Foo {
     public void method1(@MyAnnotation3 @MyAnn_21 Object param1) {
         try {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationIncorrect2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationIncorrect2.java
@@ -22,7 +22,8 @@ class InputAnnotationLocationIncorrect2
     @MyAnnotation_12(value = "") public int b; // ok
 
     @MyAnn_22 // ok
-        @MyAnnotation_12 // violation
+        // violation below '.*'MyAnnotation_12' have incorrect indentation level 8, .* should be 4.'
+        @MyAnnotation_12
 (value = "")
     public int c;
 
@@ -30,20 +31,23 @@ class InputAnnotationLocationIncorrect2
     public int d;
 
     @MyAnn_22 // ok
-        @MyAnnotation_12 // violation
+        // violation below '.*'MyAnnotation_12' have incorrect indentation level 8, .* should be 4.'
+        @MyAnnotation_12
 (value = "")
     public InputAnnotationLocationIncorrect2() {}
 
     @MyAnnotation_12("foo") @MyAnn_22 void foo1() {} // ok
 
     @MyAnnotation_12(value = "") // ok
-       @MyAnn_22 // violation
+       @MyAnn_22 // violation '.*'MyAnn_22' have incorrect indentation level 7, .* should be 4.'
     void foo2() {}
 
     @MyAnnotation_12(value = "") // ok
-        @MyAnn_22 // violation
-      @MyAnnotation_32 // violation
-          @MyAnnotation_42 // violation
+        @MyAnn_22 // violation '.*'MyAnn_22' have incorrect indentation level 8, .* should be 4.'
+      // violation below '.*'MyAnnotation_32' have incorrect indentation level 6, .* should be 4.'
+      @MyAnnotation_32
+          // violation below '.*'MyAnnotation_42' .* incorrect indentation level 10,.*should be 4.'
+          @MyAnnotation_42
     class InnerClass
     {
         @MyAnn_22 @MyAnnotation_12 // ok
@@ -53,7 +57,8 @@ class InputAnnotationLocationIncorrect2
         @MyAnnotation_12(value = "") public int b; // ok
 
         @MyAnn_22 // ok
-            @MyAnnotation_12 // violation
+            // violation below '.*'MyAnnotation_12'.*incorrect indentation level 12,.*should be 8.'
+            @MyAnnotation_12
 (value = "")
         public int c;
 
@@ -66,16 +71,19 @@ class InputAnnotationLocationIncorrect2
             // comment
         }
         @MyAnnotation_12(value = "") // ok
-            @MyAnn_22 // violation
+            // violation below '.*'MyAnn_22' have incorrect indentation level 12, .* should be 8.'
+            @MyAnn_22
         void foo1() {}
 
         @MyAnnotation_12(value = "") // ok
-            @MyAnn_22 // violation
+            // violation below '.*'MyAnn_22' have incorrect indentation level 12, .* should be 8.'
+            @MyAnn_22
         void foo2() {}
     }
 
     @MyAnnotation_12(value = "") // ok
-       @MyAnn_22 // violation
+       // violation below 'Annotation 'MyAnn_22' have incorrect indentation level 7,.*should be 4.'
+       @MyAnn_22
     InnerClass anon = new InnerClass()
     {
         @MyAnn_22 @MyAnnotation_12(value = "") public int a; // ok
@@ -90,10 +98,12 @@ class InputAnnotationLocationIncorrect2
         public int d;
 
         @MyAnnotation_12(value = "") // ok
-           @MyAnn_22 void foo1() {} // violation
+           // violation below '.*'MyAnn_22' have incorrect indentation level 11, .* should be 8.'
+           @MyAnn_22 void foo1() {}
 
         @MyAnnotation_12(value = "") // ok
-          @MyAnn_22 // violation
+          // violation below '.*'MyAnn_22' have incorrect indentation level 10, .* should be 8.'
+          @MyAnn_22
         void foo2() {}
 
         @MyAnnotation_12(value = "") void foo42() {} // ok
@@ -103,7 +113,7 @@ class InputAnnotationLocationIncorrect2
 
    @MyAnnotation_12 // ok
 (value = "")
-@MyAnn_22 // violation
+@MyAnn_22 // violation '.*'MyAnn_22' have incorrect indentation level 0, .* should be 3.'
 class Foo2 {
     public void method1(@MyAnnotation_32 @MyAnn_22 Object param1) { // ok
         try {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationIncorrect3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationIncorrect3.java
@@ -11,18 +11,22 @@ tokens = CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF,
 
 package com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation;
 
-@MyAnn_23 @com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation.MyAnn3 // violation
+// violation below 'Annotation 'MyAnn3' should be alone on line.'
+@MyAnn_23 @com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation.MyAnn3
 (value = "")
 class InputAnnotationLocationIncorrect3
 {
 
-    @MyAnn_23 @MyAnnotation_13(value = "") // violation
+    // violation below 'Annotation 'MyAnnotation_13' should be alone on line.'
+    @MyAnn_23 @MyAnnotation_13(value = "")
     public int a;
 
-    @MyAnnotation_13(value = "") public int b; // violation
+    // violation below 'Annotation 'MyAnnotation_13' should be alone on line.'
+    @MyAnnotation_13(value = "") public int b;
 
     @MyAnn_23 // ok
-        @MyAnnotation_13 // violation
+        // violation below '.*'MyAnnotation_13' have incorrect indentation level 8,.*should be 4.'
+        @MyAnnotation_13
 (value = "")
     public int c;
 
@@ -30,30 +34,37 @@ class InputAnnotationLocationIncorrect3
     public int d;
 
     @MyAnn_23
-        @MyAnnotation_13 // violation
+        // violation below '.*'MyAnnotation_13' have incorrect indentation level 8,.*should be 4.'
+        @MyAnnotation_13
 (value = "")
     public InputAnnotationLocationIncorrect3() {}
 
     @MyAnnotation_13("foo") @MyAnn_23 void foo1() {} // 2 violations
 
     @MyAnnotation_13(value = "") // ok
-       @MyAnn_23 // violation
+       // violation below 'Annotation 'MyAnn_23' have incorrect indentation level 7,.*should be 4.'
+       @MyAnn_23
     void foo2() {}
 
     @MyAnnotation_13(value = "") // ok
-        @MyAnn_23 // violation
-      @MyAnnotation_33 // violation
-          @MyAnnotation_43 // violation
+        // violation below 'Annotation 'MyAnn_23' have incorrect indentation level 8,.*should be 4.'
+        @MyAnn_23
+      // violation below '.*'MyAnnotation_33' have incorrect indentation level 6,.*should be 4.'
+      @MyAnnotation_33
+          // violation below '.*'MyAnnotation_43' .* incorrect indentation level 10,.*should be 4.'
+          @MyAnnotation_43
     class InnerClass3
     {
-        @MyAnn_23 @MyAnnotation_13 // violation
+        @MyAnn_23 @MyAnnotation_13 // violation '.*'MyAnnotation_13' should be alone on line.'
 (value = "")
         public int a;
 
-        @MyAnnotation_13(value = "") public int b; // violation
+        // violation below 'Annotation 'MyAnnotation_13' should be alone on line.'
+        @MyAnnotation_13(value = "") public int b;
 
         @MyAnn_23 // ok
-            @MyAnnotation_13 // violation
+            // violation below '.*'MyAnnotation_13'.*incorrect indentation level 12,.*should be 8.'
+            @MyAnnotation_13
 (value = "")
         public int c;
 
@@ -61,26 +72,30 @@ class InputAnnotationLocationIncorrect3
         public int d;
 
         @MyAnn_23 // ok
-        @MyAnnotation_13(value = "") public InnerClass3() // violation
+        // violation below 'Annotation 'MyAnnotation_13' should be alone on line.'
+        @MyAnnotation_13(value = "") public InnerClass3()
         {
             // comment
         }
         @MyAnnotation_13(value = "") // ok
-            @MyAnn_23 // violation
+            // violation below '.*'MyAnn_23' have incorrect indentation level 12,.*should be 8.'
+            @MyAnn_23
         void foo1() {}
 
         @MyAnnotation_13(value = "") // ok
-            @MyAnn_23 // violation
+            @MyAnn_23 // violation '.*'MyAnn_23' have incorrect indentation level 12,.*should be 8.'
         void foo2() {}
     }
 
     @MyAnnotation_13(value = "") // ok
-       @MyAnn_23 // violation
+       @MyAnn_23 // violation '.*'MyAnn_23' have incorrect indentation level 7,.*should be 4.'
     InnerClass3 anon = new InnerClass3()
     {
-        @MyAnn_23 @MyAnnotation_13(value = "") public int a; // violation
+        // violation below 'Annotation 'MyAnnotation_13' should be alone on line.'
+        @MyAnn_23 @MyAnnotation_13(value = "") public int a;
 
-        @MyAnnotation_13(value = "") public int b; // violation
+        // violation below 'Annotation 'MyAnnotation_13' should be alone on line.'
+        @MyAnnotation_13(value = "") public int b;
 
         @MyAnn_23 // ok
         @MyAnnotation_13(value = "") // ok
@@ -90,20 +105,23 @@ class InputAnnotationLocationIncorrect3
         public int d;
 
         @MyAnnotation_13(value = "") // ok
-           @MyAnn_23 void foo1() {} // violation
+           // violation below '.*'MyAnn_23' have incorrect indentation level 11,.*should be 8.'
+           @MyAnn_23 void foo1() {}
 
         @MyAnnotation_13(value = "") // ok
-          @MyAnn_23 // violation
+          // violation below '.*'MyAnn_23' have incorrect indentation level 10, .* should be 8.'
+          @MyAnn_23
         void foo2() {}
 
-        @MyAnnotation_13(value = "") void foo42() {} // violation
+        // violation below 'Annotation 'MyAnnotation_13' should be alone on line.'
+        @MyAnnotation_13(value = "") void foo42() {}
     };
 
 }
 
    @MyAnnotation_13 // ok
 (value = "")
-@MyAnn_23 // violation
+@MyAnn_23 // violation 'Annotation 'MyAnn_23' have incorrect indentation level 0, .* should be 3.'
 class Foo3 {
     public void method1(@MyAnnotation_33 @MyAnn_23 Object param1) {
         try {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationInterface.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationInterface.java
@@ -15,12 +15,16 @@ import java.lang.annotation.Repeatable;
 import java.lang.annotation.Target;
 
 @InterfaceAnnotation(value = "foo")
-  @InterfaceAnnotation // violation
-@InterfaceAnnotation("bar") interface InputAnnotationLocationInterface { // violation
+  // violation below '.*'InterfaceAnnotation' have incorrect indentation level 2,.*should be 0.'
+  @InterfaceAnnotation
+// violation below 'Annotation 'InterfaceAnnotation' should be alone on line.'
+@InterfaceAnnotation("bar") interface InputAnnotationLocationInterface {
 
     @InterfaceAnnotation(value = "foo")
-      @InterfaceAnnotation // violation
-    @InterfaceAnnotation("bar") void method( // violation
+      // violation below '.*'InterfaceAnnotation' have incorrect indentation level 6,.*should be 4.'
+      @InterfaceAnnotation
+    // violation below 'Annotation 'InterfaceAnnotation' should be alone on line.'
+    @InterfaceAnnotation("bar") void method(
         int param1,
         @InterfaceAnnotation(value = "foo")
           @InterfaceAnnotation

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationParameterized.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationParameterized.java
@@ -15,7 +15,8 @@ import java.lang.annotation.Repeatable;
 
 class InputAnnotationLocationParameterized {
 
-    @Annotation void singleParameterless() {} // violation
+    // violation below 'Annotation 'Annotation' should be alone on line.'
+    @Annotation void singleParameterless() {}
 
     @Annotation @Annotation void multipleParameterless() {} // 2 violations
 
@@ -25,7 +26,8 @@ class InputAnnotationLocationParameterized {
 
     @Annotation @Annotation("") @Annotation(value = "") void multiple() {} // 3 violations
 
-    @Annotation("") @Annotation(value = "") void multipleParametrized() {} // violation
+    // violation below 'Annotation 'Annotation' should be alone on line.'
+    @Annotation("") @Annotation(value = "") void multipleParametrized() {}
 
     @Repeatable(Annotations.class)
     @interface Annotation {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationSingleParameterless.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/InputAnnotationLocationSingleParameterless.java
@@ -19,11 +19,14 @@ class InputAnnotationLocationSingleParameterless {
 
     @Annotation void singleParameterless() {}
 
-    @Annotation @Annotation void multipleParameterless() {} // violation
+    // violation below 'Annotation 'Annotation' should be alone on line.'
+    @Annotation @Annotation void multipleParameterless() {}
 
-    @Annotation("") void parameterized() {} // violation
+    // violation below 'Annotation 'Annotation' should be alone on line.'
+    @Annotation("") void parameterized() {}
 
-    @Annotation(value = "") void namedParameterized() {} // violation
+    // violation below 'Annotation 'Annotation' should be alone on line.'
+    @Annotation(value = "") void namedParameterized() {}
 
     @Annotation @Annotation("") @Annotation(value = "") void multiple() {} // 2 violations
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/inputs/package-info.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationlocation/inputs/package-info.java
@@ -9,6 +9,8 @@ tokens = PACKAGE_DEF
 */
 
 @PackageAnnotation(value = "foo")
-  @PackageAnnotation // violation
-@PackageAnnotation("bar") package com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation.inputs; // violation
+  // violation below '.*'PackageAnnotation' have incorrect indentation level 2,.*should be 0.'
+  @PackageAnnotation
+// violation below 'Annotation 'PackageAnnotation' should be alone on line.'
+@PackageAnnotation("bar") package com.puppycrawl.tools.checkstyle.checks.annotation.annotationlocation.inputs;
 


### PR DESCRIPTION
Addresses issue #11214
Specifies the violation messages for `AnnotationLocationCheck` in all relevant `Input..` files.
# Changes
* Specified violation messages in 11 files.
* Changed the row numbers in `expected` variables in `AnnotationLocationCheckTest` due to the moved `// violation` comments.
* Removed the check from the suppresion list in `InlineConfigParser`.