### PR TITLE
Issue #11719: Activate all group for pitest-metrics

### DIFF
--- a/.ci/pitest-suppressions/pitest-metrics-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-metrics-suppressions.xml
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressedMutations>
+  <mutation unstable="false">
+    <sourceFile>AbstractClassCouplingCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.AbstractClassCouplingCheck</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/List::add</description>
+    <lineContent>excludeClassesRegexps.add(CommonUtil.createPattern(&quot;^$&quot;));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AbstractClassCouplingCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.AbstractClassCouplingCheck</mutatedClass>
+    <mutatedMethod>beginTree</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable packageName</description>
+    <lineContent>packageName = &quot;&quot;;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AbstractClassCouplingCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.AbstractClassCouplingCheck</mutatedClass>
+    <mutatedMethod>setExcludeClassesRegexps</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/util/stream/Stream::distinct with receiver</description>
+    <lineContent>.distinct()</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AbstractClassCouplingCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.AbstractClassCouplingCheck$ClassContext</mutatedClass>
+    <mutatedMethod>visitLiteralNew</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getFirstChild with receiver</description>
+    <lineContent>addReferencedClassName(ast.getFirstChild());</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AbstractClassCouplingCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.AbstractClassCouplingCheck$ClassContext</mutatedClass>
+    <mutatedMethod>visitLiteralThrows</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getNextSibling</description>
+    <lineContent>childAST = childAST.getNextSibling()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>BooleanExpressionComplexityCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.BooleanExpressionComplexityCheck</mutatedClass>
+    <mutatedMethod>leaveMethodDef</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable context</description>
+    <lineContent>context = contextStack.pop();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>BooleanExpressionComplexityCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.BooleanExpressionComplexityCheck</mutatedClass>
+    <mutatedMethod>leaveToken</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_0</mutator>
+    <description>RemoveSwitch 0 mutation</description>
+    <lineContent>switch (ast.getType()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>BooleanExpressionComplexityCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.BooleanExpressionComplexityCheck</mutatedClass>
+    <mutatedMethod>leaveToken</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_3</mutator>
+    <description>RemoveSwitch 3 mutation</description>
+    <lineContent>switch (ast.getType()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>BooleanExpressionComplexityCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.BooleanExpressionComplexityCheck$Context</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable count</description>
+    <lineContent>count = 0;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CyclomaticComplexityCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.CyclomaticComplexityCheck</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable max</description>
+    <lineContent>private int max = DEFAULT_COMPLEXITY_VALUE;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>JavaNCSSCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.JavaNCSSCheck</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable recordMaximum</description>
+    <lineContent>private int recordMaximum = RECORD_MAX_NCSS;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>JavaNCSSCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.JavaNCSSCheck</mutatedClass>
+    <mutatedMethod>isExpressionCountable</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_2</mutator>
+    <description>RemoveSwitch 2 mutation</description>
+    <lineContent>switch (parentType) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>JavaNCSSCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.JavaNCSSCheck</mutatedClass>
+    <mutatedMethod>isExpressionCountable</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_3</mutator>
+    <description>RemoveSwitch 3 mutation</description>
+    <lineContent>switch (parentType) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>JavaNCSSCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.JavaNCSSCheck</mutatedClass>
+    <mutatedMethod>isExpressionCountable</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_4</mutator>
+    <description>RemoveSwitch 4 mutation</description>
+    <lineContent>switch (parentType) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>JavaNCSSCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.JavaNCSSCheck</mutatedClass>
+    <mutatedMethod>isExpressionCountable</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_5</mutator>
+    <description>RemoveSwitch 5 mutation</description>
+    <lineContent>switch (parentType) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>JavaNCSSCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.JavaNCSSCheck</mutatedClass>
+    <mutatedMethod>isExpressionCountable</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_6</mutator>
+    <description>RemoveSwitch 6 mutation</description>
+    <lineContent>switch (parentType) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>NPathComplexityCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.NPathComplexityCheck</mutatedClass>
+    <mutatedMethod>beginTree</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable branchVisited</description>
+    <lineContent>branchVisited = false;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>NPathComplexityCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.NPathComplexityCheck</mutatedClass>
+    <mutatedMethod>beginTree</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable currentRangeValue</description>
+    <lineContent>currentRangeValue = INITIAL_VALUE;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>NPathComplexityCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.NPathComplexityCheck</mutatedClass>
+    <mutatedMethod>leaveAddingConditional</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/math/BigInteger::add with argument</description>
+    <lineContent>currentRangeValue = currentRangeValue.add(popValue().getRangeValue().add(BigInteger.ONE));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>NPathComplexityCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.NPathComplexityCheck</mutatedClass>
+    <mutatedMethod>leaveMultiplyingConditional</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/math/BigInteger::add with argument</description>
+    <lineContent>.multiply(popValue().getRangeValue().add(BigInteger.ONE));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>NPathComplexityCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.NPathComplexityCheck</mutatedClass>
+    <mutatedMethod>leaveMultiplyingConditional</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.BigIntegerMutator</mutator>
+    <description>Replaced BigInteger#multiply with BigInteger#divide.</description>
+    <lineContent>.multiply(popValue().getRangeValue().add(BigInteger.ONE));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>NPathComplexityCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.NPathComplexityCheck</mutatedClass>
+    <mutatedMethod>leaveMultiplyingConditional</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/math/BigInteger::multiply with receiver</description>
+    <lineContent>.multiply(popValue().getRangeValue().add(BigInteger.ONE));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>NPathComplexityCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.NPathComplexityCheck</mutatedClass>
+    <mutatedMethod>visitConditional</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getNextSibling with receiver</description>
+    <lineContent>for (bracketed = ast.findFirstToken(TokenTypes.LPAREN).getNextSibling();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>NPathComplexityCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.metrics.NPathComplexityCheck</mutatedClass>
+    <mutatedMethod>visitToken</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable branchVisited</description>
+    <lineContent>branchVisited = true;</lineContent>
+  </mutation>
+</suppressedMutations>

--- a/pom.xml
+++ b/pom.xml
@@ -3010,15 +3010,33 @@
               <mutators>
                 <mutator>CONDITIONALS_BOUNDARY</mutator>
                 <mutator>CONSTRUCTOR_CALLS</mutator>
-                <mutator>FALSE_RETURNS</mutator>
                 <mutator>INCREMENTS</mutator>
+                <!-- Read reason of disablement at https://github.com/checkstyle/checkstyle/issues/11895 -->
+                <!-- <mutator>INLINE_CONSTS</mutator> -->
                 <mutator>INVERT_NEGS</mutator>
                 <mutator>MATH</mutator>
                 <mutator>NEGATE_CONDITIONALS</mutator>
-                <mutator>REMOVE_CONDITIONALS</mutator>
+                <mutator>NON_VOID_METHOD_CALLS</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_IF</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_IF</mutator>
                 <mutator>RETURN_VALS</mutator>
-                <mutator>TRUE_RETURNS</mutator>
                 <mutator>VOID_METHOD_CALLS</mutator>
+                <mutator>EXPERIMENTAL_ARGUMENT_PROPAGATION</mutator>
+                <mutator>EXPERIMENTAL_BIG_DECIMAL</mutator>
+                <mutator>EXPERIMENTAL_BIG_INTEGER</mutator>
+                <mutator>EXPERIMENTAL_MEMBER_VARIABLE</mutator>
+                <mutator>EXPERIMENTAL_NAKED_RECEIVER</mutator>
+                <mutator>REMOVE_INCREMENTS</mutator>
+                <mutator>EXPERIMENTAL_RETURN_VALUES_MUTATOR</mutator>
+                <mutator>EXPERIMENTAL_SWITCH</mutator>
+                <mutator>REMOVE_SWITCH</mutator>
+                <mutator>FALSE_RETURNS</mutator>
+                <mutator>TRUE_RETURNS</mutator>
+                <mutator>EMPTY_RETURNS</mutator>
+                <mutator>NULL_RETURNS</mutator>
+                <mutator>PRIMITIVE_RETURNS</mutator>
               </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.metrics.*</param>
@@ -3030,7 +3048,7 @@
                 <param>*.Input*</param>
               </excludedTestClasses>
               <coverageThreshold>100</coverageThreshold>
-              <mutationThreshold>100</mutationThreshold>
+              <mutationThreshold>97</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>


### PR DESCRIPTION

#11719
Activating `ALL` group for `pitest-metrics`

Every mutator has been activated except `INLINE_CONSTS`

- Report with `ALL` group except `INLINE_CONSTS`: https://vyom-yadav.github.io/pitest-all-latest/pitest-metrics/index.html
