### PR TITLE
Issue #12036: Kill surviving mutation in AnnotationUseStyleCheck related to trimming strings

### DIFF
--- a/.ci/pitest-suppressions/pitest-annotation-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-annotation-suppressions.xml
@@ -28,15 +28,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>AnnotationUseStyleCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck</mutatedClass>
-    <mutatedMethod>getOption</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/lang/String::trim with receiver</description>
-    <lineContent>return Enum.valueOf(enumClass, value.trim().toUpperCase(Locale.ENGLISH));</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>SuppressWarningsCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.annotation.SuppressWarningsCheck</mutatedClass>
     <mutatedMethod>visitToken</mutatedMethod>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckTest.java
@@ -29,8 +29,10 @@ import static com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseSty
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+import de.thetaphi.forbiddenapis.SuppressForbidden;
 
 public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
 
@@ -76,6 +78,27 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
         assertWithMessage("Invalid valueOf result")
             .that(option)
             .isEqualTo(AnnotationUseStyleCheck.ClosingParensOption.ALWAYS);
+    }
+
+    /**
+     * Additional test for checking whether the properties in the configuration are set correctly
+     * when there is whitespace around them. Not possible to check with the inline config parser
+     * as it trims the whitespace around properties while setting them.
+     *
+     * @throws Exception exception
+     */
+    @SuppressForbidden
+    @Test
+    public void testNonTrimmedInput() throws Exception {
+        final DefaultConfiguration configuration =
+            createModuleConfig(AnnotationUseStyleCheck.class);
+        configuration.addProperty("elementStyle", "ignore");
+        configuration.addProperty("closingParens", " ignore  ");
+        configuration.addProperty("trailingArrayComma", " always");
+        final String filePath = getPath("InputAnnotationUseStyleWithTrailingComma.java");
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verify(configuration, filePath, expected);
     }
 
     @Test


### PR DESCRIPTION
#12036

### This mutation falls under the category:
The logic was analyzed to develop the test case.