### PR TITLE
Issue #11446: Update CommentsIndentationCheckTest to use verifyWithInlineConfigParser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1830,9 +1830,6 @@
                 <!-- this class contain forbidden verify method -->
                 <exclude>**/AbstractModuleTestSupport.class</exclude>
 
-                <!-- test should be updated -->
-                <exclude>**/CommentsIndentationCheckTest.class</exclude>
-
                 <!-- test need to be updated -->
                 <exclude>**/SuppressionFilterTest.class</exclude>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheckTest.java
@@ -26,7 +26,6 @@ import static com.puppycrawl.tools.checkstyle.checks.indentation.CommentsIndenta
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
@@ -40,8 +39,6 @@ public class CommentsIndentationCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testCommentIsAtTheEndOfBlock() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(CommentsIndentationCheck.class);
         final String[] expected = {
             "25:26: " + getCheckMessage(MSG_KEY_SINGLE, 24, 25, 8),
             "40:6: " + getCheckMessage(MSG_KEY_SINGLE, 42, 5, 4),
@@ -70,65 +67,61 @@ public class CommentsIndentationCheckTest extends AbstractModuleTestSupport {
             "329:1: " + getCheckMessage(MSG_KEY_SINGLE, 330, 0, 4),
             "343:1: " + getCheckMessage(MSG_KEY_SINGLE, 340, 0, 8),
             "362:10: " + getCheckMessage(MSG_KEY_SINGLE, 359, 9, 8),
-            "387:13: " + getCheckMessage(MSG_KEY_BLOCK, 388, 12, 8),
-            "390:13: " + getCheckMessage(MSG_KEY_SINGLE, 388, 12, 8),
-            "400:13: " + getCheckMessage(MSG_KEY_SINGLE, 399, 12, 8),
-            "407:9: " + getCheckMessage(MSG_KEY_SINGLE, 408, 8, 10),
-            "464:1: " + getCheckMessage(MSG_KEY_SINGLE, 462, 0, 8),
-            "480:11: " + getCheckMessage(MSG_KEY_BLOCK, 476, 10, 8),
-            "490:11: " + getCheckMessage(MSG_KEY_BLOCK, 484, 10, 8),
-            "498:11: " + getCheckMessage(MSG_KEY_BLOCK, 494, 10, 8),
-            "506:11: " + getCheckMessage(MSG_KEY_BLOCK, 502, 10, 8),
-            "514:11: " + getCheckMessage(MSG_KEY_BLOCK, 510, 10, 8),
-            "525:11: " + getCheckMessage(MSG_KEY_SINGLE, 518, 10, 8),
-            "532:1: " + getCheckMessage(MSG_KEY_SINGLE, 529, 0, 8),
-            "539:1: " + getCheckMessage(MSG_KEY_SINGLE, 536, 0, 8),
-            "545:1: " + getCheckMessage(MSG_KEY_SINGLE, 543, 0, 8),
-            "553:5: " + getCheckMessage(MSG_KEY_SINGLE, 549, 4, 8),
-            "558:13: " + getCheckMessage(MSG_KEY_SINGLE, 557, 12, 8),
-            "564:1: " + getCheckMessage(MSG_KEY_SINGLE, 562, 0, 8),
-            "569:1: " + getCheckMessage(MSG_KEY_SINGLE, 568, 0, 8),
-            "584:1: " + getCheckMessage(MSG_KEY_SINGLE, 581, 0, 8),
-            "596:13: " + getCheckMessage(MSG_KEY_SINGLE, 594, 12, 8),
+            "388:13: " + getCheckMessage(MSG_KEY_BLOCK, 389, 12, 8),
+            "391:13: " + getCheckMessage(MSG_KEY_SINGLE, 389, 12, 8),
+            "401:13: " + getCheckMessage(MSG_KEY_SINGLE, 400, 12, 8),
+            "408:9: " + getCheckMessage(MSG_KEY_SINGLE, 409, 8, 10),
+            "465:1: " + getCheckMessage(MSG_KEY_SINGLE, 463, 0, 8),
+            "481:11: " + getCheckMessage(MSG_KEY_BLOCK, 477, 10, 8),
+            "491:11: " + getCheckMessage(MSG_KEY_BLOCK, 485, 10, 8),
+            "499:11: " + getCheckMessage(MSG_KEY_BLOCK, 495, 10, 8),
+            "507:11: " + getCheckMessage(MSG_KEY_BLOCK, 503, 10, 8),
+            "515:11: " + getCheckMessage(MSG_KEY_BLOCK, 511, 10, 8),
+            "526:11: " + getCheckMessage(MSG_KEY_SINGLE, 519, 10, 8),
+            "533:1: " + getCheckMessage(MSG_KEY_SINGLE, 530, 0, 8),
+            "540:1: " + getCheckMessage(MSG_KEY_SINGLE, 537, 0, 8),
+            "546:1: " + getCheckMessage(MSG_KEY_SINGLE, 544, 0, 8),
+            "554:5: " + getCheckMessage(MSG_KEY_SINGLE, 550, 4, 8),
+            "559:13: " + getCheckMessage(MSG_KEY_SINGLE, 558, 12, 8),
+            "565:1: " + getCheckMessage(MSG_KEY_SINGLE, 563, 0, 8),
+            "570:1: " + getCheckMessage(MSG_KEY_SINGLE, 569, 0, 8),
+            "585:1: " + getCheckMessage(MSG_KEY_SINGLE, 582, 0, 8),
+            "597:13: " + getCheckMessage(MSG_KEY_SINGLE, 595, 12, 8),
         };
         final String testInputFile = "InputCommentsIndentationCommentIsAtTheEndOfBlock.java";
-        verify(checkConfig, getPath(testInputFile), expected);
+        verifyWithInlineConfigParser(getPath(testInputFile), expected);
     }
 
     @Test
     public void testCommentIsInsideSwitchBlock() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(CommentsIndentationCheck.class);
         final String[] expected = {
-            "26:13: " + getCheckMessage(MSG_KEY_BLOCK, 27, 12, 16),
-            "32:20: " + getCheckMessage(MSG_KEY_SINGLE, "31, 33", 19, "16, 12"),
-            "38:20: " + getCheckMessage(MSG_KEY_SINGLE, "37, 39", 19, "16, 12"),
-            "55:7: " + getCheckMessage(MSG_KEY_SINGLE, 56, 6, 16),
-            "62:9: " + getCheckMessage(MSG_KEY_SINGLE, 63, 8, 12),
-            "66:23: " + getCheckMessage(MSG_KEY_SINGLE, 65, 22, 16),
-            "75:15: " + getCheckMessage(MSG_KEY_SINGLE, "72, 76", 14, "12, 16"),
-            "95:25: " + getCheckMessage(MSG_KEY_SINGLE, 96, 24, 20),
-            "120:16: " + getCheckMessage(MSG_KEY_SINGLE, "119, 121", 15, "17, 12"),
-            "132:9: " + getCheckMessage(MSG_KEY_SINGLE, 133, 8, 12),
-            "145:5: " + getCheckMessage(MSG_KEY_SINGLE, 146, 4, 8),
-            "164:19: " + getCheckMessage(MSG_KEY_SINGLE, "163, 165", 18, "16, 12"),
-            "207:5: " + getCheckMessage(MSG_KEY_SINGLE, "206, 208", 4, "12, 12"),
-            "210:23: " + getCheckMessage(MSG_KEY_SINGLE, "209, 213", 22, "16, 12"),
-            "211:21: " + getCheckMessage(MSG_KEY_SINGLE, "209, 213", 20, "16, 12"),
-            "212:18: " + getCheckMessage(MSG_KEY_SINGLE, "209, 213", 17, "16, 12"),
-            "236:7: " + getCheckMessage(MSG_KEY_SINGLE, "235, 237", 6, "12, 12"),
-            "283:12: " + getCheckMessage(MSG_KEY_BLOCK, "282, 286", 11, "16, 12"),
-            "288:12: " + getCheckMessage(MSG_KEY_SINGLE, "287, 289", 11, "16, 12"),
-            "318:1: " + getCheckMessage(MSG_KEY_SINGLE, "319", 0, "8"),
+            "27:13: " + getCheckMessage(MSG_KEY_BLOCK, 28, 12, 16),
+            "33:20: " + getCheckMessage(MSG_KEY_SINGLE, "32, 34", 19, "16, 12"),
+            "39:20: " + getCheckMessage(MSG_KEY_SINGLE, "38, 40", 19, "16, 12"),
+            "56:7: " + getCheckMessage(MSG_KEY_SINGLE, 57, 6, 16),
+            "63:9: " + getCheckMessage(MSG_KEY_SINGLE, 64, 8, 12),
+            "67:23: " + getCheckMessage(MSG_KEY_SINGLE, 66, 22, 16),
+            "76:15: " + getCheckMessage(MSG_KEY_SINGLE, "73, 77", 14, "12, 16"),
+            "96:25: " + getCheckMessage(MSG_KEY_SINGLE, 97, 24, 20),
+            "121:16: " + getCheckMessage(MSG_KEY_SINGLE, "120, 122", 15, "17, 12"),
+            "133:9: " + getCheckMessage(MSG_KEY_SINGLE, 134, 8, 12),
+            "146:5: " + getCheckMessage(MSG_KEY_SINGLE, 147, 4, 8),
+            "165:19: " + getCheckMessage(MSG_KEY_SINGLE, "164, 166", 18, "16, 12"),
+            "208:5: " + getCheckMessage(MSG_KEY_SINGLE, "207, 209", 4, "12, 12"),
+            "211:23: " + getCheckMessage(MSG_KEY_SINGLE, "210, 214", 22, "16, 12"),
+            "212:21: " + getCheckMessage(MSG_KEY_SINGLE, "210, 214", 20, "16, 12"),
+            "213:18: " + getCheckMessage(MSG_KEY_SINGLE, "210, 214", 17, "16, 12"),
+            "237:7: " + getCheckMessage(MSG_KEY_SINGLE, "236, 238", 6, "12, 12"),
+            "284:12: " + getCheckMessage(MSG_KEY_BLOCK, "283, 287", 11, "16, 12"),
+            "289:12: " + getCheckMessage(MSG_KEY_SINGLE, "288, 290", 11, "16, 12"),
+            "319:1: " + getCheckMessage(MSG_KEY_SINGLE, "320", 0, "8"),
         };
         final String testInputFile = "InputCommentsIndentationInSwitchBlock.java";
