### PR TITLE
Issue #11736: Support qualified annotation names for MissingJavadocTypeCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtil.java
@@ -123,18 +123,35 @@ public final class AnnotationUtil {
 
         if (!annotations.isEmpty()) {
             final DetailAST firstMatchingAnnotation = findFirstAnnotation(ast, annotationNode -> {
-                DetailAST identNode = annotationNode.findFirstToken(TokenTypes.IDENT);
-                if (identNode == null) {
-                    identNode = annotationNode.findFirstToken(TokenTypes.DOT)
-                            .findFirstToken(TokenTypes.IDENT);
-                }
-
-                return annotations.contains(identNode.getText());
+                final String annotationFullIdent = getAnnotationFullIdent(annotationNode);
+                return annotations.contains(annotationFullIdent);
             });
             result = firstMatchingAnnotation != null;
         }
 
         return result;
+    }
+
+    /**
+     * Gets the full ident text of the annotation AST.
+     *
+     * @param annotationNode The annotation AST.
+     * @return The full ident text.
+     */
+    private static String getAnnotationFullIdent(DetailAST annotationNode) {
+        final DetailAST identNode = annotationNode.findFirstToken(TokenTypes.IDENT);
+        final String annotationString;
+
+        // If no `IDENT` is found, then we have a `DOT` -> more than 1 qualifier
+        if (identNode == null) {
+            final DetailAST dotNode = annotationNode.findFirstToken(TokenTypes.DOT);
+            annotationString = FullIdent.createFullIdent(dotNode).getText();
+        }
+        else {
+            annotationString = identNode.getText();
+        }
+
+        return annotationString;
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
@@ -82,7 +82,9 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void allowedAnnotationsTest() throws Exception {
-        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        final String[] expected = {
+            "32:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
         verifyWithInlineConfigParser(
                 getPath("InputMissingJavadocMethodAllowedAnnotations.java"), expected);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheckTest.java
@@ -291,4 +291,75 @@ public class MissingJavadocTypeCheckTest extends AbstractModuleTestSupport {
             expected);
     }
 
+    @Test
+    public void testQualifiedAnnotation1() throws Exception {
+        final String[] expected = {
+            "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "20:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "23:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputMissingJavadocTypeQualifiedAnnotation1.java"), expected);
+    }
+
+    @Test
+    public void testQualifiedAnnotation2() throws Exception {
+        final String[] expected = {
+            "20:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "23:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputMissingJavadocTypeQualifiedAnnotation2.java"), expected);
+    }
+
+    @Test
+    public void testQualifiedAnnotation3() throws Exception {
+        final String[] expected = {
+            "16:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "22:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputMissingJavadocTypeQualifiedAnnotation3.java"), expected);
+    }
+
+    @Test
+    public void testQualifiedAnnotation4() throws Exception {
+        final String[] expected = {
+            "17:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "21:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputMissingJavadocTypeQualifiedAnnotation4.java"), expected);
+    }
+
+    @Test
+    public void testQualifiedAnnotation5() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+            getPath("InputMissingJavadocTypeQualifiedAnnotation5.java"), expected);
+    }
+
+    @Test
+    public void testMultipleQualifiedAnnotation() throws Exception {
+        final String[] expected = {
+            "29:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "38:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputMissingJavadocTypeMultipleQualifiedAnnotation.java"), expected);
+    }
+
+    @Test
+    public void testQualifiedAnnotationWithParameters() throws Exception {
+        final String[] expected = {
+            "33:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "37:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "42:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "50:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputMissingJavadocTypeQualifiedAnnotationWithParameters.java"),
+            expected);
+    }
+
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtilTest.java
@@ -226,29 +226,6 @@ public class AnnotationUtilTest {
     }
 
     @Test
-    public void testContainsAnnotationListWithEmptyAnnotationNode() {
-        final DetailAstImpl ast = new DetailAstImpl();
-        final DetailAstImpl modifiersAst = create(
-                TokenTypes.MODIFIERS,
-                create(
-                        TokenTypes.ANNOTATION,
-                        create(
-                                TokenTypes.DOT,
-                                create(
-                                        TokenTypes.IDENT,
-                                        "Override")
-                        )
-                )
-        );
-        ast.addChild(modifiersAst);
-        final Set<String> annotations = Set.of("Override");
-        final boolean result = AnnotationUtil.containsAnnotation(ast, annotations);
-        assertWithMessage("The dot-ident variation should also work")
-                .that(result)
-                .isTrue();
-    }
-
-    @Test
     public void testContainsAnnotationListWithNoMatchingAnnotation() {
         final DetailAstImpl ast = new DetailAstImpl();
         final DetailAstImpl modifiersAst = create(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodAllowedAnnotations.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodAllowedAnnotations.java
@@ -28,6 +28,7 @@ public class InputMissingJavadocMethodAllowedAnnotations implements SomeInterfac
     @ThisIsOkToo
     public void allowed2() {}
 
+    // violation below 'Missing a Javadoc comment.'
     @com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocmethod.ThisIsOk
     public void allowed3() {}
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeMultipleQualifiedAnnotation.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeMultipleQualifiedAnnotation.java
@@ -1,0 +1,47 @@
+/*
+MissingJavadocType
+scope = (default)public
+excludeScope = (default)null
+skipAnnotations = Ann1, AnnClass.Ann3
+tokens = INTERFACE_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
+
+@interface Ann1 { }
+@interface Ann2 { }
+@interface Ann3 { }
+
+class AnnClass {
+    public @interface Ann1 { }
+    public @interface Ann2 { }
+    public @interface Ann3 { }
+}
+
+public class InputMissingJavadocTypeMultipleQualifiedAnnotation {
+    @Ann1 // ok
+    @Ann2
+    @Ann3
+    public interface A { }
+
+    @Ann2 // violation 'Missing a Javadoc comment.'
+    @Ann3
+    public interface B { }
+
+    @Ann2 // ok
+    @Ann3
+    @Ann1
+    public interface C { }
+
+    @AnnClass.Ann1 // violation 'Missing a Javadoc comment.'
+    @Ann2
+    @Ann3
+    public interface D { }
+
+    @AnnClass.Ann2 // ok
+    @Ann2
+    @AnnClass.Ann3
+    public interface E { }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation1.java
@@ -1,0 +1,26 @@
+/*
+MissingJavadocType
+scope = (default)public
+excludeScope = (default)null
+skipAnnotations = (default)Generated
+tokens = INTERFACE_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
+
+public class InputMissingJavadocTypeQualifiedAnnotation1 {
+    public @interface SomeAnnotation { }
+
+    @SomeAnnotation // violation 'Missing a Javadoc comment.'
+    public interface A { }
+
+    // violation below 'Missing a Javadoc comment.'
+    @InputMissingJavadocTypeQualifiedAnnotation1.SomeAnnotation
+    public interface B { }
+
+    @com.puppycrawl.tools.checkstyle.checks.javadoc // violation 'Missing a Javadoc comment.'
+        .missingjavadoctype.InputMissingJavadocTypeQualifiedAnnotation1.SomeAnnotation
+    public interface C { }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation2.java
@@ -1,0 +1,26 @@
+/*
+MissingJavadocType
+scope = (default)public
+excludeScope = (default)null
+skipAnnotations = SomeAnnotation
+tokens = INTERFACE_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
+
+public class InputMissingJavadocTypeQualifiedAnnotation2 {
+    public @interface SomeAnnotation { }
+
+    @SomeAnnotation // ok
+    public interface A { }
+
+    // violation below 'Missing a Javadoc comment.'
+    @InputMissingJavadocTypeQualifiedAnnotation2.SomeAnnotation
+    public interface B { }
+
+    @com.puppycrawl.tools.checkstyle.checks.javadoc // violation 'Missing a Javadoc comment.'
+        .missingjavadoctype.InputMissingJavadocTypeQualifiedAnnotation2.SomeAnnotation
+    public interface C { }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation3.java
@@ -1,0 +1,25 @@
+/*
+MissingJavadocType
+scope = (default)public
+excludeScope = (default)null
+skipAnnotations = InputMissingJavadocTypeQualifiedAnnotation3.SomeAnnotation
+tokens = INTERFACE_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
+
+public class InputMissingJavadocTypeQualifiedAnnotation3 {
+    public @interface SomeAnnotation { }
+
+    @SomeAnnotation // violation 'Missing a Javadoc comment.'
+    public interface A { }
+
+    @InputMissingJavadocTypeQualifiedAnnotation3.SomeAnnotation // ok
+    public interface B { }
+
+    @com.puppycrawl.tools.checkstyle.checks.javadoc // violation 'Missing a Javadoc comment.'
+        .missingjavadoctype.InputMissingJavadocTypeQualifiedAnnotation3.SomeAnnotation
+    public interface C { }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation4.java
@@ -1,0 +1,27 @@
+/*
+MissingJavadocType
+scope = (default)public
+excludeScope = (default)null
+skipAnnotations = com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype.\
+    InputMissingJavadocTypeQualifiedAnnotation4.SomeAnnotation
+tokens = INTERFACE_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
+
+public class InputMissingJavadocTypeQualifiedAnnotation4 {
+    public @interface SomeAnnotation { }
+
+    @SomeAnnotation // violation 'Missing a Javadoc comment.'
+    public interface A { }
+
+    // violation below 'Missing a Javadoc comment.'
+    @InputMissingJavadocTypeQualifiedAnnotation4.SomeAnnotation
+    public interface B { }
+
+     @com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype // ok
+         .InputMissingJavadocTypeQualifiedAnnotation4.SomeAnnotation
+    public interface C { }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotation5.java
@@ -1,0 +1,27 @@
+/*
+MissingJavadocType
+scope = (default)public
+excludeScope = (default)null
+skipAnnotations = SomeAnnotation, InputMissingJavadocTypeQualifiedAnnotation5.SomeAnnotation, \
+    com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype.\
+    InputMissingJavadocTypeQualifiedAnnotation5.SomeAnnotation
+tokens = INTERFACE_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
+
+public class InputMissingJavadocTypeQualifiedAnnotation5 {
+    public @interface SomeAnnotation { }
+
+    @SomeAnnotation // ok
+    public interface A { }
+
+    @InputMissingJavadocTypeQualifiedAnnotation5.SomeAnnotation // ok
+    public interface B { }
+
+     @com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype // ok
+         .InputMissingJavadocTypeQualifiedAnnotation5.SomeAnnotation
+    public interface C { }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotationWithParameters.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadoctype/InputMissingJavadocTypeQualifiedAnnotationWithParameters.java
@@ -1,0 +1,56 @@
+/*
+MissingJavadocType
+scope = (default)public
+excludeScope = (default)null
+skipAnnotations = SomeAnnotation
+tokens = INTERFACE_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadoctype;
+
+public class InputMissingJavadocTypeQualifiedAnnotationWithParameters {
+    public @interface SomeAnnotation {
+        String value() default "";
+        int quantity() default 1;
+        boolean isOk() default false;
+    }
+
+    @SomeAnnotation("value") // ok
+    public interface A { }
+
+    @SomeAnnotation(value = "value", quantity = 5, isOk = true) // ok
+    public interface B { }
+
+    @SomeAnnotation( // ok
+        value = "value",
+        isOk = true
+    )
+    public interface C { }
+
+    // violation below 'Missing a Javadoc comment.'
+    @InputMissingJavadocTypeQualifiedAnnotationWithParameters.SomeAnnotation("value")
+    public interface D { }
+
+    // violation below 'Missing a Javadoc comment.'
+    @InputMissingJavadocTypeQualifiedAnnotationWithParameters
+        .SomeAnnotation(value = "value", isOk = false)
+    public interface E { }
+
+    // violation below 'Missing a Javadoc comment.'
+    @InputMissingJavadocTypeQualifiedAnnotationWithParameters.SomeAnnotation(
+        value = "value",
+        quantity = 2,
+        isOk = false
+    )
+    public interface F { }
+
+    // violation below 'Missing a Javadoc comment.'
+    @InputMissingJavadocTypeQualifiedAnnotationWithParameters
+        .SomeAnnotation(
+        value = "value",
+        isOk = false
+    )
+    public interface G { }
+}


### PR DESCRIPTION
Addresses #11736
Adds support for qualified annotation names in `MissingJavadocTypeCheck`.
Diff Regression config: https://gist.githubusercontent.com/stoyanK7/37de7a689373daea1df3ec5f4e16efbb/raw/4f28948a768d7cf7fb3a59f6f1faf9e6152d28fa/config.xml
