### PR TITLE
Issue #11719: Activate all group for pitest-regexp

### DIFF
--- a/.ci/pitest-suppressions/pitest-regexp-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-regexp-suppressions.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressedMutations>
+  <mutation unstable="false">
+    <sourceFile>DetectorOptions.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.regexp.DetectorOptions</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable message</description>
+    <lineContent>private String message = &quot;&quot;;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>MultilineDetector.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.regexp.MultilineDetector</mutatedClass>
+    <mutatedMethod>findMatch</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/regex/Pattern::toString</description>
+    <lineContent>options.getReporter().log(1, MSG_STACKOVERFLOW, matcher.pattern().toString());</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RegexpCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck</mutatedClass>
+    <mutatedMethod>beginTree</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable errorCount</description>
+    <lineContent>errorCount = 0;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RegexpCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck</mutatedClass>
+    <mutatedMethod>beginTree</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable matchCount</description>
+    <lineContent>matchCount = 0;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RegexpCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck</mutatedClass>
+    <mutatedMethod>isIgnore</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/api/FileText::lineColumn</description>
+    <lineContent>end = text.lineColumn(0);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RegexpCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck</mutatedClass>
+    <mutatedMethod>setDuplicateLimit</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable duplicateLimit</description>
+    <lineContent>this.duplicateLimit = duplicateLimit;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RegexpMultilineCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.regexp.RegexpMultilineCheck</mutatedClass>
+    <mutatedMethod>getRegexCompileFlags</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ReturnValuesMutator</mutator>
+    <description>replaced return of primitive boolean/byte/short/integer value with (x == 1) ? 0 : x + 1</description>
+    <lineContent>return result;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RegexpSinglelineCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable format</description>
+    <lineContent>@XdocsPropertyType(PropertyType.PATTERN)</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RegexpSinglelineCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck</mutatedClass>
+    <mutatedMethod>beginProcessing</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions$Builder::compileFlags with receiver</description>
+    <lineContent>.compileFlags(0)</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RegexpSinglelineJavaCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable format</description>
+    <lineContent>@XdocsPropertyType(PropertyType.PATTERN)</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RegexpSinglelineJavaCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck</mutatedClass>
+    <mutatedMethod>beginTree</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions$Builder::compileFlags with receiver</description>
+    <lineContent>.compileFlags(0)</lineContent>
+  </mutation>
+</suppressedMutations>

--- a/pom.xml
+++ b/pom.xml
@@ -3343,15 +3343,33 @@
               <mutators>
                 <mutator>CONDITIONALS_BOUNDARY</mutator>
                 <mutator>CONSTRUCTOR_CALLS</mutator>
-                <mutator>FALSE_RETURNS</mutator>
                 <mutator>INCREMENTS</mutator>
+                <!-- Read reason of disablement at https://github.com/checkstyle/checkstyle/issues/11895 -->
+                <!-- <mutator>INLINE_CONSTS</mutator> -->
                 <mutator>INVERT_NEGS</mutator>
                 <mutator>MATH</mutator>
                 <mutator>NEGATE_CONDITIONALS</mutator>
-                <mutator>REMOVE_CONDITIONALS</mutator>
+                <mutator>NON_VOID_METHOD_CALLS</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_IF</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_IF</mutator>
                 <mutator>RETURN_VALS</mutator>
-                <mutator>TRUE_RETURNS</mutator>
                 <mutator>VOID_METHOD_CALLS</mutator>
+                <mutator>EXPERIMENTAL_ARGUMENT_PROPAGATION</mutator>
+                <mutator>EXPERIMENTAL_BIG_DECIMAL</mutator>
+                <mutator>EXPERIMENTAL_BIG_INTEGER</mutator>
+                <mutator>EXPERIMENTAL_MEMBER_VARIABLE</mutator>
+                <mutator>EXPERIMENTAL_NAKED_RECEIVER</mutator>
+                <mutator>REMOVE_INCREMENTS</mutator>
+                <mutator>EXPERIMENTAL_RETURN_VALUES_MUTATOR</mutator>
+                <mutator>EXPERIMENTAL_SWITCH</mutator>
+                <mutator>REMOVE_SWITCH</mutator>
+                <mutator>FALSE_RETURNS</mutator>
+                <mutator>TRUE_RETURNS</mutator>
+                <mutator>EMPTY_RETURNS</mutator>
+                <mutator>NULL_RETURNS</mutator>
+                <mutator>PRIMITIVE_RETURNS</mutator>
               </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.regexp.*</param>


### PR DESCRIPTION

#11719
Activating `ALL` group for `pitest-regexp`

Every mutator has been activated except `INLINE_CONSTS`

- Report with `ALL` group except `INLINE_CONSTS`: https://vyom-yadav.github.io/pitest-all-latest/pitest-regexp/index.html
