### PR TITLE
Issue #11720: Kill surviving mutation in VariableDeclarationUsageDistanceCheck related to try-catch blocks

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-1-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-1-suppressions.xml
@@ -66,15 +66,6 @@
   <mutation unstable="false">
     <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
-    <mutatedMethod>getFirstNodeInsideTryCatchFinallyBlocks</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>&amp;&amp; currentNode.getType() == TokenTypes.LITERAL_CATCH) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
     <mutatedMethod>isChild</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
     <description>removed conditional - replaced equality check with true</description>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckTest.java
@@ -85,6 +85,7 @@ public class VariableDeclarationUsageDistanceCheckTest extends
         final String[] expected = {
             "17:9: " + getCheckMessage(MSG_KEY, "first", 5, 1),
             "29:9: " + getCheckMessage(MSG_KEY, "allInvariants", 2, 1),
+            "59:9: " + getCheckMessage(MSG_KEY, "a", 2, 1),
         };
         verifyWithInlineConfigParser(
                 getPath("InputVariableDeclarationUsageDistanceGeneral2.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceGeneral2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceGeneral2.java
@@ -53,4 +53,14 @@ public class InputVariableDeclarationUsageDistanceGeneral2 {
         } else {
         }
     }
+
+    void method() throws Exception {
+        // Until https://github.com/checkstyle/checkstyle/issues/11968
+        String a = ""; // violation
+        try (AutoCloseable i = new java.io.StringReader(a)) {
+        }
+        finally {
+            a.equals("");
+        }
+    }
 }


### PR DESCRIPTION
#11720

Hardcoded mutation tested at: https://github.com/checkstyle/checkstyle/pull/11933

Check documentation: https://checkstyle.sourceforge.io/config_coding.html#VariableDeclarationUsageDistance

### Diff Reports (These are the reports with logic changed):

- validateBetweenScopesTrue: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/8bed554_2022145753/reports/diff/index.html
- validateBetweenScopesFalse: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/8bed554_2022100114/reports/diff/index.html

### This mutation falls into the category

- Diff was found in report https://github.com/checkstyle/checkstyle/pull/11933#issuecomment-1190394605

This violation looks like a false positive to me, I created #11968 for it.

