### PR TITLE
Issue #2939: Add ArchUnit test to ensure properties in modules are annotated

### DIFF
--- a/config/import-control.xml
+++ b/config/import-control.xml
@@ -46,6 +46,9 @@
   <allow class="com.puppycrawl.tools.checkstyle.XpathFileGeneratorAuditListener"
          local-only="true"/>
 
+  <!-- Allowed as module properties need to be annotated with @ModuleProperty -->
+  <allow class="com.puppycrawl.tools.checkstyle.ModuleProperty" />
+
   <file name="DetailAstImpl|JavaParser|JavaAstVisitor|CheckstyleParserErrorStrategy" regex="true">
     <allow pkg="org.antlr.v4.runtime"/>
   </file>

--- a/config/pmd-test.xml
+++ b/config/pmd-test.xml
@@ -119,7 +119,9 @@
              from the test method.
            In XdocsPagesTest PMD does not find asserts in lambdas.
            All test classes which starts with XpathRegression have asserts inside parent's method.
-           In ArchUnitTest assertion calls are not required as they are called by the library -->
+           In ArchUnitTest assertion calls are not required as they are called by the library
+           In PropertyAnnotationTest assertion calls are not required as they are called by
+             the library -->
       <property name="violationSuppressXPath"
                value="//ClassOrInterfaceDeclaration[@SimpleName='AllChecksTest'
                      or @SimpleName='AstRegressionTest'
@@ -131,6 +133,8 @@
                    | //ClassOrInterfaceDeclaration[@SimpleName='XdocsJavaDocsTest']
                        //MethodDeclaration[@Name='testAllCheckSectionJavaDocs']
                    | //ClassOrInterfaceDeclaration[starts-with(@SimpleName,'XpathRegression')]
+                       //MethodDeclaration
+                   | //ClassOrInterfaceDeclaration[@SimpleName='PropertyAnnotationTest']
                        //MethodDeclaration
                    | //ClassOrInterfaceDeclaration[@SimpleName='ArchUnitTest']
                        //MethodDeclaration"/>

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -348,10 +348,12 @@
       <!-- Main actively uses Checkstyle, logging and command line parsing API.
            Checker collects external resource locations and sets up the configuration.
            CheckstyleAntTask integrates Checkstyle with Ant.
+           Temporary suppression for TranslationCheck.
             -->
       <property name="violationSuppressXPath"
                 value="//ClassOrInterfaceDeclaration[@SimpleName='Main'
-        or @SimpleName='Checker' or @SimpleName='CheckstyleAntTask']"/>
+        or @SimpleName='Checker' or @SimpleName='CheckstyleAntTask'
+        or @SimpleName='TranslationCheck']"/>
     </properties>
   </rule>
   <rule ref="category/java/design.xml/CognitiveComplexity">

