### PR TITLE
minor: remove unnecessary checkstyle versions to diff.groovy

### DIFF
--- a/.ci/no-exception-test.sh
+++ b/.ci/no-exception-test.sh
@@ -20,8 +20,8 @@ guava-with-google-checks)
   export MAVEN_OPTS="-Xmx2048m"
   groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
       --patchConfig ../../google_checks.xml \
-      --mode single --allowExcludes -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}" -p "$BRANCH" -r ../../..
+      --mode single --allowExcludes -xm "-Dcheckstyle.failsOnError=false" \
+      -p "$BRANCH" -r ../../..
   cd ../..
   removeFolderWithProtectedFiles contribution
   rm google_checks.*
@@ -42,8 +42,8 @@ guava-with-sun-checks)
   export MAVEN_OPTS="-Xmx2048m"
   groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
       --patchConfig ../../sun_checks.xml \
-      --mode single --allowExcludes -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"  -p "$BRANCH" -r ../../..
+      --mode single --allowExcludes -xm "-Dcheckstyle.failsOnError=false" \
+      -p "$BRANCH" -r ../../..
   cd ../..
   removeFolderWithProtectedFiles contribution
   rm sun_checks.*
@@ -84,8 +84,8 @@ no-exception-lucene-and-others-javadoc)
   export MAVEN_OPTS="-Xmx2048m"
   groovy ./diff.groovy --listOfProjects projects-for-no-exception-javadoc.config \
       --patchConfig checks-only-javadoc-error.xml \
-      --mode single --allowExcludes -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"  -p "$BRANCH" -r ../../..
+      --mode single --allowExcludes -xm "-Dcheckstyle.failsOnError=false" \
+      -p "$BRANCH" -r ../../..
   cd ../..
   removeFolderWithProtectedFiles contribution
   ;;
@@ -104,8 +104,8 @@ no-exception-cassandra-storm-tapestry-javadoc)
   export MAVEN_OPTS="-Xmx2048m"
   groovy ./diff.groovy --listOfProjects projects-for-no-exception-javadoc.config \
       --patchConfig checks-only-javadoc-error.xml \
-      --mode single --allowExcludes  -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"  -p "$BRANCH" -r ../../..
+      --mode single --allowExcludes  -xm "-Dcheckstyle.failsOnError=false" \
+      -p "$BRANCH" -r ../../..
   cd ../..
   removeFolderWithProtectedFiles contribution
   ;;
@@ -125,8 +125,8 @@ no-exception-hadoop-apache-groovy-scouter-javadoc)
   export MAVEN_OPTS="-Xmx2048m"
   groovy ./diff.groovy --listOfProjects projects-for-no-exception-javadoc.config \
       --patchConfig checks-only-javadoc-error.xml \
-      --mode single --allowExcludes -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"  -p "$BRANCH" -r ../../..
+      --mode single --allowExcludes -xm "-Dcheckstyle.failsOnError=false" \
+      -p "$BRANCH" -r ../../..
   cd ../..
   removeFolderWithProtectedFiles contribution
   ;;
@@ -146,8 +146,8 @@ no-exception-only-javadoc)
   export MAVEN_OPTS="-Xmx2048m"
   groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
       --patchConfig checks-only-javadoc-error.xml --allowExcludes \
-      --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"  -p "$BRANCH" -r ../../..
+      --mode single -xm "-Dcheckstyle.failsOnError=false" \
+      -p "$BRANCH" -r ../../..
   cd ../..
   removeFolderWithProtectedFiles contribution
   ;;

--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -809,8 +809,7 @@ no-exception-struts)
   sed -i'' 's/#apache-struts/apache-struts/' projects-to-test-on.properties
   groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
       --patchConfig checks-nonjavadoc-error.xml  -p "$BRANCH" -r ../../..  \
-      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"
+      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -828,8 +827,7 @@ no-exception-checkstyle-sevntu)
   sed -i'' 's/#sevntu-checkstyle/sevntu-checkstyle/' projects-to-test-on.properties
   groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
       --patchConfig checks-nonjavadoc-error.xml  -p "$BRANCH" -r ../../..  \
-      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"
+      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -846,8 +844,7 @@ no-exception-checkstyle-sevntu-javadoc)
   sed -i'' 's/#sevntu-checkstyle/sevntu-checkstyle/' projects-to-test-on.properties
   groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
       --patchConfig checks-only-javadoc-error.xml  -p "$BRANCH" -r ../../..  \
