### PR TITLE
Issue #3770: Extend OverloadMethodsDeclarationOrderCheck to Support Multiple Groupings

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -2053,13 +2053,6 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheck.java</fileName>
-    <specifier>unboxing.of.nullable</specifier>
-    <message>unboxing a possibly-null reference methodLineNumberMap.get(methodName)</message>
-    <lineContent>methodLineNumberMap.get(methodName);</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field parameterNames</message>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheck.java
@@ -20,12 +20,20 @@
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.Scope;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
@@ -34,31 +42,85 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * name but different signatures where the signature can differ by the number of
  * input parameters or type of input parameters or both.
  * </p>
+ * <ul>
+ * <li>
+ * Property {@code modifierGroups} - control how different types of overloaded methods
+ * can be grouped by their modifiers.
+ * Type is {@code java.util.regex.Pattern[]}.
+ * Default value is {@code ""}.
+ * </li>
+ * </ul>
  * <p>
  * To configure the check:
  * </p>
  * <pre>
- * &lt;module name=&quot;OverloadMethodsDeclarationOrder&quot;/&gt;
- * </pre>
- * <p>
- * Example of correct grouping of overloaded methods:
- * </p>
- * <pre>
- * public void foo(int i) {}
- * public void foo(String s) {}
- * public void foo(String s, int i) {}
- * public void foo(int i, String s) {}
- * public void notFoo() {}
+ * &lt;module name="OverloadMethodsDeclarationOrder"/&gt;
  * </pre>
  * <p>
  * Example of incorrect grouping of overloaded methods:
  * </p>
  * <pre>
+ * public void foo() {} // OK
+ * public final void foo(int i) {} // OK
+ * void notFoo() {} // OK
+ * public static void foo(long l) {} // Violation, should be after 'foo(int i)'
+ * protected void foo(String s) {} // OK
+ * void foo(byte b) {} // OK
+ * private static void foo(String s, int i) { } // OK
+ * public void foo(String a, String b) {} // OK
+ * private void notFoo(int i) {} // Violation, should be after 'notFoo()'
+ * public final void foo(long x, long y) {} // Violation, should be after 'foo(String a, String b)'
+ * </pre>
+ * <p>
+ * Example of correct grouping of overloaded methods:
+ * </p>
+ * <pre>
  * public void foo(int i) {} // OK
- * public void foo(String s) {} // OK
- * public void notFoo() {} // violation. Have to be after foo(String s, int i)
- * public void foo(int i, String s) {}
- * public void foo(String s, int i) {}
+ * void foo(String s) {} // OK
+ * private void foo(String s, int i) {} // OK
+ * public void foo(int i, String s) {} // OK
+ * public void notFoo() {} // OK
+ * private void notFoo(int x) {} // OK
+ * </pre>
+ * <p>
+ * To configure the check to group static and private methods separately within their own
+ * individual groups
+ * </p>
+ * <pre>
+ * &lt;module name="OverloadMethodsDeclarationOrder"&gt;
+ *   &lt;property name="modifierGroups" value=".*static.*, ^public .*, (protected|package),
+ *   private"&gt;&lt;/property&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example of code with violation
+ * </p>
+ * <pre>
+ * public void foo() {} // OK
+ * public final void foo(int i) {} // OK
+ * void notFoo() {} // OK
+ * public static void foo(long l) {} // OK
+ * protected void foo(String s) {} // OK
+ * void foo(byte b) {} // OK
+ * private static void foo(String s, int i) { } // Violation, should be after 'foo(long l)'
+ * public void foo(String a, String b) {} // Violation, should be after 'foo()'
+ * private void notFoo(int i) {} // OK
+ * public final void foo(long x, long y) {} // Violation, should be after 'foo(int i)'
+ * </pre>
+ * <p>
+ * Example of compliant code
+ * </p>
+ * <pre>
+ * public void foo() {} // OK
+ * public void foo(String a, String b) {} // OK
+ * public final void foo(int i) {} // OK
+ * public final void foo(long x, long y) {} // OK
+ * void notFoo() {} // OK
+ * public static void foo(long l) {} // OK
+ * private static void foo(String s, int i) { } // OK
+ * protected void foo(String s) {} // OK
+ * void foo(byte b) {} // OK
+ * private void notFoo(int i) {} // OK
  * </pre>
  * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
