### PR TITLE
Issue #11720: Kill surviving mutations in OneStatementPerLineCheck

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -58,35 +58,8 @@
     <sourceFile>OneStatementPerLineCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck</mutatedClass>
     <mutatedMethod>checkIfSemicolonIsInDifferentLineThanPrevious</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
-    <description>removed conditional - replaced equality check with false</description>
-    <lineContent>&amp;&amp; currentStatement.getPreviousSibling().getType() == TokenTypes.RESOURCES;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>OneStatementPerLineCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck</mutatedClass>
-    <mutatedMethod>checkIfSemicolonIsInDifferentLineThanPrevious</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
-    <description>removed conditional - replaced equality check with false</description>
-    <lineContent>currentStatement.getPreviousSibling() != null</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>OneStatementPerLineCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck</mutatedClass>
-    <mutatedMethod>checkIfSemicolonIsInDifferentLineThanPrevious</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
     <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (!hasResourcesPrevSibling &amp;&amp; isMultilineStatement(currentStatement)) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>OneStatementPerLineCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck</mutatedClass>
-    <mutatedMethod>isMultilineStatement</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>multiline = !TokenUtil.areOnSameLine(prevSibling, ast)</lineContent>
+    <lineContent>|| previousSibling.getType() == TokenTypes.RESOURCES</lineContent>
   </mutation>
 </suppressedMutations>

--- a/.ci/pitest-survival-check-html.sh
+++ b/.ci/pitest-survival-check-html.sh
@@ -173,10 +173,7 @@ pitest-coding-2)
   "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>                &#38;&#38; firstChild.getType() == TokenTypes.IDENT) {</span></pre></td></tr>"
   "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (ignoreSetter &#38;&#38; ast.getType() == TokenTypes.PARAMETER_DEF) {</span></pre></td></tr>"
   "IllegalInstantiationCheck.java.html:<td class='covered'><pre><span  class='survived'>            &#38;&#38; illegal.startsWith(JAVA_LANG)) {</span></pre></td></tr>"
-  "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>                        &#38;&#38; currentStatement.getPreviousSibling().getType() == TokenTypes.RESOURCES;</span></pre></td></tr>"
-  "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>                currentStatement.getPreviousSibling() != null</span></pre></td></tr>"
-  "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>            multiline = !TokenUtil.areOnSameLine(prevSibling, ast)</span></pre></td></tr>"
-  "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (!hasResourcesPrevSibling &#38;&#38; isMultilineStatement(currentStatement)) {</span></pre></td></tr>"
+  "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>            || previousSibling.getType() == TokenTypes.RESOURCES</span></pre></td></tr>"
   );
   checkPitestReport ignoredItems
   ;;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
@@ -26,7 +26,6 @@ import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
  * <p>
@@ -258,10 +257,11 @@ public final class OneStatementPerLineCheck extends AbstractCheck {
      */
     private void checkIfSemicolonIsInDifferentLineThanPrevious(DetailAST ast) {
         DetailAST currentStatement = ast;
-        final boolean hasResourcesPrevSibling =
-                currentStatement.getPreviousSibling() != null
-                        && currentStatement.getPreviousSibling().getType() == TokenTypes.RESOURCES;
-        if (!hasResourcesPrevSibling && isMultilineStatement(currentStatement)) {
+        final DetailAST previousSibling = ast.getPreviousSibling();
+        final boolean isUnnecessarySemicolon = previousSibling == null
+            || previousSibling.getType() == TokenTypes.RESOURCES
+            || ast.getParent().getType() == TokenTypes.COMPILATION_UNIT;
+        if (!isUnnecessarySemicolon) {
             currentStatement = ast.getPreviousSibling();
         }
         if (isInLambda) {
@@ -338,25 +338,6 @@ public final class OneStatementPerLineCheck extends AbstractCheck {
                                            int forStatementEnd, int lambdaStatementEnd) {
         return lastStatementEnd == ast.getLineNo() && forStatementEnd != ast.getLineNo()
                 && lambdaStatementEnd != ast.getLineNo();
-    }
-
-    /**
-     * Checks whether statement is multiline.
-     *
-     * @param ast token for the current statement.
-     * @return true if one statement is distributed over two or more lines.
-     */
-    private static boolean isMultilineStatement(DetailAST ast) {
-        final boolean multiline;
-        if (ast.getPreviousSibling() == null) {
-            multiline = false;
-        }
-        else {
-            final DetailAST prevSibling = ast.getPreviousSibling();
-            multiline = !TokenUtil.areOnSameLine(prevSibling, ast)
-                    && ast.getParent().getType() != TokenTypes.COMPILATION_UNIT;
-        }
-        return multiline;
     }
 
 }


### PR DESCRIPTION
#11720

Check Documentation: https://checkstyle.sourceforge.io/config_coding.html#OneStatementPerLine
### Diff Reports (Clean):

- DefaultConfig: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/b2477f8_2022213233/reports/diff/index.html
- treatTryResourcesAsStatementTrueDefaultProjects: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/9574ed2_2022131711/reports/diff/index.html

### Rationale:

The condition removed is `!TokenUtil.areOnSameLine(prevSibling, ast)`, this condition helped in governing whether we would change `currentStatement` to
`currentStatement = ast.getPreviousSibling();`. If this was true i.e. `prevSibling` and `currentStatement` aren't on same line, we would do the above mentioned change.

Now this change occurs even if `prevSibling` and `currentStatement` are on the same line, in that case, this change doesn't make a difference because we only use `currentStatement`'s line number. So it is the same for it and its `prevSibling`. Hence this statement was redundant. 


---

### Generating reports again:
Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/67cdc192dee1963f831843ceed5c9e200d21987f/my_checks.xml

Diff Regression projects: https://raw.githubusercontent.com/checkstyle/contribution/master/checkstyle-tester/latest-projects-to-test-on.properties

Report label: treatTryResourcesAsStatementTrueDefaultProjects