### PR TITLE
Issue #11719: Activate all group for pitest-tree-walker

### DIFF
--- a/.ci/pitest-suppressions/pitest-tree-walker-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-tree-walker-suppressions.xml
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressedMutations>
+  <mutation unstable="false">
+    <sourceFile>DetailNodeTreeStringPrinter.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailNodeTreeStringPrinter</mutatedClass>
+    <mutatedMethod>getParseErrorMessage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser$ParseErrorMessage::getLineNumber</description>
+    <lineContent>parseErrorMessage.getLineNumber(),</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>DetailNodeTreeStringPrinter.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailNodeTreeStringPrinter</mutatedClass>
+    <mutatedMethod>parseFile</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/nio/charset/Charset::name</description>
+    <lineContent>System.getProperty(&quot;file.encoding&quot;, StandardCharsets.UTF_8.name()));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>DetailNodeTreeStringPrinter.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailNodeTreeStringPrinter</mutatedClass>
+    <mutatedMethod>parseFile</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/lang/System::getProperty with argument</description>
+    <lineContent>System.getProperty(&quot;file.encoding&quot;, StandardCharsets.UTF_8.name()));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>DetailNodeTreeStringPrinter.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailNodeTreeStringPrinter</mutatedClass>
+    <mutatedMethod>parseFile</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/io/File::getAbsoluteFile with receiver</description>
+    <lineContent>final FileText text = new FileText(file.getAbsoluteFile(),</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>JavadocDetailNodeParser.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser</mutatedClass>
+    <mutatedMethod>getMissedHtmlTag</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Deque::pop</description>
+    <lineContent>htmlTagNameStart = stack.pop();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SuppressionsStringPrinter.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.SuppressionsStringPrinter</mutatedClass>
+    <mutatedMethod>printSuppressions</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/nio/charset/Charset::name</description>
+    <lineContent>System.getProperty(&quot;file.encoding&quot;, StandardCharsets.UTF_8.name()));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SuppressionsStringPrinter.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.SuppressionsStringPrinter</mutatedClass>
+    <mutatedMethod>printSuppressions</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/lang/System::getProperty with argument</description>
+    <lineContent>System.getProperty(&quot;file.encoding&quot;, StandardCharsets.UTF_8.name()));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SuppressionsStringPrinter.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.SuppressionsStringPrinter</mutatedClass>
+    <mutatedMethod>printSuppressions</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/io/File::getAbsoluteFile with receiver</description>
+    <lineContent>final FileText fileText = new FileText(file.getAbsoluteFile(),</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>TreeWalker.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.TreeWalker</mutatedClass>
+    <mutatedMethod>createNewCheckSortedSet</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/util/Comparator::thenComparing with receiver</description>
+    <lineContent>.thenComparing(AbstractCheck::getId,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>TreeWalker.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.TreeWalker</mutatedClass>
+    <mutatedMethod>createNewCheckSortedSet</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/util/Comparator::thenComparing with receiver</description>
+    <lineContent>.thenComparing(AbstractCheck::hashCode));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>TreeWalker.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.TreeWalker</mutatedClass>
+    <mutatedMethod>createNewCheckSortedSet</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Comparator::naturalOrder</description>
+    <lineContent>Comparator.nullsLast(Comparator.naturalOrder()))</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>TreeWalker.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.TreeWalker</mutatedClass>
+    <mutatedMethod>getExternalResourceLocations</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/util/stream/Stream::map with receiver</description>
+    <lineContent>.map(ExternalResourceHolder.class::cast)</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>TreeWalker.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.TreeWalker</mutatedClass>
+    <mutatedMethod>lambda$createNewCheckSortedSet$3</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator</mutator>
+    <description>replaced return value with &quot;&quot; for com/puppycrawl/tools/checkstyle/TreeWalker::lambda$createNewCheckSortedSet$3</description>
+    <lineContent>Comparator.&lt;AbstractCheck, String&gt;comparing(check -&gt; check.getClass().getName())</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>TreeWalker.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.TreeWalker</mutatedClass>
+    <mutatedMethod>registerCheck</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/Class::getName</description>
+    <lineContent>+ &quot;method to return &apos;true&apos;&quot;, check.getClass().getName(),</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>TreeWalker.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.TreeWalker</mutatedClass>
+    <mutatedMethod>registerCheck</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/utils/TokenUtil::getTokenName</description>
+    <lineContent>TokenUtil.getTokenName(tokenId));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>TreeWalker.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.TreeWalker</mutatedClass>
+    <mutatedMethod>registerCheck</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/lang/String::format with argument</description>
+    <lineContent>final String message = String.format(Locale.ROOT, &quot;Check &apos;%s&apos; waits for comment type &quot;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>TreeWalkerAuditEvent.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.TreeWalkerAuditEvent</mutatedClass>
+    <mutatedMethod>getColumn</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ReturnValuesMutator</mutator>
+    <description>replaced return of primitive boolean/byte/short/integer value with (x == 1) ? 0 : x + 1</description>
+    <lineContent>return violation.getColumnNo();</lineContent>
+  </mutation>
+</suppressedMutations>

--- a/pom.xml
+++ b/pom.xml
@@ -3559,15 +3559,33 @@
               <mutators>
                 <mutator>CONDITIONALS_BOUNDARY</mutator>
                 <mutator>CONSTRUCTOR_CALLS</mutator>
-                <mutator>FALSE_RETURNS</mutator>
                 <mutator>INCREMENTS</mutator>
+                <!-- Read reason of disablement at https://github.com/checkstyle/checkstyle/issues/11895 -->
+                <!-- <mutator>INLINE_CONSTS</mutator> -->
                 <mutator>INVERT_NEGS</mutator>
                 <mutator>MATH</mutator>
                 <mutator>NEGATE_CONDITIONALS</mutator>
-                <mutator>REMOVE_CONDITIONALS</mutator>
+                <mutator>NON_VOID_METHOD_CALLS</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_IF</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_IF</mutator>
                 <mutator>RETURN_VALS</mutator>
-                <mutator>TRUE_RETURNS</mutator>
                 <mutator>VOID_METHOD_CALLS</mutator>
+                <mutator>EXPERIMENTAL_ARGUMENT_PROPAGATION</mutator>
+                <mutator>EXPERIMENTAL_BIG_DECIMAL</mutator>
+                <mutator>EXPERIMENTAL_BIG_INTEGER</mutator>
+                <mutator>EXPERIMENTAL_MEMBER_VARIABLE</mutator>
+                <mutator>EXPERIMENTAL_NAKED_RECEIVER</mutator>
+                <mutator>REMOVE_INCREMENTS</mutator>
+                <mutator>EXPERIMENTAL_RETURN_VALUES_MUTATOR</mutator>
+                <mutator>EXPERIMENTAL_SWITCH</mutator>
+                <mutator>REMOVE_SWITCH</mutator>
+                <mutator>FALSE_RETURNS</mutator>
+                <mutator>TRUE_RETURNS</mutator>
+                <mutator>EMPTY_RETURNS</mutator>
+                <mutator>NULL_RETURNS</mutator>
+                <mutator>PRIMITIVE_RETURNS</mutator>
               </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser*</param>
@@ -3628,7 +3646,7 @@
                 </avoidCallsTo>
               </avoidCallsTo>
               <coverageThreshold>100</coverageThreshold>
-              <mutationThreshold>99</mutationThreshold>
+              <mutationThreshold>98</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>


### PR DESCRIPTION

#11719
Activating `ALL` group for `pitest-tree-walker`

Every mutator has been activated except `INLINE_CONSTS`

- Report with `ALL` group except `INLINE_CONSTS`: https://vyom-yadav.github.io/pitest-all-latest/pitest-tree-walker/index.html
