### PR TITLE
Issue #11885: Allow SuppressWarningHolder to suppress the violation with NameCheck

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java
@@ -97,8 +97,8 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * </pre>
  * <p>
  * The general rule is that the argument of the {@code @SuppressWarnings} will be
- * matched against class name of the checker in lower case and without {@code Check}
- * suffix if present.
+ * matched against class name of the check in any letter case. Adding {@code check}
+ * suffix is also accepted.
  * </p>
  * <p>
  * If {@code aliasList} property was provided you can use your own names e.g. below
@@ -155,7 +155,7 @@ public class SuppressWarningsHolder
     private static final String JAVA_LANG_PREFIX = "java.lang.";
 
     /** Suffix to be removed from subclasses of Check. */
-    private static final String CHECK_SUFFIX = "Check";
+    private static final String CHECK_SUFFIX = "check";
 
     /** Special warning id for matching all the warnings. */
     private static final String ALL_WARNING_MATCHING_ID = "all";
@@ -182,8 +182,8 @@ public class SuppressWarningsHolder
 
     /**
      * Returns the default alias for the source name of a check, which is the
-     * source name in lower case with any dotted prefix or "Check" suffix
-     * removed.
+     * source name in lower case with any dotted prefix or "Check"/"check"
+     * suffix removed.
      *
      * @param sourceName the source name of the check (generally the class
      *        name)
@@ -191,11 +191,12 @@ public class SuppressWarningsHolder
      */
     public static String getDefaultAlias(String sourceName) {
         int endIndex = sourceName.length();
-        if (sourceName.endsWith(CHECK_SUFFIX)) {
+        final String sourceNameLower = sourceName.toLowerCase(Locale.ENGLISH);
+        if (sourceNameLower.endsWith(CHECK_SUFFIX)) {
             endIndex -= CHECK_SUFFIX.length();
         }
-        final int startIndex = sourceName.lastIndexOf('.') + 1;
-        return sourceName.substring(startIndex, endIndex).toLowerCase(Locale.ENGLISH);
+        final int startIndex = sourceNameLower.lastIndexOf('.') + 1;
+        return sourceNameLower.substring(startIndex, endIndex);
     }
 
     /**
@@ -268,7 +269,8 @@ public class SuppressWarningsHolder
             final String checkName = entry.getCheckName();
             final boolean nameMatches =
                 ALL_WARNING_MATCHING_ID.equals(checkName)
-                    || checkName.equalsIgnoreCase(checkAlias);
+                    || checkName.equalsIgnoreCase(checkAlias)
+                    || getDefaultAlias(checkName).equalsIgnoreCase(checkAlias);
             if (afterStart && beforeEnd
                     && (nameMatches || checkName.equals(event.getModuleId()))) {
                 suppressed = true;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -43,6 +43,7 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.api.Violation;
 import com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck;
+import com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck;
 import com.puppycrawl.tools.checkstyle.checks.whitespace.TypecastParenPadCheck;
@@ -503,6 +504,30 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
 
         verify(root,
             getNonCompilablePath("InputSuppressWarningsHolderTextBlocks.java"), expected);
+    }
+
+    @Test
+    public void testWithAndWithoutCheckSuffixDifferentCases() throws Exception {
+        final Configuration checkConfig = createModuleConfig(SuppressWarningsHolder.class);
+        final DefaultConfiguration treeWalker = createModuleConfig(TreeWalker.class);
+        final Configuration filter = createModuleConfig(SuppressWarningsFilter.class);
+        final DefaultConfiguration violationCheck = createModuleConfig(ConstantNameCheck.class);
+
+        treeWalker.addChild(checkConfig);
+        treeWalker.addChild(violationCheck);
+
+        final DefaultConfiguration root = createRootConfig(treeWalker);
+        root.addChild(filter);
+
+        final String pattern = "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$";
+        final String[] expected = {
+            "4:30: " + getCheckMessage(ConstantNameCheck.class,
+                AbstractNameCheck.MSG_INVALID_PATTERN, "a", pattern),
+        };
+
+        verify(root,
+                getPath("InputSuppressWarningsHolderWithAndWithoutCheckSuffixDifferentCases.java"),
+                expected);
     }
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderWithAndWithoutCheckSuffixDifferentCases.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderWithAndWithoutCheckSuffixDifferentCases.java
@@ -1,0 +1,23 @@
+package com.puppycrawl.tools.checkstyle.checks.suppresswarningsholder;
+
+public class InputSuppressWarningsHolderWithAndWithoutCheckSuffixDifferentCases {
+    private static final int a = 0; // violation 'invalid pattern'
+
+    @SuppressWarnings("checkstyle:constantnamecheck") // filtered violation 'invalid pattern'
+    private static final int b = 0;
+
+    @SuppressWarnings("checkstyle:ConstantName") // filtered violation 'invalid pattern'
+    private static final int c = 0;
+
+    @SuppressWarnings("checkstyle:ConstantNameCheck") // filtered violation 'invalid pattern'
+    private static final int d = 0;
+
+    @SuppressWarnings("checkstyle:constantname") // filtered violation 'invalid pattern'
+    private static final int e = 0;
+
+    @SuppressWarnings("checkstyle:cOnStAnTnAmEcHeCk") // filtered violation 'invalid pattern'
+    private static final int f = 0;
+
+    @SuppressWarnings("checkstyle:cOnStAnTnAmE") // filtered violation 'invalid pattern'
+    private static final int g = 0;
+}

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -1401,8 +1401,8 @@ class Test {
 }
         </source>
         <p>The general rule is that the argument of the <code>@SuppressWarnings</code> will be
-          matched against class name of the checker in lower case and without <code>Check</code>
-          suffix if present.
+          matched against class name of the check in any letter case. Adding <code>check</code>
+          suffix is also accepted.
         </p>
         <p>If <code>aliasList</code> property was provided you can use your own names e.g. below
              code will work if there was provided a <code>ParameterNumberCheck=paramnum</code> in


### PR DESCRIPTION
Resolves #11885 
Allows `SuppressWarningHolder` to suppress violations with NameCheck i.e `@SuppressWarnings("checkstyle:constantnamecheck")` or `@SuppressWarnings("checkstyle:ConstantNameCheck") `

---
Diff Regression config: https://gist.githubusercontent.com/stoyanK7/73d7efde0efd9c6496ba95f0816ccb86/raw/0e0179ee0b4e193cb5faa8b5fcfa74a6bc1a46f0/config.xml
