### PR TITLE
Issue #11720: Kill surviving mutation in FinalLocalVariableCheck related to SWITCH_RULE

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -46,24 +46,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>FinalLocalVariableCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck</mutatedClass>
-    <mutatedMethod>visitToken</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>== ast.getParent()) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>FinalLocalVariableCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck</mutatedClass>
-    <mutatedMethod>visitToken</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (ast.getParent().getType() == TokenTypes.SWITCH_RULE</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>HiddenFieldCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck</mutatedClass>
     <mutatedMethod>isIgnoredParamOfAbstractMethod</mutatedMethod>

--- a/.ci/pitest-survival-check-html.sh
+++ b/.ci/pitest-survival-check-html.sh
@@ -168,8 +168,6 @@ pitest-coding-1)
 pitest-coding-2)
   declare -a ignoredItems=(
   "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>                            &#38;&#38; isSameVariables(storedVariable, variable)</span></pre></td></tr>"
-  "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>                        == ast.getParent()) {</span></pre></td></tr>"
-  "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>                if (ast.getParent().getType() == TokenTypes.SWITCH_RULE</span></pre></td></tr>"
   "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (astIterator.getType() == childType</span></pre></td></tr>"
   "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>            result = findLastChildWhichContainsSpecifiedToken(</span></pre></td></tr>"
   "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>        return ast.getType() == TokenTypes.LITERAL_IF</span></pre></td></tr>"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -309,9 +309,7 @@ public class FinalLocalVariableCheck extends AbstractCheck {
                 break;
             case TokenTypes.EXPR:
                 // Switch labeled expression has no slist
-                if (ast.getParent().getType() == TokenTypes.SWITCH_RULE
-                    && ast.getParent().getParent().findFirstToken(TokenTypes.SWITCH_RULE)
-                        == ast.getParent()) {
+                if (ast.getParent().getType() == TokenTypes.SWITCH_RULE) {
                     storePrevScopeUninitializedVariableData();
                 }
                 break;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
@@ -291,6 +291,8 @@ public class FinalLocalVariableCheckTest
             "21:13: " + getCheckMessage(MSG_KEY, "a"),
             "44:13: " + getCheckMessage(MSG_KEY, "b"),
             "46:21: " + getCheckMessage(MSG_KEY, "x"),
+            "72:16: " + getCheckMessage(MSG_KEY, "res"),
+            "92:16: " + getCheckMessage(MSG_KEY, "res"),
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputFinalLocalVariableCheckSwitchAssignment.java"),

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableCheckSwitchAssignment.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableCheckSwitchAssignment.java
@@ -68,4 +68,32 @@ public class InputFinalLocalVariableCheckSwitchAssignment {
         };
     }
 
+    String statement1(int t) {
+        String res; // violation
+
+        switch (t) {
+            case 1 -> {
+                res = "A";
+            }
+            case 2, 3 -> res = "B-C";
+            case 4 -> throw new IllegalStateException("D");
+            default -> {
+                res = "other";
+            }
+        }
+        return res;
+    }
+
+    enum MyEnum {
+        a,b,c
+    }
+
+    void switch_rules(MyEnum value) {
+        String res; // violation
+        switch (value) {
+            case a -> throw new RuntimeException();
+            case b -> res = "2";
+            case c -> res = "3";
+        }
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableFalsePositive.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableFalsePositive.java
@@ -28,3 +28,7 @@ public class InputFinalLocalVariableFalsePositive // ok
         }
     }
 }
+
+@SuppressWarnings("removal")
+class testAnnotation {
+}


### PR DESCRIPTION
#11720
Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11837

### Diff Reports (last report is generated locally):

- DefaultConfig: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/2197fa9_2022062425/reports/diff/index.html
- validateEnhancedForLoopVariableTrueWithParameterDefWithoutOpenJDK: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/2197fa9_2022082305/reports/diff/index.html
- validateEnhancedForLoopVariableTrueWithParameterDefWithOnlyOpenJDK: https://vyom-yadav.github.io/openJdkReports/killSurvivingMutationInFinalLocalVariableCheck-1/reports/diff/index.html

### Rationale:
Just the condition `ast.getParent().getType() == TokenTypes.SWITCH_RULE` is sufficient, the other condition `ast.getParent().getParent().findFirstToken(TokenTypes.SWITCH_RULE) == ast.getParent()` results in a false negative, the related test case has been added.

---

### Generating reports again:
Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/b6cf9595bf1c29d308be0677128ed9f1e760d07b/my_checks.xml
Diff Regression projects: https://gist.githubusercontent.com/Vyom-Yadav/91807e6244cff60698d9e33e32ba2d51/raw/b8f7c60e87344c9eec0b5a04eda46a1e3bbfbfc0/projects-to-test-on.properties
Report label: validateEnhancedForLoopVariableTrueWithParameterDefWithOnlyOpenJDK

These are the default projects only (without open JDK), sonar-java was added