### PR TITLE
Issue #11985: sarif formatter option added to ant task

### DIFF
--- a/config/ant-phase-verify.xml
+++ b/config/ant-phase-verify.xml
@@ -37,6 +37,7 @@
                test/resources/**/*,test/resources-noncompilable/**/*,**/gen/**"/>
       <formatter type="plain"/>
       <formatter type="xml" toFile="${mvn.project.build.directory}/cs_errors.xml"/>
+      <formatter type="sarif" toFile="${mvn.project.build.directory}/cs_errors.sarif"/>
       <classpath path="${mvn.runtime_classpath}"/>
       <property key="checkstyle.cache.file" file="${mvn.project.build.directory}/cachefile"/>
       <property key="checkstyle.header.file" file="config/java.header"/>

--- a/config/checkstyle_non_main_files_suppressions.xml
+++ b/config/checkstyle_non_main_files_suppressions.xml
@@ -72,6 +72,8 @@
   <suppress id="lineLength"
          files="src[\\/]test[\\/]resources[\\/].*[\\/]ant[\\/]checkstyleanttask[\\/]ExpectedCheckstyleAntTaskXmlOutput\.xml"/>
   <suppress id="lineLength"
+            files="src[\\/]test[\\/]resources[\\/].*[\\/]ant[\\/]checkstyleanttask[\\/]ExpectedCheckstyleAntTaskSarifOutput\.sarif"/>
+  <suppress id="lineLength"
          files="src[\\/]test[\\/]resources[\\/].*[\\/]checks[\\/]translation[\\/]Expected.*\.xml"/>
 
   <!-- property names a too long, nothing we can do -->

--- a/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTaskTest.java
@@ -44,9 +44,11 @@ import org.apache.tools.ant.types.Reference;
 import org.apache.tools.ant.types.resources.FileResource;
 import org.junit.jupiter.api.Test;
 
+import com.google.common.truth.StandardSubjectBuilder;
 import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultLogger;
 import com.puppycrawl.tools.checkstyle.Definitions;
+import com.puppycrawl.tools.checkstyle.SarifLogger;
 import com.puppycrawl.tools.checkstyle.XMLLogger;
 import com.puppycrawl.tools.checkstyle.internal.testmodules.CheckstyleAntTaskLogStub;
 import com.puppycrawl.tools.checkstyle.internal.testmodules.CheckstyleAntTaskStub;
@@ -197,9 +199,9 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         final List<File> filesToCheck = TestRootModuleChecker.getFilesToCheck();
         assertWithMessage("There are more files to check than expected")
                 .that(filesToCheck)
-                .hasSize(8);
+                .hasSize(9);
         assertWithMessage("The path of file differs from expected")
-                .that(filesToCheck.get(5).getAbsolutePath())
+                .that(filesToCheck.get(6).getAbsolutePath())
                 .isEqualTo(getPath(FLAWLESS_INPUT));
         assertWithMessage("Amount of logged messages in unexpected")
                 .that(antTask.getLoggedMessages())
@@ -528,6 +530,43 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
     }
 
     @Test
+    public final void testSarifOutput() throws IOException {
+        final CheckstyleAntTask antTask = getCheckstyleAntTask();
+        antTask.setFile(new File(getPath(VIOLATED_INPUT)));
+        antTask.setFailOnViolation(false);
+        final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
+        final File outputFile = new File("target/log.sarif");
+        formatter.setTofile(outputFile);
+        final CheckstyleAntTask.FormatterType formatterType = new CheckstyleAntTask.FormatterType();
+        formatterType.setValue("sarif");
+        formatter.setType(formatterType);
+        antTask.addFormatter(formatter);
+        antTask.execute();
+
+        final List<String> expected = readWholeFile(
+                new File(getPath("ExpectedCheckstyleAntTaskSarifOutput.sarif")));
+        final List<String> actual = readWholeFile(outputFile);
+        for (int lineNumber = 0; lineNumber < expected.size(); lineNumber++) {
+            final String line = expected.get(lineNumber);
+            final StandardSubjectBuilder assertWithMessage =
+                    assertWithMessage("Content of file with violations differs from expected");
+            if (line.trim().startsWith("\"uri\"")) {
+                final String expectedPathEnd = line.split("\\*\\*")[1];
+                // normalize windows path
+                final String actualLine = actual.get(lineNumber).replaceAll("\\\\", "/");
+                assertWithMessage
+                        .that(actualLine)
+                        .endsWith(expectedPathEnd);
+            }
+            else {
+                assertWithMessage
+                        .that(actual.get(lineNumber))
+                        .isEqualTo(line);
+            }
+        }
+    }
+
+    @Test
     public final void testCreateListenerException() throws IOException {
         final CheckstyleAntTask antTask = getCheckstyleAntTask();
         antTask.setFile(new File(getPath(FLAWLESS_INPUT)));
@@ -552,6 +591,25 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         formatter.setTofile(outputFile);
         final CheckstyleAntTask.FormatterType formatterType = new CheckstyleAntTask.FormatterType();
         formatterType.setValue("xml");
+        formatter.setType(formatterType);
+        antTask.addFormatter(formatter);
+        final BuildException ex = assertThrows(BuildException.class,
+                antTask::execute,
+                "BuildException is expected");
+        assertWithMessage("Error message is unexpected")
+                .that(ex.getMessage())
+                .startsWith("Unable to create listeners: formatters");
+    }
+
+    @Test
+    public final void testCreateListenerExceptionWithSarifLogger() throws IOException {
+        final CheckstyleAntTask antTask = getCheckstyleAntTask();
+        antTask.setFile(new File(getPath(FLAWLESS_INPUT)));
+        final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
+        final File outputFile = new File("target/");
+        formatter.setTofile(outputFile);
+        final CheckstyleAntTask.FormatterType formatterType = new CheckstyleAntTask.FormatterType();
+        formatterType.setValue("sarif");
         formatter.setType(formatterType);
         antTask.addFormatter(formatter);
         final BuildException ex = assertThrows(BuildException.class,
@@ -646,6 +704,43 @@ public class CheckstyleAntTaskTest extends AbstractPathTestSupport {
         assertWithMessage("Listener instance has unexpected type")
             .that(formatter.createListener(null))
             .isInstanceOf(XMLLogger.class);
+    }
+
+    @Test
+    public void testSarifLoggerListener() throws IOException {
+        final CheckstyleAntTask.FormatterType formatterType = new CheckstyleAntTask.FormatterType();
+        formatterType.setValue("sarif");
+        final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
+        formatter.setType(formatterType);
+        formatter.setUseFile(false);
+        assertWithMessage("Listener instance has unexpected type")
+                .that(formatter.createListener(null))
+                .isInstanceOf(SarifLogger.class);
+    }
+
+    @Test
+    public void testSarifLoggerListenerWithToFile() throws IOException {
+        final CheckstyleAntTask.FormatterType formatterType = new CheckstyleAntTask.FormatterType();
+        formatterType.setValue("sarif");
+        final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
+        formatter.setType(formatterType);
+        formatter.setUseFile(false);
+        formatter.setTofile(new File("target/"));
+        assertWithMessage("Listener instance has unexpected type")
+                .that(formatter.createListener(null))
+                .isInstanceOf(SarifLogger.class);
+    }
+
+    @Test
+    public void testSarifLoggerWithNullToFile() throws IOException {
+        final CheckstyleAntTask.FormatterType formatterType = new CheckstyleAntTask.FormatterType();
+        formatterType.setValue("sarif");
+        final CheckstyleAntTask.Formatter formatter = new CheckstyleAntTask.Formatter();
+        formatter.setType(formatterType);
+        formatter.setTofile(null);
+        assertWithMessage("Listener instance has unexpected type")
+                .that(formatter.createListener(null))
+                .isInstanceOf(SarifLogger.class);
     }
 
     @Test

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/ant/checkstyleanttask/ExpectedCheckstyleAntTaskSarifOutput.sarif
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/ant/checkstyleanttask/ExpectedCheckstyleAntTaskSarifOutput.sarif
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "downloadUri": "https://github.com/checkstyle/checkstyle/releases/",
+          "fullName": "Checkstyle",
+          "informationUri": "https://checkstyle.org/",
+          "language": "en",
+          "name": "Checkstyle",
+          "organization": "Checkstyle",
+          "rules": [
+          ],
+          "semanticVersion": "null",
+          "version": "null"
+        }
+      },
+      "results": [
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "**/src/test/resources/com/puppycrawl/tools/checkstyle/ant/checkstyleanttask/InputCheckstyleAntTaskError.java"
+                },
+                "region": {
+                  "startLine": 7
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Line is longer than 70 characters (found 80)."
+          },
+          "ruleId": "maxLineLen"
+        },
+        {
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "**/src/test/resources/com/puppycrawl/tools/checkstyle/ant/checkstyleanttask/InputCheckstyleAntTaskError.java"
+                },
+                "region": {
+                  "startLine": 9
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Line is longer than 70 characters (found 81)."
+          },
+          "ruleId": "maxLineLen"
+        }
+      ]
+    }
+  ]
+}

