### PR TITLE
Issue #11277: update code base to have javadoc tag to explain noinspection content

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -103,6 +103,11 @@ public final class Main {
      * @param args the command line arguments.
      * @throws IOException if there is a problem with files access
      * @noinspection UseOfSystemOutOrSystemErr, CallToPrintStackTrace, CallToSystemExit
+     * @noinspectionreason UseOfSystemOutOrSystemErr - driver class for Checkstyle requires
+     *      usage of System.out and System.err
+     * @noinspectionreason CallToPrintStackTrace - driver class for Checkstyle must be able to
+     *      show all details in case of failure
+     * @noinspectionreason CallToSystemExit - driver class must call exit
      **/
     public static void main(String... args) throws IOException {
 
@@ -171,6 +176,8 @@ public final class Main {
      * @throws IOException if a file could not be read.
      * @throws CheckstyleException if something happens processing the files.
      * @noinspection UseOfSystemOutOrSystemErr
+     * @noinspectionreason UseOfSystemOutOrSystemErr - driver class for Checkstyle requires
+     *      usage of System.out and System.err
      */
     private static int execute(ParseResult parseResult, CliOptions options)
             throws IOException, CheckstyleException {
@@ -270,6 +277,8 @@ public final class Main {
      * @throws IOException if a file could not be read.
      * @throws CheckstyleException if something happens processing the files.
      * @noinspection UseOfSystemOutOrSystemErr
+     * @noinspectionreason UseOfSystemOutOrSystemErr - driver class for Checkstyle requires
+     *      usage of System.out and System.err
      */
     private static int runCli(CliOptions options, List<File> filesToProcess)
             throws IOException, CheckstyleException {
@@ -501,6 +510,8 @@ public final class Main {
      * @return output stream
      * @throws IOException might happen
      * @noinspection UseOfSystemOutOrSystemErr
+     * @noinspectionreason UseOfSystemOutOrSystemErr - driver class for Checkstyle requires
+     *      usage of System.out and System.err
      */
     @SuppressWarnings("resource")
     private static OutputStream getOutputStream(Path outputPath) throws IOException {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
@@ -1825,6 +1825,8 @@ public final class TokenTypes {
      *
      * @see FullIdent
      * @noinspection HtmlTagCanBeJavadocTag
+     * @noinspectionreason HtmlTagCanBeJavadocTag - encoded symbols were not decoded
+     *      when replaced with Javadoc tag
      **/
     public static final int DOT = JavaLanguageLexer.DOT;
     /**
@@ -3596,6 +3598,8 @@ public final class TokenTypes {
      * @see #EXPR
      * @see #COLON
      * @noinspection HtmlTagCanBeJavadocTag
+     * @noinspectionreason HtmlTagCanBeJavadocTag - encoded symbols were not decoded
+     *      when replaced with Javadoc tag
      **/
     public static final int QUESTION = JavaLanguageLexer.QUESTION;
     /**
@@ -3730,6 +3734,8 @@ public final class TokenTypes {
      *
      * @see #EXPR
      * @noinspection HtmlTagCanBeJavadocTag
+     * @noinspectionreason HtmlTagCanBeJavadocTag - encoded symbols were not decoded
+     *      when replaced with Javadoc tag
      **/
     public static final int NOT_EQUAL = JavaLanguageLexer.NOT_EQUAL;
     /**
@@ -4176,6 +4182,8 @@ public final class TokenTypes {
      * Language Specification, &sect;15.15.6</a>
      * @see #EXPR
      * @noinspection HtmlTagCanBeJavadocTag
+     * @noinspectionreason HtmlTagCanBeJavadocTag - encoded symbols were not decoded
+     *      when replaced with Javadoc tag
      **/
     public static final int LNOT = JavaLanguageLexer.LNOT;
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
@@ -194,6 +194,8 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </ul>
  *
  * @noinspection HtmlTagCanBeJavadocTag
+ * @noinspectionreason HtmlTagCanBeJavadocTag - encoded symbols were not decoded
+ *      when replaced with Javadoc tag
  * @since 3.4
  */
 @StatelessCheck

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -456,6 +456,7 @@ public class FinalLocalVariableCheck extends AbstractCheck {
      * @param prevScopeUninitializedVariableData variable for previous stack of uninitialized
      *     variables
      * @noinspection MethodParameterNamingConvention
+     * @noinspectionreason complicated check requires descriptive naming
      */
     private void updateAllUninitializedVariables(
             Deque<DetailAST> prevScopeUninitializedVariableData) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
@@ -84,6 +84,8 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *
  * @since 3.2
  * @noinspection HtmlTagCanBeJavadocTag
+ * @noinspectionreason HtmlTagCanBeJavadocTag - encoded symbols were not decoded
+ *      when replaced with Javadoc tag
  */
 @StatelessCheck
 public class StringLiteralEqualityCheck extends AbstractCheck {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java
@@ -246,6 +246,7 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
  * </ul>
  *
  * @noinspection ThisEscapedInObjectConstruction
+ * @noinspectionreason ThisEscapedInObjectConstruction - class is instantiated in handlers
  * @since 3.1
  */
 @FileStatefulCheck

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java
@@ -58,6 +58,7 @@ public class LineWrappingHandler {
          * @return enum instance.
          *
          * @noinspection BooleanParameter
+         * @noinspectionreason BooleanParameter - check property is essentially boolean
          */
         public static LineWrappingOptions ofBoolean(boolean val) {
             LineWrappingOptions option = NONE;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions.java
@@ -218,6 +218,7 @@ public final class DetectorOptions {
          * @return Builder object.
          * @noinspection ReturnOfInnerClass, BooleanParameter
          * @noinspectionreason ReturnOfInnerClass - builder is only used in enclosing class
+         * @noinspectionreason BooleanParameter - check fields are boolean
          */
         public Builder ignoreCase(boolean val) {
             ignoreCase = val;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -1857,6 +1857,8 @@ public class MainTest {
      * @param expectedExitCode the expected exit code to verify
      * @param arguments the command line arguments
      * @noinspection CallToSystemExit, ResultOfMethodCallIgnored
+     * @noinspectionreason CallToSystemExit - test helper method requires workaround to
+     *      verify exit code
      */
     private static void assertMainReturnCode(int expectedExitCode, String... arguments) {
         final Runtime mock = mock(Runtime.class);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/ViolationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/ViolationTest.java
@@ -137,9 +137,12 @@ public class ViolationTest {
     }
 
     /**
-     * Ignore resource errors for testing.
+     * Tests reload of resource bundle.
      *
      * @noinspection resource, IOResourceOpenedButNotSafelyClosed
+     * @noinspectionreason resource - we have no need to use try with resources in testing
+     * @noinspectionreason IOResourceOpenedButNotSafelyClosed - no need to close resources in
+     *      testing
      */
     @Test
     public void testBundleReloadUrlNotNull() throws IOException {
@@ -191,9 +194,12 @@ public class ViolationTest {
     }
 
     /**
-     * Ignore resource errors for testing.
+     * Tests reload of resource bundle.
      *
      * @noinspection resource, IOResourceOpenedButNotSafelyClosed
+     * @noinspectionreason resource - we have no need to use try with resources in testing
+     * @noinspectionreason IOResourceOpenedButNotSafelyClosed - no need to close resources in
+     *      testing
      */
     @Test
     public void testBundleReloadUrlNotNullFalseReload() throws IOException {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -333,6 +333,8 @@ public final class InlineConfigParser {
      * @param useFilteredViolations flag to set filtered violations.
      * @param lineNo current line.
      * @noinspection IfStatementWithTooManyBranches
+     * @noinspectionreason IfStatementWithTooManyBranches - complex logic of violation
+     *      parser requires giant if/else
      * @throws CheckstyleException if violation message is not specified
      */
     // -@cs[ExecutableStatementCount] splitting this method is not reasonable.

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheckTest.java
@@ -85,7 +85,8 @@ public class UniquePropertiesCheckTest extends AbstractModuleTestSupport {
      * Tests the {@link UniquePropertiesCheck#getLineNumber(FileText, String)}
      * method return value.
      *
-     * @noinspection JavadocReference Test javadocs should explain all.
+     * @noinspection JavadocReference
+     * @noinspectionreason JavadocReference - reference is required to specify method under test
      */
     @Test
     public void testNotFoundKey() throws Exception {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -699,7 +699,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
         private static String getJavaDocText(DetailAST node) {
             final String text = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<document>\n"
                     + node.getFirstChild().getText().replaceAll("(^|\\r?\\n)\\s*\\* ?", "\n")
-                            .replaceAll("\\n@noinspection.*\\r?\\n", "\n")
+                            .replaceAll("\\n?@noinspection.*\\r?\\n[^@]*", "\n")
                             .trim() + "\n</document>";
             String result = null;
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -1029,6 +1029,9 @@ public class XdocsPagesTest {
      * @param fieldClass The bean property's type
      * @param instance The class instance to work with
      * @return String form of property's default value
+     * @noinspection IfStatementWithTooManyBranches
+     * @noinspectionreason IfStatementWithTooManyBranches - complex nature of getting properties
+     *      from XML files requires giant if/else statement
      */
     private static String getModulePropertyExpectedValue(String sectionName, String propertyName,
             Field field, Class<?> fieldClass, Object instance) throws Exception {
@@ -1037,7 +1040,6 @@ public class XdocsPagesTest {
         if (field != null) {
             final Object value = field.get(instance);
 
-            // noinspection IfStatementWithTooManyBranches
             if ("Checker".equals(sectionName) && "localeCountry".equals(propertyName)) {
                 result = "default locale country for the Java Virtual Machine";
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CheckUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CheckUtil.java
@@ -205,7 +205,8 @@ public final class CheckUtil {
      * @param deepScan scan subclasses.
      * @return a set of checkstyle's module message fields.
      * @throws ClassNotFoundException if the attempt to read a protected class fails.
-     * @noinspection BooleanParameter Test code for easy usage.
+     * @noinspection BooleanParameter
+     * @noinspectionreason BooleanParameter - boolean parameter eases testing
      */
     public static Set<Field> getCheckMessages(Class<?> module, boolean deepScan)
             throws ClassNotFoundException {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtilTest.java
@@ -64,6 +64,8 @@ public final class MetadataGeneratorUtilTest extends AbstractModuleTestSupport {
      * @throws Exception if exception occurs during generating metadata or
      *                   if an I/O error is thrown when accessing the starting file.
      * @noinspection UseOfSystemOutOrSystemErr
+     * @noinspectionreason UseOfSystemOutOrSystemErr - generation of metadata
+     *      requires {@code System.out} for error messages
      */
     @Test
     public void testMetadataFilesGenerationAllFiles(@SystemOutGuard.SysOut Capturable systemOut)


### PR DESCRIPTION
Related to #11277 , takes care of IOResourceOpenedButNotSafelyClosed, resources, IfStatementWithTooManyBranches, ThisEscapedInObjectConstruction, UseOfSystemOutOrSystemErr, CallToPrintStackTrace, CallToSystemExit

Only second commit is under review, needed the first for removal of tags in xdocs