### PR TITLE
Issue #11277: update code base to have javadoc tag to explain noinspection content

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -455,7 +455,8 @@ public class FinalLocalVariableCheck extends AbstractCheck {
      * @param prevScopeUninitializedVariableData variable for previous stack of uninitialized
      *     variables
      * @noinspection MethodParameterNamingConvention
-     * @noinspectionreason complicated check requires descriptive naming
+     * @noinspectionreason MethodParameterNamingConvention - complicated check
+     *      requires descriptive naming
      */
     private void updateAllUninitializedVariables(
             Deque<DetailAST> prevScopeUninitializedVariableData) {


### PR DESCRIPTION
Related to #11277, takes care of HtmlTagCanBeJavadocTag, JavadocReference, BooleanParameter, MethodParameterNamingConvention