### PR TITLE
Issue #11720: Kill surviving mutation in FinalLocalVariableCheck related to if statement

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -12,15 +12,6 @@
   <mutation unstable="false">
     <sourceFile>FinalLocalVariableCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck</mutatedClass>
-    <mutatedMethod>isIfTokenWithAnElseFollowing</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>return ast.getType() == TokenTypes.LITERAL_IF</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>FinalLocalVariableCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck</mutatedClass>
     <mutatedMethod>isInTheSameLoop</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
     <description>removed conditional - replaced equality check with true</description>

--- a/.ci/pitest-survival-check-html.sh
+++ b/.ci/pitest-survival-check-html.sh
@@ -169,7 +169,6 @@ pitest-coding-2)
   declare -a ignoredItems=(
   "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>                            &#38;&#38; isSameVariables(storedVariable, variable)</span></pre></td></tr>"
   "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (astIterator.getType() == childType</span></pre></td></tr>"
-  "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>        return ast.getType() == TokenTypes.LITERAL_IF</span></pre></td></tr>"
   "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>        return loop1 != null &#38;&#38; loop1 == loop2;</span></pre></td></tr>"
   "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>                &#38;&#38; ast.getType() == TokenTypes.PARAMETER_DEF) {</span></pre></td></tr>"
   "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>                &#38;&#38; firstChild.getType() == TokenTypes.IDENT) {</span></pre></td></tr>"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -501,7 +501,7 @@ public class FinalLocalVariableCheck extends AbstractCheck {
     }
 
     /**
-     * If token is LITERAL_IF and there is an {@code else} following or token is CASE_GROUP or
+     * If there is an {@code else} following or token is CASE_GROUP or
      * SWITCH_RULE and there is another {@code case} following, then update the
      * uninitialized variables.
      *
@@ -509,18 +509,8 @@ public class FinalLocalVariableCheck extends AbstractCheck {
      * @return true if should be updated, else false
      */
     private static boolean shouldUpdateUninitializedVariables(DetailAST ast) {
-        return isIfTokenWithAnElseFollowing(ast) || isCaseTokenWithAnotherCaseFollowing(ast);
-    }
-
-    /**
-     * If token is LITERAL_IF and there is an {@code else} following.
-     *
-     * @param ast token to be checked
-     * @return true if token is LITERAL_IF and there is an {@code else} following, else false
-     */
-    private static boolean isIfTokenWithAnElseFollowing(DetailAST ast) {
-        return ast.getType() == TokenTypes.LITERAL_IF
-                && ast.getLastChild().getType() == TokenTypes.LITERAL_ELSE;
+        return ast.getLastChild().getType() == TokenTypes.LITERAL_ELSE
+            || isCaseTokenWithAnotherCaseFollowing(ast);
     }
 
     /**


### PR DESCRIPTION
#11720
Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11840

### Diff Reports:

- DefaultConfig: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/ebad84d_2022065725/reports/diff/index.html
- validateEnhancedForLoopVariableTrueWithParameterDefWithoutOpenJDK: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/d873a2b_2022082232/reports/diff/index.html

### Rationale:
Only `LITERAL_IF` can have last child as `LITERAL_ELSE`. `else` statements can be only used with `if` statemennts.

---

### Generating reports again:
Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/b6cf9595bf1c29d308be0677128ed9f1e760d07b/my_checks.xml
Diff Regression projects: https://gist.githubusercontent.com/Vyom-Yadav/91807e6244cff60698d9e33e32ba2d51/raw/c7d0fc6900b7c10681be2f69147ea60429860c79/projects-to-test-on.properties
Report label: validateEnhancedForLoopVariableTrueWithParameterDefWithoutOpenJDK

These are the default projects only (without open JDK), sonar-java was added