### PR TITLE
Issue #11720: Kill surviving mutation in UnnecessaryParenthesesCheck related to lambdas

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-1-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-1-suppressions.xml
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
-    <sourceFile>UnnecessaryParenthesesCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessaryParenthesesCheck</mutatedClass>
-    <mutatedMethod>visitToken</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (type == TokenTypes.LAMBDA &amp;&amp; isLambdaSingleParameterSurrounded(ast)) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
     <mutatedMethod>calculateDistanceInSingleScope</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
@@ -476,13 +476,13 @@ public class UnnecessaryParenthesesCheck extends AbstractCheck {
     // -@cs[CyclomaticComplexity] All logs should be in visit token.
     @Override
     public void visitToken(DetailAST ast) {
-        final int type = ast.getType();
         final DetailAST parent = ast.getParent();
 
-        if (type == TokenTypes.LAMBDA && isLambdaSingleParameterSurrounded(ast)) {
+        if (isLambdaSingleParameterSurrounded(ast)) {
             log(ast, MSG_LAMBDA, ast.getText());
         }
         else if (parent.getType() != TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR) {
+            final int type = ast.getType();
             final boolean surrounded = isSurrounded(ast);
             // An identifier surrounded by parentheses.
             if (surrounded && type == TokenTypes.IDENT) {
@@ -623,11 +623,10 @@ public class UnnecessaryParenthesesCheck extends AbstractCheck {
     }
 
     /**
-     * Tests if the given lambda node has a single parameter, no defined type, and is surrounded
-     * by parentheses.
+     * Tests if the given node has a single parameter, no defined type, and is surrounded
+     * by parentheses. This condition can only be true for lambdas.
      *
-     * @param ast a {@code DetailAST} whose type is
-     *        {@code TokenTypes.LAMBDA}.
+     * @param ast a {@code DetailAST} node
      * @return {@code true} if the lambda has a single parameter, no defined type, and is
      *         surrounded by parentheses.
      */


### PR DESCRIPTION
#11720
Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11911

Check documentation: https://checkstyle.sourceforge.io/config_coding.html#UnnecessaryParentheses

### Diff Reports:

- DefaultConfig: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/26624b9_2022085405/reports/diff/index.html

### Rationale
Only `LAMBDA` can satisfy the condition https://github.com/checkstyle/checkstyle/blob/c5934093281c83126d7f34365501404f87fb46b8/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java#L635-L646
```java
foo2 obj3 = (a) -> {};
```
AST:
```
--LAMBDA -> ->
    |--LPAREN -> (
    |--PARAMETERS -> PARAMETERS
    |   `--PARAMETER_DEF -> PARAMETER_DEF
    |       |--MODIFIERS -> MODIFIERS
    |       |--TYPE -> TYPE
    |       `--IDENT -> a
    |--RPAREN -> )
    `--SLIST -> {
        `--RCURLY -> }
```

Rest all things containing `PARAMETERS` will fail at https://github.com/checkstyle/checkstyle/blob/c5934093281c83126d7f34365501404f87fb46b8/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java#L638
Both `METHOD_DEF` and `CTOR_DEF` don't have `LPAREN`as their first child.
```java
void method(int a) {
}
```
```
METHOD_DEF -> METHOD_DEF 
 |--MODIFIERS -> MODIFIERS 
 |--TYPE -> TYPE 
 |   `--LITERAL_VOID -> void 
 |--IDENT -> method 
 |--LPAREN -> ( 
 |--PARAMETERS -> PARAMETERS 
 |   `--PARAMETER_DEF -> PARAMETER_DEF 
 |       |--MODIFIERS -> MODIFIERS 
 |       |--TYPE -> TYPE 
 |       |   `--LITERAL_INT -> int 
 |       `--IDENT -> a 
 |--RPAREN -> ) 
 `--SLIST -> { 
     `--RCURLY -> } 
```
```java
SomeClass(int a) {
}
```
```
CTOR_DEF -> CTOR_DEF 
 |--MODIFIERS -> MODIFIERS 
 |--IDENT -> SomeClass 
 |--LPAREN -> ( 
 |--PARAMETERS -> PARAMETERS 
 |   `--PARAMETER_DEF -> PARAMETER_DEF 
 |       |--MODIFIERS -> MODIFIERS 
 |       |--TYPE -> TYPE 
 |       |   `--LITERAL_INT -> int 
 |       `--IDENT -> a 
 |--RPAREN -> ) 
 `--SLIST -> { 
     `--RCURLY -> } 
```
We don't visit `METHOD_DEF` or `CTOR_DEF` as it is not in the list of required tokens or acceptable tokens. `EXPR` can reach this block and it will pass the condition at  https://github.com/checkstyle/checkstyle/blob/c5934093281c83126d7f34365501404f87fb46b8/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java#L638

```java
int a = (12);
```
```
|--VARIABLE_DEF -> VARIABLE_DEF  
|   |--MODIFIERS -> MODIFIERS  
|   |--TYPE -> TYPE  
|   |   `--LITERAL_INT -> int  
|   |--IDENT -> a  
|   `--ASSIGN -> =  
|       `--EXPR -> EXPR  
|           |--LPAREN -> (  
|           |--NUM_INT -> 12  
|           `--RPAREN -> )  
|--SEMI -> ;
```
`EXPR` has first child as `LPAREN` but it will also fail at https://github.com/checkstyle/checkstyle/blob/c5934093281c83126d7f34365501404f87fb46b8/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java#L640-L641

Also it won't throw a NPE because of the nature of conditions and their order (`a && b`).

---

### Generating reports again:

Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/d693c2dfb54829328bb20fbf1f58218191605263/my_checks.xml
Report label: DefaultConfig

