### PR TITLE
Issue #11720: Kill surviving mutation in VariableDeclarationUsageDistanceCheck in getFirstNodeInsideForWhileDoWhileBlocks

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-1-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-1-suppressions.xml
@@ -39,15 +39,6 @@
   <mutation unstable="false">
     <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
-    <mutatedMethod>getFirstNodeInsideForWhileDoWhileBlocks</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
-    <description>removed conditional - replaced equality check with false</description>
-    <lineContent>if (currentNodeType == TokenTypes.SLIST) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
     <mutatedMethod>getFirstNodeInsideIfBlock</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
     <description>removed conditional - replaced equality check with false</description>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -741,10 +741,7 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
 
             final int currentNodeType = currentNode.getType();
 
-            if (currentNodeType == TokenTypes.SLIST) {
-                firstNodeInsideBlock = currentNode.getFirstChild();
-            }
-            else if (currentNodeType != TokenTypes.EXPR) {
+            if (currentNodeType != TokenTypes.EXPR) {
                 firstNodeInsideBlock = currentNode;
             }
         }


### PR DESCRIPTION
#11720
Hardcoded mutation tested at https://github.com/checkstyle/checkstyle/pull/11936

Check documentation: https://checkstyle.sourceforge.io/config_coding.html#VariableDeclarationUsageDistance

### Diff Reports (Issue for NPE #11973):

- validateBetweenScopesTrue: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/92cf19e_2022101845/reports/diff/index.html
- validateBetweenScopesFalse: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/92cf19e_2022183001/reports/diff/index.html

### Rationale

When we remove the condition 
```java
if (currentNodeType == TokenTypes.SLIST) {
  firstNodeInsideBlock = currentNode.getFirstChild();
}
```
and if the current node is of type `SLIST`, then the method `getFirstNodeInsideForWhileDoWhileBlocks` will return `SLIST` instead of its first child. This won't make a difference because in the caller method of this method i.e. `calculateDistanceBetweenScopes`, `currentScopeAst` will change to the first child in the default branch.
https://github.com/checkstyle/checkstyle/blob/206340d46c6ff410aa1e9e7499ac6fcaff25c630/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java#L635-L662

In the previous iteration of this loop, we changed `exprWithVariableUsage` to `SLIST` in
https://github.com/checkstyle/checkstyle/blob/206340d46c6ff410aa1e9e7499ac6fcaff25c630/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java#L640-L645

and in the next iteration it will remain `SLIST` as
https://github.com/checkstyle/checkstyle/blob/206340d46c6ff410aa1e9e7499ac6fcaff25c630/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java#L621-L622

would only have `SLIST` in `List<DetailAST>` and the distance would be zero because we found in the usage in the same node (i.e. `SLIST` node) that was passed to the method.

Hence this condition can be removed safely.

---

### Generating reports again:

Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/1538ad39a090a627ff99ef5436bda5ca090835b9/my_checks.xml
Report label: validateBetweenScopesFalse