### PR TITLE
Issue #7619: Updated doc for EmptyLineSeperator

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -119,34 +119,28 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * ///////////////////////////////////////////////////
  * //HEADER
  * ///////////////////////////////////////////////////
- * package com.whitespace; // violation, 'package' should be separated from previous line.
- * import java.io.Serializable; // violation, 'import' should be separated from previous line.
- * class Foo { // violation, 'CLASS_DEF' should be separated from previous line.
- *   public static final int FOO_CONST = 1;
- *   public void foo() {} // violation, 'METHOD_DEF' should be separated from previous line.
+ * package com.whitespace; // violation , 'package' should be separated from previous line
+ * import java.io.Serializable; // violation , 'import' should be separated from previous line
+ *
+ * class FirstClass {
+ *
+ *   int var1 = 1;
+ *   int var2 = 2; // violation , 'VARIABLE_DEF' should be separated from previous line
+ *
+ *
+ *   int var3 = 3;
+ *
+ *
+ *   void method1() {}
+ *   void method2() { // violation , 'METHOD_DEF' should be separated from previous line
+ *      int var4 = 4;
+ *
+ *
+ *      int var5 = 5;
+ *   }
  * }
  * </pre>
  *
- * <p>
- * Example of declarations with empty line separator
- * that is expected by the Check by default:
- * </p>
- *
- * <pre>
- * ///////////////////////////////////////////////////
- * //HEADER
- * ///////////////////////////////////////////////////
- *
- * package com.puppycrawl.tools.checkstyle.whitespace;
- *
- * import java.io.Serializable;
- *
- * class Foo {
- *   public static final int FOO_CONST = 1;
- *
- *   public void foo() {}
- * }
- * </pre>
  * <p>
  * To check empty line before
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#VARIABLE_DEF">
@@ -156,10 +150,37 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </p>
  *
  * <pre>
- * &lt;module name=&quot;EmptyLineSeparator&quot;&gt;
+ *   &lt;module name=&quot;EmptyLineSeparator&quot;&gt;
  *   &lt;property name=&quot;tokens&quot; value=&quot;VARIABLE_DEF, METHOD_DEF&quot;/&gt;
- * &lt;/module&gt;
+ *   &lt;/module&gt;
  * </pre>
+ *
+ * <pre>
+ * ///////////////////////////////////////////////////
+ * //HEADER
+ * ///////////////////////////////////////////////////
+ * package com.whitespace;
+ * import java.io.Serializable;
+ *
+ * class FirstClass {
+ *
+ *   int var1 = 1;
+ *   int var2 = 2; // violation , 'VARIABLE_DEF' should be separated from previous line
+ *
+ *
+ *   int var3 = 3;
+ *
+ *
+ *   void method1() {}
+ *    void method2() { // violation , 'METHOD_DEF' should be separated from previous line
+ *      int var4 = 4;
+ *
+ *
+ *      int var5 = 5;
+ *   }
+ * }
+ * </pre>
+ *
  *
  * <p>
  * To allow no empty line between fields:
@@ -175,37 +196,31 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </p>
  *
  * <pre>
- * class Foo {
- *   int field1; // ok
- *   double field2; // ok
- *   long field3, field4 = 10L, field5; // ok
- * }
- * </pre>
- * <p>
- * Example of declarations with multiple empty lines between class members (allowed by default):
- * </p>
- *
- * <pre>
  * ///////////////////////////////////////////////////
  * //HEADER
  * ///////////////////////////////////////////////////
+ * package com.whitespace; // violation , 'package' should be separated from previous line
+ * import java.io.Serializable; // violation , 'import' should be separated from previous line
+ *
+ * class FirstClass {
+ *
+ *   int var1 = 1;
+ *   int var2 = 2;
  *
  *
- * package com.puppycrawl.tools.checkstyle.whitespace;
+ *   int var3 = 3;
  *
  *
- *
- * import java.io.Serializable;
- *
- *
- * class Foo {
- *   public static final int FOO_CONST = 1;
+ *   void method1() {}
+ *    void method2() { // violation , 'METHOD_DEF' should be separated from previous line
+ *      int var4 = 4;
  *
  *
- *
- *   public void foo() {} // OK
+ *      int var5 = 5;
+ *   }
  * }
  * </pre>
+ *
  * <p>
  * To disallow multiple empty lines between class members:
  * </p>
@@ -218,20 +233,25 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * ///////////////////////////////////////////////////
  * //HEADER
  * ///////////////////////////////////////////////////
+ * package com.whitespace; // violation , 'package' should be separated from previous line
+ * import java.io.Serializable; // violation , 'import' should be separated from previous line
+ *
+ * class FirstClass {
+ *
+ *   int var1 = 1;
+ *   int var2 = 2; // violation , 'VARIABLE_DEF' should be separated from previous line
  *
  *
- * package com.checkstyle.whitespace; // violation, 'package' has more than 1 empty lines before.
+ *   int var3 = 3; // violation , 'VARIABLE_DEF' has more than 1 empty lines before
  *
  *
- * import java.io.Serializable; // violation, 'import' has more than 1 empty lines before.
+ *   void method1() {} // violation , 'METHOD_DEF' has more than 1 empty lines before
+ *    void method2() { // violation , 'METHOD_DEF' should be separated from previous line
+ *      int var4 = 4;
  *
  *
- * class Foo { // violation, 'CLASS_DEF' has more than 1 empty lines before.
- *   public static final int FOO_CONST = 1;
- *
- *
- *
- *   public void foo() {} // violation, 'METHOD_DEF' has more than 1 empty lines before.
+ *      int var5 = 5;
+ *   }
  * }
  * </pre>
  *
@@ -269,40 +289,28 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * ///////////////////////////////////////////////////
  * //HEADER
  * ///////////////////////////////////////////////////
+ * package com.whitespace; // violation , 'package' should be separated from previous line
+ * import java.io.Serializable; // violation , 'import' should be separated from previous line
  *
- * package com.puppycrawl.tools.checkstyle.whitespace;
+ * class FirstClass {
  *
- * class Foo {
+ *   int var1 = 1;
+ *   int var2 = 2; // violation , 'VARIABLE_DEF' should be separated from previous line
  *
- *   public void foo() {
+ *
+ *   int var3 = 3;
  *
  *
- *     System.out.println(1); // violation, There is more than 1 empty line one after another
- *                            // in previous line.
+ *   void method1() {}
+ *   void method2() { // violation , 'METHOD_DEF' should be separated from previous line
+ *      int var4 = 4; // violation , There is more than 1 empty line after this line
+ *
+ *
+ *      int var5 = 5;
  *   }
  * }
  * </pre>
- * <p>
- * To disallow multiple empty lines between class members:
- * </p>
  *
- * <pre>
- * &lt;module name="EmptyLineSeparator"&gt;
- *   &lt;property name="allowMultipleEmptyLines" value="false"/&gt;
- * &lt;/module&gt;
- * </pre>
- * <p>Example:</p>
- * <pre>
- * package com.puppycrawl.tools.checkstyle.whitespace;
- *
- * class Test {
- *     private int k;
- *
- *
- *     private static void foo() {} // violation, 'METHOD_DEF' has more than 1 empty lines before.
- *
- * }
- * </pre>
  * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.TreeWalker}
  * </p>

--- a/src/xdocs/config_whitespace.xml
+++ b/src/xdocs/config_whitespace.xml
@@ -393,30 +393,22 @@ for (Iterator foo = very.long.line.iterator();
 ///////////////////////////////////////////////////
 //HEADER
 ///////////////////////////////////////////////////
-package com.whitespace; // violation, 'package' should be separated from previous line.
-import java.io.Serializable; // violation, 'import' should be separated from previous line.
-class Foo { // violation, 'CLASS_DEF' should be separated from previous line.
-  public static final int FOO_CONST = 1;
-  public void foo() {} // violation, 'METHOD_DEF' should be separated from previous line.
-}
-        </source>
-        <p>
-          Example of declarations with empty line separator that is expected by the Check by
-          default:
-        </p>
-        <source>
-///////////////////////////////////////////////////
-//HEADER
-///////////////////////////////////////////////////
+package com.whitespace; // violation , 'package' should be separated from previous line
+import java.io.Serializable; // violation , 'import' should be separated from previous line
 
-package com.puppycrawl.tools.checkstyle.whitespace;
+class FirstClass {
 
-import java.io.Serializable;
+  int var1 = 1;
+  int var2 = 2; // violation , 'VARIABLE_DEF' should be separated from previous line&#10;
 
-class Foo {
-  public static final int FOO_CONST = 1;
+  int var3 = 3;&#10;
 
-  public void foo() {}
+  void method1() {}
+  void method2() { // violation , 'METHOD_DEF' should be separated from previous line
+     int var4 = 4;&#10;
+
+     int var5 = 5;
+  }
 }
         </source>
         <p>
@@ -431,6 +423,29 @@ class Foo {
   &lt;property name="tokens" value="VARIABLE_DEF, METHOD_DEF"/&gt;
 &lt;/module&gt;
         </source>
+        <source>
+///////////////////////////////////////////////////
+//HEADER
+///////////////////////////////////////////////////
+package com.whitespace;
+import java.io.Serializable;
+
+class FirstClass {
+
+  int var1 = 1;
+  int var2 = 2; // violation , 'VARIABLE_DEF' should be separated from previous line&#10;
+
+  int var3 = 3;&#10;
+
+  void method1() {}
+  void method2() { // violation , 'METHOD_DEF' should be separated from previous line
+     int var4 = 4;&#10;
+
+     int var5 = 5;
+  }
+}
+        </source>
+
         <p>
           To allow no empty line between fields:
         </p>
@@ -443,29 +458,25 @@ class Foo {
           Example:
         </p>
         <source>
-class Foo {
-  int field1; // ok
-  double field2; // ok
-  long field3, field4 = 10L, field5; // ok
-}
-        </source>
-        <p>
-          Example of declarations with multiple empty lines between class members
-          (allowed by default):
-        </p>
-        <source>
 ///////////////////////////////////////////////////
 //HEADER
-///////////////////////////////////////////////////&#10;
+///////////////////////////////////////////////////
+package com.whitespace; // violation , 'package' should be separated from previous line
+import java.io.Serializable; // violation , 'import' should be separated from previous line
 
-package com.puppycrawl.tools.checkstyle.whitespace;&#10;&#10;
+class FirstClass {
 
-import java.io.Serializable;&#10;
+  int var1 = 1;
+  int var2 = 2;&#10;
 
-class Foo {
-  public static final int FOO_CONST = 1;&#10;&#10;
+  int var3 = 3;&#10;
 
-  public void foo() {} // OK
+  void method1() {}
+  void method2() { // violation , 'METHOD_DEF' should be separated from previous line
+     int var4 = 4;&#10;
+
+     int var5 = 5;
+  }
 }
         </source>
         <p>
@@ -479,16 +490,23 @@ class Foo {
         <source>
 ///////////////////////////////////////////////////
 //HEADER
-///////////////////////////////////////////////////&#10;
+///////////////////////////////////////////////////
+package com.whitespace; // violation , 'package' should be separated from previous line
+import java.io.Serializable; // violation , 'import' should be separated from previous line
 
-package com.checkstyle.whitespace; // violation, 'package' has more than 1 empty lines before.&#10;
+class FirstClass {
 
-import java.io.Serializable; // violation, 'import' has more than 1 empty lines before.&#10;
+  int var1 = 1;
+  int var2 = 2; // violation , 'VARIABLE_DEF' should be separated from previous line&#10;
 
-class Foo { // violation, 'CLASS_DEF' has more than 1 empty lines before.
-  public static final int FOO_CONST = 1;&#10;&#10;
+  int var3 = 3; // violation , 'VARIABLE_DEF' has more than 1 empty lines before&#10;
 
-  public void foo() {} // violation, 'METHOD_DEF' has more than 1 empty lines before.
+  void method1() {} // violation , 'METHOD_DEF' has more than 1 empty lines before
+  void method2() { // violation , 'METHOD_DEF' should be separated from previous line
+     int var4 = 4;&#10;
+
+     int var5 = 5;
+  }
 }
         </source>
         <p>
@@ -526,35 +544,22 @@ class Foo { // violation, 'CLASS_DEF' has more than 1 empty lines before.
 ///////////////////////////////////////////////////
 //HEADER
 ///////////////////////////////////////////////////
+package com.whitespace; // violation , 'package' should be separated from previous line
+import java.io.Serializable; // violation , 'import' should be separated from previous line
 
-package com.puppycrawl.tools.checkstyle.whitespace;
+class FirstClass {
 
-class Foo {
+  int var1 = 1;
+  int var2 = 2; // violation , 'VARIABLE_DEF' should be separated from previous line&#10;
 
-  public void foo() {&#10;
+  int var3 = 3;&#10;
 
-    System.out.println(1); // violation, There is more than 1 empty line one after another
-                           // in previous line.
+  void method1() {}
+  void method2() { // violation , 'METHOD_DEF' should be separated from previous line
+     int var4 = 4; // violation , There is more than 1 empty line after this line&#10;
+
+     int var5 = 5;
   }
-}
-        </source>
-        <p>
-          To disallow multiple empty lines between class members:
-        </p>
-        <source>
-&lt;module name="EmptyLineSeparator"&gt;
-  &lt;property name="allowMultipleEmptyLines" value="false"/&gt;
-&lt;/module&gt;
-        </source>
-        <p>Example:</p>
-        <source>
-package com.puppycrawl.tools.checkstyle.whitespace;
-
-class Test {
-    private int k;&#10;
-
-    private static void foo() {} // violation, 'METHOD_DEF' has more than 1 empty lines before.
-
 }
         </source>
       </subsection>


### PR DESCRIPTION
This is with reference to the Issue: #7619 .

I have updated examples given in the following files:

1. src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
2. src/xdocs/config_whitespace.xml

After making the necessary changes, mvn clean verify passed without test failures.

![image](https://user-images.githubusercontent.com/90137881/189267514-d9f66b0d-b5df-47a8-9819-4f61f23f670b.png)


