### PR TITLE
Issue #11720: Kill surviving mutation in FinalLocalVariableCheck related to case group

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -3,15 +3,6 @@
   <mutation unstable="false">
     <sourceFile>FinalLocalVariableCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck</mutatedClass>
-    <mutatedMethod>findLastChildWhichContainsSpecifiedToken</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (astIterator.getType() == childType</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>FinalLocalVariableCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck</mutatedClass>
     <mutatedMethod>isInTheSameLoop</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
     <description>removed conditional - replaced equality check with true</description>

--- a/.ci/pitest-survival-check-html.sh
+++ b/.ci/pitest-survival-check-html.sh
@@ -168,7 +168,6 @@ pitest-coding-1)
 pitest-coding-2)
   declare -a ignoredItems=(
   "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>                            &#38;&#38; isSameVariables(storedVariable, variable)</span></pre></td></tr>"
-  "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>            if (astIterator.getType() == childType</span></pre></td></tr>"
   "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>        return loop1 != null &#38;&#38; loop1 == loop2;</span></pre></td></tr>"
   "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>                &#38;&#38; firstChild.getType() == TokenTypes.IDENT) {</span></pre></td></tr>"
   "HiddenFieldCheck.java.html:<td class='covered'><pre><span  class='survived'>        if (ignoreSetter &#38;&#38; ast.getType() == TokenTypes.PARAMETER_DEF) {</span></pre></td></tr>"


### PR DESCRIPTION
#11720

Check Documentation: https://checkstyle.sourceforge.io/config_coding.html#FinalLocalVariable

Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11842

### Diff Reports:

- DefaultConfig: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/7fb6edf_2022111841/reports/diff/index.html
- validateEnhancedForLoopVariableTrueWithParameterDefWithoutOpenJDK: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/edbdae3_2022210449/reports/diff/index.html

### Rationale:

The reason behind this change is due to the fact that this method was always called when it is guaranteed that the `childType` will always be of type `TokenTypes.CASE_GROUP`.
Usages of this method:

- First usage
https://github.com/checkstyle/checkstyle/blob/a6dec5beda11fd54734e2c5ae655ca09448e48a0/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java#L344-L346
The second condition in `||` will only be reached when first one is `false` i.e. `ast.getParent().getType() == TokenTypes.CASE_GROUP`

- Second usage
https://github.com/checkstyle/checkstyle/blob/a6dec5beda11fd54734e2c5ae655ca09448e48a0/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java#L525-L527
The `if` statement guarantees it.

---

### Generating reports again:
Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/b6cf9595bf1c29d308be0677128ed9f1e760d07b/my_checks.xml
Diff Regression projects: https://gist.githubusercontent.com/Vyom-Yadav/91807e6244cff60698d9e33e32ba2d51/raw/c7d0fc6900b7c10681be2f69147ea60429860c79/projects-to-test-on.properties
Report label: validateEnhancedForLoopVariableTrueWithParameterDefWithoutOpenJDK