### PR TITLE
Issue #11277: update code base to have javadoc tag to explain noinspection content

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -457,6 +457,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher, RootMod
      * {@inheritDoc} Creates child module.
      *
      * @noinspection ChainOfInstanceofChecks
+     * @noinspectionreason ChainOfInstanceofChecks - we treat checks and filters differently
      */
     @Override
     protected void setupChild(Configuration childConf)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/CheckstyleException.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/CheckstyleException.java
@@ -23,6 +23,8 @@ package com.puppycrawl.tools.checkstyle.api;
  * Represents an error condition within Checkstyle.
  *
  * @noinspection CheckedExceptionClass
+ * @noinspectionreason CheckedExceptionClass - we require checked exception since we terminate
+ *      execution if thrown
  */
 public class CheckstyleException extends Exception {
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions.java
@@ -138,6 +138,7 @@ public final class DetectorOptions {
          * @param val for reporting violations.
          * @return Builder object.
          * @noinspection ReturnOfInnerClass
+         * @noinspectionreason ReturnOfInnerClass - builder is only used in enclosing class
          */
         public Builder reporter(AbstractViolationReporter val) {
             reporter = val;
@@ -151,6 +152,7 @@ public final class DetectorOptions {
          * @param val the format to use when matching lines.
          * @return Builder object.
          * @noinspection ReturnOfInnerClass
+         * @noinspectionreason ReturnOfInnerClass - builder is only used in enclosing class
          */
         public Builder compileFlags(int val) {
             compileFlags = val;
@@ -163,6 +165,7 @@ public final class DetectorOptions {
          * @param val the format to use when matching lines.
          * @return Builder object.
          * @noinspection ReturnOfInnerClass
+         * @noinspectionreason ReturnOfInnerClass - builder is only used in enclosing class
          */
         public Builder format(String val) {
             format = val;
@@ -175,6 +178,7 @@ public final class DetectorOptions {
          * @param val message to use when reporting a match.
          * @return Builder object.
          * @noinspection ReturnOfInnerClass
+         * @noinspectionreason ReturnOfInnerClass - builder is only used in enclosing class
          */
         public Builder message(String val) {
             message = val;
@@ -187,6 +191,7 @@ public final class DetectorOptions {
          * @param val the minimum allowed number of detections.
          * @return Builder object.
          * @noinspection ReturnOfInnerClass
+         * @noinspectionreason ReturnOfInnerClass - builder is only used in enclosing class
          */
         public Builder minimum(int val) {
             minimum = val;
@@ -199,6 +204,7 @@ public final class DetectorOptions {
          * @param val the maximum allowed number of detections.
          * @return Builder object.
          * @noinspection ReturnOfInnerClass
+         * @noinspectionreason ReturnOfInnerClass - builder is only used in enclosing class
          */
         public Builder maximum(int val) {
             maximum = val;
@@ -211,6 +217,7 @@ public final class DetectorOptions {
          * @param val whether to ignore case when matching.
          * @return Builder object.
          * @noinspection ReturnOfInnerClass, BooleanParameter
+         * @noinspectionreason ReturnOfInnerClass - builder is only used in enclosing class
          */
         public Builder ignoreCase(boolean val) {
             ignoreCase = val;
@@ -223,6 +230,7 @@ public final class DetectorOptions {
          * @param val the suppressor to use.
          * @return current instance
          * @noinspection ReturnOfInnerClass
+         * @noinspectionreason ReturnOfInnerClass - builder is only used in enclosing class
          */
         public Builder suppressor(MatchSuppressor val) {
             suppressor = val;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelectorPresentation.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelectorPresentation.java
@@ -45,6 +45,8 @@ public class CodeSelectorPresentation {
      * @param ast ast node.
      * @param lines2position list to map lines.
      * @noinspection AssignmentOrReturnOfFieldWithMutableType
+     * @noinspectionreason AssignmentOrReturnOfFieldWithMutableType - mutability is
+     *      expected in list of lines of code
      */
     public CodeSelectorPresentation(DetailAST ast, List<Integer> lines2position) {
         node = ast;
@@ -57,6 +59,8 @@ public class CodeSelectorPresentation {
      * @param node DetailNode node.
      * @param lines2position list to map lines.
      * @noinspection AssignmentOrReturnOfFieldWithMutableType
+     * @noinspectionreason AssignmentOrReturnOfFieldWithMutableType - mutability is expected
+     *      in list of lines of code
      */
     public CodeSelectorPresentation(DetailNode node, List<Integer> lines2position) {
         this.node = node;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -86,6 +86,8 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * CheckerTest.
  *
  * @noinspection ClassWithTooManyDependencies
+ * @noinspectionreason ClassWithTooManyDependencies - complex tests require a large number
+ *      of imports
  */
 public class CheckerTest extends AbstractModuleTestSupport {
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/grammar/javadoc/JavadocParseTreeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/grammar/javadoc/JavadocParseTreeTest.java
@@ -30,6 +30,7 @@ import com.puppycrawl.tools.checkstyle.AbstractTreeTestSupport;
  * JavadocParseTreeTest.
  *
  * @noinspection ClassOnlyUsedInOnePackage
+ * @noinspectionreason ClassOnlyUsedInOnePackage - class is internal tool, and only used in testing
  */
 public class JavadocParseTreeTest extends AbstractTreeTestSupport {
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/testmodules/TestFileSetCheck.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/testmodules/TestFileSetCheck.java
@@ -28,6 +28,7 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
  * TestFileSetCheck.
  *
  * @noinspection ClassOnlyUsedInOnePackage
+ * @noinspectionreason ClassOnlyUsedInOnePackage - class is internal tool, and only used in testing
  */
 public class TestFileSetCheck extends AbstractFileSetCheck {
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CloseAndFlushTestByteArrayOutputStream.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CloseAndFlushTestByteArrayOutputStream.java
@@ -26,6 +26,7 @@ import java.io.IOException;
  * CloseAndFlushTestByteArrayOutputStream.
  *
  * @noinspection ClassOnlyUsedInOnePackage
+ * @noinspectionreason ClassOnlyUsedInOnePackage - class is internal tool, and only used in testing
  */
 public final class CloseAndFlushTestByteArrayOutputStream extends ByteArrayOutputStream {
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XdocUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XdocUtil.java
@@ -41,6 +41,7 @@ import org.xml.sax.SAXException;
  * XdocUtil.
  *
  * @noinspection ClassOnlyUsedInOnePackage
+ * @noinspectionreason ClassOnlyUsedInOnePackage - class is internal tool, and only used in testing
  */
 public final class XdocUtil {
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XmlUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XmlUtil.java
@@ -42,6 +42,7 @@ import com.puppycrawl.tools.checkstyle.XmlLoader;
  * XmlUtil.
  *
  * @noinspection ClassOnlyUsedInOnePackage
+ * @noinspectionreason ClassOnlyUsedInOnePackage - class is internal tool, and only used in testing
  */
 public final class XmlUtil {
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XpathIteratorUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XpathIteratorUtil.java
@@ -32,6 +32,7 @@ import net.sf.saxon.om.NodeInfo;
  * XpathIteratorUtil.
  *
  * @noinspection ClassOnlyUsedInOnePackage
+ * @noinspectionreason ClassOnlyUsedInOnePackage - class is internal tool, and only used in testing
  */
 public final class XpathIteratorUtil {
 


### PR DESCRIPTION
Adds noinspection tag for ChainOfInstanceofChecks, CheckedExceptionClass, ReturnOfInnerClass, AssignmentOrReturnOfFieldWithMutableType, ClassOnlyUsedInOnePackage, part of #11277 