### PR TITLE
Issue #11720: Kill surviving mutation in FinalLocalVariableCheck related to loops

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -3,15 +3,6 @@
   <mutation unstable="false">
     <sourceFile>FinalLocalVariableCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck</mutatedClass>
-    <mutatedMethod>isInTheSameLoop</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>return loop1 != null &amp;&amp; loop1 == loop2;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>FinalLocalVariableCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck</mutatedClass>
     <mutatedMethod>updateUninitializedVariables</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
     <description>removed conditional - replaced equality check with true</description>

--- a/.ci/pitest-survival-check-html.sh
+++ b/.ci/pitest-survival-check-html.sh
@@ -168,7 +168,6 @@ pitest-coding-1)
 pitest-coding-2)
   declare -a ignoredItems=(
   "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>                            &#38;&#38; isSameVariables(storedVariable, variable)</span></pre></td></tr>"
-  "FinalLocalVariableCheck.java.html:<td class='covered'><pre><span  class='survived'>        return loop1 != null &#38;&#38; loop1 == loop2;</span></pre></td></tr>"
   "IllegalInstantiationCheck.java.html:<td class='covered'><pre><span  class='survived'>            &#38;&#38; illegal.startsWith(JAVA_LANG)) {</span></pre></td></tr>"
   );
   checkPitestReport ignoredItems


### PR DESCRIPTION
#11720

Check Documentation: https://checkstyle.sourceforge.io/config_coding.html#FinalLocalVariable

Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11839

### Diff Reports:

- DefaultConfig: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/bbf9c34_2022205708/reports/diff/index.html
- validateEnhancedForLoopVariableTrueWithParameterDefWithoutOpenJDK: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/bbf9c34_2022122035/reports/diff/index.html

### Rationale

The only case we should be concerned is when `loop1 != null` is `false` i.e. `loop1 == null`.
Now there can be a case when `loop1 == null` and `loop2 == null` which will make this method return `true` as `loop1 == loop2` when it earlier returned `false`. 

The method `isInTheSameLoop(..)` will return `true` in that condition when earlier it returned `false`. The reason why this won't make any difference depends on its usage.
https://github.com/checkstyle/checkstyle/blob/7bc872ed83b4de5779cfb496ed0d0878ae303914/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java#L676-L679
Earlier when `isInTheSameLoop(..)` returned `false`, `!isUseOfExternalVariableInsideLoop(..)` (note the **!**) 
returned `true`(due to `loop2 == null`) so overall the if statement resulted `true`. Now when `isInTheSameLoop(..)` returns `true` for the same case, it won't make a difference.

Both the methods had overlapping conditions, it was extracted to a single condition, which is what it is in the current PR.


---

### Generating reports again:

Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/b6cf9595bf1c29d308be0677128ed9f1e760d07b/my_checks.xml
Diff Regression projects: https://gist.githubusercontent.com/Vyom-Yadav/91807e6244cff60698d9e33e32ba2d51/raw/c7d0fc6900b7c10681be2f69147ea60429860c79/projects-to-test-on.properties
Report label: validateEnhancedForLoopVariableTrueWithParameterDefWithoutOpenJDK
