### PR TITLE
infra: check GITHUB_READ_ONLY_TOKEN in tweet-releasenotes.sh

### DIFF
--- a/.ci/tweet-releasenotes.sh
+++ b/.ci/tweet-releasenotes.sh
@@ -16,6 +16,7 @@ checkForVariable "TWITTER_CONSUMER_SECRET"
 checkForVariable "TWITTER_ACCESS_TOKEN"
 checkForVariable "TWITTER_ACCESS_TOKEN_SECRET"
 checkForVariable "CS_RELEASE_VERSION"
+checkForVariable "GITHUB_READ_ONLY_TOKEN"
 
 checkout_from https://github.com/checkstyle/contribution
 
@@ -51,7 +52,7 @@ java -jar contribution/releasenotes-builder/target/releasenotes-builder-1.0-all.
      -localRepoPath checkstyle \
      -startRef "$LATEST_RELEASE_TAG" \
      -releaseNumber "$CS_RELEASE_VERSION" \
-     -githubAuthToken "$READ_ONLY_TOKEN" \
+     -githubAuthToken "$GITHUB_READ_ONLY_TOKEN" \
      -twitterTemplate $BUILDER_RESOURCE_DIR/templates/twitter.template \
      -generateTwit \
      -twitterConsumerKey "$TWITTER_CONSUMER_KEY" \


### PR DESCRIPTION
tested:
```
 $ source ~/.m2/export-cs-release-vars.sh
✔ ~/java/github/romani/checkstyle [Rahulkhinchi03/setting-2 L|✚ 1] 
$ export CS_RELEASE_VERSION="10.3.1" && ./.ci/tweet-releasenotes.sh
fatal: destination path 'contribution' already exists and is not an empty directory.
^C
✘-INT ~/java/github/romani/checkstyle [Rahulkhinchi03/setting-2 L|✚ 1] 
$ rm -rf .ci-temp/
✔ ~/java/github/romani/checkstyle [Rahulkhinchi03/setting-2 L|✚ 1] 
$ export CS_RELEASE_VERSION="10.3.1" && ./.ci/tweet-releasenotes.sh

....
CS_RELEASE_VERSION=10.4-SNAPSHOT
LATEST_RELEASE_TAG="checkstyle-10.3.1"

[WARN] Issue .....

Execution succeeded!
```