### PR TITLE
Remove custom cache in Violation.java. It was extra cache for resource bundle cache for messages.

### DIFF
--- a/.ci/checker-framework-suppressions/checker-framework-formatter-suppressions.xml
+++ b/.ci/checker-framework-suppressions/checker-framework-formatter-suppressions.xml
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedErrors>
   <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java</fileName>
-    <specifier>i18nformat.key.not.found</specifier>
-    <message>a key doesn&apos;t exist in the provided translation file</message>
-    <lineContent>final String pattern = resourceBundle.getString(key);</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java</fileName>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java</fileName>
     <specifier>i18nformat.key.not.found</specifier>
     <message>a key doesn&apos;t exist in the provided translation file</message>
     <lineContent>final String pattern = resourceBundle.getString(key);</lineContent>

--- a/.ci/checker-framework-suppressions/checker-framework-nullness-optional-interning-suppressions.xml
+++ b/.ci/checker-framework-suppressions/checker-framework-nullness-optional-interning-suppressions.xml
@@ -178,35 +178,13 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter loader of getBundle.</message>
-    <lineContent>name, LOCALE, LocalizedMessage.class.getClassLoader(),</lineContent>
-    <details>
-      found   : @Initialized @Nullable ClassLoader
-      required: @Initialized @NonNull ClassLoader
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>args = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String @Initialized @NonNull []
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java</fileName>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
     <lineContent>this.args = null;</lineContent>
     <details>
       found   : null (NullType)
-      required: @Initialized @NonNull String @Initialized @NonNull []
+      required: @Initialized @NonNull Object @Initialized @NonNull []
     </details>
   </checkerFrameworkError>
 
@@ -1298,10 +1276,10 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java</fileName>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter loader of getBundle.</message>
-    <lineContent>name, sLocale, sourceClass.getClassLoader(), new Utf8Control());</lineContent>
+    <lineContent>return ResourceBundle.getBundle(bundle, locale, sourceClass.getClassLoader(),</lineContent>
     <details>
       found   : @Initialized @Nullable ClassLoader
       required: @Initialized @NonNull ClassLoader
@@ -1335,7 +1313,7 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java</fileName>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
     <lineContent>return resourceBundle;</lineContent>

--- a/.ci/checker-framework-suppressions/checker-framework-regex-property-key-compiler-message-suppressions.xml
+++ b/.ci/checker-framework-suppressions/checker-framework-regex-property-key-compiler-message-suppressions.xml
@@ -1,17 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedErrors>
   <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter key of getString.</message>
-    <lineContent>final String pattern = resourceBundle.getString(key);</lineContent>
-    <details>
-      found   : @UnknownPropertyKey String
-      required: @PropertyKey String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -133,7 +122,7 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java</fileName>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter key of getString.</message>
     <lineContent>final String pattern = resourceBundle.getString(key);</lineContent>

--- a/.ci/checker-framework-suppressions/checker-framework-signature-gui-units-init-suppressions.xml
+++ b/.ci/checker-framework-suppressions/checker-framework-signature-gui-units-init-suppressions.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedErrors>
   <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java</fileName>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter baseName of getBundle.</message>
-    <lineContent>name, LOCALE, LocalizedMessage.class.getClassLoader(),</lineContent>
+    <lineContent>return ResourceBundle.getBundle(bundle, locale, sourceClass.getClassLoader(),</lineContent>
     <details>
       found   : @SignatureUnknown String
       required: @BinaryName String
@@ -23,18 +23,7 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter baseName of getBundle.</message>
-    <lineContent>name, sLocale, sourceClass.getClassLoader(), new Utf8Control());</lineContent>
-    <details>
-      found   : @SignatureUnknown String
-      required: @BinaryName String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java</fileName>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter baseName of toBundleName.</message>
     <lineContent>final String bundleName = toBundleName(baseName, locale);</lineContent>

--- a/.ci/pitest-suppressions/pitest-common-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-common-suppressions.xml
@@ -325,17 +325,8 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>DefaultLogger.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.DefaultLogger$LocalizedMessage</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable args</description>
-    <lineContent>args = null;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>DefaultLogger.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.DefaultLogger$LocalizedMessage</mutatedClass>
+    <sourceFile>LocalizedMessage.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.LocalizedMessage</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
     <description>replaced call to java/util/Arrays::copyOf with argument</description>
@@ -343,8 +334,8 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>DefaultLogger.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.DefaultLogger$LocalizedMessage</mutatedClass>
+    <sourceFile>LocalizedMessage.java</sourceFile>
+    <mutatedClass>com.puppycrawl.tools.checkstyle.LocalizedMessage</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
     <description>Removed assignment to member variable args</description>
@@ -381,28 +372,10 @@
   <mutation unstable="false">
     <sourceFile>PackageObjectFactory.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
-    <mutatedMethod>createModule</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/Object::getClass</description>
-    <lineContent>new String[] {name, attemptedNames}, null, getClass(), null);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>PackageObjectFactory.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
     <mutatedMethod>createObjectFromFullModuleNames</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
     <description>replaced call to java/util/stream/Stream::sorted with receiver</description>
     <lineContent>.sorted()</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>PackageObjectFactory.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.PackageObjectFactory</mutatedClass>