--- a/src/xdocs/anttask.xml.vm
+++ b/src/xdocs/anttask.xml.vm
@@ -274,6 +274,10 @@
                   <code>xml</code> - specifies the <a
                   href="apidocs/com/puppycrawl/tools/checkstyle/XMLLogger.html">XMLLogger</a>
                 </li>
+                <li>
+                  <code>sarif</code> - specifies the <a
+                  href="apidocs/com/puppycrawl/tools/checkstyle/SarifLogger.html">SarifLogger</a>
+                </li>
               </ul>
               <p>Defaults to <code>"plain"</code>.</p>
             </td>
@@ -402,7 +406,7 @@
       <p>
         <b>
           Run checkstyle on a set of files and output messages to standard
-          output in plain format, and a file in XML format
+          output in plain format, and files in XML &amp; SARIF format
         </b>
       </p>
       <source>
@@ -410,6 +414,7 @@
   &lt;fileset dir=&quot;src/checkstyle&quot; includes=&quot;**/*.java&quot;/&gt;
   &lt;formatter type=&quot;plain&quot;/&gt;
   &lt;formatter type=&quot;xml&quot; toFile=&quot;build/checkstyle_errors.xml&quot;/&gt;
+  &lt;formatter type=&quot;sarif&quot; toFile=&quot;build/checkstyle_errors.sarif&quot;/&gt;
 &lt;/checkstyle&gt;
       </source>
 


### PR DESCRIPTION
#11985

1. created an uber jar using `mvn -P assembly package`
2. used the resultant jar along with the code in ant project - https://github.com/jknair0/AntCheckStyleTest/tree/pr/checkstyle-sarif-test
3. ran `ant checkstyle`
4. It generates a valid 'sarif' report.