### PR TITLE
Issue #11720: Kill surviving mutation in VariableDeclarationUsageDistanceCheck in searchVariableUsageExpressions

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-1-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-1-suppressions.xml
@@ -233,22 +233,4 @@
     <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::findFirstToken with receiver</description>
     <lineContent>.orElseGet(() -&gt; block.findFirstToken(TokenTypes.SWITCH_RULE));</lineContent>
   </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
-    <mutatedMethod>searchVariableUsageExpressions</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getType</description>
-    <lineContent>&amp;&amp; currentStatementAst.getType() != TokenTypes.RCURLY) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
-    <mutatedMethod>searchVariableUsageExpressions</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>&amp;&amp; currentStatementAst.getType() != TokenTypes.RCURLY) {</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -687,8 +687,7 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
         final List<DetailAST> variableUsageExpressions = new ArrayList<>();
         int distance = 0;
         DetailAST currentStatementAst = statementAst;
-        while (currentStatementAst != null
-                && currentStatementAst.getType() != TokenTypes.RCURLY) {
+        while (currentStatementAst != null) {
             if (currentStatementAst.getFirstChild() != null) {
                 if (isChild(currentStatementAst, variableAst)) {
                     variableUsageExpressions.add(currentStatementAst);


### PR DESCRIPTION
#11720
Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11930

Check documentation: https://checkstyle.sourceforge.io/config_coding.html#VariableDeclarationUsageDistance

### Diff Reports (Issue for NPE #11973):

- validateBetweenScopesTrue: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/8454c0e_2022065932/reports/diff/index.html
- validateBetweenScopesFalse: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/8454c0e_2022181205/reports/diff/index.html

### Rationale

In any variable declaration block, we wish to stop when the block ends, but this is already covered by the condition `currentStatementAst != null`

There cannot be more statements in the branch after reaching `RCURLY` as it is the last child (if present). So the condition `currentStatementAst != null` is enough in every use case.

---

### Generating reports again:

Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/1538ad39a090a627ff99ef5436bda5ca090835b9/my_checks.xml
Report label: validateBetweenScopesFalse

