### PR TITLE
Issue #11719: Activate all group for pitest-imports

### DIFF
--- a/.ci/pitest-suppressions/pitest-imports-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-imports-suppressions.xml
@@ -1,12 +1,102 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
+    <sourceFile>CustomImportOrderCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/regex/Pattern::compile</description>
+    <lineContent>private Pattern specialImportsRegExp = Pattern.compile(&quot;^$&quot;);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CustomImportOrderCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable specialImportsRegExp</description>
+    <lineContent>private Pattern specialImportsRegExp = Pattern.compile(&quot;^$&quot;);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CustomImportOrderCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable samePackageMatchingDepth</description>
+    <lineContent>private int samePackageMatchingDepth = 2;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CustomImportOrderCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck</mutatedClass>
+    <mutatedMethod>getFirstDomainsFromIdent</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/StringBuilder::append</description>
+    <lineContent>builder.append(tokens.nextToken()).append(&apos;.&apos;);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CustomImportOrderCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck</mutatedClass>
+    <mutatedMethod>getFirstDomainsFromIdent</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/lang/StringBuilder::append with receiver</description>
+    <lineContent>builder.append(tokens.nextToken()).append(&apos;.&apos;);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>CustomImportOrderCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck</mutatedClass>
+    <mutatedMethod>setCustomImportOrderRules</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable customImportOrderRules</description>
+    <lineContent>customImportOrderRules = inputCustomImportOrder;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FileImportControl.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.FileImportControl</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable patternForExactMatch</description>
+    <lineContent>patternForExactMatch = null;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>FileImportControl.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.FileImportControl</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
+    <description>replaced call to com/puppycrawl/tools/checkstyle/checks/imports/FileImportControl::encloseInGroup with argument</description>
+    <lineContent>this.name = encloseInGroup(name);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ImportControlCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportControlCheck</mutatedClass>
+    <mutatedMethod>beginTree</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable currentImportControl</description>
+    <lineContent>currentImportControl = null;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ImportControlLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportControlLoader</mutatedClass>
+    <mutatedMethod>load</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/lang/Exception::getMessage</description>
+    <lineContent>+ &quot; - &quot; + ex.getMessage(), ex);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
     <sourceFile>ImportControlLoader.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportControlLoader</mutatedClass>
     <mutatedMethod>startElement</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_ELSE</mutator>
     <description>removed conditional - replaced equality check with false</description>
