### PR TITLE
Issue #11277: update code base to have javadoc tag to explain noinspection content

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -29,6 +29,7 @@ import com.puppycrawl.tools.checkstyle.grammar.java.JavaLanguageLexer;
  * the circular dependency between packages.</p>
  *
  * @noinspection ClassWithTooManyDependents
+ * @noinspectionreason ClassWithTooManyDependents - this class is a core part of our API
  */
 public final class TokenTypes {
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/grammar/CommentListener.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/grammar/CommentListener.java
@@ -24,6 +24,7 @@ package com.puppycrawl.tools.checkstyle.grammar;
  * in the parsed code.
  *
  * @noinspection ClassOnlyUsedInOnePackage
+ * @noinspectionreason ClassOnlyUsedInOnePackage - we restrict all parsing to a single package
  */
 public interface CommentListener {
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractPathTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractPathTestSupport.java
@@ -78,12 +78,12 @@ public abstract class AbstractPathTestSupport {
 
     /**
      * Reads the contents of a file.
-     * IDEA inspection RedundantThrows suppressed as a false positive.
      *
      * @param filename the name of the file whose contents are to be read
      * @return contents of the file with all {@code \r\n} replaced by {@code \n}
      * @throws IOException if I/O exception occurs while reading
      * @noinspection RedundantThrows
+     * @noinspectionreason RedundantThrows - false positive
      */
     protected static String readFile(String filename) throws IOException {
         return toLfLineEnding(Files.readString(Paths.get(filename)));

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -764,6 +764,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
      * Test doesn't need to be serialized.
      *
      * @noinspection SerializableInnerClassWithNonSerializableOuterClass
+     * @noinspectionreason SerializableInnerClassWithNonSerializableOuterClass - mocked file
+     *      for test does not require serialization
      */
     @Test
     public void testCatchErrorInProcessFilesMethod() throws Exception {
@@ -816,6 +818,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
      * Test doesn't need to be serialized.
      *
      * @noinspection SerializableInnerClassWithNonSerializableOuterClass
+     * @noinspectionreason SerializableInnerClassWithNonSerializableOuterClass - mocked file
+     *      for test does not require serialization
      */
     @Test
     public void testCatchErrorWithNoFileName() throws Exception {
@@ -1121,6 +1125,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
      * Test doesn't need to be serialized.
      *
      * @noinspection SerializableInnerClassWithNonSerializableOuterClass
+     * @noinspectionreason SerializableInnerClassWithNonSerializableOuterClass - mocked file
+     *      for test does not require serialization
      */
     @Test
     public void testCatchErrorWithCache() throws Exception {
@@ -1197,6 +1203,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
      * Test doesn't need to be serialized.
      *
      * @noinspection SerializableInnerClassWithNonSerializableOuterClass
+     * @noinspectionreason SerializableInnerClassWithNonSerializableOuterClass - mocked file
+     *      for test does not require serialization
      */
     @Test
     public void testCatchErrorWithCacheWithNoFileName() throws Exception {
@@ -1266,6 +1274,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
      * Test doesn't need to be serialized.
      *
      * @noinspection SerializableInnerClassWithNonSerializableOuterClass
+     * @noinspectionreason SerializableInnerClassWithNonSerializableOuterClass - mocked file
+     *      for test does not require serialization
      */
     @Test
     public void testExceptionWithNoFileName() {
@@ -1312,6 +1322,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
      * Test doesn't need to be serialized.
      *
      * @noinspection SerializableInnerClassWithNonSerializableOuterClass
+     * @noinspectionreason SerializableInnerClassWithNonSerializableOuterClass - mocked file
+     *      for test does not require serialization
      */
     @Test
     public void testExceptionWithCacheAndNoFileName() throws Exception {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -838,6 +838,8 @@ public class MainTest {
      * Test doesn't need to be serialized.
      *
      * @noinspection SerializableInnerClassWithNonSerializableOuterClass
+     * @noinspectionreason SerializableInnerClassWithNonSerializableOuterClass - mocked file
+     *      for test does not require serialization
      */
     @Test
     public void testListFilesNotFile() throws Exception {
@@ -871,6 +873,8 @@ public class MainTest {
      * Test doesn't need to be serialized.
      *
      * @noinspection SerializableInnerClassWithNonSerializableOuterClass
+     * @noinspectionreason SerializableInnerClassWithNonSerializableOuterClass - mocked file
+     *      for test does not require serialization
      */
     @Test
     public void testListFilesDirectoryWithNull() throws Exception {
@@ -1151,12 +1155,12 @@ public class MainTest {
 
     /**
      * Verifies the output of the command line parameter "-j".
-     * IDEA inspection RedundantThrows suppressed as a false positive.
      *
      * @param systemErr wrapper for {@code System.err}
      * @param systemOut wrapper for {@code System.out}
      * @throws IOException if I/O exception occurs while reading the test input.
      * @noinspection RedundantThrows
+     * @noinspectionreason RedundantThrows - false positive
      */
     @Test
     public void testPrintTreeJavadocOption(@SysErr Capturable systemErr,
@@ -1544,12 +1548,12 @@ public class MainTest {
 
     /**
      * Verifies the output of the command line parameter "-J".
-     * IDEA inspection RedundantThrows suppressed as a false positive.
      *
      * @param systemErr wrapper for {@code System.err}
      * @param systemOut wrapper for {@code System.out}
      * @throws IOException if I/O exception occurs while reading the test input.
      * @noinspection RedundantThrows
+     * @noinspectionreason RedundantThrows - false positive
      */
     @Test
     public void testPrintFullTreeOption(@SysErr Capturable systemErr, @SysOut Capturable systemOut)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/testmodules/TestLoggingReporter.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/testmodules/TestLoggingReporter.java
@@ -25,6 +25,7 @@ import com.puppycrawl.tools.checkstyle.api.AbstractViolationReporter;
  * TestLoggingReporter.
  *
  * @noinspection ClassOnlyUsedInOnePackage
+ * @noinspectionreason ClassOnlyUsedInOnePackage - class is internal tool, and only used in testing
  */
 public final class TestLoggingReporter extends AbstractViolationReporter {
 


### PR DESCRIPTION
Related to #11277: takes care of RedundantThrows, SerializableInnerClassWithNonSerializableOuterClass, ClassOnlyUsedInOnePackage,  ClassWithTooManyDependents