### PR TITLE
minor: fix linkcheck violation on trailing slash in new version of exec-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2139,6 +2139,8 @@
             <excludedLink>http://maven.apache.org/plugins/maven-eclipse-plugin/</excludedLink>
             <excludedLink>http://maven.apache.org/plugins/maven-install-plugin/</excludedLink>
             <excludedLink>http://maven.apache.org/plugins/maven-linkcheck-plugin/</excludedLink>
+            <!-- until new plugins are released to generate link with trailing '/' -->
+            <excludedLink>https://www.mojohaus.org/exec-maven-plugin</excludedLink>
             <!-- permanent 403 -->
             <excludedLink>https://www.ej-technologies.com/*</excludedLink>
             <excludedLink>https://travis-ci.com/</excludedLink>


### PR DESCRIPTION
caused by latest version bump in exec-maven-plugin
https://github.com/checkstyle/checkstyle/runs/7373432546?check_suite_focus=true#step:3:2207

```
------------ grep of linkcheck.html--BEGIN
<td><i><a class="externalLink" href="https://www.mojohaus.org/exec-maven-plugin">https://www.mojohaus.org/exec-maven-plugin</a>: 301 Moved Permanently</i></td></tr></table></td></tr>
<td><i><a class="externalLink" href="https://www.mojohaus.org/exec-maven-plugin">https://www.mojohaus.org/exec-maven-plugin</a>: 301 Moved Permanently</i></td></tr></table></td></tr>
------------ grep of linkcheck.html--END
```

```
$ mvn site -Pno-validations
....
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  59.816 s
[INFO] Finished at: 2022-07-16T17:26:17-07:00
[INFO] ------------------------------------------------------------------------
✔ ~/java/github/romani/checkstyle [master|✔] 
$ cd target/site/
✔ ~/java/github/romani/checkstyle/target/site [master|✔] 
$ ag "https://www.mojohaus.org/exec-maven-plugin"
plugins.html
236:<td><a class="externalLink" href="https://www.mojohaus.org/exec-maven-plugin">exec-maven-plugin</a></td>

plugin-management.html
184:<td><a class="externalLink" href="https://www.mojohaus.org/exec-maven-plugin">exec-maven-plugin</a></td>

```

https://wheregoes.com/trace/20223628039/