### PR TITLE
Issue #11719: Activate all group for pitest-whitespace

### DIFF
--- a/.ci/pitest-suppressions/pitest-whitespace-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-whitespace-suppressions.xml
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressedMutations>
+  <mutation unstable="false">
+    <sourceFile>AbstractParenPadCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck</mutatedClass>
+    <mutatedMethod>setOption</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/lang/String::toUpperCase with receiver</description>
+    <lineContent>option = PadOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AbstractParenPadCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck</mutatedClass>
+    <mutatedMethod>setOption</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/lang/String::trim with receiver</description>
+    <lineContent>option = PadOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>EmptyForInitializerPadCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck</mutatedClass>
+    <mutatedMethod>setOption</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/lang/String::toUpperCase with receiver</description>
+    <lineContent>option = PadOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>EmptyForInitializerPadCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck</mutatedClass>
+    <mutatedMethod>setOption</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/lang/String::trim with receiver</description>
+    <lineContent>option = PadOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>EmptyForInitializerPadCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck</mutatedClass>
+    <mutatedMethod>visitToken</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getNextSibling with receiver</description>
+    <lineContent>final DetailAST semi = ast.getNextSibling();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>EmptyForIteratorPadCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIteratorPadCheck</mutatedClass>
+    <mutatedMethod>setOption</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/lang/String::toUpperCase with receiver</description>
+    <lineContent>option = PadOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>EmptyForIteratorPadCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIteratorPadCheck</mutatedClass>
+    <mutatedMethod>setOption</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/lang/String::trim with receiver</description>
+    <lineContent>option = PadOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>EmptyLineSeparatorCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck</mutatedClass>
+    <mutatedMethod>checkToken</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_3</mutator>
+    <description>RemoveSwitch 3 mutation</description>
+    <lineContent>switch (astType) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>EmptyLineSeparatorCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck</mutatedClass>
+    <mutatedMethod>getEmptyLinesToLog</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/Integer::intValue</description>
+    <lineContent>int previousEmptyLineNo = emptyLines.get(0);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>EmptyLineSeparatorCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck</mutatedClass>
+    <mutatedMethod>getViolationAstForPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getNextSibling with receiver</description>
+    <lineContent>DetailAST nextElement = ast.getNextSibling();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>EmptyLineSeparatorCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck</mutatedClass>
+    <mutatedMethod>getViolationAstForPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getLastChild with receiver</description>
+    <lineContent>final int lastChildLineNo = ast.getLastChild().getLineNo();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>EmptyLineSeparatorCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck</mutatedClass>
+    <mutatedMethod>hasEmptyLineAfter</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getLastChild with receiver</description>
+    <lineContent>lastToken = token.getLastChild();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>EmptyLineSeparatorCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck</mutatedClass>
+    <mutatedMethod>isLineEmptyAfterPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getNextSibling with receiver</description>
+    <lineContent>DetailAST nextElement = ast.getNextSibling();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>EmptyLineSeparatorCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck</mutatedClass>
+    <mutatedMethod>isLineEmptyAfterPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getLastChild with receiver</description>
+    <lineContent>final int lastChildLineNo = ast.getLastChild().getLineNo();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>GenericWhitespaceCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.GenericWhitespaceCheck</mutatedClass>
+    <mutatedMethod>beginTree</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable depth</description>
+    <lineContent>depth = 0;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>MethodParamPadCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCheck</mutatedClass>
+    <mutatedMethod>setOption</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/lang/String::trim with receiver</description>
+    <lineContent>option = PadOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>OperatorWrapCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.OperatorWrapCheck</mutatedClass>
+    <mutatedMethod>setOption</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/lang/String::toUpperCase with receiver</description>
+    <lineContent>option = WrapOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>OperatorWrapCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.OperatorWrapCheck</mutatedClass>
+    <mutatedMethod>setOption</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/lang/String::trim with receiver</description>
+    <lineContent>option = WrapOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ParenPadCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.ParenPadCheck</mutatedClass>
+    <mutatedMethod>visitResourceSpecification</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::findFirstToken with receiver</description>
+    <lineContent>processLeft(ast.findFirstToken(TokenTypes.LPAREN));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ParenPadCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.ParenPadCheck</mutatedClass>
+    <mutatedMethod>visitToken</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_3</mutator>
+    <description>RemoveSwitch 3 mutation</description>
+    <lineContent>switch (ast.getType()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ParenPadCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.ParenPadCheck</mutatedClass>
+    <mutatedMethod>visitToken</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_7</mutator>
+    <description>RemoveSwitch 7 mutation</description>
+    <lineContent>switch (ast.getType()) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SeparatorWrapCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.SeparatorWrapCheck</mutatedClass>
+    <mutatedMethod>setOption</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/lang/String::toUpperCase with receiver</description>
+    <lineContent>option = WrapOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SeparatorWrapCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.SeparatorWrapCheck</mutatedClass>
+    <mutatedMethod>setOption</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/lang/String::trim with receiver</description>
+    <lineContent>option = WrapOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SeparatorWrapCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.SeparatorWrapCheck</mutatedClass>
+    <mutatedMethod>visitToken</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/utils/CodePointUtil::trim with argument</description>
+    <lineContent>final int[] substringAfterToken = CodePointUtil.trim(</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SingleSpaceSeparatorCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheck</mutatedClass>
+    <mutatedMethod>visitEachToken</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getParent</description>
+    <lineContent>final DetailAST parent = node.getParent();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SingleSpaceSeparatorCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheck</mutatedClass>
+    <mutatedMethod>visitEachToken</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getParent with receiver</description>
+    <lineContent>final DetailAST parent = node.getParent();</lineContent>
+  </mutation>
+</suppressedMutations>

--- a/pom.xml
+++ b/pom.xml
@@ -3235,15 +3235,33 @@
               <mutators>
                 <mutator>CONDITIONALS_BOUNDARY</mutator>
                 <mutator>CONSTRUCTOR_CALLS</mutator>
-                <mutator>FALSE_RETURNS</mutator>
                 <mutator>INCREMENTS</mutator>
+                <!-- Read reason of disablement at https://github.com/checkstyle/checkstyle/issues/11895 -->
+                <!-- <mutator>INLINE_CONSTS</mutator> -->
                 <mutator>INVERT_NEGS</mutator>
                 <mutator>MATH</mutator>
                 <mutator>NEGATE_CONDITIONALS</mutator>
-                <mutator>REMOVE_CONDITIONALS</mutator>
+                <mutator>NON_VOID_METHOD_CALLS</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_IF</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_IF</mutator>
                 <mutator>RETURN_VALS</mutator>
-                <mutator>TRUE_RETURNS</mutator>
                 <mutator>VOID_METHOD_CALLS</mutator>
+                <mutator>EXPERIMENTAL_ARGUMENT_PROPAGATION</mutator>
+                <mutator>EXPERIMENTAL_BIG_DECIMAL</mutator>
+                <mutator>EXPERIMENTAL_BIG_INTEGER</mutator>
+                <mutator>EXPERIMENTAL_MEMBER_VARIABLE</mutator>
+                <mutator>EXPERIMENTAL_NAKED_RECEIVER</mutator>
+                <mutator>REMOVE_INCREMENTS</mutator>
+                <mutator>EXPERIMENTAL_RETURN_VALUES_MUTATOR</mutator>
+                <mutator>EXPERIMENTAL_SWITCH</mutator>
+                <mutator>REMOVE_SWITCH</mutator>
+                <mutator>FALSE_RETURNS</mutator>
+                <mutator>TRUE_RETURNS</mutator>
+                <mutator>EMPTY_RETURNS</mutator>
+                <mutator>NULL_RETURNS</mutator>
+                <mutator>PRIMITIVE_RETURNS</mutator>
               </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.whitespace.*</param>
@@ -3255,7 +3273,7 @@
                 <param>*.Input*</param>
               </excludedTestClasses>
               <coverageThreshold>100</coverageThreshold>
-              <mutationThreshold>100</mutationThreshold>
+              <mutationThreshold>99</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>


### PR DESCRIPTION

#11719
Activating `ALL` group for `pitest-whitespace`

Every mutator has been activated except `INLINE_CONSTS`

- Report with `ALL` group except `INLINE_CONSTS`: https://vyom-yadav.github.io/pitest-all-latest/pitest-whitespace/index.html
