### PR TITLE
Issue #11720: Kill surviving mutation in OneStatementPerLineCheck leaveToken

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -170,13 +170,4 @@
     <description>removed conditional - replaced equality check with true</description>
     <lineContent>multiline = !TokenUtil.areOnSameLine(prevSibling, ast)</lineContent>
   </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>OneStatementPerLineCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck</mutatedClass>
-    <mutatedMethod>leaveToken</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (countOfSemiInLambda.isEmpty()) {</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/.ci/pitest-survival-check-html.sh
+++ b/.ci/pitest-survival-check-html.sh
@@ -183,7 +183,6 @@ pitest-coding-2)
   "IllegalInstantiationCheck.java.html:<td class='covered'><pre><span  class='survived'>            &#38;&#38; illegal.startsWith(JAVA_LANG)) {</span></pre></td></tr>"
   "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>                        &#38;&#38; currentStatement.getPreviousSibling().getType() == TokenTypes.RESOURCES;</span></pre></td></tr>"
   "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>                currentStatement.getPreviousSibling() != null</span></pre></td></tr>"
-  "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>                if (countOfSemiInLambda.isEmpty()) {</span></pre></td></tr>"
   "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>            multiline = !TokenUtil.areOnSameLine(prevSibling, ast)</span></pre></td></tr>"
   "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (!hasResourcesPrevSibling &#38;&#38; isMultilineStatement(currentStatement)) {</span></pre></td></tr>"
   );

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLine.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLine.java
@@ -66,4 +66,17 @@ public class InputOneStatementPerLine {
 
   private static void good() {
   }
+
+  InputOneStatementPerLine method(foo a) {
+    foo obj = () -> {
+      method(() ->
+             {method(null);}).method(null); // ok
+    };
+    return this;
+  }
+
+  interface foo {
+    void method();
+  }
+
 }


### PR DESCRIPTION
#11720
Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11810

### Reports with hardcoded mutation:

- DefaultConfig: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/ed54487_2022191546/reports/diff/index.html
- treatTryResourcesAsStatementTrue: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/ed54487_2022202733/reports/diff/index.html
- treatTryResourcesAsStatementTrueDefaultProjects: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/ed54487_2022132649/reports/diff/index.html

### This mutation falls in the category:

- Nothing was found in the reports, the logic of the check was analyzed, and this test case was developed. (Now my brain works 10% more :) )