### PR TITLE
Issue #11637: Resolve shellcheck SC2046

### DIFF
--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -94,8 +94,8 @@ function should_run_job {
     fi
 
     # Note: this command only works in master branch
-    if [ $(git log -1 --format=%B | grep -E "\[maven-release-plugin\] prepare release" \
-              | cat | wc -l) -lt 1 ];
+    if [ "$(git log -1 --format=%B | grep -E "\[maven-release-plugin\] prepare release" \
+              | cat | wc -l)" -lt 1 ];
     then
         SKIP_JOB_BY_COMMIT="false"
     else

--- a/.ci/eclipse-compiler-javac.sh
+++ b/.ci/eclipse-compiler-javac.sh
@@ -36,7 +36,7 @@ if [ ! -f "$ECJ_PATH" ]; then
         echo please update "config/org.eclipse.jdt.core.prefs" file
         exit 1
     fi
-    mkdir -p $(dirname "$ECJ_PATH")
+    mkdir -p "$(dirname "$ECJ_PATH")"
     cp "$ECJ_JAR" "$ECJ_PATH"
     cd ..
 fi

--- a/.ci/releasenotes-gen.sh
+++ b/.ci/releasenotes-gen.sh
@@ -42,7 +42,7 @@ else
   cd ../
 fi
 cd .ci-temp/checkstyle
-LATEST_RELEASE_TAG=$(git describe $(git rev-list --tags --max-count=1))
+LATEST_RELEASE_TAG=$(git describe "$(git rev-list --tags --max-count=1)")
 cd ../../
 
 CS_RELEASE_VERSION=$(mvn -e --no-transfer-progress -q -Dexec.executable='echo' \

--- a/.ci/travis.sh
+++ b/.ci/travis.sh
@@ -88,7 +88,7 @@ run-command-after-success)
 
 deploy-snapshot)
   SKIP_DEPLOY=false
-  if [ $(git log -1 | grep -E "\[maven-release-plugin\] prepare release" | cat | wc -l) -lt 1 ];
+  if [ "$(git log -1 | grep -E "\[maven-release-plugin\] prepare release" | cat | wc -l)" -lt 1 ];
     then
       SKIP_DEPLOY=false;
     else

--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -88,7 +88,7 @@ nondex)
   mvn -e --no-transfer-progress --fail-never clean nondex:nondex -DargLine='-Xms1024m -Xmx2048m' \
     -Dtest=!JavadocPropertiesGeneratorTest#testNonExistentArgument
   mkdir -p .ci-temp
-  cat $(grep -RlE 'td class=.x' .nondex/ | cat) < /dev/null > .ci-temp/output.txt
+  cat "$(grep -RlE 'td class=.x' .nondex/ | cat)" < /dev/null > .ci-temp/output.txt
   RESULT=$(cat .ci-temp/output.txt | wc -c)
   cat .ci-temp/output.txt
   echo 'Size of output:'"$RESULT"
@@ -102,7 +102,7 @@ pr-age)
   # if it notices a merge commit
   if git show --summary HEAD | grep ^Merge: ;
   then
-    git reset --hard $(git log -n 1 --no-merges --pretty=format:"%h")
+    git reset --hard "$(git log -n 1 --no-merges --pretty=format:"%h")"
   fi
 
   PR_MASTER=$(git merge-base origin/master HEAD)
@@ -169,7 +169,7 @@ versions)
   if [ -v TRAVIS_EVENT_TYPE ] && [ "$TRAVIS_EVENT_TYPE" != "cron" ] ; then exit 0; fi
   mvn -e --no-transfer-progress clean versions:dependency-updates-report \
     versions:plugin-updates-report
-  if [ $(grep "<nextVersion>" target/*-updates-report.xml | cat | wc -l) -gt 0 ]; then
+  if [ "$(grep "<nextVersion>" target/*-updates-report.xml | cat | wc -l)" -gt 0 ]; then
     echo "Version reports (dependency-updates-report.xml):"
     cat target/dependency-updates-report.xml
     echo "Version reports (plugin-updates-report.xml):"
@@ -403,7 +403,8 @@ site)
   ;;
 
 release-dry-run)
-  if [ $(git log -1 | grep -E "\[maven-release-plugin\] prepare release" | cat | wc -l) -lt 1 ];then
+  if [ "$(git log -1 | grep -E "\[maven-release-plugin\] prepare release" | cat | wc -l)" -lt 1 ]
+  then
     mvn -e --no-transfer-progress release:prepare -DdryRun=true --batch-mode \
     -Darguments='-DskipTests -DskipITs -Djacoco.skip=true -Dpmd.skip=true \
       -Dspotbugs.skip=true -Dxml.skip=true -Dcheckstyle.ant.skip=true \

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,6 +1,5 @@
 # until https://github.com/checkstyle/checkstyle/issues/11637
 
-disable=SC2046 # (warning): Quote this to prevent word splitting.
 disable=SC2207 # (warning): Prefer mapfile or read -a to split command output.
 disable=SC2002 # (style): Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
 disable=SC2061 # (warning): Quote the parameter to -name so the shell won't interpret it.

--- a/release.sh
+++ b/release.sh
@@ -6,7 +6,8 @@ echo "Release process: https://github.com/checkstyle/checkstyle/wiki/How-to-make
 
 RELEASE=$(xmlstarlet sel -N pom=http://maven.apache.org/POM/4.0.0 \
            -t -m pom:project -v pom:version pom.xml | sed "s/-SNAPSHOT//")
-PREV_RELEASE=$(git describe --abbrev=0 $(git rev-list --tags --max-count=1) | sed "s/checkstyle-//")
+PREV_RELEASE=$(git describe --abbrev=0 "$(git rev-list --tags --max-count=1)" \
+                | sed "s/checkstyle-//")
 
 echo "PREVIOUS RELEASE version:""$PREV_RELEASE"
 echo "RELEASE version:""$RELEASE"
@@ -56,7 +57,7 @@ cd ../../
 
 NEW_RELEASE=$(git describe --abbrev=0 | cut -d '-' -f 2)
 PREV_RELEASE=$(git describe --abbrev=0 --tags \
-        $(git rev-list --tags --skip=1 --max-count=1) \
+        "$(git rev-list --tags --skip=1 --max-count=1)" \
     | cut -d '-' -f 2)
 FUTURE_RELEASE=$(xmlstarlet sel -N pom=http://maven.apache.org/POM/4.0.0 \
            -t -m pom:project -v pom:version pom.xml | sed "s/-SNAPSHOT//")
@@ -90,7 +91,7 @@ curl -i -H "Authorization: token $TKN" \
 
 
 echo "Creation of new milestone ..."
-LAST_SUNDAY_DAY=$(cal -d $(date -d "next month" +"%Y-%m") \
+LAST_SUNDAY_DAY=$(cal -d "$(date -d "next month" +"%Y-%m")" \
                     | awk '/^ *[0-9]/ { d=$1 } END { print d }')
 LAST_SUNDAY_DATETIME=$(date -d "next month" +"%Y-%m")"-$LAST_SUNDAY_DAY""T08:00:00Z"
 echo "$LAST_SUNDAY_DATETIME"


### PR DESCRIPTION
Part of #11637
> SC2046 # (warning): Quote this to prevent word splitting.

---
Taken from [this stackexchange answer](https://unix.stackexchange.com/a/443990):
> You need to use `"$(somecmd "$file")"`. 