@@ -82,6 +144,22 @@ public class OverloadMethodsDeclarationOrderCheck extends AbstractCheck {
      * file.
      */
     public static final String MSG_KEY = "overload.methods.declaration";
+
+    /**
+     * String used as separator between the regex pattern that matches a method's modifiers
+     * and the name of the method.
+     */
+    private static final String SEPARATOR = ":";
+
+    /**
+     * The abstract modifier.
+     */
+    private static final String ABSTRACT_MODIFIER = "abstract";
+
+    /**
+     * Control how different types of overloaded methods can be grouped by their modifiers.
+     */
+    private Pattern[] modifierGroups = new Pattern[0];
 
     @Override
     public int[] getDefaultTokens() {
@@ -118,6 +196,19 @@ public class OverloadMethodsDeclarationOrderCheck extends AbstractCheck {
     }
 
     /**
+     * Setter to control how different types of overloaded methods can be grouped by their
+     * modifiers.
+     *
+     * @param modifierGroupRegex the array of regex patterns
+     */
+    public void setModifierGroups(String... modifierGroupRegex) {
+        modifierGroups = new Pattern[modifierGroupRegex.length];
+        for (int index = 0; index < modifierGroupRegex.length; index++) {
+            modifierGroups[index] = CommonUtil.createPattern(modifierGroupRegex[index]);
+        }
+    }
+
+    /**
      * Checks that if overload methods are grouped together they should not be
      * separated from each other.
      *
@@ -126,27 +217,140 @@ public class OverloadMethodsDeclarationOrderCheck extends AbstractCheck {
      */
     private void checkOverloadMethodsGrouping(DetailAST objectBlock) {
         final int allowedDistance = 1;
+        final Map<String, IndexAndLine> knownMethods = new HashMap<>();
         DetailAST currentToken = objectBlock.getFirstChild();
-        final Map<String, Integer> methodIndexMap = new HashMap<>();
-        final Map<String, Integer> methodLineNumberMap = new HashMap<>();
+
         int currentIndex = 0;
         while (currentToken != null) {
             if (currentToken.getType() == TokenTypes.METHOD_DEF) {
                 currentIndex++;
-                final String methodName =
-                        currentToken.findFirstToken(TokenTypes.IDENT).getText();
-                final Integer previousIndex = methodIndexMap.get(methodName);
-                if (previousIndex != null && currentIndex - previousIndex > allowedDistance) {
-                    final int previousLineWithOverloadMethod =
-                            methodLineNumberMap.get(methodName);
-                    log(currentToken, MSG_KEY,
-                            previousLineWithOverloadMethod);
+                final int modifierGroupIndex = findModifierGroupPatternIndex(currentToken);
+                final String methodKey =
+                    String.format(Locale.ROOT, "%d%s%s", modifierGroupIndex, SEPARATOR,
+                                  currentToken.findFirstToken(TokenTypes.IDENT).getText());
+                final IndexAndLine indexAndLine =
+                    new IndexAndLine(currentIndex, currentToken.getLineNo());
+                final IndexAndLine previousMeta = knownMethods.put(methodKey, indexAndLine);
+                if (previousMeta != null
+                    && currentIndex - previousMeta.getIndex() > allowedDistance) {
+                    final int previousLineWithOverloadMethod = previousMeta.getLineNo();
+                    log(currentToken, MSG_KEY, previousLineWithOverloadMethod);
                 }
-                methodIndexMap.put(methodName, currentIndex);
-                methodLineNumberMap.put(methodName, currentToken.getLineNo());
             }
             currentToken = currentToken.getNextSibling();
         }
     }
 
+    /**
+     * Get the index of the first matching {@code modifierGroup} for the modifiers on the method.
+     *
+     * @param currentToken assumed to be a method
+     * @return index of the first modifier group that matches the modifiers on the method, or -1
+     *     if only the default group matches.
+     */
+    private int findModifierGroupPatternIndex(DetailAST currentToken) {
+        final String methodModifiers = getAllModifiersFrom(currentToken);
+        int modifierIndex = -1;
+        for (int index = 0; index < modifierGroups.length; index++) {
+            final Pattern pattern = modifierGroups[index];
+            final Matcher matcher = pattern.matcher(methodModifiers);
+            if (matcher.find()) {
+                modifierIndex = index;
+                break;
+            }
+        }
+        return modifierIndex;
+    }
+
+    /**
+     * Extract the modifier(s) of a method definition into a string.
+     *
+     * @param token expected to be TokenType.METHOD_DEF .
+     * @return modifier string for {@code token} with 'package' scope added if needed
+     */
+    private static String getAllModifiersFrom(final DetailAST token) {
+        final List<String> collectedModifiers = getExplicitModifiersFrom(token);
+        final String scope = ScopeUtil.getScope(token).getName();
+        if (!collectedModifiers.contains(scope)) {
+            collectedModifiers.add(0, scope);
+        }
+
+        // methods in interfaces can only have public, abstract, default, private,
+        // and static modifiers. a method can be abstract if and only if the only
+        // other modifier present is the public scope. If that is the case, add the implicit
+        // abstract modifier to the list
+        if (ScopeUtil.isInInterfaceBlock(token)
+            && List.of(Scope.PUBLIC.getName()).equals(collectedModifiers)) {
+            collectedModifiers.add(ABSTRACT_MODIFIER);
+        }
+
+        return String.join(" ", collectedModifiers);
+    }
+
+    /**
+     * Get the modifiers associated with a method.
+     *
+     * @param token the method token
+     * @return a list of modifiers found on the method, never empty
+     */
+    private static List<String> getExplicitModifiersFrom(final DetailAST token) {
+        final List<String> collectedModifiers = new LinkedList<>();
+        final DetailAST modifiersAst = token.findFirstToken(TokenTypes.MODIFIERS);
+        DetailAST modifier = modifiersAst.getFirstChild();
+        while (modifier != null) {
+            // skipping annotations
+            if (modifier.getType() != TokenTypes.ANNOTATION) {
+                collectedModifiers.add(modifier.getText());
+            }
+            // advance element in loop
+            modifier = modifier.getNextSibling();
+        }
+        return collectedModifiers;
+    }
+
+    /**
+     * Stores the {@code index} of a method in a class and the {@code lineNo}
+     * on which the method appears.
+     */
+    private static final class IndexAndLine {
+        /**
+         * The index of method within the containing class.
+         */
+        private final int index;
+
+        /**
+         * The line number on which the method appears in the class.
+         */
+        private final int lineNo;
+
+        /**
+         * Create a new composite tuple containing the {@code index} and {@code lineNo}
+         * of a method within a class.
+         *
+         * @param index the index of the method within the class
+         * @param lineNo the line number of the method in the class
+         */
+        private IndexAndLine(int index, int lineNo) {
+            this.index = index;
+            this.lineNo = lineNo;
+        }
+
+        /**
+         * Getter for the index.
+         *
+         * @return the method's index
+         */
+        public int getIndex() {
+            return index;
+        }
+
+        /**
+         * Getter for the line number.
+         *
+         * @return the method's line number
+         */
+        public int getLineNo() {
+            return lineNo;
+        }
+    }
 }

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/OverloadMethodsDeclarationOrderCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/OverloadMethodsDeclarationOrderCheck.xml
@@ -9,6 +9,14 @@
  name but different signatures where the signature can differ by the number of
  input parameters or type of input parameters or both.
  &lt;/p&gt;</description>
+         <properties>
+            <property default-value=""
+                       name="modifierGroups"
+                       type="java.util.regex.Pattern[]">
+               <description>control how different types of overloaded methods
+ can be grouped by their modifiers.</description>
+            </property>
+         </properties>
          <message-keys>
             <message-key key="overload.methods.declaration"/>
          </message-keys>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheckTest.java
@@ -61,6 +61,128 @@ public class OverloadMethodsDeclarationOrderCheckTest
     }
 
     @Test
+    public void testOverloadMethodsDeclarationOrderRecords2() throws Exception {
+
+        final String[] expected = {
+            "21:9: " + getCheckMessage(MSG_KEY, 16),
+            "30:9: " + getCheckMessage(MSG_KEY, 25),
+            "33:9: " + getCheckMessage(MSG_KEY, 27),
+        };
+        verifyWithInlineConfigParser(
+            getNonCompilablePath("InputOverloadMethodsDeclarationOrderRecords2.java"),
+            expected);
+    }
+
+    @Test
+    public void testBackwardsCompatibilityCatchAllGroup() throws Exception {
+        final String[] expected = {
+            "20:5: " + getCheckMessage(MSG_KEY, 15),
+            "35:9: " + getCheckMessage(MSG_KEY, 30),
+            "48:5: " + getCheckMessage(MSG_KEY, 45),
+            "80:5: " + getCheckMessage(MSG_KEY, 75),
+        };
+
+        verifyWithInlineConfigParser(
+            getPath("InputOverloadMethodsDeclarationOrder2.java"),
+            expected
+        );
+    }
+
+    @Test
+    public void testBackwardsCompatibilityEmptyModifiers() throws Exception {
+        final String[] expected = {
+            "20:5: " + getCheckMessage(MSG_KEY, 15),
+            "35:9: " + getCheckMessage(MSG_KEY, 30),
+            "48:5: " + getCheckMessage(MSG_KEY, 45),
+            "80:5: " + getCheckMessage(MSG_KEY, 75),
+        };
+
+        verifyWithInlineConfigParser(
+            getPath("InputOverloadMethodsDeclarationOrder2.java"),
+            expected
+        );
+    }
+
+    @Test
+    public void testOverloadMethodsDeclarationOrderStaticGrouped() throws Exception {
+        final String[] expected = {
+            "29:5: " + getCheckMessage(MSG_KEY, 24),
+            "37:5: " + getCheckMessage(MSG_KEY, 34),
+            "39:5: " + getCheckMessage(MSG_KEY, 35),
+            "47:5: " + getCheckMessage(MSG_KEY, 44),
+            "49:5: " + getCheckMessage(MSG_KEY, 45),
+            "57:5: " + getCheckMessage(MSG_KEY, 54),
+            "61:5: " + getCheckMessage(MSG_KEY, 58),
+            "68:5: " + getCheckMessage(MSG_KEY, 65),
+            "79:5: " + getCheckMessage(MSG_KEY, 74),
+            "92:5: " + getCheckMessage(MSG_KEY, 87),
+            "105:5: " + getCheckMessage(MSG_KEY, 102),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputOverloadMethodsDeclarationOrder3.java"), expected);
+    }
+
+    @Test
+    public void testOverloadMethodsDeclarationOrderAbstractAndPublicOrProtectedAndStatic()
+            throws Exception {
+        final String[] expected = {
+            "28:5: " + getCheckMessage(MSG_KEY, 25),
+            "30:5: " + getCheckMessage(MSG_KEY, 23),
+            "34:5: " + getCheckMessage(MSG_KEY, 26),
+            "44:5: " + getCheckMessage(MSG_KEY, 40),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputOverloadMethodsDeclarationOrder4.java"), expected);
+    }
+
+    @Test
+    public void testOverloadMethodsDeclarationOrderOrderMatters() throws Exception {
+        final String[] expected = {
+            "16:5: " + getCheckMessage(MSG_KEY, 11),
+            "19:5: " + getCheckMessage(MSG_KEY, 16),
+            "22:5: " + getCheckMessage(MSG_KEY, 19),
+            "30:5: " + getCheckMessage(MSG_KEY, 27),
+            "34:5: " + getCheckMessage(MSG_KEY, 30),
+            "36:5: " + getCheckMessage(MSG_KEY, 32),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputOverloadMethodsDeclarationOrder5.java"), expected);
+    }
+
+    @Test
+    public void testOverloadMethodsDeclarationOrderComplexRegex() throws Exception {
+        final String[] expected = {
+            "29:5: " + getCheckMessage(MSG_KEY, 26),
+            "39:5: " + getCheckMessage(MSG_KEY, 33),
+            "47:5: " + getCheckMessage(MSG_KEY, 44),
+            "56:5: " + getCheckMessage(MSG_KEY, 51),
+            "64:5: " + getCheckMessage(MSG_KEY, 61),
+            "77:5: " + getCheckMessage(MSG_KEY, 70),
+            "80:5: " + getCheckMessage(MSG_KEY, 74),
+            "92:5: " + getCheckMessage(MSG_KEY, 84),
+            "95:5: " + getCheckMessage(MSG_KEY, 88),
+            "103:5: " + getCheckMessage(MSG_KEY, 100),
+            "106:5: " + getCheckMessage(MSG_KEY, 103),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputOverloadMethodsDeclarationOrder6.java"), expected);
+    }
+
+    @Test
+    public void testOverloadMethodsDeclarationOrderDefaultModifiers() throws Exception {
+        final String[] expected = {
+            "16:5: " + getCheckMessage(MSG_KEY, 11),
+            "19:5: " + getCheckMessage(MSG_KEY, 13),
+            "35:5: " + getCheckMessage(MSG_KEY, 26),
+            "40:5: " + getCheckMessage(MSG_KEY, 28),
+            "43:5: " + getCheckMessage(MSG_KEY, 37),
+            "48:5: " + getCheckMessage(MSG_KEY, 40),
+        };
+        verifyWithInlineConfigParser(
+            getPath("InputOverloadMethodsDeclarationOrder8.java"), expected);
+    }
+
+    @Test
     public void testTokensNotNull() {
         final OverloadMethodsDeclarationOrderCheck check =
             new OverloadMethodsDeclarationOrderCheck();

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrderRecords2.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrderRecords2.java
@@ -1,0 +1,35 @@
+/*
+OverloadMethodsDeclarationOrder
+modifierGroups = static, public, protected|package
+
+
+
+*/
+
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.coding.overloadmethodsdeclarationorder;
+
+public class InputOverloadMethodsDeclarationOrderRecords2 {
+    record MyRecord1() {
+        public void foo(int i) { } // ok
+
+        public void foo(String s) { } // ok
+
+        public void notFoo() { } // ok
+
+        // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+        public void foo(int i, String s) { }
+
+        protected void foo(String s, int i) { } // ok
+
+        void foo(long l) { } // ok
+
+        static void notFoo(int i) { } // ok
+
+        // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+        void foo(String baz, long l) { }
+
+        // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+        public static void notFoo(long l) { }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrder2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrder2.java
@@ -1,0 +1,100 @@
+/*
+OverloadMethodsDeclarationOrder
+modifierGroups = .*
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.overloadmethodsdeclarationorder;
+
+class InputOverloadMethodsDeclarationOrder2
+{
+    public void overloadMethod(int i) { } // ok
+
+    public void overloadMethod(String s) { } // ok
+
+    public void overloadMethod(boolean b) { } // ok
+
+    public void fooMethod() { } // ok
+
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    public void overloadMethod(String s, Boolean b, int i) {
+
+    }
+
+    InputOverloadMethodsDeclarationOrder anonymous = new InputOverloadMethodsDeclarationOrder()
+    {
+        public void overloadMethod(int i) { } // ok
+
+        public void overloadMethod(String s) { } // ok
+
+        public void overloadMethod(boolean b) { } // ok
+
+        public void fooMethod() { } // ok
+
+        // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+        public void overloadMethod(String s, Boolean b, int i)
+        {
+            //some foo code
+        }
+    };
+}
+
+interface FooableBackwardsCompatible
+{
+    public abstract void foo(int i); // ok
+    public abstract void foo(String s); // ok
+    public abstract void noFoo(); // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    public abstract void foo(String s, Boolean b, int i);
+    private void foo() { } // ok
+}
+
+enum FooTypeBackwardsCompatible {
+    Strategy(""),
+    Shooter(""),
+    RPG("");
+
+    private String description;
+
+    private FooTypeBackwardsCompatible(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() { // ok
+        return description;
+    }
+
+    public void setDescription(String description) { // ok
+        this.description = description;
+    }
+
+    public void overloadMethod(int i) { } // ok
+
+    public void overloadMethod(String s) { } // ok
+
+    public void overloadMethod(boolean b) { } // ok
+
+    public void fooMethod() { } // ok
+
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    public void overloadMethod(String s, Boolean b, int i)
+    {
+        //some foo code
+    }
+}
+
+enum Foo2BackwardsCompatible {
+    VALUE {
+        public void value() {
+            value("");
+        } // ok
+
+        public void middle() { } // ok
+
+        public void value(String s) { } // ok
+    };
+}
+
+@interface ClassPreambleBackwardsCompatible {
+    String author(); // ok
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrder3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrder3.java
@@ -1,0 +1,106 @@
+/*
+OverloadMethodsDeclarationOrder
+modifierGroups = static
+
+
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.coding.overloadmethodsdeclarationorder;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+class InputOverloadMethodsDeclarationOrder3 {
+    void foo() {} // ok
+    void foo(String baz) { } // ok
+    void bar() { } // ok
+    static void foo(int a) { } // ok
+    static void bar(int a) { } // ok
+}
+
+class InputOverloadMethodsDeclarationOrder3_2 {
+    static private void foo(long b) { } // ok
+    void foo() {  } // ok
+    void foo(String baz) { } // ok
+    void bar() {  }
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    private static void foo(int a) { } // ok
+    private static void bar(int a) { } // ok
+}
+
+class InputOverloadMethodsDeclarationOrder3_3 {
+    public void foo(long b) { } // ok
+    public void bar(String baz) { } // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    private void foo(String baz) { }
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    void bar() { }
+    static public void foo(int a) { } // ok
+}
+
+class InputOverloadMethodsDeclarationOrder3_4 {
+    public void foo() { } // ok
+    private void bar(String baz) { } // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    private void foo(String baz) { }
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    void bar() { }
+    static protected final void foo(int a) { } // ok
+}
+
+class InputOverloadMethodsDeclarationOrder3_5 {
+    private void foo() { } // ok
+    void bar() { } // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    public void foo(String baz) { }
+    public void foo(CharSequence baz) { } // ok
+    private static void foo(int i) { } // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    private final void foo(long i) { }
+}
+
+abstract class InputOverloadMethodsDeclarationOrder3_6 {
+    protected void foo(double d) { } // ok
+    void bar() { } // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    protected abstract void foo(); // ok
+    void foo(int i) { } // ok
+    public final void foo(long b) { } // ok
+}
+
+abstract class InputOverloadMethodsDeclarationOrder3_7 {
+    private void foo(char c) { } // ok
+    void bar() { } // ok
+    static void foo(double d) { } // ok
+    static final int foo() {return  0;} // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    final void foo(String baz) { }
+    final public void foo(UUID baz) { } // ok
+    private void foo(int i) { } // ok
+    public final void foo(long i) { } // ok
+    abstract void foo(Error error); // ok
+}
+
+abstract class InputOverloadMethodsDeclarationOrder3_8 {
+    private void foo(char c) { } // ok
+    void bar() { } // ok
+    static void foo(long b) { } // ok
+    static final void foo(float f) { } // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    final void foo(String baz) { }
+    public void foo(Path baz) { } // ok
+    private void foo(int i) { } // ok
+    public @Deprecated final void foo(List<Long> list) { } // ok
+    abstract void foo(Map<Integer, Long> map); // ok
+}
+
+interface InputOverloadMethodsDeclarationOrder3_9 {
+    public abstract void foo(); // ok
+    void foo(int i); // ok
+    public abstract void foo(String bar); // ok
+    private static void foo(int i, String bar) { } // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    private void foo(long l) { }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrder4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrder4.java
@@ -1,0 +1,46 @@
+/*
+OverloadMethodsDeclarationOrder
+modifierGroups = static, abstract, public|protected|package
+
+
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.coding.overloadmethodsdeclarationorder;
+
+import java.nio.file.Path;
+
+class InputOverloadMethodsDeclarationOrder4 {
+    public void foo() { } // ok
+    protected void foo(String baz) { } // ok
+    void foo(int a) { } // ok
+    void bar() {} // ok
+    static void foo(byte b) { } // ok
+    static void bar(int a) { } // ok
+    private void foo(String s, int i) { } // ok
+}
+
+class InputOverloadMethodsDeclarationOrder4_2 {
+    static private void foo(long b) { } // ok
+    void foo() { } // ok
+    public void foo(String baz) { } // ok
+    private void foo(String s, int i) { } // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    protected void foo(byte b, int i) { }
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    private static void foo(int a) { } // ok
+    protected static void foo(int a, Path p) { } // ok
+    static void foo(long l, int i) { }
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    private void foo(byte b) { } // ok
+}
+
+interface InputOverloadMethodsDeclarationOrder4_3 {
+    public void foo(); // ok
+    void foo(int i); // ok
+    abstract void foo(String bar); // ok
+    private static void foo(byte b) { } // ok
+    void bar(long l); // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    void foo(long l); // ok
+    private void foo(int i, String bar) { } // ok
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrder5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrder5.java
@@ -1,0 +1,37 @@
+/*
+OverloadMethodsDeclarationOrder
+modifierGroups = public$, public final, static
+
+
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.coding.overloadmethodsdeclarationorder;
+
+class InputOverloadMethodsDeclarationOrder5 {
+    private void foo() { } // ok
+    void bar() { } // ok
+    static void foo(int i) { } // ok
+    static final void foo(String baz) { } // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    final void foo(String baz, int i) { }
+    final public void foo(String baz, long l) { } // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    private void foo(int i , String baz) { }
+    public final void foo(int i, long l) { } // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    void foo(long l) { }
+}
+
+interface InputOverloadMethodsDeclarationOrder5_2 {
+    void foo(); // ok
+    abstract void foo(int i); // ok
+    void bar(); // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    public abstract void foo(long l);
+    static public void foo(String baz) { } // ok
+    static void foo(long l, byte b) { } // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    public default void foo(byte b) { }
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    private static void foo( int i, String bar) { }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrder6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrder6.java
@@ -1,0 +1,108 @@
+/*
+OverloadMethodsDeclarationOrder
+modifierGroups = ^public .*, (protected|package), private, ^static$
+
+
+
+*/
+package com.puppycrawl.tools.checkstyle.checks.coding.overloadmethodsdeclarationorder;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+class InputOverloadMethodsDeclarationOrder6 {
+    public void foo() { } // ok
+    private void bar(String baz) { } // ok
+    private void foo(String baz) { } // ok
+    void bar() { } // ok
+    static protected final void foo(int a) { } // ok
+}
+
+class InputOverloadMethodsDeclarationOrder6_2 {
+    static private void foo(long b) { } // ok
+    void foo() { } // ok
+    void foo(String baz) { } // ok
+    void bar() { } // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    static void foo(int a) { }
+}
+
+class InputOverloadMethodsDeclarationOrder6_3 {
+    public void foo(long b) { } // ok
+    public void bar(String baz) { } // ok
+    private void foo(String baz) { } // ok
+    public static void foo(byte b) { } // ok
+    void bar() { } // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    static public void foo(int a) { }
+}
+
+class InputOverloadMethodsDeclarationOrder6_4 {
+    void foo() { } // ok
+    void foo(String baz) { } // ok
+    void bar() { } // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    static void foo(int a) { }
+}
+
+class InputOverloadMethodsDeclarationOrder6_5 {
+    private void foo() { } // ok
+    void bar() { } // ok
+    public void foo(String baz) { } // ok
+    public void foo(CharSequence baz) { } // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    private static void foo(int i) { }
+    private final void foo(long i) { } // ok
+}
+
+abstract class InputOverloadMethodsDeclarationOrder6_6 {
+    protected void foo(double d) { } // ok
+    void bar() { } // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    protected abstract void foo();
+    void foo(int i) { } // ok
+    public final void foo(long b) { } // ok
+}
+
+abstract class InputOverloadMethodsDeclarationOrder6_7 {
+    private void foo(char c) { } // ok
+    void bar() { } // ok
+    static void foo(double d) { } // ok
+    static final int foo() {return  0;} // ok
+    final void foo(String baz) { } // ok
+    final public void foo(UUID baz) { } // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    private void foo(int i) { }
+    public final void foo(long i) { } // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    abstract void foo(Error error);
+}
+
+abstract class InputOverloadMethodsDeclarationOrder6_8 {
+    private void foo(char c) { } // ok
+    void bar() { } // ok
+    static void foo(long b) { } // ok
+    static final void foo(float f) { } // ok
+    final void foo(String baz) { } // ok
+    public void foo(Path baz) { } // ok
+    public @Deprecated void foo(byte b) { } // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    private void foo(int i) { }
+    public @Deprecated final void foo(List<Long> list) { } // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    abstract void foo(Map<Integer, Long> map);
+}
+
+interface InputOverloadMethodsDeclarationOrder6_9 {
+    void foo(); // ok
+    abstract void foo(int i); // ok
+    void bar(); // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    public abstract void foo(long l);
+    abstract public void foo(String baz); // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    static void foo(int i, String bar) { }
+    private static void foo(String bar, int i) { } // ok
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrder7.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrder7.java
@@ -1,0 +1,100 @@
+/*
+OverloadMethodsDeclarationOrder
+modifierGroups =
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.overloadmethodsdeclarationorder;
+
+class InputOverloadMethodsDeclarationOrder7
+{
+    public void overloadMethod(int i) { } // ok
+
+    public void overloadMethod(String s) { } // ok
+
+    public void overloadMethod(boolean b) { } // ok
+
+    public void fooMethod() { } // ok
+
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    public void overloadMethod(String s, Boolean b, int i) {
+
+    }
+
+    InputOverloadMethodsDeclarationOrder anonymous = new InputOverloadMethodsDeclarationOrder()
+    {
+        public void overloadMethod(int i) { } // ok
+
+        public void overloadMethod(String s) { } // ok
+
+        public void overloadMethod(boolean b) { } // ok
+
+        public void fooMethod() { } // ok
+
+        // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+        public void overloadMethod(String s, Boolean b, int i)
+        {
+            //some foo code
+        }
+    };
+}
+
+interface InputOverloadMethodsDeclarationOrder7_2
+{
+    public abstract void foo(int i); // ok
+    public abstract void foo(String s); // ok
+    public abstract void noFoo(); // ok
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    public abstract void foo(String s, Boolean b, int i);
+    private void foo() { } // ok
+}
+
+enum InputOverloadMethodsDeclarationOrder7_3 {
+    Strategy(""),
+    Shooter(""),
+    RPG("");
+
+    private String description;
+
+    private InputOverloadMethodsDeclarationOrder7_3(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() { // ok
+        return description;
+    }
+
+    public void setDescription(String description) { // ok
+        this.description = description;
+    }
+
+    public void overloadMethod(int i) { } // ok
+
+    public void overloadMethod(String s) { } // ok
+
+    public void overloadMethod(boolean b) { } // ok
+
+    public void fooMethod() { } // ok
+
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    public void overloadMethod(String s, Boolean b, int i)
+    {
+        //some foo code
+    }
+}
+
+enum InputOverloadMethodsDeclarationOrder7_4 {
+    VALUE {
+        public void value() {
+            value("");
+        } // ok
+
+        public void middle() { } // ok
+
+        public void value(String s) { } // ok
+    };
+}
+
+@interface InputOverloadMethodsDeclarationOrder7_5 {
+    String author(); // ok
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrder8.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/overloadmethodsdeclarationorder/InputOverloadMethodsDeclarationOrder8.java
@@ -1,0 +1,49 @@
+/*
+OverloadMethodsDeclarationOrder
+modifierGroups = public$, package, public abstract$, private$
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.overloadmethodsdeclarationorder;
+
+class InputOverloadMethodsDeclarationOrder8
+{
+    public void overloadMethod(int i) { } // ok
+
+    void overloadMethod(boolean b) { } // ok
+
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    public void overloadMethod() { }
+
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    void overloadMethod(String s, Boolean b, int i) { }
+}
+
+interface InputOverloadMethodsDeclarationOrder8_2
+{
+    public abstract void foo(int i); // ok
+
+    void foo(String s); // ok
+
+    default void foo(byte b) { } // ok
+
+    private void foo(long l) { } // ok
+
+    private void foo(long l, long m) { } // ok
+
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    void foo(int i, String s);
+
+    abstract void foo(long l, byte b); // ok
+
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    public default void foo(long l, String s) { }
+
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    public void foo(int i, long l);
+
+    void foo(int i, int x); // ok
+
+    // violation below 'All overloaded methods.*Previous overloaded method located at.*'
+    static void foo(String s, byte b) { }
+}

--- a/src/xdocs/config_coding.xml
+++ b/src/xdocs/config_coding.xml
@@ -5763,26 +5763,98 @@ try (Reader r = new PipedReader(); s2; Reader s3 = new PipedReader() // violatio
         </p>
       </subsection>
 
+      <subsection name="Properties" id="OverloadMethodsDeclarationOrder_Properties">
+        <div class="wrapper">
+          <table>
+            <tr>
+              <th>name</th>
+              <th>description</th>
+              <th>type</th>
+              <th>default value</th>
+              <th>since</th>
+            </tr>
+            <tr>
+              <td>modifierGroups</td>
+              <td>control how different types of overloaded methods can be grouped by their
+                  modifiers.</td>
+              <td><a href="property_types.html#Pattern[]">Pattern[]</a></td>
+              <td><code>{}</code></td>
+              <th>10.4</th>
+            </tr>
+          </table>
+        </div>
+      </subsection>
+
       <subsection name="Examples" id="OverloadMethodsDeclarationOrder_Examples">
-        <p>To configure the check:</p>
+        <p>
+          To configure the check:
+        </p>
         <source>
 &lt;module name="OverloadMethodsDeclarationOrder"/&gt;
         </source>
+        <p>
+          Example of incorrect grouping of overloaded methods:
+        </p>
+        <source>
+public void foo() {} // OK
+public final void foo(int i) {} // OK
+void notFoo() {} // OK
+public static void foo(long l) {} // Violation, should be after 'foo(int i)'
+protected void foo(String s) {} // OK
+void foo(byte b) {} // OK
+private static void foo(String s, int i) { } // OK
+public void foo(String a, String b) {} // OK
+private void notFoo(int i) {} // Violation, should be after 'notFoo()'
+public final void foo(long x, long y) {} // Violation, should be after 'foo(String a, String b)'
+        </source>
         <p>Example of correct grouping of overloaded methods:</p>
         <source>
-public void foo(int i) {}
-public void foo(String s) {}
-public void foo(String s, int i) {}
-public void foo(int i, String s) {}
-public void notFoo() {}
-        </source>
-        <p>Example of incorrect grouping of overloaded methods:</p>
-        <source>
 public void foo(int i) {} // OK
-public void foo(String s) {} // OK
-public void notFoo() {} // violation. Have to be after foo(String s, int i)
-public void foo(int i, String s) {}
-public void foo(String s, int i) {}
+void foo(String s) {} // OK
+private void foo(String s, int i) {} // OK
+public void foo(int i, String s) {} // OK
+public void notFoo() {} // OK
+private void notFoo(int x) {} // OK
+        </source>
+        <p>
+          To configure the check to group static and private methods separately within their own
+          individual groups
+        </p>
+        <source>
+&lt;module name=&quot;OverloadMethodsDeclarationOrder&quot;&gt;
+  &lt;property name=&quot;modifierGroups&quot;
+  value=&quot;.*static.*, ^public .*, (protected|package), private&quot;&gt;&lt;/property&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Example of code with violation
+        </p>
+        <source>
+public void foo() {} // OK
+public final void foo(int i) {} // OK
+void notFoo() {} // OK
+public static void foo(long l) {} // OK
+protected void foo(String s) {} // OK
+void foo(byte b) {} // OK
+private static void foo(String s, int i) { } // Violation, should be after 'foo(long l)'
+public void foo(String a, String b) {} // Violation, should be after 'foo()'
+private void notFoo(int i) {} // OK
+public final void foo(long x, long y) {} // Violation, should be after 'foo(int i)'
+        </source>
+        <p>
+          Example of compliant code
+        </p>
+        <source>
+public void foo() {} // OK
+public void foo(String a, String b) {} // OK
+public final void foo(int i) {} // OK
+public final void foo(long x, long y) {} // OK
+void notFoo() {} // OK
+public static void foo(long l) {} // OK
+private static void foo(String s, int i) { } // OK
+protected void foo(String s) {} // OK
+void foo(byte b) {} // OK
+private void notFoo(int i) {} // OK
         </source>
       </subsection>
 


### PR DESCRIPTION
Fixes #3770

This PR completes the work initially started by @ilanKeshet to add the ability to split the overloading check into multiple different groups based on user-supplied regex patterns.

Diff Regression config: https://gist.githubusercontent.com/austinarbor/12a3207dfc1f347fd0da0083384399f0/raw/ba43cf7116d4c7c93109668869e081d1690d8316/config.xml
Diff Regression patch config: https://gist.githubusercontent.com/austinarbor/12a3207dfc1f347fd0da0083384399f0/raw/ba43cf7116d4c7c93109668869e081d1690d8316/config.xml
