### PR TITLE
config: reference issue #11846 for EmptyLineSeparatorCheckTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1807,7 +1807,7 @@
                 <!-- test needs to be updated -->
                 <exclude>**/SuppressionCommentFilterTest.class</exclude>
 
-                <!-- remain test methods should be updated -->
+                <!-- due to https://github.com/checkstyle/checkstyle/issues/11846 -->
                 <exclude>**/EmptyLineSeparatorCheckTest.class</exclude>
 
                 <!-- content header is conflicting with Input inline header -->


### PR DESCRIPTION
References issue #11846 as requested in https://github.com/checkstyle/checkstyle/pull/11793#issuecomment-1172971759.