### PR TITLE
infra: specify xwiki-platform commit

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -288,6 +288,7 @@ no-error-xwiki)
   cd ..
   checkout_from https://github.com/xwiki/xwiki-platform.git
   cd .ci-temp/xwiki-platform
+  git checkout "d8d1d85d723d""d""f""d90d7eb9d1be0ab37e0cc7d0f3"
   # Validate xwiki-platform
   mvn -e --no-transfer-progress checkstyle:check@default -Dcheckstyle.version="${CS_POM_VERSION}"
   cd ..


### PR DESCRIPTION
Fixes damaged build from xwiki-platform noted at https://app.circleci.com/pipelines/github/checkstyle/checkstyle/13922/workflows/c3c97a12-592e-41d1-90d2-7ce5da3c9d13/jobs/154090, search by "ClassFanoutComplexity"

Link to xwiki build: https://circleci.com/gh/checkstyle/checkstyle/154296?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link