### PR TITLE
Issue #11719: Activate all group for pitest-blocks

### DIFF
--- a/.ci/pitest-suppressions/pitest-blocks-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-blocks-suppressions.xml
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressedMutations>
+  <mutation unstable="false">
+    <sourceFile>EmptyBlockCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck</mutatedClass>
+    <mutatedMethod>setOption</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/lang/String::toUpperCase with receiver</description>
+    <lineContent>option = BlockOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>EmptyBlockCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck</mutatedClass>
+    <mutatedMethod>setOption</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/lang/String::trim with receiver</description>
+    <lineContent>option = BlockOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>EmptyBlockCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck</mutatedClass>
+    <mutatedMethod>visitToken</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getText</description>
+    <lineContent>ast.getText());</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>LeftCurlyCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck</mutatedClass>
+    <mutatedMethod>setOption</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/lang/String::toUpperCase with receiver</description>
+    <lineContent>option = LeftCurlyOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>LeftCurlyCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck</mutatedClass>
+    <mutatedMethod>setOption</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/lang/String::trim with receiver</description>
+    <lineContent>option = LeftCurlyOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>LeftCurlyCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyCheck</mutatedClass>
+    <mutatedMethod>visitToken</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_17</mutator>
+    <description>RemoveSwitch 17 mutation</description>
+    <lineContent>switch (ast.getType()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>NeedBracesCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.NeedBracesCheck</mutatedClass>
+    <mutatedMethod>isSingleLineIf</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::findFirstToken with receiver</description>
+    <lineContent>final DetailAST ifCondition = literalIf.findFirstToken(TokenTypes.EXPR);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RightCurlyCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck</mutatedClass>
+    <mutatedMethod>isBlockAloneOnSingleLine</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getLastChild with receiver</description>
+    <lineContent>final DetailAST doWhileSemi = nextToken.getParent().getLastChild();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RightCurlyCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck</mutatedClass>
+    <mutatedMethod>isBlockAloneOnSingleLine</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck$Details::getNextToken</description>
+    <lineContent>nextToken = Details.getNextToken(nextToken);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RightCurlyCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck</mutatedClass>
+    <mutatedMethod>setOption</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/lang/String::toUpperCase with receiver</description>
+    <lineContent>option = RightCurlyOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RightCurlyCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck</mutatedClass>
+    <mutatedMethod>setOption</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/lang/String::trim with receiver</description>
+    <lineContent>option = RightCurlyOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RightCurlyCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck$Details</mutatedClass>
+    <mutatedMethod>getDetails</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_1</mutator>
+    <description>RemoveSwitch 1 mutation</description>
+    <lineContent>switch (ast.getType()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RightCurlyCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck$Details</mutatedClass>
+    <mutatedMethod>getDetails</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_10</mutator>
+    <description>RemoveSwitch 10 mutation</description>
+    <lineContent>switch (ast.getType()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RightCurlyCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck$Details</mutatedClass>
+    <mutatedMethod>getDetails</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_11</mutator>
+    <description>RemoveSwitch 11 mutation</description>
+    <lineContent>switch (ast.getType()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RightCurlyCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck$Details</mutatedClass>
+    <mutatedMethod>getDetails</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_14</mutator>
+    <description>RemoveSwitch 14 mutation</description>
+    <lineContent>switch (ast.getType()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RightCurlyCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck$Details</mutatedClass>
+    <mutatedMethod>getDetails</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_3</mutator>
+    <description>RemoveSwitch 3 mutation</description>
+    <lineContent>switch (ast.getType()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RightCurlyCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck$Details</mutatedClass>
+    <mutatedMethod>getDetails</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_4</mutator>
+    <description>RemoveSwitch 4 mutation</description>
+    <lineContent>switch (ast.getType()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RightCurlyCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck$Details</mutatedClass>
+    <mutatedMethod>getDetails</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_5</mutator>
+    <description>RemoveSwitch 5 mutation</description>
+    <lineContent>switch (ast.getType()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RightCurlyCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck$Details</mutatedClass>
+    <mutatedMethod>getDetails</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_6</mutator>
+    <description>RemoveSwitch 6 mutation</description>
+    <lineContent>switch (ast.getType()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RightCurlyCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck$Details</mutatedClass>
+    <mutatedMethod>getDetails</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_7</mutator>
+    <description>RemoveSwitch 7 mutation</description>
+    <lineContent>switch (ast.getType()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RightCurlyCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck$Details</mutatedClass>
+    <mutatedMethod>getDetails</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_8</mutator>
+    <description>RemoveSwitch 8 mutation</description>
+    <lineContent>switch (ast.getType()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RightCurlyCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck$Details</mutatedClass>
+    <mutatedMethod>getDetails</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_9</mutator>
+    <description>RemoveSwitch 9 mutation</description>
+    <lineContent>switch (ast.getType()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RightCurlyCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck$Details</mutatedClass>
+    <mutatedMethod>getDetailsForIfElse</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck$Details::getNextToken</description>
+    <lineContent>nextToken = getNextToken(ast);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RightCurlyCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck$Details</mutatedClass>
+    <mutatedMethod>getDetailsForOthers</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getFirstChild with receiver</description>
+    <lineContent>lcurly = child.getFirstChild();</lineContent>
+  </mutation>
+</suppressedMutations>

--- a/pom.xml
+++ b/pom.xml
@@ -2467,15 +2467,33 @@
               <mutators>
                 <mutator>CONDITIONALS_BOUNDARY</mutator>
                 <mutator>CONSTRUCTOR_CALLS</mutator>
-                <mutator>FALSE_RETURNS</mutator>
                 <mutator>INCREMENTS</mutator>
+                <!-- Read reason of disablement at https://github.com/checkstyle/checkstyle/issues/11895 -->
+                <!-- <mutator>INLINE_CONSTS</mutator> -->
                 <mutator>INVERT_NEGS</mutator>
                 <mutator>MATH</mutator>
                 <mutator>NEGATE_CONDITIONALS</mutator>
-                <mutator>REMOVE_CONDITIONALS</mutator>
+                <mutator>NON_VOID_METHOD_CALLS</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_IF</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_IF</mutator>
                 <mutator>RETURN_VALS</mutator>
-                <mutator>TRUE_RETURNS</mutator>
                 <mutator>VOID_METHOD_CALLS</mutator>
+                <mutator>EXPERIMENTAL_ARGUMENT_PROPAGATION</mutator>
+                <mutator>EXPERIMENTAL_BIG_DECIMAL</mutator>
+                <mutator>EXPERIMENTAL_BIG_INTEGER</mutator>
+                <mutator>EXPERIMENTAL_MEMBER_VARIABLE</mutator>
+                <mutator>EXPERIMENTAL_NAKED_RECEIVER</mutator>
+                <mutator>REMOVE_INCREMENTS</mutator>
+                <mutator>EXPERIMENTAL_RETURN_VALUES_MUTATOR</mutator>
+                <mutator>EXPERIMENTAL_SWITCH</mutator>
+                <mutator>REMOVE_SWITCH</mutator>
+                <mutator>FALSE_RETURNS</mutator>
+                <mutator>TRUE_RETURNS</mutator>
+                <mutator>EMPTY_RETURNS</mutator>
+                <mutator>NULL_RETURNS</mutator>
+                <mutator>PRIMITIVE_RETURNS</mutator>
               </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.blocks.*</param>
@@ -2487,7 +2505,7 @@
                 <param>*.Input*</param>
               </excludedTestClasses>
               <coverageThreshold>100</coverageThreshold>
-              <mutationThreshold>100</mutationThreshold>
+              <mutationThreshold>98</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>


### PR DESCRIPTION

#11719
Activating `ALL` group for `pitest-blocks`

Every mutator has been activated except `INLINE_CONSTS`

- Report with `ALL` group except `INLINE_CONSTS`: https://vyom-yadav.github.io/pitest-all-latest/pitest-blocks/index.html
