### PR TITLE
Pull #12223: Correct the hashCode method in checker-framework.groovy

### DIFF
--- a/.ci/StarterRuleSet-AllRulesByCategory.groovy.txt
+++ b/.ci/StarterRuleSet-AllRulesByCategory.groovy.txt
@@ -387,7 +387,11 @@ ruleset {
     MethodCount
     MethodSize
     NestedBlockDepth
-    ParameterCount
+
+    // CheckerFrameworkError needs all the parameters
+    ParameterCount {
+        doNotApplyToFileNames = 'checker-framework.groovy'
+    }
 
     // rulesets/unnecessary.xml
     AddEmptyString


### PR DESCRIPTION
Contents of this PR:

- The `hashCode()` method was not implemented correctly, for two objects `equals()` could return true but the objects had different hashes.
- Now for every error, the hash code is generated from `messageWithoutNumber` and `messageWithoutNumber`.