### PR TITLE
Issue #8016: Add allowMissingBuilderJavadoc

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java
@@ -99,6 +99,13 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * Default value is {@code false}.
  * </li>
  * <li>
+ * Property {@code allowMissingBuilderJavadoc} - Control whether to allow missing Javadoc on
+ * methods using the builder pattern (a setter named like {@code withField}, {@code setField}, or
+ * {@code field} that returns an instance of the class).
+ * Type is {@code boolean}.
+ * Default value is {@code false}.
+ * </li>
+ * <li>
  * Property {@code ignoreMethodNamesRegex} - ignore method whose names are matching specified
  * regex.
  * Type is {@code java.util.regex.Pattern}.
@@ -287,6 +294,13 @@ public class MissingJavadocMethodCheck extends AbstractCheck {
      */
     private boolean allowMissingPropertyJavadoc;
 
+    /**
+     * Control whether to allow missing Javadoc on methods using the builder
+     * pattern (a setter named like {@code withField}, {@code setField}, or
+     * {@code field} that returns an instance of the class).
+     */
+    private boolean allowMissingBuilderJavadoc;
+
     /** Ignore method whose names are matching specified regex. */
     private Pattern ignoreMethodNamesRegex;
 
@@ -328,6 +342,17 @@ public class MissingJavadocMethodCheck extends AbstractCheck {
      */
     public void setAllowMissingPropertyJavadoc(final boolean flag) {
         allowMissingPropertyJavadoc = flag;
+    }
+
+    /**
+     * Setter to control whether to allow missing Javadoc on methods using the builder
+     * pattern (a setter named like {@code withField}, {@code setField}, or
+     * {@code field} that returns an instance of the class).
+     *
+     * @param flag a {@code Boolean} value
+     */
+    public void setAllowMissingBuilderJavadoc(final boolean flag) {
+        allowMissingBuilderJavadoc = flag;
     }
 
     /**
@@ -412,6 +437,7 @@ public class MissingJavadocMethodCheck extends AbstractCheck {
     private boolean isMissingJavadocAllowed(final DetailAST ast) {
         return allowMissingPropertyJavadoc
                 && (CheckUtil.isSetterMethod(ast) || CheckUtil.isGetterMethod(ast))
+            || allowMissingBuilderJavadoc && CheckUtil.isBuilderMethod(ast)
             || matchesSkipRegex(ast)
             || isContentsAllowMissingJavadoc(ast);
     }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
@@ -60,6 +61,9 @@ public final class CheckUtil {
     /** Maximum nodes allowed in a body of setter. */
     private static final int SETTER_BODY_SIZE = 3;
 
+    /** Maximum nodes allowed in a body of builder. */
+    private static final int BUILDER_BODY_SIZE = 4;
+
     /** Maximum nodes allowed in a body of getter. */
     private static final int GETTER_BODY_SIZE = 2;
 
@@ -71,6 +75,12 @@ public final class CheckUtil {
 
     /** Pattern matching names of getter methods. */
     private static final Pattern GETTER_PATTERN = Pattern.compile("^(is|get)[A-Z].*");
+
+    /**
+     * Pattern matching two styles of setter in the builder pattern. The other style
+     * is just the name of the field.
+     */
+    private static final Pattern BUILDER_PATTERN = Pattern.compile("^(with|set)[A-Z].*");
 
     /** Compiled pattern for all system newlines. */
     private static final Pattern ALL_NEW_LINES = Pattern.compile("\\R");
@@ -359,6 +369,91 @@ public final class CheckUtil {
             }
         }
         return setterMethod;
+    }
+
+    /**
+     * Returns whether an AST represents a method in a builder pattern.
+     * A builder method is named like {@code setFoo}, {@code withFoo}, or
+     * {@code foo}. It sets the field and returns an instance of the class.
+     *
+     * @param ast the AST to check with
+     * @return whether the AST represents a method in the builder pattern.
+     */
+    public static boolean isBuilderMethod(final DetailAST ast) {
+        boolean builderMethod = false;
+        // Check have a method with exactly 7 children which are all that
+        // is allowed in a proper builder method which does not throw any
+        // exceptions.
+
+        if (ast.getType() == TokenTypes.METHOD_DEF
+                && ast.getChildCount() == SETTER_GETTER_MAX_CHILDREN) {
+            final DetailAST type = ast.findFirstToken(TokenTypes.TYPE);
+            final boolean noVoidReturnType = type.findFirstToken(TokenTypes.LITERAL_VOID) == null;
+
+            final DetailAST params = ast.findFirstToken(TokenTypes.PARAMETERS);
+            final boolean singleParam = params.getChildCount(TokenTypes.PARAMETER_DEF) == 1;
+
+            if (noVoidReturnType && singleParam) {
+                // Now verify that the body consists of:
+                // EXPR -> ASSIGN of an instance field
+                // SEMI
+                // LITERAL_RETURN -> EXPR -> LITERAL_THIS
+                // RCURLY
+                final DetailAST slist = ast.findFirstToken(TokenTypes.SLIST);
+                if (slist != null && slist.getChildCount() == BUILDER_BODY_SIZE) {
+                    // Verify this method sets a field on the class.
+                    final DetailAST expr = slist.getFirstChild();
+                    final Optional<String> assignedField = getNameOfAssignedField(expr);
+
+                    // Verify that the method name matches the format setField,
+                    // withField, or field (shadowing the field in the last case).
+                    final String name = type.getNextSibling().getText();
+                    final boolean matchesBuilderFormat = BUILDER_PATTERN.matcher(name).matches()
+                            || assignedField.filter(field -> field.equals(name)).isPresent();
+
+                    if (matchesBuilderFormat) {
+                        // Verify the method returns the instance.
+                        final DetailAST literalReturn = expr.getNextSibling().getNextSibling();
+                        // Because noVoidReturnType is true, the first child is an
+                        // expression.
+                        final DetailAST returned = literalReturn.getFirstChild()
+                            .getFirstChild();
+                        builderMethod = returned != null
+                            && returned.getType() == TokenTypes.LITERAL_THIS;
+                    }
+                }
+            }
+        }
+
+        return builderMethod;
+    }
+
+    /**
+     * Parses the `a` from `this.a = b` or `a = b`.
+     *
+     * @param expr the AST to check (expected to be TokenTypes.EXPR)
+     * @return the name of the field assigned in the given expression, or empty.
+     */
+    private static Optional<String> getNameOfAssignedField(final DetailAST expr) {
+        String name = null;
+        final DetailAST assign = expr.getFirstChild();
+        if (assign.getType() == TokenTypes.ASSIGN) {
+            // this.field or field.
+            final DetailAST dotOrIdent = assign.getFirstChild();
+            if (dotOrIdent.getType() == TokenTypes.DOT) {
+                // this.field.
+                final DetailAST literalThis = dotOrIdent.getFirstChild();
+                if (literalThis.getType() == TokenTypes.LITERAL_THIS) {
+                    name = literalThis.getNextSibling().getText();
+                }
+            }
+            else if (dotOrIdent.getType() == TokenTypes.IDENT) {
+                // Field name without any prefix.
+                name = dotOrIdent.getText();
+            }
+        }
+
+        return Optional.ofNullable(name);
     }
 
     /**

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/MissingJavadocMethodCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/MissingJavadocMethodCheck.xml
@@ -62,6 +62,13 @@
                <description>Control whether to allow missing Javadoc on
  accessor methods for properties (setters and getters).</description>
             </property>
+            <property default-value="false"
+                       name="allowMissingBuilderJavadoc"
+                       type="boolean">
+               <description>Control whether to allow missing Javadoc on
+ methods using the builder pattern (a setter named like {@code withField}, {@code setField}, or
+ {@code field} that returns an instance of the class).</description>
+            </property>
             <property name="ignoreMethodNamesRegex" type="java.util.regex.Pattern">
                <description>ignore method whose names are matching specified
  regex.</description>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheckTest.java
@@ -335,6 +335,39 @@ public class MissingJavadocMethodCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testBuilderOff() throws Exception {
+        final String[] expected = {
+            "22:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "28:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "34:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputMissingJavadocMethodBuilder.java"), expected);
+    }
+
+    @Test
+    public void testBuilderOn() throws Exception {
+        final String[] expected = {
+            "42:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "47:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "59:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "65:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "72:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "77:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "102:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "108:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputMissingJavadocMethodBuilder2.java"), expected);
+        final String[] expectedForInterface = {
+            "19:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+            "21:5: " + getCheckMessage(MSG_JAVADOC_MISSING),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputMissingJavadocMethodBuilder3.java"), expectedForInterface);
+    }
+
+    @Test
     public void test11684081() throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verifyWithInlineConfigParser(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
@@ -266,6 +266,36 @@ public class CheckUtilTest extends AbstractPathTestSupport {
     }
 
     @Test
+    public void testIsBuilderMethod() throws Exception {
+        final DetailAST objBlock = getNodeFromFile(TokenTypes.OBJBLOCK);
+        final DetailAST builderClass = getNode(objBlock, TokenTypes.CLASS_DEF);
+
+        final DetailAST firstBuilderMethod = getNode(builderClass, TokenTypes.METHOD_DEF);
+        final DetailAST secondBuilderMethod = firstBuilderMethod.getNextSibling();
+        final DetailAST thirdBuilderMethod = secondBuilderMethod.getNextSibling();
+
+        assertWithMessage("Invalid result: AST provided for withFirst is builder method")
+                .that(CheckUtil.isBuilderMethod(firstBuilderMethod))
+                .isTrue();
+        assertWithMessage("Invalid result: AST provided for setSecond is builder method")
+                .that(CheckUtil.isBuilderMethod(secondBuilderMethod))
+                .isTrue();
+        assertWithMessage("Invalid result: AST provided for third is builder method")
+                .that(CheckUtil.isBuilderMethod(thirdBuilderMethod))
+                .isTrue();
+
+        DetailAST notBuilderMethod = thirdBuilderMethod.getNextSibling();
+        while (notBuilderMethod != null) {
+            final DetailAST methodName = notBuilderMethod.findFirstToken(TokenTypes.IDENT);
+            assertWithMessage("Invalid result: AST provided for " + methodName
+                    + " is not builder method")
+                .that(CheckUtil.isBuilderMethod(notBuilderMethod))
+                .isFalse();
+            notBuilderMethod = notBuilderMethod.getNextSibling();
+        }
+    }
+
+    @Test
     public void testGetAccessModifierFromModifiersToken() throws Exception {
         final DetailAST interfaceDef = getNodeFromFile(TokenTypes.INTERFACE_DEF);
         final AccessModifierOption modifierInterface = CheckUtil
@@ -356,7 +386,7 @@ public class CheckUtilTest extends AbstractPathTestSupport {
     public void testIsReceiverParameter() throws Exception {
         final DetailAST objBlock = getNodeFromFile(TokenTypes.OBJBLOCK);
         final DetailAST methodWithReceiverParameter = objBlock.getLastChild().getPreviousSibling()
-                .getPreviousSibling();
+                .getPreviousSibling().getPreviousSibling();
         final DetailAST receiverParameter =
                 getNode(methodWithReceiverParameter, TokenTypes.PARAMETER_DEF);
         final DetailAST simpleParameter =

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodBuilder.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodBuilder.java
@@ -1,0 +1,44 @@
+/*
+MissingJavadocMethod
+minLineCount = (default)-1
+allowedAnnotations = (default)Override
+scope = private
+excludeScope = (default)null
+allowMissingPropertyJavadoc = true
+allowMissingBuilderJavadoc = (default)false
+ignoreMethodNamesRegex = (default)null
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocmethod;
+
+public class InputMissingJavadocMethodBuilder
+{
+    private String mString;
+    private int mNumber;
+
+    public InputMissingJavadocMethodBuilder withString(final String string) // violation
+    {
+        mString = string;
+        return this;
+    }
+
+    public InputMissingJavadocMethodBuilder setString(final String string) // violation
+    {
+        this.mString = string;
+        return this;
+    }
+
+    public InputMissingJavadocMethodBuilder mString(final String mString) // violation
+    {
+        this.mString = mString;
+        return this;
+    }
+
+    public void setNumber(final int number) // ok
+    {
+        mNumber = number;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodBuilder2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodBuilder2.java
@@ -1,0 +1,116 @@
+/*
+MissingJavadocMethod
+minLineCount = (default)-1
+allowedAnnotations = (default)Override
+scope = private
+excludeScope = (default)null
+allowMissingPropertyJavadoc = (default)false
+allowMissingBuilderJavadoc = true
+ignoreMethodNamesRegex = (default)null
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocmethod;
+
+public class InputMissingJavadocMethodBuilder2
+{
+    private String mString;
+    private int mNumber;
+    private InputMissingJavadocMethodBuilder2 recursive;
+    private String[] array;
+
+    public InputMissingJavadocMethodBuilder2 withString(final String string) // ok
+    {
+        mString = string;
+        return this;
+    }
+
+    public InputMissingJavadocMethodBuilder2 setString(final String string) // ok
+    {
+        this.mString = string;
+        return this;
+    }
+
+    public InputMissingJavadocMethodBuilder2 mString(final String mString) // ok
+    {
+        this.mString = mString;
+        return this;
+    }
+
+    public void setNumber(final int number) // violation
+    {
+        mNumber = number;
+    }
+
+    public InputMissingJavadocMethodBuilder2 misnamed(String string) // violation
+    {
+        mString = string;
+        return this;
+    }
+
+    public InputMissingJavadocMethodBuilder2 setIncrement(int number) // ok
+    {
+        mNumber++;
+        return this;
+    }
+
+    public String setAndReturn(String string) // violation
+    {
+        mString = string;
+        return string;
+    }
+
+    public InputMissingJavadocMethodBuilder2 tooLong(String string) // violation
+    {
+        mString = string;
+        mNumber = 5;
+        return this;
+    }
+
+    public InputMissingJavadocMethodBuilder2 tooShort(String string) // violation
+    {
+        return this;
+    }
+
+    public InputMissingJavadocMethodBuilder2 setMultiple(String string, int number) // violation
+    {
+        mString = string;
+        mNumber = number;
+        return this;
+    }
+
+    public InputMissingJavadocMethodBuilder2 setRecursiveWithThis(String string) // ok
+    {
+        this.recursive.mString = string;
+        return this;
+    }
+
+    public InputMissingJavadocMethodBuilder2 setRecursive(String string) // ok
+    {
+        recursive.mString = string;
+        return this;
+    }
+
+    public InputMissingJavadocMethodBuilder2 setArray(String string) // ok
+    {
+        array[0] = string;
+        return this;
+    }
+
+    public InputMissingJavadocMethodBuilder2 setThrows(String string) throws Exception // violation
+    {
+        this.mString = string;
+        return this;
+    }
+
+    public String[] setArray(String... array) { // violation
+        this.array = array;
+        if (array.length > 0) {
+            return this.array;
+        } else {
+            return new String[4];
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodBuilder3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/missingjavadocmethod/InputMissingJavadocMethodBuilder3.java
@@ -1,0 +1,22 @@
+/*
+MissingJavadocMethod
+minLineCount = (default)-1
+allowedAnnotations = (default)Override
+scope = private
+excludeScope = (default)null
+allowMissingPropertyJavadoc = (default)false
+allowMissingBuilderJavadoc = true
+ignoreMethodNamesRegex = (default)null
+tokens = (default)METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.missingjavadocmethod;
+
+public interface InputMissingJavadocMethodBuilder3
+{
+    InputMissingJavadocMethodBuilder3 withField(String field); // violation
+
+    InputMissingJavadocMethodBuilder3 setField(String field); // violation
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtilTest.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/utils/checkutil/InputCheckUtilTest.java
@@ -71,4 +71,34 @@ public class InputCheckUtilTest<V, C> {
     public interface Example {
         void method();
     }
+
+    /**
+     * Tests three styles of builder setter (setFoo, withFoo, and foo). The following method
+     * should not match.
+     */
+    public static class Builder {
+        private String first;
+        private int second;
+        private boolean third;
+        private String fourth;
+        private Builder recursive;
+        private String[] array;
+
+        public Builder withFirst(String first) {
+            this.first = first;
+            return this;
+        }
+        public Builder setSecond(int secondWithOtherName) {
+            second = secondWithOtherName;
+            return this;
+        }
+        public Builder third(boolean third) {
+            this.third = third;
+            return this;
+        }
+        public void setFourth(String fourth) {
+            this.fourth = fourth;
+            return;
+        }
+    }
 }

