### PR TITLE
Issue #11719: Activate all group for pitest-sizes

### DIFF
--- a/.ci/pitest-suppressions/pitest-sizes-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-sizes-suppressions.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressedMutations>
+  <mutation unstable="false">
+    <sourceFile>ExecutableStatementCountCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.sizes.ExecutableStatementCountCheck</mutatedClass>
+    <mutatedMethod>visitSlist</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getParent with receiver</description>
+    <lineContent>DetailAST parent = ast.getParent();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ExecutableStatementCountCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.sizes.ExecutableStatementCountCheck$Context</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable count</description>
+    <lineContent>count = 0;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FileLengthCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.sizes.FileLengthCheck</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable max</description>
+    <lineContent>private int max = DEFAULT_MAX_LINES;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>MethodLengthCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.sizes.MethodLengthCheck</mutatedClass>
+    <mutatedMethod>countUsedLines</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getLineNo</description>
+    <lineContent>final int startLineNo = ast.getLineNo();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>OuterTypeNumberCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.sizes.OuterTypeNumberCheck</mutatedClass>
+    <mutatedMethod>beginTree</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable currentDepth</description>
+    <lineContent>currentDepth = 0;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>OuterTypeNumberCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.sizes.OuterTypeNumberCheck</mutatedClass>
+    <mutatedMethod>beginTree</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable outerNum</description>
+    <lineContent>outerNum = 0;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RecordComponentNumberCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheck</mutatedClass>
+    <mutatedMethod>setAccessModifiers</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Arrays::copyOf with argument</description>
+    <lineContent>Arrays.copyOf(accessModifiers, accessModifiers.length);</lineContent>
+  </mutation>
+</suppressedMutations>

--- a/pom.xml
+++ b/pom.xml
@@ -3388,15 +3388,33 @@
               <mutators>
                 <mutator>CONDITIONALS_BOUNDARY</mutator>
                 <mutator>CONSTRUCTOR_CALLS</mutator>
-                <mutator>FALSE_RETURNS</mutator>
                 <mutator>INCREMENTS</mutator>
+                <!-- Read reason of disablement at https://github.com/checkstyle/checkstyle/issues/11895 -->
+                <!-- <mutator>INLINE_CONSTS</mutator> -->
                 <mutator>INVERT_NEGS</mutator>
                 <mutator>MATH</mutator>
                 <mutator>NEGATE_CONDITIONALS</mutator>
-                <mutator>REMOVE_CONDITIONALS</mutator>
+                <mutator>NON_VOID_METHOD_CALLS</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_IF</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_IF</mutator>
                 <mutator>RETURN_VALS</mutator>
-                <mutator>TRUE_RETURNS</mutator>
                 <mutator>VOID_METHOD_CALLS</mutator>
+                <mutator>EXPERIMENTAL_ARGUMENT_PROPAGATION</mutator>
+                <mutator>EXPERIMENTAL_BIG_DECIMAL</mutator>
+                <mutator>EXPERIMENTAL_BIG_INTEGER</mutator>
+                <mutator>EXPERIMENTAL_MEMBER_VARIABLE</mutator>
+                <mutator>EXPERIMENTAL_NAKED_RECEIVER</mutator>
+                <mutator>REMOVE_INCREMENTS</mutator>
+                <mutator>EXPERIMENTAL_RETURN_VALUES_MUTATOR</mutator>
+                <mutator>EXPERIMENTAL_SWITCH</mutator>
+                <mutator>REMOVE_SWITCH</mutator>
+                <mutator>FALSE_RETURNS</mutator>
+                <mutator>TRUE_RETURNS</mutator>
+                <mutator>EMPTY_RETURNS</mutator>
+                <mutator>NULL_RETURNS</mutator>
+                <mutator>PRIMITIVE_RETURNS</mutator>
               </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.sizes.*</param>
@@ -3408,7 +3426,7 @@
                 <param>*.Input*</param>
               </excludedTestClasses>
               <coverageThreshold>100</coverageThreshold>
-              <mutationThreshold>100</mutationThreshold>
+              <mutationThreshold>99</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>


### PR DESCRIPTION

#11719
Activating `ALL` group for `pitest-sizes`

Every mutator has been activated except `INLINE_CONSTS`

- Report with `ALL` group except `INLINE_CONSTS`: https://vyom-yadav.github.io/pitest-all-latest/pitest-sizes/index.html
