### PR TITLE
Issue #12036: Kill surviving mutation in AnnotationUseStyleCheck related to trailingArrayComma

### DIFF
--- a/.ci/pitest-suppressions/pitest-annotation-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-annotation-suppressions.xml
@@ -3,15 +3,6 @@
   <mutation unstable="false">
     <sourceFile>AnnotationUseStyleCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable trailingArrayComma</description>
-    <lineContent>private TrailingArrayCommaOption trailingArrayComma = TrailingArrayCommaOption.NEVER;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>AnnotationUseStyleCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck</mutatedClass>
     <mutatedMethod>checkStyleType</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_3</mutator>
     <description>RemoveSwitch 3 mutation</description>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -563,13 +563,13 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
         // comma can be null if array is empty
         final DetailAST comma = rCurly.getPreviousSibling();
 
-        if (trailingArrayComma == TrailingArrayCommaOption.ALWAYS) {
-            if (comma == null || comma.getType() != TokenTypes.COMMA) {
-                log(rCurly, MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING);
+        if (trailingArrayComma == TrailingArrayCommaOption.NEVER) {
+            if (comma != null && comma.getType() == TokenTypes.COMMA) {
+                log(comma, MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT);
             }
         }
-        else if (comma != null && comma.getType() == TokenTypes.COMMA) {
-            log(comma, MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT);
+        else if (comma == null || comma.getType() != TokenTypes.COMMA) {
+            log(rCurly, MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING);
         }
     }
 


### PR DESCRIPTION
#12036 

Link to check documentation: https://checkstyle.sourceforge.io/config_annotation.html#AnnotationUseStyle

### Regression Reports:

- DefaultConfig: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/b9302d2_2022111833/reports/diff/index.html
- trailingArrayCommaAlways: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/6c1c4ca_2022160315/reports/diff/index.html
 
### Rationale:

The default value `TrailingArrayCommaOption.NEVER` was never used in the comparison, moreover the order of `if` statements guaranteed that the default value when replaced with `null` does not affect the logic.

The logic was modified a bit to use `TrailingArrayCommaOption.NEVER`.

The value of `trailingArrayCommaOption` inside `logCommaViolation(..)` won't be `TrailingArrayCommaOption.IGNORE`, following code guarantees it: https://github.com/checkstyle/checkstyle/blob/696cd880e83b6c0af3171bf003ebb142eb4c0d35/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java#L532-L534

---

### Generating reports:
Diff Regression config: https://gist.githubusercontent.com/Vyom-Yadav/98dceb63a79f4833e85fff9b2e1464a6/raw/852929bac9a634a1e3b0db40bf6b65b8dc74e2d0/my_checks.xml
Report label: trailingArrayCommaAlways