--- a/src/xdocs/config_javadoc.xml
+++ b/src/xdocs/config_javadoc.xml
@@ -2562,6 +2562,18 @@ public boolean isSomething()
               <td>8.21</td>
             </tr>
             <tr>
+              <td>allowMissingBuilderJavadoc</td>
+              <td>
+                Control whether to allow missing Javadoc on methods using the
+                builder pattern (a setter named like <code>withField</code>,
+                <code>setField</code>, or <code>field</code> that returns an
+                instance of the class).
+              </td>
+              <td><a href="property_types.html#boolean">boolean</a></td>
+              <td><code>false</code></td>
+              <td>10.4</td>
+            </tr>
+            <tr>
               <td>ignoreMethodNamesRegex</td>
               <td>ignore method whose names are matching specified regex.</td>
               <td><a href="property_types.html#Pattern">Pattern</a></td>


### PR DESCRIPTION
Issue: #8016

That issue does not have the "approved" label yet, but I wanted to propose a solution in a backwards-compatible way. This adds an `allowMissingBuilderJavadoc` boolean to `MissingJavadocMethod`. If set to `true`, methods using the builder pattern are allowed to not have Javadoc, parallel to `allowMissingPropertyJavadoc`. Three different formats are below:

```java
public class Builder {
    private String field;

    public Builder setField(String field) {
        this.field = field;
        return this;
    }
    public Builder withField(String field) {
        this.field = field;
        return this;
    }
    public Builder field(String field) {
        this.field = field;
        return this;
    }
}
```

Diff Regression config: https://gist.githubusercontent.com/nerdydrew/856c7cb06f7f97d3477d011df8ebfa3f/raw/75e0963f9e36e87c9e496c7e496825a52483ae6f/regression_config.xml

Diff Regression patch config: https://gist.githubusercontent.com/nerdydrew/aa6101785c5b74f0d550db41726b874d/raw/0f375f6d3b98317102b91c6319de384fe3745f41/regression_patch_config.xml