### PR TITLE
Issue #11720: Kill surviving mutation in VariableDeclarationUsageDistanceCheck in calculateDistanceInSingleScope

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-1-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-1-suppressions.xml
@@ -22,15 +22,6 @@
     <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
     <mutatedMethod>calculateDistanceInSingleScope</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>&amp;&amp; currentAst.getType() != TokenTypes.RCURLY) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
-    <mutatedMethod>calculateDistanceInSingleScope</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
     <description>removed conditional - replaced equality check with false</description>
     <lineContent>if (!firstUsageFound) {</lineContent>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -530,8 +530,7 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
         DetailAST currentAst = semicolonAst;
         DetailAST variableUsageAst = null;
 
-        while (!firstUsageFound && currentAst != null
-                && currentAst.getType() != TokenTypes.RCURLY) {
+        while (!firstUsageFound && currentAst != null) {
             if (currentAst.getFirstChild() != null) {
                 if (isChild(currentAst, variableIdentAst)) {
                     dist = getDistToVariableUsageInChildNode(currentAst, variableIdentAst, dist);


### PR DESCRIPTION
#11720
Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11938

Check documentation: https://checkstyle.sourceforge.io/config_coding.html#VariableDeclarationUsageDistance

### Diff Reports (Issue for NPE #11973):

- validateBetweenScopesTrue: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/be19a27_2022172028/reports/diff/index.html
- validateBetweenScopesFalse: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/be19a27_2022181609/reports/diff/index.html

### Rationale

In any variable declaration block, we wish to stop when the block ends, but this is already covered by the condition `currentAst != null`, an example will make things clearer-
```java
void method() {                 
    int a = 12;                 
    for (int i = 0; i != 0; ) { 
    }                           
    {                           
        // Empty block          
    }                           
}                                                            
```
Related AST-
```
--SLIST -> { 
   |--VARIABLE_DEF -> VARIABLE_DEF 
   |   |--MODIFIERS -> MODIFIERS 
   |   |--TYPE -> TYPE 
   |   |   `--LITERAL_INT -> int 
   |   |--IDENT -> a 
   |   `--ASSIGN -> = 
   |       `--EXPR -> EXPR 
   |           `--NUM_INT -> 12 
   |--SEMI -> ; 
   |--LITERAL_FOR -> for 
   |   |--LPAREN -> ( 
   |   |--FOR_INIT -> FOR_INIT 
   |   |   `--VARIABLE_DEF -> VARIABLE_DEF 
   |   |       |--MODIFIERS -> MODIFIERS 
   |   |       |--TYPE -> TYPE 
   |   |       |   `--LITERAL_INT -> int 
   |   |       |--IDENT -> i 
   |   |       `--ASSIGN -> = 
   |   |           `--EXPR -> EXPR 
   |   |               `--NUM_INT -> 0 
   |   |--SEMI -> ; 
   |   |--FOR_CONDITION -> FOR_CONDITION 
   |   |   `--.......
   |   |--SEMI -> ; 
   |   |--FOR_ITERATOR -> FOR_ITERATOR 
   |   |--RPAREN -> ) 
   |   `--SLIST -> { 
   |       `--RCURLY -> } 
   |--SLIST -> { 
   |   `--RCURLY -> } 
   `--RCURLY -> } 
```
In the AST above, when considering the definition of `int a`, `calculateDistanceInSingleScope` is passed the next ast (semicolon ast in this case), and the variable ident. The loop 
https://github.com/checkstyle/checkstyle/blob/32cfeee3a3b85eb26015dc515211c6db97a470f6/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java#L533-L546
 
iterates over the next sibling AST, in every case `RCURLY` is the last AST and the loop automatically stops as `currentAst` turns `null`. A variable will always be declared in a block (`{ }`), a variable declaration is not allowed in `if` blocks or other statements without `{ }` , something like
```java
if(someCondition)
    int a = 12;
```
will give a compilation error.

Also for variables declared in loops, the variable `int i` above, `currentAst` can not be `RCURLY` ever and the loop will stop when `currentAst` is null.

So it is safe to remove this condition.

---

### Generating reports again:

Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/1538ad39a090a627ff99ef5436bda5ca090835b9/my_checks.xml
Report label: validateBetweenScopesFalse

