### PR TITLE
Issue #11720: Kill surviving mutation in HiddenFieldCheck in visitOtherTokens

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -73,24 +73,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>HiddenFieldCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck</mutatedClass>
-    <mutatedMethod>visitOtherTokens</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
-    <description>removed conditional - replaced equality check with false</description>
-    <lineContent>if (type == TokenTypes.CLASS_DEF</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>HiddenFieldCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck</mutatedClass>
-    <mutatedMethod>visitOtherTokens</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (type == TokenTypes.CLASS_DEF</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>IllegalInstantiationCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.IllegalInstantiationCheck</mutatedClass>
     <mutatedMethod>isStandardClass</mutatedMethod>

--- a/.ci/pitest-survival-check-html.sh
+++ b/.ci/pitest-survival-check-html.sh
@@ -175,7 +175,6 @@ pitest-coding-2)
   "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>                &#38;&#38; firstChild.getType() == TokenTypes.IDENT) {</span></pre></td></tr>"
   "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (method.getType() == TokenTypes.METHOD_DEF) {</span></pre></td></tr>"
   "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (ignoreSetter &#38;&#38; ast.getType() == TokenTypes.PARAMETER_DEF) {</span></pre></td></tr>"
-  "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (type == TokenTypes.CLASS_DEF</span></pre></td></tr>"
   "IllegalInstantiationCheck.java.html:<td class='covered'><pre><span  class='survived'>            &#38;&#38; illegal.startsWith(JAVA_LANG)) {</span></pre></td></tr>"
   "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>                        &#38;&#38; currentStatement.getPreviousSibling().getType() == TokenTypes.RESOURCES;</span></pre></td></tr>"
   "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>                currentStatement.getPreviousSibling() != null</span></pre></td></tr>"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
@@ -459,6 +459,17 @@ public class HiddenFieldCheckTest
             getPath("InputHiddenFieldLambdas2.java"), expected);
     }
 
+    @Test
+    public void testClassNestedInRecord() throws Exception {
+
+        final String[] expected = {
+            "23:26: " + getCheckMessage(MSG_KEY, "a"),
+        };
+        verifyWithInlineConfigParser(
+            getNonCompilablePath("InputHiddenFieldClassNestedInRecord.java"),
+            expected);
+    }
+
     /**
      * We cannot reproduce situation when visitToken is called and leaveToken is not.
      * So, we have to use reflection to be sure that even in such situation

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldClassNestedInRecord.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldClassNestedInRecord.java
@@ -1,0 +1,35 @@
+/*
+HiddenField
+ignoreFormat = (default)null
+ignoreConstructorParameter = (default)false
+ignoreSetter = true
+setterCanReturnItsClass = true
+ignoreAbstractMethods = (default)false
+tokens = (default)VARIABLE_DEF, PARAMETER_DEF, PATTERN_VARIABLE_DEF, LAMBDA, RECORD_COMPONENT_DEF
+
+
+*/
+
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.coding.hiddenfield;
+
+public class InputHiddenFieldClassNestedInRecord {
+
+    record foo(int i) {
+
+        class foo2 {
+            int a, b;
+
+            foo setA(int a) { // violation
+                this.a = a;
+                return foo.this;
+            }
+
+            foo2 setB(int b) { // ok
+                this.b = b;
+                return this;
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
#11720
Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11830

### Diff Reports:

- DefaultConfig: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/7a12e30_2022144013/reports/diff/index.html
- setterCanReturnItsClassAndIgnoreSetter: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/7a12e30_2022033855/reports/diff/index.html

### This mutation falls in the category:

The logic was analyzed and a test case was developed. Though this violation looks like a false positive to me.
