### PR TITLE
Issue #12017: Kill surviving mutations in AbstractCheck related to tokens

### DIFF
--- a/.ci/pitest-suppressions/pitest-api-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-api-suppressions.xml
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
-    <sourceFile>AbstractCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.AbstractCheck</mutatedClass>
-    <mutatedMethod>getTokenNames</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to java/util/Collections::unmodifiableSet with argument</description>
-    <lineContent>return Collections.unmodifiableSet(tokens);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>AbstractViolationReporter.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.api.AbstractViolationReporter</mutatedClass>
     <mutatedMethod>setSeverity</mutatedMethod>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.api;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.nio.charset.Charset;
@@ -386,6 +387,17 @@ public class AbstractCheckTest extends AbstractModuleTestSupport {
             "1:1: Violation.",
         };
         verify(checkConfig, getPath("InputAbstractCheckTestFileContents.java"), expected);
+    }
+
+    /**
+     * S2384 - Mutable members should not be stored or returned directly.
+     * Sonarqube rule is valid, a pure unit test is required as this condition can't be recreated in
+     * a test with checks and input file as none of the checks try to modify the tokens.
+     */
+    @Test
+    public void testTokensAreUnmodifiable() {
+        final DummyAbstractCheck check = new DummyAbstractCheck();
+        assertThrows(UnsupportedOperationException.class, () -> check.getTokenNames().add(""));
     }
 
     public static final class DummyAbstractCheck extends AbstractCheck {


### PR DESCRIPTION
#12017

### This mutation falls in the category:
The logic was analyzed and the missing test case was added.
