### PR TITLE
Issue #12099: Add ArchUnit test to ensure classes in api package are not dependent on classes present in utils package

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -790,6 +790,7 @@ linkplain
 linksource
 linux
 Lisetskii
+Ljava
 lkuehne
 llll
 lmessage

--- a/config/intellij-idea-inspections.xml
+++ b/config/intellij-idea-inspections.xml
@@ -4624,7 +4624,8 @@
     ,com.google.checkstyle.test.base.AbstractModuleTestSupport,verify.*, ,
     ,com.puppycrawl.tools.checkstyle.internal.TestUtil,assert.*, ,
     ,nl.jqno.equalsverifier.EqualsVerifier,verify.*, ,
-    ,org.checkstyle.base.AbstractItModuleTestSupport,verify.*"/>
+    ,org.checkstyle.base.AbstractItModuleTestSupport,verify.*, ,
+    ,com.tngtech.archunit.lang.ArchRule,check"/>
     <option name="assertKeywordIsAssertion" value="false"/>
   </inspection_tool>
   <inspection_tool class="TestNGDataProvider" enabled="true" level="ERROR"

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/ArchUnitTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/ArchUnitTest.java
@@ -19,7 +19,11 @@
 
 package com.puppycrawl.tools.checkstyle.internal;
 
+import static com.google.common.truth.Truth.assertWithMessage;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -29,8 +33,54 @@ import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.EvaluationResult;
 
 public class ArchUnitTest {
+
+    /**
+     * Suppression list containing violations from {@code classShouldNotDependOnUtilPackages}
+     * ArchRule. Location of the violation (eg - {@code in (AutomaticBean.java:372)}) has been
+     * omitted as line number can change with modifications to the file.
+     */
+    private static final List<String> API_PACKAGE_SUPPRESSION_DETAILS = List.of(
+        "Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.lang"
+            + ".String)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil"
+            + ".EMPTY_STRING_ARRAY>",
+        "Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.util"
+            + ".List)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil"
+            + ".EMPTY_STRING_ARRAY>",
+        "Method <com.puppycrawl.tools.checkstyle.api.AbstractCheck.log(com.puppycrawl.tools"
+            + ".checkstyle.api.DetailAST, java.lang.String, [Ljava.lang.Object;)> calls method "
+            + "<com.puppycrawl.tools.checkstyle.utils.CommonUtil.lengthExpandedTabs(java.lang"
+            + ".String, int, int)>",
+        "Method <com.puppycrawl.tools.checkstyle.api.AbstractCheck.log(int, int, java.lang"
+            + ".String, [Ljava.lang.Object;)> calls method <com.puppycrawl.tools.checkstyle.utils"
+            + ".CommonUtil.lengthExpandedTabs(java.lang.String, int, int)>",
+        "Method <com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.log(int, int, java.lang"
+            + ".String, [Ljava.lang.Object;)> calls method <com.puppycrawl.tools.checkstyle.utils"
+            + ".CommonUtil.lengthExpandedTabs(java.lang.String, int, int)>",
+        "Method <com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.process(java.io.File, "
+            + "com.puppycrawl.tools.checkstyle.api.FileText)> calls method <com.puppycrawl.tools"
+            + ".checkstyle.utils.CommonUtil.matchesFileExtension(java.io.File, [Ljava.lang"
+            + ".String;)>",
+        "Method <com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.setFileExtensions"
+            + "([Ljava.lang.String;)> calls method <com.puppycrawl.tools.checkstyle.utils"
+            + ".CommonUtil.startsWithChar(java.lang.String, char)>",
+        "Method <com.puppycrawl.tools.checkstyle.api.AutomaticBean$PatternConverter.convert(java"
+            + ".lang.Class, java.lang.Object)> calls method <com.puppycrawl.tools.checkstyle"
+            + ".utils.CommonUtil.createPattern(java.lang.String)>",
+        "Method <com.puppycrawl.tools.checkstyle.api.AutomaticBean$RelaxedStringArrayConverter"
+            + ".convert(java.lang.Class, java.lang.Object)> gets field <com.puppycrawl.tools"
+            + ".checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY>",
+        "Method <com.puppycrawl.tools.checkstyle.api.AutomaticBean$UriConverter.convert(java.lang"
+            + ".Class, java.lang.Object)> calls method <com.puppycrawl.tools.checkstyle.utils"
+            + ".CommonUtil.getUriByFilename(java.lang.String)>",
+        "Method <com.puppycrawl.tools.checkstyle.api.AutomaticBean$UriConverter.convert(java.lang"
+            + ".Class, java.lang.Object)> calls method <com.puppycrawl.tools.checkstyle.utils"
+            + ".CommonUtil.isBlank(java.lang.String)>",
+        "Method <com.puppycrawl.tools.checkstyle.api.FileContents.lineIsBlank(int)> calls method "
+            + "<com.puppycrawl.tools.checkstyle.utils.CommonUtil.isBlank(java.lang.String)>"
+    );
 
     @BeforeAll
     public static void init() {
@@ -43,10 +93,6 @@ public class ArchUnitTest {
      * except for those which are annotated with {@code Override}. In the bytecode there is no
      * trace anymore if this method was annotated with {@code Override} or not (limitation of
      * Archunit), eventually we need to make checkstyle's Check on this.
-     *
-     * @noinspection JUnitTestMethodWithNoAssertions
-     * @noinspectionreason JUnitTestMethodWithNoAssertions - asserts in callstack,
-     *      but not in this method
      */
     @Test
     public void nonProtectedCheckMethodsTest() {
@@ -74,4 +120,37 @@ public class ArchUnitTest {
 
         checkMethodsShouldNotBeProtectedRule.check(importedClasses);
     }
+
+    /**
+     * The goal is to ensure all classes in api package are not dependent on classes in util
+     * packages. Changes in Util classes are not considered to be breaking changes as they are
+     * "internal". Therefore classes in api should not depend on them.
+     */
+    @Test
+    public void testClassesInApiDoNotDependOnClassesInUtil() {
+        final JavaClasses apiPackage = new ClassFileImporter()
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+            .importPackages("com.puppycrawl.tools.checkstyle.api");
+
+        final String[] utilPackages = {
+            "com.puppycrawl.tools.checkstyle.utils",
+            "com.puppycrawl.tools.checkstyle.checks.javadoc.utils",
+        };
+
+        final ArchRule classShouldNotDependOnUtilPackages = noClasses()
+            .should()
+            .dependOnClassesThat()
+            .resideInAnyPackage(utilPackages);
+
+        final EvaluationResult result = classShouldNotDependOnUtilPackages.evaluate(apiPackage);
+        final EvaluationResult filtered = result.filterDescriptionsMatching(description -> {
+            return API_PACKAGE_SUPPRESSION_DETAILS.stream()
+                .noneMatch(description::startsWith);
+        });
+
+        assertWithMessage("api package: " + classShouldNotDependOnUtilPackages.getDescription())
+            .that(filtered.getFailureReport().getDetails())
+            .isEmpty();
+    }
+
 }


### PR DESCRIPTION
#12099

### This PR contains:

1. A rule stating that classes in the API package are not dependent on classes in the utils package.
2. Suppression list containing classes that don't follow this rule.