### PR TITLE
Issue #11719: Activate all group for pitest-common

### DIFF
--- a/.ci/pitest-suppressions/pitest-common-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-common-suppressions.xml
@@ -1,6 +1,366 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
+    <sourceFile>AuditEventDefaultFormatter.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.AuditEventDefaultFormatter</mutatedClass>
+    <mutatedMethod>format</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatter::calculateBufferLength</description>
+    <lineContent>final int bufLen = calculateBufferLength(event, severityLevelName.length());</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AuditEventDefaultFormatter.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.AuditEventDefaultFormatter</mutatedClass>
+    <mutatedMethod>format</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/String::length</description>
+    <lineContent>final int bufLen = calculateBufferLength(event, severityLevelName.length());</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>AuditEventDefaultFormatter.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.AuditEventDefaultFormatter</mutatedClass>
+    <mutatedMethod>format</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatter::calculateBufferLength with argument</description>
+    <lineContent>final int bufLen = calculateBufferLength(event, severityLevelName.length());</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Checker.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.Checker</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable fileExtensions</description>
+    <lineContent>private String[] fileExtensions = CommonUtil.EMPTY_STRING_ARRAY;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Checker.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.Checker</mutatedClass>
+    <mutatedMethod>acceptFileStarted</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/utils/CommonUtil::relativizeAndNormalizePath with argument</description>
+    <lineContent>final String stripped = CommonUtil.relativizeAndNormalizePath(basedir, fileName);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Checker.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.Checker</mutatedClass>
+    <mutatedMethod>fireErrors</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/utils/CommonUtil::relativizeAndNormalizePath with argument</description>
+    <lineContent>final String stripped = CommonUtil.relativizeAndNormalizePath(basedir, fileName);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Checker.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.Checker</mutatedClass>
+    <mutatedMethod>fireFileFinished</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/utils/CommonUtil::relativizeAndNormalizePath with argument</description>
+    <lineContent>final String stripped = CommonUtil.relativizeAndNormalizePath(basedir, fileName);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Checker.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.Checker</mutatedClass>
+    <mutatedMethod>fireFileStarted</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/utils/CommonUtil::relativizeAndNormalizePath with argument</description>
+    <lineContent>final String stripped = CommonUtil.relativizeAndNormalizePath(basedir, fileName);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Checker.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.Checker</mutatedClass>
+    <mutatedMethod>getExternalResourceLocations</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/util/stream/Stream::map with receiver</description>
+    <lineContent>.map(ExternalResourceHolder.class::cast)</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Checker.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.Checker</mutatedClass>
+    <mutatedMethod>processFile</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/io/IOException::getMessage</description>
+    <lineContent>new String[] {ioe.getMessage()}, null, getClass(), null));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Checker.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.Checker</mutatedClass>
+    <mutatedMethod>processFiles</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/io/File::getPath</description>
+    <lineContent>throw new Error(&quot;Error was thrown while processing &quot; + file.getPath(), error);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Checker.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.Checker</mutatedClass>
+    <mutatedMethod>setCharset</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable charset</description>
+    <lineContent>this.charset = charset;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Checker.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.Checker</mutatedClass>
+    <mutatedMethod>setFileExtensions</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable fileExtensions</description>
+    <lineContent>fileExtensions = null;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Checker.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.Checker</mutatedClass>
+    <mutatedMethod>setSeverity</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/api/SeverityLevel::getInstance</description>
+    <lineContent>this.severity = SeverityLevel.getInstance(severity);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>Checker.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.Checker</mutatedClass>
+    <mutatedMethod>setSeverity</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable severity</description>
+    <lineContent>this.severity = SeverityLevel.getInstance(severity);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ConfigurationLoader</mutatedClass>
+    <mutatedMethod>createIdToResourceNameMap</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>map.put(DTD_PUBLIC_CS_ID_1_0, DTD_CONFIGURATION_NAME_1_0);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ConfigurationLoader</mutatedClass>
+    <mutatedMethod>createIdToResourceNameMap</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>map.put(DTD_PUBLIC_CS_ID_1_0, DTD_CONFIGURATION_NAME_1_0);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ConfigurationLoader</mutatedClass>
+    <mutatedMethod>createIdToResourceNameMap</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>map.put(DTD_PUBLIC_CS_ID_1_1, DTD_CONFIGURATION_NAME_1_1);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ConfigurationLoader</mutatedClass>
+    <mutatedMethod>createIdToResourceNameMap</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>map.put(DTD_PUBLIC_CS_ID_1_1, DTD_CONFIGURATION_NAME_1_1);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ConfigurationLoader</mutatedClass>
+    <mutatedMethod>createIdToResourceNameMap</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>map.put(DTD_PUBLIC_CS_ID_1_2, DTD_CONFIGURATION_NAME_1_2);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ConfigurationLoader</mutatedClass>
+    <mutatedMethod>createIdToResourceNameMap</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>map.put(DTD_PUBLIC_CS_ID_1_2, DTD_CONFIGURATION_NAME_1_2);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ConfigurationLoader</mutatedClass>
+    <mutatedMethod>createIdToResourceNameMap</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>map.put(DTD_PUBLIC_CS_ID_1_3, DTD_CONFIGURATION_NAME_1_3);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ConfigurationLoader</mutatedClass>
+    <mutatedMethod>createIdToResourceNameMap</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>map.put(DTD_PUBLIC_CS_ID_1_3, DTD_CONFIGURATION_NAME_1_3);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ConfigurationLoader</mutatedClass>
+    <mutatedMethod>createIdToResourceNameMap</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>map.put(DTD_PUBLIC_ID_1_0, DTD_CONFIGURATION_NAME_1_0);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ConfigurationLoader</mutatedClass>
+    <mutatedMethod>createIdToResourceNameMap</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>map.put(DTD_PUBLIC_ID_1_0, DTD_CONFIGURATION_NAME_1_0);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ConfigurationLoader</mutatedClass>
+    <mutatedMethod>createIdToResourceNameMap</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>map.put(DTD_PUBLIC_ID_1_1, DTD_CONFIGURATION_NAME_1_1);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ConfigurationLoader</mutatedClass>
+    <mutatedMethod>createIdToResourceNameMap</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>map.put(DTD_PUBLIC_ID_1_1, DTD_CONFIGURATION_NAME_1_1);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ConfigurationLoader</mutatedClass>
+    <mutatedMethod>createIdToResourceNameMap</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>map.put(DTD_PUBLIC_ID_1_2, DTD_CONFIGURATION_NAME_1_2);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ConfigurationLoader</mutatedClass>
+    <mutatedMethod>createIdToResourceNameMap</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>map.put(DTD_PUBLIC_ID_1_2, DTD_CONFIGURATION_NAME_1_2);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ConfigurationLoader</mutatedClass>
+    <mutatedMethod>createIdToResourceNameMap</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>map.put(DTD_PUBLIC_ID_1_3, DTD_CONFIGURATION_NAME_1_3);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ConfigurationLoader</mutatedClass>
+    <mutatedMethod>createIdToResourceNameMap</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>map.put(DTD_PUBLIC_ID_1_3, DTD_CONFIGURATION_NAME_1_3);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ConfigurationLoader</mutatedClass>
+    <mutatedMethod>createIdToResourceNameMap</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator</mutator>
+    <description>replaced return value with Collections.emptyMap for com/puppycrawl/tools/checkstyle/ConfigurationLoader::createIdToResourceNameMap</description>
+    <lineContent>return map;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ConfigurationLoader</mutatedClass>
+    <mutatedMethod>replaceProperties</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/StringBuilder::length</description>
+    <lineContent>sb.replace(0, sb.length(), defaultValue);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ConfigurationLoader$InternalLoader</mutatedClass>
+    <mutatedMethod>startElement</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to org/xml/sax/Attributes::getValue</description>
+    <lineContent>final String value = attributes.getValue(VALUE);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ConfigurationLoader$InternalLoader</mutatedClass>
+    <mutatedMethod>startElement</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to org/xml/sax/Attributes::getValue with argument</description>
+    <lineContent>final String value = attributes.getValue(VALUE);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ConfigurationLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.ConfigurationLoader$InternalLoader</mutatedClass>
+    <mutatedMethod>startElement</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to org/xml/sax/Attributes::getValue</description>
+    <lineContent>overridePropsResolver, attributes.getValue(DEFAULT));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>DefaultLogger.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.DefaultLogger$LocalizedMessage</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable args</description>
+    <lineContent>args = null;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>DefaultLogger.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.DefaultLogger$LocalizedMessage</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Arrays::copyOf with argument</description>
+    <lineContent>this.args = Arrays.copyOf(args, args.length);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>DefaultLogger.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.DefaultLogger$LocalizedMessage</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable args</description>
+    <lineContent>this.args = null;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>createModule</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/String::contains</description>
+    <lineContent>if (!name.contains(PACKAGE_SEPARATOR)) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
     <sourceFile>PackageObjectFactory.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
     <mutatedMethod>createModule</mutatedMethod>
