### PR TITLE
Issue #11720: Kill surviving mutation in RequireThisCheck in isInsideConstructorFrame

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-require-this-check-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-require-this-check-suppressions.xml
@@ -27,12 +27,4 @@
     <lineContent>&amp;&amp; lastChild.getType() == TokenTypes.OBJBLOCK;</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>RequireThisCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck</mutatedClass>
-    <mutatedMethod>isInsideConstructorFrame</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (fieldUsageFrame.getType() == FrameType.BLOCK_FRAME) {</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/.ci/pitest-survival-check-html.sh
+++ b/.ci/pitest-survival-check-html.sh
@@ -195,7 +195,6 @@ pitest-coding-require-this-check)
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>               &#38;&#38; parent.getType() != TokenTypes.CTOR_DEF</span></pre></td></tr>"
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>            &#38;&#38; lastChild.getType() == TokenTypes.OBJBLOCK;</span></pre></td></tr>"
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (variableDeclarationFrame.getType() == FrameType.CLASS_FRAME) {</span></pre></td></tr>"
-  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (fieldUsageFrame.getType() == FrameType.BLOCK_FRAME) {</span></pre></td></tr>"
   );
   checkPitestReport ignoredItems
   ;;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -914,17 +914,11 @@ public class RequireThisCheck extends AbstractCheck {
      * @return true if the field usage frame is inside constructor frame.
      */
     private static boolean isInsideConstructorFrame(AbstractFrame frame) {
-        boolean assignmentInConstructor = false;
         AbstractFrame fieldUsageFrame = frame;
-        if (fieldUsageFrame.getType() == FrameType.BLOCK_FRAME) {
-            while (fieldUsageFrame.getType() == FrameType.BLOCK_FRAME) {
-                fieldUsageFrame = fieldUsageFrame.getParent();
-            }
-            if (fieldUsageFrame.getType() == FrameType.CTOR_FRAME) {
-                assignmentInConstructor = true;
-            }
+        while (fieldUsageFrame.getType() == FrameType.BLOCK_FRAME) {
+            fieldUsageFrame = fieldUsageFrame.getParent();
         }
-        return assignmentInConstructor;
+        return fieldUsageFrame.getType() == FrameType.CTOR_FRAME;
     }
 
     /**


### PR DESCRIPTION
#11720
Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11780

### Reports with hardcoded mutation (clean):

- DefaultConfig: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/4d8bbaa_2022114649/reports/diff/index.html
- validateOnlyOverlappingFalse: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/4d8bbaa_2022152354/reports/diff/index.html

### This mutation falls in the category:

- Safely (no regressions) remove code to be covered

### Rationale:

The condition is redundant, the only case in which the result might not be what is expected is when the frame is `FrameType.CTOR_FRAME` in which the earlier method returned `false` but the current method will result `true`. Shouldn't be a problem, fields with `FrameType.CTOR_FRAME` are ctor parameters and variable declarations are not checked, only usages are checked-
https://github.com/checkstyle/checkstyle/blob/c8c2d8c7edaa05ce457b5babd6be27daff299528/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java#L503-L506

---
### Generating reports again:
Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/5dc88b466a50335d5759f60c1d041a239f11a5a1/my_checks.xml

Diff Regression projects: https://gist.githubusercontent.com/nick-mancuso/6159629b4aecec8d06b0c8b34484e81f/raw/e2677d43fd1f31859e470a22aec0bdd3dbb177f8/projects.properties

Report label: validateOnlyOverlappingFalseNoJdk