### PR TITLE
Issue #11720: Kill surviving mutation in UnnecessaryParenthesesCheck in isLambdaSingleParameterSurrounded

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-1-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-1-suppressions.xml
@@ -3,15 +3,6 @@
   <mutation unstable="false">
     <sourceFile>UnnecessaryParenthesesCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessaryParenthesesCheck</mutatedClass>
-    <mutatedMethod>isLambdaSingleParameterSurrounded</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (firstChild != null &amp;&amp; firstChild.getType() == TokenTypes.LPAREN) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>UnnecessaryParenthesesCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessaryParenthesesCheck</mutatedClass>
     <mutatedMethod>leaveToken</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
     <description>removed conditional - replaced equality check with false</description>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
@@ -635,7 +635,7 @@ public class UnnecessaryParenthesesCheck extends AbstractCheck {
     private static boolean isLambdaSingleParameterSurrounded(DetailAST ast) {
         final DetailAST firstChild = ast.getFirstChild();
         boolean result = false;
-        if (firstChild != null && firstChild.getType() == TokenTypes.LPAREN) {
+        if (TokenUtil.isOfType(firstChild, TokenTypes.LPAREN)) {
             final DetailAST parameters = firstChild.getNextSibling();
             if (parameters.getChildCount(TokenTypes.PARAMETER_DEF) == 1
                     && !parameters.getFirstChild().findFirstToken(TokenTypes.TYPE).hasChildren()) {


### PR DESCRIPTION
#11720
Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11907

Check documentation: https://checkstyle.sourceforge.io/config_coding.html#UnnecessaryParentheses

### Diff Reports:

- DefaultConfig: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/2036331_2022184302/reports/diff/index.html

### Rationale
Lambdas are of 3 types-
```java
foo1 obj = () -> {};  
foo2 obj2 = a -> {};  
foo2 obj3 = (a) -> {};
```
Related respective ASTs:
```
--LAMBDA -> ->
   |--LPAREN -> (
   |--PARAMETERS -> PARAMETERS
   |--RPAREN -> )
   `--SLIST -> { 
       `--RCURLY -> }
```
```
--LAMBDA -> ->
    |--IDENT -> a
    `--SLIST -> {
        `--RCURLY -> }
```
```
--LAMBDA -> ->
    |--LPAREN -> (
    |--PARAMETERS -> PARAMETERS
    |   `--PARAMETER_DEF -> PARAMETER_DEF
    |       |--MODIFIERS -> MODIFIERS
    |       |--TYPE -> TYPE
    |       `--IDENT -> a
    |--RPAREN -> )
    `--SLIST -> {
        `--RCURLY -> }
```

If I remove the condition `firstChild.getType() == TokenTypes.LPAREN` then second type of lambda would be allowed inside the block but it won't make any difference as the condition https://github.com/checkstyle/checkstyle/blob/181843f9f43b2d485239ba406b3bb50eaab997e0/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java#L639-L643

won't be true for the second case ever, this was a good optimization so I used `TokenUtil.isOfType(..)` to maintain performance and get rid of the mutation too.

---

### Generating reports again:

Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/d693c2dfb54829328bb20fbf1f58218191605263/my_checks.xml
Report label: DefaultConfig
