### PR TITLE
Issue #11720: Kill surviving mutation in VariableDeclarationUsageDistanceCheck in getFirstNodeInsideIfBlock

### DIFF
--- a/.ci/pitest-suppressions/pitest-coding-1-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-coding-1-suppressions.xml
@@ -129,51 +129,6 @@
   <mutation unstable="false">
     <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
-    <mutatedMethod>getFirstNodeInsideIfBlock</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getLastChild with receiver</description>
-    <lineContent>currentNode = currentNode.getLastChild();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
-    <mutatedMethod>getFirstNodeInsideIfBlock</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck::isChild</description>
-    <lineContent>else if (isChild(currentNode, variable)) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
-    <mutatedMethod>getFirstNodeInsideIfBlock</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
-    <description>removed conditional - replaced equality check with false</description>
-    <lineContent>else if (isChild(currentNode, variable)) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
-    <mutatedMethod>getFirstNodeInsideIfBlock</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getType</description>
-    <lineContent>if (currentNode.getType() == TokenTypes.LITERAL_IF) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
-    <mutatedMethod>getFirstNodeInsideIfBlock</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
-    <description>removed conditional - replaced equality check with false</description>
-    <lineContent>if (currentNode.getType() == TokenTypes.LITERAL_IF) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
     <mutatedMethod>getFirstNodeInsideTryCatchFinallyBlocks</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
     <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getLastChild with receiver</description>
@@ -228,7 +183,7 @@
   <mutation unstable="false">
     <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
