### PR TITLE
Issue #11720: Kill surviving mutation in RequireThisCheck related to checking static context

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-require-this-check-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-require-this-check-suppressions.xml
@@ -3,15 +3,6 @@
   <mutation unstable="false">
     <sourceFile>RequireThisCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck</mutatedClass>
-    <mutatedMethod>canBeReferencedFromStaticContext</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (variableDeclarationFrame.getType() == FrameType.CLASS_FRAME) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>RequireThisCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck</mutatedClass>
     <mutatedMethod>collectDeclarations</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
     <description>removed conditional - replaced equality check with true</description>

--- a/.ci/pitest-survival-check-html.sh
+++ b/.ci/pitest-survival-check-html.sh
@@ -195,7 +195,6 @@ pitest-coding-require-this-check)
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>                        &#38;&#38; ast.getParent().getType() != TokenTypes.LITERAL_CATCH) {</span></pre></td></tr>"
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>               &#38;&#38; parent.getType() != TokenTypes.CTOR_DEF</span></pre></td></tr>"
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>            &#38;&#38; lastChild.getType() == TokenTypes.OBJBLOCK;</span></pre></td></tr>"
-  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (variableDeclarationFrame.getType() == FrameType.CLASS_FRAME) {</span></pre></td></tr>"
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (fieldUsageFrame.getType() == FrameType.BLOCK_FRAME) {</span></pre></td></tr>"
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>        return left.getType() == right.getType() &#38;&#38; left.getText().equals(right.getText());</span></pre></td></tr>"
   );

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -848,28 +848,13 @@ public class RequireThisCheck extends AbstractCheck {
      * @param ident ident token.
      * @return true if field can be referenced from a static context.
      */
-    private boolean canBeReferencedFromStaticContext(DetailAST ident) {
-        AbstractFrame variableDeclarationFrame = findFrame(ident, false);
-        while (variableDeclarationFrame.getType() == FrameType.BLOCK_FRAME
-            || variableDeclarationFrame.getType() == FrameType.FOR_FRAME) {
-            variableDeclarationFrame = variableDeclarationFrame.getParent();
-        }
-
+    private static boolean canBeReferencedFromStaticContext(DetailAST ident) {
         boolean staticContext = false;
-
-        if (variableDeclarationFrame.getType() == FrameType.CLASS_FRAME) {
-            final DetailAST codeBlockDefinition = getCodeBlockDefinitionToken(ident);
-            if (codeBlockDefinition != null) {
-                final DetailAST modifiers = codeBlockDefinition.getFirstChild();
-                staticContext = codeBlockDefinition.getType() == TokenTypes.STATIC_INIT
-                    || modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) != null;
-            }
-        }
-        else {
-            final DetailAST frameNameIdent = variableDeclarationFrame.getFrameNameIdent();
-            final DetailAST definitionToken = frameNameIdent.getParent();
-            staticContext = definitionToken.findFirstToken(TokenTypes.MODIFIERS)
-                .findFirstToken(TokenTypes.LITERAL_STATIC) != null;
+        final DetailAST codeBlockDefinition = getCodeBlockDefinitionToken(ident);
+        if (codeBlockDefinition != null) {
+            final DetailAST modifiers = codeBlockDefinition.getFirstChild();
+            staticContext = codeBlockDefinition.getType() == TokenTypes.STATIC_INIT
+                || modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) != null;
         }
         return !staticContext;
     }


### PR DESCRIPTION
#11720
Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11777

### Reports with hardcoded mutation (clean): Modification will be more than just hardcoding mutation, reports will be generated again.

- DefaultConfig: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/8839f1f_2022105805/reports/diff/index.html
- validateOnlyOverlappingFalseWithoutOpenJDK: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/8839f1f_2022042945/reports/diff/index.html

`validateOnlyOverlapping = false` report was not generated with OpenJDK (Out of memory in GitHub actions), though it is very unlikely that it will show any difference, still, if it is required, ping me, and I will generate it locally.

### This mutation falls in the category:

- Safely (no regressions) remove code to be covered

### Rationale:

If `staticContext` is going to be `true`, then `codeBlockDefinition` is not going to be null, so the condition will be sufficient. It is not going to be null as we can have either a static method or a static block.

---
### Generating reports again:
Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/5dc88b466a50335d5759f60c1d041a239f11a5a1/my_checks.xml
Diff Regression projects: https://raw.githubusercontent.com/checkstyle/contribution/4d44ec5e49358d8a0ddbf1925dbc677ab26a69b2/checkstyle-tester/latest-projects-to-test-on.properties
Report label: validateOnlyOverlappingFalse
