### PR TITLE
Issue #12036: Kill surviving mutation in AnnotationUseStyleCheck related to closingParens

### DIFF
--- a/.ci/pitest-suppressions/pitest-annotation-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-annotation-suppressions.xml
@@ -5,15 +5,6 @@
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable closingParens</description>
-    <lineContent>private ClosingParensOption closingParens = ClosingParensOption.NEVER;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>AnnotationUseStyleCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
     <description>Removed assignment to member variable trailingArrayComma</description>
     <lineContent>private TrailingArrayCommaOption trailingArrayComma = TrailingArrayCommaOption.NEVER;</lineContent>
   </mutation>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -583,13 +583,13 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
         if (closingParens != ClosingParensOption.IGNORE) {
             final DetailAST paren = ast.getLastChild();
 
-            if (closingParens == ClosingParensOption.ALWAYS) {
-                if (paren.getType() != TokenTypes.RPAREN) {
-                    log(ast, MSG_KEY_ANNOTATION_PARENS_MISSING);
+            if (closingParens == ClosingParensOption.NEVER) {
+                if (paren.getPreviousSibling().getType() == TokenTypes.LPAREN) {
+                    log(ast, MSG_KEY_ANNOTATION_PARENS_PRESENT);
                 }
             }
-            else if (paren.getPreviousSibling().getType() == TokenTypes.LPAREN) {
-                log(ast, MSG_KEY_ANNOTATION_PARENS_PRESENT);
+            else if (paren.getType() != TokenTypes.RPAREN) {
+                log(ast, MSG_KEY_ANNOTATION_PARENS_MISSING);
             }
         }
     }


### PR DESCRIPTION
#12036 

Link to check documentation: https://checkstyle.sourceforge.io/config_annotation.html#AnnotationUseStyle

### Diff Reports:

- DefaultConfig: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/cab090f_2022112136/reports/diff/index.html
- closingParensAlways: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/3a1700c_2022155641/reports/diff/index.html
 
### Rationale:

The default value `ClosingParensOption.NEVER` was never used in the comparison, moreover the order of `if` statements guaranteed that the default value when replaced with `null` does not affect the logic.

The logic was modified a bit to use `ClosingParensOption.NEVER`.

---

### Generating reports:
Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/8b937c2d78d340904640249dd597e382380dc6ea/my_checks.xml
Report label: closingParensAlways