### PR TITLE
Issue #11277: update code base to have javadoc tag to explain noinspection content

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/XmlLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/XmlLoader.java
@@ -45,6 +45,8 @@ import org.xml.sax.helpers.DefaultHandler;
  * </p>
  *
  * @noinspection ThisEscapedInObjectConstruction
+ * @noinspectionreason ThisEscapedInObjectConstruction - only reference is used and not
+ *      accessed until initialized
  */
 public class XmlLoader
     extends DefaultHandler {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
@@ -338,6 +338,8 @@ public class FinalClassCheck
      * @param countProvider the function to apply to calculate the name matching count
      * @return {@link Optional} of {@link ClassDesc} object of the nearest class with the same name.
      * @noinspection CallToStringConcatCanBeReplacedByOperator
+     * @noinspectionreason CallToStringConcatCanBeReplacedByOperator - operator causes
+     *      pitest to fail
      */
     private Optional<ClassDesc> getNearestClassWithSameName(String className,
         Function<ClassDesc, Integer> countProvider) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java
@@ -46,6 +46,8 @@ public class HandlerFactory {
      * Creates a HandlerFactory.
      *
      * @noinspection OverlyCoupledMethod
+     * @noinspectionreason OverlyCoupledMethod - complex nature of indentation check
+     *      requires this coupling
      */
     public HandlerFactory() {
         register(TokenTypes.CASE_GROUP, CaseHandler.class);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java
@@ -60,6 +60,8 @@ import net.sf.saxon.trans.XPathException;
  * Original&nbsp;Source&nbsp;Location</a>
  *
  * @noinspection ThisEscapedInObjectConstruction
+ * @noinspectionreason ThisEscapedInObjectConstruction - only reference is used and not
+ *      accessed until initialized
  */
 public final class TreeTable extends JTable {
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageNamesLoaderTest.java
@@ -39,11 +39,13 @@ import org.xml.sax.SAXException;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 
 /**
- * Custom class loader is needed to pass URLs to pretend these are loaded from the classpath
- * though we can't add/change the files for testing. The class loader is nested in this class,
- * so the custom class loader we are using is safe.
+ * Tests loading of package names from XML files.
  *
  * @noinspection ClassLoaderInstantiation
+ * @noinspectionreason ClassLoaderInstantiation - Custom class loader is needed to pass URLs to
+ *      pretend these are loaded from the classpath though we can't add/change the files for
+ *      testing. The class loader is nested in this class, so the custom class loader we
+ *      are using is safe.
  */
 public class PackageNamesLoaderTest extends AbstractPathTestSupport {
 
@@ -227,10 +229,11 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
     }
 
     /**
-     * Custom class loader is needed to pass URLs to pretend these are loaded from the classpath
-     * though we can't add/change the files for testing.
+     * Mocked ClassLoader for testing URL loading.
      *
      * @noinspection CustomClassloader
+     * @noinspectionreason CustomClassloader - needed to pass URLs to pretend these are loaded
+     *      from the classpath though we can't add/change the files for testing
      */
     private static class TestUrlsClassLoader extends ClassLoader {
 
@@ -247,9 +250,11 @@ public class PackageNamesLoaderTest extends AbstractPathTestSupport {
     }
 
     /**
-     * Custom class loader is needed to throw an exception to test a catch statement.
+     * Mocked ClassLoader for testing exceptions.
      *
      * @noinspection CustomClassloader
+     * @noinspectionreason CustomClassloader - needed to throw an exception to
+     *      test a catch statement
      */
     private static class TestIoExceptionClassLoader extends ClassLoader {
         @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/ViolationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/ViolationTest.java
@@ -47,6 +47,8 @@ import nl.jqno.equalsverifier.EqualsVerifierReport;
  * so the custom class loader we are using is safe.
  *
  * @noinspection ClassLoaderInstantiation
+ * @noinspectionreason ClassLoaderInstantiation - Custom class loader is needed to
+ *      pass URLs for testing
  */
 public class ViolationTest {
 
@@ -438,10 +440,11 @@ public class ViolationTest {
     }
 
     /**
-     * Custom class loader is needed to pass URLs to pretend these are loaded from the classpath
-     * though we can't add/change the files for testing.
+     * Mocked ClassLoader for testing URL loading.
      *
      * @noinspection CustomClassloader
+     * @noinspectionreason CustomClassloader - needed to pass URLs to pretend these are loaded
+     *      from the classpath though we can't add/change the files for testing
      */
     private static class TestUrlsClassLoader extends ClassLoader {
 


### PR DESCRIPTION
Related to #11277, takes care of CallToStringConcatCanBeReplacedByOperator, OverlyCoupledMethod, ThisEscapedInObjectConstruction, ClassLoaderInstantiation, CustomClassloader