### PR TITLE
Issue #12017: Kill surviving mutations in AbstractCheck for tabWidth

### DIFF
--- a/.ci/pitest-suppressions/pitest-api-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-api-suppressions.xml
@@ -3,15 +3,6 @@
   <mutation unstable="false">
     <sourceFile>AbstractCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.api.AbstractCheck</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable tabWidth</description>
-    <lineContent>private int tabWidth = CommonUtil.DEFAULT_TAB_WIDTH;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>AbstractCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.AbstractCheck</mutatedClass>
     <mutatedMethod>getTokenNames</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
     <description>replaced call to java/util/Collections::unmodifiableSet with argument</description>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java
@@ -51,8 +51,11 @@ public abstract class AbstractCheck extends AbstractViolationReporter {
     /** The tokens the check is interested in. */
     private final Set<String> tokens = new HashSet<>();
 
-    /** The tab width for column reporting. */
-    private int tabWidth = CommonUtil.DEFAULT_TAB_WIDTH;
+    /**
+     * The tab width for column reporting. Default is uninitialized as the value is inherited from
+     * the parent module.
+     */
+    private int tabWidth;
 
     /**
      * Returns the default token a check is interested in. Only used if the


### PR DESCRIPTION
#12017 

### Rationale:
No need to specifically initialize `tabWidth` to a default value, the default value is inherited from the parent module. Only the root modules need to explicitly instantiate `tabWidth` with a default value (Only `Checker` needs to instantiate the field)

https://github.com/checkstyle/checkstyle/blob/a54849afccd9cdc371c6040398d27225947debe0/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java#L256-L265