### PR TITLE
Issue #2160: Activate error-prone

### DIFF
--- a/.ci/StarterRuleSet-AllRulesByCategory.groovy.txt
+++ b/.ci/StarterRuleSet-AllRulesByCategory.groovy.txt
@@ -138,7 +138,8 @@ ruleset {
     // it is ok to use duplication, every number cannot be represented by the same logic
     //DuplicateNumberLiteral
 
-    //DuplicateStringLiteral  // it is ok to use simple duplication in scripts
+    // it is ok to use simple duplication in scripts
+    //DuplicateStringLiteral
 
     // rulesets/enhanced.xml
     CloneWithoutCloneable
@@ -270,7 +271,10 @@ ruleset {
     ImportFromSamePackage
     ImportFromSunPackages
     MisorderedStaticImports
-    //NoWildcardImports // it is ok to keep scripts as small as possible in header
+
+    // it is ok to keep scripts as small as possible in header
+    //NoWildcardImports
+
     UnnecessaryGroovyImport {
         doNotApplyToFileNames = 'codenarc.groovy'
     }
@@ -316,7 +320,10 @@ ruleset {
     LoggingSwallowsStacktrace
     MultipleLoggers
     PrintStackTrace
-    //Println // We use groovy as scripted java, usage of std output is required by design
+
+    // We use groovy as scripted java, usage of std output is required by design
+    //Println
+
     SystemErrPrint
     SystemOutPrint
 
@@ -344,7 +351,10 @@ ruleset {
     // rulesets/security.xml
     FileCreateTempFile
     InsecureRandom
-    //JavaIoPackageAccess // we do not care about  EJB container rules
+
+    // we do not care about  EJB container rules
+    //JavaIoPackageAccess
+
     NonFinalPublicField
     NonFinalSubclassOfSensitiveInterface
     ObjectFinalize
@@ -361,10 +371,17 @@ ruleset {
     SerializableClassMustDefineSerialVersionUID
 
     // rulesets/size.xml
-    AbcMetric   // Requires the GMetrics jar
+
+    // Requires the GMetrics jar
+    AbcMetric
+
     ClassSize
-    CrapMetric   // Requires the GMetrics jar and a Cobertura coverage file
-    CyclomaticComplexity   // Requires the GMetrics jar
+
+    // Requires the GMetrics jar and a Cobertura coverage file
+    CrapMetric
+
+    // Requires the GMetrics jar
+    CyclomaticComplexity
     MethodCount
     MethodSize
     NestedBlockDepth
@@ -393,8 +410,12 @@ ruleset {
     UnnecessaryElseStatement
     UnnecessaryFinalOnPrivateMethod
     UnnecessaryFloatInstantiation
-    //UnnecessaryGString // just to be the same as in java, as our primary language
-    //UnnecessaryGetter // we are ok with code to looks like Java
+
+    // just to be the same as in java, as our primary language
+    //UnnecessaryGString
+
+    // we are ok with code to looks like Java
+    //UnnecessaryGetter
     UnnecessaryIfStatement
     UnnecessaryInstanceOfCheck
     UnnecessaryInstantiationToGetClass

--- a/.ci/StarterRuleSet-AllRulesByCategory.groovy.txt
+++ b/.ci/StarterRuleSet-AllRulesByCategory.groovy.txt
@@ -134,7 +134,10 @@ ruleset {
     // rulesets/dry.xml
     DuplicateListLiteral
     DuplicateMapLiteral
-    DuplicateNumberLiteral
+
+    // it is ok to use duplication, every number cannot be represented by the same logic
+    //DuplicateNumberLiteral
+
     //DuplicateStringLiteral  // it is ok to use simple duplication in scripts
 
     // rulesets/enhanced.xml
@@ -335,7 +338,7 @@ ruleset {
     PropertyName
     VariableName {
         finalRegex = null
-        ignoreVariableNames = 'SEPARATOR'
+        ignoreVariableNames = 'SEPARATOR,PROFILES,USAGE_STRING'
     }
 
     // rulesets/security.xml
@@ -347,7 +350,7 @@ ruleset {
     ObjectFinalize
     PublicFinalizeMethod
     SystemExit {
-        doNotApplyToFileNames = 'pitest-survival-check-xml.groovy'
+        doNotApplyToFileNames = 'pitest-survival-check-xml.groovy,error-prone-check.groovy'
     }
     UnsafeArrayDeclaration
 

--- a/.ci/error-prone-check.groovy
+++ b/.ci/error-prone-check.groovy
@@ -1,0 +1,344 @@
+import groovy.transform.EqualsAndHashCode
+import groovy.transform.Field
+import groovy.transform.Immutable
+import groovy.xml.XmlUtil
+
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+@Field static final String SEPARATOR = System.getProperty("file.separator")
+@Field static final Set<String> PROFILES = Set.of("compile", "test-compile")
+@Field static final String USAGE_STRING = "Usage groovy ./.ci/error-prone-check.groovy" +
+        " (compile | test-compile) [-g | --generate-suppression]\n"
+
+int exitCode = 1
+if (args.length == 2) {
+    exitCode = parseArgumentAndExecute(args[0], args[1])
+}
+else if (args.length == 1) {
+    exitCode = parseArgumentAndExecute(args[0], null)
+}
+else {
+    throw new IllegalArgumentException(USAGE_STRING)
+}
+System.exit(exitCode)
+
+/**
+ * Parse the command line arguments passed in and execute the branch based on the arguments.
+ * compile - compile the source code of the project.
+ * test-compile - compile the test source code into the test destination directory.
+ *
+ * @param argument command line argument
+ * @return {@code 0} if command executes successfully, {@code 1} otherwise
+ */
+private int parseArgumentAndExecute(String argument, String flag) {
+    final int exitCode
+    if (PROFILES.contains(argument)) {
+        if (flag != null && flag != "-g" && flag != "--generate-suppression") {
+            final String exceptionMessage = "Unexpected flag: '${flag}'\n" + USAGE_STRING
+            throw new IllegalArgumentException(exceptionMessage)
+        }
+        exitCode = checkErrorProneReport(argument, flag)
+    }
+    else {
+        final String exceptionMessage = "Unexpected argument: '${argument}'\n" + USAGE_STRING
+        throw new IllegalArgumentException(exceptionMessage)
+    }
+    return exitCode
+}
+
+/**
+ * Check the generated error prone report. Parse the errors and compare them with the suppressed
+ * errors.
+ *
+ * @param profile the error prone profile to execute
+ * @param flag command line argument flag to determine output format
+ * @return {@code 0} if error prone report is as expected, {@code 1} otherwise
+ */
+private static int checkErrorProneReport(String profile, String flag) {
+    final XmlParser xmlParser = new XmlParser()
+    final String suppressedErrorsFileUri =
+            ".${SEPARATOR}.ci${SEPARATOR}" +
+                    "error-prone-suppressions${SEPARATOR}${profile}-phase-suppressions.xml"
+    final List<String> errorProneErrors = getErrorProneErrors(profile)
+    Set<ErrorProneError> errors = Collections.emptySet()
+    if (!errorProneErrors.isEmpty()) {
+        errors = getErrorFromText(errorProneErrors)
+    }
+    final File suppressionFile = new File(suppressedErrorsFileUri)
+    Set<ErrorProneError> suppressedErrors = Collections.emptySet()
+    if (suppressionFile.exists()) {
+        final Node suppressedErrorsNode = xmlParser.parse(suppressedErrorsFileUri)
+        suppressedErrors = getSuppressedErrors(suppressedErrorsNode)
+    }
+    return compareErrors(errors, suppressedErrors, flag)
+}
+
+/**
+ * Generates the error prone report and filters out the errors.
+ *
+ * @param profile the error prone profile to execute
+ * @return A set of errors
+ */
+private static List<String> getErrorProneErrors(String profile) {
+    final List<String> errorProneErrors = [] as ArrayList
+    final String command = "mvn -e --no-transfer-progress clean" +
+            " ${profile} -Perror-prone-${profile}"
+    final Process process = command.execute()
+    process.in.eachLine { line ->
+        if (line.startsWith("[ERROR]")) {
+            errorProneErrors.add(line)
+        }
+        println(line)
+    }
+    process.waitFor()
+    return errorProneErrors
+}
+
+/**
+ * Get a set of {@link ErrorProneError} from text.
+ *
+ * @param errorsText errors in text format
+ * @return A set of errors
+ */
+private static Set<ErrorProneError> getErrorFromText(List<String> errorsText) {
+    final Set<ErrorProneError> errors = new HashSet<>()
+    final Pattern errorExtractingPattern = Pattern
+            .compile(".*/(.*\\.java):\\[(\\d+).*\\[(\\w+)\\](.*)");
+    final Pattern filePathExtractingPattern = Pattern.compile("\\[ERROR\\] (.*\\.java)")
+    final int sourceFileGroup = 1
+    final int lineNumberGroup = 2
+    final int bugPatternGroup = 3
+    final int descriptionGroup = 4
+    errorsText.each { error ->
+        final Matcher matcher = errorExtractingPattern.matcher(error)
+        String sourceFile = null
+        String bugPattern = null
+        String description = null
+        String lineContent = null
+        int lineNumber = 0
+        if (matcher.matches()) {
+            sourceFile = matcher.group(sourceFileGroup)
+            lineNumber = Integer.parseInt(matcher.group(lineNumberGroup))
+            bugPattern = matcher.group(bugPatternGroup).trim()
+            description = XmlUtil.escapeXml(matcher.group(descriptionGroup).trim())
+
+            final Matcher filePathMatcher = filePathExtractingPattern.matcher(error)
+            if (filePathMatcher.find()) {
+                final String absoluteFilePath = filePathMatcher.group(1)
+                final File file = new File(absoluteFilePath)
+                lineContent = XmlUtil.escapeXml(file.readLines().get(lineNumber - 1).trim())
+            }
+
+            final ErrorProneError errorProneError = new ErrorProneError(
+                    sourceFile, bugPattern, description, lineContent, lineNumber)
+            errors.add(errorProneError)
+        }
+    }
+    return errors
+}
+
+/**
+ * Get the suppressed error. All child nodes of the main {@code suppressedErrors} node
+ * are parsed.
+ *
+ * @param mainNode the main {@code suppressedErrors} node
+ * @return A set of suppressed errors
+ */
+private static Set<ErrorProneError> getSuppressedErrors(Node mainNode) {
+    final List<Node> children = mainNode.children()
+    final Set<ErrorProneError> suppressedErrors = new HashSet<>()
+
+    children.each { node ->
+        final Node errorNode = node as Node
+        suppressedErrors.add(getError(errorNode))
+    }
+    return suppressedErrors
+}
+
+/**
+ * Construct the {@link ErrorProneError} object from the {@code error} XML node.
+ * The suppression file is parsed to get the {@code errorNode}.
+ *
+ * @param errorNode the {@code error} XML node
+ * @return {@link ErrorProneError} object represented by the {@code error} XML node
+ */
+private static ErrorProneError getError(Node errorNode) {
+    final List childNodes = errorNode.children()
+
+    String sourceFile = null
+    String bugPattern = null
+    String description = null
+    String lineContent = null
+    final int lineNumber = -1
+    childNodes.each {
+        final Node childNode = it as Node
+        final String text = childNode.name()
+
+        final String childNodeText = XmlUtil.escapeXml(childNode.text())
+        switch (text) {
+            case "sourceFile":
+                sourceFile = childNodeText
+                break
+            case "bugPattern":
+                bugPattern = childNodeText
+                break
+            case "description":
+                description = childNodeText
+                break
+            case "lineContent":
+                lineContent = childNodeText
+                break
+        }
+    }
+
+    return new ErrorProneError(sourceFile, bugPattern, description, lineContent, lineNumber)
+}
+
+/**
+ * Compare the actual and the suppressed errors. The comparison passes successfully
+ * (i.e. returns 0) when:
+ * <ol>
+ *     <li>Surviving and suppressed errors are equal.</li>
+ * </ol>
+ * The comparison fails when (i.e. returns 1) when:
+ * <ol>
+ *     <li>Surviving errors are not present in the suppressed list.</li>
+ *     <li>There are errors in the suppression list that are not there is surviving list.</li>
+ * </ol>
+ *
+ * @param actualErrors A set of actual errors reported by error prone
+ * @param suppressedErrors A set of suppressed errors from suppression file
+ * @param flag command line argument flag to determine output format
+ * @return {@code 0} if comparison passes successfully
+ */
+private static int compareErrors(Set<ErrorProneError> actualErrors,
+                                    Set<ErrorProneError> suppressedErrors,
+                                    String flag) {
+    final Set<Error> unsuppressedErrors =
+            setDifference(actualErrors, suppressedErrors)
+    final Set<Error> extraSuppressions =
+            setDifference(suppressedErrors, actualErrors)
+
+    final int exitCode
+    if (actualErrors == suppressedErrors) {
+        exitCode = 0
+    }
+    else {
+        if (!unsuppressedErrors.isEmpty()) {
+            println "New surviving error(s) found:"
+            unsuppressedErrors.each {
+                printError(flag, it)
+            }
+        }
+        if (!extraSuppressions.isEmpty()) {
+            println "\nUnnecessary suppressed error(s) found and should be removed:"
+            extraSuppressions.each {
+                printError(flag, it)
+            }
+        }
+        exitCode = 1
+    }
+    return exitCode
+}
+
+/**
+ * Prints the error according to the nature of the flag.
+ *
+ * @param flag command line argument flag to determine output format
+ * @param error error to print
+ */
+private static void printError(String flag, ErrorProneError error) {
+    if (flag != null) {
+        println error.toXmlString()
+    }
+    else {
+        println error
+    }
+}
+
+/**
+ * Determine the difference between 2 sets. The result is {@code setOne - setTwo}.
+ *
+ * @param setOne The first set in the difference
+ * @param setTwo The second set in the difference
+ * @return {@code setOne - setTwo}
+ */
+private static Set<Error> setDifference(final Set<ErrorProneError> setOne,
+                                           final Set<ErrorProneError> setTwo) {
+    final Set<Error> result = new TreeSet<>(setOne)
+    result.removeIf { error -> setTwo.contains(error) }
+    return result
+}
+
+/**
+ * A class to represent the XML {@code error} node.
+ */
+@EqualsAndHashCode(excludes = "lineNumber")
+@Immutable
+class ErrorProneError implements Comparable<ErrorProneError> {
+
+    /**
+     * Error nodes present in suppressions file do not have a {@code lineNumber}.
+     * The {@code lineNumber} is set to {@code -1} for such errors.
+     */
+    private static final int LINE_NUMBER_NOT_PRESENT_VALUE = -1
+
+    String sourceFile
+    String bugPattern
+    String description
+    String lineContent
+    int lineNumber
+
+    @Override
+    String toString() {
+        String toString = """
+            Source File: "${getSourceFile()}"
+            Bug Pattern: "${getBugPattern()}"
+            Description: "${getDescription()}"
+            Line Contents: "${getLineContent()}"
+            """.stripIndent()
+        if (getLineNumber() != LINE_NUMBER_NOT_PRESENT_VALUE) {
+            toString += 'Line Number: ' + getLineNumber()
+        }
+        return toString
+    }
+
+    @Override
+    int compareTo(ErrorProneError other) {
+        int i = getSourceFile() <=> other.getSourceFile()
+        if (i != 0) {
+            return i
+        }
+
+        i = getBugPattern() <=> other.getBugPattern()
+        if (i != 0) {
+            return i
+        }
+
+        i = getLineContent() <=> other.getLineContent()
+        if (i != 0) {
+            return i
+        }
+
+        return getDescription() <=> other.getDescription()
+    }
+
+    /**
+     * XML format of the error.
+     *
+     * @return XML format of the error
+     */
+    String toXmlString() {
+        return """
+            <error>
+              <sourceFile>${getSourceFile()}</sourceFile>
+              <bugPattern>${getBugPattern()}</bugPattern>
+              <description>${getDescription()}</description>
+              <lineContent>${getLineContent()}</lineContent>
+            </error>
+            """.stripIndent(10)
+    }
+
+}
+

--- a/.ci/error-prone-suppressions/compile-phase-suppressions.xml
+++ b/.ci/error-prone-suppressions/compile-phase-suppressions.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressedErrors>
+  <error>
+    <sourceFile>JavadocNodeImpl.java</sourceFile>
+    <bugPattern>ArrayHashCode</bugPattern>
+    <description>hashcode method on array does not hash array contents</description>
+    <lineContent>+ &quot;, children=&quot; + Objects.hashCode(children)</lineContent>
+  </error>
+</suppressedErrors>

--- a/.ci/error-prone-suppressions/test-compile-phase-suppressions.xml
+++ b/.ci/error-prone-suppressions/test-compile-phase-suppressions.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressedErrors>
+  <error>
+    <sourceFile>CheckUtil.java</sourceFile>
+    <bugPattern>ReturnValueIgnored</bugPattern>
+    <description>Return value of &apos;findFirst&apos; must be used</description>
+    <lineContent>.findFirst();</lineContent>
+  </error>
+
+  <error>
+    <sourceFile>PropertyCacheFileTest.java</sourceFile>
+    <bugPattern>CheckReturnValue</bugPattern>
+    <description>The result of `toByteArray(...)` must be used</description>
+    <lineContent>byteStream.when(() -&gt; ByteStreams.toByteArray(any(BufferedInputStream.class)))</lineContent>
+  </error>
+</suppressedErrors>

--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -1054,6 +1054,7 @@ pdf
 Peclipse
 Penable
 perl
+Perror
 pgjdbc
 Pgpg
 pguyot
@@ -1480,8 +1481,10 @@ Xandy
 xar
 xargs
 xcode
+XDcompile
 xdoc
 xdocspagetitle
+Xep
 Xerces
 xf
 xfeff
@@ -1512,6 +1515,7 @@ xpathfilterelement
 xpathmapper
 xpathquerygenerator
 Xpkginfo
+Xplugin
 xright
 xsd
 xsi

--- a/.github/workflows/error-prone.yml
+++ b/.github/workflows/error-prone.yml
@@ -1,0 +1,29 @@
+name: Error-Prone
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  error-prone:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Install groovy
+        run: sudo apt install groovy
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Execute Error-Prone on compile phase
+        run: groovy ./.ci/error-prone-check.groovy compile
+      # Require to compile again in case previous step fails and sources are not compiled
+      - name: Do a clean compile
+        if: always()
+        run: mvn -e --no-transfer-progress clean compile
+      - name: Execute Error-Prone on test-compile phase
+        if: always()
+        run: groovy ./.ci/error-prone-check.groovy test-compile

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,10 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/config/checkstyle_non_main_files_suppressions.xml
+++ b/config/checkstyle_non_main_files_suppressions.xml
@@ -89,6 +89,9 @@
   <!-- this file cannot be line wrapped, It contains a list of suppressions -->
   <suppress id="lineLength" files=".ci[\\/]pitest-suppressions[\\/].*"/>
 
+  <!-- this file cannot be line wrapped, It contains a list of suppressions -->
+  <suppress id="lineLength" files=".ci[\\/]error-prone-suppressions[\\/].*"/>
+
   <!-- this file cannot be line wrapped, it contains cdg pitest licence -->
   <suppress id="lineLength" files="cdg-pitest-licence.txt"/>
 

--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,7 @@
     <junit.version>5.9.0</junit.version>
     <forbiddenapis.version>3.3</forbiddenapis.version>
     <json-schema-validator.version>1.2.0</json-schema-validator.version>
+    <error-prone.version>2.15.0</error-prone.version>
   </properties>
 
   <dependencies>
@@ -751,46 +752,6 @@
             <arg>-Xpkginfo:always</arg>
           </compilerArgs>
         </configuration>
-        <!-- till https://github.com/checkstyle/checkstyle/issues/2160
-        <executions>
-          <execution>
-            <id>compile-without-error-prone</id>
-            <goals>
-              <goal>testCompile</goal>
-            </goals>
-            <configuration>
-              <testIncludes>
-                <testInclude>**/Input*.java</testInclude>
-              </testIncludes>
-            </configuration>
-          </execution>
-          <execution>
-            <id>compile-with-error-prone</id>
-            <goals>
-              <goal>testCompile</goal>
-            </goals>
-            <configuration>
-              <compilerId>javac-with-errorprone</compilerId>
-              <forceJavacCompilerUse>true</forceJavacCompilerUse>
-              <testExcludes>
-                <testExclude>**/*Input*.java</testExclude>
-              </testExcludes>
-            </configuration>
-          </execution>
-        </executions>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-compiler-javac-errorprone</artifactId>
-            <version>2.6</version>
-          </dependency>
-          <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_core</artifactId>
-            <version>2.0.5</version>
-          </dependency>
-        </dependencies>
-        -->
       </plugin>
 
       <plugin>
@@ -2311,6 +2272,111 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>sonar-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>error-prone-compile</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.10.1</version>
+            <executions>
+              <!-- Skip the default-compile execution as we don't want to execute the compile goal twice -->
+              <execution>
+                <id>default-compile</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+                <configuration>
+                  <skipMain>true</skipMain>
+                </configuration>
+              </execution>
+              <execution>
+                <id>error-prone-compile</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+                <configuration>
+                  <failOnError>false</failOnError>
+                  <source>${java.version}</source>
+                  <target>${java.version}</target>
+                  <compilerArgs>
+                    <arg>-Xpkginfo:always</arg>
+                    <arg>-XDcompilePolicy=simple</arg>
+                    <arg>
+                      -Xplugin:ErrorProne
+                    </arg>
+                  </compilerArgs>
+                  <annotationProcessorPaths>
+                    <path>
+                      <groupId>com.google.errorprone</groupId>
+                      <artifactId>error_prone_core</artifactId>
+                      <version>${error-prone.version}</version>
+                    </path>
+                  </annotationProcessorPaths>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>error-prone-test-compile</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.10.1</version>
+            <executions>
+              <!-- Skip the default-testCompile execution as we don't want to execute the testCompile goal twice -->
+              <execution>
+                <id>default-testCompile</id>
+                <phase>test-compile</phase>
+                <goals>
+                  <goal>testCompile</goal>
+                </goals>
+                <configuration>
+                  <skip>true</skip>
+                </configuration>
+              </execution>
+              <execution>
+                <id>error-prone-test-compile</id>
+                <phase>test-compile</phase>
+                <goals>
+                  <goal>testCompile</goal>
+                </goals>
+                <configuration>
+                  <failOnError>false</failOnError>
+                  <source>${java.version}</source>
+                  <target>${java.version}</target>
+                  <compilerArgs>
+                    <arg>-Xpkginfo:always</arg>
+                    <arg>-XDcompilePolicy=simple</arg>
+                    <arg>
+                      -Xplugin:ErrorProne \
+                      -XepExcludedPaths:.*[\\/]resources[\\/].*
+                    </arg>
+                  </compilerArgs>
+                  <annotationProcessorPaths>
+                    <path>
+                      <groupId>com.google.errorprone</groupId>
+                      <artifactId>error_prone_core</artifactId>
+                      <version>${error-prone.version}</version>
+                    </path>
+                  </annotationProcessorPaths>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Resolves #2160

Enabling error-prone for the project, all `.*[\\/]resources[\\/].*` are excluded from error-prone evaluation.
https://errorprone.info/docs/flags

---

**Proof of Working:**

- `New surviving error(s) found:` https://github.com/checkstyle/checkstyle/runs/7965373088?check_suite_focus=true
- `Unnecessary suppressed error(s) found and should be removed:` https://github.com/checkstyle/checkstyle/runs/7965413923?check_suite_focus=true
- Both `New surviving error(s) found:` and `Unnecessary suppressed error(s) found and should be removed:` https://github.com/checkstyle/checkstyle/runs/7965481307?check_suite_focus=true

---

### Reason for adding `jvm.config` file:
`--add-exports` and `--add-opens` is required on JDK 16 and newer due to [JEP 396: Strongly Encapsulate JDK Internals by Default](https://openjdk.java.net/jeps/396)
