### PR TITLE
Issue #12017: Kill surviving mutations in AbstractCheck related to custom message keys

### DIFF
--- a/.ci/pitest-suppressions/pitest-api-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-api-suppressions.xml
@@ -19,15 +19,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>AbstractCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.AbstractCheck</mutatedClass>
-    <mutatedMethod>log</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/Map::get</description>
-    <lineContent>getCustomMessages().get(key)));</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>AbstractFileSetCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -479,4 +479,20 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
         verifyWithInlineConfigParser(
                 getPath("InputJavadocMethodEnum.java"), expected);
     }
+
+    @Test
+    public void testCustomMessages() throws Exception {
+        final String msgReturnExpectedCustom =
+            "@return tag should be present and have description :)";
+        final String msgUnusedTagCustom = "Unused @param tag for 'unused' :)";
+        final String msgExpectedTagCustom = "Expected @param tag for 'a' :)";
+        final String[] expected = {
+            "20: " + msgReturnExpectedCustom,
+            "24:9: " + msgUnusedTagCustom,
+            "31:22: " + msgExpectedTagCustom,
+        };
+
+        verifyWithInlineConfigParser(
+            getPath("InputJavadocMethodCustomMessage.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodCustomMessage.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethodCustomMessage.java
@@ -1,0 +1,33 @@
+/*
+JavadocMethod
+allowedAnnotations = (default)Override
+validateThrows = (default)false
+accessModifiers = (default)public, protected, package, private
+allowMissingParamTags = (default)false
+allowMissingReturnTag = (default)false
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+message.javadoc.return.expected = @return tag should be present and have description :)
+message.javadoc.expectedTag = Expected {0} tag for ''{1}'' :)
+message.javadoc.unusedTag = Unused {0} tag for ''{1}'' :)
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
+
+public class InputJavadocMethodCustomMessage {
+
+    /** missing return **/
+    int method3() { // violation '@return tag should be present and have description :)'
+        return 3;
+    }
+
+    /** @param unused asd **/ // violation 'Unused @param tag for 'unused' :)'
+    void method2() {
+    }
+
+    /**
+     * Missing param tag.
+     */
+    void method3(int a) { // violation 'Expected @param tag for 'a' :)'
+    }
+}


### PR DESCRIPTION
#12017 

### This mutation falls under the category

- Logic was analyzed to develop the test case.

### Note:
This was not just a single mutation, this showcases the limitation of the pitest report checking model + the `mutations.xml` report provided by pitest. The problem of uniquely identifying mutations when `sourceFile`, `mutatedClass`, `mutatedMethod`, `mutator`, `description`, and `lineContent` is the same.

