### PR TITLE
Issue #11719: Activate all group for pitest-common-2

### DIFF
--- a/.ci/pitest-suppressions/pitest-common-2-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-common-2-suppressions.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressedMutations>
+  <mutation unstable="false">
+    <sourceFile>DetailAstImpl.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable childCount</description>
+    <lineContent>private int childCount = NOT_INITIALIZED;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>DetailAstImpl.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
+    <mutatedMethod>addChild</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/DetailAstImpl::getLastChild</description>
+    <lineContent>astImpl.previousSibling = (DetailAstImpl) getLastChild();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>DetailAstImpl.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
+    <mutatedMethod>addChild</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable previousSibling</description>
+    <lineContent>astImpl.previousSibling = (DetailAstImpl) getLastChild();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>DetailAstImpl.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
+    <mutatedMethod>addNextSibling</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable previousSibling</description>
+    <lineContent>astImpl.previousSibling = this;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>DetailAstImpl.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
+    <mutatedMethod>addNextSibling</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable previousSibling</description>
+    <lineContent>sibling.previousSibling = astImpl;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>DetailAstImpl.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
+    <mutatedMethod>addPreviousSibling</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable previousSibling</description>
+    <lineContent>astImpl.previousSibling = previousSiblingNode;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>DetailAstImpl.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
+    <mutatedMethod>addPreviousSibling</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable previousSibling</description>
+    <lineContent>previousSibling = astImpl;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>DetailAstImpl.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
+    <mutatedMethod>getHiddenAfter</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Collections::unmodifiableList with argument</description>
+    <lineContent>returnList = Collections.unmodifiableList(hiddenAfter);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>DetailAstImpl.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
+    <mutatedMethod>getHiddenBefore</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Collections::unmodifiableList with argument</description>
+    <lineContent>returnList = Collections.unmodifiableList(hiddenBefore);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>DetailAstImpl.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
+    <mutatedMethod>removeChildren</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable firstChild</description>
+    <lineContent>firstChild = null;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>DetailAstImpl.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
+    <mutatedMethod>setHiddenAfter</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Collections::unmodifiableList with argument</description>
+    <lineContent>this.hiddenAfter = Collections.unmodifiableList(hiddenAfter);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>DetailAstImpl.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
+    <mutatedMethod>setHiddenBefore</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Collections::unmodifiableList with argument</description>
+    <lineContent>this.hiddenBefore = Collections.unmodifiableList(hiddenBefore);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>DetailAstImpl.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
+    <mutatedMethod>toString</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/DetailAstImpl::getColumnNo</description>
+    <lineContent>return text + &quot;[&quot; + getLineNo() + &quot;x&quot; + getColumnNo() + &quot;]&quot;;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>DetailAstImpl.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
+    <mutatedMethod>toString</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/DetailAstImpl::getLineNo</description>
+    <lineContent>return text + &quot;[&quot; + getLineNo() + &quot;x&quot; + getColumnNo() + &quot;]&quot;;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>JavaParser.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.JavaParser</mutatedClass>
+    <mutatedMethod>appendHiddenCommentNodes</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.NullReturnValsMutator</mutator>
+    <description>replaced return value with null for com/puppycrawl/tools/checkstyle/JavaParser::appendHiddenCommentNodes</description>
+    <lineContent>return root;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>JavaParser.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.JavaParser</mutatedClass>
+    <mutatedMethod>parseFile</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/io/File::getAbsoluteFile with receiver</description>
+    <lineContent>final FileText text = new FileText(file.getAbsoluteFile(),</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>JavadocPropertiesGenerator.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.JavadocPropertiesGenerator</mutatedClass>
+    <mutatedMethod>getFirstJavadocSentence</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getNextSibling</description>
+    <lineContent>child = child.getNextSibling()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>JavadocPropertiesGenerator.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.JavadocPropertiesGenerator</mutatedClass>
+    <mutatedMethod>main</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to picocli/CommandLine::setUsageHelpWidth with receiver</description>
+    <lineContent>final CommandLine cmd = new CommandLine(cliOptions).setUsageHelpWidth(USAGE_HELP_WIDTH);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XmlLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.XmlLoader</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::copyOf with argument</description>
+    <lineContent>this.publicIdToResourceNameMap = Map.copyOf(publicIdToResourceNameMap);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XmlLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.XmlLoader</mutatedClass>
+    <mutatedMethod>resolveEntity</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to org/xml/sax/helpers/DefaultHandler::resolveEntity</description>
+    <lineContent>inputSource = super.resolveEntity(publicId, systemId);</lineContent>
+  </mutation>
+</suppressedMutations>

--- a/pom.xml
+++ b/pom.xml
@@ -3688,15 +3688,33 @@
               <mutators>
                 <mutator>CONDITIONALS_BOUNDARY</mutator>
                 <mutator>CONSTRUCTOR_CALLS</mutator>
-                <mutator>FALSE_RETURNS</mutator>
                 <mutator>INCREMENTS</mutator>
+                <!-- Read reason of disablement at https://github.com/checkstyle/checkstyle/issues/11895 -->
+                <!-- <mutator>INLINE_CONSTS</mutator> -->
                 <mutator>INVERT_NEGS</mutator>
                 <mutator>MATH</mutator>
                 <mutator>NEGATE_CONDITIONALS</mutator>
-                <mutator>REMOVE_CONDITIONALS</mutator>
+                <mutator>NON_VOID_METHOD_CALLS</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_IF</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_IF</mutator>
                 <mutator>RETURN_VALS</mutator>
-                <mutator>TRUE_RETURNS</mutator>
                 <mutator>VOID_METHOD_CALLS</mutator>
+                <mutator>EXPERIMENTAL_ARGUMENT_PROPAGATION</mutator>
+                <mutator>EXPERIMENTAL_BIG_DECIMAL</mutator>
+                <mutator>EXPERIMENTAL_BIG_INTEGER</mutator>
+                <mutator>EXPERIMENTAL_MEMBER_VARIABLE</mutator>
+                <mutator>EXPERIMENTAL_NAKED_RECEIVER</mutator>
+                <mutator>REMOVE_INCREMENTS</mutator>
+                <mutator>EXPERIMENTAL_RETURN_VALUES_MUTATOR</mutator>
+                <mutator>EXPERIMENTAL_SWITCH</mutator>
+                <mutator>REMOVE_SWITCH</mutator>
+                <mutator>FALSE_RETURNS</mutator>
+                <mutator>TRUE_RETURNS</mutator>
+                <mutator>EMPTY_RETURNS</mutator>
+                <mutator>NULL_RETURNS</mutator>
+                <mutator>PRIMITIVE_RETURNS</mutator>
               </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.DetailAstImpl*</param>
@@ -3726,7 +3744,7 @@
                 </avoidCallsTo>
               </avoidCallsTo>
               <coverageThreshold>100</coverageThreshold>
-              <mutationThreshold>100</mutationThreshold>
+              <mutationThreshold>97</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>


### PR DESCRIPTION

#11719
Activating `ALL` group for `pitest-common-2`

Every mutator has been activated except `INLINE_CONSTS`

- Report with `ALL` group except `INLINE_CONSTS`: https://vyom-yadav.github.io/pitest-all-latest/pitest-common-2/index.html
