### PR TITLE
Issue #11720: Kill surviving mutation in VariableDeclarationUsageDistanceCheck related to usage distance

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-1-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-1-suppressions.xml
@@ -111,15 +111,6 @@
   <mutation unstable="false">
     <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
-    <mutatedMethod>calculateDistanceInSingleScope</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
-    <description>removed conditional - replaced equality check with false</description>
-    <lineContent>if (!firstUsageFound) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
     <mutatedMethod>getDistToVariableUsageInChildNode</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_1</mutator>
     <description>RemoveSwitch 1 mutation</description>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -522,6 +522,8 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
      * @param variableIdentAst
      *        Variable which distance is calculated for.
      * @return entry which contains expression with variable usage and distance.
+     *         If variable usage is not found, then the expression node is null,
+     *         although the distance can be greater than zero.
      */
     private static Entry<DetailAST, Integer> calculateDistanceInSingleScope(
             DetailAST semicolonAst, DetailAST variableIdentAst) {
@@ -542,11 +544,6 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
                 }
             }
             currentAst = currentAst.getNextSibling();
-        }
-
-        // If variable wasn't used after its declaration, distance is 0.
-        if (!firstUsageFound) {
-            dist = 0;
         }
 
         return new SimpleEntry<>(variableUsageAst, dist);


### PR DESCRIPTION
#11720
Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11937

Check documentation: https://checkstyle.sourceforge.io/config_coding.html#VariableDeclarationUsageDistance

### Diff Reports (Issue for NPE #11973):

- validateBetweenScopesTrue: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/1931469_2022164752/reports/diff/index.html
- validateBetweenScopesFalse: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/1931469_2022181908/reports/diff/index.html

### Rationale
If variable wasn't used after its declaration then `variableUsageAst` will be null, this method returns 
`Entry<DetailAST, Integer>` , `new SimpleEntry<>(variableUsageAst, dist)` this method
(`calculateDistanceInSingleScope`) is only called at-
https://github.com/checkstyle/checkstyle/blob/32cfeee3a3b85eb26015dc515211c6db97a470f6/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java#L407-L425

Whatever the value of distance was, no violation will be logged because of the condition 
https://github.com/checkstyle/checkstyle/blob/32cfeee3a3b85eb26015dc515211c6db97a470f6/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java#L417-L418

When `variableUsageAst` is `null`, the method `isInitializationSequence` returns `true` hence making this condition `false` https://github.com/checkstyle/checkstyle/blob/32cfeee3a3b85eb26015dc515211c6db97a470f6/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java#L459-L468
No violation will be logged, so it is safe to remove this method.

---

### Generating reports again:

Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/1538ad39a090a627ff99ef5436bda5ca090835b9/my_checks.xml
Report label: validateBetweenScopesFalse
