### PR TITLE
Issue #11277: update code base to have javadoc tag to explain noinspection content

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java
@@ -52,6 +52,7 @@ import com.puppycrawl.tools.checkstyle.gui.MainFrameModel.ParseMode;
  * using a JFileChooser.
  *
  * @noinspection MagicNumber
+ * @noinspectionreason MagicNumber - "magic numbers" are required to set GUI elements
  */
 public class MainFrame extends JFrame {
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -1859,6 +1859,7 @@ public class MainTest {
      * @noinspection CallToSystemExit, ResultOfMethodCallIgnored
      * @noinspectionreason CallToSystemExit - test helper method requires workaround to
      *      verify exit code
+     * @noinspectionreason ResultOfMethodCallIgnored - temporary suppression until #11589
      */
     private static void assertMainReturnCode(int expectedExitCode, String... arguments) {
         final Runtime mock = mock(Runtime.class);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PropertyCacheFileTest.java
@@ -333,6 +333,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
      * until #11589
      *
      * @noinspection ResultOfMethodCallIgnored
+     * @noinspectionreason ResultOfMethodCallIgnored - temporary suppression until #11589
      */
     @Test
     public void testNonExistentResource() throws IOException {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtilTest.java
@@ -200,6 +200,7 @@ public class ModuleReflectionUtilTest {
      * AbstractInvalidClass.
      *
      * @noinspection AbstractClassNeverImplemented
+     * @noinspectionreason AbstractClassNeverImplemented - class is only used in testing
      */
     private abstract static class AbstractInvalidClass extends AutomaticBean {
 


### PR DESCRIPTION
Related to #11277: takes care of MagicNumber, AbstractClassNeverImplemented, ResultOfMethodCallIgnored, and a few others that were missed elsewhere 