### PR TITLE
Issue #12195: Checkstyle should use dependencyConvergence maven-enfor…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -381,6 +381,10 @@
           <groupId>xml-apis</groupId>
           <artifactId>xml-apis</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>
@@ -1309,6 +1313,7 @@
                 <requireMavenVersion>
                   <version>3.3.9</version>
                 </requireMavenVersion>
+                <dependencyConvergence/>
                 <!-- we can not use this as it require same version for all dependencies -->
                 <!--
                 <enforceBytecodeVersion>


### PR DESCRIPTION
Closes #12195

From commit https://github.com/checkstyle/checkstyle/pull/12196/commits/582a7e067c9384636fa2e07f70752fd9fa517967 in https://github.com/checkstyle/checkstyle/runs/8309826728?check_suite_focus=true#step:5:1668 :
```
Warning:  
Dependency convergence error for org.slf4j:slf4j-api:jar:1.7.32:compile paths to dependency are:
+-com.puppycrawl.tools:checkstyle:jar:10.3.4-SNAPSHOT
  +-org.reflections:reflections:jar:0.10.2:compile
    +-org.slf4j:slf4j-api:jar:1.7.32:compile
and
+-com.puppycrawl.tools:checkstyle:jar:10.3.4-SNAPSHOT
  +-net.sf.saxon:Saxon-HE:jar:11.4:compile
    +-org.xmlresolver:xmlresolver:jar:4.4.3:compile
      +-org.apache.httpcomponents.client5:httpclient5:jar:5.1.3:runtime
        +-org.slf4j:slf4j-api:jar:1.7.25:runtime

Error:  Rule 2: org.apache.maven.plugins.enforcer.DependencyConvergence failed with message:
Failed while enforcing releasability. See above detailed error message.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  12.720 s
[INFO] Finished at: 2022-09-12T15:51:48Z
[INFO] ------------------------------------------------------------------------
Error:  Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.1.0:enforce (enforce-versions) on project checkstyle: Some Enforcer rules have failed. Look above for specific messages explaining why the rule failed. -> [Help 1]

```