### PR TITLE
Issue #12017: Kill surviving mutations in AbstractCheck and AbstractFileSetCheck

### DIFF
--- a/.ci/pitest-suppressions/pitest-api-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-api-suppressions.xml
@@ -28,15 +28,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>AbstractCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.AbstractCheck</mutatedClass>
-    <mutatedMethod>log</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/api/AbstractCheck::getId</description>
-    <lineContent>getId(),</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>AbstractFileSetCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>
@@ -70,33 +61,6 @@
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to java/util/Map::get</description>
     <lineContent>getCustomMessages().get(key)));</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>AbstractFileSetCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck</mutatedClass>
-    <mutatedMethod>log</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to java/util/Map::get with argument</description>
-    <lineContent>getCustomMessages().get(key)));</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>AbstractFileSetCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck</mutatedClass>
-    <mutatedMethod>log</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck::getId</description>
-    <lineContent>getId(),</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>AbstractFileSetCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck</mutatedClass>
-    <mutatedMethod>log</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck::getSeverityLevel</description>
-    <lineContent>getSeverityLevel(),</lineContent>
   </mutation>
 
   <mutation unstable="false">

--- a/pom.xml
+++ b/pom.xml
@@ -4067,6 +4067,7 @@
                 <param>com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheckTest</param>
                 <param>org.checkstyle.suppressionxpathfilter.XpathRegressionJavadocMethodTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.filters.SuppressWithPlainTextCommentFilterTest</param>
               </targetTests>
               <excludedTestClasses>
                 <param>*.Input*</param>
@@ -4081,7 +4082,7 @@
                 <param>destroy</param>
               </excludedMethods>
               <coverageThreshold>100</coverageThreshold>
-              <mutationThreshold>96</mutationThreshold>
+              <mutationThreshold>97</mutationThreshold>
               <timeoutFactor>${pitest.plugin.timeout.factor}</timeoutFactor>
               <timeoutConstant>${pitest.plugin.timeout.constant}</timeoutConstant>
               <threads>${pitest.plugin.threads}</threads>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilterTest.java
@@ -20,6 +20,9 @@
 package com.puppycrawl.tools.checkstyle.filters;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_EXPECTED_TAG;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_RETURN_EXPECTED;
+import static com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck.MSG_UNUSED_TAG;
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheck.MSG_CONTAINS_TAB;
 import static com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheck.MSG_FILE_CONTAINS_TAB;
 
@@ -37,6 +40,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.api.Violation;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck;
 import com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck;
 import com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheck;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
@@ -490,6 +494,31 @@ public class SuppressWithPlainTextCommentFilterTest extends AbstractModuleTestSu
 
         verifyFilterWithInlineConfigParser(
             getPath("InputSuppressWithPlainTextCommentFilterSuppressById5.java"),
+            expectedViolationMessages,
+            removeSuppressed(expectedViolationMessages, suppressedViolationMessages)
+        );
+    }
+
+    @Test
+    public void testSuppressedByIdJavadocCheck() throws Exception {
+        final String[] suppressedViolationMessages = {
+            "28: " + getCheckMessage(JavadocMethodCheck.class, MSG_RETURN_EXPECTED),
+            "32:9: " + getCheckMessage(JavadocMethodCheck.class,
+                                       MSG_UNUSED_TAG, "@param", "unused"),
+            "39:22: " + getCheckMessage(JavadocMethodCheck.class,
+                                        MSG_EXPECTED_TAG, "@param", "a"),
+        };
+
+        final String[] expectedViolationMessages = {
+            "28: " + getCheckMessage(JavadocMethodCheck.class, MSG_RETURN_EXPECTED),
+            "32:9: " + getCheckMessage(JavadocMethodCheck.class,
+                                       MSG_UNUSED_TAG, "@param", "unused"),
+            "39:22: " + getCheckMessage(JavadocMethodCheck.class,
+                                        MSG_EXPECTED_TAG, "@param", "a"),
+        };
+
+        verifyFilterWithInlineConfigParser(
+            getPath("InputSuppressWithPlainTextCommentFilterSuppressByIdJavadocCheck.java"),
             expectedViolationMessages,
             removeSuppressed(expectedViolationMessages, suppressedViolationMessages)
         );

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressByIdJavadocCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/filters/suppresswithplaintextcommentfilter/InputSuppressWithPlainTextCommentFilterSuppressByIdJavadocCheck.java
@@ -1,0 +1,43 @@
+/*
+SuppressWithPlainTextCommentFilter
+offCommentFormat = (default)// CHECKSTYLE:OFF
+onCommentFormat = (default)// CHECKSTYLE:ON
+checkFormat = (default).*
+messageFormat = (default)(null)
+idFormat = foo
+
+
+com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck
+allowedAnnotations = (default)Override
+validateThrows = (default)false
+accessModifiers = (default)public, protected, package, private
+allowMissingParamTags = (default)false
+allowMissingReturnTag = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+id = foo
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.filters.suppresswithplaintextcommentfilter;
+
+public class InputSuppressWithPlainTextCommentFilterSuppressByIdJavadocCheck {
+    // CHECKSTYLE:OFF
+
+    /** missing return **/
+    int method3() { // filtered violation
+        return 3;
+    }
+
+    /** @param unused asd **/ // filtered violation
+    void method2() {
+    }
+
+    /**
+     * Missing param tag.
+     */
+    void method3(int a) { // filtered violation
+    }
+    // CHECKSTYLE:ON
+
+}


### PR DESCRIPTION
#12017 

### This mutation falls under the category:

- Logic was analyzed to develop the test case