### PR TITLE
Issue #11720: Kill surviving mutation in CheckstyleAntTask related to logging

### DIFF
--- a/.ci/pitest-suppressions/pitest-ant-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-ant-suppressions.xml
@@ -3,15 +3,6 @@
   <mutation unstable="false">
     <sourceFile>CheckstyleAntTask.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
-    <mutatedMethod>execute</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.MathMutator</mutator>
-    <description>Replaced long subtraction with addition</description>
-    <lineContent>log(&quot;Total execution took &quot; + (endTime - startTime) + TIME_SUFFIX,</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CheckstyleAntTask.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask</mutatedClass>
     <mutatedMethod>processFiles</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.MathMutator</mutator>
     <description>Replaced long subtraction with addition</description>

--- a/.ci/pitest-survival-check-html.sh
+++ b/.ci/pitest-survival-check-html.sh
@@ -109,7 +109,6 @@ pitest-ant)
   "CheckstyleAntTask.java.html:<td class='covered'><pre><span  class='survived'>            if (toFile == null || !useFile) {</span></pre></td></tr>"
   "CheckstyleAntTask.java.html:<td class='covered'><pre><span  class='survived'>            if (toFile == null || !useFile) {</span></pre></td></tr>"
   "CheckstyleAntTask.java.html:<td class='covered'><pre><span  class='survived'>            log(&#34;To process the files took &#34; + (processingEndTime - processingStartTime)</span></pre></td></tr>"
-  "CheckstyleAntTask.java.html:<td class='covered'><pre><span  class='survived'>            log(&#34;Total execution took &#34; + (endTime - startTime) + TIME_SUFFIX,</span></pre></td></tr>"
   "CheckstyleAntTask.java.html:<td class='covered'><pre><span  class='survived'>        log(&#34;To locate the files took &#34; + (endTime - startTime) + TIME_SUFFIX,</span></pre></td></tr>"
   );
   checkPitestReport ignoredItems

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
@@ -780,8 +782,34 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
                         .startsWith("Unable to process files:");
     }
 
+    @Test
+    public void testLoggedTime() throws IOException {
+        final CheckstyleAntTaskLogStub antTask = new CheckstyleAntTaskLogStub();
+        antTask.setConfig(getPath(CONFIG_FILE));
+        antTask.setProject(new Project());
+        antTask.setFile(new File(getPath(FLAWLESS_INPUT)));
+        final long startTime = System.currentTimeMillis();
+        antTask.execute();
+        final long endTime = System.currentTimeMillis();
+        final List<MessageLevelPair> loggedMessages = antTask.getLoggedMessages();
+        final long loggedTimeInExecute =
+            getNumberFromLine(loggedMessages.get(loggedMessages.size() - 1).getMsg());
+
+        assertWithMessage("Logged time inside method cannot be more than "
+                              + "logged time outside the method")
+            .that(loggedTimeInExecute)
+            .isAtMost(endTime - startTime);
+
+    }
+
     private static List<String> readWholeFile(File outputFile) throws IOException {
         return Files.readAllLines(outputFile.toPath(), StandardCharsets.UTF_8);
+    }
+
+    private static long getNumberFromLine(String line) {
+        final Matcher matcher = Pattern.compile("(\\d+)").matcher(line);
+        matcher.find();
+        return Long.parseLong(matcher.group(1));
     }
 
 }


### PR DESCRIPTION
#11720 
Checkstyle Ant Task documentation: https://checkstyle.sourceforge.io/anttask.html

### Diff Reports:
 N/A
### Rationale:

`antTask.execute()` uses `System.currentTimeMillis()` to calculate the time elapsed, if we note the time before and after the execution of the method, that will be more than or equal to the time calculated inside the method.

Now the order of execution of instructions can change in a multithreaded program as the scheduler controls the threads, but all the related methods run on a single thread only.
