### PR TITLE
minor: Exclude .teamcity dir from ant-phase-verify.xml and spellchecker

### DIFF
--- a/.ci/jsoref-spellchecker/exclude.pl
+++ b/.ci/jsoref-spellchecker/exclude.pl
@@ -16,6 +16,7 @@ my @excludes=qw(
   /.*_..\.translation[^/]*$
   /openjdk17-excluded\.files$
   ^cdg-pitest-licence.txt$
+  ^.teamcity/
 );
 my $exclude = join "|", @excludes;
 while (<>) {

--- a/config/ant-phase-verify.xml
+++ b/config/ant-phase-verify.xml
@@ -68,6 +68,8 @@
       <path>
         <fileset dir="${basedir}" includes="**/*">
           <exclude name=".git/**/*"/>
+          <!-- TeamCity config is generated and contains embedded CDATA -->
+          <exclude name=".teamcity/**/*"/>
           <exclude name="src/main/**/*"/>
           <exclude name="src/test/java/**/*"/>
           <exclude name="src/site/resources/images/**/*"/>


### PR DESCRIPTION
Excluded as TeamCity config is generated and contains embedded CDATA