### PR TITLE
Issue #12017: Kill surviving mutations in AutomaticBean related to trimming strings

### DIFF
--- a/.ci/pitest-suppressions/pitest-api-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-api-suppressions.xml
@@ -38,24 +38,6 @@
 
   <mutation unstable="false">
     <sourceFile>AutomaticBean.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.AutomaticBean$RelaxedAccessModifierArrayConverter</mutatedClass>
-    <mutatedMethod>convert</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/lang/String::trim with receiver</description>
-    <lineContent>result.add(AccessModifierOption.getInstance(token.trim()));</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>AutomaticBean.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.AutomaticBean$RelaxedAccessModifierArrayConverter</mutatedClass>
-    <mutatedMethod>convert</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/lang/String::trim with receiver</description>
-    <lineContent>value.toString().trim(), COMMA_SEPARATOR);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>AutomaticBean.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.api.AutomaticBean$RelaxedStringArrayConverter</mutatedClass>
     <mutatedMethod>convert</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
@@ -391,12 +391,12 @@ public abstract class AutomaticBean
         public Object convert(Class type, Object value) {
             // Converts to a String and trims it for the tokenizer.
             final StringTokenizer tokenizer = new StringTokenizer(
-                value.toString().trim(), COMMA_SEPARATOR);
+                value.toString(), COMMA_SEPARATOR);
             final List<AccessModifierOption> result = new ArrayList<>();
 
             while (tokenizer.hasMoreTokens()) {
                 final String token = tokenizer.nextToken();
-                result.add(AccessModifierOption.getInstance(token.trim()));
+                result.add(AccessModifierOption.getInstance(token));
             }
 
             return result.toArray(EMPTY_MODIFIER_ARRAY);


### PR DESCRIPTION
#12017 

### Rationale:

`RelaxedAccessModifierArrayConverter` is only used for `AccessModifierOption[].class`.

No need to invoke `trim()` here, they are trimmed at:
https://github.com/checkstyle/checkstyle/blob/74d8802acfb8833cd34538447d0852baa58e6c5b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AccessModifierOption.java#L65-L67

