### PR TITLE
Issue #11720: Kill surviving mutation in HiddenFieldCheck related to lambda expressions

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -28,15 +28,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>HiddenFieldCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck</mutatedClass>
-    <mutatedMethod>processLambda</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>&amp;&amp; firstChild.getType() == TokenTypes.IDENT) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>IllegalInstantiationCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.IllegalInstantiationCheck</mutatedClass>
     <mutatedMethod>isStandardClass</mutatedMethod>

--- a/.ci/pitest-survival-check-html.sh
+++ b/.ci/pitest-survival-check-html.sh
@@ -170,7 +170,6 @@ pitest-coding-2)
   "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>                            &#38;&#38; isSameVariables(storedVariable, variable)</span></pre></td></tr>"
   "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (astIterator.getType() == childType</span></pre></td></tr>"
   "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>        return loop1 != null &#38;&#38; loop1 == loop2;</span></pre></td></tr>"
-  "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>                &#38;&#38; firstChild.getType() == TokenTypes.IDENT) {</span></pre></td></tr>"
   "IllegalInstantiationCheck.java.html:<td class='covered'><pre><span  class='survived'>            &#38;&#38; illegal.startsWith(JAVA_LANG)) {</span></pre></td></tr>"
   "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>            || previousSibling.getType() == TokenTypes.RESOURCES</span></pre></td></tr>"
   );

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -424,8 +424,7 @@ public class HiddenFieldCheck
      */
     private void processLambda(DetailAST ast) {
         final DetailAST firstChild = ast.getFirstChild();
-        if (firstChild != null
-                && firstChild.getType() == TokenTypes.IDENT) {
+        if (TokenUtil.isOfType(firstChild, TokenTypes.IDENT)) {
             final String untypedLambdaParameterName = firstChild.getText();
             if (frame.containsStaticField(untypedLambdaParameterName)
                 || isInstanceField(firstChild, untypedLambdaParameterName)) {


### PR DESCRIPTION
#11720

Check Documentation: https://checkstyle.sourceforge.io/config_coding.html#HiddenField

Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11831

### Diff Reports:

- DefaultConfig: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/1aacc82_2022220212/reports/diff/index.html
- setterCanReturnItsClassAndIgnoreSetter: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/5702a2e_2022200904/reports/diff/index.html

### Rationale

Lambdas are of 3 types-
```java
foo1 obj = () -> {};  
foo2 obj2 = a -> {};  
foo2 obj3 = (a) -> {};
```
Related respective ASTs:
```
--LAMBDA -> ->
   |--LPAREN -> (
   |--PARAMETERS -> PARAMETERS
   |--RPAREN -> )
   `--SLIST -> { 
       `--RCURLY -> }
```
```
--LAMBDA -> ->
    |--IDENT -> a
    `--SLIST -> {
        `--RCURLY -> }
```
```
--LAMBDA -> ->
    |--LPAREN -> (
    |--PARAMETERS -> PARAMETERS
    |   `--PARAMETER_DEF -> PARAMETER_DEF
    |       |--MODIFIERS -> MODIFIERS
    |       |--TYPE -> TYPE
    |       `--IDENT -> a
    |--RPAREN -> )
    `--SLIST -> {
        `--RCURLY -> }
```
If lambda has parameters, it is handled by:
https://github.com/checkstyle/checkstyle/blob/2fabfede8c1396457085dd199605a32c33df764b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java#L402-L407

And if it has a parameter without `(..)` then the current logic i.e. `processLambda(..)` method handles it, there should be no problem ignoring the condition `firstChild.getType() == TokenTypes.IDENT` as we later compare the text of the first child with a variable name and no variable can have `(` (`LPAREN`) as its name.

---

### Generating reports again:
Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/e0470443cc49f5f6f9b4849340a2c8c241693ffb/my_checks.xml
Report label: setterCanReturnItsClassAndIgnoreSetter