-        verify(checkConfig, getPath(testInputFile), expected);
+        verifyWithInlineConfigParser(getPath(testInputFile), expected);
     }
 
     @Test
     public void testCommentIsInsideEmptyBlock() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(CommentsIndentationCheck.class);
         final String[] expected = {
             "16:20: " + getCheckMessage(MSG_KEY_SINGLE, 19, 19, 31),
             "17:24: " + getCheckMessage(MSG_KEY_BLOCK, 19, 23, 31),
@@ -139,45 +132,38 @@ public class CommentsIndentationCheckTest extends AbstractModuleTestSupport {
             "114:1: " + getCheckMessage(MSG_KEY_SINGLE, 115, 0, 8),
         };
         final String testInputFile = "InputCommentsIndentationInEmptyBlock.java";
-        verify(checkConfig, getPath(testInputFile), expected);
+        verifyWithInlineConfigParser(getPath(testInputFile), expected);
     }
 
     @Test
     public void testSurroundingCode() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(CommentsIndentationCheck.class);
         final String[] expected = {
             "20:15: " + getCheckMessage(MSG_KEY_SINGLE, 21, 14, 12),
-            "30:17: " + getCheckMessage(MSG_KEY_BLOCK, 31, 16, 12),
-            "32:17: " + getCheckMessage(MSG_KEY_BLOCK, 34, 16, 12),
-            "35:17: " + getCheckMessage(MSG_KEY_BLOCK, 38, 16, 12),
-            "57:28: " + getCheckMessage(MSG_KEY_SINGLE, 60, 27, 36),
-            "58:24: " + getCheckMessage(MSG_KEY_BLOCK, 60, 23, 36),
-            "97:15: " + getCheckMessage(MSG_KEY_SINGLE, 98, 14, 8),
-            "105:14: " + getCheckMessage(MSG_KEY_SINGLE, 107, 13, 8),
-            "115:34: " + getCheckMessage(MSG_KEY_SINGLE, 116, 33, 8),
-            "137:13: " + getCheckMessage(MSG_KEY_BLOCK, 138, 12, 8),
-            "142:5: " + getCheckMessage(MSG_KEY_BLOCK, 143, 4, 8),
-            "148:5: " + getCheckMessage(MSG_KEY_BLOCK, 147, 4, 8),
+            "31:17: " + getCheckMessage(MSG_KEY_BLOCK, 32, 16, 12),
+            "33:17: " + getCheckMessage(MSG_KEY_BLOCK, 35, 16, 12),
+            "36:17: " + getCheckMessage(MSG_KEY_BLOCK, 39, 16, 12),
+            "58:28: " + getCheckMessage(MSG_KEY_SINGLE, 61, 27, 36),
+            "59:24: " + getCheckMessage(MSG_KEY_BLOCK, 61, 23, 36),
+            "98:15: " + getCheckMessage(MSG_KEY_SINGLE, 99, 14, 8),
+            "106:14: " + getCheckMessage(MSG_KEY_SINGLE, 108, 13, 8),
+            "116:34: " + getCheckMessage(MSG_KEY_SINGLE, 117, 33, 8),
+            "138:13: " + getCheckMessage(MSG_KEY_BLOCK, 139, 12, 8),
+            "144:5: " + getCheckMessage(MSG_KEY_BLOCK, 145, 4, 8),
+            "151:5: " + getCheckMessage(MSG_KEY_BLOCK, 149, 4, 8),
         };
         final String testInputFile = "InputCommentsIndentationSurroundingCode.java";
-        verify(checkConfig, getPath(testInputFile), expected);
+        verifyWithInlineConfigParser(getPath(testInputFile), expected);
     }
 
     @Test
     public void testNoNpeWhenBlockCommentEndsClassFile() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(CommentsIndentationCheck.class);
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         final String testInputFile = "InputCommentsIndentationNoNpe.java";
-        verify(checkConfig, getPath(testInputFile), expected);
+        verifyWithInlineConfigParser(getPath(testInputFile), expected);
     }
 
     @Test
     public void testCheckOnlySingleLineComments() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(CommentsIndentationCheck.class);
