### PR TITLE
Issue #11720: Kill surviving mutation in VariableDeclarationUsageDistanceCheck in isVariableInOperatorExpr

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-1-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-1-suppressions.xml
@@ -93,15 +93,6 @@
   <mutation unstable="false">
     <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
-    <mutatedMethod>isVariableInOperatorExpr</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (!isVarInOperatorDeclaration &amp;&amp; operator.getType() == TokenTypes.LITERAL_IF) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
     <mutatedMethod>searchVariableUsageExpressions</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
     <description>removed conditional - replaced equality check with true</description>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -959,7 +959,7 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
 
         // Variable may be met in ELSE declaration
         // So, check variable usage in these declarations.
-        if (!isVarInOperatorDeclaration && operator.getType() == TokenTypes.LITERAL_IF) {
+        if (!isVarInOperatorDeclaration) {
             final DetailAST elseBlock = operator.getLastChild();
 
             if (elseBlock.getType() == TokenTypes.LITERAL_ELSE) {


### PR DESCRIPTION
#11720
Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11931

Check documentation: https://checkstyle.sourceforge.io/config_coding.html#VariableDeclarationUsageDistance

### Diff Reports:

- validateBetweenScopesTrue: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/409dd3b_2022065548/reports/diff/index.html
- validateBetweenScopesFalse: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/409dd3b_2022181524/reports/diff/index.html

### Rationale

Redundant condition, the following condition 
`if (elseBlock.getType() == TokenTypes.LITERAL_ELSE) {` makes sure that only `if` statements enter the main logic block. Also, NPE is not possible as only `LITERAL_FOR`, `LITERAL_WHILE`, `LITERAL_DO`, `LITERAL_IF`, `LITERAL_SWITCH`, enter the method `isVariableInOperatorExpr` and each of these has a last child. 
 
---

### Generating reports again:

Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/1538ad39a090a627ff99ef5436bda5ca090835b9/my_checks.xml
Report label: validateBetweenScopesFalse