--- a/src/main/java/com/puppycrawl/tools/checkstyle/ModuleProperty.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/ModuleProperty.java
@@ -1,0 +1,33 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2022 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation indicates that the field is a module property.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ModuleProperty {
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/ArrayTypeStyleCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -117,6 +118,7 @@ public class ArrayTypeStyleCheck extends AbstractCheck {
     public static final String MSG_KEY = "array.type.style";
 
     /** Control whether to enforce Java style (true) or C style (false). */
+    @ModuleProperty
     private boolean javaStyle = true;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java
@@ -26,6 +26,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TextBlock;
@@ -296,15 +297,19 @@ public class AvoidEscapedUnicodeCharactersCheck
     private Map<Integer, List<TextBlock>> blockComments;
 
     /** Allow use escapes for non-printable, control characters. */
+    @ModuleProperty
     private boolean allowEscapesForControlCharacters;
 
     /** Allow use escapes if trail comment is present. */
+    @ModuleProperty
     private boolean allowByTailComment;
 
     /** Allow if all characters in literal are escaped. */
+    @ModuleProperty
     private boolean allowIfAllCharactersEscaped;
 
     /** Allow use escapes for non-printable, whitespace characters. */
+    @ModuleProperty
     private boolean allowNonPrintableEscapes;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks;
 import java.util.Arrays;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.PropertyType;
 import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
@@ -333,24 +334,32 @@ public class DescendantTokenCheck extends AbstractCheck {
     public static final String MSG_KEY_SUM_MAX = "descendant.token.sum.max";
 
     /** Specify the minimum depth for descendant counts. */
+    @ModuleProperty
     private int minimumDepth;
     /** Specify the maximum depth for descendant counts. */
+    @ModuleProperty
     private int maximumDepth = Integer.MAX_VALUE;
     /** Specify a minimum count for descendants. */
+    @ModuleProperty
     private int minimumNumber;
     /** Specify a maximum count for descendants. */
+    @ModuleProperty
     private int maximumNumber = Integer.MAX_VALUE;
     /**
      * Control whether the number of tokens found should be calculated from
      * the sum of the individual token counts.
      */
+    @ModuleProperty
     private boolean sumTokenCounts;
     /** Specify set of tokens with limited occurrences as descendants. */
     @XdocsPropertyType(PropertyType.TOKEN_ARRAY)
+    @ModuleProperty
     private int[] limitedTokens = CommonUtil.EMPTY_INT_ARRAY;
     /** Define the violation message when the minimum count is not reached. */
+    @ModuleProperty
     private String minimumMessage;
     /** Define the violation message when the maximum count is exceeded. */
+    @ModuleProperty
     private String maximumMessage;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks;
 
 import java.util.BitSet;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -163,6 +164,7 @@ public class FinalParametersCheck extends AbstractCheck {
     /**
      * Ignore primitive types as parameters.
      */
+    @ModuleProperty
     private boolean ignorePrimitiveTypes;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.util.Locale;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.FileText;
@@ -187,6 +188,7 @@ public class NewlineAtEndOfFileCheck
     public static final String MSG_KEY_WRONG_ENDING = "wrong.line.end";
 
     /** Specify the type of line separator. */
+    @ModuleProperty
     private LineSeparatorOption lineSeparator = LineSeparatorOption.LF_CR_CRLF;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks;
 
 import java.util.regex.Pattern;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -101,6 +102,7 @@ public class TodoCommentCheck
     /**
      * Specify pattern to match comments against.
      */
+    @ModuleProperty
     private Pattern format = Pattern.compile("TODO:");
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks;
 import java.util.Arrays;
 import java.util.regex.Pattern;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -214,9 +215,11 @@ public class TrailingCommentCheck extends AbstractCheck {
      * Define pattern for text allowed in trailing comments.
      * This pattern will not be applied to multiline comments.
      */
+    @ModuleProperty
     private Pattern legalComment;
 
     /** Specify pattern for strings allowed before the comment. */
+    @ModuleProperty
     private Pattern format = Pattern.compile("^[\\s});]*$");
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -45,6 +45,7 @@ import org.apache.commons.logging.LogFactory;
 
 import com.puppycrawl.tools.checkstyle.Definitions;
 import com.puppycrawl.tools.checkstyle.GlobalStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.MessageDispatcher;
@@ -271,11 +272,13 @@ public class TranslationCheck extends AbstractFileSetCheck {
      * Base name</a> of resource bundles which contain message resources.
      * It helps the check to distinguish config and localization resources.
      */
+    @ModuleProperty
     private Pattern baseName;
 
     /**
      * Specify language codes of required translations which must exist in project.
      */
+    @ModuleProperty
     private Set<String> requiredTranslations = new HashSet<>();
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -148,6 +149,7 @@ public class UncommentedMainCheck
      * Specify pattern for qualified names of classes which are allowed to
      * have a {@code main} method.
      */
+    @ModuleProperty
     private Pattern excludedClasses = Pattern.compile("^$");
     /** Current class name. */
     private String currentClass;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationLocationCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.annotation;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -241,18 +242,21 @@ public class AnnotationLocationCheck extends AbstractCheck {
      * Allow single parameterless annotation to be located on the same line as
      * target element.
      */
+    @ModuleProperty
     private boolean allowSamelineSingleParameterlessAnnotation = true;
 
     /**
      * Allow one and only parameterized annotation to be located on the same line as
      * target element.
      */
+    @ModuleProperty
     private boolean allowSamelineParameterizedAnnotation;
 
     /**
      * Allow annotation(s) to be located on the same line as
      * target element.
      */
+    @ModuleProperty
     private boolean allowSamelineMultipleAnnotations;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.annotation;
 
 import java.util.Locale;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -338,17 +339,20 @@ public final class AnnotationUseStyleCheck extends AbstractCheck {
     /**
      * Define the annotation element styles.
      */
+    @ModuleProperty
     private ElementStyleOption elementStyle = ElementStyleOption.COMPACT_NO_ARRAY;
 
     // defaulting to NEVER because of the strange compiler behavior
     /**
      * Define the policy for trailing comma in arrays.
      */
+    @ModuleProperty
     private TrailingArrayCommaOption trailingArrayComma = TrailingArrayCommaOption.NEVER;
 
     /**
      * Define the policy for ending parenthesis.
      */
+    @ModuleProperty
     private ClosingParensOption closingParens = ClosingParensOption.NEVER;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -191,6 +192,7 @@ public final class MissingOverrideCheck extends AbstractCheck {
     /**
      * Enable java 5 compatibility mode.
      */
+    @ModuleProperty
     private boolean javaFiveCompatibility;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -165,6 +166,7 @@ public class SuppressWarningsCheck extends AbstractCheck {
      * Specify the RegExp to match against warnings. Any warning
      * being suppressed matching this pattern will be flagged.
      */
+    @ModuleProperty
     private Pattern format = Pattern.compile("^\\s*+$");
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/AvoidNestedBlocksCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.blocks;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -156,6 +157,7 @@ public class AvoidNestedBlocksCheck extends AbstractCheck {
     /**
      * Allow nested blocks if they are the only child of a switch case.
      */
+    @ModuleProperty
     private boolean allowInSwitchCase;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.blocks;
 import java.util.Arrays;
 import java.util.Locale;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -189,6 +190,7 @@ public class EmptyBlockCheck
     public static final String MSG_KEY_BLOCK_EMPTY = "block.empty";
 
     /** Specify the policy on block contents. */
+    @ModuleProperty
     private BlockOption option = BlockOption.STATEMENT;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyCatchBlockCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.blocks;
 
 import java.util.regex.Pattern;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -242,6 +243,7 @@ public class EmptyCatchBlockCheck extends AbstractCheck {
      * Specify the RegExp for the name of the variable associated with exception.
      * If check meets variable name matching specified value - empty block is suppressed.
      */
+    @ModuleProperty
     private Pattern exceptionVariableName = Pattern.compile("^$");
 
     /**
@@ -249,6 +251,7 @@ public class EmptyCatchBlockCheck extends AbstractCheck {
      * If check meets comment inside empty catch block matching specified format - empty
      * block is suppressed. If it is multi-line comment - only its first line is analyzed.
      */
+    @ModuleProperty
     private Pattern commentFormat = Pattern.compile(".*");
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.blocks;
 
 import java.util.Locale;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -248,11 +249,13 @@ public class LeftCurlyCheck
     private static final String OPEN_CURLY_BRACE = "{";
 
     /** Allow to ignore enums when left curly brace policy is EOL. */
+    @ModuleProperty
     private boolean ignoreEnums = true;
 
     /**
      * Specify the policy on placement of a left curly brace (<code>'{'</code>).
      * */
+    @ModuleProperty
     private LeftCurlyOption option = LeftCurlyOption.EOL;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/NeedBracesCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.blocks;
 
 import java.util.Optional;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -273,11 +274,13 @@ public class NeedBracesCheck extends AbstractCheck {
     /**
      * Allow single-line statements without braces.
      */
+    @ModuleProperty
     private boolean allowSingleLineStatement;
 
     /**
      * Allow loops with empty bodies.
      */
+    @ModuleProperty
     private boolean allowEmptyLoopBody;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.blocks;
 import java.util.Arrays;
 import java.util.Locale;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -248,6 +249,7 @@ public class RightCurlyCheck extends AbstractCheck {
     /**
      * Specify the policy on placement of a right curly brace (<code>'}'</code>).
      */
+    @ModuleProperty
     private RightCurlyOption option = RightCurlyOption.SAME;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ArrayTrailingCommaCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -206,6 +207,7 @@ public class ArrayTrailingCommaCheck extends AbstractCheck {
     /**
      * Control whether to always check for a trailing comma, even when an array is inline.
      */
+    @ModuleProperty
     private boolean alwaysDemandTrailingComma;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.Scope;
@@ -246,8 +247,10 @@ public class DeclarationOrderCheck extends AbstractCheck {
     private Set<String> classFieldNames;
 
     /** Control whether to ignore constructors. */
+    @ModuleProperty
     private boolean ignoreConstructors;
     /** Control whether to ignore modifiers (fields, ...). */
+    @ModuleProperty
     private boolean ignoreModifiers;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DefaultComesLastCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DefaultComesLastCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.util.Objects;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -151,6 +152,7 @@ public class DefaultComesLastCheck extends AbstractCheck {
             "default.comes.last.in.casegroup";
 
     /** Control whether to allow {@code default} along with {@code case} if they are not last. */
+    @ModuleProperty
     private boolean skipIfLastAndSharedWithCase;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -127,6 +128,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
     private static final String LEFT_CURLY = "{";
 
     /** Control whether to ignore {@code String.equalsIgnoreCase(String)} invocations. */
+    @ModuleProperty
     private boolean ignoreEqualsIgnoreCase;
 
     /** Stack of sets of field names, one for each class of a set of nested classes. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ExplicitInitializationCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -141,6 +142,7 @@ public class ExplicitInitializationCheck extends AbstractCheck {
     /**
      * Control whether only explicit initializations made to null for objects should be checked.
      **/
+    @ModuleProperty
     private boolean onlyObjectReferences;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -216,12 +217,14 @@ public class FallThroughCheck extends AbstractCheck {
     public static final String MSG_FALL_THROUGH_LAST = "fall.through.last";
 
     /** Control whether the last case group must be checked. */
+    @ModuleProperty
     private boolean checkLastCaseGroup;
 
     /**
      * Define the RegExp to match the relief comment that suppresses
      * the warning about a fall through.
      */
+    @ModuleProperty
     private Pattern reliefPattern = Pattern.compile("falls?[ -]?thr(u|ough)");
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -195,6 +196,7 @@ public class FinalLocalVariableCheck extends AbstractCheck {
      * <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-14.html#jls-14.14.2">
      * enhanced for-loop</a> variable.
      */
+    @ModuleProperty
     private boolean validateEnhancedForLoopVariable;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.Scope;
@@ -342,23 +343,28 @@ public class HiddenFieldCheck
     private FieldFrame frame;
 
     /** Define the RegExp for names of variables and parameters to ignore. */
+    @ModuleProperty
     private Pattern ignoreFormat;
 
     /**
      * Allow to ignore the parameter of a property setter method.
      */
+    @ModuleProperty
     private boolean ignoreSetter;
 
     /**
      * Allow to expand the definition of a setter method to include methods
      * that return the class' instance.
      */
+    @ModuleProperty
     private boolean setterCanReturnItsClass;
 
     /** Control whether to ignore constructor parameters. */
+    @ModuleProperty
     private boolean ignoreConstructorParameter;
 
     /** Control whether to ignore parameters of abstract methods. */
+    @ModuleProperty
     private boolean ignoreAbstractMethods;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -152,6 +153,7 @@ public final class IllegalCatchCheck extends AbstractCheck {
     public static final String MSG_KEY = "illegal.catch";
 
     /** Specify exception class names to reject. */
+    @ModuleProperty
     private final Set<String> illegalClassNames = Arrays.stream(new String[] {"Exception", "Error",
         "RuntimeException", "Throwable", "java.lang.Error", "java.lang.Exception",
         "java.lang.RuntimeException", "java.lang.Throwable", }).collect(Collectors.toSet());

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -220,6 +221,7 @@ public class IllegalInstantiationCheck
     private final Set<DetailAST> instantiations = new HashSet<>();
 
     /** Specify fully qualified class names that should not be instantiated. */
+    @ModuleProperty
     private Set<String> classes = new HashSet<>();
 
     /** Name of the package. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheck.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -159,10 +160,12 @@ public final class IllegalThrowsCheck extends AbstractCheck {
     public static final String MSG_KEY = "illegal.throw";
 
     /** Specify names of methods to ignore. */
+    @ModuleProperty
     private final Set<String> ignoredMethodNames =
         Arrays.stream(new String[] {"finalize", }).collect(Collectors.toSet());
 
     /** Specify throw class names to reject. */
+    @ModuleProperty
     private final Set<String> illegalClassNames = Arrays.stream(
         new String[] {"Error", "RuntimeException", "Throwable", "java.lang.Error",
                       "java.lang.RuntimeException", "java.lang.Throwable", })
@@ -172,6 +175,7 @@ public final class IllegalThrowsCheck extends AbstractCheck {
      * Allow to ignore checking overridden methods (marked with {@code Override}
      * or {@code java.lang.Override} annotation).
      */
+    @ModuleProperty
     private boolean ignoreOverriddenMethods = true;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -157,15 +158,18 @@ public class IllegalTokenTextCheck
      * Define the message which is used to notify about violations;
      * if empty then the default message is used.
      */
+    @ModuleProperty
     private String message = "";
 
     /** The format string of the regexp. */
     private String formatString = "^$";
 
     /** Define the RegExp for illegal pattern. */
+    @ModuleProperty
     private Pattern format = Pattern.compile(formatString);
 
     /** Control whether to ignore case when matching. */
+    @ModuleProperty
     private boolean ignoreCase;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.PropertyType;
 import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
@@ -371,26 +372,32 @@ public final class IllegalTypeCheck extends AbstractCheck {
      * Specify classes that should not be used as types in variable declarations,
      * return values or parameters.
      */
+    @ModuleProperty
     private final Set<String> illegalClassNames = new HashSet<>();
     /** Illegal short classes. */
     private final Set<String> illegalShortClassNames = new HashSet<>();
     /** Define abstract classes that may be used as types. */
+    @ModuleProperty
     private final Set<String> legalAbstractClassNames = new HashSet<>();
     /** Specify methods that should not be checked. */
+    @ModuleProperty
     private final Set<String> ignoredMethodNames = new HashSet<>();
     /**
      * Control whether to check only methods and fields with any of the specified modifiers.
      * This property does not affect method calls nor method references nor record components.
      */
     @XdocsPropertyType(PropertyType.TOKEN_ARRAY)
+    @ModuleProperty
     private BitSet memberModifiers = new BitSet();
 
     /** Specify RegExp for illegal abstract class names. */
+    @ModuleProperty
     private Pattern illegalAbstractClassNameFormat = Pattern.compile("^(.*[.])?Abstract.*$");
 
     /**
      * Control whether to validate abstract class names.
      */
+    @ModuleProperty
     private boolean validateAbstractClassNames;
 
     /** Creates new instance of the check. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 import java.util.Arrays;
 import java.util.BitSet;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.PropertyType;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
@@ -295,6 +296,7 @@ public class MagicNumberCheck extends AbstractCheck {
      * number literal to the enclosing constant definition.
      */
     @XdocsPropertyType(PropertyType.TOKEN_ARRAY)
+    @ModuleProperty
     private BitSet constantWaiverParentToken = TokenUtil.asBitSet(
         TokenTypes.ASSIGN,
         TokenTypes.ARRAY_INIT,
@@ -312,18 +314,23 @@ public class MagicNumberCheck extends AbstractCheck {
     );
 
     /** Specify non-magic numbers. */
+    @ModuleProperty
     private double[] ignoreNumbers = {-1, 0, 1, 2};
 
     /** Ignore magic numbers in hashCode methods. */
+    @ModuleProperty
     private boolean ignoreHashCodeMethod;
 
     /** Ignore magic numbers in annotation declarations. */
+    @ModuleProperty
     private boolean ignoreAnnotation;
 
     /** Ignore magic numbers in field declarations. */
+    @ModuleProperty
     private boolean ignoreFieldDeclaration;
 
     /** Ignore magic numbers in annotation elements defaults. */
+    @ModuleProperty
     private boolean ignoreAnnotationElementDefaults = true;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -223,6 +224,7 @@ public class MatchXpathCheck extends AbstractCheck {
     public static final String MSG_KEY = "matchxpath.match";
 
     /** Specify Xpath query. */
+    @ModuleProperty
     private String query = "";
 
     /** Xpath expression. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -166,6 +167,7 @@ public final class ModifiedControlVariableCheck extends AbstractCheck {
      * <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-14.html#jls-14.14.2">
      * enhanced for-loop</a> variable.
      */
+    @ModuleProperty
     private boolean skipEnhancedForLoopVariable;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.PropertyType;
 import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
@@ -204,16 +205,19 @@ public class MultipleStringLiteralsCheck extends AbstractCheck {
      * contexts like annotations or static initializers from the check.
      */
     @XdocsPropertyType(PropertyType.TOKEN_ARRAY)
+    @ModuleProperty
     private final BitSet ignoreOccurrenceContext = new BitSet();
 
     /**
      * Specify the maximum number of occurrences to allow without generating a warning.
      */
+    @ModuleProperty
     private int allowedDuplicates = 1;
 
     /**
      * Specify RegExp for ignored strings (with quotation marks).
      */
+    @ModuleProperty
     private Pattern ignoreStringsRegexp;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheck.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -105,6 +106,7 @@ public final class NestedForDepthCheck extends AbstractCheck {
     public static final String MSG_KEY = "nested.for.depth";
 
     /** Specify maximum allowed nesting depth. */
+    @ModuleProperty
     private int max = 1;
     /** Current nesting depth. */
     private int depth;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedIfDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedIfDepthCheck.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -116,6 +117,7 @@ public final class NestedIfDepthCheck extends AbstractCheck {
     public static final String MSG_KEY = "nested.if.depth";
 
     /** Specify maximum allowed nesting depth. */
+    @ModuleProperty
     private int max = 1;
     /** Current nesting depth. */
     private int depth;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedTryDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedTryDepthCheck.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -153,6 +154,7 @@ public final class NestedTryDepthCheck extends AbstractCheck {
     public static final String MSG_KEY = "nested.try.depth";
 
     /** Specify maximum allowed nesting depth. */
+    @ModuleProperty
     private int max = 1;
     /** Current nesting depth. */
     private int depth;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
@@ -23,6 +23,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -168,6 +169,7 @@ public final class OneStatementPerLineCheck extends AbstractCheck {
     /**
      * Enable resources processing.
      */
+    @ModuleProperty
     private boolean treatTryResourcesAsStatement;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 import java.io.File;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -119,6 +120,7 @@ public final class PackageDeclarationCheck extends AbstractCheck {
     private boolean defined;
 
     /** Control whether to check for directory and package name match. */
+    @ModuleProperty
     private boolean matchDirectoryStructure = true;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java
@@ -30,6 +30,7 @@ import java.util.Queue;
 import java.util.Set;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -311,10 +312,13 @@ public class RequireThisCheck extends AbstractCheck {
     private Map<DetailAST, AbstractFrame> frames;
 
     /** Control whether to check references to fields. */
+    @ModuleProperty
     private boolean checkFields = true;
     /** Control whether to check references to methods. */
+    @ModuleProperty
     private boolean checkMethods = true;
     /** Control whether to check only overlapping by variables or arguments. */
+    @ModuleProperty
     private boolean validateOnlyOverlapping = true;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java
@@ -24,6 +24,7 @@ import java.util.Deque;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -304,11 +305,14 @@ public final class ReturnCountCheck extends AbstractCheck {
     private final Deque<Context> contextStack = new ArrayDeque<>();
 
     /** Specify method names to ignore. */
+    @ModuleProperty
     private Pattern format = Pattern.compile("^equals$");
 
     /** Specify maximum allowed number of return statements in non-void methods/lambdas. */
+    @ModuleProperty
     private int max = 2;
     /** Specify maximum allowed number of return statements in void methods/constructors/lambdas. */
+    @ModuleProperty
     private int maxForVoid = 1;
     /** Current method context. */
     private Context context;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonInTryWithResourcesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessarySemicolonInTryWithResourcesCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -105,6 +106,7 @@ public final class UnnecessarySemicolonInTryWithResourcesCheck extends AbstractC
     public static final String MSG_SEMI = "unnecessary.semicolon";
 
     /** Allow unnecessary semicolon if closing paren is not on the same line. */
+    @ModuleProperty
     private boolean allowWhenNoBraceAfterSemicolon = true;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -319,21 +320,25 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
      * Specify distance between declaration of variable and its first usage.
      * Values should be greater than 0.
      */
+    @ModuleProperty
     private int allowedDistance = DEFAULT_DISTANCE;
 
     /**
      * Define RegExp to ignore distance calculation for variables listed in
      * this pattern.
      */
+    @ModuleProperty
     private Pattern ignoreVariablePattern = Pattern.compile("");
 
     /**
      * Allow to calculate the distance between declaration of variable and its
      * first usage in the different scopes.
      */
+    @ModuleProperty
     private boolean validateBetweenScopes;
 
     /** Allow to ignore variables with a 'final' modifier. */
+    @ModuleProperty
     private boolean ignoreFinal = true;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
@@ -28,6 +28,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -294,6 +295,7 @@ public class DesignForExtensionCheck extends AbstractCheck {
     /**
      * Specify annotations which allow the check to skip the method from validation.
      */
+    @ModuleProperty
     private Set<String> ignoredAnnotations = Arrays.stream(new String[] {"Test", "Before", "After",
         "BeforeClass", "AfterClass", }).collect(Collectors.toSet());
 
@@ -301,6 +303,7 @@ public class DesignForExtensionCheck extends AbstractCheck {
      * Specify the comment text pattern which qualifies a method as designed for extension.
      * Supports multi-line regex.
      */
+    @ModuleProperty
     private Pattern requiredJavadocPhrase = Pattern.compile(".*");
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/InterfaceIsTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/InterfaceIsTypeCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.design;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -113,6 +114,7 @@ public final class InterfaceIsTypeCheck
     public static final String MSG_KEY = "interface.type";
 
     /** Control whether marker interfaces like Serializable are allowed. */
+    @ModuleProperty
     private boolean allowMarkerInterfaces = true;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java
@@ -24,6 +24,7 @@ import java.util.Deque;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -94,10 +95,12 @@ public final class MutableExceptionCheck extends AbstractCheck {
     /** Stack of checking information for classes. */
     private final Deque<Boolean> checkingStack = new ArrayDeque<>();
     /** Specify pattern for extended class names. */
+    @ModuleProperty
     private Pattern extendedClassNameFormat = Pattern.compile(DEFAULT_FORMAT);
     /** Should we check current class or not. */
     private boolean checking;
     /** Specify pattern for exception class names. */
+    @ModuleProperty
     private Pattern format = extendedClassNameFormat;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/ThrowsCountCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.design;
 
 import java.util.Objects;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -201,9 +202,11 @@ public final class ThrowsCountCheck extends AbstractCheck {
     private static final int DEFAULT_MAX = 4;
 
     /** Allow private methods to be ignored. */
+    @ModuleProperty
     private boolean ignorePrivateMethods = true;
 
     /** Specify maximum allowed number of throws statements. */
+    @ModuleProperty
     private int max;
 
     /** Creates new instance of the check. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java
@@ -28,6 +28,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -473,6 +474,7 @@ public class VisibilityModifierCheck
     /**
      * Specify pattern for public members that should be ignored.
      */
+    @ModuleProperty
     private Pattern publicMemberPattern = Pattern.compile("^serialVersionUID$");
 
     /** Set of ignore annotations short names. */
@@ -487,21 +489,27 @@ public class VisibilityModifierCheck
      * Specify annotations canonical names which ignore variables in
      * consideration.
      */
+    @ModuleProperty
     private Set<String> ignoreAnnotationCanonicalNames = DEFAULT_IGNORE_ANNOTATIONS;
 
     /** Control whether protected members are allowed. */
+    @ModuleProperty
     private boolean protectedAllowed;
 
     /** Control whether package visible members are allowed. */
+    @ModuleProperty
     private boolean packageAllowed;
 
     /** Allow immutable fields to be declared as public if defined in final class. */
+    @ModuleProperty
     private boolean allowPublicImmutableFields;
 
     /** Allow final fields to be declared as public. */
+    @ModuleProperty
     private boolean allowPublicFinalFields;
 
     /** Specify immutable classes canonical names. */
+    @ModuleProperty
     private Set<String> immutableClassCanonicalNames = DEFAULT_IMMUTABLE_TYPES;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.header;
 import java.io.File;
 import java.util.BitSet;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
@@ -150,6 +151,7 @@ public class HeaderCheck extends AbstractHeaderCheck {
     public static final String MSG_MISMATCH = "header.mismatch";
 
     /** Specify the line numbers to ignore. */
+    @ModuleProperty
     private BitSet ignoreLines = new BitSet();
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
@@ -236,6 +237,7 @@ public class RegexpHeaderCheck extends AbstractHeaderCheck {
     private final List<Pattern> headerRegexps = new ArrayList<>();
 
     /** Specify the line numbers to repeat (zero or more times). */
+    @ModuleProperty
     private BitSet multiLines = new BitSet();
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStarImportCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.imports;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -194,18 +195,21 @@ public class AvoidStarImportCheck
      * Specify packages where starred class imports are
      * allowed and classes where starred static member imports are allowed.
      */
+    @ModuleProperty
     private final Set<String> excludes = new HashSet<>();
 
     /**
      * Control whether to allow starred class imports like
      * {@code import java.util.*;}.
      */
+    @ModuleProperty
     private boolean allowClassImports;
 
     /**
      * Control whether to allow starred static member imports like
      * {@code import static org.junit.Assert.*;}.
      */
+    @ModuleProperty
     private boolean allowStaticMemberImports;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.imports;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -115,6 +116,7 @@ public class AvoidStaticImportCheck
      * to be excluded like {@code java.lang.System.out} for a variable or
      * {@code java.lang.Math.random} for a method. See notes section for details.
      */
+    @ModuleProperty
     private String[] excludes = CommonUtil.EMPTY_STRING_ARRAY;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -26,6 +26,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -723,27 +724,33 @@ public class CustomImportOrderCheck extends AbstractCheck {
     private final List<ImportDetails> importToGroupList = new ArrayList<>();
 
     /** Specify format of order declaration customizing by user. */
+    @ModuleProperty
     private String customImportOrderRules = "";
 
     /** Specify RegExp for SAME_PACKAGE group imports. */
     private String samePackageDomainsRegExp = "";
 
     /** Specify RegExp for STANDARD_JAVA_PACKAGE group imports. */
+    @ModuleProperty
     private Pattern standardPackageRegExp = Pattern.compile("^(java|javax)\\.");
 
     /** Specify RegExp for THIRD_PARTY_PACKAGE group imports. */
+    @ModuleProperty
     private Pattern thirdPartyPackageRegExp = Pattern.compile(".*");
 
     /** Specify RegExp for SPECIAL_IMPORTS group imports. */
+    @ModuleProperty
     private Pattern specialImportsRegExp = Pattern.compile("^$");
 
     /** Force empty line separator between import groups. */
+    @ModuleProperty
     private boolean separateLineBetweenGroups = true;
 
     /**
      * Force grouping alphabetically,
      * in <a href="https://en.wikipedia.org/wiki/ASCII#Order"> ASCII sort order</a>.
      */
+    @ModuleProperty
     private boolean sortImportsInGroupAlphabetically;
 
     /** Number of first domains for SAME_PACKAGE group. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -297,6 +298,7 @@ public class IllegalImportCheck
      * list of packages will be interpreted as regular expressions.
      * Note, all properties for match will be used.
      */
+    @ModuleProperty
     private String[] illegalPkgs;
 
     /**
@@ -305,12 +307,14 @@ public class IllegalImportCheck
      * then list of class names will be interpreted as regular expressions.
      * Note, all properties for match will be used.
      */
+    @ModuleProperty
     private String[] illegalClasses;
 
     /**
      * Control whether the {@code illegalPkgs} and {@code illegalClasses}
      * should be interpreted as regular expressions.
      */
+    @ModuleProperty
     private boolean regexp;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -477,6 +478,7 @@ public class ImportControlCheck extends AbstractCheck implements ExternalResourc
      * It can be a regular file, URL or resource path. It will try loading the path
      * as a URL first, then as a file, and finally as a resource.
      */
+    @ModuleProperty
     private URI file;
 
     /**
@@ -484,6 +486,7 @@ public class ImportControlCheck extends AbstractCheck implements ExternalResourc
      * Files that don't match the pattern will not be checked. The pattern will
      * be matched against the full absolute file path.
      */
+    @ModuleProperty
     private Pattern path = Pattern.compile(".*");
     /** Whether to process the current file. */
     private boolean processCurrentFile;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -24,6 +24,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FullIdent;
@@ -587,6 +588,7 @@ public class ImportOrderCheck
      * located at the end. Thus, the empty list of type groups (the default value) means one group
      * for all type imports.
      */
+    @ModuleProperty
     private Pattern[] groups = EMPTY_PATTERN_ARRAY;
 
     /**
@@ -597,6 +599,7 @@ public class ImportOrderCheck
      * static imports. This property has effect only when the property {@code option} is set to
      * {@code top} or {@code bottom}.
      */
+    @ModuleProperty
     private Pattern[] staticGroups = EMPTY_PATTERN_ARRAY;
 
     /**
@@ -604,6 +607,7 @@ public class ImportOrderCheck
      * line or comment and aren't separated internally. It doesn't affect separations for static
      * imports.
      */
+    @ModuleProperty
     private boolean separated;
 
     /**
@@ -612,12 +616,14 @@ public class ImportOrderCheck
      * property {@code option} is set to {@code top} or {@code bottom} and when property
      * {@code staticGroups} is enabled.
      */
+    @ModuleProperty
     private boolean separatedStaticGroups;
 
     /**
      * Control whether type imports within each group should be sorted.
      * It doesn't affect sorting for static imports.
      */
+    @ModuleProperty
     private boolean ordered = true;
 
     /**
@@ -625,6 +631,7 @@ public class ImportOrderCheck
      * sorting is in <a href="https://en.wikipedia.org/wiki/ASCII#Order">ASCII sort order</a>.
      * It affects both type imports and static imports.
      */
+    @ModuleProperty
     private boolean caseSensitive = true;
 
     /** Last imported group. */
@@ -650,17 +657,20 @@ public class ImportOrderCheck
      * Control whether <b>static imports</b> located at <b>top</b> or <b>bottom</b> are
      * sorted within the group.
      */
+    @ModuleProperty
     private boolean sortStaticImportsAlphabetically;
 
     /**
      * Control whether to use container ordering (Eclipse IDE term) for static imports
      * or not.
      */
+    @ModuleProperty
     private boolean useContainerOrderingForStatic;
 
     /**
      * Specify policy on the relative order between type imports and static imports.
      */
+    @ModuleProperty
     private ImportOrderOption option = ImportOrderOption.UNDER;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -28,6 +28,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
@@ -145,6 +146,7 @@ public class UnusedImportsCheck extends AbstractCheck {
     /** Flag to indicate when time to start collecting references. */
     private boolean collect;
     /** Control whether to process Javadoc comments. */
+    @ModuleProperty
     private boolean processJavadoc = true;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 
@@ -323,21 +324,27 @@ public class IndentationCheck extends AbstractCheck {
     private Set<Integer> incorrectIndentationLines;
 
     /** Specify how far new indentation level should be indented when on the next line. */
+    @ModuleProperty
     private int basicOffset = DEFAULT_INDENTATION;
 
     /** Specify how far a case label should be indented when on next line. */
+    @ModuleProperty
     private int caseIndent = DEFAULT_INDENTATION;
 
     /** Specify how far a braces should be indented when on the next line. */
+    @ModuleProperty
     private int braceAdjustment;
 
     /** Specify how far a throws clause should be indented when on next line. */
+    @ModuleProperty
     private int throwsIndent = DEFAULT_INDENTATION;
 
     /** Specify how far an array initialisation should be indented when on next line. */
+    @ModuleProperty
     private int arrayInitIndent = DEFAULT_INDENTATION;
 
     /** Specify how far continuation line should be indented when line-wrapping is present. */
+    @ModuleProperty
     private int lineWrappingIndentation = DEFAULT_INDENTATION;
 
     /**
@@ -345,6 +352,7 @@ public class IndentationCheck extends AbstractCheck {
      * have to be same as lineWrappingIndentation parameter. If value is false, line wrap indent
      * could be bigger on any value user would like.
      */
+    @ModuleProperty
     private boolean forceStrictCondition;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.PropertyType;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
@@ -174,6 +175,7 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck {
      * Specify block tags targeted.
      */
     @XdocsPropertyType(PropertyType.TOKEN_ARRAY)
+    @ModuleProperty
     private BitSet target = TokenUtil.asBitSet(
         TokenTypes.CLASS_DEF,
         TokenTypes.INTERFACE_DEF,
@@ -188,6 +190,7 @@ public class AtclauseOrderCheck extends AbstractJavadocCheck {
     /**
      * Specify the order by tags.
      */
+    @ModuleProperty
     private List<String> tagOrder = Arrays.asList(DEFAULT_ORDER);
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheck.java
@@ -25,6 +25,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
@@ -182,6 +183,7 @@ public class JavadocBlockTagLocationCheck extends AbstractJavadocCheck {
     /**
      * Specify the javadoc tags to process.
      */
+    @ModuleProperty
     private Set<String> tags;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import java.util.Locale;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -166,6 +167,7 @@ public class JavadocContentLocationCheck extends AbstractCheck {
     /**
      * Specify the policy on placement of the Javadoc content.
      */
+    @ModuleProperty
     private JavadocContentLocationOption location = JavadocContentLocationOption.SECOND_LINE;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -32,6 +32,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
@@ -362,6 +363,7 @@ public class JavadocMethodCheck extends AbstractCheck {
     private String currentClassName;
 
     /** Specify the access modifiers where Javadoc comments are checked. */
+    @ModuleProperty
     private AccessModifierOption[] accessModifiers = {
         AccessModifierOption.PUBLIC,
         AccessModifierOption.PROTECTED,
@@ -372,21 +374,25 @@ public class JavadocMethodCheck extends AbstractCheck {
     /**
      * Control whether to validate {@code throws} tags.
      */
+    @ModuleProperty
     private boolean validateThrows;
 
     /**
      * Control whether to ignore violations when a method has parameters but does
      * not have matching {@code param} tags in the javadoc.
      */
+    @ModuleProperty
     private boolean allowMissingParamTags;
 
     /**
      * Control whether to ignore violations when a method returns non-void type
      * and does not have a {@code return} tag in the javadoc.
      */
+    @ModuleProperty
     private boolean allowMissingReturnTag;
 
     /** Specify annotations that allow missed documentation. */
+    @ModuleProperty
     private Set<String> allowedAnnotations = Set.of("Override");
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheck.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.puppycrawl.tools.checkstyle.GlobalStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.FileText;
@@ -101,6 +102,7 @@ public class JavadocPackageCheck extends AbstractFileSetCheck {
     private final Set<File> directoriesChecked = ConcurrentHashMap.newKeySet();
 
     /** Allow legacy {@code package.html} file to be used. */
+    @ModuleProperty
     private boolean allowLegacy;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocParagraphCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
@@ -169,6 +170,7 @@ public class JavadocParagraphCheck extends AbstractJavadocCheck {
     /**
      * Control whether the &lt;p&gt; tag should be placed immediately before the first word.
      */
+    @ModuleProperty
     private boolean allowNewlineParagraph = true;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -344,27 +345,33 @@ public class JavadocStyleCheck
     );
 
     /** Specify the visibility scope where Javadoc comments are checked. */
+    @ModuleProperty
     private Scope scope = Scope.PRIVATE;
 
     /** Specify the visibility scope where Javadoc comments are not checked. */
+    @ModuleProperty
     private Scope excludeScope;
 
     /** Specify the format for matching the end of a sentence. */
+    @ModuleProperty
     private Pattern endOfSentenceFormat = Pattern.compile("([.?!][ \t\n\r\f<])|([.?!]$)");
 
     /**
      * Control whether to check the first sentence for proper end of sentence.
      */
+    @ModuleProperty
     private boolean checkFirstSentence = true;
 
     /**
      * Control whether to check for incomplete HTML tags.
      */
+    @ModuleProperty
     private boolean checkHtml = true;
 
     /**
      * Control whether to check if the Javadoc is missing a describing text.
      */
+    @ModuleProperty
     private boolean checkEmptyJavadoc;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
@@ -148,6 +149,7 @@ public class JavadocTagContinuationIndentationCheck extends AbstractJavadocCheck
     /**
      * Specify how many spaces to use for new indentation level.
      */
+    @ModuleProperty
     private int offset = DEFAULT_INDENTATION;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -252,25 +253,32 @@ public class JavadocTypeCheck
             Pattern.compile("\\s+");
 
     /** Specify the visibility scope where Javadoc comments are checked. */
+    @ModuleProperty
     private Scope scope = Scope.PRIVATE;
     /** Specify the visibility scope where Javadoc comments are not checked. */
+    @ModuleProperty
     private Scope excludeScope;
     /** Specify the pattern for {@code @author} tag. */
+    @ModuleProperty
     private Pattern authorFormat;
     /** Specify the pattern for {@code @version} tag. */
+    @ModuleProperty
     private Pattern versionFormat;
     /**
      * Control whether to ignore violations when a class has type parameters but
      * does not have matching param tags in the Javadoc.
      */
+    @ModuleProperty
     private boolean allowMissingParamTags;
     /** Control whether to ignore violations when a Javadoc tag is not recognised. */
+    @ModuleProperty
     private boolean allowUnknownTags;
 
     /**
      * Specify annotations that allow missed documentation.
      * Only short names are allowed, e.g. {@code Generated}.
      */
+    @ModuleProperty
     private Set<String> allowedAnnotations = Set.of("Generated");
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import java.util.regex.Pattern;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -184,12 +185,15 @@ public class JavadocVariableCheck
     public static final String MSG_JAVADOC_MISSING = "javadoc.missing";
 
     /** Specify the visibility scope where Javadoc comments are checked. */
+    @ModuleProperty
     private Scope scope = Scope.PRIVATE;
 
     /** Specify the visibility scope where Javadoc comments are not checked. */
+    @ModuleProperty
     private Scope excludeScope;
 
     /** Specify the regexp to define variable names to ignore. */
+    @ModuleProperty
     private Pattern ignoreNamePattern;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java
@@ -24,6 +24,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
@@ -273,24 +274,30 @@ public class MissingJavadocMethodCheck extends AbstractCheck {
     private static final int DEFAULT_MIN_LINE_COUNT = -1;
 
     /** Specify the visibility scope where Javadoc comments are checked. */
+    @ModuleProperty
     private Scope scope = Scope.PUBLIC;
 
     /** Specify the visibility scope where Javadoc comments are not checked. */
+    @ModuleProperty
     private Scope excludeScope;
 
     /** Control the minimal amount of lines in method to allow no documentation.*/
+    @ModuleProperty
     private int minLineCount = DEFAULT_MIN_LINE_COUNT;
 
     /**
      * Control whether to allow missing Javadoc on accessor methods for
      * properties (setters and getters).
      */
+    @ModuleProperty
     private boolean allowMissingPropertyJavadoc;
 
     /** Ignore method whose names are matching specified regex. */
+    @ModuleProperty
     private Pattern ignoreMethodNamesRegex;
 
     /** Configure annotations that allow missed documentation. */
+    @ModuleProperty
     private Set<String> allowedAnnotations = Set.of("Override");
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import java.util.Set;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -191,8 +192,10 @@ public class MissingJavadocTypeCheck extends AbstractCheck {
     public static final String MSG_JAVADOC_MISSING = "javadoc.missing";
 
     /** Specify the visibility scope where Javadoc comments are checked. */
+    @ModuleProperty
     private Scope scope = Scope.PUBLIC;
     /** Specify the visibility scope where Javadoc comments are not checked. */
+    @ModuleProperty
     private Scope excludeScope;
 
     /**
@@ -200,6 +203,7 @@ public class MissingJavadocTypeCheck extends AbstractCheck {
      * If annotation is present in target sources in multiple forms of qualified
      * name, all forms should be listed in this property.
      */
+    @ModuleProperty
     private Set<String> skipAnnotations = Set.of("Generated");
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SingleLineJavadocCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 
 import java.util.Set;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
@@ -255,6 +256,7 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
      * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
      * block tags</a> which are ignored by the check.
      */
+    @ModuleProperty
     private Set<String> ignoredTags = Set.of();
 
     /**
@@ -262,6 +264,7 @@ public class SingleLineJavadocCheck extends AbstractJavadocCheck {
      * <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
      * inline tags</a> must be ignored.
      */
+    @ModuleProperty
     private boolean ignoreInlineTags = true;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
@@ -24,6 +24,7 @@ import java.util.BitSet;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
@@ -270,11 +271,13 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
     /**
      * Specify the regexp for forbidden summary fragments.
      */
+    @ModuleProperty
     private Pattern forbiddenSummaryFragments = CommonUtil.createPattern("^$");
 
     /**
      * Specify the period symbol at the end of first javadoc sentence.
      */
+    @ModuleProperty
     private String period = DEFAULT_PERIOD;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -207,11 +208,14 @@ public class WriteTagCheck
     /** Compiled regexp to match tag. */
     private Pattern tagRegExp;
     /** Specify the regexp to match tag content. */
+    @ModuleProperty
     private Pattern tagFormat;
 
     /** Specify the name of tag. */
+    @ModuleProperty
     private String tag;
     /** Specify the severity level when tag is found and printed. */
+    @ModuleProperty
     private SeverityLevel tagSeverity = SeverityLevel.INFO;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/BooleanExpressionComplexityCheck.java
@@ -23,6 +23,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -172,6 +173,7 @@ public final class BooleanExpressionComplexityCheck extends AbstractCheck {
     /** Stack of contexts. */
     private final Deque<Context> contextStack = new ArrayDeque<>();
     /** Specify the maximum number of boolean operations allowed in one expression. */
+    @ModuleProperty
     private int max;
     /** Current context. */
     private Context context = new Context(false);

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/CyclomaticComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/CyclomaticComplexityCheck.java
@@ -24,6 +24,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -258,12 +259,14 @@ public class CyclomaticComplexityCheck
     private final Deque<BigInteger> valueStack = new ArrayDeque<>();
 
     /** Control whether to treat the whole switch block as a single decision point. */
+    @ModuleProperty
     private boolean switchBlockAsSingleDecisionPoint;
 
     /** The current value. */
     private BigInteger currentValue = INITIAL_VALUE;
 
     /** Specify the maximum threshold allowed. */
+    @ModuleProperty
     private int max = DEFAULT_COMPLEXITY_VALUE;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java
@@ -23,6 +23,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -236,15 +237,19 @@ public class JavaNCSSCheck extends AbstractCheck {
      * Specify the maximum allowed number of non commenting lines in a file
      * including all top level and nested classes.
      */
+    @ModuleProperty
     private int fileMaximum = FILE_MAX_NCSS;
 
     /** Specify the maximum allowed number of non commenting lines in a class. */
+    @ModuleProperty
     private int classMaximum = CLASS_MAX_NCSS;
 
     /** Specify the maximum allowed number of non commenting lines in a record. */
+    @ModuleProperty
     private int recordMaximum = RECORD_MAX_NCSS;
 
     /** Specify the maximum allowed number of non commenting lines in a method. */
+    @ModuleProperty
     private int methodMaximum = METHOD_MAX_NCSS;
 
     /** List containing the stacked counters. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/NPathComplexityCheck.java
@@ -25,6 +25,7 @@ import java.util.Deque;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -269,6 +270,7 @@ public final class NPathComplexityCheck extends AbstractCheck {
     private BigInteger currentRangeValue = INITIAL_VALUE;
 
     /** Specify the maximum threshold allowed. */
+    @ModuleProperty
     private int max = DEFAULT_MAX;
 
     /** True, when branch is visited, but not leaved. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.modifier;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -141,18 +142,21 @@ public class ClassMemberImpliedModifierCheck
      * Control whether to enforce that {@code static} is explicitly coded
      * on nested enums in classes and records.
      */
+    @ModuleProperty
     private boolean violateImpliedStaticOnNestedEnum = true;
 
     /**
      * Control whether to enforce that {@code static} is explicitly coded
      * on nested interfaces in classes and records.
      */
+    @ModuleProperty
     private boolean violateImpliedStaticOnNestedInterface = true;
 
     /**
      * Control whether to enforce that {@code static} is explicitly coded
      * on nested records in classes and records.
      */
+    @ModuleProperty
     private boolean violateImpliedStaticOnNestedRecord = true;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.modifier;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -234,42 +235,49 @@ public class InterfaceMemberImpliedModifierCheck
      * Control whether to enforce that {@code public} is explicitly coded
      * on interface fields.
      */
+    @ModuleProperty
     private boolean violateImpliedPublicField = true;
 
     /**
      * Control whether to enforce that {@code static} is explicitly coded
      * on interface fields.
      */
+    @ModuleProperty
     private boolean violateImpliedStaticField = true;
 
     /**
      * Control whether to enforce that {@code final} is explicitly coded
      * on interface fields.
      */
+    @ModuleProperty
     private boolean violateImpliedFinalField = true;
 
     /**
      * Control whether to enforce that {@code public} is explicitly coded
      * on interface methods.
      */
+    @ModuleProperty
     private boolean violateImpliedPublicMethod = true;
 
     /**
      * Control whether to enforce that {@code abstract} is explicitly coded
      * on interface methods.
      */
+    @ModuleProperty
     private boolean violateImpliedAbstractMethod = true;
 
     /**
      * Control whether to enforce that {@code public} is explicitly coded
      * on interface nested types.
      */
+    @ModuleProperty
     private boolean violateImpliedPublicNested = true;
 
     /**
      * Control whether to enforce that {@code static} is explicitly coded
      * on interface nested types.
      */
+    @ModuleProperty
     private boolean violateImpliedStaticNested = true;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -328,27 +329,33 @@ public class AbbreviationAsWordInNameCheck extends AbstractCheck {
      * targeted identifiers (abbreviations in the classes, interfaces, variables
      * and methods names, ... ).
      */
+    @ModuleProperty
     private int allowedAbbreviationLength =
             DEFAULT_ALLOWED_ABBREVIATIONS_LENGTH;
 
     /**
      * Specify abbreviations that must be skipped for checking.
      */
+    @ModuleProperty
     private Set<String> allowedAbbreviations = new HashSet<>();
 
     /** Allow to skip variables with {@code final} modifier. */
+    @ModuleProperty
     private boolean ignoreFinal = true;
 
     /** Allow to skip variables with {@code static} modifier. */
+    @ModuleProperty
     private boolean ignoreStatic = true;
 
     /** Allow to skip variables with both {@code static} and {@code final} modifiers. */
+    @ModuleProperty
     private boolean ignoreStaticFinal = true;
 
     /**
      * Allow to ignore methods tagged with {@code @Override} annotation (that
      * usually mean inherited name).
      */
+    @ModuleProperty
     private boolean ignoreOverriddenMethods = true;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.naming;
 
 import java.util.regex.Pattern;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -152,6 +153,7 @@ public final class AbstractClassNameCheck extends AbstractCheck {
      * Control whether to ignore checking for the {@code abstract} modifier on
      * classes that match the name.
      */
+    @ModuleProperty
     private boolean ignoreModifier;
 
     /**
@@ -159,9 +161,11 @@ public final class AbstractClassNameCheck extends AbstractCheck {
      * if using the check to identify that match name and do not have the
      * {@code abstract} modifier.
      */
+    @ModuleProperty
     private boolean ignoreName;
 
     /** Specify valid identifiers. */
+    @ModuleProperty
     private Pattern format = Pattern.compile("^Abstract.+$");
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/LocalVariableNameCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
@@ -171,6 +172,7 @@ public class LocalVariableNameCheck
      * initialization expressions</a>
      * in FOR loop if one char variable name is prohibited by {@code format} regexp.
      */
+    @ModuleProperty
     private boolean allowOneCharVarInForLoop;
 
     /** Creates a new {@code LocalVariableNameCheck} instance. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/MethodNameCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.naming;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.AnnotationUtil;
@@ -205,6 +206,7 @@ public class MethodNameCheck
      * }
      * </pre>
      */
+    @ModuleProperty
     private boolean allowClassName;
 
     /** Creates a new {@code MethodNameCheck} instance. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/PackageNameCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.naming;
 
 import java.util.regex.Pattern;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -114,6 +115,7 @@ public class PackageNameCheck
     // Uppercase letters seem rather uncommon, but they're allowed in
     // https://docs.oracle.com/javase/specs/
     //  second_edition/html/packages.doc.html#40169
+    @ModuleProperty
     private Pattern format = Pattern.compile("^[a-z]+(\\.[a-zA-Z_]\\w*)*$");
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.naming;
 import java.util.Arrays;
 import java.util.Optional;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
@@ -175,9 +176,11 @@ public class ParameterNameCheck extends AbstractNameCheck {
     /**
      * Allows to skip methods with Override annotation from validation.
      */
+    @ModuleProperty
     private boolean ignoreOverridden;
 
     /** Access modifiers of methods where parameters are checked. */
+    @ModuleProperty
     private AccessModifierOption[] accessModifiers = {
         AccessModifierOption.PUBLIC,
         AccessModifierOption.PROTECTED,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
@@ -23,6 +23,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
@@ -506,15 +507,19 @@ public class RegexpCheck extends AbstractCheck {
      * Specify message which is used to notify about violations,
      * if empty then the default (hard-coded) message is used.
      */
+    @ModuleProperty
     private String message;
 
     /** Control whether to ignore matches found within comments. */
+    @ModuleProperty
     private boolean ignoreComments;
 
     /** Control whether the pattern is required or illegal. */
+    @ModuleProperty
     private boolean illegalPattern;
 
     /** Specify the maximum number of violations before the check will abort. */
+    @ModuleProperty
     private int errorLimit = DEFAULT_ERROR_LIMIT;
 
     /**
@@ -523,6 +528,7 @@ public class RegexpCheck extends AbstractCheck {
      * any positive value is used as the maximum number of allowed duplicates,
      * if the limit is exceeded violations will be logged.
      */
+    @ModuleProperty
     private int duplicateLimit;
 
     /** Boolean to say if we should check for duplicates. */
@@ -535,6 +541,7 @@ public class RegexpCheck extends AbstractCheck {
     private int errorCount;
 
     /** Specify the pattern to match against. */
+    @ModuleProperty
     private Pattern format = Pattern.compile("^$", Pattern.MULTILINE);
 
     /** The matcher. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.regexp;
 import java.io.File;
 import java.util.regex.Pattern;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.PropertyType;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
@@ -253,19 +254,25 @@ public class RegexpMultilineCheck extends AbstractFileSetCheck {
 
     /** Specify the format of the regular expression to match. */
     @XdocsPropertyType(PropertyType.PATTERN)
+    @ModuleProperty
     private String format = "$.";
     /**
      * Specify the message which is used to notify about violations,
      * if empty then default (hard-coded) message is used.
      */
+    @ModuleProperty
     private String message;
     /** Specify the minimum number of matches required in each file. */
+    @ModuleProperty
     private int minimum;
     /** Specify the maximum number of matches required in each file. */
+    @ModuleProperty
     private int maximum;
     /** Control whether to ignore case when searching. */
+    @ModuleProperty
     private boolean ignoreCase;
     /** Control whether to match expressions across multiple lines. */
+    @ModuleProperty
     private boolean matchAcrossLines;
 
     /** The detector to use. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheck.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.regex.Pattern;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -274,15 +275,19 @@ public class RegexpOnFilenameCheck extends AbstractFileSetCheck {
     public static final String MSG_MISMATCH = "regexp.filename.mismatch";
 
     /** Specify the regular expression to match the folder path against. */
+    @ModuleProperty
     private Pattern folderPattern;
     /** Specify the regular expression to match the file name against. */
+    @ModuleProperty
     private Pattern fileNamePattern;
     /**
      * Control whether to look for a match or mismatch on the file name,
      * if the fileNamePattern is supplied, otherwise it is applied on the folderPattern.
      */
+    @ModuleProperty
     private boolean match = true;
     /** Control whether to ignore the file extension for the file name match. */
+    @ModuleProperty
     private boolean ignoreFileNameExtensions;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.regexp;
 
 import java.io.File;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.PropertyType;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
@@ -198,17 +199,22 @@ public class RegexpSinglelineCheck extends AbstractFileSetCheck {
 
     /** Specify the format of the regular expression to match. */
     @XdocsPropertyType(PropertyType.PATTERN)
+    @ModuleProperty
     private String format = "$.";
     /**
      * Specify the message which is used to notify about violations,
      * if empty then default (hard-coded) message is used.
      */
+    @ModuleProperty
     private String message;
     /** Specify the minimum number of matches required in each file. */
+    @ModuleProperty
     private int minimum;
     /** Specify the maximum number of matches required in each file. */
+    @ModuleProperty
     private int maximum;
     /** Control whether to ignore case when searching. */
+    @ModuleProperty
     private boolean ignoreCase;
 
     /** The detector to use. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.regexp;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.PropertyType;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
@@ -213,19 +214,25 @@ public class RegexpSinglelineJavaCheck extends AbstractCheck {
 
     /** Specify the format of the regular expression to match. */
     @XdocsPropertyType(PropertyType.PATTERN)
+    @ModuleProperty
     private String format = "$.";
     /**
      * Specify the message which is used to notify about violations,
      * if empty then default (hard-coded) message is used.
      */
+    @ModuleProperty
     private String message;
     /** Specify the minimum number of matches required in each file. */
+    @ModuleProperty
     private int minimum;
     /** Specify the maximum number of matches required in each file. */
+    @ModuleProperty
     private int maximum;
     /** Control whether to ignore case when searching. */
+    @ModuleProperty
     private boolean ignoreCase;
     /** Control whether to ignore text in comments when searching. */
+    @ModuleProperty
     private boolean ignoreComments;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/AnonInnerLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/AnonInnerLengthCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.sizes;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -83,6 +84,7 @@ public class AnonInnerLengthCheck extends AbstractCheck {
     private static final int DEFAULT_MAX = 20;
 
     /** Specify the maximum number of lines allowed. */
+    @ModuleProperty
     private int max = DEFAULT_MAX;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java
@@ -23,6 +23,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -103,6 +104,7 @@ public final class ExecutableStatementCountCheck
     private final Deque<Context> contextStack = new ArrayDeque<>();
 
     /** Specify the maximum threshold allowed. */
+    @ModuleProperty
     private int max;
 
     /** Current method context. */

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/FileLengthCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.sizes;
 
 import java.io.File;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.FileText;
@@ -87,6 +88,7 @@ public class FileLengthCheck extends AbstractFileSetCheck {
     private static final int DEFAULT_MAX_LINES = 2000;
 
     /** Specify the maximum number of lines allowed. */
+    @ModuleProperty
     private int max = DEFAULT_MAX_LINES;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LambdaBodyLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LambdaBodyLengthCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.sizes;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -151,6 +152,7 @@ public class LambdaBodyLengthCheck extends AbstractCheck {
     private static final int DEFAULT_MAX = 10;
 
     /** Specify the maximum number of lines allowed. */
+    @ModuleProperty
     private int max = DEFAULT_MAX;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/LineLengthCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.sizes;
 import java.io.File;
 import java.util.regex.Pattern;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.FileText;
@@ -159,9 +160,11 @@ public class LineLengthCheck extends AbstractFileSetCheck {
     private static final int DEFAULT_MAX_COLUMNS = 80;
 
     /** Specify the maximum line length allowed. */
+    @ModuleProperty
     private int max = DEFAULT_MAX_COLUMNS;
 
     /** Specify pattern for lines to ignore. */
+    @ModuleProperty
     private Pattern ignorePattern = Pattern.compile("^(package|import) .*");
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java
@@ -25,6 +25,7 @@ import java.util.EnumMap;
 import java.util.Map;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.Scope;
@@ -207,14 +208,19 @@ public final class MethodCountCheck extends AbstractCheck {
     private final Deque<MethodCounter> counters = new ArrayDeque<>();
 
     /** Specify the maximum number of {@code private} methods allowed. */
+    @ModuleProperty
     private int maxPrivate = DEFAULT_MAX_METHODS;
     /** Specify the maximum number of {@code package} methods allowed. */
+    @ModuleProperty
     private int maxPackage = DEFAULT_MAX_METHODS;
     /** Specify the maximum number of {@code protected} methods allowed. */
+    @ModuleProperty
     private int maxProtected = DEFAULT_MAX_METHODS;
     /** Specify the maximum number of {@code public} methods allowed. */
+    @ModuleProperty
     private int maxPublic = DEFAULT_MAX_METHODS;
     /** Specify the maximum number of methods allowed at all scope levels. */
+    @ModuleProperty
     private int maxTotal = DEFAULT_MAX_METHODS;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheck.java
@@ -25,6 +25,7 @@ import java.util.Deque;
 import java.util.Objects;
 import java.util.stream.Stream;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -206,9 +207,11 @@ public class MethodLengthCheck extends AbstractCheck {
     private static final int DEFAULT_MAX_LINES = 150;
 
     /** Control whether to count empty lines and comments. */
+    @ModuleProperty
     private boolean countEmpty = true;
 
     /** Specify the maximum number of lines allowed. */
+    @ModuleProperty
     private int max = DEFAULT_MAX_LINES;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/OuterTypeNumberCheck.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.sizes;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
@@ -76,6 +77,7 @@ public class OuterTypeNumberCheck extends AbstractCheck {
     public static final String MSG_KEY = "maxOuterTypes";
 
     /** Specify the maximum number of outer types allowed. */
+    @ModuleProperty
     private int max = 1;
     /** Tracks the current depth in types. */
     private int currentDepth;

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ParameterNumberCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.sizes;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -119,9 +120,11 @@ public class ParameterNumberCheck
     private static final int DEFAULT_MAX_PARAMETERS = 7;
 
     /** Specify the maximum number of parameters allowed. */
+    @ModuleProperty
     private int max = DEFAULT_MAX_PARAMETERS;
 
     /** Ignore number of parameters for methods with {@code @Override} annotation. */
+    @ModuleProperty
     private boolean ignoreOverriddenMethods;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/RecordComponentNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/RecordComponentNumberCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.sizes;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -145,12 +146,14 @@ public class RecordComponentNumberCheck extends AbstractCheck {
     private static final int DEFAULT_MAX_COMPONENTS = 8;
 
     /** Specify the maximum number of components allowed in the header of a record definition. */
+    @ModuleProperty
     private int max = DEFAULT_MAX_COMPONENTS;
 
     /**
      * Access modifiers of record definitions where the number
      * of record components should be checked.
      */
+    @ModuleProperty
     private AccessModifierOption[] accessModifiers = {
         AccessModifierOption.PUBLIC,
         AccessModifierOption.PROTECTED,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
 import java.util.Locale;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -118,6 +119,7 @@ public class EmptyForInitializerPadCheck
     private static final String SEMICOLON = ";";
 
     /** Specify policy on how to pad an empty for iterator. */
+    @ModuleProperty
     private PadOption option = PadOption.NOSPACE;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
 import java.util.Locale;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -121,6 +122,7 @@ public class EmptyForIteratorPadCheck
     private static final String SEMICOLON = ";";
 
     /** Specify policy on how to pad an empty for iterator. */
+    @ModuleProperty
     private PadOption option = PadOption.NOSPACE;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -24,6 +24,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -357,12 +358,15 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
             "empty.line.separator.multiple.lines.inside";
 
     /** Allow no empty line between fields. */
+    @ModuleProperty
     private boolean allowNoEmptyLineBetweenFields;
 
     /** Allow multiple empty lines between class members. */
+    @ModuleProperty
     private boolean allowMultipleEmptyLines = true;
 
     /** Allow multiple empty lines inside class members. */
+    @ModuleProperty
     private boolean allowMultipleEmptyLinesInsideClassMembers = true;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/FileTabCharacterCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
 import java.io.File;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.FileText;
@@ -168,6 +169,7 @@ public class FileTabCharacterCheck extends AbstractFileSetCheck {
     public static final String MSG_FILE_CONTAINS_TAB = "file.containsTab";
 
     /** Control whether to report on each line containing a tab, or just the first instance. */
+    @ModuleProperty
     private boolean eachLine;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
 import java.util.Locale;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -171,9 +172,11 @@ public class MethodParamPadCheck
     /**
      * Allow a line break between the identifier and left parenthesis.
      */
+    @ModuleProperty
     private boolean allowLineBreaks;
 
     /** Specify policy on how to pad method parameter. */
+    @ModuleProperty
     private PadOption option = PadOption.NOSPACE;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
 import java.util.Optional;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -181,6 +182,7 @@ public class NoWhitespaceAfterCheck extends AbstractCheck {
     public static final String MSG_KEY = "ws.followed";
 
     /** Control whether whitespace is allowed if the token is at a linebreak. */
+    @ModuleProperty
     private boolean allowLineBreaks = true;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceBeforeCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -173,6 +174,7 @@ public class NoWhitespaceBeforeCheck
     public static final String MSG_KEY = "ws.preceded";
 
     /** Control whether whitespace is allowed if the token is at a linebreak. */
+    @ModuleProperty
     private boolean allowLineBreaks;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/OperatorWrapCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace;
 import java.util.Locale;
 import java.util.function.UnaryOperator;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -214,6 +215,7 @@ public class OperatorWrapCheck
     public static final String MSG_LINE_PREVIOUS = "line.previous";
 
     /** Specify policy on how to wrap lines. */
+    @ModuleProperty
     private WrapOption option = WrapOption.NL;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheck.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace;
 import java.util.Arrays;
 import java.util.Locale;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -176,6 +177,7 @@ public class SeparatorWrapCheck
     public static final String MSG_LINE_NEW = "line.new";
 
     /** Specify policy on how to wrap lines. */
+    @ModuleProperty
     private WrapOption option = WrapOption.EOL;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
 import java.util.Arrays;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -134,6 +135,7 @@ public class SingleSpaceSeparatorCheck extends AbstractCheck {
     public static final String MSG_KEY = "single.space.separator";
 
     /** Control whether to validate whitespaces surrounding comments. */
+    @ModuleProperty
     private boolean validateComments;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.checks.whitespace;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
@@ -476,22 +477,29 @@ public class WhitespaceAroundCheck extends AbstractCheck {
     public static final String MSG_WS_NOT_FOLLOWED = "ws.notFollowed";
 
     /** Allow empty constructor bodies. */
+    @ModuleProperty
     private boolean allowEmptyConstructors;
     /** Allow empty method bodies. */
+    @ModuleProperty
     private boolean allowEmptyMethods;
     /** Allow empty class, interface and enum bodies. */
+    @ModuleProperty
     private boolean allowEmptyTypes;
     /** Allow empty loop bodies. */
+    @ModuleProperty
     private boolean allowEmptyLoops;
     /** Allow empty lambda bodies. */
+    @ModuleProperty
     private boolean allowEmptyLambdas;
     /** Allow empty catch bodies. */
+    @ModuleProperty
     private boolean allowEmptyCatches;
     /**
      * Ignore whitespace around colon in
      * <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-14.html#jls-14.14.2">
      * enhanced for</a> loop.
      */
+    @ModuleProperty
     private boolean ignoreEnhancedForColon = true;
 
     @Override

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filefilters/BeforeExecutionExclusionFileFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filefilters/BeforeExecutionExclusionFileFilter.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.filefilters;
 
 import java.util.regex.Pattern;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.BeforeExecutionFileFilter;
 
@@ -93,6 +94,7 @@ public final class BeforeExecutionExclusionFileFilter extends AutomaticBean
         implements BeforeExecutionFileFilter {
 
     /** Define regular expression to match the file name against. */
+    @ModuleProperty
     private Pattern fileNamePattern;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SeverityMatchFilter.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle.filters;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.Filter;
@@ -69,6 +70,7 @@ public class SeverityMatchFilter
     implements Filter {
 
     /** Specify the severity level of this filter. */
+    @ModuleProperty
     private SeverityLevel severity = SeverityLevel.ERROR;
 
     /**
@@ -78,6 +80,7 @@ public class SeverityMatchFilter
      * if and only if there is not a match between the event's severity level
      * and property severity.
      */
+    @ModuleProperty
     private boolean acceptOnMatch = true;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -28,6 +28,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.PropertyType;
 import com.puppycrawl.tools.checkstyle.TreeWalkerAuditEvent;
 import com.puppycrawl.tools.checkstyle.TreeWalkerFilter;
@@ -277,32 +278,39 @@ public class SuppressWithNearbyCommentFilter
     private final List<Tag> tags = new ArrayList<>();
 
     /** Control whether to check C style comments ({@code &#47;* ... *&#47;}). */
+    @ModuleProperty
     private boolean checkC = true;
 
     /** Control whether to check C++ style comments ({@code //}). */
     // -@cs[AbbreviationAsWordInName] We can not change it as,
     // check's property is a part of API (used in configurations).
+    @ModuleProperty
     private boolean checkCPP = true;
 
     /** Specify comment pattern to trigger filter to begin suppression. */
+    @ModuleProperty
     private Pattern commentFormat = Pattern.compile(DEFAULT_COMMENT_FORMAT);
 
     /** Specify check pattern to suppress. */
     @XdocsPropertyType(PropertyType.PATTERN)
+    @ModuleProperty
     private String checkFormat = DEFAULT_CHECK_FORMAT;
 
     /** Define message pattern to suppress. */
     @XdocsPropertyType(PropertyType.PATTERN)
+    @ModuleProperty
     private String messageFormat;
 
     /** Specify check ID pattern to suppress. */
     @XdocsPropertyType(PropertyType.PATTERN)
+    @ModuleProperty
     private String idFormat;
 
     /**
      * Specify negative/zero/positive value that defines the number of lines
      * preceding/at/following the suppression comment.
      */
+    @ModuleProperty
     private String influenceFormat = DEFAULT_INFLUENCE_FORMAT;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java
@@ -31,6 +31,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.PropertyType;
 import com.puppycrawl.tools.checkstyle.XdocsPropertyType;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
@@ -328,21 +329,26 @@ public class SuppressWithPlainTextCommentFilter extends AutomaticBean implements
     private static final String DEFAULT_CHECK_FORMAT = ".*";
 
     /** Specify comment pattern to trigger filter to begin suppression. */
+    @ModuleProperty
     private Pattern offCommentFormat = CommonUtil.createPattern(DEFAULT_OFF_FORMAT);
 
     /** Specify comment pattern to trigger filter to end suppression. */
+    @ModuleProperty
     private Pattern onCommentFormat = CommonUtil.createPattern(DEFAULT_ON_FORMAT);
 
     /** Specify check pattern to suppress. */
     @XdocsPropertyType(PropertyType.PATTERN)
+    @ModuleProperty
     private String checkFormat = DEFAULT_CHECK_FORMAT;
 
     /** Specify message pattern to suppress. */
     @XdocsPropertyType(PropertyType.PATTERN)
+    @ModuleProperty
     private String messageFormat;
 
     /** Specify check ID pattern to suppress. */
     @XdocsPropertyType(PropertyType.PATTERN)
+    @ModuleProperty
     private String idFormat;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -29,6 +29,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.PropertyType;
 import com.puppycrawl.tools.checkstyle.TreeWalkerAuditEvent;
 import com.puppycrawl.tools.checkstyle.TreeWalkerFilter;
@@ -361,29 +362,36 @@ public class SuppressionCommentFilter
     private final List<Tag> tags = new ArrayList<>();
 
     /** Control whether to check C style comments ({@code &#47;* ... *&#47;}). */
+    @ModuleProperty
     private boolean checkC = true;
 
     /** Control whether to check C++ style comments ({@code //}). */
     // -@cs[AbbreviationAsWordInName] we can not change it as,
     // Check property is a part of API (used in configurations)
+    @ModuleProperty
     private boolean checkCPP = true;
 
     /** Specify comment pattern to trigger filter to begin suppression. */
+    @ModuleProperty
     private Pattern offCommentFormat = Pattern.compile(DEFAULT_OFF_FORMAT);
 
     /** Specify comment pattern to trigger filter to end suppression. */
+    @ModuleProperty
     private Pattern onCommentFormat = Pattern.compile(DEFAULT_ON_FORMAT);
 
     /** Specify check pattern to suppress. */
     @XdocsPropertyType(PropertyType.PATTERN)
+    @ModuleProperty
     private String checkFormat = DEFAULT_CHECK_FORMAT;
 
     /** Specify message pattern to suppress. */
     @XdocsPropertyType(PropertyType.PATTERN)
+    @ModuleProperty
     private String messageFormat;
 
     /** Specify check ID pattern to suppress. */
     @XdocsPropertyType(PropertyType.PATTERN)
+    @ModuleProperty
     private String idFormat;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.filters;
 import java.util.Collections;
 import java.util.Set;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -222,6 +223,7 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
 public class SuppressionFilter extends AutomaticBean implements Filter, ExternalResourceHolder {
 
     /** Specify the location of the <em>suppressions XML document</em> file. */
+    @ModuleProperty
     private String file;
     /**
      * Control what to do when the file is not existing. If {@code optional} is
@@ -229,6 +231,7 @@ public class SuppressionFilter extends AutomaticBean implements Filter, External
      * On the other hand if optional is {@code true} and file is not found,
      * the filter accept all audit events.
      */
+    @ModuleProperty
     private boolean optional;
     /** Set of individual suppresses. */
     private FilterSet filters = new FilterSet();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilter.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.filters;
 
 import java.util.regex.Pattern;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.Filter;
@@ -205,29 +206,35 @@ public class SuppressionSingleFilter extends AutomaticBean implements Filter {
     /**
      * Define the RegExp for matching against the file name associated with an audit event.
      */
+    @ModuleProperty
     private Pattern files;
     /**
      * Define the RegExp for matching against the name of the check associated with an audit event.
      */
+    @ModuleProperty
     private Pattern checks;
     /**
      * Define the RegExp for matching against the message of the check associated with an audit
      * event.
      */
+    @ModuleProperty
     private Pattern message;
     /**
      * Specify a string matched against the ID of the check associated with an audit event.
      */
+    @ModuleProperty
     private String id;
     /**
      * Specify a comma-separated list of values, where each value is an integer or a range of
      * integers denoted by integer-integer.
      */
+    @ModuleProperty
     private String lines;
     /**
      * Specify a comma-separated list of values, where each value is an integer or a range of
      * integers denoted by integer-integer.
      */
+    @ModuleProperty
     private String columns;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.TreeWalkerAuditEvent;
 import com.puppycrawl.tools.checkstyle.TreeWalkerFilter;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
@@ -511,6 +512,7 @@ public class SuppressionXpathFilter extends AutomaticBean implements
     private final Set<TreeWalkerFilter> filters = new HashSet<>();
 
     /** Specify the location of the <em>suppressions XML document</em> file. */
+    @ModuleProperty
     private String file;
     /**
      * Control what to do when the file is not existing.
@@ -518,6 +520,7 @@ public class SuppressionXpathFilter extends AutomaticBean implements
      * On the other hand if optional is true and file is not found,
      * the filter accepts all audit events.
      */
+    @ModuleProperty
     private boolean optional;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilter.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.filters;
 
 import java.util.regex.Pattern;
 
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
 import com.puppycrawl.tools.checkstyle.TreeWalkerAuditEvent;
 import com.puppycrawl.tools.checkstyle.TreeWalkerFilter;
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
@@ -418,24 +419,29 @@ public class SuppressionXpathSingleFilter extends AutomaticBean implements
     /**
      * Define a Regular Expression matched against the file name associated with an audit event.
      */
+    @ModuleProperty
     private Pattern files;
     /**
      * Define a Regular Expression matched against the name of the check associated
      * with an audit event.
      */
+    @ModuleProperty
     private Pattern checks;
     /**
      * Define a Regular Expression matched against the message of the check
      * associated with an audit event.
      */
+    @ModuleProperty
     private Pattern message;
     /**
      * Define a string matched against the ID of the check associated with an audit event.
      */
+    @ModuleProperty
     private String id;
     /**
      * Define a string xpath query.
      */
+    @ModuleProperty
     private String query;
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java
@@ -22,8 +22,10 @@ package com.puppycrawl.tools.checkstyle.meta;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -67,10 +69,11 @@ public final class XmlMetaReader {
      *
      * @param thirdPartyPackages fully qualified third party package names(can be only a
      *                           hint, e.g. for SevNTU it can be com.github.sevntu / com.github)
-     * @return list of module details found in the classpath satisfying the above conditions
+     * @return map of module full qualified name to module details found in the classpath satisfying
+     *         the above conditions
      * @throws IllegalStateException if there was a problem reading the module metadata files
      */
-    public static List<ModuleDetails> readAllModulesIncludingThirdPartyIfAny(
+    public static Map<String, ModuleDetails> readAllModulesIncludingThirdPartyIfAny(
             String... thirdPartyPackages) {
         final Set<String> standardModuleFileNames = new Reflections(
                 "com.puppycrawl.tools.checkstyle.meta", Scanners.Resources)
@@ -83,7 +86,7 @@ public final class XmlMetaReader {
             allMetadataSources.addAll(thirdPartyModuleFileNames);
         }
 
-        final List<ModuleDetails> result = new ArrayList<>(allMetadataSources.size());
+        final Map<String, ModuleDetails> result = new HashMap<>(allMetadataSources.size(), 1.0F);
         for (String fileName : allMetadataSources) {
             final ModuleType moduleType;
             if (fileName.endsWith("FileFilter.xml")) {
@@ -104,7 +107,7 @@ public final class XmlMetaReader {
                 throw new IllegalStateException("Problem to read all modules including third "
                         + "party if any. Problem detected at file: " + fileName, ex);
             }
-            result.add(moduleDetails);
+            result.put(moduleDetails.getFullQualifiedName(), moduleDetails);
         }
 
         return result;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/PropertyAnnotationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/PropertyAnnotationTest.java
@@ -1,0 +1,111 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2022 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.internal;
+
+import static com.tngtech.archunit.base.DescribedPredicate.not;
+import static com.tngtech.archunit.lang.conditions.ArchPredicates.are;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.puppycrawl.tools.checkstyle.ModuleProperty;
+import com.puppycrawl.tools.checkstyle.meta.ModuleDetails;
+import com.puppycrawl.tools.checkstyle.meta.ModulePropertyDetails;
+import com.puppycrawl.tools.checkstyle.meta.XmlMetaReader;
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+
+public class PropertyAnnotationTest {
+
+    private static final Map<String, ModuleDetails> MODULE_DETAILS_MAP =
+        XmlMetaReader.readAllModulesIncludingThirdPartyIfAny();
+
+    private static final DescribedPredicate<JavaField> MODULE_PROPERTIES = moduleProperties();
+
+    private static final JavaClasses IMPORTED_CLASSES = new ClassFileImporter()
+        .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+        .importPackages("com.puppycrawl.tools.checkstyle.filters",
+                        "com.puppycrawl.tools.checkstyle.filefilters",
+                        "com.puppycrawl.tools.checkstyle.checks");
+
+    private static DescribedPredicate<JavaField> moduleProperties() {
+        return new DescribedPredicate<>(
+            "module properties") {
+            @Override
+            public boolean apply(JavaField input) {
+                boolean result = false;
+                final JavaClass containingClass = input.getOwner();
+                final ModuleDetails moduleDetails = MODULE_DETAILS_MAP.get(
+                    containingClass.getFullName());
+                if (moduleDetails != null) {
+                    final List<ModulePropertyDetails> properties = moduleDetails.getProperties();
+                    result = properties.stream()
+                        .map(ModulePropertyDetails::getName)
+                        .anyMatch(moduleName -> moduleName.equals(input.getName()));
+                }
+                return result;
+            }
+        };
+    }
+
+    /**
+     * Test that fields that are module properties should be annotated with
+     * {@link ModuleProperty}.
+     *
+     * @noinspection JUnitTestMethodWithNoAssertions
+     * @noinspectionreason JUnitTestMethodWithNoAssertions - asserts in callstack,
+     *     but not in this method
+     */
+    @Test
+    public void modulePropertiesAnnotatedTest() {
+        final ArchRule modulePropertiesShouldBeAnnotated = fields()
+            .that(are(MODULE_PROPERTIES))
+            .should()
+            .beAnnotatedWith(ModuleProperty.class);
+
+        modulePropertiesShouldBeAnnotated.check(IMPORTED_CLASSES);
+    }
+
+    /**
+     * Test that fields that are not module properties should not be annotated with
+     * {@link ModuleProperty}.
+     *
+     * @noinspection JUnitTestMethodWithNoAssertions
+     * @noinspectionreason JUnitTestMethodWithNoAssertions - asserts in callstack,
+     *     but not in this method
+     */
+    @Test
+    public void nonModulePropertiesAreNotAnnotatedTest() {
+        final ArchRule nonModulePropertiesShouldNotBeAnnotated = fields()
+            .that(are(not(MODULE_PROPERTIES)))
+            .should()
+            .notBeAnnotatedWith(ModuleProperty.class);
+
+        nonModulePropertiesShouldNotBeAnnotated.check(IMPORTED_CLASSES);
+    }
+}


### PR DESCRIPTION
#12099
#2939

### Contents of this PR:

1. Adds a new annotation `ModuleProperty`.
2. Verifies that properties are correctly annotated.
3. Modified XmlMetaReader to return Map instead of a List.
4. Added annotation to modules (except `Checker`, `AbstractCheck`, and `AbstractFileSetCheck`)