### PR TITLE
Issue #11720: Kill surviving mutation in RequireThisCheck related to static blocks

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-require-this-check-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-require-this-check-suppressions.xml
@@ -4,15 +4,6 @@
     <sourceFile>RequireThisCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck</mutatedClass>
     <mutatedMethod>canBeReferencedFromStaticContext</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
-    <description>removed conditional - replaced equality check with false</description>
-    <lineContent>if (definitionToken.getType() == TokenTypes.STATIC_INIT) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>RequireThisCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck</mutatedClass>
-    <mutatedMethod>canBeReferencedFromStaticContext</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
     <description>removed conditional - replaced equality check with true</description>
     <lineContent>if (variableDeclarationFrame.getType() == FrameType.CLASS_FRAME) {</lineContent>

--- a/.ci/pitest-survival-check-html.sh
+++ b/.ci/pitest-survival-check-html.sh
@@ -202,8 +202,7 @@ pitest-coding-require-this-check)
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>                if (isAnonymousClassDef(ast)) {</span></pre></td></tr>"
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>               &#38;&#38; parent.getType() != TokenTypes.CTOR_DEF</span></pre></td></tr>"
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>            &#38;&#38; lastChild.getType() == TokenTypes.OBJBLOCK;</span></pre></td></tr>"
-  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (definitionToken.getType() == TokenTypes.STATIC_INIT) {</span></pre></td></tr>"
-  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (variableDeclarationFrame.getType() == FrameType.CLASS_FRAME) {</span></pre></td></tr>"
+  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (variableDeclarationFrame.getType() == FrameType.CLASS_FRAME) {</span></pre></td></tr>"
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (fieldUsageFrame.getType() == FrameType.BLOCK_FRAME) {</span></pre></td></tr>"
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>        return left.getType() == right.getType() &#38;&#38; left.getText().equals(right.getText());</span></pre></td></tr>"
   );

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -850,37 +850,26 @@ public class RequireThisCheck extends AbstractCheck {
      */
     private boolean canBeReferencedFromStaticContext(DetailAST ident) {
         AbstractFrame variableDeclarationFrame = findFrame(ident, false);
-        boolean staticInitializationBlock = false;
         while (variableDeclarationFrame.getType() == FrameType.BLOCK_FRAME
-                || variableDeclarationFrame.getType() == FrameType.FOR_FRAME) {
-            final DetailAST blockFrameNameIdent = variableDeclarationFrame.getFrameNameIdent();
-            final DetailAST definitionToken = blockFrameNameIdent.getParent();
-            if (definitionToken.getType() == TokenTypes.STATIC_INIT) {
-                staticInitializationBlock = true;
-                break;
-            }
+            || variableDeclarationFrame.getType() == FrameType.FOR_FRAME) {
             variableDeclarationFrame = variableDeclarationFrame.getParent();
         }
 
         boolean staticContext = false;
-        if (staticInitializationBlock) {
-            staticContext = true;
+
+        if (variableDeclarationFrame.getType() == FrameType.CLASS_FRAME) {
+            final DetailAST codeBlockDefinition = getCodeBlockDefinitionToken(ident);
+            if (codeBlockDefinition != null) {
+                final DetailAST modifiers = codeBlockDefinition.getFirstChild();
+                staticContext = codeBlockDefinition.getType() == TokenTypes.STATIC_INIT
+                    || modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) != null;
+            }
         }
         else {
-            if (variableDeclarationFrame.getType() == FrameType.CLASS_FRAME) {
-                final DetailAST codeBlockDefinition = getCodeBlockDefinitionToken(ident);
-                if (codeBlockDefinition != null) {
-                    final DetailAST modifiers = codeBlockDefinition.getFirstChild();
-                    staticContext = codeBlockDefinition.getType() == TokenTypes.STATIC_INIT
-                        || modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) != null;
-                }
-            }
-            else {
-                final DetailAST frameNameIdent = variableDeclarationFrame.getFrameNameIdent();
-                final DetailAST definitionToken = frameNameIdent.getParent();
-                staticContext = definitionToken.findFirstToken(TokenTypes.MODIFIERS)
-                        .findFirstToken(TokenTypes.LITERAL_STATIC) != null;
-            }
+            final DetailAST frameNameIdent = variableDeclarationFrame.getFrameNameIdent();
+            final DetailAST definitionToken = frameNameIdent.getParent();
+            staticContext = definitionToken.findFirstToken(TokenTypes.MODIFIERS)
+                .findFirstToken(TokenTypes.LITERAL_STATIC) != null;
         }
         return !staticContext;
     }


### PR DESCRIPTION
#11720
Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11776

### Reports with hardcoded mutation (clean):

- DefaultConfig: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/dc3d699_2022053018/reports/diff/index.html
- validateOnlyOverlappingFalseWithoutOpenJDK: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/dc3d699_2022072839/reports/diff/index.html

`validateOnlyOverlapping = false` report was not generated with OpenJDK (Out of memory in GitHub actions), though it is very unlikely that it will show any difference, still, if it is required, ping me, and I will generate it locally.

### This mutation falls in the category:

- Safely (no regressions) remove code to be covered

### Rationale:

The condition `definitionToken.getType() == TokenTypes.STATIC_INIT` is same as the condition 
`codeBlockDefinition.getType() == TokenTypes.STATIC_INIT`. A variable declared in static block scope, will always have an enclosing `CLASS_FRAME`.

In the current logic, we skip all frames of type `BLOCK_FRAME`, and `FOR_FRAME` to reach the `CLASS_FRAME`, if we can't reach `CLASS_FRAME` (maybe `METHOD_FRAME` is in between), then we can be assured that there is no static block present.

So if there is a static block, we will surely go into the branch
`if (variableDeclarationFrame.getType() == FrameType.CLASS_FRAME)` in which we check for the condition-
```java
staticContext = codeBlockDefinition.getType() == TokenTypes.STATIC_INIT
    || modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) != null;
```
Hence the line can be safely removed, in theory, we would take a hit in TC, as we would make another traversal in `getCodeBlockDefinitionToken(..)` but in reality, there will be no difference, in real case use scenario, 2-3 more iterations.

---
### Generating reports again:
Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/5dc88b466a50335d5759f60c1d041a239f11a5a1/my_checks.xml
Diff Regression projects: https://gist.githubusercontent.com/Vyom-Yadav/91807e6244cff60698d9e33e32ba2d51/raw/ccf3b6b9e053f27b371eb6d1e848d7199dd1f567/projects-to-test-on.properties
Report label: validateOnlyOverlappingFalseWithoutOpenJDK
