### PR TITLE
Issue #11720: Kill surviving mutation in CheckstyleAntTask related to creating logger

### DIFF
--- a/.ci/pitest-suppressions/pitest-ant-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-ant-suppressions.xml
@@ -26,22 +26,4 @@
     <description>Replaced long subtraction with addition</description>
     <lineContent>log(&quot;To process the files took &quot; + (processingEndTime - processingStartTime)</lineContent>
   </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CheckstyleAntTask.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask$Formatter</mutatedClass>
-    <mutatedMethod>createDefaultLogger</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (toFile == null || !useFile) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CheckstyleAntTask.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTask$Formatter</mutatedClass>
-    <mutatedMethod>createXmlLogger</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (toFile == null || !useFile) {</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/.ci/pitest-survival-check-html.sh
+++ b/.ci/pitest-survival-check-html.sh
@@ -106,8 +106,6 @@ pitest-common)
 
 pitest-ant)
   declare -a ignoredItems=(
-  "CheckstyleAntTask.java.html:<td class='covered'><pre><span  class='survived'>            if (toFile == null || !useFile) {</span></pre></td></tr>"
-  "CheckstyleAntTask.java.html:<td class='covered'><pre><span  class='survived'>            if (toFile == null || !useFile) {</span></pre></td></tr>"
   "CheckstyleAntTask.java.html:<td class='covered'><pre><span  class='survived'>            log(&#34;To process the files took &#34; + (processingEndTime - processingStartTime)</span></pre></td></tr>"
   "CheckstyleAntTask.java.html:<td class='covered'><pre><span  class='survived'>            log(&#34;Total execution took &#34; + (endTime - startTime) + TIME_SUFFIX,</span></pre></td></tr>"
   "CheckstyleAntTask.java.html:<td class='covered'><pre><span  class='survived'>        log(&#34;To locate the files took &#34; + (endTime - startTime) + TIME_SUFFIX,</span></pre></td></tr>"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -625,6 +625,27 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
     }
 
     @Test
+    public void testDefaultLoggerWithNullToFile() throws IOException {
+        final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
+        formatter.setTofile(null);
+        assertWithMessage("Listener instance has unexpected type")
+            .that(formatter.createListener(null))
+            .isInstanceOf(DefaultLogger.class);
+    }
+
+    @Test
+    public void testXmlLoggerWithNullToFile() throws IOException {
+        final CheckstyleAntTask.FormatterType formatterType = new CheckstyleAntTask.FormatterType();
+        formatterType.setValue("xml");
+        final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
+        formatter.setType(formatterType);
+        formatter.setTofile(null);
+        assertWithMessage("Listener instance has unexpected type")
+            .that(formatter.createListener(null))
+            .isInstanceOf(XMLLogger.class);
+    }
+
+    @Test
     public void testSetClasspath() {
         final CheckstyleAntTask antTask = new CheckstyleAntTask();
         final Project project = new Project();


### PR DESCRIPTION
https://github.com/checkstyle/checkstyle/issues/11720
Checkstyle Ant Task documentation: https://checkstyle.sourceforge.io/anttask.html
### Diff Reports:

N/A
### Rationale:

These mutations were getting killed without any new test case when I `replaced equality check with true`. But the mutations were surviving in the `mutationCoverage` report due to branch optimization.
https://github.com/checkstyle/checkstyle/blob/40b3384a7f22ef41e434cbe747f0a803d2b2d7a2/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java#L698-L706

After branch optimization changed to-
```java
if (toFile != null && useFile) {                                                   
    final OutputStream infoStream = Files.newOutputStream(toFile.toPath());        
    defaultLogger =                                                                
            new DefaultLogger(infoStream, AutomaticBean.OutputStreamOptions.CLOSE, 
                    infoStream, AutomaticBean.OutputStreamOptions.NONE);           
}                                                                                  
else {                                                                             
```
Where there was survival and the missing test case was added. I covered both the mutations in a single PR as they were similar. 
 