### PR TITLE
Issue #11719: Activate all group for pitest-packagenamesloader

### DIFF
--- a/.ci/pitest-suppressions/pitest-packagenamesloader-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-packagenamesloader-suppressions.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressedMutations>
+  <mutation unstable="false">
+    <sourceFile>PackageNamesLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageNamesLoader</mutatedClass>
+    <mutatedMethod>createIdToResourceNameMap</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>map.put(DTD_PUBLIC_CS_ID, DTD_RESOURCE_NAME);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageNamesLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageNamesLoader</mutatedClass>
+    <mutatedMethod>createIdToResourceNameMap</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>map.put(DTD_PUBLIC_CS_ID, DTD_RESOURCE_NAME);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageNamesLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageNamesLoader</mutatedClass>
+    <mutatedMethod>createIdToResourceNameMap</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>map.put(DTD_PUBLIC_ID, DTD_RESOURCE_NAME);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageNamesLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageNamesLoader</mutatedClass>
+    <mutatedMethod>createIdToResourceNameMap</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>map.put(DTD_PUBLIC_ID, DTD_RESOURCE_NAME);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageNamesLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageNamesLoader</mutatedClass>
+    <mutatedMethod>createIdToResourceNameMap</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator</mutator>
+    <description>replaced return value with Collections.emptyMap for com/puppycrawl/tools/checkstyle/PackageNamesLoader::createIdToResourceNameMap</description>
+    <lineContent>return map;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageNamesLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageNamesLoader</mutatedClass>
+    <mutatedMethod>getPackageNames</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Collections::unmodifiableSet with argument</description>
+    <lineContent>return Collections.unmodifiableSet(result);</lineContent>
+  </mutation>
+</suppressedMutations>

--- a/pom.xml
+++ b/pom.xml
@@ -3560,15 +3560,33 @@
               <mutators>
                 <mutator>CONDITIONALS_BOUNDARY</mutator>
                 <mutator>CONSTRUCTOR_CALLS</mutator>
-                <mutator>FALSE_RETURNS</mutator>
                 <mutator>INCREMENTS</mutator>
+                <!-- Read reason of disablement at https://github.com/checkstyle/checkstyle/issues/11895 -->
+                <!-- <mutator>INLINE_CONSTS</mutator> -->
                 <mutator>INVERT_NEGS</mutator>
                 <mutator>MATH</mutator>
                 <mutator>NEGATE_CONDITIONALS</mutator>
-                <mutator>REMOVE_CONDITIONALS</mutator>
+                <mutator>NON_VOID_METHOD_CALLS</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_IF</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_IF</mutator>
                 <mutator>RETURN_VALS</mutator>
-                <mutator>TRUE_RETURNS</mutator>
                 <mutator>VOID_METHOD_CALLS</mutator>
+                <mutator>EXPERIMENTAL_ARGUMENT_PROPAGATION</mutator>
+                <mutator>EXPERIMENTAL_BIG_DECIMAL</mutator>
+                <mutator>EXPERIMENTAL_BIG_INTEGER</mutator>
+                <mutator>EXPERIMENTAL_MEMBER_VARIABLE</mutator>
+                <mutator>EXPERIMENTAL_NAKED_RECEIVER</mutator>
+                <mutator>REMOVE_INCREMENTS</mutator>
+                <mutator>EXPERIMENTAL_RETURN_VALUES_MUTATOR</mutator>
+                <mutator>EXPERIMENTAL_SWITCH</mutator>
+                <mutator>REMOVE_SWITCH</mutator>
+                <mutator>FALSE_RETURNS</mutator>
+                <mutator>TRUE_RETURNS</mutator>
+                <mutator>EMPTY_RETURNS</mutator>
+                <mutator>NULL_RETURNS</mutator>
+                <mutator>PRIMITIVE_RETURNS</mutator>
               </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.PackageNamesLoader*</param>
@@ -3577,7 +3595,7 @@
                 <param>com.puppycrawl.tools.checkstyle.PackageNamesLoaderTest</param>
               </targetTests>
               <coverageThreshold>100</coverageThreshold>
-              <mutationThreshold>100</mutationThreshold>
+              <mutationThreshold>91</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>


### PR DESCRIPTION

#11719
Activating `ALL` group for `pitest-packagenamesloader`

Every mutator has been activated except `INLINE_CONSTS`

- Report with `ALL` group except `INLINE_CONSTS`: https://vyom-yadav.github.io/pitest-all-latest/pitest-packagenamesloader/index.html
