### PR TITLE
Issue #6658: Kill Surviving mutation in ImportControlLoader

### DIFF
--- a/.ci/pitest-suppressions/pitest-imports-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-imports-suppressions.xml
@@ -94,24 +94,6 @@
     <sourceFile>ImportControlLoader.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportControlLoader</mutatedClass>
     <mutatedMethod>startElement</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
-    <description>removed conditional - replaced equality check with false</description>
-    <lineContent>else if (ALLOW_ELEMENT_NAME.equals(qName) || &quot;disallow&quot;.equals(qName)) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>ImportControlLoader.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportControlLoader</mutatedClass>
-    <mutatedMethod>startElement</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>else if (ALLOW_ELEMENT_NAME.equals(qName) || &quot;disallow&quot;.equals(qName)) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>ImportControlLoader.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportControlLoader</mutatedClass>
-    <mutatedMethod>startElement</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader::containsRegexAttribute</description>
     <lineContent>final boolean regex = containsRegexAttribute(attributes);</lineContent>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java
@@ -187,7 +187,7 @@ public final class ImportControlLoader extends XmlLoader {
             parentImportControl.addChild(importControl);
             stack.push(importControl);
         }
-        else if (ALLOW_ELEMENT_NAME.equals(qName) || "disallow".equals(qName)) {
+        else {
             final AbstractImportRule rule = createImportRule(qName, attributes);
             stack.peek().addImportRule(rule);
         }


### PR DESCRIPTION
#6658

**Check Documentation:** https://checkstyle.sourceforge.io/config_imports.html#ImportControl

### Diff Reports:

N/A

### Rationale:

https://github.com/checkstyle/checkstyle/blob/7b88df3043a92eb8c821ea9370d0f286c3f1207d/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java#L190-L193

is redundant as only `allow` and `disallow` can reach that branch, all other branches are covered before.