-    <mutatedMethod>createObjectFromFullModuleNames</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/Object::getClass</description>
-    <lineContent>new String[] {name, optionalNames}, null, getClass(), null);</lineContent>
   </mutation>
 
   <mutation unstable="false">

--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -60,7 +60,7 @@
     <allow class="org.antlr.v4.runtime.CommonToken"/>
   </file>
 
-  <file name="DefaultLogger">
+  <file name="LocalizedMessage">
     <allow class="java.text.MessageFormat"/>
   </file>
 
@@ -116,6 +116,9 @@
     </file>
     <file name="TokenTypes">
       <allow class="org.antlr.v4.runtime.Recognizer"/>
+    </file>
+    <file name="Violation">
+      <allow class="com.puppycrawl.tools.checkstyle.LocalizedMessage"/>
     </file>
   </subpackage>
 

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -71,7 +71,7 @@
   <suppress checks="ClassDataAbstractionCoupling"
              files="(CheckerTest|AbstractModuleTestSupport|AbstractItModuleTestSupport|
                     |CheckstyleAntTaskTest|
-                    |TranslationCheckTest|ViolationTest|AbstractFileSetCheckTest|
+                    |TranslationCheckTest|LocalizedMessageTest|AbstractFileSetCheckTest|
                     |AbstractCheckTest)\.java"/>
   <suppress checks="ClassDataAbstractionCoupling"
              files="XpathFileGeneratorAuditListenerTest\.java"/>

--- a/pom.xml
+++ b/pom.xml
@@ -4222,6 +4222,7 @@
                 <param>com.puppycrawl.tools.checkstyle.DefaultContext*</param>
                 <param>com.puppycrawl.tools.checkstyle.DefaultLogger*</param>
                 <param>com.puppycrawl.tools.checkstyle.Definitions*</param>
+                <param>com.puppycrawl.tools.checkstyle.LocalizedMessage*</param>
                 <param>com.puppycrawl.tools.checkstyle.XMLLogger*</param>
                 <param>com.puppycrawl.tools.checkstyle.SarifLogger*</param>
                 <param>com.puppycrawl.tools.checkstyle.MetadataGeneratorLogger*</param>
@@ -4250,6 +4251,7 @@
                 <param>com.puppycrawl.tools.checkstyle.DefaultConfigurationTest</param>
                 <param>com.puppycrawl.tools.checkstyle.DefaultLoggerTest</param>
                 <param>com.puppycrawl.tools.checkstyle.DefinitionsTest</param>
+                <param>com.puppycrawl.tools.checkstyle.LocalizedMessageTest</param>
                 <param>com.puppycrawl.tools.checkstyle.XMLLoggerTest</param>
                 <param>com.puppycrawl.tools.checkstyle.SarifLoggerTest</param>
                 <param>com.puppycrawl.tools.checkstyle.MetadataGeneratorLoggerTest</param>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java
