### PR TITLE
Issue #11720: Kill surviving mutation in HiddenFieldCheck in isIgnoredSetterParam

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -30,15 +30,6 @@
   <mutation unstable="false">
     <sourceFile>HiddenFieldCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck</mutatedClass>
-    <mutatedMethod>isIgnoredSetterParam</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (ignoreSetter &amp;&amp; ast.getType() == TokenTypes.PARAMETER_DEF) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>HiddenFieldCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck</mutatedClass>
     <mutatedMethod>processLambda</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
     <description>removed conditional - replaced equality check with true</description>

--- a/.ci/pitest-survival-check-html.sh
+++ b/.ci/pitest-survival-check-html.sh
@@ -171,7 +171,6 @@ pitest-coding-2)
   "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (astIterator.getType() == childType</span></pre></td></tr>"
   "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>        return loop1 != null &#38;&#38; loop1 == loop2;</span></pre></td></tr>"
   "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>                &#38;&#38; firstChild.getType() == TokenTypes.IDENT) {</span></pre></td></tr>"
-  "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (ignoreSetter &#38;&#38; ast.getType() == TokenTypes.PARAMETER_DEF) {</span></pre></td></tr>"
   "IllegalInstantiationCheck.java.html:<td class='covered'><pre><span  class='survived'>            &#38;&#38; illegal.startsWith(JAVA_LANG)) {</span></pre></td></tr>"
   "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>                        &#38;&#38; currentStatement.getPreviousSibling().getType() == TokenTypes.RESOURCES;</span></pre></td></tr>"
   "OneStatementPerLineCheck.java.html:<td class='covered'><pre><span  class='survived'>                currentStatement.getPreviousSibling() != null</span></pre></td></tr>"

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -614,7 +614,7 @@ public class HiddenFieldCheck
      */
     private boolean isIgnoredSetterParam(DetailAST ast, String name) {
         boolean isIgnoredSetterParam = false;
-        if (ignoreSetter && ast.getType() == TokenTypes.PARAMETER_DEF) {
+        if (ignoreSetter) {
             final DetailAST parametersAST = ast.getParent();
             final DetailAST methodAST = parametersAST.getParent();
             if (parametersAST.getChildCount() == 1


### PR DESCRIPTION
#11720

Check Documentation: https://checkstyle.sourceforge.io/config_coding.html#HiddenField

Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11832

### Diff Reports:

- DefaultConfig: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/1d0786f_2022212117/reports/diff/index.html
- setterCanReturnItsClassAndIgnoreSetter: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/1d0786f_2022123815/reports/diff/index.html

### Rationale

Only 4 tokens at present can reach this method. `VARIABLE_DEF`, `PARAMETER_DEF`, `PATTERN_VARIABLE_DEF` and `RECORD_COMPONENT_DEF`. This condition is redundant as the upcoming conditions make sure that it can be only `PARAMETER_DEF` that can change the result of the method.

The upcoming conditions-
```java
final DetailAST parametersAST = ast.getParent();
final DetailAST methodAST = parametersAST.getParent();
if (parametersAST.getChildCount() == 1
    && methodAST.getType() == TokenTypes.METHOD_DEF
    && isSetterMethod(methodAST, name)) {
        isIgnoredSetterParam = true;
}
```
Now out of 4 only, `PARAMETER_DEF` and `VARIABLE_DEF` can have `METHOD_DEF` as grand-parent. `VARIABLE_DEF` will also fail to satisfy the condition `parametersAST.getChildCount() == 1`. AST will help to understand this.
```
METHOD_DEF -> METHOD_DEF
  |--MODIFIERS -> MODIFIERS
  |   `--LITERAL_PUBLIC -> public
  |--TYPE -> TYPE
  |   `--LITERAL_VOID -> void
  |--IDENT -> method
  |--LPAREN -> (
  |--PARAMETERS -> PARAMETERS
  |--RPAREN -> )
  `--SLIST -> { 
      |--VARIABLE_DEF -> VARIABLE_DEF
      |   |--MODIFIERS -> MODIFIERS
      |   |--TYPE -> TYPE 
      |   |   `--LITERAL_INT -> int
      |   |--IDENT -> ab
      |   `--ASSIGN -> =
      |       `--EXPR -> EXPR
      |           `--NUM_INT -> 12
      |--SEMI -> ;
      `--RCURLY -> }
``` 
As soon as we introduce `VARIABLE_DEF`, the number of children of its parent increases to `3`, which fails the condition.

---

### Generating reports again:
Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/e0470443cc49f5f6f9b4849340a2c8c241693ffb/my_checks.xml
Report label: setterCanReturnItsClassAndIgnoreSetter
