### PR TITLE
Issue #12017: Kill surviving mutations in AutomaticBean related to String.format

### DIFF
--- a/.ci/pitest-suppressions/pitest-api-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-api-suppressions.xml
@@ -56,15 +56,6 @@
 
   <mutation unstable="false">
     <sourceFile>AutomaticBean.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.AutomaticBean</mutatedClass>
-    <mutatedMethod>tryCopyProperty</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to java/lang/String::format with argument</description>
-    <lineContent>final String message = String.format(Locale.ROOT,</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>AutomaticBean.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.api.AutomaticBean$RelaxedAccessModifierArrayConverter</mutatedClass>
     <mutatedMethod>convert</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AutomaticBeanTest.java
@@ -137,7 +137,7 @@ public class AutomaticBeanTest {
                     .fail();
         }
         catch (CheckstyleException ex) {
-            final String expected = "Cannot set property ";
+            final String expected = "Cannot set property 'exceptionalMethod' to '123.0'";
             assertWithMessage("Invalid exception cause, should be: ReflectiveOperationException")
                     .that(ex)
                     .hasCauseThat()
@@ -145,7 +145,7 @@ public class AutomaticBeanTest {
             assertWithMessage("Invalid exception message, should start with: " + expected)
                     .that(ex)
                     .hasMessageThat()
-                    .startsWith(expected);
+                    .isEqualTo(expected);
         }
     }
 


### PR DESCRIPTION
#12017 

### This mutation falls under the category:

- Logic was analyzed and the test case was modified.