### PR TITLE
Issue #11719: Activate all group for pitest-misc

### DIFF
--- a/.ci/pitest-suppressions/pitest-misc-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-misc-suppressions.xml
@@ -1,0 +1,272 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressedMutations>
+  <mutation unstable="false">
+    <sourceFile>DescendantTokenCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.DescendantTokenCheck</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable limitedTokens</description>
+    <lineContent>@XdocsPropertyType(PropertyType.TOKEN_ARRAY)</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>DescendantTokenCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.DescendantTokenCheck</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable counts</description>
+    <lineContent>private int[] counts = CommonUtil.EMPTY_INT_ARRAY;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>NewlineAtEndOfFileCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck</mutatedClass>
+    <mutatedMethod>readAndCheckFile</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/io/File::getPath</description>
+    <lineContent>log(1, MSG_KEY_NO_NEWLINE_EOF, file.getPath());</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>NewlineAtEndOfFileCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck</mutatedClass>
+    <mutatedMethod>readAndCheckFile</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/io/File::getPath</description>
+    <lineContent>log(1, MSG_KEY_WRONG_ENDING, file.getPath());</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>NewlineAtEndOfFileCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck</mutatedClass>
+    <mutatedMethod>setLineSeparator</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/lang/String::toUpperCase with receiver</description>
+    <lineContent>.toUpperCase(Locale.ENGLISH));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>NewlineAtEndOfFileCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck</mutatedClass>
+    <mutatedMethod>setLineSeparator</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/lang/String::trim with receiver</description>
+    <lineContent>Enum.valueOf(LineSeparatorOption.class, lineSeparatorParam.trim()</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>OrderedPropertiesCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck</mutatedClass>
+    <mutatedMethod>getKeyPattern</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/regex/Matcher::quoteReplacement</description>
+    <lineContent>.replaceAll(Matcher.quoteReplacement(&quot;\\\\ &quot;)) + &quot;[\\s:=].*&quot;;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>OrderedPropertiesCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck</mutatedClass>
+    <mutatedMethod>getKeyPattern</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/regex/Matcher::quoteReplacement with argument</description>
+    <lineContent>.replaceAll(Matcher.quoteReplacement(&quot;\\\\ &quot;)) + &quot;[\\s:=].*&quot;;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>OrderedPropertiesCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck$SequencedProperties</mutatedClass>
+    <mutatedMethod>put</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Properties::put</description>
+    <lineContent>return super.put(key, value);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>OrderedPropertiesCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck$SequencedProperties</mutatedClass>
+    <mutatedMethod>put</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Properties::put with argument</description>
+    <lineContent>return super.put(key, value);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>OrderedPropertiesCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck$SequencedProperties</mutatedClass>
+    <mutatedMethod>put</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ReturnValuesMutator</mutator>
+    <description>replaced return of object reference value with [see docs for details]</description>
+    <lineContent>return super.put(key, value);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>OrderedPropertiesCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck$SequencedProperties</mutatedClass>
+    <mutatedMethod>put</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.NullReturnValsMutator</mutator>
+    <description>replaced return value with null for com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck$SequencedProperties::put</description>
+    <lineContent>return super.put(key, value);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>OuterTypeFilenameCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck</mutatedClass>
+    <mutatedMethod>beginTree</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable hasPublic</description>
+    <lineContent>hasPublic = false;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>OuterTypeFilenameCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck</mutatedClass>
+    <mutatedMethod>beginTree</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable seenFirstToken</description>
+    <lineContent>seenFirstToken = false;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>OuterTypeFilenameCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck</mutatedClass>
+    <mutatedMethod>beginTree</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable wrongType</description>
+    <lineContent>wrongType = null;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RecordComponentNumberCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheck</mutatedClass>
+    <mutatedMethod>setAccessModifiers</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Arrays::copyOf with argument</description>
+    <lineContent>Arrays.copyOf(accessModifiers, accessModifiers.length);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SuppressWarningsHolder.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder</mutatedClass>
+    <mutatedMethod>addSuppressions</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getColumnNo</description>
+    <lineContent>final int firstColumn = targetAST.getColumnNo();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SuppressWarningsHolder.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder</mutatedClass>
+    <mutatedMethod>findAllExpressionsInChildren</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getNextSibling</description>
+    <lineContent>childAST = childAST.getNextSibling();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SuppressWarningsHolder.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder</mutatedClass>
+    <mutatedMethod>getStringExpr</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getLastChild with receiver</description>
+    <lineContent>expr = firstChild.getLastChild().getText();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SuppressWarningsHolder.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder</mutatedClass>
+    <mutatedMethod>getStringExpr</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_0</mutator>
+    <description>RemoveSwitch 0 mutation</description>
+    <lineContent>switch (firstChild.getType()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SuppressWarningsHolder.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder</mutatedClass>
+    <mutatedMethod>getStringExpr</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_1</mutator>
+    <description>RemoveSwitch 1 mutation</description>
+    <lineContent>switch (firstChild.getType()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>TodoCommentCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/regex/Pattern::compile</description>
+    <lineContent>private Pattern format = Pattern.compile(&quot;TODO:&quot;);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>TodoCommentCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable format</description>
+    <lineContent>private Pattern format = Pattern.compile(&quot;TODO:&quot;);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>TranslationCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.TranslationCheck</mutatedClass>
+    <mutatedMethod>logException</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/checks/TranslationCheck::getId</description>
+    <lineContent>getId(),</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>TranslationCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.TranslationCheck</mutatedClass>
+    <mutatedMethod>validateUserSpecifiedLanguageCodes</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/checks/TranslationCheck::getId</description>
+    <lineContent>WRONG_LANGUAGE_CODE_KEY, new Object[] {code}, getId(), getClass(), null);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>TranslationCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.TranslationCheck$ResourceBundle</mutatedClass>
+    <mutatedMethod>getFiles</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Collections::unmodifiableSet with argument</description>
+    <lineContent>return Collections.unmodifiableSet(files);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>UncommentedMainCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.UncommentedMainCheck</mutatedClass>
+    <mutatedMethod>beginTree</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable classDepth</description>
+    <lineContent>classDepth = 0;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>UncommentedMainCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.UncommentedMainCheck</mutatedClass>
+    <mutatedMethod>beginTree</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable currentClass</description>
+    <lineContent>currentClass = null;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>UncommentedMainCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.UncommentedMainCheck</mutatedClass>
+    <mutatedMethod>beginTree</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/api/FullIdent::createFullIdent</description>
+    <lineContent>packageName = FullIdent.createFullIdent(null);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>UncommentedMainCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.UncommentedMainCheck</mutatedClass>
+    <mutatedMethod>beginTree</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable packageName</description>
+    <lineContent>packageName = FullIdent.createFullIdent(null);</lineContent>
+  </mutation>
+</suppressedMutations>

--- a/pom.xml
+++ b/pom.xml
@@ -2330,15 +2330,33 @@
               <mutators>
                 <mutator>CONDITIONALS_BOUNDARY</mutator>
                 <mutator>CONSTRUCTOR_CALLS</mutator>
-                <mutator>FALSE_RETURNS</mutator>
                 <mutator>INCREMENTS</mutator>
+                <!-- Read reason of disablement at https://github.com/checkstyle/checkstyle/issues/11895 -->
+                <!-- <mutator>INLINE_CONSTS</mutator> -->
                 <mutator>INVERT_NEGS</mutator>
                 <mutator>MATH</mutator>
                 <mutator>NEGATE_CONDITIONALS</mutator>
-                <mutator>REMOVE_CONDITIONALS</mutator>
+                <mutator>NON_VOID_METHOD_CALLS</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_IF</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_IF</mutator>
                 <mutator>RETURN_VALS</mutator>
-                <mutator>TRUE_RETURNS</mutator>
                 <mutator>VOID_METHOD_CALLS</mutator>
+                <mutator>EXPERIMENTAL_ARGUMENT_PROPAGATION</mutator>
+                <mutator>EXPERIMENTAL_BIG_DECIMAL</mutator>
+                <mutator>EXPERIMENTAL_BIG_INTEGER</mutator>
+                <mutator>EXPERIMENTAL_MEMBER_VARIABLE</mutator>
+                <mutator>EXPERIMENTAL_NAKED_RECEIVER</mutator>
+                <mutator>REMOVE_INCREMENTS</mutator>
+                <mutator>EXPERIMENTAL_RETURN_VALUES_MUTATOR</mutator>
+                <mutator>EXPERIMENTAL_SWITCH</mutator>
+                <mutator>REMOVE_SWITCH</mutator>
+                <mutator>FALSE_RETURNS</mutator>
+                <mutator>TRUE_RETURNS</mutator>
+                <mutator>EMPTY_RETURNS</mutator>
+                <mutator>NULL_RETURNS</mutator>
+                <mutator>PRIMITIVE_RETURNS</mutator>
               </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.ArrayTypeStyleCheck*</param>
@@ -2397,7 +2415,7 @@
                 <param>destroy</param>
               </excludedMethods>
               <coverageThreshold>100</coverageThreshold>
-              <mutationThreshold>100</mutationThreshold>
+              <mutationThreshold>98</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>


### PR DESCRIPTION

#11719
Activating `ALL` group for `pitest-misc`

Every mutator has been activated except `INLINE_CONSTS`

- Report with `ALL` group except `INLINE_CONSTS`: https://vyom-yadav.github.io/pitest-all-latest/pitest-misc/index.html