@@ -16,5 +376,3713 @@
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
     <description>removed conditional - replaced equality check with true</description>
     <lineContent>if (thirdPartyNameToFullModuleNames == null) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>createModule</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/Object::getClass</description>
+    <lineContent>new String[] {name, attemptedNames}, null, getClass(), null);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>createObjectFromFullModuleNames</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/util/stream/Stream::sorted with receiver</description>
+    <lineContent>.sorted()</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>createObjectFromFullModuleNames</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/Object::getClass</description>
+    <lineContent>new String[] {name, optionalNames}, null, getClass(), null);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromAnnotationPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AnnotationLocationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromAnnotationPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AnnotationLocationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromAnnotationPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AnnotationOnSameLineCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromAnnotationPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AnnotationOnSameLineCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromAnnotationPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AnnotationUseStyleCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromAnnotationPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AnnotationUseStyleCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromAnnotationPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MissingDeprecatedCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromAnnotationPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MissingDeprecatedCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromAnnotationPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MissingOverrideCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromAnnotationPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MissingOverrideCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromAnnotationPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;PackageAnnotationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromAnnotationPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;PackageAnnotationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromAnnotationPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuppressWarningsCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromAnnotationPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuppressWarningsCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromBlocksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AvoidNestedBlocksCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromBlocksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AvoidNestedBlocksCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromBlocksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;EmptyBlockCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromBlocksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;EmptyBlockCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromBlocksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;EmptyCatchBlockCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromBlocksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;EmptyCatchBlockCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromBlocksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;LeftCurlyCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromBlocksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;LeftCurlyCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromBlocksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NeedBracesCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromBlocksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NeedBracesCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromBlocksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RightCurlyCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromBlocksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RightCurlyCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ArrayTrailingCommaCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ArrayTrailingCommaCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AvoidDoubleBraceInitializationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AvoidDoubleBraceInitializationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AvoidInlineConditionalsCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AvoidInlineConditionalsCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AvoidNoArgumentSuperConstructorCallCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AvoidNoArgumentSuperConstructorCallCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;CovariantEqualsCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;CovariantEqualsCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;DeclarationOrderCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;DeclarationOrderCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;DefaultComesLastCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;DefaultComesLastCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;EmptyStatementCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;EmptyStatementCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;EqualsAvoidNullCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;EqualsAvoidNullCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;EqualsHashCodeCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;EqualsHashCodeCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ExplicitInitializationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ExplicitInitializationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;FallThroughCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;FallThroughCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;FinalLocalVariableCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;FinalLocalVariableCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;HiddenFieldCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;HiddenFieldCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;IllegalCatchCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;IllegalCatchCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;IllegalInstantiationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;IllegalInstantiationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;IllegalThrowsCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;IllegalThrowsCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;IllegalTokenCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;IllegalTokenCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;IllegalTokenTextCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;IllegalTokenTextCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;IllegalTypeCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;IllegalTypeCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;InnerAssignmentCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;InnerAssignmentCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MagicNumberCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MagicNumberCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MatchXpathCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MatchXpathCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MissingCtorCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MissingCtorCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MissingSwitchDefaultCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MissingSwitchDefaultCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ModifiedControlVariableCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ModifiedControlVariableCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MultipleStringLiteralsCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MultipleStringLiteralsCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MultipleVariableDeclarationsCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MultipleVariableDeclarationsCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NestedForDepthCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NestedForDepthCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NestedIfDepthCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NestedIfDepthCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NestedTryDepthCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NestedTryDepthCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NoArrayTrailingCommaCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NoArrayTrailingCommaCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NoCloneCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NoCloneCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NoEnumTrailingCommaCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NoEnumTrailingCommaCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NoFinalizerCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NoFinalizerCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;OneStatementPerLineCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;OneStatementPerLineCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;OverloadMethodsDeclarationOrderCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;OverloadMethodsDeclarationOrderCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;PackageDeclarationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;PackageDeclarationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ParameterAssignmentCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ParameterAssignmentCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RequireThisCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RequireThisCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ReturnCountCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ReturnCountCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SimplifyBooleanExpressionCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SimplifyBooleanExpressionCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SimplifyBooleanReturnCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SimplifyBooleanReturnCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;StringLiteralEqualityCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;StringLiteralEqualityCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuperCloneCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuperCloneCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuperFinalizeCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuperFinalizeCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;UnnecessaryParenthesesCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;UnnecessaryParenthesesCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;UnnecessarySemicolonAfterOuterTypeDeclarationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;UnnecessarySemicolonAfterOuterTypeDeclarationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;UnnecessarySemicolonAfterTypeMemberDeclarationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;UnnecessarySemicolonAfterTypeMemberDeclarationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;UnnecessarySemicolonInEnumerationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;UnnecessarySemicolonInEnumerationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;UnnecessarySemicolonInTryWithResourcesCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;UnnecessarySemicolonInTryWithResourcesCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;UnusedLocalVariableCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;UnusedLocalVariableCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;VariableDeclarationUsageDistanceCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromCodingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;VariableDeclarationUsageDistanceCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromDesignPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;DesignForExtensionCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromDesignPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;DesignForExtensionCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromDesignPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;FinalClassCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromDesignPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;FinalClassCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromDesignPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;HideUtilityClassConstructorCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromDesignPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;HideUtilityClassConstructorCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromDesignPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;InnerTypeLastCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromDesignPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;InnerTypeLastCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromDesignPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;InterfaceIsTypeCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromDesignPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;InterfaceIsTypeCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromDesignPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MutableExceptionCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromDesignPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MutableExceptionCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromDesignPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;OneTopLevelClassCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromDesignPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;OneTopLevelClassCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromDesignPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ThrowsCountCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromDesignPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ThrowsCountCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromDesignPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;VisibilityModifierCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromDesignPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;VisibilityModifierCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromHeaderPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;HeaderCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromHeaderPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;HeaderCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromHeaderPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RegexpHeaderCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromHeaderPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RegexpHeaderCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromImportsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AvoidStarImportCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromImportsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AvoidStarImportCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromImportsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AvoidStaticImportCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromImportsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AvoidStaticImportCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromImportsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;CustomImportOrderCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromImportsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;CustomImportOrderCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromImportsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;IllegalImportCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromImportsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;IllegalImportCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromImportsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ImportControlCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromImportsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ImportControlCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromImportsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ImportOrderCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromImportsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ImportOrderCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromImportsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RedundantImportCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromImportsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RedundantImportCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromImportsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;UnusedImportsCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromImportsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;UnusedImportsCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromIndentationPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;CommentsIndentationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromIndentationPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;CommentsIndentationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromIndentationPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;IndentationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromIndentationPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;IndentationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AtclauseOrderCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AtclauseOrderCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;InvalidJavadocPositionCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;InvalidJavadocPositionCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavadocBlockTagLocationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavadocBlockTagLocationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavadocContentLocationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavadocContentLocationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavadocMethodCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavadocMethodCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavadocMissingLeadingAsteriskCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavadocMissingLeadingAsteriskCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavadocMissingWhitespaceAfterAsteriskCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavadocMissingWhitespaceAfterAsteriskCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavadocPackageCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavadocPackageCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavadocParagraphCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavadocParagraphCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavadocStyleCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavadocStyleCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavadocTagContinuationIndentationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavadocTagContinuationIndentationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavadocTypeCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavadocTypeCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavadocVariableCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavadocVariableCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MissingJavadocMethodCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MissingJavadocMethodCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MissingJavadocPackageCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MissingJavadocPackageCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MissingJavadocTypeCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MissingJavadocTypeCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NonEmptyAtclauseDescriptionCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NonEmptyAtclauseDescriptionCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RequireEmptyLineBeforeBlockTagGroupCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RequireEmptyLineBeforeBlockTagGroupCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SingleLineJavadocCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SingleLineJavadocCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SummaryJavadocCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SummaryJavadocCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;WriteTagCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromJavadocPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;WriteTagCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromMetricsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;BooleanExpressionComplexityCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromMetricsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;BooleanExpressionComplexityCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromMetricsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ClassDataAbstractionCouplingCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromMetricsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ClassDataAbstractionCouplingCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromMetricsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ClassFanOutComplexityCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromMetricsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ClassFanOutComplexityCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromMetricsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;CyclomaticComplexityCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromMetricsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;CyclomaticComplexityCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromMetricsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavaNCSSCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromMetricsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;JavaNCSSCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromMetricsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NPathComplexityCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromMetricsPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NPathComplexityCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromModifierPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ClassMemberImpliedModifierCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromModifierPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ClassMemberImpliedModifierCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromModifierPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;InterfaceMemberImpliedModifierCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromModifierPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;InterfaceMemberImpliedModifierCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromModifierPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ModifierOrderCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromModifierPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ModifierOrderCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromModifierPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RedundantModifierCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromModifierPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RedundantModifierCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AbbreviationAsWordInNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AbbreviationAsWordInNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AbstractClassNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AbstractClassNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;CatchParameterNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;CatchParameterNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ClassTypeParameterNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ClassTypeParameterNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ConstantNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ConstantNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;IllegalIdentifierNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;IllegalIdentifierNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;InterfaceTypeParameterNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;InterfaceTypeParameterNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;LambdaParameterNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;LambdaParameterNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;LocalFinalVariableNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;LocalFinalVariableNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;LocalVariableNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;LocalVariableNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MemberNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MemberNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MethodNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MethodNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MethodTypeParameterNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MethodTypeParameterNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;PackageNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;PackageNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ParameterNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ParameterNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;PatternVariableNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;PatternVariableNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RecordComponentNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RecordComponentNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RecordTypeParameterNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RecordTypeParameterNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;StaticVariableNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;StaticVariableNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;TypeNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromNamingPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;TypeNameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromRegexpPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RegexpCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromRegexpPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RegexpCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromRegexpPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RegexpMultilineCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromRegexpPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RegexpMultilineCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromRegexpPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RegexpOnFilenameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromRegexpPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RegexpOnFilenameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromRegexpPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RegexpSinglelineCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromRegexpPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RegexpSinglelineCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromRegexpPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RegexpSinglelineJavaCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromRegexpPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RegexpSinglelineJavaCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromSizesPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AnonInnerLengthCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromSizesPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AnonInnerLengthCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromSizesPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ExecutableStatementCountCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromSizesPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ExecutableStatementCountCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromSizesPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;FileLengthCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromSizesPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;FileLengthCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromSizesPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;LambdaBodyLengthCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromSizesPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;LambdaBodyLengthCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromSizesPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;LineLengthCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromSizesPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;LineLengthCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromSizesPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MethodCountCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromSizesPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MethodCountCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromSizesPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MethodLengthCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromSizesPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MethodLengthCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromSizesPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;OuterTypeNumberCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromSizesPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;OuterTypeNumberCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromSizesPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ParameterNumberCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromSizesPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ParameterNumberCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromSizesPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RecordComponentNumberCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromSizesPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;RecordComponentNumberCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;EmptyForInitializerPadCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;EmptyForInitializerPadCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;EmptyForIteratorPadCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;EmptyForIteratorPadCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;EmptyLineSeparatorCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;EmptyLineSeparatorCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;FileTabCharacterCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;FileTabCharacterCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;GenericWhitespaceCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;GenericWhitespaceCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MethodParamPadCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;MethodParamPadCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NoLineWrapCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NoLineWrapCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NoWhitespaceAfterCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NoWhitespaceAfterCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NoWhitespaceBeforeCaseDefaultColonCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NoWhitespaceBeforeCaseDefaultColonCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NoWhitespaceBeforeCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NoWhitespaceBeforeCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;OperatorWrapCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;OperatorWrapCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ParenPadCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ParenPadCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SeparatorWrapCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SeparatorWrapCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SingleSpaceSeparatorCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SingleSpaceSeparatorCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;TypecastParenPadCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;TypecastParenPadCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;WhitespaceAfterCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;WhitespaceAfterCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;WhitespaceAroundCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillChecksFromWhitespacePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;WhitespaceAroundCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ArrayTypeStyleCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;ArrayTypeStyleCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AvoidEscapedUnicodeCharactersCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;AvoidEscapedUnicodeCharactersCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;DescendantTokenCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;DescendantTokenCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;FinalParametersCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;FinalParametersCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NewlineAtEndOfFileCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NewlineAtEndOfFileCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NoCodeInFileCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;NoCodeInFileCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;OrderedPropertiesCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;OrderedPropertiesCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;OuterTypeFilenameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;OuterTypeFilenameCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuppressWarningsHolder&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuppressWarningsHolder&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;TodoCommentCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;TodoCommentCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;TrailingCommentCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;TrailingCommentCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;TranslationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;TranslationCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;UncommentedMainCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;UncommentedMainCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;UniquePropertiesCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;UniquePropertiesCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;UpperEllCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromChecksPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;UpperEllCheck&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromCheckstylePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;Checker&quot;, BASE_PACKAGE + &quot;.Checker&quot;);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromCheckstylePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;Checker&quot;, BASE_PACKAGE + &quot;.Checker&quot;);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromCheckstylePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;TreeWalker&quot;, BASE_PACKAGE + &quot;.TreeWalker&quot;);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromCheckstylePackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;TreeWalker&quot;, BASE_PACKAGE + &quot;.TreeWalker&quot;);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromFilefiltersPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;BeforeExecutionExclusionFileFilter&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromFilefiltersPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;BeforeExecutionExclusionFileFilter&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromFiltersPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SeverityMatchFilter&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromFiltersPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SeverityMatchFilter&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromFiltersPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuppressWarningsFilter&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromFiltersPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuppressWarningsFilter&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromFiltersPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuppressWithNearbyCommentFilter&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromFiltersPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuppressWithNearbyCommentFilter&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromFiltersPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuppressWithPlainTextCommentFilter&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromFiltersPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuppressWithPlainTextCommentFilter&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromFiltersPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuppressionCommentFilter&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromFiltersPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuppressionCommentFilter&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromFiltersPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuppressionFilter&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromFiltersPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuppressionFilter&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromFiltersPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuppressionSingleFilter&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromFiltersPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuppressionSingleFilter&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromFiltersPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuppressionXpathFilter&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromFiltersPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuppressionXpathFilter&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromFiltersPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::put</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuppressionXpathSingleFilter&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PackageObjectFactory.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
+    <mutatedMethod>fillModulesFromFiltersPackage</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::put with argument</description>
+    <lineContent>NAME_TO_FULL_MODULE_NAME.put(&quot;SuppressionXpathSingleFilter&quot;,</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SarifLogger.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.SarifLogger</mutatedClass>
+    <mutatedMethod>addError</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/SarifLogger::escape with argument</description>
+    <lineContent>.replace(MESSAGE_PLACEHOLDER, escape(event.getMessage()))</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SarifLogger.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.SarifLogger</mutatedClass>
+    <mutatedMethod>auditFinished</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/Package::getImplementationVersion</description>
+    <lineContent>final String version = SarifLogger.class.getPackage().getImplementationVersion();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SarifLogger.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.SarifLogger</mutatedClass>
+    <mutatedMethod>readResource</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/io/InputStream::read</description>
+    <lineContent>int length = inputStream.read(buffer);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>SarifLogger.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.SarifLogger</mutatedClass>
+    <mutatedMethod>renderSeverityLevel</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_3</mutator>
+    <description>RemoveSwitch 3 mutation</description>
+    <lineContent>switch (severityLevel) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XMLLogger.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.XMLLogger</mutatedClass>
+    <mutatedMethod>auditStarted</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/Package::getImplementationVersion</description>
+    <lineContent>final String version = XMLLogger.class.getPackage().getImplementationVersion();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XMLLogger.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.XMLLogger</mutatedClass>
+    <mutatedMethod>fileFinished</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/Map::remove</description>
+    <lineContent>fileMessages.remove(fileName);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XMLLogger.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.XMLLogger</mutatedClass>
+    <mutatedMethod>fileFinished</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Map::remove with argument</description>
+    <lineContent>fileMessages.remove(fileName);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XMLLogger.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.XMLLogger</mutatedClass>
+    <mutatedMethod>writeFileError</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/XMLLogger::encode with argument</description>
+    <lineContent>+ encode(event.getMessage())</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XMLLogger.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.XMLLogger</mutatedClass>
+    <mutatedMethod>writeFileError</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/XMLLogger::encode with argument</description>
+    <lineContent>writer.print(encode(event.getModuleId()));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XMLLogger.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.XMLLogger</mutatedClass>
+    <mutatedMethod>writeFileError</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/XMLLogger::encode with argument</description>
+    <lineContent>writer.print(encode(event.getSourceName()));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XMLLogger.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.XMLLogger</mutatedClass>
+    <mutatedMethod>writeFileOpeningTag</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/XMLLogger::encode with argument</description>
+    <lineContent>writer.println(&quot;&lt;file name=\&quot;&quot; + encode(fileName) + &quot;\&quot;&gt;&quot;);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XMLLogger.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.XMLLogger$FileMessages</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Collections::synchronizedList with argument</description>
+    <lineContent>private final List&lt;AuditEvent&gt; errors = Collections.synchronizedList(new ArrayList&lt;&gt;());</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XMLLogger.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.XMLLogger$FileMessages</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Collections::synchronizedList with argument</description>
+    <lineContent>private final List&lt;Throwable&gt; exceptions = Collections.synchronizedList(new ArrayList&lt;&gt;());</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XMLLogger.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.XMLLogger$FileMessages</mutatedClass>
+    <mutatedMethod>getErrors</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Collections::unmodifiableList with argument</description>
+    <lineContent>return Collections.unmodifiableList(errors);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>XMLLogger.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.XMLLogger$FileMessages</mutatedClass>
+    <mutatedMethod>getExceptions</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to java/util/Collections::unmodifiableList with argument</description>
+    <lineContent>return Collections.unmodifiableList(exceptions);</lineContent>
   </mutation>
 </suppressedMutations>

--- a/pom.xml
+++ b/pom.xml
@@ -3602,15 +3602,33 @@
               <mutators>
                 <mutator>CONDITIONALS_BOUNDARY</mutator>
                 <mutator>CONSTRUCTOR_CALLS</mutator>
-                <mutator>FALSE_RETURNS</mutator>
                 <mutator>INCREMENTS</mutator>
+                <!-- Read reason of disablement at https://github.com/checkstyle/checkstyle/issues/11895 -->
+                <!-- <mutator>INLINE_CONSTS</mutator> -->
                 <mutator>INVERT_NEGS</mutator>
                 <mutator>MATH</mutator>
                 <mutator>NEGATE_CONDITIONALS</mutator>
-                <mutator>REMOVE_CONDITIONALS</mutator>
+                <mutator>NON_VOID_METHOD_CALLS</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_IF</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_IF</mutator>
                 <mutator>RETURN_VALS</mutator>
-                <mutator>TRUE_RETURNS</mutator>
                 <mutator>VOID_METHOD_CALLS</mutator>
+                <mutator>EXPERIMENTAL_ARGUMENT_PROPAGATION</mutator>
+                <mutator>EXPERIMENTAL_BIG_DECIMAL</mutator>
+                <mutator>EXPERIMENTAL_BIG_INTEGER</mutator>
+                <mutator>EXPERIMENTAL_MEMBER_VARIABLE</mutator>
+                <mutator>EXPERIMENTAL_NAKED_RECEIVER</mutator>
+                <mutator>REMOVE_INCREMENTS</mutator>
+                <mutator>EXPERIMENTAL_RETURN_VALUES_MUTATOR</mutator>
+                <mutator>EXPERIMENTAL_SWITCH</mutator>
+                <mutator>REMOVE_SWITCH</mutator>
+                <mutator>FALSE_RETURNS</mutator>
+                <mutator>TRUE_RETURNS</mutator>
+                <mutator>EMPTY_RETURNS</mutator>
+                <mutator>NULL_RETURNS</mutator>
+                <mutator>PRIMITIVE_RETURNS</mutator>
               </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.AuditEventDefaultFormatter*</param>
@@ -3662,8 +3680,8 @@
                 <!-- This test is the primary user of metadataGeneratorLogger -->
                 <param>com.puppycrawl.tools.checkstyle.meta.MetadataGeneratorUtilTest</param>
               </targetTests>
-              <coverageThreshold>99</coverageThreshold>
-              <mutationThreshold>95</mutationThreshold>
+              <coverageThreshold>100</coverageThreshold>
+              <mutationThreshold>77</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>


### PR DESCRIPTION

#11719
Activating `ALL` group for `pitest-common`

Every mutator has been activated except `INLINE_CONSTS`

- Report with `ALL` group except `INLINE_CONSTS`: https://vyom-yadav.github.io/pitest-all-latest/pitest-common/index.html
