### PR TITLE
minor: Fix sorting issue in pitest survival checking script

### DIFF
--- a/.ci/pitest-survival-check-xml.groovy
+++ b/.ci/pitest-survival-check-xml.groovy
@@ -119,7 +119,7 @@ private static int checkPitestReport(String profile, String flag) {
 private static Set<Mutation> getSurvivingMutations(Node mainNode) {
 
     final List<Node> children = mainNode.children()
-    final Set<Mutation> survivingMutations = new TreeSet<>()
+    final Set<Mutation> survivingMutations = new HashSet<>()
 
     children.each { node ->
         final Node mutationNode = node as Node
@@ -142,7 +142,7 @@ private static Set<Mutation> getSurvivingMutations(Node mainNode) {
  */
 private static Set<Mutation> getSuppressedMutations(Node mainNode) {
     final List<Node> children = mainNode.children()
-    final Set<Mutation> suppressedMutations = new TreeSet<>()
+    final Set<Mutation> suppressedMutations = new HashSet<>()
 
     children.each { node ->
         final Node mutationNode = node as Node
@@ -311,7 +311,7 @@ private static void printMutation(String flag, Mutation mutation) {
  */
 private static Set<Mutation> setDifference(final Set<Mutation> setOne,
                                            final Set<Mutation> setTwo) {
-    final Set<Mutation> result = new HashSet<>(setOne)
+    final Set<Mutation> result = new TreeSet<>(setOne)
     result.removeIf { mutation -> setTwo.contains(mutation) }
     return result
 }


### PR DESCRIPTION
The problem was with the `setDifference(..)` method, both `setOne` and `setTwo` it received were sorted, but as result was a `HashSet`, and the sorting had no effect.

The correct order of elements is displayed now, moreover instead of sorting elements earlier, we sort them while calculating `setDifference(..)`, `setOne` and `setTwo` are of type `HashSet` instead of `TreeSet`, this also executes `setTwo.contains(mutation)` in `O(1)` (on an avg.)