### PR TITLE
Issue #11719: Activate all group for pitest-java-ast-visitor

### DIFF
--- a/.ci/pitest-suppressions/pitest-java-ast-visitor-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-java-ast-visitor-suppressions.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressedMutations>
+  <mutation unstable="false">
+    <sourceFile>JavaAstVisitor.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.JavaAstVisitor</mutatedClass>
+    <mutatedMethod>visitClassOrInterfaceType</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/util/List::subList with receiver</description>
+    <lineContent>.children.subList(1, extendedContext.children.size());</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>JavaAstVisitor.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.JavaAstVisitor</mutatedClass>
+    <mutatedMethod>visitFormalLambdaParam</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/JavaAstVisitor::visit</description>
+    <lineContent>final DetailAstImpl parameters = Optional.ofNullable(visit(ctx.formalParameterList()))</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>JavaAstVisitor.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.JavaAstVisitor</mutatedClass>
+    <mutatedMethod>visitFormalLambdaParam</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/grammar/java/JavaLanguageParser$FormalLambdaParamContext::formalParameterList</description>
+    <lineContent>final DetailAstImpl parameters = Optional.ofNullable(visit(ctx.formalParameterList()))</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>JavaAstVisitor.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.JavaAstVisitor</mutatedClass>
+    <mutatedMethod>visitInvOp</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/JavaAstVisitor::visit</description>
+    <lineContent>final DetailAstImpl expressionList = Optional.ofNullable(visit(ctx.expressionList()))</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>JavaAstVisitor.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.JavaAstVisitor</mutatedClass>
+    <mutatedMethod>visitInvOp</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/grammar/java/JavaLanguageParser$InvOpContext::expressionList</description>
+    <lineContent>final DetailAstImpl expressionList = Optional.ofNullable(visit(ctx.expressionList()))</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>JavaAstVisitor.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.JavaAstVisitor</mutatedClass>
+    <mutatedMethod>visitSuperExp</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/DetailAstImpl::getFirstChild with receiver</description>
+    <lineContent>DetailAstImpl firstChild = superSuffixParent.getFirstChild();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>JavaAstVisitor.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.JavaAstVisitor</mutatedClass>
+    <mutatedMethod>visitSuperSuffixDot</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/JavaAstVisitor::visit</description>
+    <lineContent>final DetailAstImpl expressionList = Optional.ofNullable(visit(ctx.expressionList()))</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>JavaAstVisitor.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.JavaAstVisitor</mutatedClass>
+    <mutatedMethod>visitSuperSuffixDot</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/grammar/java/JavaLanguageParser$SuperSuffixDotContext::expressionList</description>
+    <lineContent>final DetailAstImpl expressionList = Optional.ofNullable(visit(ctx.expressionList()))</lineContent>
+  </mutation>
+</suppressedMutations>

--- a/pom.xml
+++ b/pom.xml
@@ -3986,17 +3986,40 @@
             <version>${pitest.plugin.version}</version>
             <configuration>
               <mutators>
-                <mutator>CONDITIONALS_BOUNDARY</mutator>
-                <mutator>CONSTRUCTOR_CALLS</mutator>
-                <mutator>FALSE_RETURNS</mutator>
-                <mutator>INCREMENTS</mutator>
-                <mutator>INVERT_NEGS</mutator>
-                <mutator>MATH</mutator>
-                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_IF</mutator>
                 <mutator>REMOVE_CONDITIONALS</mutator>
-                <mutator>RETURN_VALS</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_IF</mutator>
                 <mutator>TRUE_RETURNS</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_ELSE</mutator>
                 <mutator>VOID_METHOD_CALLS</mutator>
+                <mutator>PRIMITIVE_RETURNS</mutator>
+                <mutator>FALSE_RETURNS</mutator>
+                <mutator>NON_VOID_METHOD_CALLS</mutator>
+                <mutator>EXPERIMENTAL_RETURN_VALUES_MUTATOR</mutator>
+                <mutator>INVERT_NEGS</mutator>
+                <mutator>CONDITIONALS_BOUNDARY</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_ELSE</mutator>
+                <mutator>DEFAULTS</mutator>
+                <mutator>RETURN_VALS</mutator>
+                <mutator>OLD_DEFAULTS</mutator>
+                <mutator>EXPERIMENTAL_SWITCH</mutator>
+                <mutator>RETURNS</mutator>
+                <mutator>EXPERIMENTAL_MEMBER_VARIABLE</mutator>
+                <mutator>NULL_RETURNS</mutator>
+                <mutator>EXPERIMENTAL_BIG_DECIMAL</mutator>
+                <mutator>MATH</mutator>
+                <mutator>EXPERIMENTAL_BIG_INTEGER</mutator>
+                <mutator>INCREMENTS</mutator>
+                <mutator>EXPERIMENTAL_ARGUMENT_PROPAGATION</mutator>
+                <mutator>EXPERIMENTAL_NAKED_RECEIVER</mutator>
+                <mutator>CONSTRUCTOR_CALLS</mutator>
+                <mutator>REMOVE_SWITCH</mutator>
+                <!-- Read reason of disablement at https://github.com/checkstyle/checkstyle/issues/11895 -->
+                <!-- <mutator>INLINE_CONSTS</mutator> -->
+                <mutator>STRONGER</mutator>
+                <mutator>REMOVE_INCREMENTS</mutator>
+                <mutator>NEGATE_CONDITIONALS</mutator>
+                <mutator>EMPTY_RETURNS</mutator>
               </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.JavaAstVisitor</param>


### PR DESCRIPTION

#11719
Activating `ALL` group for `pitest-java-ast-visitor`

Every mutator has been activated except `INLINE_CONSTS`

- Report with `ALL` group except `INLINE_CONSTS`: https://vyom-yadav.github.io/pitest-all-latest/pitest-java-ast-visitor/index.html