@@ -1,0 +1,158 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2022 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.MissingResourceException;
+import java.util.PropertyResourceBundle;
+import java.util.ResourceBundle;
+import java.util.ResourceBundle.Control;
+
+/**
+ * Represents a message that can be localised. The translations come from
+ * message.properties files. The underlying implementation uses
+ * java.text.MessageFormat.
+ */
+public class LocalizedMessage {
+
+    /** Name of the resource bundle to get messages from. **/
+    private final String bundle;
+
+    /**
+     * The locale to localise messages to.
+     **/
+    private final Locale locale;
+
+    /** Class of the source for this message. */
+    private final Class<?> sourceClass;
+
+    /**
+     * Key for the message format.
+     **/
+    private final String key;
+
+    /**
+     * Arguments for MessageFormat.
+     */
+    private final Object[] args;
+
+    /**
+     * Creates a new {@code LocalizedMessage} instance.
+     *
+     * @param bundle resource bundle name
+     * @param locale The locale to localise messages to.
+     * @param sourceClass the Class that is the source of the message
+     * @param key the key to locate the translation.
+     * @param args arguments for the translation.
+     */
+    public LocalizedMessage(String bundle, Locale locale, Class<?> sourceClass, String key,
+            Object... args) {
+        this.bundle = bundle;
+        this.locale = locale;
+        this.sourceClass = sourceClass;
+        this.key = key;
+        if (args == null) {
+            this.args = null;
+        }
+        else {
+            this.args = Arrays.copyOf(args, args.length);
+        }
+    }
+
+    /**
+     * Gets the translated message.
+     *
+     * @return the translated message.
+     */
+    public String getMessage() {
+        String result;
+        try {
+            // Important to use the default class loader, and not the one in
+            // the GlobalProperties object. This is because the class loader in
+            // the GlobalProperties is specified by the user for resolving
+            // custom classes.
+            final ResourceBundle resourceBundle = getBundle();
+            final String pattern = resourceBundle.getString(key);
+            final MessageFormat formatter = new MessageFormat(pattern, Locale.ROOT);
+            result = formatter.format(args);
+        }
+        catch (final MissingResourceException ignored) {
+            // If the Check author didn't provide i18n resource bundles
+            // and logs audit event messages directly, this will return
+            // the author's original message
+            final MessageFormat formatter = new MessageFormat(key, Locale.ROOT);
+            result = formatter.format(args);
+        }
+        return result;
+    }
+
+    /**
+     * Obtain the ResourceBundle. Uses the classloader
+     * of the class emitting this message, to be sure to get the correct
+     * bundle.
+     *
+     * @return a ResourceBundle.
+     */
+    private ResourceBundle getBundle() {
+        return ResourceBundle.getBundle(bundle, locale, sourceClass.getClassLoader(),
+                new Utf8Control());
+    }
+
+    /**
+     * <p>
+     * Custom ResourceBundle.Control implementation which allows explicitly read
+     * the properties files as UTF-8.
+     * </p>
+     */
+    public static class Utf8Control extends Control {
+
+        @Override
+        public ResourceBundle newBundle(String baseName, Locale locale, String format,
+                 ClassLoader loader, boolean reload) throws IOException {
+            // The below is a copy of the default implementation.
+            final String bundleName = toBundleName(baseName, locale);
+            final String resourceName = toResourceName(bundleName, "properties");
+            final URL url = loader.getResource(resourceName);
+            ResourceBundle resourceBundle = null;
+            if (url != null) {
+                final URLConnection connection = url.openConnection();
+                if (connection != null) {
+                    connection.setUseCaches(!reload);
+                    try (Reader streamReader = new InputStreamReader(connection.getInputStream(),
+                            StandardCharsets.UTF_8)) {
+                        // Only this line is changed to make it read property files as UTF-8.
+                        resourceBundle = new PropertyResourceBundle(streamReader);
+                    }
+                }
+            }
+            return resourceBundle;
+        }
+
+    }
+
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -40,8 +40,8 @@ import java.util.ResourceBundle;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.Maps;
+import com.puppycrawl.tools.checkstyle.LocalizedMessage.Utf8Control;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
-import com.puppycrawl.tools.checkstyle.api.Violation;
 import com.puppycrawl.tools.checkstyle.bdd.InlineConfigParser;
 import com.puppycrawl.tools.checkstyle.bdd.TestInputConfiguration;
 import com.puppycrawl.tools.checkstyle.bdd.TestInputViolation;
@@ -508,7 +508,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
                 messageBundle,
                 Locale.getDefault(),
                 Thread.currentThread().getContextClassLoader(),
-                new Violation.Utf8Control());
+                new Utf8Control());
         final String pattern = resourceBundle.getString(messageKey);
         final MessageFormat formatter = new MessageFormat(pattern, Locale.ROOT);
         return formatter.format(arguments);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
@@ -26,40 +26,32 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Locale;
-import java.util.Map;
 import java.util.ResourceBundle;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.DefaultLocale;
 
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean.OutputStreamOptions;
 import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
 import com.puppycrawl.tools.checkstyle.api.Violation;
