### PR TITLE
Issue #12017: Kill surviving mutations in AbstractFileSetCheck related to custom message keys

### DIFF
--- a/.ci/pitest-suppressions/pitest-api-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-api-suppressions.xml
@@ -37,15 +37,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>AbstractFileSetCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck</mutatedClass>
-    <mutatedMethod>log</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/Map::get</description>
-    <lineContent>getCustomMessages().get(key)));</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>AbstractViolationReporter.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.api.AbstractViolationReporter</mutatedClass>
     <mutatedMethod>setSeverity</mutatedMethod>

--- a/pom.xml
+++ b/pom.xml
@@ -4068,6 +4068,8 @@
                 <param>org.checkstyle.suppressionxpathfilter.XpathRegressionJavadocMethodTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheckTest</param>
                 <param>com.puppycrawl.tools.checkstyle.filters.SuppressWithPlainTextCommentFilterTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.whitespace.FileTabCharacterCheckTest</param>
+                <param>com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheckTest</param>
               </targetTests>
               <excludedTestClasses>
                 <param>*.Input*</param>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheckTest.java
@@ -110,8 +110,9 @@ public class NewlineAtEndOfFileCheckTest
 
     @Test
     public void testNoNewlineAtEndOfFile() throws Exception {
+        final String msgKeyNoNewlineEof = "File does not end with a newline :)";
         final String[] expected = {
-            "1: " + getCheckMessage(MSG_KEY_NO_NEWLINE_EOF),
+            "1: " + msgKeyNoNewlineEof,
         };
         verifyWithInlineConfigParser(
                 getPath("InputNewlineAtEndOfFileNoNewline2.java"),

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterCheckTest.java
@@ -36,8 +36,10 @@ public class FileTabCharacterCheckTest
 
     @Test
     public void testDefault() throws Exception {
+        final String msgFileContainsTab =
+            "File contains tab characters (this is the first instance) :)";
         final String[] expected = {
-            "22:25: " + getCheckMessage(MSG_FILE_CONTAINS_TAB),
+            "23:25: " + msgFileContainsTab,
         };
         verifyWithInlineConfigParser(
                 getPath("InputFileTabCharacterSimple.java"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/InputNewlineAtEndOfFileNoNewline2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/newlineatendoffile/InputNewlineAtEndOfFileNoNewline2.java
@@ -2,6 +2,7 @@
 NewlineAtEndOfFile
 lineSeparator = (default)LF_CR_CRLF
 fileExtensions = (default)all files
+message.noNewlineAtEOF = File does not end with a newline :)
 
 
 */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/filetabcharacter/InputFileTabCharacterSimple.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/filetabcharacter/InputFileTabCharacterSimple.java
@@ -2,6 +2,7 @@
 FileTabCharacter
 eachLine = (default)false
 fileExtensions = (default)
+message.file.containsTab = File contains tab characters (this is the first instance) :)
 
 
 */


### PR DESCRIPTION
#12017

### This mutation falls under the category:

- Logic was analyzed to develop the test case.

In general, we make a new test case, but I didn't create one as the check logic coverage won't be affected by modifying the test configuration.