### PR TITLE
Issue #11720: Kill surviving mutation in RequireThisCheck related to checking overlapping by local variable

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-require-this-check-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-require-this-check-suppressions.xml
@@ -71,13 +71,4 @@
     <description>removed conditional - replaced equality check with true</description>
     <lineContent>if (fieldUsageFrame.getType() == FrameType.BLOCK_FRAME) {</lineContent>
   </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>RequireThisCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck</mutatedClass>
-    <mutatedMethod>isOverlappingByLocalVariable</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (sibling != null &amp;&amp; isAssignToken(parent.getType())) {</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/.ci/pitest-survival-check-html.sh
+++ b/.ci/pitest-survival-check-html.sh
@@ -205,7 +205,6 @@ pitest-coding-require-this-check)
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (definitionToken.getType() == TokenTypes.STATIC_INIT) {</span></pre></td></tr>"
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (variableDeclarationFrame.getType() == FrameType.CLASS_FRAME) {</span></pre></td></tr>"
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (fieldUsageFrame.getType() == FrameType.BLOCK_FRAME) {</span></pre></td></tr>"
-  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (sibling != null &#38;&#38; isAssignToken(parent.getType())) {</span></pre></td></tr>"
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>        return left.getType() == right.getType() &#38;&#38; left.getText().equals(right.getText());</span></pre></td></tr>"
   );
   checkPitestReport ignoredItems

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -973,10 +973,10 @@ public class RequireThisCheck extends AbstractCheck {
     private boolean isOverlappingByLocalVariable(DetailAST ast) {
         boolean overlapping = false;
         final DetailAST parent = ast.getParent();
-        final DetailAST sibling = ast.getNextSibling();
-        if (sibling != null && isAssignToken(parent.getType())) {
+        if (isAssignToken(parent.getType())) {
             final ClassFrame classFrame = (ClassFrame) findFrame(ast, true);
-            final Set<DetailAST> exprIdents = getAllTokensOfType(sibling, TokenTypes.IDENT);
+            final Set<DetailAST> exprIdents =
+                getAllTokensOfType(ast.getNextSibling(), TokenTypes.IDENT);
             overlapping = classFrame.containsFieldOrVariableDef(exprIdents, ast);
         }
         return overlapping;


### PR DESCRIPTION
#11720
Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11781

### Reports with hardcoded mutation (clean):

- DefaultConfig: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/a13586b_2022121954/reports/diff/index.html
- validateOnlyOverlappingFalseWithoutOpenJDK: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/a13586b_2022042830/reports/diff/index.html

`validateOnlyOverlapping = false` report was not generated with OpenJDK (Out of memory in GitHub actions), though it is very unlikely that it will show any difference, still, if it is required, ping me, and I will generate it locally.

### This mutation falls in the category:

- Safely (no regressions) remove code to be covered

### Rationale:

The next sibling is used at
`final Set<DetailAST> exprIdents = getAllTokensOfType(sibling, TokenTypes.IDENT);`
The method `getAllTokensOfType(..)` already has a null check-
https://github.com/checkstyle/checkstyle/blob/c8c2d8c7edaa05ce457b5babd6be27daff299528/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java#L1023-L1028

If `exprIdents` is empty, then the result won't change to `true` on line
`overlapping = classFrame.containsFieldOrVariableDef(exprIdents, ast)`
https://github.com/checkstyle/checkstyle/blob/c8c2d8c7edaa05ce457b5babd6be27daff299528/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java#L1363-L1372

---
### Generating reports again:
Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/b424881849408a0cc74460d762ba178bc3957f67/my_checks.xml
Report label: DefaultConfig