### PR TITLE
infra: disable xmlstarlet install

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -39,15 +39,15 @@ task:
     - choco install -y --no-progress ant
     - choco install -y --no-progress maven --version %MAVEN_VERSION%
     - choco install -y --no-progress openjdk --version %OPENJDK_VERSION%
-    - choco install -y --no-progress xsltproc
-    - choco install -y --no-progress xmlstarlet
+    # - choco install -y --no-progress xsltproc
+    # - choco install -y --no-progress xmlstarlet
   version_script:
     - set
     - ant -version
     - java --version
     - mvn --version
-    - xsltproc --version
-    - xml --version
+    # - xsltproc --version
+    # - xml --version
   sevntu_script:
     - cd ci
     - .ci/validation.cmd sevntu


### PR DESCRIPTION
This is just an experiment for now to see what fails if we do not install this package.

This build has been failing frequently lately from bad install of xmlstarlet: https://github.com/checkstyle/checkstyle/runs/7314089466

```
Added C:\ProgramData\chocolatey\bin\xsltproc.exe shim pointed to '..\lib\xsltproc\tools\xsltproc.bat'.
 ShimGen has successfully created a shim for iconv.exe
 ShimGen has successfully created a shim for xmlcatalog.exe
 ShimGen has successfully created a shim for xmllint.exe
 The install of xsltproc was successful.
  Software installed to 'C:\ProgramData\chocolatey\lib\xsltproc\tools\..\dist'

Chocolatey installed 1/1 packages. 
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build>if 0 NEQ 0 exit /b 0 

C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build>call choco install -y --no-progress xmlstarlet 
Chocolatey v1.1.0
Installing the following packages:
xmlstarlet
By installing, you accept licenses for the packages.

xmlstarlet.portable v1.6.1 [Approved] - Possibly broken
xmlstarlet.portable package files install completed. Performing other installation steps.
WARNING: Missing package checksums are not allowed (by default for HTTP/FTP, 
 HTTPS when feature 'allowEmptyChecksumsSecure' is disabled) for 
 safety and security reasons. Although we strongly advise against it, 
 if you need this functionality, please set the feature 
 'allowEmptyChecksums' ('choco feature enable -n 
 allowEmptyChecksums') 
 or pass in the option '--allow-empty-checksums'. You can also pass 
 checksums at runtime (recommended). See choco install -? for details.
The integrity of the file 'xmlstarlet-1.6.1-win32.zip' from 'http://sourceforge.net/projects/xmlstar/files/xmlstarlet/
1.6.1/xmlstarlet-1.6.1-win32.zip/download' has not been verified by a checksum in the package scripts.
Do you wish to allow the install to continue (not recommended)?
[Y] Yes [N] No (default is "N")
  Confirmation (`-y`) is set.
  Respond within 30 seconds or the default selection will be chosen.
WARNING: Write-ChocolateyFailure was removed in Chocolatey CLI v1. If you are the package maintainer, please use 'throw $_.Exception' instead.
WARNING: If you are not the maintainer, please contact the maintainer to update the xmlstarlet package.
ERROR: Empty checksums are no longer allowed by default for non-secure sources. Please ask the maintainer to add checksums to this package. In the meantime if you need this package to work correctly, please enable the feature allowEmptyChecksums, provide the runtime switch '--allow-empty-checksums', or pass in checksums at runtime (recommended - see 'choco install -?' / 'choco upgrade -?' for details). It is strongly advised against allowing empty checksums for non-internal HTTP/FTP sources.
The install of xmlstarlet.portable was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\xmlstarlet.portable\tools\chocolateyInstall.ps1'.
 See log for details.

xmlstarlet v1.6.1 [Approved]
xmlstarlet package files install completed. Performing other installation steps.
 The install of xmlstarlet was successful.
  Software install location not explicitly set, it could be in package or
  default install location of installer.

Chocolatey installed 1/2 packages. 1 packages failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Failures
 - xmlstarlet.portable (exited -1) - Error while running
     'C:\ProgramData\chocolatey\lib\xmlstarlet.portable\tools\chocolateyInstall.ps1'.
 See log for details.

C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build>if -1 NEQ 0 exit /b -1 

Exit status: 4294967295
```
