### PR TITLE
Issue #12101: move global locale to localized message 

### DIFF
--- a/.ci/checker-framework-suppressions/checker-framework-index-suppressions.xml
+++ b/.ci/checker-framework-suppressions/checker-framework-index-suppressions.xml
@@ -663,24 +663,6 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java</fileName>
-    <specifier>array.initializer</specifier>
-    <message>incompatible types in array initializer.</message>
-    <lineContent>WRONG_LANGUAGE_CODE_KEY, new Object[] {code}, getId(), getClass(), null);</lineContent>
-    <details>
-      found   : @SameLen({&quot;code&quot;, &quot;iter#num0.next()&quot;}) String
-      required: @SameLen({&quot;code&quot;, &quot;[error for expression: iter#num0.next(); error: Invalid &apos;iter#num0.next()&apos; because the expression did not parse. Error message: Lexical error at line 1, column 5.  Encountered: &quot;#&quot; (35), after : &quot;&quot;]&quot;}) Object
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java</fileName>
-    <specifier>expression.unparsable</specifier>
-    <message>Expression invalid in dependent type annotation: [error for expression: iter#num0.next(); error: Invalid &apos;iter#num0.next()&apos; because the expression did not parse. Error message: Lexical error at line 1, column 5.  Encountered: &quot;#&quot; (35), after : &quot;&quot;]</message>
-    <lineContent>WRONG_LANGUAGE_CODE_KEY, new Object[] {code}, getId(), getClass(), null);</lineContent>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>

--- a/.ci/checker-framework-suppressions/checker-framework-nullness-optional-interning-suppressions.xml
+++ b/.ci/checker-framework-suppressions/checker-framework-nullness-optional-interning-suppressions.xml
@@ -1279,7 +1279,7 @@
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter loader of getBundle.</message>
-    <lineContent>return ResourceBundle.getBundle(bundle, locale, sourceClass.getClassLoader(),</lineContent>
+    <lineContent>return ResourceBundle.getBundle(bundle, sLocale, sourceClass.getClassLoader(),</lineContent>
     <details>
       found   : @Initialized @Nullable ClassLoader
       required: @Initialized @NonNull ClassLoader
@@ -1320,17 +1320,6 @@
     <details>
       type of expression: @Initialized @Nullable ResourceBundle
       method return type: @Initialized @NonNull ResourceBundle
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java</fileName>
-    <specifier>return</specifier>
-    <message>incompatible types in return.</message>
-    <lineContent>return violation;</lineContent>
-    <details>
-      type of expression: @Initialized @Nullable String
-      method return type: @Initialized @NonNull String
     </details>
   </checkerFrameworkError>
 

--- a/.ci/checker-framework-suppressions/checker-framework-nullness-optional-interning-suppressions.xml
+++ b/.ci/checker-framework-suppressions/checker-framework-nullness-optional-interning-suppressions.xml
@@ -289,17 +289,6 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter customMessage of Violation.</message>
-    <lineContent>null);</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter child of addChild.</message>
@@ -492,55 +481,11 @@
   <checkerFrameworkError unstable="false">
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
     <specifier>argument</specifier>
-    <message>incompatible argument for parameter customMessage of Violation.</message>
-    <lineContent>new String[] {String.valueOf(errorCounter)}, null, Main.class, null);</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter customMessage of Violation.</message>
-    <lineContent>new String[] {file.getAbsolutePath()}, null, Main.class, null);</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
-    <specifier>argument</specifier>
     <message>incompatible argument for parameter moduleClassLoader of getRootModule.</message>
     <lineContent>final RootModule rootModule = getRootModule(config.getName(), moduleClassLoader);</lineContent>
     <details>
       found   : @Initialized @Nullable ClassLoader
       required: @Initialized @NonNull ClassLoader
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter moduleId of Violation.</message>
-    <lineContent>new String[] {String.valueOf(errorCounter)}, null, Main.class, null);</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter moduleId of Violation.</message>
-    <lineContent>new String[] {file.getAbsolutePath()}, null, Main.class, null);</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String
     </details>
   </checkerFrameworkError>
 
@@ -653,55 +598,11 @@
   <checkerFrameworkError unstable="false">
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java</fileName>
     <specifier>argument</specifier>
-    <message>incompatible argument for parameter args of Violation.</message>
-    <lineContent>new String[] {name, attemptedNames}, null, getClass(), null);</lineContent>
+    <message>incompatible argument for parameter args of LocalizedMessage.</message>
+    <lineContent>UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE, name, attemptedNames);</lineContent>
     <details>
-      found   : @Initialized @Nullable String @Initialized @NonNull []
-      required: @Initialized @NonNull Object @Initialized @NonNull []
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter customMessage of Violation.</message>
-    <lineContent>new String[] {name, attemptedNames}, null, getClass(), null);</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter customMessage of Violation.</message>
-    <lineContent>new String[] {name, optionalNames}, null, getClass(), null);</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter moduleId of Violation.</message>
-    <lineContent>new String[] {name, attemptedNames}, null, getClass(), null);</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter moduleId of Violation.</message>
-    <lineContent>new String[] {name, optionalNames}, null, getClass(), null);</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String
+         found   : @Initialized @Nullable String
+         required: @Initialized @NonNull Object
     </details>
   </checkerFrameworkError>
 
@@ -1439,17 +1340,6 @@
     <details>
       found   : @Initialized @NonNull String @Initialized @Nullable []
       required: @Initialized @NonNull Object @Initialized @NonNull []
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter customMessage of Violation.</message>
-    <lineContent>WRONG_LANGUAGE_CODE_KEY, new Object[] {code}, getId(), getClass(), null);</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String
     </details>
   </checkerFrameworkError>
 

