### PR TITLE
Issue #12017: Kill surviving mutations in AbstractFileSetCheck related to fileExtensions

### DIFF
--- a/.ci/pitest-suppressions/pitest-api-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-api-suppressions.xml
@@ -12,15 +12,6 @@
   <mutation unstable="false">
     <sourceFile>AbstractFileSetCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck</mutatedClass>
-    <mutatedMethod>getFileExtensions</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to java/util/Arrays::copyOf with argument</description>
-    <lineContent>return Arrays.copyOf(fileExtensions, fileExtensions.length);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>AbstractFileSetCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck</mutatedClass>
     <mutatedMethod>log</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to java/util/Map::get</description>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheckTest.java
@@ -263,6 +263,20 @@ public class AbstractFileSetCheckTest extends AbstractModuleTestSupport {
                 .isEqualTo(2);
     }
 
+    /**
+     * S2384 - Mutable members should not be stored or returned directly.
+     * Inspection is valid, a pure unit test is required as this condition can't be recreated in
+     * a test with checks and input file as none of the checks try to modify the fileExtensions.
+     */
+    @Test
+    public void testCopiedArrayIsReturned() {
+        final DummyFileSetCheck check = new DummyFileSetCheck();
+        check.setFileExtensions(".tmp");
+        assertWithMessage("Extensions should be copied")
+            .that(check.getFileExtensions())
+            .isNotSameInstanceAs(check.getFileExtensions());
+    }
+
     public static class DummyFileSetCheck extends AbstractFileSetCheck {
 
         private static final String MSG_KEY = "File should not be empty.";


### PR DESCRIPTION
#12017

### This mutation falls under the category:

- Logic was analyzed to develop the test case.