### PR TITLE
Issue #11720: Kill surviving mutation in HiddenFieldCheck related to setter method

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -87,15 +87,6 @@
     <mutatedMethod>isIgnoredSetterParam</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
     <description>removed conditional - replaced equality check with true</description>
-    <lineContent>&amp;&amp; methodAST.getType() == TokenTypes.METHOD_DEF</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>HiddenFieldCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck</mutatedClass>
-    <mutatedMethod>isIgnoredSetterParam</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
     <lineContent>if (ignoreSetter &amp;&amp; ast.getType() == TokenTypes.PARAMETER_DEF) {</lineContent>
   </mutation>
 

--- a/.ci/pitest-survival-check-html.sh
+++ b/.ci/pitest-survival-check-html.sh
@@ -176,7 +176,6 @@ pitest-coding-2)
   "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>        return loop1 != null &#38;&#38; loop1 == loop2;</span></pre></td></tr>"
   "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>                &#38;&#38; ast.getType() == TokenTypes.PARAMETER_DEF) {</span></pre></td></tr>"
   "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>                &#38;&#38; firstChild.getType() == TokenTypes.IDENT) {</span></pre></td></tr>"
-  "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>                &#38;&#38; methodAST.getType() == TokenTypes.METHOD_DEF</span></pre></td></tr>"
   "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (method.getType() == TokenTypes.METHOD_DEF) {</span></pre></td></tr>"
   "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (ignoreSetter &#38;&#38; ast.getType() == TokenTypes.PARAMETER_DEF) {</span></pre></td></tr>"
   "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (type == TokenTypes.CLASS_DEF</span></pre></td></tr>"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheckTest.java
@@ -450,6 +450,15 @@ public class HiddenFieldCheckTest
                 getNonCompilablePath("InputHiddenFieldRecords.java"), expected);
     }
 
+    @Test
+    public void testHiddenFieldLambdasInNestedScope() throws Exception {
+        final String[] expected = {
+            "21:34: " + getCheckMessage(MSG_KEY, "value"),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputHiddenFieldLambdas2.java"), expected);
+    }
+
     /**
      * We cannot reproduce situation when visitToken is called and leaveToken is not.
      * So, we have to use reflection to be sure that even in such situation

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldLambdas2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/hiddenfield/InputHiddenFieldLambdas2.java
@@ -1,0 +1,23 @@
+/*
+HiddenField
+ignoreFormat = (default)null
+ignoreConstructorParameter = (default)false
+ignoreSetter = true
+setterCanReturnItsClass = true
+ignoreAbstractMethods = (default)false
+tokens = (default)VARIABLE_DEF, PARAMETER_DEF, PATTERN_VARIABLE_DEF, LAMBDA, RECORD_COMPONENT_DEF
+
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.coding.hiddenfield;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class InputHiddenFieldLambdas2 {
+    List<Integer> numbers = Arrays.asList(1, 2, 3, 4, 5, 6);
+    Integer value = Integer.valueOf(1);
+    {
+        numbers.forEach((Integer value) -> String.valueOf(value)); // violation
+    }
+}


### PR DESCRIPTION
#11720
Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11833

### Diff Reports (contains diff):

- DefaultConfig: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/ec40b73_2022185735/reports/diff/index.html
- setterCanReturnItsClassAndIgnoreSetter: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/ec40b73_2022035007/reports/diff/index.html

### This mutations falls in category:

- Missing test case was added from the diff report.

---

### Generating reports again:

Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/a116179eb9e7b14ffc38b86575e8cb2796489dde/my_checks.xml
Diff Regression projects: https://gist.githubusercontent.com/Vyom-Yadav/91807e6244cff60698d9e33e32ba2d51/raw/bd2c453cc3ac1e892a11225639415edd1b027900/projects-to-test-on.properties
Report label: DefaultConfig

These are the default projects only, sonar-java was added