-      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"
+      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -863,8 +860,7 @@ no-exception-guava)
   sed -i'' 's/#guava/guava/' projects-to-test-on.properties
   groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
       --patchConfig checks-nonjavadoc-error.xml  -p "$BRANCH" -r ../../..  \
-      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"
+      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -879,8 +875,7 @@ no-exception-hibernate-orm)
   sed -i.'' 's/#hibernate-orm/hibernate-orm/' projects-to-test-on.properties
   groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
       --patchConfig checks-nonjavadoc-error.xml  -p "$BRANCH" -r ../../..  \
-       --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"
+       --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -895,8 +890,7 @@ no-exception-spotbugs)
   sed -i.'' 's/#spotbugs/spotbugs/' projects-to-test-on.properties
   groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
       --patchConfig checks-nonjavadoc-error.xml  -p "$BRANCH" -r ../../..  \
-      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"
+      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -911,8 +905,7 @@ no-exception-spoon)
   sed -i.'' 's/#spoon/spoon/' projects-to-test-on.properties
   groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
       --patchConfig checks-nonjavadoc-error.xml  -p "$BRANCH" -r ../../..  \
-      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"
+      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -927,8 +920,7 @@ no-exception-spring-framework)
   sed -i.'' 's/#spring-framework/spring-framework/' projects-to-test-on.properties
   groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
       --patchConfig checks-nonjavadoc-error.xml  -p "$BRANCH" -r ../../..  \
-       --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"
+       --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -943,8 +935,7 @@ no-exception-hbase)
   sed -i.'' 's/#Hbase/Hbase/' projects-to-test-on.properties
   groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
       --patchConfig checks-nonjavadoc-error.xml  -p "$BRANCH" -r ../../..  \
-      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"
+      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -961,8 +952,7 @@ no-exception-Pmd-elasticsearch-lombok-ast)
   sed -i.'' 's/#lombok-ast/lombok-ast/' projects-to-test-on.properties
   groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
       --patchConfig checks-nonjavadoc-error.xml  -p "$BRANCH" -r ../../..  \
-      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"
+      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -982,8 +972,7 @@ no-exception-alot-of-projects)
   sed -i.'' 's/#android-launcher/android-launcher/' projects-to-test-on.properties
   groovy ./diff.groovy --listOfProjects projects-to-test-on.properties \
       --patchConfig checks-nonjavadoc-error.xml  -p "$BRANCH" -r ../../.. \
-      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false \
-      -Dcheckstyle.version=${CS_POM_VERSION}"
+      --allowExcludes --mode single -xm "-Dcheckstyle.failsOnError=false"
   cd ../../
   removeFolderWithProtectedFiles contribution
   ;;
@@ -999,7 +988,7 @@ no-warning-imports-guava)
   cd .ci-temp/contribution/checkstyle-tester
   groovy ./diff.groovy --listOfProjects $PROJECTS --patchConfig $CONFIG \
       --allowExcludes -p "$BRANCH" -r ../../.. \
-      --mode single -xm "-Dcheckstyle.failsOnError=false -Dcheckstyle.version=${CS_POM_VERSION}"
+      --mode single -xm "-Dcheckstyle.failsOnError=false"
   RESULT=$(grep -A 5 "&#160;Warning</td>" $REPORT | cat)
   cd ../../
   removeFolderWithProtectedFiles contribution
@@ -1024,7 +1013,7 @@ no-warning-imports-java-design-patterns)
   cd .ci-temp/contribution/checkstyle-tester
   groovy ./diff.groovy --listOfProjects $PROJECTS --patchConfig $CONFIG \
       --allowExcludes -p "$BRANCH" -r ../../..\
-      --mode single -xm "-Dcheckstyle.version=${CS_POM_VERSION}"
+      --mode single
   RESULT=$(grep -A 5 "&#160;Warning</td>" $REPORT | cat)
   cd ../../
   removeFolderWithProtectedFiles contribution


### PR DESCRIPTION
Appears to be left over when integrating `launch.groovy` into `diff.groovy` at https://github.com/checkstyle/checkstyle/commit/f0eb2638866e2718983b7f580d1b77de6496a105#diff-c0ec6ae84b678dd1c2f581efe7cf8ec0255cc01f4e1b4c9fc66069907ed0a0b9L18

`diff.groovy` right now always checks the Git's POM to get the version.
https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/diff.groovy#L222
And passes through to the maven command.
https://github.com/checkstyle/contribution/blob/master/checkstyle-tester/diff.groovy#L632

So it appears this parameter is not necessary and possible could cause conflicts.