### PR TITLE
Issue #12017: Kill surviving mutations in AutomaticBean related to trimming strings in RelaxedStringArrayConverter

### DIFF
--- a/.ci/pitest-suppressions/pitest-api-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-api-suppressions.xml
@@ -37,15 +37,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>AutomaticBean.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.AutomaticBean$RelaxedStringArrayConverter</mutatedClass>
-    <mutatedMethod>convert</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/lang/String::trim with receiver</description>
-    <lineContent>value.toString().trim(), COMMA_SEPARATOR);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>BeforeExecutionFileFilterSet.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.api.BeforeExecutionFileFilterSet</mutatedClass>
     <mutatedMethod>getBeforeExecutionFileFilters</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java
@@ -360,9 +360,8 @@ public abstract class AutomaticBean
         @SuppressWarnings("unchecked")
         @Override
         public Object convert(Class type, Object value) {
-            // Convert to a String and trim it for the tokenizer.
             final StringTokenizer tokenizer = new StringTokenizer(
-                value.toString().trim(), COMMA_SEPARATOR);
+                value.toString(), COMMA_SEPARATOR);
             final List<String> result = new ArrayList<>();
 
             while (tokenizer.hasMoreTokens()) {


### PR DESCRIPTION
#12017 

### Rationale:
No need to trim strings here, they are trimmed further down in the method:
```java
while (tokenizer.hasMoreTokens()) {
  final String token = tokenizer.nextToken();
  result.add(token.trim());
}
```