### PR TITLE
Issue #11720: Kill surviving mutation in RequireThisCheck related to getting block-definition for the code

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-require-this-check-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-require-this-check-suppressions.xml
@@ -8,13 +8,4 @@
     <description>removed conditional - replaced equality check with true</description>
     <lineContent>if (variableDeclarationFrame.getType() == FrameType.CLASS_FRAME) {</lineContent>
   </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>RequireThisCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck</mutatedClass>
-    <mutatedMethod>getCodeBlockDefinitionToken</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>&amp;&amp; parent.getType() != TokenTypes.CTOR_DEF</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/.ci/pitest-survival-check-html.sh
+++ b/.ci/pitest-survival-check-html.sh
@@ -192,7 +192,6 @@ pitest-coding-2)
 
 pitest-coding-require-this-check)
   declare -a ignoredItems=(
-  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>               &#38;&#38; parent.getType() != TokenTypes.CTOR_DEF</span></pre></td></tr>"
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (variableDeclarationFrame.getType() == FrameType.CLASS_FRAME) {</span></pre></td></tr>"
   );
   checkPitestReport ignoredItems

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -882,7 +882,6 @@ public class RequireThisCheck extends AbstractCheck {
         DetailAST parent = ident.getParent();
         while (parent != null
                && parent.getType() != TokenTypes.METHOD_DEF
-               && parent.getType() != TokenTypes.CTOR_DEF
                && parent.getType() != TokenTypes.STATIC_INIT) {
             parent = parent.getParent();
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheckTest.java
@@ -447,6 +447,14 @@ public class RequireThisCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testLocalClassesInsideLambdas() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+            getPath("InputRequireThisLocalClassesInsideLambdas.java"),
+            expected);
+    }
+
+    @Test
     public void testUnusedMethod() throws Exception {
         final DetailAstImpl ident = new DetailAstImpl();
         ident.setText("testName");

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisLocalClassesInsideLambdas.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/requirethis/InputRequireThisLocalClassesInsideLambdas.java
@@ -1,0 +1,31 @@
+/*
+RequireThis
+checkFields = (default)true
+checkMethods = (default)true
+validateOnlyOverlapping = false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.requirethis;
+
+import java.util.function.Consumer;
+
+public interface InputRequireThisLocalClassesInsideLambdas {
+
+    private static void method(Consumer<String> consumer) {
+        consumer.accept("foo");
+    }
+
+    private static void testCtorNestedInLambdaWithViolation() {
+        method(s -> {
+            class InnerSubscriber implements InputRequireThisLocalClassesInsideLambdas {
+                int index;
+
+                public InnerSubscriber(int index) {
+                    this.index = index; // ok
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
#11720
Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11787

### Reports with hardcoded mutation (difference is present in report, killed false positive):

- DefaultConfig: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/afd61f5_2022053245/reports/diff/index.html
- validateOnlyOverlappingFalseWithoutOpenJDK: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/afd61f5_2022072739/reports/diff/index.html

### This mutation falls in the category:

- Safely (no regressions) remove code to be covered

### Rationale:

This method is only used at: https://github.com/checkstyle/checkstyle/blob/c8c2d8c7edaa05ce457b5babd6be27daff299528/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java#L870-L876

Where we check `codeBlockDefinition` for having a `static` modifier that can't be used with constructors. The rationale for adding this at that time could be to save a few iterations. In a real case scenario, it shouldn't be a problem. 

---
### Generating reports again:
Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/5dc88b466a50335d5759f60c1d041a239f11a5a1/my_checks.xml
Diff Regression projects: https://gist.githubusercontent.com/Vyom-Yadav/91807e6244cff60698d9e33e32ba2d51/raw/ccf3b6b9e053f27b371eb6d1e848d7199dd1f567/projects-to-test-on.properties
Report label: validateOnlyOverlappingFalseWithoutOpenJDK

