### PR TITLE
Issue #11865: Resolve DeprecatedIsStillUsed idea violations

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -98,6 +98,7 @@ public interface DetailAST {
      *      traversal of subtrees to be written per the needs of each check
      *      to avoid unintended side effects.
      */
+    @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated(since = "8.43")
     boolean branchContains(int type);
 


### PR DESCRIPTION
Resolves #11865 
The method is used in unit testing, we must maintain coverage until it is removed.