### PR TITLE
infra: checkout stable commit from xwiki-commons

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -255,6 +255,7 @@ no-error-xwiki)
   mvn -e --no-transfer-progress clean install -Pno-validations
   checkout_from "https://github.com/xwiki/xwiki-commons.git"
   cd .ci-temp/xwiki-commons
+  git checkout "47cad118926ea880fe""deb6af8fded""db04d""f9d964"
   # Build custom Checkstyle rules
   mvn -e --no-transfer-progress -f \
     xwiki-commons-tools/xwiki-commons-tool-verification-resources/pom.xml \


### PR DESCRIPTION
Build failure in xwiki-commons: https://app.circleci.com/pipelines/github/checkstyle/checkstyle/13681/workflows/f8556257-7af1-4c75-9cbe-34e53c647980/jobs/149782

Link to passing xwiki build: https://circleci.com/gh/checkstyle/checkstyle/149839?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link