### PR TITLE
Issue #11720: Kill surviving mutation in UnnecessaryParenthesesCheck in visitToken

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-1-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-1-suppressions.xml
@@ -33,15 +33,6 @@
     <mutatedMethod>visitToken</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
     <description>removed conditional - replaced equality check with true</description>
-    <lineContent>else if (type != TokenTypes.ASSIGN</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>UnnecessaryParenthesesCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessaryParenthesesCheck</mutatedClass>
-    <mutatedMethod>visitToken</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
     <lineContent>if (type == TokenTypes.LAMBDA &amp;&amp; isLambdaSingleParameterSurrounded(ast)) {</lineContent>
   </mutation>
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
@@ -482,8 +482,7 @@ public class UnnecessaryParenthesesCheck extends AbstractCheck {
         if (type == TokenTypes.LAMBDA && isLambdaSingleParameterSurrounded(ast)) {
             log(ast, MSG_LAMBDA, ast.getText());
         }
-        else if (type != TokenTypes.ASSIGN
-            || parent.getType() != TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR) {
+        else if (parent.getType() != TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR) {
             final boolean surrounded = isSurrounded(ast);
             // An identifier surrounded by parentheses.
             if (surrounded && type == TokenTypes.IDENT) {


### PR DESCRIPTION
#11720
Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11910

Check documentation: https://checkstyle.sourceforge.io/config_coding.html#UnnecessaryParentheses

### Diff Reports:

- DefaultConfig: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/e1420ec_2022144656/reports/diff/index.html

### Rationale

```java
@MyAnnotation1(name = "ABC")
```
parses as:
```
ANNOTATION -> ANNOTATION 
 |--AT -> @ 
 |--IDENT -> MyAnnotation1 
 |--LPAREN -> ( 
 |--ANNOTATION_MEMBER_VALUE_PAIR -> ANNOTATION_MEMBER_VALUE_PAIR
 |   |--IDENT -> name 
 |   |--ASSIGN -> = 
 |   `--EXPR -> EXPR 
 |       `--STRING_LITERAL -> "ABC" 
 `--RPAREN -> ) 
```

It has `IDENT`, `ASSIGN` and `EXPR` as its children, removing the condition  
`type != TokenTypes.ASSIGN` will also prevent `IDENT` and `EXPR` from going inside the block. `EXPR` is not checked inside the current block so it possesses no issues. `IDENT` is checked but it can never be surrounded in this case i.e. something like `@MyAnnotation1((name) = "ABC")` or
`@MyAnnotation1((name = "ABC"))` is not possible (compile-time error). 
Hence this condition can be safely removed.

---

### Generating reports again:

Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/d693c2dfb54829328bb20fbf1f58218191605263/my_checks.xml
Report label: DefaultConfig
