### PR TITLE
minor: correct links detected by linkcheck plugin

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -1212,6 +1212,7 @@ sickboy
 Simplifiable
 simplifybooleanexpression
 simplifybooleanreturn
+simplifystartswith
 singleline
 singlelined
 singlelinejavadoc

--- a/pom.xml
+++ b/pom.xml
@@ -2146,6 +2146,7 @@
             <excludedLink>https://travis-ci.com/</excludedLink>
             <!-- permanent 403 -->
             <excludedLink>https://docs.github.com/en/rest/checks</excludedLink>
+            <excludedLink>https://www.ietf.org/rfc/rfc4627.txt</excludedLink>
             <!-- until https://github.com/checkstyle/checkstyle/issues/11754 -->
             <excludedLink>https://checkstyle.sourceforge.io/version/6.18</excludedLink>
           </excludedLinks>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java
@@ -335,7 +335,7 @@ public final class ConfigurationLoader {
      * outside inner class for easier testing since inner class requires an instance.
      *
      * <p>Code copied from
-     * <a href="http://cvs.apache.org/viewcvs/jakarta-ant/src/main/org/apache/tools/ant/ProjectHelper.java">
+     * <a href="https://github.com/apache/ant/blob/master/src/main/org/apache/tools/ant/ProjectHelper.java">
      * ant
      * </a>
      *

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
@@ -278,7 +278,7 @@ public final class CommonUtil {
      * It is faster version of {@link String#startsWith(String)} optimized for
      *  one-character prefixes at the expense of
      * some readability. Suggested by
-     * <a href="http://pmd.sourceforge.net/pmd-5.3.1/pmd-java/rules/java/optimizations.html#SimplifyStartsWith">
+     * <a href="https://pmd.github.io/latest/pmd_rules_java_performance.html#simplifystartswith">
      * SimplifyStartsWith</a> PMD rule:
      * </p>
      *
@@ -299,7 +299,7 @@ public final class CommonUtil {
      * It is faster version of {@link String#endsWith(String)} optimized for
      *  one-character suffixes at the expense of
      * some readability. Suggested by
-     * <a href="http://pmd.sourceforge.net/pmd-5.3.1/pmd-java/rules/java/optimizations.html#SimplifyStartsWith">
+     * <a href="https://pmd.github.io/latest/pmd_rules_java_performance.html#simplifystartswith">
      * SimplifyStartsWith</a> PMD rule:
      * </p>
      *


### PR DESCRIPTION
https://github.com/checkstyle/checkstyle/runs/7934338572?check_suite_focus=true#step:3:2454
```
 ------------ grep of linkcheck.html--BEGIN
<td><i><a class="externalLink" href="https://www.ietf.org/rfc/rfc4627.txt">https://www.ietf.org/rfc/rfc4627.txt</a>: 403 Forbidden</i></td></tr></table></td></tr>
<td><i><a class="externalLink" href="http://cvs.apache.org/viewcvs/jakarta-ant/src/main/org/apache/tools/ant/ProjectHelper.java">http://cvs.apache.org/viewcvs/jakarta-ant/src/main/org/apache/tools/ant/ProjectHelper.java</a>: 404 Not Found</i></td></tr></table></td></tr>
<td><i><a class="externalLink" href="http://pmd.sourceforge.net/pmd-5.3.1/pmd-java/rules/java/optimizations.html#SimplifyStartsWith">http://pmd.sourceforge.net/pmd-5.3.1/pmd-java/rules/java/optimizations.html#SimplifyStartsWith</a>: 403 Forbidden</i></td></tr></table></td></tr>
------------ grep of linkcheck.html--END
```