--- a/.ci/checker-framework-suppressions/checker-framework-signature-gui-units-init-suppressions.xml
+++ b/.ci/checker-framework-suppressions/checker-framework-signature-gui-units-init-suppressions.xml
@@ -4,7 +4,7 @@
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter baseName of getBundle.</message>
-    <lineContent>return ResourceBundle.getBundle(bundle, locale, sourceClass.getClassLoader(),</lineContent>
+    <lineContent>return ResourceBundle.getBundle(bundle, sLocale, sourceClass.getClassLoader(),</lineContent>
     <details>
       found   : @SignatureUnknown String
       required: @BinaryName String

--- a/.ci/pitest-suppressions/pitest-misc-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-misc-suppressions.xml
@@ -209,15 +209,6 @@
 
   <mutation unstable="false">
     <sourceFile>TranslationCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.TranslationCheck</mutatedClass>
-    <mutatedMethod>validateUserSpecifiedLanguageCodes</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/checks/TranslationCheck::getId</description>
-    <lineContent>WRONG_LANGUAGE_CODE_KEY, new Object[] {code}, getId(), getClass(), null);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>TranslationCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.TranslationCheck$ResourceBundle</mutatedClass>
     <mutatedMethod>getFiles</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>

--- a/.ci/pitest-suppressions/pitest-tree-walker-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-tree-walker-suppressions.xml
@@ -3,15 +3,6 @@
   <mutation unstable="false">
     <sourceFile>DetailNodeTreeStringPrinter.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.DetailNodeTreeStringPrinter</mutatedClass>
-    <mutatedMethod>getParseErrorMessage</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser$ParseErrorMessage::getLineNumber</description>
-    <lineContent>parseErrorMessage.getLineNumber(),</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>DetailNodeTreeStringPrinter.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailNodeTreeStringPrinter</mutatedClass>
     <mutatedMethod>parseFile</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to java/nio/charset/Charset::name</description>

--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -136,6 +136,9 @@
     <allow class="com.puppycrawl.tools.checkstyle.FileStatefulCheck"/>
     <allow class="com.puppycrawl.tools.checkstyle.GlobalStatefulCheck"/>
 
+    <file name="TranslationCheck">
+      <allow class="com.puppycrawl.tools.checkstyle.LocalizedMessage"/>
+    </file>
     <subpackage name="imports">
       <allow class="com.puppycrawl.tools.checkstyle.XmlLoader" local-only="true"/>
     </subpackage>

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -336,10 +336,12 @@
       <!-- Main actively uses Checkstyle, logging and command line parsing API.
            Checker collects external resource locations and sets up the configuration.
            CheckstyleAntTask integrates Checkstyle with Ant.
+           TranslationCheck uses a lot of imports for it's logic and custom violations.
             -->
       <property name="violationSuppressXPath"
                 value="//ClassOrInterfaceDeclaration[@SimpleName='Main'
-        or @SimpleName='Checker' or @SimpleName='CheckstyleAntTask']"/>
+        or @SimpleName='Checker' or @SimpleName='CheckstyleAntTask'
+        or @SimpleName='TranslationCheck']"/>
     </properties>
   </rule>
   <rule ref="category/java/design.xml/CognitiveComplexity">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -431,7 +431,7 @@ public class Checker extends AutomaticBean implements MessageDispatcher, RootMod
     @Override
     protected void finishLocalSetup() throws CheckstyleException {
         final Locale locale = new Locale(localeLanguage, localeCountry);
-        Violation.setLocale(locale);
+        LocalizedMessage.setLocale(locale);
 
         if (moduleFactory == null) {
             if (moduleClassLoader == null) {

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DefaultLogger.java
@@ -24,7 +24,6 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.util.Locale;
 
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AuditListener;
@@ -161,7 +160,7 @@ public class DefaultLogger extends AutomaticBean implements AuditListener {
     public void addException(AuditEvent event, Throwable throwable) {
         synchronized (errorWriter) {
             final LocalizedMessage exceptionMessage = new LocalizedMessage(
-                    Definitions.CHECKSTYLE_BUNDLE, Locale.getDefault(), DefaultLogger.class,
+                    Definitions.CHECKSTYLE_BUNDLE, DefaultLogger.class,
                     ADD_EXCEPTION_MESSAGE, event.getFileName());
             errorWriter.println(exceptionMessage.getMessage());
             throwable.printStackTrace(errorWriter);
@@ -171,7 +170,7 @@ public class DefaultLogger extends AutomaticBean implements AuditListener {
     @Override
     public void auditStarted(AuditEvent event) {
         final LocalizedMessage auditStartMessage = new LocalizedMessage(
-                Definitions.CHECKSTYLE_BUNDLE, Locale.getDefault(), DefaultLogger.class,
+                Definitions.CHECKSTYLE_BUNDLE, DefaultLogger.class,
                 AUDIT_STARTED_MESSAGE);
         infoWriter.println(auditStartMessage.getMessage());
         infoWriter.flush();
@@ -180,7 +179,7 @@ public class DefaultLogger extends AutomaticBean implements AuditListener {
     @Override
     public void auditFinished(AuditEvent event) {
         final LocalizedMessage auditFinishMessage = new LocalizedMessage(
-                Definitions.CHECKSTYLE_BUNDLE, Locale.getDefault(), DefaultLogger.class,
+                Definitions.CHECKSTYLE_BUNDLE, DefaultLogger.class,
                 AUDIT_FINISHED_MESSAGE);
         infoWriter.println(auditFinishMessage.getMessage());
         closeStreams();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
@@ -29,7 +29,6 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
-import com.puppycrawl.tools.checkstyle.api.Violation;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 import com.puppycrawl.tools.checkstyle.utils.ParserUtil;
 
@@ -91,15 +90,12 @@ public final class DetailNodeTreeStringPrinter {
      * @return error violation
      */
     private static String getParseErrorMessage(ParseErrorMessage parseErrorMessage) {
-        final Violation lmessage = new Violation(
-                parseErrorMessage.getLineNumber(),
+        final LocalizedMessage message = new LocalizedMessage(
                 "com.puppycrawl.tools.checkstyle.checks.javadoc.messages",
-                parseErrorMessage.getMessageKey(),
-                parseErrorMessage.getMessageArguments(),
-                "",
                 DetailNodeTreeStringPrinter.class,
-                null);
-        return "[ERROR:" + parseErrorMessage.getLineNumber() + "] " + lmessage.getViolation();
+                parseErrorMessage.getMessageKey(),
+                parseErrorMessage.getMessageArguments());
+        return "[ERROR:" + parseErrorMessage.getLineNumber() + "] " + message.getMessage();
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java
@@ -40,13 +40,11 @@ import java.util.ResourceBundle.Control;
  */
 public class LocalizedMessage {
 
+    /** The locale to localise messages to. **/
+    private static Locale sLocale = Locale.getDefault();
+
     /** Name of the resource bundle to get messages from. **/
     private final String bundle;
-
-    /**
-     * The locale to localise messages to.
-     **/
-    private final Locale locale;
 
     /** Class of the source for this message. */
     private final Class<?> sourceClass;
@@ -65,15 +63,13 @@ public class LocalizedMessage {
      * Creates a new {@code LocalizedMessage} instance.
      *
      * @param bundle resource bundle name
-     * @param locale The locale to localise messages to.
      * @param sourceClass the Class that is the source of the message
      * @param key the key to locate the translation.
      * @param args arguments for the translation.
      */
-    public LocalizedMessage(String bundle, Locale locale, Class<?> sourceClass, String key,
+    public LocalizedMessage(String bundle, Class<?> sourceClass, String key,
             Object... args) {
         this.bundle = bundle;
-        this.locale = locale;
         this.sourceClass = sourceClass;
         this.key = key;
         if (args == null) {
@@ -81,6 +77,20 @@ public class LocalizedMessage {
         }
         else {
             this.args = Arrays.copyOf(args, args.length);
+        }
+    }
+
+    /**
+     * Sets a locale to use for localization.
+     *
+     * @param locale the locale to use for localization
+     */
+    public static void setLocale(Locale locale) {
+        if (Locale.ENGLISH.getLanguage().equals(locale.getLanguage())) {
+            sLocale = Locale.ROOT;
+        }
+        else {
+            sLocale = locale;
         }
     }
 
@@ -119,7 +129,7 @@ public class LocalizedMessage {
      * @return a ResourceBundle.
      */
     private ResourceBundle getBundle() {
-        return ResourceBundle.getBundle(bundle, locale, sourceClass.getClassLoader(),
+        return ResourceBundle.getBundle(bundle, sLocale, sourceClass.getClassLoader(),
                 new Utf8Control());
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Main.java
@@ -48,7 +48,6 @@ import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.api.RootModule;
-import com.puppycrawl.tools.checkstyle.api.Violation;
 import com.puppycrawl.tools.checkstyle.utils.ChainedPropertyUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import com.puppycrawl.tools.checkstyle.utils.XpathUtil;
@@ -146,12 +145,12 @@ public final class Main {
         finally {
             // return exit code base on validation of Checker
             if (errorCounter > 0) {
-                final Violation errorCounterViolation = new Violation(1,
-                        Definitions.CHECKSTYLE_BUNDLE, ERROR_COUNTER,
-                        new String[] {String.valueOf(errorCounter)}, null, Main.class, null);
+                final LocalizedMessage errorCounterViolation = new LocalizedMessage(
+                        Definitions.CHECKSTYLE_BUNDLE, Main.class,
+                        ERROR_COUNTER, String.valueOf(errorCounter));
                 // print error count statistic to error output stream,
                 // output stream might be used by validation report content
-                System.err.println(errorCounterViolation.getViolation());
+                System.err.println(errorCounterViolation.getMessage());
             }
         }
         Runtime.getRuntime().exit(exitStatus);
@@ -439,10 +438,10 @@ public final class Main {
             properties.load(stream);
         }
         catch (final IOException ex) {
-            final Violation loadPropertiesExceptionMessage = new Violation(1,
-                    Definitions.CHECKSTYLE_BUNDLE, LOAD_PROPERTIES_EXCEPTION,
-                    new String[] {file.getAbsolutePath()}, null, Main.class, null);
-            throw new CheckstyleException(loadPropertiesExceptionMessage.getViolation(), ex);
+            final LocalizedMessage loadPropertiesExceptionMessage = new LocalizedMessage(
+                    Definitions.CHECKSTYLE_BUNDLE, Main.class,
+                    LOAD_PROPERTIES_EXCEPTION, file.getAbsolutePath());
+            throw new CheckstyleException(loadPropertiesExceptionMessage.getMessage(), ex);
         }
 
         return ChainedPropertyUtil.getResolvedProperties(properties);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -31,7 +31,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
-import com.puppycrawl.tools.checkstyle.api.Violation;
 import com.puppycrawl.tools.checkstyle.utils.ModuleReflectionUtil;
 
 /**
@@ -209,10 +208,10 @@ public class PackageObjectFactory implements ModuleFactory {
                         + STRING_SEPARATOR + nameCheck + STRING_SEPARATOR
                         + joinPackageNamesWithClassName(nameCheck, packages);
             }
-            final Violation exceptionMessage = new Violation(1,
-                Definitions.CHECKSTYLE_BUNDLE, UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE,
-                new String[] {name, attemptedNames}, null, getClass(), null);
-            throw new CheckstyleException(exceptionMessage.getViolation());
+            final LocalizedMessage exceptionMessage = new LocalizedMessage(
+                Definitions.CHECKSTYLE_BUNDLE, getClass(),
+                UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE, name, attemptedNames);
+            throw new CheckstyleException(exceptionMessage.getMessage());
         }
         return instance;
     }
@@ -285,10 +284,10 @@ public class PackageObjectFactory implements ModuleFactory {
             final String optionalNames = fullModuleNames.stream()
                     .sorted()
                     .collect(Collectors.joining(STRING_SEPARATOR));
-            final Violation exceptionMessage = new Violation(1,
-                    Definitions.CHECKSTYLE_BUNDLE, AMBIGUOUS_MODULE_NAME_EXCEPTION_MESSAGE,
-                    new String[] {name, optionalNames}, null, getClass(), null);
-            throw new CheckstyleException(exceptionMessage.getViolation());
+            final LocalizedMessage exceptionMessage = new LocalizedMessage(
+                    Definitions.CHECKSTYLE_BUNDLE, getClass(),
+                    AMBIGUOUS_MODULE_NAME_EXCEPTION_MESSAGE, name, optionalNames);
+            throw new CheckstyleException(exceptionMessage.getMessage());
         }
         return returnValue;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java
@@ -46,9 +46,6 @@ public final class Violation
     /** The default severity level if one is not specified. */
     private static final SeverityLevel DEFAULT_SEVERITY = SeverityLevel.ERROR;
 
-    /** The locale to localise violations to. **/
-    private static Locale sLocale = Locale.getDefault();
-
     /** The line number. **/
     private final int lineNo;
     /** The column number. **/
@@ -359,20 +356,6 @@ public final class Violation
     }
 
     /**
-     * Sets a locale to use for localization.
-     *
-     * @param locale the locale to use for localization
-     */
-    public static void setLocale(Locale locale) {
-        if (Locale.ENGLISH.getLanguage().equals(locale.getLanguage())) {
-            sLocale = Locale.ROOT;
-        }
-        else {
-            sLocale = locale;
-        }
-    }
-
-    /**
      * Indicates whether some other object is "equal to" this one.
      * Suppression on enumeration is needed so code stays consistent.
      *
@@ -451,7 +434,7 @@ public final class Violation
         String violation = getCustomViolation();
 
         if (violation == null) {
-            violation = new LocalizedMessage(bundle, sLocale, sourceClass, key, args).getMessage();
+            violation = new LocalizedMessage(bundle, sourceClass, key, args).getMessage();
         }
         return violation;
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java
@@ -431,26 +431,15 @@ public final class Violation
      * @return the translated violation
      */
     public String getViolation() {
-        String violation = getCustomViolation();
+        final String violation;
 
-        if (violation == null) {
+        if (customMessage != null) {
+            violation = new MessageFormat(customMessage, Locale.ROOT).format(args);
+        }
+        else {
             violation = new LocalizedMessage(bundle, sourceClass, key, args).getMessage();
         }
-        return violation;
-    }
 
-    /**
-     * Returns the formatted custom violation if one is configured.
-     *
-     * @return the formatted custom violation or {@code null}
-     *          if there is no custom violation
-     */
-    private String getCustomViolation() {
-        String violation = null;
-        if (customMessage != null) {
-            final MessageFormat formatter = new MessageFormat(customMessage, Locale.ROOT);
-            violation = formatter.format(args);
-        }
         return violation;
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -45,6 +45,7 @@ import org.apache.commons.logging.LogFactory;
 
 import com.puppycrawl.tools.checkstyle.Definitions;
 import com.puppycrawl.tools.checkstyle.GlobalStatefulCheck;
+import com.puppycrawl.tools.checkstyle.LocalizedMessage;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.MessageDispatcher;
@@ -318,11 +319,9 @@ public class TranslationCheck extends AbstractFileSetCheck {
     private void validateUserSpecifiedLanguageCodes(Set<String> languageCodes) {
         for (String code : languageCodes) {
             if (!isValidLanguageCode(code)) {
-                final Violation msg = new Violation(1, TRANSLATION_BUNDLE,
-                        WRONG_LANGUAGE_CODE_KEY, new Object[] {code}, getId(), getClass(), null);
-                final String exceptionMessage = String.format(Locale.ROOT,
-                        "%s [%s]", msg.getViolation(), TranslationCheck.class.getSimpleName());
-                throw new IllegalArgumentException(exceptionMessage);
+                final LocalizedMessage msg = new LocalizedMessage(TRANSLATION_BUNDLE,
+                        getClass(), WRONG_LANGUAGE_CODE_KEY, code);
+                throw new IllegalArgumentException(msg.getMessage());
             }
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -491,7 +491,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
             .that(context.get("basedir"))
             .isEqualTo("testBaseDir");
 
-        final Field sLocale = Violation.class.getDeclaredField("sLocale");
+        final Field sLocale = LocalizedMessage.class.getDeclaredField("sLocale");
         sLocale.setAccessible(true);
         final Locale locale = (Locale) sLocale.get(null);
         assertWithMessage("Locale is set to unexpected value")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DefaultLoggerTest.java
@@ -307,17 +307,17 @@ public class DefaultLoggerTest {
     }
 
     private static LocalizedMessage getAuditStartMessageClass() {
-        return new LocalizedMessage(Definitions.CHECKSTYLE_BUNDLE, Locale.getDefault(),
+        return new LocalizedMessage(Definitions.CHECKSTYLE_BUNDLE,
                 DefaultLogger.class, "DefaultLogger.auditStarted");
     }
 
     private static LocalizedMessage getAuditFinishMessageClass() {
-        return new LocalizedMessage(Definitions.CHECKSTYLE_BUNDLE, Locale.getDefault(),
+        return new LocalizedMessage(Definitions.CHECKSTYLE_BUNDLE,
                 DefaultLogger.class, "DefaultLogger.auditFinished");
     }
 
     private static LocalizedMessage getAddExceptionMessageClass(Object... arguments) {
-        return new LocalizedMessage(Definitions.CHECKSTYLE_BUNDLE, Locale.getDefault(),
+        return new LocalizedMessage(Definitions.CHECKSTYLE_BUNDLE,
                 DefaultLogger.class, "DefaultLogger.addException", arguments);
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
@@ -30,7 +30,6 @@ import java.io.File;
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.ParseErrorMessage;
-import com.puppycrawl.tools.checkstyle.api.Violation;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 
 public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
@@ -83,15 +82,13 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
         final String actual = TestUtil.invokeStaticMethod(DetailNodeTreeStringPrinter.class,
                 "getParseErrorMessage",
                 new ParseErrorMessage(35, MSG_JAVADOC_MISSED_HTML_CLOSE, 7, "xyz"));
-        final Violation violation = new Violation(
-                35,
+        final LocalizedMessage violation = new LocalizedMessage(
                 "com.puppycrawl.tools.checkstyle.checks.javadoc.messages",
-                MSG_JAVADOC_MISSED_HTML_CLOSE,
-                new Object[] {7, "xyz"},
-                "",
                 DetailNodeTreeStringPrinter.class,
-                null);
-        final String expected = "[ERROR:35] " + violation.getViolation();
+                MSG_JAVADOC_MISSED_HTML_CLOSE,
+                7,
+                "xyz");
+        final String expected = "[ERROR:35] " + violation.getMessage();
         assertWithMessage("Javadoc parse error violation for missed HTML tag "
                 + "doesn't meet expectations")
             .that(actual)
@@ -104,15 +101,13 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
                 "getParseErrorMessage",
                 new ParseErrorMessage(10, MSG_JAVADOC_PARSE_RULE_ERROR,
                         9, "no viable alternative at input ' xyz'", "SOME_JAVADOC_ELEMENT"));
-        final Violation violation = new Violation(
-                10,
+        final LocalizedMessage violation = new LocalizedMessage(
                 "com.puppycrawl.tools.checkstyle.checks.javadoc.messages",
-                MSG_JAVADOC_PARSE_RULE_ERROR,
-                new Object[] {9, "no viable alternative at input ' xyz'", "SOME_JAVADOC_ELEMENT"},
-                "",
                 DetailNodeTreeStringPrinter.class,
-                null);
-        final String expected = "[ERROR:10] " + violation.getViolation();
+                MSG_JAVADOC_PARSE_RULE_ERROR,
+                9,
+                "no viable alternative at input ' xyz'", "SOME_JAVADOC_ELEMENT");
+        final String expected = "[ERROR:10] " + violation.getMessage();
         assertWithMessage("Javadoc parse error violation doesn't meet expectations")
             .that(actual)
             .isEqualTo(expected);
@@ -124,15 +119,13 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
                 "getParseErrorMessage",
                 new ParseErrorMessage(100, MSG_JAVADOC_WRONG_SINGLETON_TAG,
                         9, "tag"));
-        final Violation violation = new Violation(
-                100,
+        final LocalizedMessage violation = new LocalizedMessage(
                 "com.puppycrawl.tools.checkstyle.checks.javadoc.messages",
-                MSG_JAVADOC_WRONG_SINGLETON_TAG,
-                new Object[] {9, "tag"},
-                "",
                 DetailNodeTreeStringPrinter.class,
-                null);
-        final String expected = "[ERROR:100] " + violation.getViolation();
+                MSG_JAVADOC_WRONG_SINGLETON_TAG,
+                9,
+                "tag");
+        final String expected = "[ERROR:100] " + violation.getMessage();
         assertWithMessage("Javadoc parse error violation for void elements with close tag "
                     + "doesn't meet expectations")
             .that(actual)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -186,16 +186,16 @@ public class MainTest {
     @TempDir
     public File temporaryFolder;
 
-    private final Violation auditStartMessage = new Violation(1,
-            Definitions.CHECKSTYLE_BUNDLE, "DefaultLogger.auditStarted", null, null,
-            getClass(), null);
+    private final LocalizedMessage auditStartMessage = new LocalizedMessage(
+            Definitions.CHECKSTYLE_BUNDLE, getClass(),
+            "DefaultLogger.auditStarted");
 
-    private final Violation auditFinishMessage = new Violation(1,
-            Definitions.CHECKSTYLE_BUNDLE, "DefaultLogger.auditFinished", null, null,
-            getClass(), null);
+    private final LocalizedMessage auditFinishMessage = new LocalizedMessage(
+            Definitions.CHECKSTYLE_BUNDLE, getClass(),
+            "DefaultLogger.auditFinished");
 
-    private final String noViolationsOutput = auditStartMessage.getViolation() + EOL
-                    + auditFinishMessage.getViolation() + EOL;
+    private final String noViolationsOutput = auditStartMessage.getMessage() + EOL
+                    + auditFinishMessage.getMessage() + EOL;
 
     private static String getPath(String filename) {
         return "src/test/resources/com/puppycrawl/tools/checkstyle/main/" + filename;
@@ -388,8 +388,8 @@ public class MainTest {
                 getPath("InputMain.java"));
         assertWithMessage("Unexpected output log")
             .that(systemOut.getCapturedData())
-            .isEqualTo(addEndOfLine(auditStartMessage.getViolation(),
-                auditFinishMessage.getViolation()));
+            .isEqualTo(addEndOfLine(auditStartMessage.getMessage(),
+                auditFinishMessage.getMessage()));
         assertWithMessage("Unexpected system error log")
             .that(systemErr.getCapturedData())
             .isEqualTo("");
@@ -470,8 +470,8 @@ public class MainTest {
                 getPath("InputMain.java"));
         assertWithMessage("Unexpected output log")
             .that(systemOut.getCapturedData())
-            .isEqualTo(addEndOfLine(auditStartMessage.getViolation(),
-                auditFinishMessage.getViolation()));
+            .isEqualTo(addEndOfLine(auditStartMessage.getMessage(),
+                auditFinishMessage.getMessage()));
         assertWithMessage("Unexpected system error log")
             .that(systemErr.getCapturedData())
             .isEqualTo("");
@@ -493,14 +493,14 @@ public class MainTest {
         final String expectedPath = getFilePath("InputMain.java");
         assertWithMessage("Unexpected output log")
             .that(systemOut.getCapturedData())
-            .isEqualTo(addEndOfLine(auditStartMessage.getViolation(),
+            .isEqualTo(addEndOfLine(auditStartMessage.getMessage(),
                     "[WARN] " + expectedPath + ":3:14: "
                         + invalidPatternMessageMain.getViolation()
                         + " [TypeName]",
                     "[WARN] " + expectedPath + ":5:7: "
                         + invalidPatternMessageMainInner.getViolation()
                         + " [TypeName]",
-                    auditFinishMessage.getViolation()));
+                    auditFinishMessage.getMessage()));
         assertWithMessage("Unexpected system error log")
             .that(systemErr.getCapturedData())
             .isEqualTo("");
@@ -555,12 +555,12 @@ public class MainTest {
         final String expectedPath = getFilePath("InputMain.java");
         assertWithMessage("Unexpected output log")
             .that(systemOut.getCapturedData())
-            .isEqualTo(addEndOfLine(auditStartMessage.getViolation(),
+            .isEqualTo(addEndOfLine(auditStartMessage.getMessage(),
                     "[ERROR] " + expectedPath + ":3:14: "
                         + invalidPatternMessageMain.getViolation() + " [TypeName]",
                     "[ERROR] " + expectedPath + ":5:7: "
                         + invalidPatternMessageMainInner.getViolation() + " [TypeName]",
-                    auditFinishMessage.getViolation()));
+                    auditFinishMessage.getMessage()));
         assertWithMessage("Unexpected system error log")
             .that(systemErr.getCapturedData())
             .isEqualTo(addEndOfLine(errorCounterTwoMessage.getViolation()));
@@ -588,10 +588,10 @@ public class MainTest {
         final String expectedPath = getFilePath("InputMain1.java");
         assertWithMessage("Unexpected output log")
             .that(systemOut.getCapturedData())
-            .isEqualTo(addEndOfLine(auditStartMessage.getViolation(),
+            .isEqualTo(addEndOfLine(auditStartMessage.getMessage(),
                     "[ERROR] " + expectedPath + ":3:14: "
                         + invalidPatternMessageMain.getViolation() + " [TypeName]",
-                    auditFinishMessage.getViolation()));
+                    auditFinishMessage.getMessage()));
         assertWithMessage("Unexpected system error log")
             .that(systemErr.getCapturedData())
             .isEqualTo(addEndOfLine(errorCounterTwoMessage.getViolation()));
@@ -611,9 +611,9 @@ public class MainTest {
         final String expectedPath = getFilePath("InputMain1.java");
         assertWithMessage("Unexpected output log")
             .that(systemOut.getCapturedData())
-            .isEqualTo(addEndOfLine(auditStartMessage.getViolation(),
+            .isEqualTo(addEndOfLine(auditStartMessage.getMessage(),
                 "[ERROR] " + expectedPath + ":1: " + message.getViolation() + " [JavadocPackage]",
-                auditFinishMessage.getViolation()));
+                auditFinishMessage.getMessage()));
         assertWithMessage("Unexpected system error log")
             .that(systemErr.getCapturedData())
             .isEqualTo(addEndOfLine(errorCounterTwoMessage.getViolation()));
@@ -670,8 +670,8 @@ public class MainTest {
                 "-p", getPath("InputMainMycheckstyle.properties"), getPath("InputMain.java"));
         assertWithMessage("Unexpected output log")
             .that(systemOut.getCapturedData())
-            .isEqualTo(addEndOfLine(auditStartMessage.getViolation(),
-                auditFinishMessage.getViolation()));
+            .isEqualTo(addEndOfLine(auditStartMessage.getMessage(),
+                auditFinishMessage.getMessage()));
         assertWithMessage("Unexpected system error log")
             .that(systemErr.getCapturedData())
             .isEqualTo("");
@@ -685,8 +685,8 @@ public class MainTest {
 
         assertWithMessage("Unexpected output log")
             .that(systemOut.getCapturedData())
-            .isEqualTo(addEndOfLine(auditStartMessage.getViolation(),
-                auditFinishMessage.getViolation()));
+            .isEqualTo(addEndOfLine(auditStartMessage.getMessage(),
+                auditFinishMessage.getMessage()));
         assertWithMessage("Unexpected system error log")
             .that(systemErr.getCapturedData())
             .isEqualTo("");
@@ -813,7 +813,7 @@ public class MainTest {
                 getPath(""));
         final String expectedPath = getFilePath("") + File.separator;
         final StringBuilder sb = new StringBuilder(28);
-        sb.append(auditStartMessage.getViolation())
+        sb.append(auditStartMessage.getMessage())
                 .append(EOL);
         final String format = "[WARN] " + expectedPath + outputValues[0][0] + ".java:"
                 + outputValues[0][1] + ": ";
@@ -824,7 +824,7 @@ public class MainTest {
             final String line = format + violation + " [FileLength]";
             sb.append(line).append(EOL);
         }
-        sb.append(auditFinishMessage.getViolation())
+        sb.append(auditFinishMessage.getMessage())
                 .append(EOL);
         assertWithMessage("Unexpected output log")
             .that(systemOut.getCapturedData())
@@ -1740,19 +1740,20 @@ public class MainTest {
         assertMainReturnCode(-2, "-c", getPath("InputMainConfig-custom-simple-root-module.xml"),
                 getPath("InputMain.java"));
         final String checkstylePackage = "com.puppycrawl.tools.checkstyle.";
-        final Violation unableToInstantiateExceptionMessage = new Violation(1,
+        final LocalizedMessage unableToInstantiateExceptionMessage = new LocalizedMessage(
                 Definitions.CHECKSTYLE_BUNDLE,
+                getClass(),
                 "PackageObjectFactory.unableToInstantiateExceptionMessage",
-                new String[] {"TestRootModuleChecker", checkstylePackage
+                "TestRootModuleChecker",
+                checkstylePackage
                         + "TestRootModuleChecker, "
                         + "TestRootModuleCheckerCheck, " + checkstylePackage
-                        + "TestRootModuleCheckerCheck"},
-                null, getClass(), null);
+                        + "TestRootModuleCheckerCheck");
         assertWithMessage(
                 "Unexpected system error log")
                         .that(systemErr.getCapturedData()
                                 .startsWith(checkstylePackage + "api.CheckstyleException: "
-                                        + unableToInstantiateExceptionMessage.getViolation()))
+                                        + unableToInstantiateExceptionMessage.getMessage()))
                         .isTrue();
         assertWithMessage("Invalid checker state")
                 .that(TestRootModuleChecker.isProcessed())

--- a/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/PackageObjectFactoryTest.java
@@ -156,12 +156,12 @@ public class PackageObjectFactoryTest {
             assertWithMessage("Exception is expected").fail();
         }
         catch (CheckstyleException ex) {
-            final Violation exceptionMessage = new Violation(1,
-                    Definitions.CHECKSTYLE_BUNDLE, UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE,
-                    new String[] {name, null}, null, factory.getClass(), null);
+            final LocalizedMessage exceptionMessage = new LocalizedMessage(
+                    Definitions.CHECKSTYLE_BUNDLE, factory.getClass(),
+                    UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE, name, null);
             assertWithMessage("Invalid exception message")
                 .that(ex.getMessage())
-                .isEqualTo(exceptionMessage.getViolation());
+                .isEqualTo(exceptionMessage.getMessage());
         }
     }
 
@@ -177,12 +177,12 @@ public class PackageObjectFactoryTest {
                 final String attemptedNames = BASE_PACKAGE + PACKAGE_SEPARATOR + name
                     + STRING_SEPARATOR + name + CHECK_SUFFIX + STRING_SEPARATOR
                     + BASE_PACKAGE + PACKAGE_SEPARATOR + name + CHECK_SUFFIX;
-                final Violation exceptionMessage = new Violation(1,
-                    Definitions.CHECKSTYLE_BUNDLE, UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE,
-                    new String[] {name, attemptedNames}, null, factory.getClass(), null);
+                final LocalizedMessage exceptionMessage = new LocalizedMessage(
+                    Definitions.CHECKSTYLE_BUNDLE, factory.getClass(),
+                    UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE, name, attemptedNames);
                 assertWithMessage("Invalid exception message")
                     .that(ex.getMessage())
-                    .isEqualTo(exceptionMessage.getViolation());
+                    .isEqualTo(exceptionMessage.getMessage());
             }
         }
     }
@@ -250,12 +250,12 @@ public class PackageObjectFactoryTest {
         catch (CheckstyleException ex) {
             final String optionalNames = barPackage + PACKAGE_SEPARATOR + name
                     + STRING_SEPARATOR + fooPackage + PACKAGE_SEPARATOR + name;
-            final Violation exceptionMessage = new Violation(1,
-                    Definitions.CHECKSTYLE_BUNDLE, AMBIGUOUS_MODULE_NAME_EXCEPTION_MESSAGE,
-                    new String[] {name, optionalNames}, null, getClass(), null);
+            final LocalizedMessage exceptionMessage = new LocalizedMessage(
+                    Definitions.CHECKSTYLE_BUNDLE, getClass(),
+                    AMBIGUOUS_MODULE_NAME_EXCEPTION_MESSAGE, name, optionalNames);
             assertWithMessage("Invalid exception message")
                 .that(ex.getMessage())
-                .isEqualTo(exceptionMessage.getViolation());
+                .isEqualTo(exceptionMessage.getMessage());
         }
     }
 
@@ -278,12 +278,12 @@ public class PackageObjectFactoryTest {
                     + checkName + STRING_SEPARATOR
                     + package1 + PACKAGE_SEPARATOR + checkName + STRING_SEPARATOR
                     + package2 + PACKAGE_SEPARATOR + checkName;
-            final Violation exceptionMessage = new Violation(1,
-                    Definitions.CHECKSTYLE_BUNDLE, UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE,
-                    new String[] {name, attemptedNames}, null, getClass(), null);
+            final LocalizedMessage exceptionMessage = new LocalizedMessage(
+                    Definitions.CHECKSTYLE_BUNDLE, getClass(),
+                    UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE, name, attemptedNames);
             assertWithMessage("Invalid exception message")
                 .that(ex.getMessage())
-                .isEqualTo(exceptionMessage.getViolation());
+                .isEqualTo(exceptionMessage.getMessage());
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/ViolationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/ViolationTest.java
@@ -21,11 +21,7 @@ package com.puppycrawl.tools.checkstyle.api;
 
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_OBJECT_ARRAY;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-import java.util.Locale;
-
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.DefaultLocale;
 
@@ -33,34 +29,6 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.EqualsVerifierReport;
 
 public class ViolationTest {
-
-    private static final Locale DEFAULT_LOCALE = Locale.getDefault();
-
-    /**
-     * Verifies that the language specified with the system property {@code user.language} exists.
-     */
-    @Test
-    public void testLanguageIsValid() {
-        final String language = DEFAULT_LOCALE.getLanguage();
-        assumeFalse(language.isEmpty(), "Locale not set");
-        assertWithMessage("Invalid language")
-                .that(Locale.getISOLanguages())
-                .asList()
-                .contains(language);
-    }
-
-    /**
-     * Verifies that the country specified with the system property {@code user.country} exists.
-     */
-    @Test
-    public void testCountryIsValid() {
-        final String country = DEFAULT_LOCALE.getCountry();
-        assumeFalse(country.isEmpty(), "Locale not set");
-        assertWithMessage("Invalid country")
-                .that(Locale.getISOCountries())
-                .asList()
-                .contains(country);
-    }
 
     @Test
     public void testEqualsAndHashCode() {
@@ -98,41 +66,9 @@ public class ViolationTest {
             .isEqualTo("com.puppycrawl.tools.checkstyle.api.Violation");
     }
 
+    @DefaultLocale("en")
     @Test
     public void testMessageInEnglish() {
-        final Violation violation = createSampleViolation();
-        Violation.setLocale(Locale.ENGLISH);
-
-        assertWithMessage("Invalid violation")
-            .that(violation.getViolation())
-            .isEqualTo("Empty statement.");
-    }
-
-    @Test
-    public void testMessageInFrench() {
-        final Violation violation = createSampleViolation();
-        Violation.setLocale(Locale.FRENCH);
-
-        assertWithMessage("Invalid violation")
-            .that(violation.getViolation())
-            .isEqualTo("Instruction vide.");
-    }
-
-    @DefaultLocale("fr")
-    @Test
-    public void testEnforceEnglishLanguageBySettingUnitedStatesLocale() {
-        Violation.setLocale(Locale.US);
-        final Violation violation = createSampleViolation();
-
-        assertWithMessage("Invalid violation")
-            .that(violation.getViolation())
-            .isEqualTo("Empty statement.");
-    }
-
-    @DefaultLocale("fr")
-    @Test
-    public void testEnforceEnglishLanguageBySettingRootLocale() {
-        Violation.setLocale(Locale.ROOT);
         final Violation violation = createSampleViolation();
 
         assertWithMessage("Invalid violation")
@@ -143,7 +79,6 @@ public class ViolationTest {
     @DefaultLocale("fr")
     @Test
     public void testGetKey() {
-        Violation.setLocale(Locale.US);
         final Violation violation = createSampleViolation();
 
         assertWithMessage("Invalid violation key")
@@ -250,11 +185,6 @@ public class ViolationTest {
         return new Violation(1, column,
                 "com.puppycrawl.tools.checkstyle.checks.coding.messages", "empty.statement",
                 EMPTY_OBJECT_ARRAY, "module", Violation.class, null);
-    }
-
-    @AfterEach
-    public void tearDown() {
-        Violation.setLocale(DEFAULT_LOCALE);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
@@ -231,12 +231,12 @@ public class TranslationCheckTest extends AbstractXmlTestSupport {
         assertWithMessage("expected number of errors to fire")
             .that(dispatcher.savedErrors)
             .hasSize(1);
-        final Violation violation = new Violation(1,
+        final Violation violation = new Violation(0,
                 Definitions.CHECKSTYLE_BUNDLE, "general.fileNotFound",
-                null, null, getClass(), null);
+                null, null, TranslationCheck.class, null);
         assertWithMessage("Invalid violation")
-            .that(dispatcher.savedErrors.iterator().next().getViolation())
-            .isEqualTo(violation.getViolation());
+            .that(dispatcher.savedErrors.iterator().next())
+            .isEqualTo(violation);
     }
 
     @Test
@@ -256,12 +256,12 @@ public class TranslationCheckTest extends AbstractXmlTestSupport {
         assertWithMessage("expected number of errors to fire")
             .that(dispatcher.savedErrors.size())
             .isEqualTo(1);
-        final Violation violation = new Violation(1,
+        final Violation violation = new Violation(0,
                 Definitions.CHECKSTYLE_BUNDLE, "general.exception",
-                new String[] {exception.getMessage()}, null, getClass(), null);
+                new String[] {exception.getMessage()}, null, TranslationCheck.class, null);
         assertWithMessage("Invalid violation")
-            .that(dispatcher.savedErrors.iterator().next().getViolation())
-            .isEqualTo(violation.getViolation());
+            .that(dispatcher.savedErrors.iterator().next())
+            .isEqualTo(violation);
     }
 
     @Test
@@ -269,9 +269,9 @@ public class TranslationCheckTest extends AbstractXmlTestSupport {
         final DefaultConfiguration checkConfig = createModuleConfig(TranslationCheck.class);
         checkConfig.addProperty("baseName", "^bad.*$");
         final String[] expected = {
-            "0: " + new Violation(1, Definitions.CHECKSTYLE_BUNDLE, "general.exception",
-                new String[] {"Malformed \\uxxxx encoding." }, null, getClass(),
-                    null).getViolation(), "1: " + getCheckMessage(MSG_KEY, "test"),
+            "0: " + getCheckMessage(Checker.class, "general.exception",
+                    "Malformed \\uxxxx encoding."),
+            "1: " + getCheckMessage(MSG_KEY, "test"),
         };
         final File[] propertyFiles = {
             new File(getPath("bad.properties")),
@@ -607,9 +607,6 @@ public class TranslationCheckTest extends AbstractXmlTestSupport {
             assertWithMessage("Error message is unexpected")
                     .that(exceptionMessage)
                     .contains("11");
-            assertWithMessage("Error message is unexpected")
-                    .that(exceptionMessage)
-                    .endsWith("[TranslationCheck]");
         }
     }
 


### PR DESCRIPTION
Issue #12101

The issue is our exceptions use LocalizedMessage though it does not have access to the global locale. It is expecting to be supplied the locale, but we never provide it the overridden locale from the config.

As the class name implies, LocalizedMessage should **currently** be the central place for the locale storage. (This does not resolve #12104 but does proceed to better management). The locale does not need to be provided to `LocalizedMessage` in the constructor anymore as anyone using should use the global locale, **currently**.

The second commit converts a bunch of `Violation` uses to `LocalizedMessage`. The areas being used are not actual violations but just being used for locale messages. Violation and LocalizedMessage both use the global locale, so this is really a no change. Any fields dropped when passing to the constructor were not being used anyways. So we basically get the same effect, with less unnecessary coding.

This is built on top of https://github.com/checkstyle/checkstyle/pull/12102 and thus this PR is blocked until the other is merged, hence why this is drafted.