-import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 public class DefaultLoggerTest {
 
     private static final Locale DEFAULT_LOCALE = Locale.getDefault();
 
     @AfterEach
-    public void tearDown() throws Exception {
-        final Constructor<?> cons = getConstructor();
-        final Map<String, ResourceBundle> bundleCache =
-                TestUtil.getInternalStaticState(cons.getDeclaringClass(), "BUNDLE_CACHE");
-        bundleCache.clear();
+    public void tearDown() {
+        ResourceBundle.clearCache();
     }
 
     @Test
-    public void testCtor() throws Exception {
+    public void testCtor() {
         final OutputStream infoStream = new ByteArrayOutputStream();
         final ByteArrayOutputStream errorStream = new ByteArrayOutputStream();
         final DefaultLogger dl = new DefaultLogger(infoStream, OutputStreamOptions.CLOSE,
@@ -67,16 +59,11 @@ public class DefaultLoggerTest {
         dl.addException(new AuditEvent(5000, "myfile"), new IllegalStateException("upsss"));
         dl.auditFinished(new AuditEvent(6000, "myfile"));
         final String output = errorStream.toString(StandardCharsets.UTF_8);
-        final Constructor<?> cons = getConstructor();
-        cons.setAccessible(true);
-        final Object addExceptionMessage = cons.newInstance(DefaultLogger.ADD_EXCEPTION_MESSAGE,
-                new String[] {"myfile"});
-        final Method getMessage = addExceptionMessage.getClass().getDeclaredMethod("getMessage");
-        getMessage.setAccessible(true);
-        final Object returnValue = getMessage.invoke(addExceptionMessage);
+        final LocalizedMessage addExceptionMessage = getAddExceptionMessageClass("myfile");
+        final String message = addExceptionMessage.getMessage();
         assertWithMessage("Invalid exception")
                 .that(output)
-                .contains(returnValue.toString());
+                .contains(message);
         assertWithMessage("Invalid exception class")
                 .that(output)
                 .contains("java.lang.IllegalStateException: upsss");
@@ -151,11 +138,11 @@ public class DefaultLoggerTest {
     }
 
     @Test
-    public void testAddError() throws Exception {
+    public void testAddError() {
         final OutputStream infoStream = new ByteArrayOutputStream();
         final OutputStream errorStream = new ByteArrayOutputStream();
-        final Method auditStartMessage = getAuditStartMessage();
-        final Method auditFinishMessage = getAuditFinishMessage();
+        final String auditStartMessage = getAuditStartMessage();
+        final String auditFinishMessage = getAuditFinishMessage();
         final DefaultLogger dl = new DefaultLogger(infoStream,
                 AutomaticBean.OutputStreamOptions.CLOSE, errorStream,
                 AutomaticBean.OutputStreamOptions.CLOSE);
@@ -164,13 +151,11 @@ public class DefaultLoggerTest {
         dl.addError(new AuditEvent(this, "fileName", new Violation(1, 2, "bundle", "key",
                 null, null, getClass(), "customViolation")));
         dl.auditFinished(null);
-        auditFinishMessage.setAccessible(true);
-        auditStartMessage.setAccessible(true);
         assertWithMessage("expected output")
             .that(infoStream.toString())
-            .isEqualTo(auditStartMessage.invoke(getAuditStartMessageClass())
+            .isEqualTo(auditStartMessage
                         + System.lineSeparator()
-                        + auditFinishMessage.invoke(getAuditFinishMessageClass())
+                        + auditFinishMessage
                         + System.lineSeparator());
         assertWithMessage("expected output")
             .that(errorStream.toString())
@@ -179,11 +164,11 @@ public class DefaultLoggerTest {
     }
 
     @Test
-    public void testAddErrorModuleId() throws Exception {
+    public void testAddErrorModuleId() {
         final OutputStream infoStream = new ByteArrayOutputStream();
         final OutputStream errorStream = new ByteArrayOutputStream();
-        final Method auditFinishMessage = getAuditFinishMessage();
-        final Method auditStartMessage = getAuditStartMessage();
+        final String auditFinishMessage = getAuditFinishMessage();
+        final String auditStartMessage = getAuditStartMessage();
         final DefaultLogger dl = new DefaultLogger(infoStream, OutputStreamOptions.CLOSE,
                 errorStream, OutputStreamOptions.CLOSE);
         dl.finishLocalSetup();
@@ -191,13 +176,11 @@ public class DefaultLoggerTest {
         dl.addError(new AuditEvent(this, "fileName", new Violation(1, 2, "bundle", "key",
                 null, "moduleId", getClass(), "customViolation")));
         dl.auditFinished(null);
-        auditFinishMessage.setAccessible(true);
-        auditStartMessage.setAccessible(true);
         assertWithMessage("expected output")
             .that(infoStream.toString())
-            .isEqualTo(auditStartMessage.invoke(getAuditStartMessageClass())
+            .isEqualTo(auditStartMessage
                         + System.lineSeparator()
-                        + auditFinishMessage.invoke(getAuditFinishMessageClass())
+                        + auditFinishMessage
                         + System.lineSeparator());
         assertWithMessage("expected output")
             .that(errorStream.toString())
@@ -259,46 +242,6 @@ public class DefaultLoggerTest {
         assertWithMessage("Invalid country")
                 .that(Arrays.asList(Locale.getISOCountries()))
                 .contains(country);
-    }
-
-    @DefaultLocale("fr")
-    @Test
-    public void testCleatBundleCache() throws Exception {
-        final Constructor<?> cons = getConstructor();
-        cons.setAccessible(true);
-        final Object messageClass = cons.newInstance(DefaultLogger.ADD_EXCEPTION_MESSAGE, null);
-        final Method message = messageClass.getClass().getDeclaredMethod("getMessage");
-        message.setAccessible(true);
-        final Map<String, ResourceBundle> bundleCache =
-                TestUtil.getInternalStaticState(message.getDeclaringClass(), "BUNDLE_CACHE");
-        assertWithMessage("Invalid message")
-            .that(message.invoke(messageClass))
-            .isEqualTo("Une erreur est survenue {0}");
-        assertWithMessage("Invalid bundle cache size")
-            .that(bundleCache)
-            .hasSize(1);
-    }
-
-    @Test
-    public void testNullArgs() throws Exception {
-        final Constructor<?> cons = getConstructor();
-        cons.setAccessible(true);
-        final Object messageClass = cons.newInstance(DefaultLogger.ADD_EXCEPTION_MESSAGE,
-                new String[] {"myfile"});
-        final Method message = messageClass.getClass().getDeclaredMethod("getMessage");
-        message.setAccessible(true);
-        final String output = (String) message.invoke(messageClass);
-        assertWithMessage("Violation should contain exception info")
-                .that(output)
-                .contains("Error auditing myfile");
-
-        final Object nullClass = cons.newInstance(DefaultLogger.ADD_EXCEPTION_MESSAGE, null);
-        final Method nullMessage = nullClass.getClass().getDeclaredMethod("getMessage");
-        nullMessage.setAccessible(true);
-        final String outputForNullArgs = (String) nullMessage.invoke(nullClass);
-        assertWithMessage("Violation should contain exception info")
-                .that(outputForNullArgs)
-                .contains("Error auditing {0}");
     }
 
     @Test
@@ -363,37 +306,29 @@ public class DefaultLoggerTest {
         }
     }
 
-    private static Constructor<?> getConstructor() throws Exception {
-        final Class<?> message = getDefaultLoggerClass().getDeclaredClasses()[0];
-        return message.getDeclaredConstructor(String.class, String[].class);
+    private static LocalizedMessage getAuditStartMessageClass() {
+        return new LocalizedMessage(Definitions.CHECKSTYLE_BUNDLE, Locale.getDefault(),
+                DefaultLogger.class, "DefaultLogger.auditStarted");
     }
 
-    private static Object getAuditStartMessageClass() throws Exception {
-        final Constructor<?> cons = getConstructor();
-        return cons.newInstance("DefaultLogger.auditStarted", null);
+    private static LocalizedMessage getAuditFinishMessageClass() {
+        return new LocalizedMessage(Definitions.CHECKSTYLE_BUNDLE, Locale.getDefault(),
+                DefaultLogger.class, "DefaultLogger.auditFinished");
     }
 
-    private static Object getAuditFinishMessageClass() throws Exception {
-        final Constructor<?> cons = getConstructor();
-        return cons.newInstance("DefaultLogger.auditFinished", null);
+    private static LocalizedMessage getAddExceptionMessageClass(Object... arguments) {
+        return new LocalizedMessage(Definitions.CHECKSTYLE_BUNDLE, Locale.getDefault(),
+                DefaultLogger.class, "DefaultLogger.addException", arguments);
     }
 
-    private static Method getAuditStartMessage() throws Exception {
-        final Constructor<?> cons = getConstructor();
-        cons.setAccessible(true);
-        final Object auditStartMessageClass = getAuditStartMessageClass();
-        return auditStartMessageClass.getClass().getDeclaredMethod("getMessage");
+    private static String getAuditStartMessage() {
+        final LocalizedMessage auditStartMessage = getAuditStartMessageClass();
+        return auditStartMessage.getMessage();
     }
 
-    private static Method getAuditFinishMessage() throws Exception {
-        final Constructor<?> cons = getConstructor();
-        cons.setAccessible(true);
-        final Object auditFinishMessageClass = getAuditFinishMessageClass();
-        return auditFinishMessageClass.getClass().getDeclaredMethod("getMessage");
-    }
-
-    private static Class<?> getDefaultLoggerClass() throws Exception {
-        return Class.forName("com.puppycrawl.tools.checkstyle.DefaultLogger");
+    private static String getAuditFinishMessage() {
+        final LocalizedMessage auditFinishMessage = getAuditFinishMessageClass();
+        return auditFinishMessage.getMessage();
     }
 
     private static class MockByteArrayOutputStream extends ByteArrayOutputStream {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/LocalizedMessageTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/LocalizedMessageTest.java
@@ -1,0 +1,230 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2022 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.util.Locale;
+import java.util.ResourceBundle;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.LocalizedMessage.Utf8Control;
+
+/**
+ * Custom class loader is needed to pass URLs to pretend these are loaded from the classpath
+ * though we can't add/change the files for testing. The class loader is nested in this class,
+ * so the custom class loader we are using is safe.
+ *
+ * @noinspection ClassLoaderInstantiation
+ * @noinspectionreason ClassLoaderInstantiation - Custom class loader is needed to
+ *      pass URLs for testing
+ */
+public class LocalizedMessageTest {
+
+    @Test
+    public void testNullArgs() {
+        final LocalizedMessage messageClass = new LocalizedMessage(Definitions.CHECKSTYLE_BUNDLE,
+                Locale.getDefault(), DefaultLogger.class, "DefaultLogger.addException", "myfile");
+        assertWithMessage("Violation should contain exception info")
+                .that(messageClass.getMessage())
+                .contains("Error auditing myfile");
+
+        final LocalizedMessage nullClass = new LocalizedMessage(Definitions.CHECKSTYLE_BUNDLE,
+                Locale.getDefault(), DefaultLogger.class, "DefaultLogger.addException");
+        final String outputForNullArgs = nullClass.getMessage();
+        assertWithMessage("Violation should contain exception info")
+                .that(outputForNullArgs)
+                .contains("Error auditing {0}");
+    }
+
+    @Test
+    public void testBundleReloadUrlNull() throws IOException {
+        final Utf8Control control = new Utf8Control();
+        final ResourceBundle bundle = control.newBundle(
+                "com.puppycrawl.tools.checkstyle.checks.coding.messages",
+                Locale.ENGLISH, "java.class",
+                Thread.currentThread().getContextClassLoader(), true);
+        assertWithMessage("Bundle should be null when reload is true and URL is null")
+                .that(bundle)
+                .isNull();
+    }
+
+    /**
+     * Tests reload of resource bundle.
+     *
+     * @noinspection resource, IOResourceOpenedButNotSafelyClosed
+     * @noinspectionreason resource - we have no need to use try with resources in testing
+     * @noinspectionreason IOResourceOpenedButNotSafelyClosed - no need to close resources in
+     *      testing
+     */
+    @Test
+    public void testBundleReloadUrlNotNull() throws IOException {
+        final AtomicBoolean closed = new AtomicBoolean();
+
+        final InputStream inputStream = new InputStream() {
+            @Override
+            public int read() {
+                return -1;
+            }
+
+            @Override
+            public void close() {
+                closed.set(true);
+            }
+        };
+        final URLConnection urlConnection = new URLConnection(null) {
+            @Override
+            public void connect() {
+                // no code
+            }
+
+            @Override
+            public InputStream getInputStream() {
+                return inputStream;
+            }
+        };
+        final URL url = new URL("test", null, 0, "", new URLStreamHandler() {
+            @Override
+            protected URLConnection openConnection(URL u) {
+                return urlConnection;
+            }
+        });
+
+        final Utf8Control control = new Utf8Control();
+        final ResourceBundle bundle = control.newBundle(
+                "com.puppycrawl.tools.checkstyle.checks.coding.messages", Locale.ENGLISH,
+                "java.class", new TestUrlsClassLoader(url), true);
+
+        assertWithMessage("Bundle should not be null when stream is not null")
+                .that(bundle)
+                .isNotNull();
+        assertWithMessage("connection should not be using caches")
+                .that(urlConnection.getUseCaches())
+                .isFalse();
+        assertWithMessage("connection should be closed")
+                .that(closed.get())
+                .isTrue();
+    }
+
+    /**
+     * Tests reload of resource bundle.
+     *
+     * @noinspection resource, IOResourceOpenedButNotSafelyClosed
+     * @noinspectionreason resource - we have no need to use try with resources in testing
+     * @noinspectionreason IOResourceOpenedButNotSafelyClosed - no need to close resources in
+     *      testing
+     */
+    @Test
+    public void testBundleReloadUrlNotNullFalseReload() throws IOException {
+        final AtomicBoolean closed = new AtomicBoolean();
+
+        final InputStream inputStream = new InputStream() {
+            @Override
+            public int read() {
+                return -1;
+            }
+
+            @Override
+            public void close() {
+                closed.set(true);
+            }
+        };
+        final URLConnection urlConnection = new URLConnection(null) {
+            @Override
+            public void connect() {
+                // no code
+            }
+
+            @Override
+            public InputStream getInputStream() {
+                return inputStream;
+            }
+        };
+        final URL url = new URL("test", null, 0, "", new URLStreamHandler() {
+            @Override
+            protected URLConnection openConnection(URL u) {
+                return urlConnection;
+            }
+        });
+
+        final Utf8Control control = new Utf8Control();
+        final ResourceBundle bundle = control.newBundle(
+                "com.puppycrawl.tools.checkstyle.checks.coding.messages", Locale.ENGLISH,
+                "java.class", new TestUrlsClassLoader(url), false);
+
+        assertWithMessage("Bundle should not be null when stream is not null")
+                .that(bundle)
+                .isNotNull();
+        assertWithMessage("connection should not be using caches")
+                .that(urlConnection.getUseCaches())
+                .isTrue();
+        assertWithMessage("connection should be closed")
+                .that(closed.get())
+                .isTrue();
+    }
+
+    @Test
+    public void testBundleReloadUrlNotNullStreamNull() throws IOException {
+        final URL url = new URL("test", null, 0, "", new URLStreamHandler() {
+            @Override
+            protected URLConnection openConnection(URL ignore) {
+                return null;
+            }
+        });
+
+        final Utf8Control control = new Utf8Control();
+        final ResourceBundle bundle = control.newBundle(
+                "com.puppycrawl.tools.checkstyle.checks.coding.messages",
+                Locale.ENGLISH, "java.class",
+                new TestUrlsClassLoader(url), true);
+        assertWithMessage("Bundle should be null when stream is null")
+                .that(bundle)
+                .isNull();
+    }
+
+    /**
+     * Mocked ClassLoader for testing URL loading.
+     *
+     * @noinspection CustomClassloader
+     * @noinspectionreason CustomClassloader - needed to pass URLs to pretend these are loaded
+     *      from the classpath though we can't add/change the files for testing
+     */
+    private static class TestUrlsClassLoader extends ClassLoader {
+
+        private final URL url;
+
+        /* package */ TestUrlsClassLoader(URL url) {
+            this.url = url;
+        }
+
+        @Override
+        public URL getResource(String name) {
+            return url;
+        }
+    }
+
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/ViolationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/ViolationTest.java
@@ -23,33 +23,15 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_OBJECT_ARRAY;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.net.URLConnection;
-import java.net.URLStreamHandler;
 import java.util.Locale;
-import java.util.Map;
-import java.util.ResourceBundle;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.DefaultLocale;
 
-import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.EqualsVerifierReport;
 
-/**
- * Custom class loader is needed to pass URLs to pretend these are loaded from the classpath
- * though we can't add/change the files for testing. The class loader is nested in this class,
- * so the custom class loader we are using is safe.
- *
- * @noinspection ClassLoaderInstantiation
- * @noinspectionreason ClassLoaderInstantiation - Custom class loader is needed to
- *      pass URLs for testing
- */
 public class ViolationTest {
 
     private static final Locale DEFAULT_LOCALE = Locale.getDefault();
@@ -127,151 +109,6 @@ public class ViolationTest {
     }
 
     @Test
-    public void testBundleReloadUrlNull() throws IOException {
-        final Violation.Utf8Control control = new Violation.Utf8Control();
-        final ResourceBundle bundle = control.newBundle(
-                "com.puppycrawl.tools.checkstyle.checks.coding.messages",
-                Locale.ENGLISH, "java.class",
-                Thread.currentThread().getContextClassLoader(), true);
-        assertWithMessage("Bundle should be null when reload is true and URL is null")
-            .that(bundle)
-            .isNull();
-    }
-
-    /**
-     * Tests reload of resource bundle.
-     *
-     * @noinspection resource, IOResourceOpenedButNotSafelyClosed
-     * @noinspectionreason resource - we have no need to use try with resources in testing
-     * @noinspectionreason IOResourceOpenedButNotSafelyClosed - no need to close resources in
-     *      testing
-     */
-    @Test
-    public void testBundleReloadUrlNotNull() throws IOException {
-        final AtomicBoolean closed = new AtomicBoolean();
-
-        final InputStream inputStream = new InputStream() {
-            @Override
-            public int read() {
-                return -1;
-            }
-
-            @Override
-            public void close() {
-                closed.set(true);
-            }
-        };
-        final URLConnection urlConnection = new URLConnection(null) {
-            @Override
-            public void connect() {
-                // no code
-            }
-
-            @Override
-            public InputStream getInputStream() {
-                return inputStream;
-            }
-        };
-        final URL url = new URL("test", null, 0, "", new URLStreamHandler() {
-            @Override
-            protected URLConnection openConnection(URL u) {
-                return urlConnection;
-            }
-        });
-
-        final Violation.Utf8Control control = new Violation.Utf8Control();
-        final ResourceBundle bundle = control.newBundle(
-                "com.puppycrawl.tools.checkstyle.checks.coding.messages", Locale.ENGLISH,
-                "java.class", new TestUrlsClassLoader(url), true);
-
-        assertWithMessage("Bundle should not be null when stream is not null")
-            .that(bundle)
-            .isNotNull();
-        assertWithMessage("connection should not be using caches")
-                .that(urlConnection.getUseCaches())
-                .isFalse();
-        assertWithMessage("connection should be closed")
-                .that(closed.get())
-                .isTrue();
-    }
-
-    /**
-     * Tests reload of resource bundle.
-     *
-     * @noinspection resource, IOResourceOpenedButNotSafelyClosed
-     * @noinspectionreason resource - we have no need to use try with resources in testing
-     * @noinspectionreason IOResourceOpenedButNotSafelyClosed - no need to close resources in
-     *      testing
-     */
-    @Test
-    public void testBundleReloadUrlNotNullFalseReload() throws IOException {
-        final AtomicBoolean closed = new AtomicBoolean();
-
-        final InputStream inputStream = new InputStream() {
-            @Override
-            public int read() {
-                return -1;
-            }
-
-            @Override
-            public void close() {
-                closed.set(true);
-            }
-        };
-        final URLConnection urlConnection = new URLConnection(null) {
-            @Override
-            public void connect() {
-                // no code
-            }
-
-            @Override
-            public InputStream getInputStream() {
-                return inputStream;
-            }
-        };
-        final URL url = new URL("test", null, 0, "", new URLStreamHandler() {
-            @Override
-            protected URLConnection openConnection(URL u) {
-                return urlConnection;
-            }
-        });
-
-        final Violation.Utf8Control control = new Violation.Utf8Control();
-        final ResourceBundle bundle = control.newBundle(
-                "com.puppycrawl.tools.checkstyle.checks.coding.messages", Locale.ENGLISH,
-                "java.class", new TestUrlsClassLoader(url), false);
-
-        assertWithMessage("Bundle should not be null when stream is not null")
-            .that(bundle)
-            .isNotNull();
-        assertWithMessage("connection should not be using caches")
-                .that(urlConnection.getUseCaches())
-                .isTrue();
-        assertWithMessage("connection should be closed")
-                .that(closed.get())
-                .isTrue();
-    }
-
-    @Test
-    public void testBundleReloadUrlNotNullStreamNull() throws IOException {
-        final URL url = new URL("test", null, 0, "", new URLStreamHandler() {
-            @Override
-            protected URLConnection openConnection(URL u) {
-                return null;
-            }
-        });
-
-        final Violation.Utf8Control control = new Violation.Utf8Control();
-        final ResourceBundle bundle = control.newBundle(
-                "com.puppycrawl.tools.checkstyle.checks.coding.messages",
-                Locale.ENGLISH, "java.class",
-                new TestUrlsClassLoader(url), true);
-        assertWithMessage("Bundle should be null when stream is null")
-            .that(bundle)
-            .isNull();
-    }
-
-    @Test
     public void testMessageInFrench() {
         final Violation violation = createSampleViolation();
         Violation.setLocale(Locale.FRENCH);
@@ -312,30 +149,6 @@ public class ViolationTest {
         assertWithMessage("Invalid violation key")
             .that(violation.getKey())
             .isEqualTo("empty.statement");
-    }
-
-    @DefaultLocale("fr")
-    @Test
-    public void testCleatBundleCache() {
-        Violation.setLocale(Locale.ROOT);
-        final Violation violation = createSampleViolation();
-
-        assertWithMessage("Invalid violation")
-            .that(violation.getViolation())
-            .isEqualTo("Empty statement.");
-
-        final Map<String, ResourceBundle> bundleCache =
-                TestUtil.getInternalStaticState(Violation.class, "BUNDLE_CACHE");
-
-        assertWithMessage("Invalid bundle cache size")
-            .that(bundleCache)
-            .hasSize(1);
-
-        Violation.setLocale(Locale.CHINA);
-
-        assertWithMessage("Invalid bundle cache size")
-            .that(bundleCache)
-            .isEmpty();
     }
 
     @Test
@@ -441,29 +254,7 @@ public class ViolationTest {
 
     @AfterEach
     public void tearDown() {
-        Violation.clearCache();
         Violation.setLocale(DEFAULT_LOCALE);
-    }
-
-    /**
-     * Mocked ClassLoader for testing URL loading.
-     *
-     * @noinspection CustomClassloader
-     * @noinspectionreason CustomClassloader - needed to pass URLs to pretend these are loaded
-     *      from the classpath though we can't add/change the files for testing
-     */
-    private static class TestUrlsClassLoader extends ClassLoader {
-
-        private final URL url;
-
-        /* package */ TestUrlsClassLoader(URL url) {
-            this.url = url;
-        }
-
-        @Override
-        public URL getResource(String name) {
-            return url;
-        }
     }
 
 }


### PR DESCRIPTION
Identified at https://github.com/hcoles/pitest/issues/1081#issuecomment-1226105481
while looking at https://github.com/checkstyle/checkstyle/pull/12053

`java.util.ResourceBundle.getBundle` has its own cache. It's cache is in the form `CacheKey(baseName, locale, module, callerModule)`. So extra cache in our code for this looks like not required.
The double cache has been there since 2002. The commit, 7e083cf6cbbe2b1590b92bf3feae547e5f58d6ac, says it is a 8% performance improvement.

While looking into this, bug was identified and posted at https://github.com/checkstyle/checkstyle/issues/12101 .

`Utf8Control` was made public in 7c2f448ad61f66224168d197dfc6195e7b8d9409 for no reason than for tests and not production code.

`DefaultLoggerTest#testCountryIsValid` and `DefaultLoggerTest#testLanguageIsValid` has no connection to `DefaultLogger`.

`Violation.clearCache()` is removed.

PR is currently the first stage of changes and I am going to add more changes:
Stage 2 is at https://github.com/checkstyle/checkstyle/pull/12105 and waiting for this to be merged.
Stage 3 is planned to be https://github.com/checkstyle/checkstyle/issues/12104 .
Stage 4 was probably going to be some other left over things, possibly things 2 did not finish.
All of this is to basically assist with resolving issues found at https://github.com/checkstyle/checkstyle/pull/12053 .