### PR TITLE
Issue #11727: Include CDG Accelerator Plugin to boost pitest performance

### DIFF
--- a/.ci/jsoref-spellchecker/exclude.pl
+++ b/.ci/jsoref-spellchecker/exclude.pl
@@ -15,6 +15,7 @@ my @excludes=qw(
   /releasenotes\.xml$
   /.*_..\.translation[^/]*$
   /openjdk17-excluded\.files$
+  ^cdg-pitest-licence.txt$
 );
 my $exclude = join "|", @excludes;
 while (<>) {

--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -528,6 +528,7 @@ Grenner
 grep
 grepped
 groovyism
+groupcdg
 groupon
 grp
 Gsp

--- a/cdg-pitest-licence.txt
+++ b/cdg-pitest-licence.txt
@@ -1,0 +1,7 @@
+#Licence file for pitest extensions
+#Mon Jun 13 09:05:28 BST 2022
+expires=13/06/2024
+keyVersion=1
+signature=K7Oqt8FQtO/RZfNf0Z4VMwg9iS9bGJUGD7qfr4NsQOtmRIm0Fwm+xOiKiACYxCPQwloB1+iw6YIpBPT+wGtT9eB0n59nAoYQyq65Gmu3D8Vr3hIKAG7saWjpRbt4l+LzpLDyImKtR+dIVxadZlTB/qpTjuZ2InTd2AwiR03Ti+A\=
+packages=com.puppycrawl.tools.checkstyle.*
+type=OSSS

--- a/config/checkstyle_non_main_files_suppressions.xml
+++ b/config/checkstyle_non_main_files_suppressions.xml
@@ -90,6 +90,9 @@
   <!-- this file cannot be line wrapped, It contains a list of suppressions -->
   <suppress id="lineLength" files=".ci[\\/]pitest-suppressions[\\/].*"/>
 
+  <!-- this file cannot be line wrapped, it contains cdg pitest licence -->
+  <suppress id="lineLength" files="cdg-pitest-licence.txt"/>
+
   <!-- apply check numberOfTestCasesInXpath only for files in suppressionxpathfilter directory -->
   <suppress id="numberOfTestCasesInXpath"
          files="src[\\/]it[\\/]java[\\/]com[\\/].*" />

--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,7 @@
     <pitest.plugin.timeout.constant>50000</pitest.plugin.timeout.constant>
     <pitest.plugin.threads>4</pitest.plugin.threads>
     <pitest.junit5.plugin.version>1.0.0</pitest.junit5.plugin.version>
+    <pitest.accelerator.junit5.plugin.version>1.0.0</pitest.accelerator.junit5.plugin.version>
     <sonar.test.exclusions>**/test/resources/**/*,**/it/resources/**/*</sonar.test.exclusions>
     <junit.version>5.8.2</junit.version>
     <forbiddenapis.version>3.3</forbiddenapis.version>
@@ -431,6 +432,11 @@
           <artifactId>pitest-maven</artifactId>
           <version>${pitest.plugin.version}</version>
           <dependencies>
+            <dependency>
+              <groupId>com.groupcdg.pitest</groupId>
+              <artifactId>pitest-accelerator-junit5</artifactId>
+              <version>${pitest.accelerator.junit5.plugin.version}</version>
+            </dependency>
             <dependency>
               <groupId>org.pitest</groupId>
               <artifactId>pitest-junit5-plugin</artifactId>


### PR DESCRIPTION
Resolves #11727 

---

### key
```diff
+ decreased execution time
- increased execution time
```

---

Compared with https://github.com/checkstyle/checkstyle/pull/11866

Run with accelerator: https://github.com/checkstyle/checkstyle/actions/runs/2640881429
Run without accelerator (#11866): https://github.com/checkstyle/checkstyle/actions/runs/2636912598
Run without licence: https://github.com/checkstyle/checkstyle/actions/runs/2641406919

```diff
@@ Profile                           New time               Previous time @@

+  pitest-annotation                 1m 44s                 2m 13s 
+  pitest-ant                        1m 42s                 1m 51s 
+  pitest-api                        2m 50s                 4m 30s 
+  pitest-blocks                     1m 54s                 3m 35s 
+  pitest-coding-1                   5m 58s                 6m 38s 
+  pitest-coding-2                   4m 7s                  6m 37s 
+  pitest-coding-require-this-check  15m 36s                16m 35s
+  pitest-common                     7m 32s                 7m 50s 
+  pitest-common-2                   4m 40s                 8m 23s 
+  pitest-design                     1m 54s                 3m 36s 
+  pitest-filters                    2m 44s                 3m 9s  
+  pitest-header                     2m 5s                  2m 26s 
+  pitest-imports                    2m 42s                 3m 43s 
+  pitest-indentation                4m 59s                 11m 36s
+  pitest-javadoc                    5m 43s                 10m 28s
+  pitest-main                       1m 49s                 3m 34s 
+  pitest-metrics                    1m 42s                 2m 24s 
+  pitest-misc                       3m 13s                 4m 21s 
+  pitest-modifier                   2m 39s                 2m 51s 
+  pitest-naming                     2m 21s                 4m 9s  
+  pitest-packagenamesloader         1m 7s                  1m 45s 
+  pitest-regexp                     2m 29s                 3m 28s 
+  pitest-sizes                      1m 57s                 3m 23s 
+  pitest-tree-walker                2m 51s                 4m 22s 
+  pitest-utils                      3m 17s                 6m 12s 
+  pitest-whitespace                 3m 9s                  3m 52s 
+  pitest-xpath                      4m 38s                 13m 36s
+  pitest-java-ast-visitor           3m 15s                 5m 24s 
```