-        checkConfig.addProperty("tokens", "SINGLE_LINE_COMMENT");
         final String[] expected = {
             "20:15: " + getCheckMessage(MSG_KEY_SINGLE, 21, 14, 12),
             "57:28: " + getCheckMessage(MSG_KEY_SINGLE, 60, 27, 36),
@@ -186,25 +172,22 @@ public class CommentsIndentationCheckTest extends AbstractModuleTestSupport {
             "115:34: " + getCheckMessage(MSG_KEY_SINGLE, 116, 33, 8),
         };
         final String testInputFile = "InputCommentsIndentationSurroundingCode2.java";
-        verify(checkConfig, getPath(testInputFile), expected);
+        verifyWithInlineConfigParser(getPath(testInputFile), expected);
     }
 
     @Test
     public void testCheckOnlyBlockComments() throws Exception {
-        final DefaultConfiguration checkConfig =
-            createModuleConfig(CommentsIndentationCheck.class);
-        checkConfig.addProperty("tokens", "BLOCK_COMMENT_BEGIN");
         final String[] expected = {
             "30:17: " + getCheckMessage(MSG_KEY_BLOCK, 31, 16, 12),
             "32:17: " + getCheckMessage(MSG_KEY_BLOCK, 34, 16, 12),
             "35:17: " + getCheckMessage(MSG_KEY_BLOCK, 38, 16, 12),
-            "58:24: " + getCheckMessage(MSG_KEY_BLOCK, 60, 23, 36),
-            "137:13: " + getCheckMessage(MSG_KEY_BLOCK, 138, 12, 8),
-            "142:5: " + getCheckMessage(MSG_KEY_BLOCK, 143, 4, 8),
-            "148:5: " + getCheckMessage(MSG_KEY_BLOCK, 147, 4, 8),
+            "57:24: " + getCheckMessage(MSG_KEY_BLOCK, 59, 23, 36),
+            "133:13: " + getCheckMessage(MSG_KEY_BLOCK, 134, 12, 8),
+            "139:5: " + getCheckMessage(MSG_KEY_BLOCK, 140, 4, 8),
+            "146:5: " + getCheckMessage(MSG_KEY_BLOCK, 144, 4, 8),
         };
         final String testInputFile = "InputCommentsIndentationSurroundingCode3.java";
-        verify(checkConfig, getPath(testInputFile), expected);
+        verifyWithInlineConfigParser(getPath(testInputFile), expected);
     }
 
     @Test
