### PR TITLE
Issue #11720: Kill surviving mutation in FinalLocalVariableCheck related to switch statement

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -12,15 +12,6 @@
   <mutation unstable="false">
     <sourceFile>FinalLocalVariableCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck</mutatedClass>
-    <mutatedMethod>isCaseTokenWithAnotherCaseFollowing</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>result = findLastChildWhichContainsSpecifiedToken(</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>FinalLocalVariableCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck</mutatedClass>
     <mutatedMethod>isIfTokenWithAnElseFollowing</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
     <description>removed conditional - replaced equality check with true</description>

--- a/.ci/pitest-survival-check-html.sh
+++ b/.ci/pitest-survival-check-html.sh
@@ -171,7 +171,6 @@ pitest-coding-2)
   "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>                        == ast.getParent()) {</span></pre></td></tr>"
   "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>                if (ast.getParent().getType() == TokenTypes.SWITCH_RULE</span></pre></td></tr>"
   "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (astIterator.getType() == childType</span></pre></td></tr>"
-  "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>            result = findLastChildWhichContainsSpecifiedToken(</span></pre></td></tr>"
   "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>        return ast.getType() == TokenTypes.LITERAL_IF</span></pre></td></tr>"
   "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>        return loop1 != null &#38;&#38; loop1 == loop2;</span></pre></td></tr>"
   "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>                &#38;&#38; ast.getType() == TokenTypes.PARAMETER_DEF) {</span></pre></td></tr>"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheckTest.java
@@ -297,4 +297,12 @@ public class FinalLocalVariableCheckTest
             expected);
     }
 
+    @Test
+    public void testFinalLocalVariableSwitchStatement() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+            getPath("InputFinalLocalVariableSwitchStatement.java"),
+            expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableSwitchStatement.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableSwitchStatement.java
@@ -1,0 +1,48 @@
+/*
+FinalLocalVariable
+validateEnhancedForLoopVariable = (default)false
+tokens = (default)VARIABLE_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.finallocalvariable;
+
+public class InputFinalLocalVariableSwitchStatement {
+
+    enum T {
+        A, B, C;
+    }
+
+    public void foo() {
+        int x; // ok
+
+        {
+            final T y = T.A;
+
+            switch (y) {
+                case A:
+                    x = 0;
+                case B:
+                    x = 0;
+                case C:
+                    x = 0;
+            }
+
+        }
+
+        {
+            final T y = T.A;
+
+            switch (y) {
+                case A:
+                    x = 1;
+                case B:
+                    x = 1;
+                case C:
+                    x = 1;
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/checkstyle/checkstyle/issues/11720
Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11841
### Diff Reports (From harcoded mutation PR):

- DefaultConfig: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/8a3ffff_2022191625/reports/diff/index.html
- validateEnhancedForLoopVariableTrueWithParameterDefWithoutOpenJDK: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/8a3ffff_2022130102/reports/diff/index.html

### This mutation falls in the category:

The logic was analyzed and a test case was developed.