### PR TITLE
doc: fix formatting mistake in SuppressWarningsFilter

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilter.java
@@ -27,7 +27,7 @@ import com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder;
 /**
  * <p>
  * Filter {@code SuppressWarningsFilter} uses annotation
- * {@code SuppressWarnings} to suppress audit events.
+ * {@code @SuppressWarnings} to suppress audit events.
  * </p>
  * <p>
  * Rationale: Same as for {@code SuppressionCommentFilter}. In the contrary to it here,

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressWarningsFilter.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressWarningsFilter.xml
@@ -6,7 +6,7 @@
                parent="com.puppycrawl.tools.checkstyle.Checker">
          <description>&lt;p&gt;
  Filter {@code SuppressWarningsFilter} uses annotation
- {@code SuppressWarnings} to suppress audit events.
+ {@code @SuppressWarnings} to suppress audit events.
  &lt;/p&gt;
  &lt;p&gt;
  Rationale: Same as for {@code SuppressionCommentFilter}. In the contrary to it here,

--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -1839,7 +1839,7 @@ public class TestClass {
       <subsection name="Description" id="SuppressWarningsFilter_Description">
         <p>
           Filter <code>SuppressWarningsFilter</code> uses annotation
-          {@code SuppressWarnings} to suppress audit events.
+          <code>@SuppressWarnings</code> to suppress audit events.
         </p>
         <p>
           Rationale: Same as for


### PR DESCRIPTION
Fixes typo in https://checkstyle.org/config_filters.html#SuppressWarningsFilter
`{@code SuppressWarnings}` -> `@SuppressWarnings`.
## Before
![Screenshot from 2022-09-30 15-26-08](https://user-images.githubusercontent.com/23459549/193279766-e4df39fe-6a1e-41f7-9108-2aa24085dda2.png)

## After
![Screenshot from 2022-09-30 15-25-58](https://user-images.githubusercontent.com/23459549/193279747-40fa9cf2-f19d-466f-a0a2-8f3f5626fa1a.png)
