### PR TITLE
infra: turns off create dependency reduced pom for shade plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2241,6 +2241,7 @@
                       </excludes>
                     </filter>
                   </filters>
+                  <createDependencyReducedPom>false</createDependencyReducedPom>
                   <shadedArtifactAttached>true</shadedArtifactAttached>
                   <shadedClassifierName>all</shadedClassifierName>
                   <transformers>


### PR DESCRIPTION
Bug identified at https://github.com/rnveach/checkstyle-backport-jre8/issues/8#issuecomment-1172031439
Details of why this is an issue and how it screwed the backport release process at https://github.com/rnveach/checkstyle-backport-jre8/issues/8#issuecomment-1172386376

Extra file is created in repo:
```
mvn package -Passembly
....
[INFO] --- maven-shade-plugin:3.3.0:shade (default) @ checkstyle ---
[INFO] Including info.picocli:picocli:jar:4.6.3 in the shaded jar.
......
[INFO] Including org.xmlresolver:xmlresolver:jar:data:4.2.0 in the shaded jar.
[INFO] Dependency-reduced POM written at:
    /home/rivanov/java/github/checkstyle/checkstyle/dependency-reduced-pom.xml
[WARNING] Saxon-HE-11.3.jar, antlr4-runtime-4.10.1.jar, checker-qual-3.12.0.jar, 
checkstyle-10.4-SNAPSHOT.jar, commons-beanutils-1.9.4.jar, commons-codec-1.11.jar,
 commons-collections-3.2.2.jar, commons-logging-1.2.jar, error_prone_annotations-2.11.0.jar, 
failureaccess-1.0.1.jar, guava-31.1-jre.jar, httpclient-4.5.13.jar, httpcore-4.4.13.jar,
 j2objc-annotations-1.3.jar, javassist-3.28.0-GA.jar, jsr305-3.0.2.jar,
 listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar, picocli-4.6.3.jar,
 reflections-0.10.2.jar, slf4j-api-1.7.32.jar, xmlresolver-4.2.0-data.jar, xmlresolver-4.2.0.jar
 define 1 overlapping resource: 
[WARNING]   - META-INF/MANIFEST.MF
[WARNING] httpclient-4.5.13.jar, httpcore-4.4.13.jar define 3 overlapping resources: 
[WARNING]   - META-INF/DEPENDENCIES
[WARNING]   - META-INF/LICENSE
[WARNING]   - META-INF/NOTICE
[WARNING] commons-beanutils-1.9.4.jar, commons-codec-1.11.jar, commons-collections-3.2.2.jar, 
commons-logging-1.2.jar define 1 overlapping resource: 
[WARNING]   - META-INF/NOTICE.txt
[WARNING] checker-qual-3.12.0.jar, commons-beanutils-1.9.4.jar, commons-codec-1.11.jar, 
commons-collections-3.2.2.jar, commons-logging-1.2.jar define 1 overlapping resource: 
[WARNING]   - META-INF/LICENSE.txt
[WARNING] maven-shade-plugin has detected that some class files are
[WARNING] present in two or more JARs. When this happens, only one
[WARNING] single version of the class is copied to the uber jar.
[WARNING] Usually this is not harmful and you can skip these warnings,
[WARNING] otherwise try to manually exclude artifacts based on
[WARNING] mvn dependency:tree -Ddetail=true and the above output.
[WARNING] See https://maven.apache.org/plugins/maven-shade-plugin/
[INFO] Attaching shaded artifact.
[INFO] 
[INFO] --- maven-assembly-plugin:3.3.0:single (make-bundle) @ checkstyle ---
.......
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  49.708 s
[INFO] Finished at: 2022-07-02T11:18:52-07:00
[INFO] ------------------------------------------------------------------------

✔ ~/java/github/checkstyle/checkstyle [master|…1] 
$ git status
On branch master
Your branch is up-to-date with 'origin/master'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	dependency-reduced-pom.xml

nothing added to commit but untracked files present (use "git add" to track)

```

attention to: `[INFO] Dependency-reduced POM written at: /home/rivanov/java/github/checkstyle/checkstyle/dependency-reduced-pom.xml`

there should be no extra  files.
https://maven.apache.org/plugins/maven-shade-plugin/shade-mojo.html#createDependencyReducedPom

**Issue:**
During backport's release of 10.2, tidy was failing and it could not be identified why. `MojoFailureException: The POM violates the code style. Please format it by running mvn tidy:pom.` We ended up skipping the process and continuing on with the releases. However, that would be a mistake as after releasing 10.3.1, it was determined backport users couldn't use checkstyle as they were getting a bad POM with no dependencies.

**Problem:**
After some digging, @nick-mancuso found the problem to be maven-shade. https://issues.apache.org/jira/browse/MSHADE-321 . `createDependencyReducedPom` wasn't being respected in maven-shade. Unbeknownst to us when they fixed it, maven-shade was actually putting the reduced pom as our deployed pom. The bug was fixed in 3.3.0 of maven-shade, and checkstyle upgraded maven-shade to 3.3.0 in 10.2 . Tidy was complaining as it was going against the reduced POM instead of the actual POM. So fixing maven-shade also fixed the tidy issue.

**Final:**
This is currently not a known issue in checkstyle's release. When doing `package -Passembly` in checkstyle, it is creating a `dependency-reduced-pom.xml` in the root folder of checkstyle. This change will atleast stop that random file being created during that goal, but this change is also being done to make to ensure it doesn't become an issue like in backport. We don't want the reduced POM now anyways so it is nothing we are missing.

Fix found by @nick-mancuso 