-    <lineContent>else if (ALLOW_ELEMENT_NAME.equals(qName) || "disallow".equals(qName)) {</lineContent>
+    <lineContent>else if (ALLOW_ELEMENT_NAME.equals(qName) || &quot;disallow&quot;.equals(qName)) {</lineContent>
   </mutation>
 
   <mutation unstable="false">
@@ -15,6 +105,123 @@
     <mutatedMethod>startElement</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
     <description>removed conditional - replaced equality check with true</description>
-    <lineContent>else if (ALLOW_ELEMENT_NAME.equals(qName) || "disallow".equals(qName)) {</lineContent>
+    <lineContent>else if (ALLOW_ELEMENT_NAME.equals(qName) || &quot;disallow&quot;.equals(qName)) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ImportControlLoader.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportControlLoader</mutatedClass>
+    <mutatedMethod>startElement</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader::containsRegexAttribute</description>
+    <lineContent>final boolean regex = containsRegexAttribute(attributes);</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ImportOrderCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck</mutatedClass>
+    <mutatedMethod>beginTree</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable lastImport</description>
+    <lineContent>lastImport = &quot;&quot;;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ImportOrderCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck</mutatedClass>
+    <mutatedMethod>beginTree</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable lastImportStatic</description>
+    <lineContent>lastImportStatic = false;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ImportOrderCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck</mutatedClass>
+    <mutatedMethod>getGroupNumber</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/regex/Matcher::end</description>
+    <lineContent>bestEnd = matcher.end();</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ImportOrderCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck</mutatedClass>
+    <mutatedMethod>getGroupNumber</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
+    <description>removed call to java/util/regex/Matcher::start</description>
+    <lineContent>if (matcher.start() &lt; bestPos) {</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>ImportOrderCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck</mutatedClass>
+    <mutatedMethod>setOption</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/lang/String::trim with receiver</description>
+    <lineContent>option = ImportOrderOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PkgImportControl.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.PkgImportControl</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable patternForExactMatch</description>
+    <lineContent>patternForExactMatch = null;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PkgImportControl.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.PkgImportControl</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable patternForPartialMatch</description>
+    <lineContent>patternForPartialMatch = null;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>PkgImportControl.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.PkgImportControl</mutatedClass>
+    <mutatedMethod>&lt;init&gt;</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable regex</description>
+    <lineContent>this.regex = false;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>RedundantImportCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.RedundantImportCheck</mutatedClass>
+    <mutatedMethod>beginTree</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable pkgName</description>
+    <lineContent>pkgName = null;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>UnusedImportsCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck</mutatedClass>
+    <mutatedMethod>beginTree</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
+    <description>Removed assignment to member variable collect</description>
+    <lineContent>collect = false;</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>UnusedImportsCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck</mutatedClass>
+    <mutatedMethod>collectReferencesFromJavadoc</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/util/stream/Stream::filter with receiver</description>
+    <lineContent>.filter(JavadocTag::canReferenceImports)</lineContent>
+  </mutation>
+
+  <mutation unstable="false">
+    <sourceFile>UnusedImportsCheck.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck</mutatedClass>
+    <mutatedMethod>processJavadocTag</mutatedMethod>
+    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
+    <description>replaced call to java/lang/String::trim with receiver</description>
+    <lineContent>final String identifier = tag.getFirstArg().trim();</lineContent>
   </mutation>
 </suppressedMutations>

--- a/pom.xml
+++ b/pom.xml
@@ -2840,15 +2840,33 @@
               <mutators>
                 <mutator>CONDITIONALS_BOUNDARY</mutator>
                 <mutator>CONSTRUCTOR_CALLS</mutator>
-                <mutator>FALSE_RETURNS</mutator>
                 <mutator>INCREMENTS</mutator>
+                <!-- Read reason of disablement at https://github.com/checkstyle/checkstyle/issues/11895 -->
+                <!-- <mutator>INLINE_CONSTS</mutator> -->
                 <mutator>INVERT_NEGS</mutator>
                 <mutator>MATH</mutator>
                 <mutator>NEGATE_CONDITIONALS</mutator>
-                <mutator>REMOVE_CONDITIONALS</mutator>
+                <mutator>NON_VOID_METHOD_CALLS</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_EQUAL_IF</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_ELSE</mutator>
+                <mutator>REMOVE_CONDITIONALS_ORDER_IF</mutator>
                 <mutator>RETURN_VALS</mutator>
-                <mutator>TRUE_RETURNS</mutator>
                 <mutator>VOID_METHOD_CALLS</mutator>
+                <mutator>EXPERIMENTAL_ARGUMENT_PROPAGATION</mutator>
+                <mutator>EXPERIMENTAL_BIG_DECIMAL</mutator>
+                <mutator>EXPERIMENTAL_BIG_INTEGER</mutator>
+                <mutator>EXPERIMENTAL_MEMBER_VARIABLE</mutator>
+                <mutator>EXPERIMENTAL_NAKED_RECEIVER</mutator>
+                <mutator>REMOVE_INCREMENTS</mutator>
+                <mutator>EXPERIMENTAL_RETURN_VALUES_MUTATOR</mutator>
+                <mutator>EXPERIMENTAL_SWITCH</mutator>
+                <mutator>REMOVE_SWITCH</mutator>
+                <mutator>FALSE_RETURNS</mutator>
+                <mutator>TRUE_RETURNS</mutator>
+                <mutator>EMPTY_RETURNS</mutator>
+                <mutator>NULL_RETURNS</mutator>
+                <mutator>PRIMITIVE_RETURNS</mutator>
               </mutators>
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.checks.imports.*</param>
@@ -2860,7 +2878,7 @@
                 <param>*.Input*</param>
               </excludedTestClasses>
               <coverageThreshold>100</coverageThreshold>
-              <mutationThreshold>97</mutationThreshold>
+              <mutationThreshold>98</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>


### PR DESCRIPTION

#11719
Activating `ALL` group for `pitest-imports`

Every mutator has been activated except `INLINE_CONSTS`

- Report with `ALL` group except `INLINE_CONSTS`: https://vyom-yadav.github.io/pitest-all-latest/pitest-imports/index.html
