### PR TITLE
infra: remove specific commits from no-error-xwiki build

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -255,7 +255,6 @@ no-error-xwiki)
   mvn -e --no-transfer-progress clean install -Pno-validations
   checkout_from "https://github.com/xwiki/xwiki-commons.git"
   cd .ci-temp/xwiki-commons
-  git checkout "47cad118926ea880fe""deb6af8fded""db04d""f9d964"
   # Build custom Checkstyle rules
   mvn -e --no-transfer-progress -f \
     xwiki-commons-tools/xwiki-commons-tool-verification-resources/pom.xml \
@@ -288,7 +287,6 @@ no-error-xwiki)
   cd ..
   checkout_from https://github.com/xwiki/xwiki-platform.git
   cd .ci-temp/xwiki-platform
-  git checkout "d8d1d85d723d""d""f""d90d7eb9d1be0ab37e0cc7d0f3"
   # Validate xwiki-platform
   mvn -e --no-transfer-progress checkstyle:check@default -Dcheckstyle.version="${CS_POM_VERSION}"
   cd ..


### PR DESCRIPTION
Fixes failing no-error-xwiki build noted at https://circleci.com/gh/checkstyle/checkstyle/tree/master

no-error-xwiki build: https://circleci.com/gh/checkstyle/checkstyle/161144?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link