### PR TITLE
Issue #11140: solve more OCP_OVERLY_CONCRETE_PARAMETER

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -495,7 +495,7 @@ public class JavadocTypeCheck
      * @param typeParamName the name of the type parameter
      */
     private void checkTypeParamTag(DetailAST ast,
-            List<JavadocTag> tags, String typeParamName) {
+            Collection<JavadocTag> tags, String typeParamName) {
         final String typeParamNameWithBrackets =
             OPEN_ANGLE_BRACKET + typeParamName + CLOSE_ANGLE_BRACKET;
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtil.java
@@ -37,6 +37,7 @@ import com.puppycrawl.tools.checkstyle.MetadataGeneratorLogger;
 import com.puppycrawl.tools.checkstyle.TreeWalker;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.RootModule;
 
 /** Class which handles all the metadata generation and writing calls. */
 public final class MetadataGeneratorUtil {
@@ -81,12 +82,12 @@ public final class MetadataGeneratorUtil {
      * Process files using the checker passed and write to corresponding XML files.
      *
      * @param moduleFolders folders to check
-     * @param checker checker
+     * @param root root module
      * @param path rootPath
      * @throws CheckstyleException checkstyleException
      * @throws IOException ioException
      */
-    private static void dumpMetadata(Checker checker, String path, String... moduleFolders)
+    private static void dumpMetadata(RootModule root, String path, String... moduleFolders)
             throws CheckstyleException,
             IOException {
         final List<File> validFiles = new ArrayList<>();
@@ -104,6 +105,6 @@ public final class MetadataGeneratorUtil {
                         .collect(Collectors.toList()));
             }
         }
-        checker.process(validFiles);
+        root.process(validFiles);
     }
 }


### PR DESCRIPTION
Issue #11140

>OCP_OVERLY_CONCRETE_PARAMETER
This method uses concrete classes for parameters when only methods defined in an implemented interface or superclass are used. Consider increasing the abstraction of the interface to make low impact changes easier to accomplish in the future.
Take the following example:
 private void appendToList(ArrayList<String> list) { if (list.size() < 100) { list.add("Foo"); } } 
The parameter list is currently defined as an ArrayList, which is a concrete implementation of the List interface. Specifying ArrayList is unnecessary here, because we aren't using any ArrayList-specific methods (like ensureCapacity() or trimToSize()). Instead of using the concrete definition, it is better to do something like:
 private void appendToList(List<String> list) { ... 
If the design ever changes, e.g. a LinkedList is used instead, this code won't have to change.
IDEs tend to have tools to help generalize parameters. For example, in Eclipse, the refactoring tool [Generalize Declared Type](http://help.eclipse.org/luna/index.jsp?topic=%2Forg.eclipse.jdt.doc.user%2Freference%2Fref-menu-refactor.htm) helps find an appropriate level of concreteness.

````
[INFO] --- spotbugs-maven-plugin:4.7.1.1:check (default) @ checkstyle-backport-jre8 ---
[INFO] BugInstance size is 2
[INFO] Error size is 0
[INFO] Total bugs: 2
[ERROR] Medium: com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck.checkTypeParamTag(DetailAST, List, String): 2nd parameter 'tags' could be declared as java.util.Collection instead [com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck] At JavadocTypeCheck.java:[line 504] OCP_OVERLY_CONCRETE_PARAMETER
[ERROR] Medium: com.puppycrawl.tools.checkstyle.meta.MetadataGeneratorUtil.dumpMetadata(Checker, String, String[]): 1st parameter 'checker' could be declared as com.puppycrawl.tools.checkstyle.api.RootModule instead [com.puppycrawl.tools.checkstyle.meta.MetadataGeneratorUtil] At MetadataGeneratorUtil.java:[line 92] OCP_OVERLY_CONCRETE_PARAMETER
````

I assume this is some type of issue between Java 8 (backport) and 11.