### PR TITLE
Issue #11719: Activate all group for pitest-xpath

### DIFF
--- a/.ci/pitest-suppressions/pitest-xpath-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-xpath-suppressions.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressedMutations>
+  <mutation unstable="false">
+    <sourceFile>DescendantIterator.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.iterators.DescendantIterator</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable descendantEnum</description>
+    <lineContent>descendantEnum = null;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ElementNode.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.ElementNode</mutatedClass>
+    <mutatedMethod>getAttributeNode</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable attributeNode</description>
+    <lineContent>attributeNode = null;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ElementNode.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.ElementNode</mutatedClass>
+    <mutatedMethod>iterateAxis</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_8</mutator>
+    <description>RemoveSwitch 8 mutation</description>
+    <lineContent>switch (axisNumber) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FollowingIterator.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.iterators.FollowingIterator</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable descendantEnum</description>
+    <lineContent>descendantEnum = null;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FollowingIterator.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.iterators.FollowingIterator</mutatedClass>
+    <mutatedMethod>next</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable siblingEnum</description>
+    <lineContent>siblingEnum = null;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PrecedingIterator.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.iterators.PrecedingIterator</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable descendantEnum</description>
+    <lineContent>descendantEnum = null;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PrecedingIterator.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.iterators.PrecedingIterator</mutatedClass>
+    <mutatedMethod>next</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable previousSiblingEnum</description>
+    <lineContent>previousSiblingEnum = null;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ReverseListIterator.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.iterators.ReverseListIterator</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable items</description>
+    <lineContent>this.items = null;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RootNode.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.RootNode</mutatedClass>
+    <mutatedMethod>getColumnNumber</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getColumnNo</description>
+    <lineContent>return detailAst.getColumnNo();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RootNode.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.RootNode</mutatedClass>
+    <mutatedMethod>getColumnNumber</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.PrimitiveReturnsMutator</mutator>
+    <description>replaced int return with 0 for com/puppycrawl/tools/checkstyle/xpath/RootNode::getColumnNumber</description>
+    <lineContent>return detailAst.getColumnNo();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RootNode.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.RootNode</mutatedClass>
+    <mutatedMethod>iterateAxis</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_1</mutator>
+    <description>RemoveSwitch 1 mutation</description>
+    <lineContent>switch (axisNumber) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RootNode.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.RootNode</mutatedClass>
+    <mutatedMethod>iterateAxis</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_2</mutator>
+    <description>RemoveSwitch 2 mutation</description>
+    <lineContent>switch (axisNumber) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RootNode.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.RootNode</mutatedClass>
+    <mutatedMethod>iterateAxis</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_5</mutator>
+    <description>RemoveSwitch 5 mutation</description>
+    <lineContent>switch (axisNumber) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RootNode.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.RootNode</mutatedClass>
+    <mutatedMethod>iterateAxis</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_8</mutator>
+    <description>RemoveSwitch 8 mutation</description>
+    <lineContent>switch (axisNumber) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XpathQueryGenerator.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.XpathQueryGenerator</mutatedClass>
+    <mutatedMethod>findChildWithTextAttributeRecursively</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getNextSibling</description>
+    <lineContent>ast = ast.getNextSibling()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XpathQueryGenerator.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.XpathQueryGenerator</mutatedClass>
+    <mutatedMethod>findPositionAmongSiblings</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getPreviousSibling</description>
+    <lineContent>cur = cur.getPreviousSibling();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XpathQueryGenerator.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.XpathQueryGenerator</mutatedClass>
+    <mutatedMethod>hasAtLeastOneSiblingWithSameTokenType</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getNextSibling</description>
+    <lineContent>next = next.getNextSibling();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XpathQueryGenerator.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.xpath.XpathQueryGenerator</mutatedClass>
+    <mutatedMethod>hasAtLeastOneSiblingWithSameTokenType</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getPreviousSibling</description>
+    <lineContent>prev = prev.getPreviousSibling();</lineContent>
+  </mutation>
+</suppressedMutations>

--- a/pom.xml
+++ b/pom.xml
@@ -3939,15 +3939,33 @@
               <mutators>
                 <mutator>CONDITIONALS_BOUNDARY</mutator>
                 <mutator>CONSTRUCTOR_CALLS</mutator>
-                <mutator>FALSE_RETURNS</mutator>
                 <mutator>INCREMENTS</mutator>
+                <!-- Read reason of disablement at https://github.com/checkstyle/checkstyle/issues/11895 -->
+                <!-- <mutator>INLINE_CONSTS</mutator> -->
                 <mutator>INVERT_NEGS</mutator>
                 <mutator>MATH</mutator>
                 <mutator>NEGATE_CONDITIONALS</mutator>
-                <mutator>REMOVE_CONDITIONALS</mutator>
+                <mutator>NON_VOID_METHOD_CALLS</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_IF</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_IF</mutator>
                 <mutator>RETURN_VALS</mutator>
-                <mutator>TRUE_RETURNS</mutator>
                 <mutator>VOID_METHOD_CALLS</mutator>
+                <mutator>EXPERIMENTAL_ARGUMENT_PROPAGATION</mutator>
+                <mutator>EXPERIMENTAL_BIG_DECIMAL</mutator>
+                <mutator>EXPERIMENTAL_BIG_INTEGER</mutator>
+                <mutator>EXPERIMENTAL_MEMBER_VARIABLE</mutator>
+                <mutator>EXPERIMENTAL_NAKED_RECEIVER</mutator>
+                <mutator>REMOVE_INCREMENTS</mutator>
+                <mutator>EXPERIMENTAL_RETURN_VALUES_MUTATOR</mutator>
+                <mutator>EXPERIMENTAL_SWITCH</mutator>
+                <mutator>REMOVE_SWITCH</mutator>
+                <mutator>FALSE_RETURNS</mutator>
+                <mutator>TRUE_RETURNS</mutator>
+                <mutator>EMPTY_RETURNS</mutator>
+                <mutator>NULL_RETURNS</mutator>
+                <mutator>PRIMITIVE_RETURNS</mutator>
               </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.xpath.*</param>
@@ -3963,7 +3981,7 @@
                 <param>*.Input*</param>
               </excludedTestClasses>
               <coverageThreshold>100</coverageThreshold>
-              <mutationThreshold>96</mutationThreshold>
+              <mutationThreshold>98</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>


### PR DESCRIPTION

#11719
Activating `ALL` group for `pitest-xpath`

Every mutator has been activated except `INLINE_CONSTS`

- Report with `ALL` group except `INLINE_CONSTS`: https://vyom-yadav.github.io/pitest-all-latest/pitest-xpath/index.html