@@ -227,20 +210,18 @@ public class CommentsIndentationCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testJavadoc() throws Exception {
-        final DefaultConfiguration checkConfig = createModuleConfig(CommentsIndentationCheck.class);
         final String[] expected = {
             "10:3: " + getCheckMessage(MSG_KEY_BLOCK, 13, 2, 0),
-            "15:1: " + getCheckMessage(MSG_KEY_BLOCK, 16, 0, 4),
-            "18:9: " + getCheckMessage(MSG_KEY_BLOCK, 21, 8, 4),
-            "24:11: " + getCheckMessage(MSG_KEY_BLOCK, 25, 10, 8),
+            "16:1: " + getCheckMessage(MSG_KEY_BLOCK, 17, 0, 4),
+            "19:9: " + getCheckMessage(MSG_KEY_BLOCK, 22, 8, 4),
+            "26:11: " + getCheckMessage(MSG_KEY_BLOCK, 27, 10, 8),
         };
         final String testInputFile = "InputCommentsIndentationJavadoc.java";
-        verify(checkConfig, getPath(testInputFile), expected);
+        verifyWithInlineConfigParser(getPath(testInputFile), expected);
     }
 
     @Test
     public void testMultiblockStructures() throws Exception {
-        final DefaultConfiguration checkConfig = createModuleConfig(CommentsIndentationCheck.class);
         final String[] expected = {
             "19:9: " + getCheckMessage(MSG_KEY_SINGLE, 18, 8, 12),
             "25:17: " + getCheckMessage(MSG_KEY_SINGLE, "24, 26", 16, "12, 8"),
@@ -262,12 +243,11 @@ public class CommentsIndentationCheckTest extends AbstractModuleTestSupport {
             "135:1: " + getCheckMessage(MSG_KEY_SINGLE, "134, 136", 0, "12, 8"),
         };
         final String testInputFile = "InputCommentsIndentationInMultiblockStructures.java";
-        verify(checkConfig, getPath(testInputFile), expected);
+        verifyWithInlineConfigParser(getPath(testInputFile), expected);
     }
 
     @Test
     public void testCommentsAfterAnnotation() throws Exception {
-        final DefaultConfiguration checkConfig = createModuleConfig(CommentsIndentationCheck.class);
         final String[] expected = {
             "21:5: " + getCheckMessage(MSG_KEY_SINGLE, 22, 4, 0),
             "25:9: " + getCheckMessage(MSG_KEY_SINGLE, 26, 8, 4),
@@ -276,55 +256,51 @@ public class CommentsIndentationCheckTest extends AbstractModuleTestSupport {
             "57:3: " + getCheckMessage(MSG_KEY_SINGLE, 58, 2, 4),
         };
         final String testInputFile = "InputCommentsIndentationAfterAnnotation.java";
-        verify(checkConfig, getPath(testInputFile), expected);
+        verifyWithInlineConfigParser(getPath(testInputFile), expected);
     }
 
     @Test
     public void testCommentsInSameMethodCallWithSameIndent() throws Exception {
-        final DefaultConfiguration checkConfig = createModuleConfig(CommentsIndentationCheck.class);
         final String[] expected = {
             "23:7: " + getCheckMessage(MSG_KEY_SINGLE, 24, 6, 4),
             "30:11: " + getCheckMessage(MSG_KEY_SINGLE, 31, 10, 4),
         };
-        verify(checkConfig,
-                getPath("InputCommentsIndentationWithInMethodCallWithSameIndent.java"),
-                expected);
+        verifyWithInlineConfigParser(
+            getPath("InputCommentsIndentationWithInMethodCallWithSameIndent.java"),
+            expected);
     }
 
     @Test
     public void testCommentIndentationWithEmoji() throws Exception {
-        final DefaultConfiguration checkConfig = createModuleConfig(CommentsIndentationCheck.class);
         final String[] expected = {
-            "7:9: " + getCheckMessage(MSG_KEY_SINGLE, 8, 8, 16),
-            "18:13: " + getCheckMessage(MSG_KEY_SINGLE, 17, 12, 8),
-            "20:9: " + getCheckMessage(MSG_KEY_SINGLE, 22, 8, 4),
-            "39:17: " + getCheckMessage(MSG_KEY_SINGLE, 38, 16, 24),
-            "63:13: " + getCheckMessage(MSG_KEY_SINGLE, 65, 12, 8),
-            "67:9: " + getCheckMessage(MSG_KEY_SINGLE, 66, 8, 12),
-            "81:13: " + getCheckMessage(MSG_KEY_SINGLE, 83, 12, 8),
-            "90:17: " + getCheckMessage(MSG_KEY_BLOCK, 91, 16, 12),
-            "92:17: " + getCheckMessage(MSG_KEY_BLOCK, 94, 16, 12),
-            "95:17: " + getCheckMessage(MSG_KEY_BLOCK, 108, 16, 12, 1),
+            "14:9: " + getCheckMessage(MSG_KEY_SINGLE, 15, 8, 16),
+            "25:13: " + getCheckMessage(MSG_KEY_SINGLE, 24, 12, 8),
+            "27:9: " + getCheckMessage(MSG_KEY_SINGLE, 29, 8, 4),
+            "46:17: " + getCheckMessage(MSG_KEY_SINGLE, 45, 16, 24),
+            "70:13: " + getCheckMessage(MSG_KEY_SINGLE, 72, 12, 8),
+            "74:9: " + getCheckMessage(MSG_KEY_SINGLE, 73, 8, 12),
+            "88:13: " + getCheckMessage(MSG_KEY_SINGLE, 90, 12, 8),
+            "98:17: " + getCheckMessage(MSG_KEY_BLOCK, 99, 16, 12),
+            "100:17: " + getCheckMessage(MSG_KEY_BLOCK, 102, 16, 12),
+            "103:17: " + getCheckMessage(MSG_KEY_BLOCK, 116, 16, 12, 1),
         };
-        verify(checkConfig,
-                getPath("InputCommentsIndentationCheckWithEmoji.java"),
-                expected);
+        verifyWithInlineConfigParser(
+            getPath("InputCommentsIndentationCheckWithEmoji.java"),
+            expected);
     }
 
     @Test
     public void testCommentsBlockCommentBeforePackage() throws Exception {
-        final DefaultConfiguration checkConfig = createModuleConfig(CommentsIndentationCheck.class);
         final String[] expected = {
             "8:1: " + getCheckMessage(MSG_KEY_BLOCK, 11, 0, 1),
         };
-        verify(checkConfig,
-                getPath("InputCommentsIndentationBlockCommentBeforePackage.java"),
-                expected);
+        verifyWithInlineConfigParser(
+            getPath("InputCommentsIndentationBlockCommentBeforePackage.java"),
+            expected);
     }
 
     @Test
     public void testCommentsAfterRecordsAndCompactCtors() throws Exception {
-        final DefaultConfiguration checkConfig = createModuleConfig(CommentsIndentationCheck.class);
         final String[] expected = {
             "15:17: " + getCheckMessage(MSG_KEY_SINGLE, 16, 16, 20),
             "28:1: " + getCheckMessage(MSG_KEY_SINGLE, 29, 0, 4),
@@ -332,20 +308,19 @@ public class CommentsIndentationCheckTest extends AbstractModuleTestSupport {
             "37:9: " + getCheckMessage(MSG_KEY_SINGLE, 40, 8, 5),
             "42:9: " + getCheckMessage(MSG_KEY_SINGLE, 40, 8, 5),
         };
-        verify(checkConfig,
+        verifyWithInlineConfigParser(
             getNonCompilablePath("InputCommentsIndentationRecordsAndCompactCtors.java"),
             expected);
     }
 
     @Test
     public void testCommentsAtTheEndOfMethodCall() throws Exception {
-        final DefaultConfiguration checkConfig = createModuleConfig(CommentsIndentationCheck.class);
         final String[] expected = {
             "24:16: " + getCheckMessage(MSG_KEY_SINGLE, 20, 15, 8),
         };
-        verify(checkConfig,
-                getPath("InputCommentsIndentationCommentsAfterMethodCall.java"),
-                expected);
+        verifyWithInlineConfigParser(
+            getPath("InputCommentsIndentationCommentsAfterMethodCall.java"),
+            expected);
     }
 
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationRecordsAndCompactCtors.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationRecordsAndCompactCtors.java
@@ -12,7 +12,7 @@ public class InputCommentsIndentationRecordsAndCompactCtors {
     public record MyRecord(int x) {
         public void myMethod() {
             String breaks = "J"
-                // violation
+                // violation '.* incorrect .* level 16, expected is 20, .* same .* as line 16.'
                     + "A"
                     // it is OK
                     + "V"
@@ -25,19 +25,19 @@ public class InputCommentsIndentationRecordsAndCompactCtors {
     public record MyOtherRecord() {
 // comment
 //  block
-// violation
+// violation '.* incorrect .* level 0, expected is 4, .* same .* as line 29.'
     }
 
-        ///////////// violation
+        ///////////// violation '.* incorrect .* level 8, expected is 4, .* same .* as line 32.'
     public record myOtherOtherRecord() {
 
     }
      class
         WrappedClass { }
-        // violation
+        // violation '.* incorrect .* level 8, expected is 5, .* same .* as line 40.'
 
 
      record
         WrappedRecord() { }
-        // violation
+        // violation '.* incorrect .* level 8, expected is 5, .* same .* as line 40.'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationAfterAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationAfterAnnotation.java
@@ -18,11 +18,11 @@ public class InputCommentsIndentationAfterAnnotation {
 }
 
 @AfterAnnotationCommentsAnnotation1
-    // violation
+    // violation '.* incorrect .* level 4, expected is 0, .* same .* as line 22.'
 class InputCommentsIndentationAfterAnnotation1 {
 
     @AfterAnnotationCommentsAnnotation1
-        // violation
+        // violation '.* incorrect .* level 8, expected is 4, .* same .* as line 26.'
     public int input;
 
 }
@@ -40,12 +40,12 @@ class InputCommentsIndentationAfterAnnotation3 {
 }
 
 @AfterAnnotationCommentsAnnotation1
-    // violation
+    // violation '.* incorrect .* level 4, expected is 0, .* same .* as line 44.'
 @AfterAnnotationCommentsAnnotation2
 class InputCommentsIndentationAfterAnnotation4 {
 
     @AfterAnnotationCommentsAnnotation1
-        // violation
+        // violation '.* incorrect .* level 8, expected is 4, .* same .* as line 49.'
     @AfterAnnotationCommentsAnnotation2
     public int input;
 
@@ -54,7 +54,7 @@ class InputCommentsIndentationAfterAnnotation4 {
 class InputCommentsIndentationAfterAnnotation5 {
 
     @AfterAnnotationCommentsAnnotation1
-  // violation
+  // violation '.* incorrect .* level 2, expected is 4, .* same .* as line 58.'
     @AfterAnnotationCommentsAnnotation2
     public int input;
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationBlockCommentBeforePackage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationBlockCommentBeforePackage.java
@@ -5,7 +5,7 @@ tokens = (default)SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN
 
 */
 
-/* // violation
+/* // violation '.* incorrect .* level 0, expected is 1, .* same .* as line 11.'
  * Some comment here.
  */
  package com.puppycrawl.tools.checkstyle.checks.indentation.commentsindentation;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationCheckWithEmoji.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationCheckWithEmoji.java
@@ -1,3 +1,10 @@
+/*
+CommentsIndentation
+tokens = (default)SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN
+
+
+*/
+
 package com.puppycrawl.tools.checkstyle.checks.indentation.commentsindentation;
 
 public class InputCommentsIndentationCheckWithEmoji {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationCheckWithEmoji.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationCheckWithEmoji.java
@@ -4,7 +4,7 @@ public class InputCommentsIndentationCheckWithEmoji {
 
     public void myMethod() {
         String breaks = "J"
-        // warn 'Indentation should be the same level as line 8' 👇🏻
+        // violation '.* incorrect .* level 8, expected is 16, .* same .* as line 15.'
                 + "🥳"
                 // it is OK 👍
                 + "🥳VASd🥳"
@@ -15,9 +15,9 @@ public class InputCommentsIndentationCheckWithEmoji {
 
     public void test() {
         String a = "🥳";
-            // warn 'Indentation should be the same level as line 17' 👆
+            // violation '.* incorrect .* level 12, expected is 8, .* same .* as line 24.'
     }
-        // warn 'Indentation should be the same level as line 22' 👇🏻
+        // violation '.* incorrect .* level 8, expected is 4, .* same .* as line 29.'
 
     String s = String.format(java.util.Locale.ENGLISH, " 🥳 🥳 🥳asdda   🥳"
                     + "🎄" + "🎄  🎄🎄       ",
@@ -36,7 +36,7 @@ public class InputCommentsIndentationCheckWithEmoji {
                 // 👈🏻 comment
             default: a = "🎄".
                         toString();
-                // warn 'Indentation should be the same level as line 38' 🧐
+                // violation '.* incorrect .* level 16, expected is 24, .* same .* as line 45.'
         }
     }
 
@@ -60,11 +60,11 @@ public class InputCommentsIndentationCheckWithEmoji {
                 .toLowerCase()
                 // comment 👆🏻
                 .charAt(0);
-            // warn 'Indentation should be the same level as line 65' 👈🏻
+            // violation '.* incorrect .* level 12, expected is 8, .* same .* as line 72.'
 
         try {
             assert a.equals("🎄") == true;
-        // warn 'Indentation should be the same level as line 66' 👉🏻
+        // violation '.* incorrect .* level 8, expected is 12, .* same .* as line 73.'
         }
         catch (Exception ex) {
 
@@ -78,7 +78,7 @@ public class InputCommentsIndentationCheckWithEmoji {
             // comment
             // ... 🧐
             // block
-            // warn 🤔 'Indentation should be the same level as line 83'
+            // violation '.* incorrect .* level 12, expected is 8, .* same .* as line 90.'
         // comment
         String someStr = "🎄🎄😅";
     }
@@ -87,12 +87,13 @@ public class InputCommentsIndentationCheckWithEmoji {
         if (true) {
             /* some 👌🏻 */
             String k = "🎄🎄😅";
-                /* warn 'Indentation should be the same level as line 91' 👎🏻*/
+            // violation below '.* incorrect .* level 16, expected is 12,.* same .* as line 99.'
+                /* hello there some comment with emoji 👌 */
             int b = Integer.parseInt("🎄🎄😅");
-                /* warn 😏 'Indentation should be the same level as line 94'
+                /* // violation '.* incorrect .* level 16, expected is 12, .* same .* as line 102.'
                 * */
             double d; /* trailing comment */
-                /* warn 'Indentation should be the same level as line 108'
+                /* // violation '.* incorrect .* level 16, expected is 12, .* same .* as line 116.'
              *🎄
                 */
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationCommentIsAtTheEndOfBlock.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationCommentIsAtTheEndOfBlock.java
@@ -22,7 +22,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 
     public void foo2() {
         foo3();
-                         // violation
+                         // violation '.* incorrect .* level 25, expected is 8,.*same.*as line 24.'
     }
 
     public void foo3() {
@@ -36,12 +36,12 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
     }
 
     public void foooooooooooooooooooooooooooooooooooooooooo() { }
-
-     /////////////////////////////// violation (a single-line border to separate a group of methods)
+    // violation below '.* incorrect .* level 5, expected is 4, .* same .* as line 42.'
+     /////////////////////////////// (a single-line border to separate a group of methods)
 
     public void foo7() {
         int a = 0;
-// violation
+// violation '.* incorrect .* level 0, expected is 8, .* same .* as line 43.'
     }
 
     /////////////////////////////// (a single-line border to separate a group of methods)
@@ -51,14 +51,14 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
     public class TestClass {
         public void test() {
             int a = 0;
-               // violation
+               // violation '.* incorrect .* level 15, expected is 12, .* same .* as line 53.'
         }
-          // violation
+          // violation '.* incorrect .* level 10, expected is 8, .* same .* as line 52.'
     }
 
     public void foo9() {
         this.foo1();
-             // violation
+             // violation '.* incorrect .* level 13, expected is 8, .* same .* as line 60.'
     }
 
     //    public void foo10() {
@@ -78,7 +78,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
             .valueOf(new Integer(0))
             .trim()
             .length();
-                  // violation
+                  // violation '.* incorrect .* level 18, expected is 8, .* same .* as line 77.'
     }
 
     public void foo13() {
@@ -92,7 +92,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
         String.valueOf(new Integer(0))
             .trim()
             .length();
-                               // violation
+                               // violation '.* incorrect .* level 31, expected is 8,.*as line 92.'
     }
 
     public void foo15() {
@@ -104,7 +104,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
     public void foo16() {
         String
             .valueOf(new Integer(0));
-                     // violation
+                     // violation '.* incorrect .* level 21, expected is 8,.* same .* as line 105.'
     }
 
     public void foo17() {
@@ -119,7 +119,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
         String
             .valueOf(new Integer(0))
             .trim()
-                             // violation
+                             // violation '.* incorrect .* level 29, expected is 12,.*as line 123.'
             .length();
     }
 
@@ -142,7 +142,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
             }
         })).
             run();
-                          // violation
+                          // violation '.* incorrect .* level 26, expected is 8, .* as line 138.'
     }
 
     public void foo21() {
@@ -168,7 +168,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
         String s = String.format(java.util.Locale.ENGLISH, "The array element "
                 + "immediately following the end of the collection should be nulled",
             array[1]);
-                                 // violation
+                                 // violation '.*incorrect.*level 33, expected is 8,.*as line 168.'
     }
 
     public void foo23() {
@@ -178,7 +178,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 
     public void foo24() {
         new Object();
-                     // violation
+                     // violation '.* incorrect .* level 21, expected is 8,.* same .* as line 180.'
     }
 
     public String foo25() {
@@ -190,7 +190,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
     public String foo26() {
         return String.format(java.util.Locale.ENGLISH, "%d",
             1);
-                                  // violation
+                                  // violation '.*incorrect.*level 34, expected is 8,.*as line 191.'
     }
 
     public void foo27() {
@@ -212,13 +212,13 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
         int a = 5;
         return String.format(java.util.Locale.ENGLISH, "%d",
             1);
-                          // violation
+                          // violation '.* incorrect .* level 26, expected is 8, .* as line 213.'
     }
 
     public void foo30() {
         // comment
         int a = 5;
-//        violation
+//        violation '.* incorrect .* level 0, expected is 8, .* same .* as line 220.'
     }
 
     public void foo31() {
@@ -232,13 +232,13 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
         String s = new String ("A"
             + "B"
             + "C");
-            // violation
+            // violation '.* incorrect .* level 12, expected is 8, .* same .* as line 232.'
     }
 
     public void foo33() {
         // comment
         this.foo22();
-//        violation
+//        violation '.* incorrect .* level 0, expected is 8, .* same .* as line 240.'
     }
 
     public void foo34() throws Exception {
@@ -252,14 +252,14 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
         throw new Exception("",
             new Exception()
         );
-            // violation
+            // violation '.* incorrect .* level 12, expected is 8, .* same .* as line 252.'
     }
 
     public void foo36() throws Exception {
         throw new Exception("",
             new Exception()
         );
-// violation
+// violation '.* incorrect .* level 0, expected is 8, .* same .* as line 259.'
     }
 
     public void foo37() throws Exception {
@@ -269,19 +269,19 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 
     public void foo38() throws Exception {
         throw new Exception("", new Exception());
-              // violation
+              // violation '.* incorrect .* level 14, expected is 8, .* same .* as line 271.'
     }
 
     public void foo39() throws Exception {
         throw new Exception("",
             new Exception());
-         // violation
+         // violation '.* incorrect .* level 9, expected is 8, .* same .* as line 276.'
     }
 
     public void foo40() throws Exception {
         int a = 88;
         throw new Exception("", new Exception());
-         // violation
+         // violation '.* incorrect .* level 9, expected is 8, .* same .* as line 283.'
     }
 
     public void foo41() throws Exception {
@@ -320,13 +320,13 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
         int ar = 5;
         // comment
         ar = 6;
-         // violation
+         // violation '.* incorrect .* level 9, expected is 8, .* same .* as line 322.'
     }
 
     public void foo46() {
 // comment
 // block
-// violation
+// violation '.* incorrect .* level 0, expected is 4, .* same .* as line 330.'
     }
 
     public void foo47() {
@@ -340,7 +340,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
         int a = 5;
 // comment
 // block
-// violation
+// violation '.* incorrect .* level 0, expected is 8, .* same .* as line 340.'
     }
 
     public void foo49() {
@@ -359,7 +359,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
         return String
             .valueOf("11"
             );
-         // violation
+         // violation '.* incorrect .* level 9, expected is 8, .* same .* as line 359.'
     }
 
     public String foo52() {
@@ -384,10 +384,11 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
     }
 
     void foo55() {
+        // violation below '.* incorrect .* level 12, expected is 8, .* same .* as line 389.'
             /* violation */
         new Object()
             .toString();
-            // violation
+            // violation '.* incorrect .* level 12, expected is 8, .* same .* as line 389.'
     }
 
     void foo56() {
@@ -397,14 +398,14 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
 
     void foo57() {
         new Object().toString();
-            // violation
+            // violation '.* incorrect .* level 12, expected is 8, .* same .* as line 400.'
     }
 
     void foo58() {
         /*
            comment
            */
-        // violation
+        // violation '.* incorrect .* level 8, expected is 10, .* same .* as line 409.'
           foo1();
           // comment
     }
@@ -461,7 +462,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
     void foo64()  {
         foo1();
 
-//  violation
+//  violation '.* incorrect .* level 0, expected is 8, .* same .* as line 463.'
     }
 
     void foo65() {
@@ -476,7 +477,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
         if (true) {
             getClass();
         }
-
+        // violation below '.* incorrect .* level 10, expected is 8, .* same .* as line 477.'
           /* violation */
     }
 
@@ -486,7 +487,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
         } finally {
             hashCode();
         }
-
+        // violation below '.* incorrect .* level 10, expected is 8, .* same .* as line 485.'
           /* violation */
     }
 
@@ -494,7 +495,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
         for (int i = 0; i < 0; i++) {
             getClass();
         }
-
+        // violation below '.* incorrect .* level 10, expected is 8, .* same .* as line 495.'
           /* violation */
     }
 
@@ -502,7 +503,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
         while (true) {
             getClass();
         }
-
+        // violation below '.* incorrect .* level 10, expected is 8, .* same .* as line 503.'
           /* violation */
     }
 
@@ -510,7 +511,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
         do {
             getClass();
         } while (true);
-
+        // violation below '.* incorrect .* level 10, expected is 8, .* same .* as line 511.'
           /* violation */
     }
 
@@ -522,27 +523,27 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
                 break;
         }
 
-          // violation
+          // violation '.* incorrect .* level 10, expected is 8, .* same .* as line 519.'
     }
 
     void foo72() {
         int u = 1;
 
 /* comment */
-// violation
+// violation '.* incorrect .* level 0, expected is 8, .* same .* as line 530.'
     }
 
     void foo73() {
         class Foo { }
 
 /* comment */
-// violation
+// violation '.* incorrect .* level 0, expected is 8, .* same .* as line 537.'
     }
 
     interface Bar1 {
         interface NestedBar { }
 
-// violation
+// violation '.* incorrect .* level 0, expected is 8, .* same .* as line 544.'
     }
 
     static class Bar2 {
@@ -550,23 +551,23 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
             A;
         }
 
-    // violation
+    // violation '.* incorrect .* level 4, expected is 8, .* same .* as line 550.'
     }
 
     static class Bar3 {
         @interface Foo { }
-            // violation
+            // violation '.* incorrect .* level 12, expected is 8, .* same .* as line 558.'
     }
 
     void foo74() {
         getClass(); // comment
 // comment
-// comment
+// violation '.* incorrect .* level 0, expected is 8, .* same .* as line 563.'
     }
 
     void foo75() {
         getClass();
-// comment
+// violation '.* incorrect .* level 0, expected is 8, .* same .* as line 569.'
         // comment
     }
 
@@ -581,7 +582,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
         return 0;
         /* test
 * test */
-//         test
+//         violation '.* incorrect .* level 0, expected is 8, .* same .* as line 582.'
     }
 
     void foo77() {
@@ -593,7 +594,7 @@ public class InputCommentsIndentationCommentIsAtTheEndOfBlock {
         /* violation */
         new Object()
             .toString();
-            // violation
+            // violation '.* incorrect .* level 12, expected is 8, .* same .* as line 595.'
     }
     void foo79() {
         /* violation */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationCommentsAfterMethodCall.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationCommentsAfterMethodCall.java
@@ -21,7 +21,7 @@ public class InputCommentsIndentationCommentsAfterMethodCall {
                 // ok
                 .flatMap()
                 .flatMap();
-               // violation
+               // violation '.* incorrect .* level 15, expected is 8, .* same .* as line 20.'
     }
     public static InputCommentsIndentationCommentsAfterMethodCall flatMap(int i, int h) {
         return new InputCommentsIndentationCommentsAfterMethodCall();

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationInEmptyBlock.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationInEmptyBlock.java
@@ -13,8 +13,8 @@ public class InputCommentsIndentationInEmptyBlock {
         int a = 5, b = 3, v = 6;
         if (a == b
             && v == b || ( a ==1
-                   /// violation
-                       /* violation
+                   /// violation '.* incorrect .* level 19, expected is 31, .* same .* as line 19.'
+                       /* // violation '.* incorrect .* level 23, expected is 31, .* as line 19.'
                         * one fine day ... */
                                && b == 1)   ) {
             // Cannot clearly detect user intention of explanation target.
@@ -37,7 +37,7 @@ public class InputCommentsIndentationInEmptyBlock {
         if (a == b
             && v == b || (a == 1
             && b == 1)) {
-// violation
+// violation '.* incorrect .* level 0, expected is 8, .* same .* as line 41.'
         }
     }
 
@@ -61,7 +61,7 @@ public class InputCommentsIndentationInEmptyBlock {
     private static void foo5() { // trailing
         if (true) // trailing comment
         {
-// violation
+// violation '.* incorrect .* level 0, expected is 8, .* same .* as line 65.'
         }
         if (true) { // trailing comment
 
@@ -75,7 +75,7 @@ public class InputCommentsIndentationInEmptyBlock {
         try {
 
         } catch (Exception e) {
-// violation
+// violation '.* incorrect .* level 0, expected is 8, .* same .* as line 79.'
         }
     }
 
@@ -107,11 +107,11 @@ public class InputCommentsIndentationInEmptyBlock {
         // comment
         };
         String[] array4 = {
-// violation
+// violation '.* incorrect .* level 0, expected is 8, .* same .* as line 111.'
         };
         String[] array5 = {
 
-// violation
+// violation '.* incorrect .* level 0, expected is 8, .* same .* as line 115.'
         };
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationInMultiblockStructures.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationInMultiblockStructures.java
@@ -16,18 +16,18 @@ public class InputCommentsIndentationInMultiblockStructures {
 
         if (true) {
             assert true;
-        // violation
+        // violation '.* incorrect .* level 8, expected is 12, .* same .* as line 18.'
         }
         else {}
 
         if (true) {
             assert true;
-                // violation
+                // violation '.* incorrect .* level 16, expected is 12, 8,.*same .* as line 24, 26.'
         } else {}
 
         if (true) {
             assert true;
-// violation
+// violation '.* incorrect .* level 0, expected is 12, 8, .* same .* as line 29, 31.'
         } else {}
 
         try {
@@ -37,18 +37,18 @@ public class InputCommentsIndentationInMultiblockStructures {
 
         try {
             assert true;
-        // violation
+        // violation '.* incorrect .* level 8, expected is 12, .* same .* as line 39.'
         }
         catch (Exception ex) {}
 
         try {
             assert true;
-// violation
+// violation '.* incorrect .* level 0, expected is 12, 8, .* same .* as line 45, 47.'
         } catch (Exception ex) {}
 
         try {
             assert true;
-                // violation
+                // violation '.* incorrect .* level 16, expected is 12, 8,.* same.* as line 50, 52.'
         } catch (Exception ex) {}
 
         try {
@@ -58,18 +58,18 @@ public class InputCommentsIndentationInMultiblockStructures {
 
         try {
             assert true;
-        // violation
+        // violation '.* incorrect .* level 8, expected is 12, .* same .* as line 60.'
         }
         finally {}
 
         try {
             assert true;
-// violation
+// violation '.* incorrect .* level 0, expected is 12, 8, .* same .* as line 66, 68.'
         } finally {}
 
         try {
             assert true;
-                // violation
+                // violation '.* incorrect .* level 16, expected is 12, 8,.* same.* as line 71, 73.'
         } finally {}
 
         try {} catch (Exception ex) {
@@ -79,18 +79,18 @@ public class InputCommentsIndentationInMultiblockStructures {
 
         try {} catch (Exception ex) {
             assert true;
-        // violation
+        // violation '.* incorrect .* level 8, expected is 12, .* same .* as line 81.'
         }
         finally {}
 
         try {} catch (Exception ex) {
             assert true;
-// violation
+// violation '.* incorrect .* level 0, expected is 12, 8, .* same .* as line 87, 89.'
         } finally {}
 
         try {} catch (Exception ex) {
             assert true;
-                // violation
+                // violation '.* incorrect .* level 16, expected is 12, 8,.*same.* as line 92, 94.'
         } finally {}
 
         try {} catch (ClassCastException ex) {
@@ -100,18 +100,18 @@ public class InputCommentsIndentationInMultiblockStructures {
 
         try {} catch (ClassCastException ex) {
             assert true;
-        // violation
+        // violation '.* incorrect .* level 8, expected is 12, .* same .* as line 102.'
         }
         catch (Exception ex) {}
 
         try {} catch (ClassCastException ex) {
             assert true;
-// violation
+// violation '.* incorrect .* level 0, expected is 12, 8, .* same .* as line 108, 110.'
         } catch (Exception ex) {}
 
         try {} catch (ClassCastException ex) {
             assert true;
-                // violation
+                // violation '.* incorrect .* level 16, expected is 12, 8,.*same.*as line 113, 115.'
         } catch (Exception ex) {}
 
         do {
@@ -121,18 +121,18 @@ public class InputCommentsIndentationInMultiblockStructures {
 
         do {
             assert true;
-        // violation
+        // violation '.* incorrect .* level 8, expected is 12, .* same .* as line 123.'
         }
         while (false);
 
         do {
             assert true;
-                // violation
+                // violation '.* incorrect .* level 16, expected is 12, 8,.*same.*as line 129, 131.'
         } while (false);
 
         do {
             assert true;
-// violation
+// violation '.* incorrect .* level 0, expected is 12, 8, .* same .* as line 134, 136.'
         } while (false);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationInSwitchBlock.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationInSwitchBlock.java
@@ -23,19 +23,20 @@ public class InputCommentsIndentationInSwitchBlock {
                 // comment
                 break;
             case "3":
+                // violation below '.* incorrect .* level 12, expected is 16,.* same.* as line 28.'
             /* violation */
                 foo1();
                 /* com */
                 break;
             case "5":
                 foo1();
-                   // violation
+                   // violation '.* incorrect .* level 19, expected is 16, 12, .* as line 32, 34.'
             case "6":
                 int k = 7;
                 // fall through
             case "7":
                 if (true) {}
-                   // violation
+                   // violation '.* incorrect .* level 19, expected is 16, 12, .* as line 38, 40.'
             case "8":
                 break;
             case "9":
@@ -52,18 +53,18 @@ public class InputCommentsIndentationInSwitchBlock {
                 // fall through
             }
             case "12": {
-      // violation
+      // violation '.* incorrect .* level 6, expected is 16, .* same .* as line 57.'
                 int i;
             }
             case "13": {
                        // some comment in empty case block
             }
             case "14": {
-        // OOOO: violation
+        // violation '.* incorrect .* level 8, expected is 12, .* same .* as line 64.'
             }
             case "15": {
                 foo1();
-                      // violation
+                      // violation '.* incorrect .* level 22, expected is 16,.* same.* as line 66.'
             }
             case "16": {
                 int a;
@@ -72,7 +73,7 @@ public class InputCommentsIndentationInSwitchBlock {
             case "17": {
                 int a;
             }
-              // violation
+              // violation '.* incorrect .* level 14, expected is 12, 16,.* same.* as line 73, 77.'
                 case "18": { System.lineSeparator();
                 }   // trailing comment
             case "19":
@@ -92,7 +93,7 @@ public class InputCommentsIndentationInSwitchBlock {
                 case 0:
 
                 case 1:
-                        // violation
+                        // violation '.* incorrect .* level 24, expected is 20,.*same.* as line 97.'
                     int b = 10;
                 default:
                  // comment
@@ -117,7 +118,7 @@ public class InputCommentsIndentationInSwitchBlock {
             case -1:
                  // what
                  s.indexOf("no way");
-               // violation
+               // violation '.* incorrect.*level 15, expected is 17, 12,.*same.* as line 120, 122.'
             case 1:
             case 2:
                 i--;
@@ -129,7 +130,7 @@ public class InputCommentsIndentationInSwitchBlock {
         }
 
         String breaks = ""
-        // violation
+        // violation '.* incorrect .* level 8, expected is 12, .* same .* as line 134.'
             + "</table>"
             // middle
             + ""
@@ -142,7 +143,7 @@ public class InputCommentsIndentationInSwitchBlock {
         switch (a) {
             case 1:
             default:
-    // violation
+    // violation '.* incorrect .* level 4, expected is 8, .* same .* as line 147.'
         }
     }
 
@@ -161,7 +162,7 @@ public class InputCommentsIndentationInSwitchBlock {
         switch (a) {
             case 1:
                 int b;
-                  // violation
+                  // violation '.* incorrect .* level 18, expected is 16, 12, .* as line 164, 166.'
             default:
         }
     }
@@ -204,12 +205,12 @@ public class InputCommentsIndentationInSwitchBlock {
                 // comment
                 // comment
             case 4:
-    // violation
+    // violation '.* incorrect .* level 4, expected is 12, 12, .* same .* as line 207, 209.'
             case 5:
                 s.toString().toString().toString();
-                      // violation
-                    // violation
-                 // violation
+                      // violation '.*incorrect.* level 22, expected is 16, 12,.*as line 210, 214.'
+                    // violation '.* incorrect .* level 20, expected is 16, 12,.*as line 210, 214.'
+                 // violation '.* incorrect .* level 17, expected is 16, 12, .* as line 210, 214.'
             default:
         }
     }
@@ -233,7 +234,7 @@ public class InputCommentsIndentationInSwitchBlock {
                 s.toString().toString().toString();
                 // comment
             case 4:
-      // violation
+      // violation '.* incorrect .* level 6, expected is 12, 12, .* same .* as line 236, 238.'
             default:
         }
     }
@@ -280,12 +281,12 @@ public class InputCommentsIndentationInSwitchBlock {
                 /* comment */
             case 2:
                 hashCode();
-           /*
+           /* // violation '.* incorrect .* level 11, expected is 16, 12, .* as line 283, 287.'
             violation
             */
             case 3: // comment
                 hashCode();
-           // violation
+           // violation '.* incorrect .* level 11, expected is 16, 12,.* same .* as line 288, 290.'
             case 4: // comment
                 if (true) {
 
@@ -315,7 +316,7 @@ public class InputCommentsIndentationInSwitchBlock {
         switch (a) {
             case 1:
             default:
-// violation
+// violation '.* incorrect .* level 0, expected is 8, .* same .* as line 320.'
         }
     }
 
@@ -324,7 +325,7 @@ public class InputCommentsIndentationInSwitchBlock {
         switch (a) {
             case 1:
             default:
-        // violation
+        // comment
         }
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationJavadoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationJavadoc.java
@@ -7,21 +7,23 @@ tokens = (default)SINGLE_LINE_COMMENT, BLOCK_COMMENT_BEGIN
 
 package com.puppycrawl.tools.checkstyle.checks.indentation.commentsindentation;
 
-  /**
-   * // violation
+  /** // violation '.* incorrect .* level 2, expected is 0, .* same .* as line 13.'
+   *
    */
 public class InputCommentsIndentationJavadoc {
 
-/** violation */
+// violation below '.* incorrect .* level 0, expected is 4, .* same .* as line 17.'
+/** some comment */
     int i;
 
-        /**
-         * // violation
+        /** // violation '.* incorrect .* level 8, expected is 4, .* same .* as line 22.'
+         *
          */
     void foo() {}
 
     enum Bar {
-          /** violation */
+        // violation below '.* incorrect .* level 10, expected is 8, .* same .* as line 27.'
+          /** some comment */
         A;
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationSurroundingCode.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationSurroundingCode.java
@@ -17,7 +17,7 @@ public class InputCommentsIndentationSurroundingCode
         if (true) {
             // here initialize some variables
             int k = 0; // trailing comment
-              // violation
+              // violation '.* incorrect .* level 14, expected is 12, .* same .* as line 21.'
             int b = 10;
             // sss
         }
@@ -27,12 +27,13 @@ public class InputCommentsIndentationSurroundingCode
         if (true) {
             /* some */
             int k = 0;
-                /* violation */
+            // violation below '.* incorrect .* level 16, expected is 12, .* same .* as line 32.'
+                /* some comment */
             int b = 10;
-                /* violation
+                /* // violation '.* incorrect .* level 16, expected is 12, .* same .* as line 35.'
                  * */
             double d; /* trailing comment */
-                /* violation
+                /* // violation '.* incorrect .* level 16, expected is 12, .* same .* as line 39.'
              *
                 */
             boolean bb;
@@ -54,8 +55,8 @@ public class InputCommentsIndentationSurroundingCode
         int a = 5, b = 3, v = 6;
         if (a == b
             && v == b || ( a ==1
-                           /// violation
-                       /* violation
+                           /// violation '.* incorrect .* level 27, expected is 36, .* as line 61.'
+                       /* // violation '.* incorrect .* level 23, expected is 36, .* as line 61.'
                         * one fine day ... */
                                     && b == 1)   ) {
         }
@@ -94,7 +95,7 @@ public class InputCommentsIndentationSurroundingCode
               // ...
               // block
               // ...
-              // violation
+              // violation '.* incorrect .* level 14, expected is 8, .* same .* as line 99.'
         String someStr = new String();
     }
 
@@ -102,7 +103,7 @@ public class InputCommentsIndentationSurroundingCode
              // comment
              // ...
              // block
-             // violation
+             // violation '.* incorrect .* level 13, expected is 8, .* same .* as line 108.'
         // comment
         String someStr = new String();
     }
@@ -112,7 +113,7 @@ public class InputCommentsIndentationSurroundingCode
                                  // ...
                                  // block
                                  // ...
-                                 // violation
+                                 // violation '.* incorrect.*level 33, expected is 8,.*as line 117.'
         String someStr = new String();
     }
 
@@ -133,18 +134,20 @@ public class InputCommentsIndentationSurroundingCode
     }
 
     public void foo11() {
-
+        // violation below '.* incorrect .* level 12, expected is 8, .* same .* as line 139.'
             /* empty */
         hashCode();
     }
 
     public void foo12() {
+        // violation below '.* incorrect .* level 4, expected is 8, .* same .* as line 145.'
     /* empty */
         hashCode();
     }
 
     public void foo13() {
         hashCode();
+        // violation below '.* incorrect .* level 4, expected is 8, .* same .* as line 149.'
     /* empty */
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationSurroundingCode2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationSurroundingCode2.java
@@ -17,7 +17,7 @@ public class InputCommentsIndentationSurroundingCode2
         if (true) {
             // here initialize some variables
             int k = 0; // trailing comment
-              // violation
+              // violation '.* incorrect .* level 14, expected is 12, .* same .* as line 21.'
             int b = 10;
             // sss
         }
@@ -54,7 +54,7 @@ public class InputCommentsIndentationSurroundingCode2
         int a = 5, b = 3, v = 6;
         if (a == b
             && v == b || ( a ==1
-                           /// violation
+                           /// violation '.* incorrect .* level 27, expected is 36, .* as line 60.'
                        /* violation
                         * one fine day ... */
                                     && b == 1)   ) {
@@ -94,7 +94,7 @@ public class InputCommentsIndentationSurroundingCode2
               // ...
               // block
               // ...
-              // violation
+              // violation '.* incorrect .* level 14, expected is 8, .* same .* as line 98.'
         String someStr = new String();
     }
 
@@ -102,7 +102,7 @@ public class InputCommentsIndentationSurroundingCode2
              // comment
              // ...
              // block
-             // violation
+             // violation '.* incorrect .* level 13, expected is 8, .* same .* as line 107.'
         // comment
         String someStr = new String();
     }
@@ -112,7 +112,7 @@ public class InputCommentsIndentationSurroundingCode2
                                  // ...
                                  // block
                                  // ...
-                                 // violation
+                                 // violation '.*incorrect.*level 33, expected is 8,.*as line 116.'
         String someStr = new String();
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationSurroundingCode3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationSurroundingCode3.java
@@ -17,7 +17,6 @@ public class InputCommentsIndentationSurroundingCode3
         if (true) {
             // here initialize some variables
             int k = 0; // trailing comment
-              // violation
             int b = 10;
             // sss
         }
@@ -27,12 +26,13 @@ public class InputCommentsIndentationSurroundingCode3
         if (true) {
             /* some */
             int k = 0;
-                /* violation */
+            // violation below '.* incorrect .* level 16, expected is 12, .* same .* as line 31.'
+                /* some comment */
             int b = 10;
-                /* violation
+                /* // violation '.* incorrect .* level 16, expected is 12, .* same .* as line 34.'
                  * */
             double d; /* trailing comment */
-                /* violation
+                /* // violation '.* incorrect .* level 16, expected is 12, .* same .* as line 38.'
              *
                 */
             boolean bb;
@@ -54,8 +54,7 @@ public class InputCommentsIndentationSurroundingCode3
         int a = 5, b = 3, v = 6;
         if (a == b
             && v == b || ( a ==1
-                           /// violation
-                       /* violation
+                       /* // violation '.* incorrect .* level 23, expected is 36, .* as line 59.'
                         * one fine day ... */
                                     && b == 1)   ) {
         }
@@ -94,7 +93,6 @@ public class InputCommentsIndentationSurroundingCode3
               // ...
               // block
               // ...
-              // violation
         String someStr = new String();
     }
 
@@ -102,7 +100,6 @@ public class InputCommentsIndentationSurroundingCode3
              // comment
              // ...
              // block
-             // violation
         // comment
         String someStr = new String();
     }
@@ -112,7 +109,6 @@ public class InputCommentsIndentationSurroundingCode3
                                  // ...
                                  // block
                                  // ...
-                                 // violation
         String someStr = new String();
     }
 
@@ -133,19 +129,21 @@ public class InputCommentsIndentationSurroundingCode3
     }
 
     public void foo11() {
-
-            /* empty */
+        // violation below '.* incorrect .* level 12, expected is 8, .* same .* as line 134.'
+            /* some comment */
         hashCode();
     }
 
     public void foo12() {
-    /* empty */
+        // violation below '.* incorrect .* level 4, expected is 8, .* same .* as line 140.'
+    /* some comment */
         hashCode();
     }
 
     public void foo13() {
         hashCode();
-    /* empty */
+        // violation below '.* incorrect .* level 4, expected is 8, .* same .* as line 144.'
+    /* some comment */
     }
 
     public void foo14() {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationWithInMethodCallWithSameIndent.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/commentsindentation/InputCommentsIndentationWithInMethodCallWithSameIndent.java
@@ -20,14 +20,14 @@ public class InputCommentsIndentationWithInMethodCallWithSameIndent {
         // Some comment here
         s1,
         s2
-      // violation
+      // violation '.* incorrect .* level 6, expected is 4, .* same .* as line 24.'
     );
 
     private final boolean isEqualsThree = equals(
         // Some comment here
         s1,
         s2
-          // violation
+          // violation '.* incorrect .* level 10, expected is 4, .* same .* as line 31.'
     );
 
     private boolean equals(String s1, String s2) {


### PR DESCRIPTION
Addresses #11214  
and #11446 
 
* Updates all `CommentsIndentationCheckTest` methods to use `verifyWithInlineConfigParser()`.
* Adds violation messages to all related `InputCommentsIndentation*.java` files.