-    <mutatedMethod>lambda$getFirstCaseGroupOrSwitchRule$1</mutatedMethod>
+    <mutatedMethod>lambda$getFirstCaseGroupOrSwitchRule$2</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
     <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::findFirstToken with receiver</description>
     <lineContent>.orElseGet(() -&gt; block.findFirstToken(TokenTypes.SWITCH_RULE));</lineContent>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -761,37 +761,26 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
         DetailAST firstNodeInsideBlock = null;
 
         if (!isVariableInOperatorExpr(block, variable)) {
-            DetailAST currentNode = block.getLastChild();
-            final List<DetailAST> variableUsageExpressions =
-                    new ArrayList<>();
+            final Optional<DetailAST> slistToken = TokenUtil
+                .findFirstTokenByPredicate(block, token -> token.getType() == TokenTypes.SLIST);
+            final DetailAST lastNode = block.getLastChild();
+            DetailAST previousNode = lastNode.getPreviousSibling();
 
-            while (currentNode != null
-                    && currentNode.getType() == TokenTypes.LITERAL_ELSE) {
-                final DetailAST previousNode =
-                        currentNode.getPreviousSibling();
+            if (slistToken.isEmpty()
+                && lastNode.getType() == TokenTypes.LITERAL_ELSE) {
 
-                // Checking variable usage inside IF block.
-                if (isChild(previousNode, variable)) {
-                    variableUsageExpressions.add(previousNode);
-                }
-
-                // Looking into ELSE block, get its first child and analyze it.
-                currentNode = currentNode.getFirstChild();
-
-                if (currentNode.getType() == TokenTypes.LITERAL_IF) {
-                    currentNode = currentNode.getLastChild();
-                }
-                else if (isChild(currentNode, variable)) {
-                    variableUsageExpressions.add(currentNode);
-                    currentNode = null;
-                }
+                // Is if statement without '{}' and has a following else branch,
+                // then change previousNode to the if statement body.
+                previousNode = previousNode.getPreviousSibling();
             }
 
-            // If IF block doesn't include ELSE then analyze variable usage
-            // only inside IF block.
-            if (currentNode != null
-                    && isChild(currentNode, variable)) {
-                variableUsageExpressions.add(currentNode);
+            final List<DetailAST> variableUsageExpressions = new ArrayList<>();
+            if (isChild(previousNode, variable)) {
+                variableUsageExpressions.add(previousNode);
+            }
+
+            if (isChild(lastNode, variable)) {
+                variableUsageExpressions.add(lastNode);
             }
 
             // If variable usage exists in several related blocks, then

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheckTest.java
@@ -92,6 +92,23 @@ public class VariableDeclarationUsageDistanceCheckTest extends
     }
 
     @Test
+    public void testIfStatements() throws Exception {
+        final String[] expected = {
+            "18:9: " + getCheckMessage(MSG_KEY, "a", 4, 1),
+            "28:9: " + getCheckMessage(MSG_KEY, "a", 2, 1),
+            "32:9: " + getCheckMessage(MSG_KEY, "b", 2, 1),
+            "38:9: " + getCheckMessage(MSG_KEY, "c", 3, 1),
+            "49:9: " + getCheckMessage(MSG_KEY, "b", 2, 1),
+            "50:9: " + getCheckMessage(MSG_KEY, "c", 3, 1),
+            "51:9: " + getCheckMessage(MSG_KEY, "d", 4, 1),
+            "63:9: " + getCheckMessage(MSG_KEY, "a", 4, 1),
+
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputVariableDeclarationUsageDistanceIfStatements.java"), expected);
+    }
+
+    @Test
     public void testDistance() throws Exception {
         final String[] expected = {
             "83:9: " + getCheckMessage(MSG_KEY, "count", 4, 3),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceIfStatements.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/variabledeclarationusagedistance/InputVariableDeclarationUsageDistanceIfStatements.java
@@ -1,0 +1,72 @@
+/*
+VariableDeclarationUsageDistance
+allowedDistance = 1
+ignoreVariablePattern = (default)
+validateBetweenScopes = true
+ignoreFinal = false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.variabledeclarationusagedistance;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class InputVariableDeclarationUsageDistanceIfStatements {
+    void method2() {
+        int a = 12; // violation
+        if (true) {
+            method2();
+            checkIfStatementWithoutParen();
+            method2();
+            a++;
+        }
+    }
+
+    void checkIfStatementWithoutParen() {
+        int a = 12; // violation
+        method2();
+        if (true)
+            a++;
+        int b = 12; // violation
+        method2();
+        if (false)
+            method2();
+        else if(true)
+            b++;
+        int c = 12; // violation
+        method2();
+        checkIfStatementWithoutParen();
+        if (true)
+            c++;
+        else
+            method2();
+    }
+
+    void testConsecutiveIfStatements() {
+        int a = 12; // ok
+        int b = 13; // violation
+        int c = 14; // violation
+        int d = 15; // violation
+        if (true)
+            a++;
+        if (true)
+            b++;
+        if (false)
+            c++;
+        if (true)
+            d++;
+    }
+
+    int testReturnStatement() {
+        int a = 1; // violation
+        testConsecutiveIfStatements();
+        testConsecutiveIfStatements();
+        testConsecutiveIfStatements();
+        if (true)
+            return a;
+
+        return 0;
+    }
+}


### PR DESCRIPTION
Closes #11720

Check documentation: https://checkstyle.sourceforge.io/config_coding.html#VariableDeclarationUsageDistance

### Diff Reports (Contains diff, Issue for NPE at #11973):

- validateBetweenScopesFalse: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/78d2c37_2022195745/reports/diff/index.html
- validateBetweenScopesTrue: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/3fe931a_2022125544/reports/diff/index.html

### Rationale

There is no need to loop and check all the statements in the `if-else` chain at once, just check the current statement, the next statement (if present), and the outer method i.e. `calculateDistanceBetweenScopes` will iterate over the remaining branches, we just add the head of the remaining branches to `variableUsageExpressions` for it to be analyzed in the next iteration.

Also support for `if` statements without `{}` was added, it rationale is present below. 
Previous Logic:
```java
private static DetailAST getFirstNodeInsideIfBlock(
        DetailAST block, DetailAST variable) {
    DetailAST firstNodeInsideBlock = null;


    if (!isVariableInOperatorExpr(block, variable)) {
        DetailAST currentNode = block.getLastChild();
        final List<DetailAST> variableUsageExpressions =
                new ArrayList<>();


        while (currentNode != null
                && currentNode.getType() == TokenTypes.LITERAL_ELSE) {
            final DetailAST previousNode =
                    currentNode.getPreviousSibling();


            // Checking variable usage inside IF block.
            if (isChild(previousNode, variable)) {
                variableUsageExpressions.add(previousNode);
            }


            // Looking into ELSE block, get its first child and analyze it.
            currentNode = currentNode.getFirstChild();


            if (currentNode.getType() == TokenTypes.LITERAL_IF) {
                currentNode = currentNode.getLastChild();
            }
            else if (isChild(currentNode, variable)) {
                variableUsageExpressions.add(currentNode);
                currentNode = null;
            }
        }


        // If IF block doesn't include ELSE then analyze variable usage
        // only inside IF block.
        if (currentNode != null
                && isChild(currentNode, variable)) {
            variableUsageExpressions.add(currentNode);
        }


        // If variable usage exists in several related blocks, then
        // firstNodeInsideBlock = null, otherwise if variable usage exists
        // only inside one block, then get node from
        // variableUsageExpressions.
        if (variableUsageExpressions.size() == 1) {
            firstNodeInsideBlock = variableUsageExpressions.get(0);
        }
    }


    return firstNodeInsideBlock;
}
```
If we see the initial logic, we get the if statements last-child, for if statements without `{}`, it will be:
```java
if (true)    
    method();
```
AST-
```
LITERAL_IF -> if 
   |--LPAREN -> ( 
   |--EXPR -> EXPR 
   |   `--LITERAL_TRUE -> true 
   |--RPAREN -> ) 
   |--EXPR -> EXPR 
   |   `--METHOD_CALL -> ( 
   |       |--IDENT -> method 
   |       |--ELIST -> ELIST 
   |       `--RPAREN -> ) 
   `--SEMI -> ; 
```
Now the last child is `SEMI` and the according to the logic, it was supposed to be if statements body.
The logic was built for if statements with `{}` where the last child is `SLIST` i.e. if statement's body.
```
LITERAL_IF -> if 
  |--LPAREN -> ( 
  |--EXPR -> EXPR 
  |   `--LITERAL_TRUE -> true 
  |--RPAREN -> ) 
  `--SLIST -> { 
      |--EXPR -> EXPR 
      |   `--METHOD_CALL -> ( 
      |       |--IDENT -> method 
      |       |--ELIST -> ELIST 
      |       `--RPAREN -> ) 
      |--SEMI -> ; 
      `--RCURLY -> } 
```
Cases like this in combination with `else` were missing, support for that was added.


---

### Generating reports again:

Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/a06fa3c8f525c4466a67c1ee057d4ed843db2301/my_checks.xml
Report label: validateBetweenScopesTrue