### PR TITLE
Issue #11140: solve OCP_OVERLY_CONCRETE_PARAMETER

### DIFF
--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -178,6 +178,12 @@
     <Bug pattern="SLS_SUSPICIOUS_LOOP_SEARCH"/>
   </Match>
   <Match>
+    <!-- Better to use DetailAstImpl here to avoid needless dependency of API package. -->
+    <Class name="com.puppycrawl.tools.checkstyle.JavaAstVisitor"/>
+    <Method name="addLastSibling"/>
+    <Bug pattern="OCP_OVERLY_CONCRETE_PARAMETER"/>
+  </Match>
+  <Match>
     <!-- Unable to resolve the item. -->
     <Class name="com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck"/>
     <Method name="findLastChildWhichContainsSpecifiedToken"/>
@@ -217,7 +223,6 @@
       MOM_MISLEADING_OVERLOAD_MODEL,
       NFF_NON_FUNCTIONAL_FIELD,
       NMCS_NEEDLESS_MEMBER_COLLECTION_SYNCHRONIZATION,
-      OCP_OVERLY_CONCRETE_PARAMETER,
       OPM_OVERLY_PERMISSIVE_METHOD,
       PMB_INSTANCE_BASED_THREAD_LOCAL,
       SEO_SUBOPTIMAL_EXPRESSION_ORDER,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -387,18 +388,18 @@ public final class ConfigurationLoader {
 
     /**
      * Parses a string containing {@code ${xxx}} style property
-     * references into two lists. The first list is a collection
+     * references into two collections. The first one is a collection
      * of text fragments, while the other is a set of string property names.
-     * {@code null} entries in the first list indicate a property
-     * reference from the second list.
+     * {@code null} entries in the first collection indicate a property
+     * reference from the second collection.
      *
      * <p>Code copied from ant -
      * http://cvs.apache.org/viewcvs/jakarta-ant/src/main/org/apache/tools/ant/ProjectHelper.java
      *
      * @param value     Text to parse. Must not be {@code null}.
-     * @param fragments List to add text fragments to.
+     * @param fragments Collection to add text fragments to.
      *                  Must not be {@code null}.
-     * @param propertyRefs List to add property names to.
+     * @param propertyRefs Collection to add property names to.
      *                     Must not be {@code null}.
      *
      * @throws CheckstyleException if the string contains an opening
@@ -406,8 +407,8 @@ public final class ConfigurationLoader {
      *                           {@code }}
      */
     private static void parsePropertyString(String value,
-                                           List<String> fragments,
-                                           List<String> propertyRefs)
+                                           Collection<String> fragments,
+                                           Collection<String> propertyRefs)
             throws CheckstyleException {
         int prev = 0;
         // search for the next instance of $ from the 'prev' position

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavaParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavaParser.java
@@ -222,7 +222,7 @@ public final class JavaParser {
      * @param token to create the AST
      * @return DetailAST with SINGLE_LINE_COMMENT type
      */
-    private static DetailAST createSlCommentNode(CommonToken token) {
+    private static DetailAST createSlCommentNode(Token token) {
         final DetailAstImpl slComment = new DetailAstImpl();
         slComment.setType(TokenTypes.SINGLE_LINE_COMMENT);
         slComment.setText("//");

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java
@@ -263,7 +263,7 @@ public class JavadocDetailNodeParser {
      * @return array of Javadoc nodes
      */
     private JavadocNodeImpl[]
-            createChildrenNodes(JavadocNodeImpl parentJavadocNode, ParseTree parseTreeNode) {
+            createChildrenNodes(DetailNode parentJavadocNode, ParseTree parseTreeNode) {
         final JavadocNodeImpl[] children =
                 new JavadocNodeImpl[parseTreeNode.getChildCount()];
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -244,11 +244,11 @@ public final class Main {
      * patterns supplied.
      *
      * @param path The path of the directory/file to check
-     * @param patternsToExclude The list of patterns to exclude from searching or being added as
-     *        files.
+     * @param patternsToExclude The collection of patterns to exclude from searching
+     *        or being added as files.
      * @return True if the directory/file matches one of the patterns.
      */
-    private static boolean isPathExcluded(String path, List<Pattern> patternsToExclude) {
+    private static boolean isPathExcluded(String path, Iterable<Pattern> patternsToExclude) {
         boolean result = false;
 
         for (Pattern pattern : patternsToExclude) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.design;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -901,7 +902,7 @@ public class VisibilityModifierCheck
      * @param typeArgsClassNames type arguments class names.
      * @return true if all generic type arguments are immutable.
      */
-    private boolean areImmutableTypeArguments(List<String> typeArgsClassNames) {
+    private boolean areImmutableTypeArguments(Collection<String> typeArgsClassNames) {
         return typeArgsClassNames.stream().noneMatch(
             typeName -> {
                 return !immutableClassShortNames.contains(typeName)

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -21,11 +21,13 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
+import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -652,14 +654,14 @@ public class JavadocMethodCheck extends AbstractCheck {
     /**
      * Calculates column number using Javadoc tag matcher.
      *
-     * @param javadocTagMatcher found javadoc tag matcher
+     * @param javadocTagMatchResult found javadoc tag match result
      * @param lineNumber line number of Javadoc tag in comment
      * @param startColumnNumber column number of Javadoc comment beginning
      * @return column number
      */
-    private static int calculateTagColumn(Matcher javadocTagMatcher,
+    private static int calculateTagColumn(MatchResult javadocTagMatchResult,
             int lineNumber, int startColumnNumber) {
-        int col = javadocTagMatcher.start(1) - 1;
+        int col = javadocTagMatchResult.start(1) - 1;
         if (lineNumber == 0) {
             col += startColumnNumber;
         }
@@ -828,16 +830,16 @@ public class JavadocMethodCheck extends AbstractCheck {
     }
 
     /**
-     * Combine ExceptionInfo lists together by matching names.
+     * Combine ExceptionInfo collections together by matching names.
      *
-     * @param list1 list of ExceptionInfo
-     * @param list2 list of ExceptionInfo
+     * @param first the first collection of ExceptionInfo
+     * @param second the second collection of ExceptionInfo
      * @return combined list of ExceptionInfo
      */
-    private static List<ExceptionInfo> combineExceptionInfo(List<ExceptionInfo> list1,
-                                                     List<ExceptionInfo> list2) {
-        final List<ExceptionInfo> result = new ArrayList<>(list1);
-        for (ExceptionInfo exceptionInfo : list2) {
+    private static List<ExceptionInfo> combineExceptionInfo(Collection<ExceptionInfo> first,
+                                                            Iterable<ExceptionInfo> second) {
+        final List<ExceptionInfo> result = new ArrayList<>(first);
+        for (ExceptionInfo exceptionInfo : second) {
             if (result.stream().noneMatch(item -> isExceptionInfoSame(item, exceptionInfo))) {
                 result.add(exceptionInfo);
             }
@@ -940,12 +942,12 @@ public class JavadocMethodCheck extends AbstractCheck {
      * Returns true if required type found in type parameters.
      *
      * @param typeParams
-     *            list of type parameters
+     *            collection of type parameters
      * @param requiredTypeName
      *            name of required type
      * @return true if required type found in type parameters.
      */
-    private static boolean searchMatchingTypeParameter(List<DetailAST> typeParams,
+    private static boolean searchMatchingTypeParameter(Iterable<DetailAST> typeParams,
             String requiredTypeName) {
         // Loop looking for matching type param
         final Iterator<DetailAST> typeParamsIt = typeParams.iterator();
@@ -969,7 +971,7 @@ public class JavadocMethodCheck extends AbstractCheck {
      * @param paramName name of parameter
      * @return true if parameter found and removed
      */
-    private static boolean removeMatchingParam(List<DetailAST> params, String paramName) {
+    private static boolean removeMatchingParam(Iterable<DetailAST> params, String paramName) {
         boolean found = false;
         final Iterator<DetailAST> paramIt = params.iterator();
         while (paramIt.hasNext()) {
@@ -1062,16 +1064,16 @@ public class JavadocMethodCheck extends AbstractCheck {
     /**
      * Verifies that documented exception is in throws.
      *
-     * @param throwsList list of throws
+     * @param throwsIterable collection of throws
      * @param documentedClassInfo documented exception class info
      * @param foundThrows previously found throws
      */
-    private static void processThrows(List<ExceptionInfo> throwsList,
+    private static void processThrows(Iterable<ExceptionInfo> throwsIterable,
                                       ClassInfo documentedClassInfo, Set<String> foundThrows) {
         ExceptionInfo foundException = null;
 
         // First look for matches on the exception name
-        for (ExceptionInfo exceptionInfo : throwsList) {
+        for (ExceptionInfo exceptionInfo : throwsIterable) {
             if (isClassNamesSame(exceptionInfo.getName().getText(),
                     documentedClassInfo.getName().getText())) {
                 foundException = exceptionInfo;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTags.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTags.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -38,7 +39,7 @@ public final class JavadocTags {
      * @param tags valid tags
      * @param invalidTags invalid tags
      */
-    public JavadocTags(List<JavadocTag> tags, List<InvalidJavadocTag> invalidTags) {
+    public JavadocTags(Collection<JavadocTag> tags, Collection<InvalidJavadocTag> invalidTags) {
         validTags = List.copyOf(tags);
         this.invalidTags = List.copyOf(invalidTags);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -442,7 +443,7 @@ public class JavadocTypeCheck
      * @param tagName the required tag name.
      * @param formatPattern regexp for the tag value.
      */
-    private void checkTag(DetailAST ast, List<JavadocTag> tags, String tagName,
+    private void checkTag(DetailAST ast, Iterable<JavadocTag> tags, String tagName,
                           Pattern formatPattern) {
         if (formatPattern != null) {
             boolean hasTag = false;
@@ -471,7 +472,7 @@ public class JavadocTypeCheck
      * @param recordComponentName the name of the type parameter
      */
     private void checkComponentParamTag(DetailAST ast,
-                                        List<JavadocTag> tags,
+                                        Collection<JavadocTag> tags,
                                         String recordComponentName) {
 
         final boolean found = tags

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -476,11 +477,11 @@ public class SuppressWithPlainTextCommentFilter extends AutomaticBean implements
      * the given {@link AuditEvent}. The nearest suppression is the suppression which scope
      * is before the line and column of the event.
      *
-     * @param suppressions {@link Suppression} instance.
+     * @param suppressions collection of {@link Suppression} instances.
      * @param event {@link AuditEvent} instance.
      * @return {@link Suppression} instance.
      */
-    private static Suppression getNearestSuppression(List<Suppression> suppressions,
+    private static Suppression getNearestSuppression(Collection<Suppression> suppressions,
                                                      AuditEvent event) {
         return suppressions
             .stream()

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelector.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelector.java
@@ -21,7 +21,7 @@ package com.puppycrawl.tools.checkstyle.gui;
 
 import java.awt.Color;
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
 
 import javax.swing.JTextArea;
 
@@ -43,10 +43,10 @@ public class CodeSelector {
      *
      * @param node ast node.
      * @param editor text area editor.
-     * @param lines2position list to map lines.
+     * @param lines2position positions of lines.
      */
     public CodeSelector(final Object node, final JTextArea editor,
-                        final List<Integer> lines2position) {
+                        final Collection<Integer> lines2position) {
         this.editor = editor;
         if (node instanceof DetailAST) {
             pModel = new CodeSelectorPresentation((DetailAST) node,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelectorPresentation.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelectorPresentation.java
@@ -43,7 +43,7 @@ public class CodeSelectorPresentation {
      * Constructor.
      *
      * @param ast ast node.
-     * @param lines2position list to map lines.
+     * @param lines2position positions of lines.
      * @noinspection AssignmentOrReturnOfFieldWithMutableType
      */
     public CodeSelectorPresentation(DetailAST ast, List<Integer> lines2position) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java
@@ -27,6 +27,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Deque;
 import java.util.EventObject;
 import java.util.List;
@@ -344,11 +345,11 @@ public final class TreeTable extends JTable {
     }
 
     /**
-     * Sets line position list.
+     * Sets line positions.
      *
-     * @param linePositionList Line position list.
+     * @param linePositionList positions of lines.
      */
-    public void setLinePositionList(List<Integer> linePositionList) {
+    public void setLinePositionList(Collection<Integer> linePositionList) {
         this.linePositionList = new ArrayList<>(linePositionList);
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.utils;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -563,10 +564,10 @@ public final class CheckUtil {
      * Helper method for stripIndentAndInitialNewLineFromTextBlock, to determine the smallest
      * indent in a text block string literal.
      *
-     * @param lines list of actual text block content, split by line.
+     * @param lines collection of actual text block content, split by line.
      * @return number of spaces representing the smallest indent in this text block.
      */
-    private static int getSmallestIndent(List<String> lines) {
+    private static int getSmallestIndent(Collection<String> lines) {
         return lines.stream()
             .mapToInt(CommonUtil::indexOfNonWhitespace)
             .min()

--- a/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseListIterator.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseListIterator.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.xpath.iterators;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import net.sf.saxon.om.NodeInfo;
@@ -41,9 +42,9 @@ public class ReverseListIterator implements AxisIterator {
     /**
      * Constructor for {@code ReverseListIterator} class.
      *
-     * @param items the list of nodes.
+     * @param items the collection of nodes.
      */
-    public ReverseListIterator(List<? extends NodeInfo> items) {
+    public ReverseListIterator(Collection<? extends NodeInfo> items) {
         if (items == null) {
             this.items = null;
             index = -1;


### PR DESCRIPTION
Part of #11140 

[Description](http://fb-contrib.sourceforge.net/bugdescriptions.html#OCP_OVERLY_CONCRETE_PARAMETER)

> This method uses concrete classes for parameters when only methods defined in an implemented interface or superclass are used. Consider increasing the abstraction of the interface to make low impact changes easier to accomplish in the future.

In general, this makes sense. But sometimes it requires additional imports from foreign packages.

Code:
```java
    private static void addLastSibling(DetailAstImpl self, DetailAstImpl sibling) {
```

Report:
```
[ERROR] Medium: com.puppycrawl.tools.checkstyle.JavaAstVisitor.addLastSibling(DetailAstImpl, DetailAstImpl):
2nd parameter 'sibling' could be declared as com.puppycrawl.tools.checkstyle.api.DetailAST instead 
[com.puppycrawl.tools.checkstyle.JavaAstVisitor] At JavaAstVisitor.java:[line 2145] OCP_OVERLY_CONCRETE_PARAMETER
```

Suggested code:
```java
import com.puppycrawl.tools.checkstyle.api.DetailAST; // New import required

    private static void addLastSibling(DetailAstImpl self, DetailAST sibling) {
```

such cases are false positives and should be suppressed.