### PR TITLE
Issue #11719: Activate all group for pitest-header

### DIFF
--- a/.ci/pitest-suppressions/pitest-header-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-header-suppressions.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressedMutations>
+  <mutation unstable="false">
+    <sourceFile>AbstractHeaderCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.header.AbstractHeaderCheck</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/nio/charset/Charset::name</description>
+    <lineContent>StandardCharsets.UTF_8.name()));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AbstractHeaderCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.header.AbstractHeaderCheck</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck::createCharset</description>
+    <lineContent>private Charset charset = createCharset(System.getProperty(&quot;file.encoding&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AbstractHeaderCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.header.AbstractHeaderCheck</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/lang/System::getProperty with argument</description>
+    <lineContent>private Charset charset = createCharset(System.getProperty(&quot;file.encoding&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AbstractHeaderCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.header.AbstractHeaderCheck</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable charset</description>
+    <lineContent>private Charset charset = createCharset(System.getProperty(&quot;file.encoding&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AbstractHeaderCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.header.AbstractHeaderCheck</mutatedClass>
+    <mutatedMethod>setCharset</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable charset</description>
+    <lineContent>this.charset = createCharset(charset);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RegexpHeaderCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck</mutatedClass>
+    <mutatedMethod>postProcessHeaderLines</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/List::size</description>
+    <lineContent>+ (headerRegexps.size() + 1)</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RegexpHeaderCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.header.RegexpHeaderCheck</mutatedClass>
+    <mutatedMethod>postProcessHeaderLines</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/List::add</description>
+    <lineContent>headerRegexps.add(BLANK_LINE);</lineContent>
+  </mutation>
+</suppressedMutations>

--- a/pom.xml
+++ b/pom.xml
@@ -2795,15 +2795,33 @@
               <mutators>
                 <mutator>CONDITIONALS_BOUNDARY</mutator>
                 <mutator>CONSTRUCTOR_CALLS</mutator>
-                <mutator>FALSE_RETURNS</mutator>
                 <mutator>INCREMENTS</mutator>
+                <!-- Read reason of disablement at https://github.com/checkstyle/checkstyle/issues/11895 -->
+                <!-- <mutator>INLINE_CONSTS</mutator> -->
                 <mutator>INVERT_NEGS</mutator>
                 <mutator>MATH</mutator>
                 <mutator>NEGATE_CONDITIONALS</mutator>
-                <mutator>REMOVE_CONDITIONALS</mutator>
+                <mutator>NON_VOID_METHOD_CALLS</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_IF</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_IF</mutator>
                 <mutator>RETURN_VALS</mutator>
-                <mutator>TRUE_RETURNS</mutator>
                 <mutator>VOID_METHOD_CALLS</mutator>
+                <mutator>EXPERIMENTAL_ARGUMENT_PROPAGATION</mutator>
+                <mutator>EXPERIMENTAL_BIG_DECIMAL</mutator>
+                <mutator>EXPERIMENTAL_BIG_INTEGER</mutator>
+                <mutator>EXPERIMENTAL_MEMBER_VARIABLE</mutator>
+                <mutator>EXPERIMENTAL_NAKED_RECEIVER</mutator>
+                <mutator>REMOVE_INCREMENTS</mutator>
+                <mutator>EXPERIMENTAL_RETURN_VALUES_MUTATOR</mutator>
+                <mutator>EXPERIMENTAL_SWITCH</mutator>
+                <mutator>REMOVE_SWITCH</mutator>
+                <mutator>FALSE_RETURNS</mutator>
+                <mutator>TRUE_RETURNS</mutator>
+                <mutator>EMPTY_RETURNS</mutator>
+                <mutator>NULL_RETURNS</mutator>
+                <mutator>PRIMITIVE_RETURNS</mutator>
               </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.header.*</param>
@@ -2814,7 +2832,7 @@
               <excludedTestClasses>
                 <param>*.Input*</param>
               </excludedTestClasses>
-              <coverageThreshold>98</coverageThreshold>
+              <coverageThreshold>100</coverageThreshold>
               <mutationThreshold>97</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>


### PR DESCRIPTION

#11719
Activating `ALL` group for `pitest-header`

Every mutator has been activated except `INLINE_CONSTS`

- Report with `ALL` group except `INLINE_CONSTS`: https://vyom-yadav.github.io/pitest-all-latest/pitest-header/index.html
