### PR TITLE
Issue #11720: Kill surviving mutation in RequireThisCheck in collectDeclarations

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-require-this-check-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-require-this-check-suppressions.xml
@@ -12,15 +12,6 @@
   <mutation unstable="false">
     <sourceFile>RequireThisCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck</mutatedClass>
-    <mutatedMethod>collectDeclarations</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>&amp;&amp; ast.getParent().getType() != TokenTypes.LITERAL_CATCH) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>RequireThisCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck</mutatedClass>
     <mutatedMethod>getCodeBlockDefinitionToken</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
     <description>removed conditional - replaced equality check with true</description>

--- a/.ci/pitest-survival-check-html.sh
+++ b/.ci/pitest-survival-check-html.sh
@@ -192,7 +192,6 @@ pitest-coding-2)
 
 pitest-coding-require-this-check)
   declare -a ignoredItems=(
-  "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>                        &#38;&#38; ast.getParent().getType() != TokenTypes.LITERAL_CATCH) {</span></pre></td></tr>"
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>               &#38;&#38; parent.getType() != TokenTypes.CTOR_DEF</span></pre></td></tr>"
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>            &#38;&#38; lastChild.getType() == TokenTypes.OBJBLOCK;</span></pre></td></tr>"
   "RequireThisCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (variableDeclarationFrame.getType() == FrameType.CLASS_FRAME) {</span></pre></td></tr>"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -551,8 +551,7 @@ public class RequireThisCheck extends AbstractCheck {
                 break;
             case TokenTypes.PARAMETER_DEF:
                 if (!CheckUtil.isReceiverParameter(ast)
-                        && !isLambdaParameter(ast)
-                        && ast.getParent().getType() != TokenTypes.LITERAL_CATCH) {
+                        && !isLambdaParameter(ast)) {
                     final DetailAST parameterIdent = ast.findFirstToken(TokenTypes.IDENT);
                     frame.addIdent(parameterIdent);
                 }
@@ -590,8 +589,6 @@ public class RequireThisCheck extends AbstractCheck {
                 break;
             case TokenTypes.LITERAL_CATCH:
                 final AbstractFrame catchFrame = new CatchFrame(frame, ast);
-                catchFrame.addIdent(ast.findFirstToken(TokenTypes.PARAMETER_DEF).findFirstToken(
-                        TokenTypes.IDENT));
                 frameStack.addFirst(catchFrame);
                 break;
             case TokenTypes.LITERAL_FOR:


### PR DESCRIPTION
#11720
Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11778

### Reports with hardcoded mutation (clean):

- DefaultConfig: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/b264150_2022061102/reports/diff/index.html
- validateOnlyOverlappingFalseWithoutOpenJDK: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/156cf72_2022113923/reports/diff/index.html

### This mutation falls in the category:

- Safely (no regressions) remove code to be covered

### Rationale:

Instead of `addIdent(..)` when visiting the `LITERAL_CATCH` token, we just add `catchFrame` to the `frameStack` and when we visit `PARAMETER_DEF` in the visitor pattern, we add that token, it will be added to `catchFrame` as it was the last frame added to the stack.

---
### Generating reports again:
Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/5dc88b466a50335d5759f60c1d041a239f11a5a1/my_checks.xml
Diff Regression projects: https://gist.githubusercontent.com/Vyom-Yadav/91807e6244cff60698d9e33e32ba2d51/raw/ccf3b6b9e053f27b371eb6d1e848d7199dd1f567/projects-to-test-on.properties
Report label: validateOnlyOverlappingFalseWithoutOpenJDK