### PR TITLE
Pull #12244: Replace numbers in details and message in checker-framework.groovy

### DIFF
--- a/.ci/checker-framework-suppressions/checker-framework-formatter-suppressions.xml
+++ b/.ci/checker-framework-suppressions/checker-framework-formatter-suppressions.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedErrors>
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java</fileName>
     <specifier>i18nformat.key.not.found</specifier>
     <message>a key doesn&apos;t exist in the provided translation file</message>
     <lineContent>final String pattern = resourceBundle.getString(key);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java</fileName>
     <specifier>format.string</specifier>
     <message>invalid format string (is a @Format annotation missing?)</message>
     <lineContent>Locale.ROOT, PROP_DEFAULT_VALUE_MISSING, propertyName)</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java</fileName>
     <specifier>format.string</specifier>
     <message>invalid format string (is a @Format annotation missing?)</message>
     <lineContent>Locale.ROOT, PROP_TYPE_MISSING, propertyName)</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java</fileName>
     <specifier>i18nformat.key.not.found</specifier>
     <message>a key doesn&apos;t exist in the provided translation file</message>

--- a/.ci/checker-framework-suppressions/checker-framework-index-suppressions.xml
+++ b/.ci/checker-framework-suppressions/checker-framework-index-suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedErrors>
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -11,7 +11,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/AuditEventDefaultFormatter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter capacity of StringBuilder.</message>
@@ -22,7 +22,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -33,7 +33,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of set.</message>
@@ -44,7 +44,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -55,7 +55,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -66,7 +66,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java</fileName>
     <specifier>array.access.unsafe.high.range</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -78,7 +78,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -89,7 +89,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java</fileName>
     <specifier>array.length.negative</specifier>
     <message>Variable used in array creation could be negative.</message>
@@ -100,7 +100,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java</fileName>
     <specifier>array.length.negative</specifier>
     <message>Variable used in array creation could be negative.</message>
@@ -111,18 +111,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter beginIndex of substring.</message>
-    <lineContent>ent.substring(prefixLength, ent.length() - 1), radix);</lineContent>
-    <details>
-      found   : int
-      required: @LTEqLengthOf(&quot;ent&quot;) int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -133,7 +122,18 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter beginIndex of substring.</message>
+    <lineContent>ent.substring(prefixLength, ent.length() - 1), radix);</lineContent>
+    <details>
+      found   : int
+      required: @LTEqLengthOf(&quot;ent&quot;) int
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -144,7 +144,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -155,7 +155,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -166,7 +166,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -177,7 +177,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -188,7 +188,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -199,7 +199,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -210,7 +210,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -221,7 +221,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -232,7 +232,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -243,7 +243,29 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter beginIndex of substring.</message>
+    <lineContent>returnValue[0] = line(startLineNo - 1).substring(startColNo);</lineContent>
+    <details>
+      found   : int
+      required: @LTEqLengthOf(&quot;this.line(startLineNo - 1)&quot;) int
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter beginIndex of substring.</message>
+    <lineContent>returnValue[0] = line(startLineNo - 1).substring(startColNo,</lineContent>
+    <details>
+      found   : int
+      required: @LTEqLengthOf(&quot;this.line(startLineNo - 1)&quot;) int
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -254,18 +276,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter beginIndex of substring.</message>
-    <lineContent>returnValue[0] = line(startLineNo - 1).substring(startColNo);</lineContent>
-    <details>
-      found   : int
-      required: @LTEqLengthOf(&quot;this.line(startLineNo - 1)&quot;) int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -276,18 +287,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter beginIndex of substring.</message>
-    <lineContent>returnValue[0] = line(startLineNo - 1).substring(startColNo,</lineContent>
-    <details>
-      found   : int
-      required: @LTEqLengthOf(&quot;this.line(startLineNo - 1)&quot;) int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -298,7 +298,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -309,7 +309,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -320,7 +320,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -331,7 +331,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -342,7 +342,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java</fileName>
     <specifier>array.access.unsafe.high.constant</specifier>
     <message>Potentially unsafe array access: the constant index 0 could be larger than the array&apos;s bound</message>
@@ -353,18 +353,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java</fileName>
-    <specifier>array.access.unsafe.low</specifier>
-    <message>Potentially unsafe array access: the index could be negative.</message>
-    <lineContent>returnValue[i - startLineNo + 1] = line(i);</lineContent>
-    <details>
-      found   : int
-      required: an integer &gt;= 0 (@NonNegative or @Positive)
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -375,7 +364,18 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java</fileName>
+    <specifier>array.access.unsafe.low</specifier>
+    <message>Potentially unsafe array access: the index could be negative.</message>
+    <lineContent>returnValue[i - startLineNo + 1] = line(i);</lineContent>
+    <details>
+      found   : int
+      required: an integer &gt;= 0 (@NonNegative or @Positive)
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java</fileName>
     <specifier>array.length.negative</specifier>
     <message>Variable used in array creation could be negative.</message>
@@ -386,7 +386,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -397,7 +397,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -408,7 +408,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java</fileName>
     <specifier>array.access.unsafe.high.constant</specifier>
     <message>Potentially unsafe array access: the constant index 0 could be larger than the array&apos;s bound</message>
@@ -419,7 +419,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java</fileName>
     <specifier>array.access.unsafe.high.range</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -431,7 +431,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -442,7 +442,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -453,7 +453,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java</fileName>
     <specifier>array.length.negative</specifier>
     <message>Variable used in array creation could be negative.</message>
@@ -464,7 +464,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter from of copyOfRange.</message>
@@ -475,7 +475,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter from of copyOfRange.</message>
@@ -486,7 +486,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -497,7 +497,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -508,7 +508,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -519,7 +519,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -530,7 +530,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -541,7 +541,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/FinalParametersCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -552,7 +552,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter pos of seek.</message>
@@ -563,7 +563,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java</fileName>
     <specifier>array.length.negative</specifier>
     <message>Variable used in array creation could be negative.</message>
@@ -574,7 +574,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -585,7 +585,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -596,7 +596,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -607,7 +607,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -618,7 +618,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter from of copyOfRange.</message>
@@ -629,7 +629,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter from of copyOfRange.</message>
@@ -640,7 +640,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -651,7 +651,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -662,7 +662,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -673,7 +673,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingDeprecatedCheck.java</fileName>
     <specifier>array.access.unsafe.high.constant</specifier>
     <message>Potentially unsafe array access: the constant index 0 could be larger than the array&apos;s bound</message>
@@ -684,7 +684,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -695,7 +695,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/SuppressWarningsCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -706,7 +706,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter from of copyOfRange.</message>
@@ -717,18 +717,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter from of copyOfRange.</message>
-    <lineContent>slistColNo + 1, codePointsFirstLine.length);</lineContent>
-    <details>
-      found   : int
-      required: @NonNegative int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter from of copyOfRange.</message>
@@ -739,7 +728,18 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter from of copyOfRange.</message>
+    <lineContent>slistColNo + 1, codePointsFirstLine.length);</lineContent>
+    <details>
+      found   : int
+      required: @NonNegative int
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/EmptyBlockCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter from of copyOfRange.</message>
@@ -750,7 +750,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -761,7 +761,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -772,7 +772,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/AvoidDoubleBraceInitializationCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -783,7 +783,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -794,7 +794,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -805,7 +805,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -816,7 +816,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -827,7 +827,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -838,7 +838,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -849,7 +849,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -860,7 +860,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -871,7 +871,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -882,7 +882,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/InnerAssignmentCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -893,7 +893,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -904,7 +904,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -915,7 +915,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -926,7 +926,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of set.</message>
@@ -937,7 +937,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/PackageDeclarationCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -948,7 +948,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -959,7 +959,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -970,7 +970,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -981,7 +981,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/InnerTypeLastCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -992,7 +992,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -1003,7 +1003,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -1014,7 +1014,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/AvoidStaticImportCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -1025,7 +1025,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -1036,7 +1036,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -1047,7 +1047,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -1058,7 +1058,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java</fileName>
     <specifier>array.access.unsafe.high.range</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -1070,7 +1070,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -1081,7 +1081,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -1092,7 +1092,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -1103,7 +1103,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -1114,7 +1114,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgImportControl.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -1125,7 +1125,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -1136,7 +1136,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -1147,7 +1147,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AnnotationArrayInitHandler.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -1158,7 +1158,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AnnotationArrayInitHandler.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -1169,7 +1169,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AnnotationArrayInitHandler.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -1180,7 +1180,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -1191,7 +1191,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -1202,7 +1202,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -1213,18 +1213,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java</fileName>
-    <specifier>array.access.unsafe.high</specifier>
-    <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
-    <lineContent>final char[] line = getLines()[lineNo - 1].toCharArray();</lineContent>
-    <details>
-      found   : int
-      required: @IndexFor(&quot;this.getLines()&quot;) or @LTLengthOf(&quot;this.getLines()&quot;) -- an integer less than this.getLines()&apos;s length
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -1235,7 +1224,18 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java</fileName>
+    <specifier>array.access.unsafe.high</specifier>
+    <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
+    <lineContent>final char[] line = getLines()[lineNo - 1].toCharArray();</lineContent>
+    <details>
+      found   : int
+      required: @IndexFor(&quot;this.getLines()&quot;) or @LTLengthOf(&quot;this.getLines()&quot;) -- an integer less than this.getLines()&apos;s length
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java</fileName>
     <specifier>array.access.unsafe.high.range</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -1247,7 +1247,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -1258,7 +1258,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -1269,7 +1269,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>array.access.unsafe.high.range</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -1281,7 +1281,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentLevel.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -1292,7 +1292,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentLevel.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of set.</message>
@@ -1303,7 +1303,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentLevel.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of set.</message>
@@ -1314,7 +1314,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentLevel.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of set.</message>
@@ -1325,7 +1325,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -1336,7 +1336,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SlistHandler.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -1347,7 +1347,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AtclauseOrderCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -1358,7 +1358,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/HtmlTag.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -1369,7 +1369,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/HtmlTag.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -1380,7 +1380,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/HtmlTag.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -1391,7 +1391,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/HtmlTag.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -1402,7 +1402,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/HtmlTag.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -1413,7 +1413,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -1424,7 +1424,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -1435,7 +1435,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -1446,7 +1446,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -1457,7 +1457,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -1468,7 +1468,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMissingWhitespaceAfterAsteriskCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -1479,7 +1479,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMissingWhitespaceAfterAsteriskCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -1490,7 +1490,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -1501,7 +1501,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -1512,18 +1512,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter index of charAt.</message>
-    <lineContent>if (Character.isWhitespace(builder.charAt(index))) {</lineContent>
-    <details>
-      found   : int
-      required: @NonNegative int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -1534,7 +1523,18 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter index of charAt.</message>
+    <lineContent>if (Character.isWhitespace(builder.charAt(index))) {</lineContent>
+    <details>
+      found   : int
+      required: @NonNegative int
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -1545,7 +1545,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -1556,7 +1556,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of deleteCharAt.</message>
@@ -1567,7 +1567,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of deleteCharAt.</message>
@@ -1578,7 +1578,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -1589,7 +1589,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -1600,7 +1600,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -1611,7 +1611,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -1622,7 +1622,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfo.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -1633,7 +1633,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfo.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -1644,7 +1644,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/RequireEmptyLineBeforeBlockTagGroupCheck.java</fileName>
     <specifier>array.access.unsafe.high.constant</specifier>
     <message>Potentially unsafe array access: the constant index 0 could be larger than the array&apos;s bound</message>
@@ -1655,7 +1655,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -1666,7 +1666,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter end of append.</message>
@@ -1677,7 +1677,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -1688,7 +1688,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java</fileName>
     <specifier>array.access.unsafe.high.constant</specifier>
     <message>Potentially unsafe array access: the constant index 0 could be larger than the array&apos;s bound</message>
@@ -1699,7 +1699,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java</fileName>
     <specifier>array.access.unsafe.high.constant</specifier>
     <message>Potentially unsafe array access: the constant index 0 could be larger than the array&apos;s bound</message>
@@ -1710,7 +1710,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java</fileName>
     <specifier>array.access.unsafe.high.constant</specifier>
     <message>Potentially unsafe array access: the constant index 0 could be larger than the array&apos;s bound</message>
@@ -1721,7 +1721,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java</fileName>
     <specifier>array.access.unsafe.high.constant</specifier>
     <message>Potentially unsafe array access: the constant index 1 could be larger than the array&apos;s bound</message>
@@ -1732,7 +1732,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java</fileName>
     <specifier>array.access.unsafe.high.constant</specifier>
     <message>Potentially unsafe array access: the constant index 1 could be larger than the array&apos;s bound</message>
@@ -1743,7 +1743,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java</fileName>
     <specifier>array.access.unsafe.high.constant</specifier>
     <message>Potentially unsafe array access: the constant index 1 could be larger than the array&apos;s bound</message>
@@ -1754,7 +1754,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java</fileName>
     <specifier>array.access.unsafe.high.constant</specifier>
     <message>Potentially unsafe array access: the constant index 1 could be larger than the array&apos;s bound</message>
@@ -1765,7 +1765,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java</fileName>
     <specifier>array.access.unsafe.high.constant</specifier>
     <message>Potentially unsafe array access: the constant index 1 could be larger than the array&apos;s bound</message>
@@ -1776,7 +1776,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java</fileName>
     <specifier>array.access.unsafe.high.constant</specifier>
     <message>Potentially unsafe array access: the constant index 3 could be larger than the array&apos;s bound</message>
@@ -1787,7 +1787,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -1798,29 +1798,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter endIndex of substring.</message>
-    <lineContent>.substring(0, toPoint.getColumnNo() + 1).endsWith(&quot;--&gt;&quot;)) {</lineContent>
-    <details>
-      found   : int
-      required: @LTEqLengthOf(&quot;text[toPoint.getLineNo()]&quot;) int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter endIndex of substring.</message>
-    <lineContent>.substring(0, toPoint.getColumnNo() + 1).endsWith(&quot;--&gt;&quot;)) {</lineContent>
-    <details>
-      found   : int
-      required: @NonNegative int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -1831,7 +1809,29 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter endIndex of substring.</message>
+    <lineContent>.substring(0, toPoint.getColumnNo() + 1).endsWith(&quot;--&gt;&quot;)) {</lineContent>
+    <details>
+      found   : int
+      required: @LTEqLengthOf(&quot;text[toPoint.getLineNo()]&quot;) int
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter endIndex of substring.</message>
+    <lineContent>.substring(0, toPoint.getColumnNo() + 1).endsWith(&quot;--&gt;&quot;)) {</lineContent>
+    <details>
+      found   : int
+      required: @NonNegative int
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -1842,18 +1842,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter index of charAt.</message>
-    <lineContent>&amp;&amp; text[curr.getLineNo()].charAt(curr.getColumnNo()) != character) {</lineContent>
-    <details>
-      found   : int
-      required: @NonNegative int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -1864,7 +1853,18 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter index of charAt.</message>
+    <lineContent>&amp;&amp; text[curr.getLineNo()].charAt(curr.getColumnNo()) != character) {</lineContent>
+    <details>
+      found   : int
+      required: @NonNegative int
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -1875,7 +1875,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -1886,7 +1886,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -1897,7 +1897,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -1908,29 +1908,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
-    <specifier>array.access.unsafe.high</specifier>
-    <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
-    <lineContent>&amp;&amp; text[curr.getLineNo()].charAt(curr.getColumnNo()) != character) {</lineContent>
-    <details>
-      found   : int
-      required: @IndexFor(&quot;text&quot;) or @LTLengthOf(&quot;text&quot;) -- an integer less than text&apos;s length
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
-    <specifier>array.access.unsafe.high</specifier>
-    <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
-    <lineContent>&amp;&amp; text[endTag.getLineNo()]</lineContent>
-    <details>
-      found   : int
-      required: @IndexFor(&quot;text&quot;) or @LTLengthOf(&quot;text&quot;) -- an integer less than text&apos;s length
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -1941,7 +1919,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -1952,7 +1930,29 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
+    <specifier>array.access.unsafe.high</specifier>
+    <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
+    <lineContent>&amp;&amp; text[curr.getLineNo()].charAt(curr.getColumnNo()) != character) {</lineContent>
+    <details>
+      found   : int
+      required: @IndexFor(&quot;text&quot;) or @LTLengthOf(&quot;text&quot;) -- an integer less than text&apos;s length
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
+    <specifier>array.access.unsafe.high</specifier>
+    <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
+    <lineContent>&amp;&amp; text[endTag.getLineNo()]</lineContent>
+    <details>
+      found   : int
+      required: @IndexFor(&quot;text&quot;) or @LTLengthOf(&quot;text&quot;) -- an integer less than text&apos;s length
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -1963,7 +1963,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -1974,7 +1974,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -1985,7 +1985,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -1996,7 +1996,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -2007,7 +2007,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -2018,7 +2018,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -2029,7 +2029,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -2040,7 +2040,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -2051,7 +2051,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -2062,7 +2062,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -2073,7 +2073,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -2084,7 +2084,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -2095,7 +2095,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/BlockTagUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -2106,7 +2106,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/BlockTagUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -2117,7 +2117,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/InlineTagUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of subSequence.</message>
@@ -2128,7 +2128,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/InlineTagUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of subSequence.</message>
@@ -2139,7 +2139,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -2150,7 +2150,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -2161,7 +2161,18 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter beginIndex of substring.</message>
+    <lineContent>result = str.substring(beginIndex, endIndex);</lineContent>
+    <details>
+      found   : int
+      required: @LTEqLengthOf(&quot;str&quot;) int
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -2172,18 +2183,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter beginIndex of substring.</message>
-    <lineContent>result = str.substring(beginIndex, endIndex);</lineContent>
-    <details>
-      found   : int
-      required: @LTEqLengthOf(&quot;str&quot;) int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -2194,7 +2194,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -2205,7 +2205,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -2216,7 +2216,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/SinglelineDetector.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter start of find.</message>
@@ -2227,7 +2227,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of set.</message>
@@ -2238,7 +2238,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter fromIndex of set.</message>
@@ -2249,7 +2249,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter toIndex of set.</message>
@@ -2260,7 +2260,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/AbstractParenPadCheck.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -2271,7 +2271,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/AbstractParenPadCheck.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -2282,7 +2282,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -2293,7 +2293,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -2304,7 +2304,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -2315,7 +2315,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java</fileName>
     <specifier>array.access.unsafe.high.constant</specifier>
     <message>Potentially unsafe array access: the constant index 0 could be larger than the array&apos;s bound</message>
@@ -2326,7 +2326,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -2337,7 +2337,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -2348,7 +2348,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/GenericWhitespaceCheck.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -2359,7 +2359,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -2370,7 +2370,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter from of copyOfRange.</message>
@@ -2381,7 +2381,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SeparatorWrapCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter from of copyOfRange.</message>
@@ -2392,7 +2392,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheck.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -2403,7 +2403,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheck.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -2414,7 +2414,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAfterCheck.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -2425,7 +2425,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java</fileName>
     <specifier>array.access.unsafe.high.constant</specifier>
     <message>Potentially unsafe array access: the constant index 0 could be larger than the array&apos;s bound</message>
@@ -2436,7 +2436,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAroundCheck.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -2447,7 +2447,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
     <specifier>array.access.unsafe.high.constant</specifier>
     <message>Potentially unsafe array access: the constant index 0 could be larger than the array&apos;s bound</message>
@@ -2458,7 +2458,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java</fileName>
     <specifier>array.access.unsafe.high.constant</specifier>
     <message>Potentially unsafe array access: the constant index 0 could be larger than the array&apos;s bound</message>
@@ -2469,7 +2469,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelectorPresentation.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -2480,7 +2480,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentation.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -2491,7 +2491,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentation.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -2502,7 +2502,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentation.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -2513,7 +2513,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentation.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -2524,7 +2524,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableModelAdapter.java</fileName>
     <specifier>override.return</specifier>
     <message>Incompatible return type.</message>
@@ -2539,7 +2539,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableModelAdapter.java</fileName>
     <specifier>override.return</specifier>
     <message>Incompatible return type.</message>
@@ -2554,7 +2554,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -2565,7 +2565,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -2576,7 +2576,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter initialCapacity of ArrayList.</message>
@@ -2587,7 +2587,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter initialCapacity of ArrayList.</message>
@@ -2598,7 +2598,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaWriter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -2609,7 +2609,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaWriter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -2620,7 +2620,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/ChainedPropertyUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -2631,29 +2631,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter beginIndex of substring.</message>
-    <lineContent>returnString = line.substring(indent, lastNonWhitespace);</lineContent>
-    <details>
-      found   : int
-      required: @LTEqLengthOf(&quot;line&quot;) int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter beginIndex of substring.</message>
-    <lineContent>returnString = line.substring(indent, lastNonWhitespace);</lineContent>
-    <details>
-      found   : int
-      required: @NonNegative int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -2664,10 +2642,10 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
     <specifier>argument</specifier>
-    <message>incompatible argument for parameter endIndex of substring.</message>
+    <message>incompatible argument for parameter beginIndex of substring.</message>
     <lineContent>returnString = line.substring(indent, lastNonWhitespace);</lineContent>
     <details>
       found   : int
@@ -2675,7 +2653,18 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter beginIndex of substring.</message>
+    <lineContent>returnString = line.substring(indent, lastNonWhitespace);</lineContent>
+    <details>
+      found   : int
+      required: @NonNegative int
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -2686,7 +2675,18 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter endIndex of substring.</message>
+    <lineContent>returnString = line.substring(indent, lastNonWhitespace);</lineContent>
+    <details>
+      found   : int
+      required: @LTEqLengthOf(&quot;line&quot;) int
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter radix of parseInt.</message>
@@ -2697,7 +2697,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter radix of parseInt.</message>
@@ -2708,7 +2708,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter radix of parseLong.</message>
@@ -2719,7 +2719,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter radix of parseLong.</message>
@@ -2730,7 +2730,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter radix of parseUnsignedInt.</message>
@@ -2741,7 +2741,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter radix of parseUnsignedInt.</message>
@@ -2752,7 +2752,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter radix of parseUnsignedLong.</message>
@@ -2763,7 +2763,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter radix of parseUnsignedLong.</message>
@@ -2774,7 +2774,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CodePointUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter from of copyOfRange.</message>
@@ -2785,7 +2785,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -2796,18 +2796,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter index of charAt.</message>
-    <lineContent>if (!Character.isWhitespace(line.charAt(i))) {</lineContent>
-    <details>
-      found   : int
-      required: @LTLengthOf(&quot;line&quot;) int
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -2818,7 +2807,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of charAt.</message>
@@ -2829,7 +2818,18 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter index of charAt.</message>
+    <lineContent>if (!Character.isWhitespace(line.charAt(i))) {</lineContent>
+    <details>
+      found   : int
+      required: @LTLengthOf(&quot;line&quot;) int
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter index of codePointAt.</message>
@@ -2840,7 +2840,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -2851,7 +2851,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java</fileName>
     <specifier>array.access.unsafe.high.constant</specifier>
     <message>Potentially unsafe array access: the constant index 0 could be larger than the array&apos;s bound</message>
@@ -2862,7 +2862,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -2873,7 +2873,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -2884,7 +2884,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtil.java</fileName>
     <specifier>array.access.unsafe.high</specifier>
     <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
@@ -2895,7 +2895,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtil.java</fileName>
     <specifier>array.access.unsafe.high.constant</specifier>
     <message>Potentially unsafe array access: the constant index 0 could be larger than the array&apos;s bound</message>
@@ -2906,7 +2906,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtil.java</fileName>
     <specifier>array.access.unsafe.low</specifier>
     <message>Potentially unsafe array access: the index could be negative.</message>
@@ -2917,7 +2917,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java</fileName>
     <specifier>methodref.param</specifier>
     <message>Incompatible parameter type for bitIndex</message>
@@ -2932,7 +2932,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java</fileName>
     <specifier>methodref.param</specifier>
     <message>Incompatible parameter type for bitIndex</message>
@@ -2947,7 +2947,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/XpathUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter beginIndex of substring.</message>
@@ -2958,7 +2958,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/XpathUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter bitIndex of get.</message>
@@ -2969,7 +2969,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/XpathUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter endIndex of substring.</message>
@@ -2980,7 +2980,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGenerator.java</fileName>
     <specifier>array.access.unsafe.high.constant</specifier>
     <message>Potentially unsafe array access: the constant index 0 could be larger than the array&apos;s bound</message>

--- a/.ci/checker-framework-suppressions/checker-framework-lock-tainting-suppressions.xml
+++ b/.ci/checker-framework-suppressions/checker-framework-lock-tainting-suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedErrors>
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java</fileName>
     <specifier>methodref.receiver.bound</specifier>
     <message>Incompatible receiver type</message>
@@ -15,21 +15,21 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java</fileName>
     <specifier>method.guarantee.violated</specifier>
     <message>@SideEffectFree method toString calls method getColumnNo with a weaker @ReleasesNoLocks side effect guarantee</message>
     <lineContent>return text + &quot;[&quot; + getLineNo() + &quot;x&quot; + getColumnNo() + &quot;]&quot;;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java</fileName>
     <specifier>method.guarantee.violated</specifier>
     <message>@SideEffectFree method toString calls method getLineNo with a weaker @ReleasesNoLocks side effect guarantee</message>
     <lineContent>return text + &quot;[&quot; + getLineNo() + &quot;x&quot; + getColumnNo() + &quot;]&quot;;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -44,14 +44,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
     <specifier>method.guarantee.violated</specifier>
     <message>@SideEffectFree method toString calls method name with a weaker @ReleasesNoLocks side effect guarantee</message>
     <lineContent>return name().toLowerCase(Locale.ROOT);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
     <specifier>methodref.receiver.bound</specifier>
     <message>Incompatible receiver type</message>
@@ -66,7 +66,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -81,7 +81,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java</fileName>
     <specifier>methodref.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -96,7 +96,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java</fileName>
     <specifier>methodref.receiver.bound</specifier>
     <message>Incompatible receiver type</message>
@@ -111,7 +111,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java</fileName>
     <specifier>methodref.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -126,7 +126,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java</fileName>
     <specifier>methodref.receiver.bound</specifier>
     <message>Incompatible receiver type</message>
@@ -141,21 +141,21 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/XmlLoader.java</fileName>
     <specifier>method.guarantee.violated</specifier>
     <message>@Pure method resolveEntity calls method getClassLoader with a weaker @ReleasesNoLocks side effect guarantee</message>
     <lineContent>getClass().getClassLoader();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/XmlLoader.java</fileName>
     <specifier>method.guarantee.violated</specifier>
     <message>@Pure method resolveEntity calls method getResourceAsStream with a weaker @ReleasesNoLocks side effect guarantee</message>
     <lineContent>loader.getResourceAsStream(dtdResourceName);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/BeforeExecutionFileFilterSet.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -170,7 +170,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/Comment.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -185,7 +185,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FilterSet.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -200,21 +200,21 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java</fileName>
     <specifier>method.guarantee.violated</specifier>
     <message>@SideEffectFree method toString calls method getColumnNo with a weaker @ReleasesNoLocks side effect guarantee</message>
     <lineContent>+ &quot;[&quot; + detailAst.getLineNo() + &quot;x&quot; + detailAst.getColumnNo() + &quot;]&quot;;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java</fileName>
     <specifier>method.guarantee.violated</specifier>
     <message>@SideEffectFree method toString calls method getLineNo with a weaker @ReleasesNoLocks side effect guarantee</message>
     <lineContent>+ &quot;[&quot; + detailAst.getLineNo() + &quot;x&quot; + detailAst.getColumnNo() + &quot;]&quot;;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -229,7 +229,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for other.</message>
@@ -244,22 +244,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java</fileName>
-    <specifier>override.receiver</specifier>
-    <message>Incompatible receiver type</message>
-    <lineContent>public boolean equals(Object other) {</lineContent>
-    <details>
-      found   : @GuardedBy LineColumn
-      required: @GuardSatisfied Object
-      Consequence: method in @GuardedBy LineColumn
-      @GuardedBy boolean equals(@GuardedBy LineColumn this, @GuardedBy Object p0)
-      cannot override method in @GuardedBy Object
-      @GuardedBy boolean equals(@GuardSatisfied Object this, @GuardSatisfied Object p0)
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -274,7 +259,22 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java</fileName>
+    <specifier>override.receiver</specifier>
+    <message>Incompatible receiver type</message>
+    <lineContent>public boolean equals(Object other) {</lineContent>
+    <details>
+      found   : @GuardedBy LineColumn
+      required: @GuardSatisfied Object
+      Consequence: method in @GuardedBy LineColumn
+      @GuardedBy boolean equals(@GuardedBy LineColumn this, @GuardedBy Object p0)
+      cannot override method in @GuardedBy Object
+      @GuardedBy boolean equals(@GuardSatisfied Object this, @GuardSatisfied Object p0)
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -289,14 +289,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/Scope.java</fileName>
     <specifier>method.guarantee.violated</specifier>
     <message>@SideEffectFree method toString calls method getName with a weaker @ReleasesNoLocks side effect guarantee</message>
     <lineContent>return getName();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/Scope.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -311,14 +311,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/SeverityLevel.java</fileName>
     <specifier>method.guarantee.violated</specifier>
     <message>@SideEffectFree method toString calls method getName with a weaker @ReleasesNoLocks side effect guarantee</message>
     <lineContent>return getName();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/SeverityLevel.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -333,14 +333,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java</fileName>
     <specifier>method.guarantee.violated</specifier>
     <message>@Pure method compareTo calls method getViolation with a weaker @ReleasesNoLocks side effect guarantee</message>
     <lineContent>result = getViolation().compareTo(other.getViolation());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for object.</message>
@@ -355,22 +355,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java</fileName>
-    <specifier>override.receiver</specifier>
-    <message>Incompatible receiver type</message>
-    <lineContent>public boolean equals(Object object) {</lineContent>
-    <details>
-      found   : @GuardedBy Violation
-      required: @GuardSatisfied Object
-      Consequence: method in @GuardedBy Violation
-      @GuardedBy boolean equals(@GuardedBy Violation this, @GuardedBy Object p0)
-      cannot override method in @GuardedBy Object
-      @GuardedBy boolean equals(@GuardSatisfied Object this, @GuardSatisfied Object p0)
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -385,7 +370,22 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java</fileName>
+    <specifier>override.receiver</specifier>
+    <message>Incompatible receiver type</message>
+    <lineContent>public boolean equals(Object object) {</lineContent>
+    <details>
+      found   : @GuardedBy Violation
+      required: @GuardSatisfied Object
+      Consequence: method in @GuardedBy Violation
+      @GuardedBy boolean equals(@GuardedBy Violation this, @GuardedBy Object p0)
+      cannot override method in @GuardedBy Object
+      @GuardedBy boolean equals(@GuardSatisfied Object this, @GuardSatisfied Object p0)
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -400,7 +400,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -415,7 +415,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -430,7 +430,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java</fileName>
     <specifier>methodref.param</specifier>
     <message>Incompatible parameter type for obj</message>
@@ -445,7 +445,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java</fileName>
     <specifier>methodref.param</specifier>
     <message>Incompatible parameter type for arg0</message>
@@ -460,7 +460,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java</fileName>
     <specifier>methodref.receiver.bound</specifier>
     <message>Incompatible receiver type</message>
@@ -475,7 +475,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java</fileName>
     <specifier>methodref.receiver.bound</specifier>
     <message>Incompatible receiver type</message>
@@ -490,7 +490,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java</fileName>
     <specifier>methodref.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -505,21 +505,21 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentLevel.java</fileName>
     <specifier>method.guarantee.violated</specifier>
     <message>@SideEffectFree method toString calls method append with a weaker @ReleasesNoLocks side effect guarantee</message>
     <lineContent>sb.append(&quot;, &quot;);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentLevel.java</fileName>
     <specifier>method.guarantee.violated</specifier>
     <message>@SideEffectFree method toString calls method append with a weaker @ReleasesNoLocks side effect guarantee</message>
     <lineContent>sb.append(i);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentLevel.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -534,7 +534,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/HtmlTag.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -549,7 +549,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -564,14 +564,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java</fileName>
     <specifier>method.guarantee.violated</specifier>
     <message>@SideEffectFree method toString calls method getTokenName with a weaker @ReleasesNoLocks side effect guarantee</message>
     <lineContent>+ &quot;, type=&quot; + JavadocUtil.getTokenName(type)</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -586,14 +586,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTag.java</fileName>
     <specifier>method.guarantee.violated</specifier>
     <message>@SideEffectFree method toString calls method getName with a weaker @ReleasesNoLocks side effect guarantee</message>
     <lineContent>return &quot;JavadocTag[tag=&apos;&quot; + tagInfo.getName()</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTag.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -608,7 +608,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagInfo.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -623,7 +623,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java</fileName>
     <specifier>methodref.receiver.bound</specifier>
     <message>Incompatible receiver type</message>
@@ -638,14 +638,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AccessModifierOption.java</fileName>
     <specifier>method.guarantee.violated</specifier>
     <message>@SideEffectFree method toString calls method getName with a weaker @ReleasesNoLocks side effect guarantee</message>
     <lineContent>return getName();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AccessModifierOption.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -660,7 +660,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodLengthCheck.java</fileName>
     <specifier>methodref.param</specifier>
     <message>Incompatible parameter type for obj</message>
@@ -675,7 +675,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/CsvFilterElement.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for object.</message>
@@ -690,7 +690,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/CsvFilterElement.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -705,7 +705,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/CsvFilterElement.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -720,14 +720,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilterElement.java</fileName>
     <specifier>method.guarantee.violated</specifier>
     <message>@Pure method hashCode calls method valueOf with a weaker @SideEffectFree side effect guarantee</message>
     <lineContent>return Integer.valueOf(matchValue).hashCode();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilterElement.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for object.</message>
@@ -742,7 +742,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilterElement.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -757,7 +757,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilterElement.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -772,7 +772,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilterElement.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -787,7 +787,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilterElement.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for other.</message>
@@ -802,7 +802,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilterElement.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -817,7 +817,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilterElement.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -832,7 +832,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for other.</message>
@@ -847,7 +847,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -862,7 +862,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -877,7 +877,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for other.</message>
@@ -892,7 +892,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -907,7 +907,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -922,7 +922,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -937,7 +937,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for other.</message>
@@ -952,7 +952,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -967,7 +967,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -982,7 +982,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for other.</message>
@@ -997,37 +997,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java</fileName>
-    <specifier>override.receiver</specifier>
-    <message>Incompatible receiver type</message>
-    <lineContent>public String toString() {</lineContent>
-    <details>
-      found   : @GuardedBy Tag
-      required: @GuardSatisfied Object
-      Consequence: method in @GuardedBy Tag
-      @GuardedBy String toString(@GuardedBy Tag this)
-      cannot override method in @GuardedBy Object
-      @GuardedBy String toString(@GuardSatisfied Object this)
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java</fileName>
-    <specifier>override.receiver</specifier>
-    <message>Incompatible receiver type</message>
-    <lineContent>public boolean equals(Object other) {</lineContent>
-    <details>
-      found   : @GuardedBy Tag
-      required: @GuardSatisfied Object
-      Consequence: method in @GuardedBy Tag
-      @GuardedBy boolean equals(@GuardedBy Tag this, @GuardedBy Object p0)
-      cannot override method in @GuardedBy Object
-      @GuardedBy boolean equals(@GuardSatisfied Object this, @GuardSatisfied Object p0)
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -1042,7 +1012,37 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java</fileName>
+    <specifier>override.receiver</specifier>
+    <message>Incompatible receiver type</message>
+    <lineContent>public String toString() {</lineContent>
+    <details>
+      found   : @GuardedBy Tag
+      required: @GuardSatisfied Object
+      Consequence: method in @GuardedBy Tag
+      @GuardedBy String toString(@GuardedBy Tag this)
+      cannot override method in @GuardedBy Object
+      @GuardedBy String toString(@GuardSatisfied Object this)
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java</fileName>
+    <specifier>override.receiver</specifier>
+    <message>Incompatible receiver type</message>
+    <lineContent>public boolean equals(Object other) {</lineContent>
+    <details>
+      found   : @GuardedBy Tag
+      required: @GuardSatisfied Object
+      Consequence: method in @GuardedBy Tag
+      @GuardedBy boolean equals(@GuardedBy Tag this, @GuardedBy Object p0)
+      cannot override method in @GuardedBy Object
+      @GuardedBy boolean equals(@GuardSatisfied Object this, @GuardSatisfied Object p0)
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -1057,7 +1057,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for obj.</message>
@@ -1072,7 +1072,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -1087,7 +1087,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -1102,7 +1102,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for other.</message>
@@ -1117,7 +1117,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -1132,7 +1132,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -1147,7 +1147,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModel.java</fileName>
     <specifier>override.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -1162,7 +1162,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java</fileName>
     <specifier>methodref.receiver</specifier>
     <message>Incompatible receiver type</message>
@@ -1177,7 +1177,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java</fileName>
     <specifier>methodref.receiver</specifier>
     <message>Incompatible receiver type</message>

--- a/.ci/checker-framework-suppressions/checker-framework-methods-resource-fenum-suppressions.xml
+++ b/.ci/checker-framework-suppressions/checker-framework-methods-resource-fenum-suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedErrors>
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
     <specifier>required.method.not.called</specifier>
     <message>@MustCall method close may not have been invoked on out or any of its aliases.</message>
@@ -11,11 +11,10 @@
     </details>
   </checkerFrameworkError>
 
-  <!-- Error is considered unstable as temp-var changes with each run. -->
-  <checkerFrameworkError unstable="true">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
     <specifier>required.method.not.called</specifier>
-    <message>@MustCall method close may not have been invoked on temp-var-10288 or any of its aliases.</message>
+    <message>@MustCall method close may not have been invoked on temp-var or any of its aliases.</message>
     <lineContent>listener = new XpathFileGeneratorAuditListener(getOutputStream(options.outputPath),</lineContent>
     <details>
       The type of object is: java.io.OutputStream.
@@ -23,7 +22,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -34,7 +33,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/XmlLoader.java</fileName>
     <specifier>required.method.not.called</specifier>
     <message>@MustCall method close may not have been invoked on dtdIs or any of its aliases.</message>
@@ -45,7 +44,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
     <specifier>required.method.not.called</specifier>
     <message>@MustCall method close may not have been invoked on debug or any of its aliases.</message>
@@ -56,7 +55,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
     <specifier>required.method.not.called</specifier>
     <message>@MustCall method close may not have been invoked on err or any of its aliases.</message>
@@ -67,7 +66,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
     <specifier>required.method.not.called</specifier>
     <message>@MustCall method close may not have been invoked on infoStream or any of its aliases.</message>
@@ -78,23 +77,10 @@
     </details>
   </checkerFrameworkError>
 
-  <!-- Error is considered unstable as temp-var changes with each run. -->
-  <checkerFrameworkError unstable="true">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
     <specifier>required.method.not.called</specifier>
-    <message>@MustCall method close may not have been invoked on temp-var-20912 or any of its aliases.</message>
-    <lineContent>sarifLogger = new SarifLogger(new LogOutputStream(task, Project.MSG_INFO),</lineContent>
-    <details>
-      The type of object is: org.apache.tools.ant.taskdefs.LogOutputStream.
-      Reason for going out of scope: possible exceptional exit due to new SarifLogger(new LogOutputStream(task, Project.MSG_INFO), AutomaticBean.OutputStreamOptions.CLOSE) with exception type java.io.IOException
-    </details>
-  </checkerFrameworkError>
-
-  <!-- Error is considered unstable as temp-var changes with each run. -->
-  <checkerFrameworkError unstable="true">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
-    <specifier>required.method.not.called</specifier>
-    <message>@MustCall method close may not have been invoked on temp-var-20915 or any of its aliases.</message>
+    <message>@MustCall method close may not have been invoked on temp-var or any of its aliases.</message>
     <lineContent>sarifLogger = new SarifLogger(Files.newOutputStream(toFile.toPath()),</lineContent>
     <details>
       The type of object is: java.io.OutputStream.
@@ -102,47 +88,10 @@
     </details>
   </checkerFrameworkError>
 
-  <!-- Error is considered unstable as temp-var changes with each run. -->
-  <checkerFrameworkError unstable="true">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
     <specifier>required.method.not.called</specifier>
-    <message>@MustCall method close may not have been invoked on temp-var-20917 or any of its aliases.</message>
-    <lineContent>new LogOutputStream(task, Project.MSG_DEBUG),</lineContent>
-    <details>
-      The type of object is: org.apache.tools.ant.taskdefs.LogOutputStream.
-      Reason for going out of scope: regular method exit
-    </details>
-  </checkerFrameworkError>
-
-  <!-- Error is considered unstable as temp-var changes with each run. -->
-  <checkerFrameworkError unstable="true">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
-    <specifier>required.method.not.called</specifier>
-    <message>@MustCall method close may not have been invoked on temp-var-20918 or any of its aliases.</message>
-    <lineContent>new LogOutputStream(task, Project.MSG_ERR),</lineContent>
-    <details>
-      The type of object is: org.apache.tools.ant.taskdefs.LogOutputStream.
-      Reason for going out of scope: regular method exit
-    </details>
-  </checkerFrameworkError>
-
-  <!-- Error is considered unstable as temp-var changes with each run. -->
-  <checkerFrameworkError unstable="true">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
-    <specifier>required.method.not.called</specifier>
-    <message>@MustCall method close may not have been invoked on temp-var-20923 or any of its aliases.</message>
-    <lineContent>xmlLogger = new XMLLogger(new LogOutputStream(task, Project.MSG_INFO),</lineContent>
-    <details>
-      The type of object is: org.apache.tools.ant.taskdefs.LogOutputStream.
-      Reason for going out of scope: regular method exit
-    </details>
-  </checkerFrameworkError>
-
-  <!-- Error is considered unstable as temp-var changes with each run. -->
-  <checkerFrameworkError unstable="true">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
-    <specifier>required.method.not.called</specifier>
-    <message>@MustCall method close may not have been invoked on temp-var-20926 or any of its aliases.</message>
+    <message>@MustCall method close may not have been invoked on temp-var or any of its aliases.</message>
     <lineContent>xmlLogger = new XMLLogger(Files.newOutputStream(toFile.toPath()),</lineContent>
     <details>
       The type of object is: java.io.OutputStream.
@@ -150,7 +99,51 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
+    <specifier>required.method.not.called</specifier>
+    <message>@MustCall method close may not have been invoked on temp-var or any of its aliases.</message>
+    <lineContent>sarifLogger = new SarifLogger(new LogOutputStream(task, Project.MSG_INFO),</lineContent>
+    <details>
+      The type of object is: org.apache.tools.ant.taskdefs.LogOutputStream.
+      Reason for going out of scope: possible exceptional exit due to new SarifLogger(new LogOutputStream(task, Project.MSG_INFO), AutomaticBean.OutputStreamOptions.CLOSE) with exception type java.io.IOException
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
+    <specifier>required.method.not.called</specifier>
+    <message>@MustCall method close may not have been invoked on temp-var or any of its aliases.</message>
+    <lineContent>new LogOutputStream(task, Project.MSG_DEBUG),</lineContent>
+    <details>
+      The type of object is: org.apache.tools.ant.taskdefs.LogOutputStream.
+      Reason for going out of scope: regular method exit
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
+    <specifier>required.method.not.called</specifier>
+    <message>@MustCall method close may not have been invoked on temp-var or any of its aliases.</message>
+    <lineContent>new LogOutputStream(task, Project.MSG_ERR),</lineContent>
+    <details>
+      The type of object is: org.apache.tools.ant.taskdefs.LogOutputStream.
+      Reason for going out of scope: regular method exit
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
+    <specifier>required.method.not.called</specifier>
+    <message>@MustCall method close may not have been invoked on temp-var or any of its aliases.</message>
+    <lineContent>xmlLogger = new XMLLogger(new LogOutputStream(task, Project.MSG_INFO),</lineContent>
+    <details>
+      The type of object is: org.apache.tools.ant.taskdefs.LogOutputStream.
+      Reason for going out of scope: regular method exit
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -161,7 +154,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -172,7 +165,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter horizontalAlignment of JLabel.</message>
@@ -183,11 +176,10 @@
     </details>
   </checkerFrameworkError>
 
-  <!-- Error is considered unstable as temp-var changes with each run. -->
-  <checkerFrameworkError unstable="true">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java</fileName>
     <specifier>required.method.not.called</specifier>
-    <message>@MustCall method close may not have been invoked on temp-var-23288 or any of its aliases.</message>
+    <message>@MustCall method close may not have been invoked on temp-var or any of its aliases.</message>
     <lineContent>moduleDetails = read(XmlMetaReader.class.getResourceAsStream(&quot;/&quot; + fileName),</lineContent>
     <details>
       The type of object is: java.io.InputStream.
@@ -195,7 +187,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/AbstractNode.java</fileName>
     <specifier>required.method.not.called</specifier>
     <message>@MustCall method close may not have been invoked on axisIterator or any of its aliases.</message>
@@ -206,11 +198,10 @@
     </details>
   </checkerFrameworkError>
 
-  <!-- Error is considered unstable as temp-var changes with each run. -->
-  <checkerFrameworkError unstable="true">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/DescendantIterator.java</fileName>
     <specifier>required.method.not.called</specifier>
-    <message>@MustCall method close may not have been invoked on temp-var-20533 or any of its aliases.</message>
+    <message>@MustCall method close may not have been invoked on temp-var or any of its aliases.</message>
     <lineContent>descendantEnum = SingleNodeIterator.makeIterator(start);</lineContent>
     <details>
       The type of object is: net.sf.saxon.tree.iter.AxisIterator.
@@ -218,23 +209,10 @@
     </details>
   </checkerFrameworkError>
 
-  <!-- Error is considered unstable as temp-var changes with each run. -->
-  <checkerFrameworkError unstable="true">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/DescendantIterator.java</fileName>
     <specifier>required.method.not.called</specifier>
-    <message>@MustCall method close may not have been invoked on temp-var-20534 or any of its aliases.</message>
-    <lineContent>descendantEnum = start.iterateAxis(AxisInfo.CHILD);</lineContent>
-    <details>
-      The type of object is: net.sf.saxon.tree.iter.AxisIterator.
-      Reason for going out of scope: regular method exit
-    </details>
-  </checkerFrameworkError>
-
-  <!-- Error is considered unstable as temp-var changes with each run. -->
-  <checkerFrameworkError unstable="true">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/DescendantIterator.java</fileName>
-    <specifier>required.method.not.called</specifier>
-    <message>@MustCall method close may not have been invoked on temp-var-20536 or any of its aliases.</message>
+    <message>@MustCall method close may not have been invoked on temp-var or any of its aliases.</message>
     <lineContent>descendantEnum = queue.poll().iterateAxis(AxisInfo.CHILD);</lineContent>
     <details>
       The type of object is: net.sf.saxon.tree.iter.AxisIterator.
@@ -242,11 +220,21 @@
     </details>
   </checkerFrameworkError>
 
-  <!-- Error is considered unstable as temp-var changes with each run. -->
-  <checkerFrameworkError unstable="true">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/DescendantIterator.java</fileName>
+    <specifier>required.method.not.called</specifier>
+    <message>@MustCall method close may not have been invoked on temp-var or any of its aliases.</message>
+    <lineContent>descendantEnum = start.iterateAxis(AxisInfo.CHILD);</lineContent>
+    <details>
+      The type of object is: net.sf.saxon.tree.iter.AxisIterator.
+      Reason for going out of scope: regular method exit
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/FollowingIterator.java</fileName>
     <specifier>required.method.not.called</specifier>
-    <message>@MustCall method close may not have been invoked on temp-var-20414 or any of its aliases.</message>
+    <message>@MustCall method close may not have been invoked on temp-var or any of its aliases.</message>
     <lineContent>ancestorEnum = start.iterateAxis(AxisInfo.ANCESTOR);</lineContent>
     <details>
       The type of object is: net.sf.saxon.tree.iter.AxisIterator.
@@ -254,23 +242,10 @@
     </details>
   </checkerFrameworkError>
 
-  <!-- Error is considered unstable as temp-var changes with each run. -->
-  <checkerFrameworkError unstable="true">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/FollowingIterator.java</fileName>
     <specifier>required.method.not.called</specifier>
-    <message>@MustCall method close may not have been invoked on temp-var-20415 or any of its aliases.</message>
-    <lineContent>siblingEnum = start.iterateAxis(AxisInfo.FOLLOWING_SIBLING);</lineContent>
-    <details>
-      The type of object is: net.sf.saxon.tree.iter.AxisIterator.
-      Reason for going out of scope: regular method exit
-    </details>
-  </checkerFrameworkError>
-
-  <!-- Error is considered unstable as temp-var changes with each run. -->
-  <checkerFrameworkError unstable="true">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/FollowingIterator.java</fileName>
-    <specifier>required.method.not.called</specifier>
-    <message>@MustCall method close may not have been invoked on temp-var-20418 or any of its aliases.</message>
+    <message>@MustCall method close may not have been invoked on temp-var or any of its aliases.</message>
     <lineContent>descendantEnum = result.iterateAxis(AxisInfo.DESCENDANT);</lineContent>
     <details>
       The type of object is: net.sf.saxon.tree.iter.AxisIterator.
@@ -278,11 +253,10 @@
     </details>
   </checkerFrameworkError>
 
-  <!-- Error is considered unstable as temp-var changes with each run. -->
-  <checkerFrameworkError unstable="true">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/FollowingIterator.java</fileName>
     <specifier>required.method.not.called</specifier>
-    <message>@MustCall method close may not have been invoked on temp-var-20420 or any of its aliases.</message>
+    <message>@MustCall method close may not have been invoked on temp-var or any of its aliases.</message>
     <lineContent>siblingEnum = parent.iterateAxis(AxisInfo.FOLLOWING_SIBLING);</lineContent>
     <details>
       The type of object is: net.sf.saxon.tree.iter.AxisIterator.
@@ -290,11 +264,32 @@
     </details>
   </checkerFrameworkError>
 
-  <!-- Error is considered unstable as temp-var changes with each run. -->
-  <checkerFrameworkError unstable="true">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/FollowingIterator.java</fileName>
+    <specifier>required.method.not.called</specifier>
+    <message>@MustCall method close may not have been invoked on temp-var or any of its aliases.</message>
+    <lineContent>siblingEnum = start.iterateAxis(AxisInfo.FOLLOWING_SIBLING);</lineContent>
+    <details>
+      The type of object is: net.sf.saxon.tree.iter.AxisIterator.
+      Reason for going out of scope: regular method exit
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/PrecedingIterator.java</fileName>
     <specifier>required.method.not.called</specifier>
-    <message>@MustCall method close may not have been invoked on temp-var-10345 or any of its aliases.</message>
+    <message>@MustCall method close may not have been invoked on temp-var or any of its aliases.</message>
+    <lineContent>descendantEnum = new ReverseDescendantIterator(result);</lineContent>
+    <details>
+      The type of object is: com.puppycrawl.tools.checkstyle.xpath.iterators.ReverseDescendantIterator.
+      Reason for going out of scope: regular method exit
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/PrecedingIterator.java</fileName>
+    <specifier>required.method.not.called</specifier>
+    <message>@MustCall method close may not have been invoked on temp-var or any of its aliases.</message>
     <lineContent>ancestorEnum = start.iterateAxis(AxisInfo.ANCESTOR);</lineContent>
     <details>
       The type of object is: net.sf.saxon.tree.iter.AxisIterator.
@@ -302,36 +297,10 @@
     </details>
   </checkerFrameworkError>
 
-  <!-- Error is considered unstable as temp-var changes with each run. -->
-  <checkerFrameworkError unstable="true">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/PrecedingIterator.java</fileName>
     <specifier>required.method.not.called</specifier>
-    <message>@MustCall method close may not have been invoked on temp-var-10346 or any of its aliases.</message>
-    <lineContent>previousSiblingEnum = start.iterateAxis(AxisInfo.PRECEDING_SIBLING);</lineContent>
-    <details>
-      The type of object is: net.sf.saxon.tree.iter.AxisIterator.
-      Reason for going out of scope: regular method exit
-    </details>
-  </checkerFrameworkError>
-
-  <!-- Error is considered unstable as temp-var changes with each run. -->
-  <checkerFrameworkError unstable="true">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/PrecedingIterator.java</fileName>
-    <specifier>required.method.not.called</specifier>
-    <message>@MustCall method close may not have been invoked on temp-var-10349 or any of its aliases.</message>
-    <lineContent>descendantEnum = new ReverseDescendantIterator(result);</lineContent>
-
-    <details>
-      The type of object is: com.puppycrawl.tools.checkstyle.xpath.iterators.ReverseDescendantIterator.
-      Reason for going out of scope: regular method exit
-    </details>
-  </checkerFrameworkError>
-
-  <!-- Error is considered unstable as temp-var changes with each run. -->
-  <checkerFrameworkError unstable="true">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/PrecedingIterator.java</fileName>
-    <specifier>required.method.not.called</specifier>
-    <message>@MustCall method close may not have been invoked on temp-var-10351 or any of its aliases.</message>
+    <message>@MustCall method close may not have been invoked on temp-var or any of its aliases.</message>
     <lineContent>previousSiblingEnum = result.iterateAxis(AxisInfo.PRECEDING_SIBLING);</lineContent>
     <details>
       The type of object is: net.sf.saxon.tree.iter.AxisIterator.
@@ -339,24 +308,33 @@
     </details>
   </checkerFrameworkError>
 
-  <!-- Error is considered unstable as temp-var changes with each run. -->
-  <checkerFrameworkError unstable="true">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseDescendantIterator.java</fileName>
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/PrecedingIterator.java</fileName>
     <specifier>required.method.not.called</specifier>
-    <message>@MustCall method close may not have been invoked on temp-var-22037 or any of its aliases.</message>
-    <lineContent>pushToStack(start.iterateAxis(AxisInfo.CHILD));</lineContent>
+    <message>@MustCall method close may not have been invoked on temp-var or any of its aliases.</message>
+    <lineContent>previousSiblingEnum = start.iterateAxis(AxisInfo.PRECEDING_SIBLING);</lineContent>
     <details>
       The type of object is: net.sf.saxon.tree.iter.AxisIterator.
       Reason for going out of scope: regular method exit
     </details>
   </checkerFrameworkError>
 
-  <!-- Error is considered unstable as temp-var changes with each run. -->
-  <checkerFrameworkError unstable="true">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseDescendantIterator.java</fileName>
     <specifier>required.method.not.called</specifier>
-    <message>@MustCall method close may not have been invoked on temp-var-22043 or any of its aliases.</message>
+    <message>@MustCall method close may not have been invoked on temp-var or any of its aliases.</message>
     <lineContent>pushToStack(queue.poll().iterateAxis(AxisInfo.CHILD));</lineContent>
+    <details>
+      The type of object is: net.sf.saxon.tree.iter.AxisIterator.
+      Reason for going out of scope: regular method exit
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseDescendantIterator.java</fileName>
+    <specifier>required.method.not.called</specifier>
+    <message>@MustCall method close may not have been invoked on temp-var or any of its aliases.</message>
+    <lineContent>pushToStack(start.iterateAxis(AxisInfo.CHILD));</lineContent>
     <details>
       The type of object is: net.sf.saxon.tree.iter.AxisIterator.
       Reason for going out of scope: regular method exit

--- a/.ci/checker-framework-suppressions/checker-framework-nullness-optional-interning-suppressions.xml
+++ b/.ci/checker-framework-suppressions/checker-framework-nullness-optional-interning-suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedErrors>
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter args of Violation.</message>
@@ -11,7 +11,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter customMessage of Violation.</message>
@@ -22,7 +22,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter customMessage of Violation.</message>
@@ -33,7 +33,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter moduleId of Violation.</message>
@@ -44,7 +44,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter moduleId of Violation.</message>
@@ -55,7 +55,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -66,14 +66,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: basedir, moduleFactory, moduleClassLoader, childContext, cacheFile</message>
     <lineContent>public Checker() {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to addListener(com.puppycrawl.tools.checkstyle.api.AuditListener) not allowed on the given receiver.</message>
@@ -84,7 +84,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter arg0 of add.</message>
@@ -95,42 +95,42 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference parentModule</message>
     <lineContent>parentModule.removeChild(recentModule);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference top</message>
     <lineContent>top.addChild(conf);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference top</message>
     <lineContent>top.addMessage(key, value);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference top</message>
     <lineContent>top.addProperty(name, value);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: configuration</message>
     <lineContent>private InternalLoader()</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -141,7 +141,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -152,21 +152,21 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java</fileName>
     <specifier>toarray.nullable.elements.not.newarray</specifier>
     <message>call of toArray on collection of non-null elements yields an array of possibly-null elements; omit the argument to toArray or make it an explicit array constructor</message>
     <lineContent>return children.toArray(</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DefaultConfiguration.java</fileName>
     <specifier>toarray.nullable.elements.not.newarray</specifier>
     <message>call of toArray on collection of non-null elements yields an array of possibly-null elements; omit the argument to toArray or make it an explicit array constructor</message>
     <lineContent>return keySet.toArray(CommonUtil.EMPTY_STRING_ARRAY);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DefaultContext.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -177,29 +177,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>this.args = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull Object @Initialized @NonNull []
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>firstChild = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull DetailAstImpl
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -210,74 +188,74 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java</fileName>
+    <specifier>assignment</specifier>
+    <message>incompatible types in assignment.</message>
+    <lineContent>firstChild = null;</lineContent>
+    <details>
+      found   : null (NullType)
+      required: @Initialized @NonNull DetailAstImpl
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field branchTokenTypes</message>
     <lineContent>private BitSet branchTokenTypes;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field firstChild</message>
     <lineContent>private DetailAstImpl firstChild;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field hiddenAfter</message>
     <lineContent>private List&lt;Token&gt; hiddenAfter;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field hiddenBefore</message>
     <lineContent>private List&lt;Token&gt; hiddenBefore;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field nextSibling</message>
     <lineContent>private DetailAstImpl nextSibling;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field parent</message>
     <lineContent>private DetailAstImpl parent;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field previousSibling</message>
     <lineContent>private DetailAstImpl previousSibling;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field text</message>
     <lineContent>private String text;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java</fileName>
-    <specifier>return</specifier>
-    <message>incompatible types in return.</message>
-    <lineContent>return returnList;</lineContent>
-    <details>
-      type of expression: @Initialized @Nullable List&lt;@Initialized @NonNull Token&gt;
-      method return type: @Initialized @NonNull List&lt;@Initialized @NonNull Token&gt;
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -288,7 +266,18 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java</fileName>
+    <specifier>return</specifier>
+    <message>incompatible types in return.</message>
+    <lineContent>return returnList;</lineContent>
+    <details>
+      type of expression: @Initialized @Nullable List&lt;@Initialized @NonNull Token&gt;
+      method return type: @Initialized @NonNull List&lt;@Initialized @NonNull Token&gt;
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter child of addChild.</message>
@@ -299,49 +288,49 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field child</message>
     <lineContent>private DetailAstImpl child;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field root</message>
     <lineContent>private DetailAstImpl root;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java</fileName>
     <specifier>introduce.eliminate</specifier>
     <message>It is bad style to create an Optional just to chain methods to get a value.</message>
     <lineContent>.orElseGet(() -&gt; createImaginary(TokenTypes.ELIST));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java</fileName>
     <specifier>introduce.eliminate</specifier>
     <message>It is bad style to create an Optional just to chain methods to get a value.</message>
     <lineContent>.orElseGet(() -&gt; createImaginary(TokenTypes.PARAMETERS));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>else if (ctx.children.get(i) == expression) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>if (ctx.children.get(i) == rbrack) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -352,7 +341,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -363,7 +352,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavaAstVisitor.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -374,7 +363,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter parent of createJavadocNode.</message>
@@ -385,53 +374,42 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference stack.peek()</message>
     <lineContent>if (stack.peek().getText().equals(token.getText())) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field errorMessage</message>
     <lineContent>private ParseErrorMessage errorMessage;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field firstNonTightHtmlTag</message>
     <lineContent>private Token firstNonTightHtmlTag;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field parseErrorMessage</message>
     <lineContent>private ParseErrorMessage parseErrorMessage;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field tree</message>
     <lineContent>private DetailNode tree;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java</fileName>
-    <specifier>return</specifier>
-    <message>incompatible types in return.</message>
-    <lineContent>return nextSibling;</lineContent>
-    <details>
-      type of expression: @Initialized @Nullable ParseTree
-      method return type: @Initialized @NonNull ParseTree
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -442,32 +420,32 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParser.java</fileName>
+    <specifier>return</specifier>
+    <message>incompatible types in return.</message>
+    <lineContent>return nextSibling;</lineContent>
+    <details>
+      type of expression: @Initialized @Nullable ParseTree
+      method return type: @Initialized @NonNull ParseTree
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGenerator.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field inputFile</message>
     <lineContent>private File inputFile;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGenerator.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field outputFile</message>
     <lineContent>private File outputFile;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGenerator.java</fileName>
-    <specifier>return</specifier>
-    <message>incompatible types in return.</message>
-    <lineContent>return firstSentence;</lineContent>
-    <details>
-      type of expression: @Initialized @Nullable String
-      method return type: @Initialized @NonNull String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGenerator.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -478,7 +456,51 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGenerator.java</fileName>
+    <specifier>return</specifier>
+    <message>incompatible types in return.</message>
+    <lineContent>return firstSentence;</lineContent>
+    <details>
+      type of expression: @Initialized @Nullable String
+      method return type: @Initialized @NonNull String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter loader of getBundle.</message>
+    <lineContent>return ResourceBundle.getBundle(bundle, sLocale, sourceClass.getClassLoader(),</lineContent>
+    <details>
+      found   : @Initialized @Nullable ClassLoader
+      required: @Initialized @NonNull ClassLoader
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java</fileName>
+    <specifier>assignment</specifier>
+    <message>incompatible types in assignment.</message>
+    <lineContent>this.args = null;</lineContent>
+    <details>
+      found   : null (NullType)
+      required: @Initialized @NonNull Object @Initialized @NonNull []
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java</fileName>
+    <specifier>return</specifier>
+    <message>incompatible types in return.</message>
+    <lineContent>return resourceBundle;</lineContent>
+    <details>
+      type of expression: @Initialized @Nullable ResourceBundle
+      method return type: @Initialized @NonNull ResourceBundle
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter moduleClassLoader of getRootModule.</message>
@@ -489,91 +511,91 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference Checker.class.getPackage()</message>
     <lineContent>Checker.class.getPackage().getName(), moduleClassLoader);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference Main.class.getPackage()</message>
     <lineContent>+ Main.class.getPackage().getImplementationVersion());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference Main.class.getPackage()</message>
     <lineContent>private final String packageName = Main.class.getPackage().getName();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference Main.class.getPackage()</message>
     <lineContent>return &quot;Checkstyle version: &quot; + Main.class.getPackage().getImplementationVersion();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference logRecord.getLoggerName()</message>
     <lineContent>return logRecord.getLoggerName().startsWith(packageName);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference parentLogger</message>
     <lineContent>parentLogger.addHandler(handler);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field configurationFile</message>
     <lineContent>private String configurationFile;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field files</message>
     <lineContent>private List&lt;File&gt; files;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field outputPath</message>
     <lineContent>private Path outputPath;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field propertiesFile</message>
     <lineContent>private File propertiesFile;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field suppressionLineColumnNumber</message>
     <lineContent>private String suppressionLineColumnNumber;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field xpath</message>
     <lineContent>private String xpath;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -584,7 +606,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter arg0 of contains.</message>
@@ -595,32 +617,32 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter args of LocalizedMessage.</message>
     <lineContent>UNABLE_TO_INSTANTIATE_EXCEPTION_MESSAGE, name, attemptedNames);</lineContent>
     <details>
-         found   : @Initialized @Nullable String
-         required: @Initialized @NonNull Object
+      found   : @Initialized @Nullable String
+      required: @Initialized @NonNull Object
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: thirdPartyNameToFullModuleNames</message>
     <lineContent>public PackageObjectFactory(Set&lt;String&gt; packageNames, ClassLoader moduleClassLoader,</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: thirdPartyNameToFullModuleNames, moduleLoadOption</message>
     <lineContent>public PackageObjectFactory(String packageName, ClassLoader moduleClassLoader) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java</fileName>
     <specifier>methodref.return</specifier>
     <message>Incompatible return type</message>
@@ -635,7 +657,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -646,7 +668,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java</fileName>
     <specifier>methodref.return</specifier>
     <message>Incompatible return type</message>
@@ -661,7 +683,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PropertiesExpander.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -672,21 +694,21 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference cachedHashSum</message>
     <lineContent>if (!cachedHashSum.equals(contentHashSum)) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: configHash</message>
     <lineContent>public PropertyCacheFile(Configuration config, String fileName) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -697,14 +719,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/SarifLogger.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference SarifLogger.class.getPackage()</message>
     <lineContent>final String version = SarifLogger.class.getPackage().getImplementationVersion();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/SuppressionsStringPrinter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter s of parseInt.</message>
@@ -715,7 +737,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/SuppressionsStringPrinter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter s of parseInt.</message>
@@ -726,14 +748,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: childContext, moduleFactory</message>
     <lineContent>public TreeWalker() {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to setFileExtensions(java.lang.String...) not allowed on the given receiver.</message>
@@ -744,7 +766,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/TreeWalker.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -755,7 +777,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter messages of writeFileMessages.</message>
@@ -766,14 +788,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/XMLLogger.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference XMLLogger.class.getPackage()</message>
     <lineContent>final String version = XMLLogger.class.getPackage().getImplementationVersion();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/XmlLoader.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter byteStream of InputSource.</message>
@@ -784,7 +806,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/XmlLoader.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter handler of createXmlReader.</message>
@@ -795,14 +817,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/XmlLoader.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference loader</message>
     <lineContent>loader.getResourceAsStream(dtdResourceName);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/XmlLoader.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for publicId.</message>
@@ -817,7 +839,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/XpathFileGeneratorAstFilter.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -828,7 +850,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter checkstyleVersion of realExecute.</message>
@@ -839,7 +861,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter moduleClassLoader of PackageObjectFactory.</message>
@@ -850,7 +872,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter moduleClassLoader of setModuleClassLoader.</message>
@@ -861,84 +883,84 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference Checker.class.getPackage()</message>
     <lineContent>Checker.class.getPackage().getName() + &quot;.&quot;, moduleClassLoader);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference CheckstyleAntTask.class.getPackage()</message>
     <lineContent>final String version = CheckstyleAntTask.class.getPackage().getImplementationVersion();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field classpath</message>
     <lineContent>private Path classpath;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field config</message>
     <lineContent>private String config;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field failureProperty</message>
     <lineContent>private String failureProperty;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field fileName</message>
     <lineContent>private String fileName;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field key</message>
     <lineContent>private String key;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field properties</message>
     <lineContent>private File properties;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field toFile</message>
     <lineContent>private File toFile;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field type</message>
     <lineContent>private FormatterType type;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field value</message>
     <lineContent>private String value;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter customMessage of Violation.</message>
@@ -949,14 +971,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field fileContents</message>
     <lineContent>private FileContents fileContents;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractCheck.java</fileName>
     <specifier>type.argument</specifier>
     <message>incompatible type argument for type parameter T of ThreadLocal.</message>
@@ -967,7 +989,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter customMessage of Violation.</message>
@@ -978,28 +1000,28 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field fileContents</message>
     <lineContent>private FileContents fileContents;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field fileExtensions</message>
     <lineContent>private String[] fileExtensions;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field messageDispatcher</message>
     <lineContent>private MessageDispatcher messageDispatcher;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractFileSetCheck.java</fileName>
     <specifier>type.argument</specifier>
     <message>incompatible type argument for type parameter T of ThreadLocal.</message>
@@ -1010,14 +1032,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/AbstractViolationReporter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field id</message>
     <lineContent>private String id;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/AuditEvent.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter fileName of AuditEvent.</message>
@@ -1028,7 +1050,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/AuditEvent.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter violation of AuditEvent.</message>
@@ -1039,14 +1061,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field configuration</message>
     <lineContent>private Configuration configuration;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -1057,21 +1079,21 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java</fileName>
     <specifier>toarray.nullable.elements.not.newarray</specifier>
     <message>call of toArray on collection of non-null elements yields an array of possibly-null elements; omit the argument to toArray or make it an explicit array constructor</message>
     <lineContent>return result.toArray(CommonUtil.EMPTY_STRING_ARRAY);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/AutomaticBean.java</fileName>
     <specifier>toarray.nullable.elements.not.newarray</specifier>
     <message>call of toArray on collection of non-null elements yields an array of possibly-null elements; omit the argument to toArray or make it an explicit array constructor</message>
     <lineContent>return result.toArray(EMPTY_MODIFIER_ARRAY);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileContents.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -1082,7 +1104,29 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java</fileName>
+    <specifier>assignment</specifier>
+    <message>incompatible types in assignment.</message>
+    <lineContent>lines = textLines.toArray(CommonUtil.EMPTY_STRING_ARRAY);</lineContent>
+    <details>
+      found   : @Initialized @Nullable String @Initialized @NonNull []
+      required: @Initialized @NonNull String @Initialized @NonNull []
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java</fileName>
+    <specifier>assignment</specifier>
+    <message>incompatible types in assignment.</message>
+    <lineContent>this.lines = lines.toArray(CommonUtil.EMPTY_STRING_ARRAY);</lineContent>
+    <details>
+      found   : @Initialized @Nullable String @Initialized @NonNull []
+      required: @Initialized @NonNull String @Initialized @NonNull []
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -1093,7 +1137,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -1104,64 +1148,42 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>lines = textLines.toArray(CommonUtil.EMPTY_STRING_ARRAY);</lineContent>
-    <details>
-      found   : @Initialized @Nullable String @Initialized @NonNull []
-      required: @Initialized @NonNull String @Initialized @NonNull []
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>this.lines = lines.toArray(CommonUtil.EMPTY_STRING_ARRAY);</lineContent>
-    <details>
-      found   : @Initialized @Nullable String @Initialized @NonNull []
-      required: @Initialized @NonNull String @Initialized @NonNull []
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: lineBreaks</message>
     <lineContent>public FileText(File file, List&lt;String&gt; lines) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: lineBreaks</message>
     <lineContent>public FileText(File file, String charsetName) throws IOException {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java</fileName>
     <specifier>toarray.nullable.elements.not.newarray</specifier>
     <message>call of toArray on collection of non-null elements yields an array of possibly-null elements; omit the argument to toArray or make it an explicit array constructor</message>
     <lineContent>lines = textLines.toArray(CommonUtil.EMPTY_STRING_ARRAY);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java</fileName>
     <specifier>toarray.nullable.elements.not.newarray</specifier>
     <message>call of toArray on collection of non-null elements yields an array of possibly-null elements; omit the argument to toArray or make it an explicit array constructor</message>
     <lineContent>this.lines = lines.toArray(CommonUtil.EMPTY_STRING_ARRAY);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: detailAst</message>
     <lineContent>private FullIdent() {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/LineColumn.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for other.</message>
@@ -1176,18 +1198,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter loader of getBundle.</message>
-    <lineContent>return ResourceBundle.getBundle(bundle, sLocale, sourceClass.getClassLoader(),</lineContent>
-    <details>
-      found   : @Initialized @Nullable ClassLoader
-      required: @Initialized @NonNull ClassLoader
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -1198,7 +1209,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for object.</message>
@@ -1213,46 +1224,35 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java</fileName>
-    <specifier>return</specifier>
-    <message>incompatible types in return.</message>
-    <lineContent>return resourceBundle;</lineContent>
-    <details>
-      type of expression: @Initialized @Nullable ResourceBundle
-      method return type: @Initialized @NonNull ResourceBundle
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field blockComments</message>
     <lineContent>private Map&lt;Integer, List&lt;TextBlock&gt;&gt; blockComments;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field singlelineComments</message>
     <lineContent>private Map&lt;Integer, TextBlock&gt; singlelineComments;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field maximumMessage</message>
     <lineContent>private String maximumMessage;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/DescendantTokenCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field minimumMessage</message>
     <lineContent>private String minimumMessage;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter args of log.</message>
@@ -1263,7 +1263,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to setFileExtensions(java.lang.String...) not allowed on the given receiver.</message>
@@ -1274,7 +1274,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java</fileName>
     <specifier>override.return</specifier>
     <message>Incompatible return type.</message>
@@ -1289,7 +1289,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheck.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -1300,21 +1300,21 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field fileName</message>
     <lineContent>private String fileName;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field wrongType</message>
     <lineContent>private DetailAST wrongType;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolder.java</fileName>
     <specifier>type.argument</specifier>
     <message>incompatible type argument for type parameter T of ThreadLocal.</message>
@@ -1325,14 +1325,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/TrailingCommentCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field legalComment</message>
     <lineContent>private Pattern legalComment;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter args of Violation.</message>
@@ -1343,7 +1343,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter customMessage of Violation.</message>
@@ -1354,7 +1354,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter languageCode of getMissingFileName.</message>
@@ -1365,7 +1365,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -1376,7 +1376,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to setFileExtensions(java.lang.String...) not allowed on the given receiver.</message>
@@ -1387,7 +1387,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter ast of createFullIdent.</message>
@@ -1398,7 +1398,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -1409,21 +1409,21 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field currentClass</message>
     <lineContent>private String currentClass;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field packageName</message>
     <lineContent>private FullIdent packageName;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter args of log.</message>
@@ -1434,7 +1434,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to setFileExtensions(java.lang.String...) not allowed on the given receiver.</message>
@@ -1445,14 +1445,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/MissingOverrideCheck.java</fileName>
     <specifier>introduce.eliminate</specifier>
     <message>It is bad style to create an Optional just to chain methods to get a value.</message>
     <lineContent>.orElse(modifiers);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/LeftCurlyCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -1463,7 +1463,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter rcurly of Details.</message>
@@ -1474,7 +1474,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter rcurly of Details.</message>
@@ -1485,7 +1485,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -1496,7 +1496,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter state of processModifiersState.</message>
@@ -1507,35 +1507,35 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference state</message>
     <lineContent>if (state.currentScopeState &gt; STATE_CTOR_DEF) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference state</message>
     <lineContent>state.currentScopeState = STATE_METHOD_DEF;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field classFieldNames</message>
     <lineContent>private Set&lt;String&gt; classFieldNames;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field scopeStates</message>
     <lineContent>private Deque&lt;ScopeState&gt; scopeStates;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DefaultComesLastCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -1546,7 +1546,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter parent of FieldFrame.</message>
@@ -1557,21 +1557,21 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field currentFrame</message>
     <lineContent>private FieldFrame currentFrame;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: frameName</message>
     <lineContent>private FieldFrame(FieldFrame parent) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -1582,7 +1582,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -1593,7 +1593,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter prevScopeUninitializedVariableData of updateAllUninitializedVariables.</message>
@@ -1604,105 +1604,105 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference candidate</message>
     <lineContent>shouldRemove = candidate.alreadyAssigned;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference currentScopeAssignedVariables.peek()</message>
     <lineContent>currentScopeAssignedVariables.peek().add(ast);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference currentScopeAssignedVariables.peek()</message>
     <lineContent>final Iterator&lt;DetailAST&gt; iterator = currentScopeAssignedVariables.peek().iterator();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference scopeData</message>
     <lineContent>scopeData.uninitializedVariables.forEach(prevScopeUninitializedVariableData::push);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference scopeStack.peek()</message>
     <lineContent>containsBreak = scopeStack.peek().containsBreak;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference scopeStack.peek()</message>
     <lineContent>final Map&lt;String, FinalVariableCandidate&gt; scope = scopeStack.peek().scope;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference scopeStack.peek()</message>
     <lineContent>scopeStack.peek().containsBreak = true;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference scopeStack.peek()</message>
     <lineContent>scopeStack.peek().uninitializedVariables.add(astNode);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>== ast.getParent()) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>if (currAstLoopAstParent == currVarLoopAstParent) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>result = findLastCaseGroupWhichContainsSlist(ast.getParent()) != ast;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>return classOrMethodOfAst1 == classOrMethodOfAst2 &amp;&amp; ast1.getText().equals(ast2.getText());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>|| ast.getParent().getParent().findFirstToken(TokenTypes.CASE_GROUP)</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>|| findLastCaseGroupWhichContainsSlist(parentAst.getParent()) == parentAst) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -1713,7 +1713,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter frameName of FieldFrame.</message>
@@ -1724,7 +1724,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter frameName of FieldFrame.</message>
@@ -1735,7 +1735,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter parent of FieldFrame.</message>
@@ -1746,21 +1746,21 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field frame</message>
     <lineContent>private FieldFrame frame;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/HiddenFieldCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field ignoreFormat</message>
     <lineContent>private Pattern ignoreFormat;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -1771,14 +1771,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field pkgName</message>
     <lineContent>private String pkgName;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -1789,7 +1789,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalInstantiationCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -1800,14 +1800,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>while (astNode != constantDefAST) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -1818,14 +1818,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field xpathExpression</message>
     <lineContent>private XPathExpression xpathExpression;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ModifiedControlVariableCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -1836,7 +1836,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -1847,14 +1847,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: ignoreStringsRegexp</message>
     <lineContent>public MultipleStringLiteralsCheck() {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to setIgnoreStringsRegexp(java.util.regex.Pattern) not allowed on the given receiver.</message>
@@ -1865,21 +1865,21 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OverloadMethodsDeclarationOrderCheck.java</fileName>
     <specifier>unboxing.of.nullable</specifier>
     <message>unboxing a possibly-null reference methodLineNumberMap.get(methodName)</message>
     <lineContent>methodLineNumberMap.get(methodName);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ParameterAssignmentCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field parameterNames</message>
     <lineContent>private Set&lt;String&gt; parameterNames;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter arg0 of push.</message>
@@ -1890,7 +1890,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter arg1 of put.</message>
@@ -1901,7 +1901,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter frame of collectMethodDeclarations.</message>
@@ -1912,7 +1912,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter frame of collectVariableDeclarations.</message>
@@ -1923,7 +1923,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter frame of findFrame.</message>
@@ -1934,7 +1934,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter frame of findFrame.</message>
@@ -1945,7 +1945,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter ident of ClassFrame.</message>
@@ -1956,7 +1956,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter parent of AnonymousClassFrame.</message>
@@ -1967,7 +1967,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter parent of BlockFrame.</message>
@@ -1978,7 +1978,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter parent of CatchFrame.</message>
@@ -1989,7 +1989,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter parent of ClassFrame.</message>
@@ -2000,7 +2000,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter parent of ConstructorFrame.</message>
@@ -2011,7 +2011,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter parent of ForFrame.</message>
@@ -2022,7 +2022,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter parent of TryWithResourcesFrame.</message>
@@ -2033,67 +2033,56 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference ((ClassFrame)frame)</message>
     <lineContent>((ClassFrame) frame).addInstanceMember(componentIdent);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference ((ClassFrame)frame)</message>
     <lineContent>((ClassFrame) frame).addStaticMember(ident);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference current.peek()</message>
     <lineContent>if (current.peek().getType() == FrameType.TRY_WITH_RESOURCES_FRAME) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference frame</message>
     <lineContent>frame.addIdent(parameterIdent);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference frame</message>
     <lineContent>frame.addIdent(resourceIdent);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference frame</message>
     <lineContent>while (frame.getType() != FrameType.CLASS_FRAME) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field frames</message>
     <lineContent>private Map&lt;DetailAST, AbstractFrame&gt; frames;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
-    <specifier>return</specifier>
-    <message>incompatible types in return.</message>
-    <lineContent>return blockEndToken;</lineContent>
-    <details>
-      type of expression: @Initialized @Nullable DetailAST
-      method return type: @Initialized @NonNull DetailAST
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -2104,7 +2093,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -2115,7 +2104,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -2126,21 +2115,32 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/RequireThisCheck.java</fileName>
+    <specifier>return</specifier>
+    <message>incompatible types in return.</message>
+    <lineContent>return blockEndToken;</lineContent>
+    <details>
+      type of expression: @Initialized @Nullable DetailAST
+      method return type: @Initialized @NonNull DetailAST
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field context</message>
     <lineContent>private Context context;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: maxAllowed</message>
     <lineContent>private Context(boolean checking) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -2151,21 +2151,21 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field parentToSkip</message>
     <lineContent>private DetailAST parentToSkip;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>if (parentToSkip != ast &amp;&amp; isExprSurrounded(ast)) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter arg1 of put.</message>
@@ -2176,7 +2176,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter outerClassQualifiedName of getQualifiedTypeDeclarationName.</message>
@@ -2187,7 +2187,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -2198,70 +2198,81 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference anonInnerAstToTypeDeclDesc.get(literalNewAst)</message>
     <lineContent>anonInnerAstToTypeDeclDesc.get(literalNewAst).getQualifiedName(),</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference typeDeclAstToTypeDeclDesc.get(obtainedClass.getTypeDeclAst())</message>
     <lineContent>.get(obtainedClass.getTypeDeclAst())</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference typeDeclAstToTypeDeclDesc.get(parentAst.getParent())</message>
     <lineContent>typeDeclAstToTypeDeclDesc.get(parentAst.getParent()).addInstOrClassVar(desc);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference typeDeclarations.peek()</message>
     <lineContent>outerClassQualifiedName = typeDeclarations.peek().getQualifiedName();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference variablesStack.peek()</message>
     <lineContent>while (!variablesStack.isEmpty() &amp;&amp; variablesStack.peek().getScope() == scopeAst) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>&amp;&amp; identAst != parent.getLastChild();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>&amp;&amp; parent.getFirstChild() != identAst;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>while (!variablesStack.isEmpty() &amp;&amp; variablesStack.peek().getScope() == scopeAst) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>while (currNode != ast &amp;&amp; toVisit == null) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java</fileName>
+    <specifier>return</specifier>
+    <message>incompatible types in return.</message>
+    <lineContent>return result;</lineContent>
+    <details>
+      type of expression: @Initialized @Nullable DetailAST
+      method return type: @Initialized @NonNull DetailAST
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -2272,18 +2283,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java</fileName>
-    <specifier>return</specifier>
-    <message>incompatible types in return.</message>
-    <lineContent>return result;</lineContent>
-    <details>
-      type of expression: @Initialized @Nullable DetailAST
-      method return type: @Initialized @NonNull DetailAST
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter key of SimpleEntry.</message>
@@ -2294,14 +2294,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>if (curNode == parent) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -2312,7 +2312,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -2323,21 +2323,21 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>if (curNode == token) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>return currentNode != methodImplCloseBrace</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter outerClassQualifiedName of getQualifiedTypeDeclarationName.</message>
@@ -2348,49 +2348,49 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference typeDeclarations.peek()</message>
     <lineContent>.put(ast, typeDeclarations.peek().getQualifiedName());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference typeDeclarations.peek()</message>
     <lineContent>outerTypeDeclarationQualifiedName = typeDeclarations.peek().getQualifiedName();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field anonInnerClassToOuterTypeDecl</message>
     <lineContent>private Map&lt;DetailAST, String&gt; anonInnerClassToOuterTypeDecl;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field innerClasses</message>
     <lineContent>private Map&lt;String, ClassDesc&gt; innerClasses;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field packageName</message>
     <lineContent>private String packageName;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field typeDeclarations</message>
     <lineContent>private Deque&lt;TypeDeclarationDescription&gt; typeDeclarations;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -2401,7 +2401,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/OneTopLevelClassCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter typeDef of isPublic.</message>
@@ -2412,7 +2412,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/VisibilityModifierCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -2423,14 +2423,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/AbstractHeaderCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field headerFile</message>
     <lineContent>private URI headerFile;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter previousImport of isAlphabeticalOrderBroken.</message>
@@ -2441,7 +2441,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter previousImport of validateExtraEmptyLine.</message>
@@ -2452,7 +2452,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter previousImport of validateMissedEmptyLine.</message>
@@ -2463,7 +2463,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/FileImportControl.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -2474,7 +2474,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/FileImportControl.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -2485,14 +2485,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: illegalPkgs, illegalClasses</message>
     <lineContent>public IllegalImportCheck() {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/IllegalImportCheck.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to setIllegalPkgs(java.lang.String...) not allowed on the given receiver.</message>
@@ -2503,7 +2503,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -2514,42 +2514,42 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field currentImportControl</message>
     <lineContent>private AbstractImportControl currentImportControl;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field file</message>
     <lineContent>private URI file;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field fileName</message>
     <lineContent>private String fileName;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field packageName</message>
     <lineContent>private String packageName;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field root</message>
     <lineContent>private PkgImportControl root;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter parent of FileImportControl.</message>
@@ -2560,7 +2560,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter parent of PkgImportControl.</message>
@@ -2571,21 +2571,21 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference parentImportControl</message>
     <lineContent>parentImportControl.addChild(importControl);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference stack.peek()</message>
     <lineContent>stack.peek().addImportRule(rule);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlLoader.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -2596,14 +2596,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field lastImport</message>
     <lineContent>private String lastImport;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgImportControl.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter parent of AbstractImportControl.</message>
@@ -2614,7 +2614,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgImportControl.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -2625,7 +2625,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgImportControl.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -2636,7 +2636,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgImportControl.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -2647,7 +2647,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -2658,14 +2658,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/RedundantImportCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field pkgName</message>
     <lineContent>private String pkgName;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter parent of Frame.</message>
@@ -2676,7 +2676,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter type of topLevelType.</message>
@@ -2687,28 +2687,28 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field currentFrame</message>
     <lineContent>private Frame currentFrame;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: indent</message>
     <lineContent>protected AbstractExpressionHandler(IndentationCheck indentCheck, String typeName,</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>while (curNode != ast &amp;&amp; toVisit == null) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AnnotationArrayInitHandler.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -2719,7 +2719,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ArrayInitHandler.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -2730,14 +2730,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/BlockParentHandler.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>if (nonList != nonListStartAst) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ClassDefHandler.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -2748,14 +2748,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>while (nextToken != null &amp;&amp; nextToken != currentStatement &amp;&amp; isComment(nextToken)) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -2766,7 +2766,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -2777,7 +2777,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/CommentsIndentationCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -2788,7 +2788,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/DetailAstSet.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -2799,7 +2799,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/DetailAstSet.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -2810,19 +2810,18 @@
     </details>
   </checkerFrameworkError>
 
-  <!-- Unstable as 'capture#' keeps changing in different runs. -->
-  <checkerFrameworkError unstable="true">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter constructor of invokeConstructor.</message>
     <lineContent>handlerCtor, indentCheck, ast, parent);</lineContent>
     <details>
-      found   : @Initialized @Nullable Constructor&lt;capture#788 extends @Initialized @Nullable Object&gt;
-      required: @Initialized @NonNull Constructor&lt;capture#788 extends @Initialized @Nullable Object&gt;
+      found   : @Initialized @Nullable Constructor&lt;capture extends @Initialized @Nullable Object&gt;
+      required: @Initialized @NonNull Constructor&lt;capture extends @Initialized @Nullable Object&gt;
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -2833,7 +2832,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -2844,7 +2843,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -2855,7 +2854,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -2866,7 +2865,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -2877,7 +2876,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -2888,7 +2887,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -2899,7 +2898,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -2910,7 +2909,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -2921,7 +2920,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -2932,7 +2931,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -2943,7 +2942,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -2954,7 +2953,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -2965,7 +2964,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -2976,7 +2975,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -2987,7 +2986,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -2998,7 +2997,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -3009,7 +3008,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -3020,7 +3019,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -3031,7 +3030,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -3042,7 +3041,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -3053,7 +3052,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -3064,7 +3063,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -3075,7 +3074,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -3086,7 +3085,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -3097,7 +3096,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -3108,7 +3107,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -3119,7 +3118,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -3130,7 +3129,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -3141,7 +3140,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -3152,7 +3151,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -3163,7 +3162,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -3174,7 +3173,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -3185,7 +3184,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -3196,7 +3195,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -3207,7 +3206,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -3218,7 +3217,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -3229,7 +3228,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;T&gt;register(int,java.lang.Class&lt;T&gt;) not allowed on the given receiver.</message>
@@ -3240,7 +3239,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -3251,19 +3250,18 @@
     </details>
   </checkerFrameworkError>
 
-  <!-- Unstable as 'capture#' keeps changing in different runs. -->
-  <checkerFrameworkError unstable="true">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/HandlerFactory.java</fileName>
     <specifier>type.argument</specifier>
     <message>incompatible type argument for type parameter T extends Object of invokeConstructor.</message>
     <lineContent>resultHandler = (AbstractExpressionHandler) CommonUtil.invokeConstructor(</lineContent>
     <details>
-      found   : capture#788[ extends @UnknownKeyFor Object super @KeyForBottom Void]
+      found   : capture[ extends @UnknownKeyFor Object super @KeyForBottom Void]
       required: [extends @UnknownKeyFor Object super @UnknownKeyFor NullType]
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter instance of LineWrappingHandler.</message>
@@ -3274,7 +3272,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter parent of getHandler.</message>
@@ -3285,7 +3283,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -3296,21 +3294,21 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/IndentationCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field incorrectIndentationLines</message>
     <lineContent>private Set&lt;Integer&gt; incorrectIndentationLines;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/LineWrappingHandler.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>while (curNode != lastNode) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/MethodDefHandler.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -3321,7 +3319,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/ObjectBlockHandler.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -3332,7 +3330,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/PrimordialHandler.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter expr of AbstractExpressionHandler.</message>
@@ -3343,7 +3341,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/PrimordialHandler.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter parent of AbstractExpressionHandler.</message>
@@ -3354,7 +3352,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/PrimordialHandler.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter typeName of AbstractExpressionHandler.</message>
@@ -3365,7 +3363,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SlistHandler.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -3376,7 +3374,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/SwitchHandler.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -3387,14 +3385,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field blockCommentAst</message>
     <lineContent>private DetailAST blockCommentAst;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java</fileName>
     <specifier>type.argument</specifier>
     <message>incompatible type argument for type parameter T of ThreadLocal.</message>
@@ -3405,7 +3403,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheck.java</fileName>
     <specifier>type.argument</specifier>
     <message>incompatible type argument for type parameter T of ThreadLocal.</message>
@@ -3416,7 +3414,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter arg0 of contains.</message>
@@ -3427,14 +3425,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheck.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: tags</message>
     <lineContent>public JavadocBlockTagLocationCheck() {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocBlockTagLocationCheck.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to setTags(java.lang.String...) not allowed on the given receiver.</message>
@@ -3445,7 +3443,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter firstArg of JavadocTag.</message>
@@ -3456,7 +3454,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter firstArg of JavadocTag.</message>
@@ -3467,7 +3465,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter tag of JavadocTag.</message>
@@ -3478,7 +3476,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter tag of JavadocTag.</message>
@@ -3489,7 +3487,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter tag of JavadocTag.</message>
@@ -3500,7 +3498,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter tag of JavadocTag.</message>
@@ -3511,7 +3509,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter tag of JavadocTag.</message>
@@ -3522,70 +3520,70 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field currentClassName</message>
     <lineContent>private String currentClassName;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>if (curNode != root) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>return ancestor != methodBodyAst;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>while (ancestor != methodBodyAst) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>while (curNode != root &amp;&amp; curNode.getNextSibling() == null) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>} while (curNode != root);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field children</message>
     <lineContent>private DetailNode[] children;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field parent</message>
     <lineContent>private DetailNode parent;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocNodeImpl.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field text</message>
     <lineContent>private String text;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter arg0 of add.</message>
@@ -3596,7 +3594,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocPackageCheck.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to setFileExtensions(java.lang.String...) not allowed on the given receiver.</message>
@@ -3607,14 +3605,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field excludeScope</message>
     <lineContent>private Scope excludeScope;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTag.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter firstArg of JavadocTag.</message>
@@ -3625,77 +3623,77 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference matchInAngleBrackets.group(1)</message>
     <lineContent>typeParamName = matchInAngleBrackets.group(1).trim();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field authorFormat</message>
     <lineContent>private Pattern authorFormat;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field excludeScope</message>
     <lineContent>private Scope excludeScope;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field versionFormat</message>
     <lineContent>private Pattern versionFormat;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field excludeScope</message>
     <lineContent>private Scope excludeScope;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocVariableCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field ignoreNamePattern</message>
     <lineContent>private Pattern ignoreNamePattern;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field excludeScope</message>
     <lineContent>private Scope excludeScope;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field ignoreMethodNamesRegex</message>
     <lineContent>private Pattern ignoreMethodNamesRegex;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocMethodCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>if (lcurly.getFirstChild() == rcurly) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/MissingJavadocTypeCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field excludeScope</message>
     <lineContent>private Scope excludeScope;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter javadocInlineTag of isInlineReturnTag.</message>
@@ -3706,7 +3704,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter javadocInlineTag of isSummaryTag.</message>
@@ -3717,7 +3715,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -3728,7 +3726,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/TagParser.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to parseTags(java.lang.String[],int) not allowed on the given receiver.</message>
@@ -3739,28 +3737,28 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field tag</message>
     <lineContent>private String tag;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field tagFormat</message>
     <lineContent>private Pattern tagFormat;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field tagRegExp</message>
     <lineContent>private Pattern tagRegExp;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/BlockTagUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter name of TagInfo.</message>
@@ -3771,7 +3769,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/InlineTagUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter name of TagInfo.</message>
@@ -3782,7 +3780,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/InlineTagUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter source of removeLeadingJavaDoc.</message>
@@ -3793,7 +3791,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter ast of ClassContext.</message>
@@ -3804,49 +3802,49 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference classesContexts.peek()</message>
     <lineContent>classesContexts.peek().addReferencedClassName(type.getText());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference classesContexts.peek()</message>
     <lineContent>classesContexts.peek().visitLiteralNew(ast);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference classesContexts.peek()</message>
     <lineContent>classesContexts.peek().visitLiteralThrows(ast);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference classesContexts.peek()</message>
     <lineContent>classesContexts.peek().visitType(ast);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/AbstractClassCouplingCheck.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: packageName</message>
     <lineContent>protected AbstractClassCouplingCheck(int defaultMax) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/metrics/JavaNCSSCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field counters</message>
     <lineContent>private Deque&lt;Counter&gt; counters;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -3857,7 +3855,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/AbbreviationAsWordInNameCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -3868,7 +3866,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -3879,77 +3877,77 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: reporter, format, suppressor, pattern</message>
     <lineContent>private DetectorOptions() {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions.java</fileName>
     <specifier>introduce.eliminate</specifier>
     <message>It is bad style to create an Optional just to chain methods to get a value.</message>
     <lineContent>message = Optional.ofNullable(message).orElse(&quot;&quot;);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions.java</fileName>
     <specifier>introduce.eliminate</specifier>
     <message>It is bad style to create an Optional just to chain methods to get a value.</message>
     <lineContent>suppressor = Optional.ofNullable(suppressor).orElse(NeverSuppress.INSTANCE);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/MultilineDetector.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: matcher, text</message>
     <lineContent>/* package */ MultilineDetector(DetectorOptions options) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field matcher</message>
     <lineContent>private Matcher matcher;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field message</message>
     <lineContent>private String message;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field detector</message>
     <lineContent>private MultilineDetector detector;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpMultilineCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field message</message>
     <lineContent>private String message;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field fileNamePattern</message>
     <lineContent>private Pattern fileNamePattern;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field folderPattern</message>
     <lineContent>private Pattern folderPattern;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpOnFilenameCheck.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -3960,21 +3958,21 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field detector</message>
     <lineContent>private SinglelineDetector detector;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field message</message>
     <lineContent>private String message;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter val of suppressor.</message>
@@ -3985,14 +3983,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field message</message>
     <lineContent>private String message;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter ast of Context.</message>
@@ -4003,77 +4001,77 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: context</message>
     <lineContent>public ExecutableStatementCountCheck() {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/ExecutableStatementCountCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>if (parent == contextAST) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference actualCounter</message>
     <lineContent>actualCounter.increment(scope);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference counters.peek()</message>
     <lineContent>final DetailAST latestDefinition = counters.peek().getScopeDefinition();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/sizes/MethodCountCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>result = latestDefinition == methodDef.getParent().getParent();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/NoWhitespaceAfterCheck.java</fileName>
     <specifier>introduce.eliminate</specifier>
     <message>It is bad style to create an Optional just to chain methods to get a value.</message>
     <lineContent>return Optional.ofNullable(referencedMemberDot).orElse(referencedClassDot);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>while (currentNode.getNextSibling() == null &amp;&amp; currentNode.getParent() != ast) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/SingleSpaceSeparatorCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>while (currentNode.getNextSibling() == null &amp;&amp; currentNode.getParent() != parent) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/TypecastParenPadCheck.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>&amp;&amp; ast.getParent().findFirstToken(TokenTypes.RPAREN) == ast) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filefilters/BeforeExecutionExclusionFileFilter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field fileNamePattern</message>
     <lineContent>private Pattern fileNamePattern;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/CsvFilterElement.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to addFilter(com.puppycrawl.tools.checkstyle.filters.IntFilterElement) not allowed on the given receiver.</message>
@@ -4084,7 +4082,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/CsvFilterElement.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to addFilter(com.puppycrawl.tools.checkstyle.filters.IntFilterElement) not allowed on the given receiver.</message>
@@ -4095,7 +4093,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/CsvFilterElement.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for object.</message>
@@ -4110,7 +4108,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntMatchFilterElement.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for object.</message>
@@ -4125,7 +4123,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/IntRangeFilterElement.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for other.</message>
@@ -4140,29 +4138,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>checkPattern = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>checkRegexp = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull Pattern
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -4173,40 +4149,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>columnsCsv = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>filePattern = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>fileRegexp = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull Pattern
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -4217,29 +4160,29 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
-    <lineContent>linesCsv = null;</lineContent>
+    <lineContent>checkRegexp = null;</lineContent>
     <details>
       found   : null (NullType)
-      required: @Initialized @NonNull String
+      required: @Initialized @NonNull Pattern
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
-    <lineContent>messagePattern = null;</lineContent>
+    <lineContent>fileRegexp = null;</lineContent>
     <details>
       found   : null (NullType)
-      required: @Initialized @NonNull String
+      required: @Initialized @NonNull Pattern
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -4250,7 +4193,62 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
+    <specifier>assignment</specifier>
+    <message>incompatible types in assignment.</message>
+    <lineContent>checkPattern = null;</lineContent>
+    <details>
+      found   : null (NullType)
+      required: @Initialized @NonNull String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
+    <specifier>assignment</specifier>
+    <message>incompatible types in assignment.</message>
+    <lineContent>columnsCsv = null;</lineContent>
+    <details>
+      found   : null (NullType)
+      required: @Initialized @NonNull String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
+    <specifier>assignment</specifier>
+    <message>incompatible types in assignment.</message>
+    <lineContent>filePattern = null;</lineContent>
+    <details>
+      found   : null (NullType)
+      required: @Initialized @NonNull String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
+    <specifier>assignment</specifier>
+    <message>incompatible types in assignment.</message>
+    <lineContent>linesCsv = null;</lineContent>
+    <details>
+      found   : null (NullType)
+      required: @Initialized @NonNull String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
+    <specifier>assignment</specifier>
+    <message>incompatible types in assignment.</message>
+    <lineContent>messagePattern = null;</lineContent>
+    <details>
+      found   : null (NullType)
+      required: @Initialized @NonNull String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for other.</message>
@@ -4265,7 +4263,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter text of addTag.</message>
@@ -4276,7 +4274,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -4287,7 +4285,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -4298,28 +4296,28 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field idFormat</message>
     <lineContent>private String idFormat;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field messageFormat</message>
     <lineContent>private String messageFormat;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>if (getFileContents() != currentContents) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for other.</message>
@@ -4334,7 +4332,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -4345,7 +4343,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter text of Suppression.</message>
@@ -4356,7 +4354,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter text of Suppression.</message>
@@ -4367,7 +4365,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -4378,7 +4376,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -4389,21 +4387,21 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field idFormat</message>
     <lineContent>private String idFormat;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field messageFormat</message>
     <lineContent>private String messageFormat;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for other.</message>
@@ -4418,18 +4416,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java</fileName>
-    <specifier>return</specifier>
-    <message>incompatible types in return.</message>
-    <lineContent>.orElse(null);</lineContent>
-    <details>
-      type of expression: @Initialized @Nullable Suppression
-      method return type: @Initialized @NonNull Suppression
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -4440,7 +4427,18 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java</fileName>
+    <specifier>return</specifier>
+    <message>incompatible types in return.</message>
+    <lineContent>.orElse(null);</lineContent>
+    <details>
+      type of expression: @Initialized @Nullable Suppression
+      method return type: @Initialized @NonNull Suppression
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter text of addTag.</message>
@@ -4451,7 +4449,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter text of addTag.</message>
@@ -4462,7 +4460,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -4473,7 +4471,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -4484,28 +4482,28 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field idFormat</message>
     <lineContent>private String idFormat;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field messageFormat</message>
     <lineContent>private String messageFormat;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>if (getFileContents() != currentContents) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for other.</message>
@@ -4520,7 +4518,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -4531,7 +4529,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -4542,70 +4540,70 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field file</message>
     <lineContent>private String file;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field checks</message>
     <lineContent>private Pattern checks;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field columns</message>
     <lineContent>private String columns;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field files</message>
     <lineContent>private Pattern files;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field filter</message>
     <lineContent>private SuppressFilterElement filter;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field id</message>
     <lineContent>private String id;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field lines</message>
     <lineContent>private String lines;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field message</message>
     <lineContent>private Pattern message;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field file</message>
     <lineContent>private String file;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for obj.</message>
@@ -4620,7 +4618,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilter.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -4631,7 +4629,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilter.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -4642,7 +4640,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilter.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -4653,49 +4651,49 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field checks</message>
     <lineContent>private Pattern checks;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field files</message>
     <lineContent>private Pattern files;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field id</message>
     <lineContent>private String id;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field message</message>
     <lineContent>private Pattern message;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field query</message>
     <lineContent>private String query;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilter.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field xpathFilter</message>
     <lineContent>private XpathFilterElement xpathFilter;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter checks of XpathFilterElement.</message>
@@ -4706,7 +4704,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter contextItem of createDynamicContext.</message>
@@ -4717,7 +4715,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter files of XpathFilterElement.</message>
@@ -4728,7 +4726,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter message of XpathFilterElement.</message>
@@ -4739,18 +4737,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>checkPattern = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -4761,18 +4748,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>filePattern = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -4783,18 +4759,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>messagePattern = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -4805,7 +4770,40 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
+    <specifier>assignment</specifier>
+    <message>incompatible types in assignment.</message>
+    <lineContent>checkPattern = null;</lineContent>
+    <details>
+      found   : null (NullType)
+      required: @Initialized @NonNull String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
+    <specifier>assignment</specifier>
+    <message>incompatible types in assignment.</message>
+    <lineContent>filePattern = null;</lineContent>
+    <details>
+      found   : null (NullType)
+      required: @Initialized @NonNull String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
+    <specifier>assignment</specifier>
+    <message>incompatible types in assignment.</message>
+    <lineContent>messagePattern = null;</lineContent>
+    <details>
+      found   : null (NullType)
+      required: @Initialized @NonNull String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -4816,7 +4814,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
     <specifier>override.param</specifier>
     <message>Incompatible parameter type for other.</message>
@@ -4831,7 +4829,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/BaseCellEditor.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -4842,7 +4840,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/ListToTreeSelectionModelWrapper.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to getListSelectionModel() not allowed on the given receiver.</message>
@@ -4853,7 +4851,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/ListToTreeSelectionModelWrapper.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to updateSelectedPathsFromSelectedRows() not allowed on the given receiver.</message>
@@ -4864,7 +4862,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter arg0 of getImage.</message>
@@ -4875,7 +4873,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter event of actionPerformed.</message>
@@ -4886,7 +4884,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter sourceFile of openFile.</message>
@@ -4897,14 +4895,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: textArea, xpathTextArea, treeTable</message>
     <lineContent>public MainFrame() {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to createContent() not allowed on the given receiver.</message>
@@ -4915,7 +4913,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModel.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter parseTree of ParseTreeTableModel.</message>
@@ -4926,14 +4924,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModel.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: currentFile, text</message>
     <lineContent>public MainFrameModel() {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModel.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -4944,7 +4942,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTableModel.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter childIndices of fireTreeStructureChanged.</message>
@@ -4955,7 +4953,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTableModel.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter children of fireTreeStructureChanged.</message>
@@ -4966,7 +4964,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTableModel.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to setParseTree(com.puppycrawl.tools.checkstyle.api.DetailAST) not allowed on the given receiver.</message>
@@ -4977,14 +4975,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentation.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: parseMode</message>
     <lineContent>public ParseTreeTablePresentation(DetailAST parseTree) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentation.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -4995,7 +4993,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter font of getFontMetrics.</message>
@@ -5006,7 +5004,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter jTreeTable of ListToTreeSelectionModelWrapper.</message>
@@ -5017,7 +5015,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter selectionModel of setSelectionModel.</message>
@@ -5028,7 +5026,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter treeTable of TreeTableCellRenderer.</message>
@@ -5039,7 +5037,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -5050,14 +5048,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: editor, xpathEditor, linePositionList</message>
     <lineContent>public TreeTable(ParseTreeTableModel treeTableModel) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to addMouseListener(java.awt.event.MouseListener) not allowed on the given receiver.</message>
@@ -5068,7 +5066,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to expandSelectedNode() not allowed on the given receiver.</message>
@@ -5079,7 +5077,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to getActionMap() not allowed on the given receiver.</message>
@@ -5090,7 +5088,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to getInputMap() not allowed on the given receiver.</message>
@@ -5101,7 +5099,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to getListSelectionModel() not allowed on the given receiver.</message>
@@ -5112,7 +5110,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to getRowHeight() not allowed on the given receiver.</message>
@@ -5123,7 +5121,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to setColumnsInitialWidth() not allowed on the given receiver.</message>
@@ -5134,7 +5132,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to setDefaultEditor(java.lang.Class&lt;?&gt;,javax.swing.table.TableCellEditor) not allowed on the given receiver.</message>
@@ -5145,7 +5143,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to setDefaultRenderer(java.lang.Class&lt;?&gt;,javax.swing.table.TableCellRenderer) not allowed on the given receiver.</message>
@@ -5156,7 +5154,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to setIntercellSpacing(java.awt.Dimension) not allowed on the given receiver.</message>
@@ -5167,7 +5165,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to setModel(javax.swing.table.TableModel) not allowed on the given receiver.</message>
@@ -5178,7 +5176,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to setRowHeight(int) not allowed on the given receiver.</message>
@@ -5189,7 +5187,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to setSelectionModel(javax.swing.ListSelectionModel) not allowed on the given receiver.</message>
@@ -5200,7 +5198,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to setShowGrid(boolean) not allowed on the given receiver.</message>
@@ -5211,7 +5209,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter arg0 of add.</message>
@@ -5222,7 +5220,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter nodeTag of getTextFromTag.</message>
@@ -5233,21 +5231,21 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field moduleDetails</message>
     <lineContent>private ModuleDetails moduleDetails;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field rootNode</message>
     <lineContent>private DetailNode rootNode;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to &lt;X&gt;orElseThrow(java.util.function.Supplier&lt;? extends X&gt;) not allowed on the given receiver.</message>
@@ -5258,7 +5256,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/JavadocMetadataScraper.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -5269,7 +5267,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter moduleClassLoader of setModuleClassLoader.</message>
@@ -5280,77 +5278,77 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/ModuleDetails.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field description</message>
     <lineContent>private String description;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/ModuleDetails.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field fullQualifiedName</message>
     <lineContent>private String fullQualifiedName;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/ModuleDetails.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field moduleType</message>
     <lineContent>private ModuleType moduleType;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/ModuleDetails.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field name</message>
     <lineContent>private String name;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/ModuleDetails.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field parent</message>
     <lineContent>private String parent;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/ModulePropertyDetails.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field defaultValue</message>
     <lineContent>private String defaultValue;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/ModulePropertyDetails.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field description</message>
     <lineContent>private String description;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/ModulePropertyDetails.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field name</message>
     <lineContent>private String name;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/ModulePropertyDetails.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field type</message>
     <lineContent>private String type;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/ModulePropertyDetails.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field validationType</message>
     <lineContent>private String validationType;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter description of setDescription.</message>
@@ -5361,7 +5359,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter description of setDescription.</message>
@@ -5372,7 +5370,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter element of getAttributeValue.</message>
@@ -5383,7 +5381,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter element of getAttributeValue.</message>
@@ -5394,7 +5392,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter moduleMetadataStream of read.</message>
@@ -5405,60 +5403,49 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference children.item(i)</message>
     <lineContent>if (children.item(i).getParentNode().equals(element)) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference children.item(i).getParentNode()</message>
     <lineContent>if (children.item(i).getParentNode().equals(element)) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference element.getAttributes()</message>
     <lineContent>return element.getAttributes().getNamedItem(attribute).getNodeValue();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference element.getAttributes().getNamedItem(attribute)</message>
     <lineContent>return element.getAttributes().getNamedItem(attribute).getNodeValue();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference getDirectChildsByTag(mod, XML_TAG_DESCRIPTION).get(0).getFirstChild()</message>
     <lineContent>.getFirstChild().getNodeValue());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference getDirectChildsByTag(prop, XML_TAG_DESCRIPTION).get(0).getFirstChild()</message>
     <lineContent>.get(0).getFirstChild().getNodeValue());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java</fileName>
-    <specifier>return</specifier>
-    <message>incompatible types in return.</message>
-    <lineContent>return element.getAttributes().getNamedItem(attribute).getNodeValue();</lineContent>
-    <details>
-      type of expression: @Initialized @Nullable String
-      method return type: @Initialized @NonNull String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -5469,7 +5456,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -5480,7 +5467,18 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReader.java</fileName>
+    <specifier>return</specifier>
+    <message>incompatible types in return.</message>
+    <lineContent>return element.getAttributes().getNamedItem(attribute).getNodeValue();</lineContent>
+    <details>
+      type of expression: @Initialized @Nullable String
+      method return type: @Initialized @NonNull String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/AnnotationUtil.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -5491,7 +5489,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/ChainedPropertyUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter input of matcher.</message>
@@ -5502,7 +5500,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -5513,7 +5511,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter replacement of replaceAll.</message>
@@ -5524,18 +5522,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java</fileName>
-    <specifier>return</specifier>
-    <message>incompatible types in return.</message>
-    <lineContent>return CommonUtil.class.getResource(name);</lineContent>
-    <details>
-      type of expression: @Initialized @Nullable URL
-      method return type: @Initialized @NonNull URL
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -5546,14 +5533,25 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java</fileName>
+    <specifier>return</specifier>
+    <message>incompatible types in return.</message>
+    <lineContent>return CommonUtil.class.getResource(name);</lineContent>
+    <details>
+      type of expression: @Initialized @Nullable URL
+      method return type: @Initialized @NonNull URL
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtil.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>if (curNode == toVisit) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtil.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -5564,7 +5562,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtil.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -5575,7 +5573,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtil.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -5586,7 +5584,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/JavadocUtil.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -5597,14 +5595,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java</fileName>
     <specifier>introduce.eliminate</specifier>
     <message>It is bad style to create an Optional just to chain methods to get a value.</message>
     <lineContent>.orElseGet(() -&gt; getDefaultScope(aMods.getParent()));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -5615,7 +5613,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/ScopeUtil.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -5626,21 +5624,21 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/AbstractNode.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: children</message>
     <lineContent>protected AbstractNode(TreeInfo treeInfo) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/AbstractNode.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>return this == nodeInfo;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/AttributeNode.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter treeInfo of AbstractNode.</message>
@@ -5651,7 +5649,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/ElementNode.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter name of AttributeNode.</message>
@@ -5662,7 +5660,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/ElementNode.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter nodes of OfNodes.</message>
@@ -5673,7 +5671,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/ElementNode.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter nodes of OfNodes.</message>
@@ -5684,7 +5682,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/ElementNode.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter value of AttributeNode.</message>
@@ -5695,7 +5693,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/ElementNode.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -5706,14 +5704,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/ElementNode.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>if (attributeNode == ATTRIBUTE_NODE_UNINITIALIZED) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/ElementNode.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -5724,21 +5722,21 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/ElementNode.java</fileName>
     <specifier>toarray.nullable.elements.not.newarray</specifier>
     <message>call of toArray on collection of non-null elements yields an array of possibly-null elements; omit the argument to toArray or make it an explicit array constructor</message>
     <lineContent>getChildren().toArray(EMPTY_ABSTRACT_NODE_ARRAY));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/ElementNode.java</fileName>
     <specifier>toarray.nullable.elements.not.newarray</specifier>
     <message>call of toArray on collection of non-null elements yields an array of possibly-null elements; omit the argument to toArray or make it an explicit array constructor</message>
     <lineContent>getFollowingSiblings().toArray(EMPTY_ABSTRACT_NODE_ARRAY));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/RootNode.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter nodes of OfNodes.</message>
@@ -5749,7 +5747,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/RootNode.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -5760,14 +5758,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/RootNode.java</fileName>
     <specifier>toarray.nullable.elements.not.newarray</specifier>
     <message>call of toArray on collection of non-null elements yields an array of possibly-null elements; omit the argument to toArray or make it an explicit array constructor</message>
     <lineContent>getChildren().toArray(EMPTY_ABSTRACT_NODE_ARRAY));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGenerator.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter root of getXpathQuery.</message>
@@ -5778,21 +5776,21 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGenerator.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>if (child != null &amp;&amp; child != ast) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGenerator.java</fileName>
     <specifier>not.interned</specifier>
     <message>attempting to use a non-@Interned comparison operand</message>
     <lineContent>while (cur != root) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/XpathQueryGenerator.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -5803,7 +5801,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/DescendantIterator.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -5814,14 +5812,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/DescendantIterator.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference queue.poll()</message>
     <lineContent>descendantEnum = queue.poll().iterateAxis(AxisInfo.CHILD);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/DescendantIterator.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -5832,7 +5830,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/FollowingIterator.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -5843,7 +5841,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/FollowingIterator.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -5854,7 +5852,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/FollowingIterator.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -5865,7 +5863,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/PrecedingIterator.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -5876,7 +5874,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/PrecedingIterator.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -5887,14 +5885,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseDescendantIterator.java</fileName>
     <specifier>dereference.of.nullable</specifier>
     <message>dereference of possibly-null reference queue.poll()</message>
     <lineContent>pushToStack(queue.poll().iterateAxis(AxisInfo.CHILD));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseDescendantIterator.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to pushToStack(net.sf.saxon.tree.iter.AxisIterator) not allowed on the given receiver.</message>
@@ -5905,7 +5903,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseDescendantIterator.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>
@@ -5916,7 +5914,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseListIterator.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
@@ -5927,7 +5925,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/xpath/iterators/ReverseListIterator.java</fileName>
     <specifier>return</specifier>
     <message>incompatible types in return.</message>

--- a/.ci/checker-framework-suppressions/checker-framework-purity-value-returns-suppressions.xml
+++ b/.ci/checker-framework-suppressions/checker-framework-purity-value-returns-suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedErrors>
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter radix of parseInt.</message>
@@ -11,7 +11,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter radix of parseLong.</message>
@@ -22,7 +22,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter radix of parseUnsignedInt.</message>
@@ -33,7 +33,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CheckUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter radix of parseUnsignedLong.</message>
@@ -44,7 +44,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java</fileName>
     <specifier>methodref.param</specifier>
     <message>Incompatible parameter type for bitIndex</message>

--- a/.ci/checker-framework-suppressions/checker-framework-regex-property-key-compiler-message-suppressions.xml
+++ b/.ci/checker-framework-suppressions/checker-framework-regex-property-key-compiler-message-suppressions.xml
@@ -1,127 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedErrors>
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter regex of compile.</message>
-    <lineContent>.map(pattern -&gt; Pattern.compile(&quot;^&quot; + pattern + &quot;$&quot;))</lineContent>
-    <details>
-      found   : String
-      required: @Regex String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter key of getProperty.</message>
-    <lineContent>final String cachedConfigHash = details.getProperty(CONFIG_HASH_KEY);</lineContent>
-    <details>
-      found   : @UnknownPropertyKey String
-      required: @PropertyKey String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter key of getProperty.</message>
-    <lineContent>final String cachedHashSum = details.getProperty(location);</lineContent>
-    <details>
-      found   : @UnknownPropertyKey String
-      required: @PropertyKey String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter key of getProperty.</message>
-    <lineContent>final String cachedHashSum = details.getProperty(resource.location);</lineContent>
-    <details>
-      found   : @UnknownPropertyKey String
-      required: @PropertyKey String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter key of getProperty.</message>
-    <lineContent>final String lastChecked = details.getProperty(uncheckedFileName);</lineContent>
-    <details>
-      found   : @UnknownPropertyKey String
-      required: @PropertyKey String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter key of getProperty.</message>
-    <lineContent>return details.getProperty(name);</lineContent>
-    <details>
-      found   : @UnknownPropertyKey String
-      required: @PropertyKey String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter key of setProperty.</message>
-    <lineContent>.forEach(resource -&gt; details.setProperty(resource.location, resource.contentHashSum));</lineContent>
-    <details>
-      found   : @UnknownPropertyKey String
-      required: @PropertyKey String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter key of setProperty.</message>
-    <lineContent>details.setProperty(CONFIG_HASH_KEY, configHash);</lineContent>
-    <details>
-      found   : @UnknownPropertyKey String
-      required: @PropertyKey String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter key of setProperty.</message>
-    <lineContent>details.setProperty(checkedFileName, Long.toString(timestamp));</lineContent>
-    <details>
-      found   : @UnknownPropertyKey String
-      required: @PropertyKey String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter key of setProperty.</message>
-    <lineContent>returnValue.setProperty(entry.getKey(), value);</lineContent>
-    <details>
-      found   : @UnknownPropertyKey String
-      required: @PropertyKey String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter key of setProperty.</message>
-    <lineContent>returnValue.setProperty(p.getKey(), p.getValue());</lineContent>
-    <details>
-      found   : @UnknownPropertyKey String
-      required: @PropertyKey String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter key of getString.</message>
@@ -132,7 +11,128 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter regex of compile.</message>
+    <lineContent>.map(pattern -&gt; Pattern.compile(&quot;^&quot; + pattern + &quot;$&quot;))</lineContent>
+    <details>
+      found   : String
+      required: @Regex String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter key of getProperty.</message>
+    <lineContent>final String cachedConfigHash = details.getProperty(CONFIG_HASH_KEY);</lineContent>
+    <details>
+      found   : @UnknownPropertyKey String
+      required: @PropertyKey String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter key of getProperty.</message>
+    <lineContent>final String cachedHashSum = details.getProperty(location);</lineContent>
+    <details>
+      found   : @UnknownPropertyKey String
+      required: @PropertyKey String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter key of getProperty.</message>
+    <lineContent>final String cachedHashSum = details.getProperty(resource.location);</lineContent>
+    <details>
+      found   : @UnknownPropertyKey String
+      required: @PropertyKey String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter key of getProperty.</message>
+    <lineContent>final String lastChecked = details.getProperty(uncheckedFileName);</lineContent>
+    <details>
+      found   : @UnknownPropertyKey String
+      required: @PropertyKey String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter key of getProperty.</message>
+    <lineContent>return details.getProperty(name);</lineContent>
+    <details>
+      found   : @UnknownPropertyKey String
+      required: @PropertyKey String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter key of setProperty.</message>
+    <lineContent>.forEach(resource -&gt; details.setProperty(resource.location, resource.contentHashSum));</lineContent>
+    <details>
+      found   : @UnknownPropertyKey String
+      required: @PropertyKey String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter key of setProperty.</message>
+    <lineContent>details.setProperty(CONFIG_HASH_KEY, configHash);</lineContent>
+    <details>
+      found   : @UnknownPropertyKey String
+      required: @PropertyKey String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PropertyCacheFile.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter key of setProperty.</message>
+    <lineContent>details.setProperty(checkedFileName, Long.toString(timestamp));</lineContent>
+    <details>
+      found   : @UnknownPropertyKey String
+      required: @PropertyKey String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter key of setProperty.</message>
+    <lineContent>returnValue.setProperty(entry.getKey(), value);</lineContent>
+    <details>
+      found   : @UnknownPropertyKey String
+      required: @PropertyKey String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/ant/CheckstyleAntTask.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter key of setProperty.</message>
+    <lineContent>returnValue.setProperty(p.getKey(), p.getValue());</lineContent>
+    <details>
+      found   : @UnknownPropertyKey String
+      required: @PropertyKey String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/AvoidEscapedUnicodeCharactersCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -143,7 +143,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -154,7 +154,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of matches.</message>
@@ -165,7 +165,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of replaceAll.</message>
@@ -176,7 +176,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/UniquePropertiesCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -187,7 +187,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/MutableExceptionCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -198,7 +198,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -209,7 +209,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ClassImportRule.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of matches.</message>
@@ -220,7 +220,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/FileImportControl.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -231,7 +231,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -242,7 +242,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgImportControl.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -253,7 +253,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgImportControl.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -264,7 +264,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgImportRule.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of matches.</message>
@@ -275,7 +275,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/PkgImportRule.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of matches.</message>
@@ -286,91 +286,91 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java</fileName>
     <specifier>group.count</specifier>
     <message>invalid groups parameter 1. Only 0 groups are guaranteed to exist for matcher.</message>
     <lineContent>references.add(topLevelType(matcher.group(1)));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>group.count</specifier>
     <message>invalid groups parameter 1. Only 0 groups are guaranteed to exist for javadocArgMatcher.</message>
     <lineContent>tags.add(new JavadocTag(currentLine, col, javadocArgMatcher.group(1),</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>group.count</specifier>
     <message>invalid groups parameter 1. Only 0 groups are guaranteed to exist for javadocArgMissingDescriptionMatcher.</message>
     <lineContent>javadocArgMissingDescriptionMatcher.group(1),</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>group.count</specifier>
     <message>invalid groups parameter 1. Only 0 groups are guaranteed to exist for javadocNoargMatcher.</message>
     <lineContent>tags.add(new JavadocTag(currentLine, col, javadocNoargMatcher.group(1)));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>group.count</specifier>
     <message>invalid groups parameter 1. Only 0 groups are guaranteed to exist for javadocTagMatchResult.</message>
     <lineContent>int col = javadocTagMatchResult.start(1) - 1;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>group.count</specifier>
     <message>invalid groups parameter 1. Only 0 groups are guaranteed to exist for multilineCont.</message>
     <lineContent>final String lFin = multilineCont.group(1);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>group.count</specifier>
     <message>invalid groups parameter 1. Only 0 groups are guaranteed to exist for noargCurlyMatcher.</message>
     <lineContent>tags.add(new JavadocTag(currentLine, col, noargCurlyMatcher.group(1)));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>group.count</specifier>
     <message>invalid groups parameter 1. Only 0 groups are guaranteed to exist for noargMultilineStart.</message>
     <lineContent>final String param1 = noargMultilineStart.group(1);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>group.count</specifier>
     <message>invalid groups parameter 1. Only 0 groups are guaranteed to exist for noargMultilineStart.</message>
     <lineContent>final int col = noargMultilineStart.start(1) - 1;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>group.count</specifier>
     <message>invalid groups parameter 2. Only 0 groups are guaranteed to exist for javadocArgMatcher.</message>
     <lineContent>javadocArgMatcher.group(2)));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java</fileName>
     <specifier>group.count</specifier>
     <message>invalid groups parameter 2. Only 0 groups are guaranteed to exist for javadocArgMissingDescriptionMatcher.</message>
     <lineContent>javadocArgMissingDescriptionMatcher.group(2)));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/WriteTagCheck.java</fileName>
     <specifier>group.count</specifier>
     <message>invalid groups parameter 1. Only 0 groups are guaranteed to exist for matcher.</message>
     <lineContent>final int contentStart = matcher.start(1);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/DetectorOptions.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -381,7 +381,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -392,7 +392,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -403,7 +403,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressFilterElement.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -414,7 +414,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -425,7 +425,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -436,7 +436,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -447,7 +447,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -458,7 +458,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -469,7 +469,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -480,7 +480,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithPlainTextCommentFilter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -491,7 +491,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -502,7 +502,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -513,7 +513,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -524,7 +524,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -535,7 +535,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -546,7 +546,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionSingleFilter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -557,7 +557,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -568,7 +568,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -579,7 +579,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathSingleFilter.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -590,7 +590,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
     <specifier>methodref.param</specifier>
     <message>Incompatible parameter type for regex</message>
@@ -605,7 +605,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElement.java</fileName>
     <specifier>methodref.param</specifier>
     <message>Incompatible parameter type for regex</message>
@@ -620,7 +620,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/ChainedPropertyUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter key of getProperty.</message>
@@ -631,7 +631,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/ChainedPropertyUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter key of getProperty.</message>
@@ -642,7 +642,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/ChainedPropertyUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter key of setProperty.</message>
@@ -653,7 +653,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -664,7 +664,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of compile.</message>
@@ -675,7 +675,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter regex of replaceAll.</message>
@@ -686,14 +686,14 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java</fileName>
     <specifier>group.count.unknown</specifier>
     <message>unable to verify non-literal groups parameter.</message>
     <lineContent>result = result.replaceAll(&quot;\\$&quot; + i, matcher.group(i));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/utils/TokenUtil.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter key of getString.</message>

--- a/.ci/checker-framework-suppressions/checker-framework-signature-gui-units-init-suppressions.xml
+++ b/.ci/checker-framework-suppressions/checker-framework-signature-gui-units-init-suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedErrors>
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter baseName of getBundle.</message>
@@ -11,18 +11,7 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
-    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java</fileName>
-    <specifier>argument</specifier>
-    <message>incompatible argument for parameter name of forName.</message>
-    <lineContent>clazz = Class.forName(className, true, moduleClassLoader);</lineContent>
-    <details>
-      found   : @SignatureUnknown String
-      required: @ClassGetName String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/LocalizedMessage.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter baseName of toBundleName.</message>
@@ -33,903 +22,914 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
+    <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter name of forName.</message>
+    <lineContent>clazz = Class.forName(className, true, moduleClassLoader);</lineContent>
+    <details>
+      found   : @SignatureUnknown String
+      required: @ClassGetName String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/BaseCellEditor.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>((CellEditorListener) listeners[i + 1]).editingCanceled(new ChangeEvent(this));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/BaseCellEditor.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>((CellEditorListener) listeners[i + 1]).editingStopped(new ChangeEvent(this));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/BaseCellEditor.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>final Object[] listeners = listenerList.getListenerList();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/BaseCellEditor.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>listenerList.add(CellEditorListener.class, listener);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/BaseCellEditor.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>listenerList.remove(CellEditorListener.class, listener);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelector.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>editor.moveCaretPosition(pModel.getSelectionEnd());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelector.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>editor.requestFocusInWindow();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelector.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>editor.setCaretPosition(pModel.getSelectionStart());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/CodeSelector.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>editor.setSelectedTextColor(Color.blue);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/ListToTreeSelectionModelWrapper.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>final TreePath selPath = treeTable.getTree().getPathForRow(counter);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/ListToTreeSelectionModelWrapper.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>final int max = listSelectionModel.getMaxSelectionIndex();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/ListToTreeSelectionModelWrapper.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>final int min = listSelectionModel.getMinSelectionIndex();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/ListToTreeSelectionModelWrapper.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>getListSelectionModel().addListSelectionListener(event -&gt; {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/ListToTreeSelectionModelWrapper.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>if (listSelectionModel.isSelectedIndex(counter)) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>mainFrame.pack();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>mainFrame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>mainFrame.setTitle(&quot;Checkstyle GUI&quot;);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/Main.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>mainFrame.setVisible(true);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>JOptionPane.showMessageDialog(this, ex.getMessage());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>add(splitPane, BorderLayout.CENTER);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>add(xpathAreaPanel, BorderLayout.PAGE_END);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>buttonPanel.add(openFileButton);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>buttonPanel.add(reloadFileButton);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>buttonPanel.setLayout(new GridLayout(1, 2));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>expandButton.setName(&quot;expandButton&quot;);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>expandButton.setText(&quot;Expand/Collapse&quot;);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>fileChooser.setFileFilter(filter);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>final Border title = BorderFactory.createTitledBorder(&quot;Xpath Query&quot;);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>final File file = fileChooser.getSelectedFile();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>final int returnCode = fileChooser.showOpenDialog(MainFrame.this);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>findNodeButton.setName(&quot;findNodeButton&quot;);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>findNodeButton.setText(&quot;Find node by Xpath&quot;);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>mainPanel.add(buttonPanel);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>mainPanel.add(modesPanel, BorderLayout.LINE_END);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>mainPanel.add(xpathButtonsPanel, BorderLayout.LINE_START);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>mainPanel.setLayout(new BorderLayout());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>modesCombobox.addActionListener(event -&gt; {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>modesCombobox.setName(&quot;modesCombobox&quot;);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>modesCombobox.setSelectedIndex(0);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>modesLabel.setBorder(BorderFactory.createEmptyBorder(0, leftIndentation, 0, 0));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>modesLabel.setDisplayedMnemonic(KeyEvent.VK_M);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>modesLabel.setLabelFor(modesCombobox);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>modesPanel.add(modesCombobox);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>modesPanel.add(modesLabel);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>openFileButton.setMnemonic(KeyEvent.VK_O);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>openFileButton.setName(&quot;openFileButton&quot;);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>openFileButton.setText(&quot;Open File&quot;);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>private class ExpandCollapseAction extends AbstractAction {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>private class FileSelectionAction extends AbstractAction {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>private class FindNodeByXpathAction extends AbstractAction {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>private class ReloadAction extends AbstractAction {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>public MainFrame() {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>reloadAction.setEnabled(false);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>reloadAction.setEnabled(model.isReloadActionEnabled());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>reloadFileButton.setMnemonic(KeyEvent.VK_R);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>reloadFileButton.setText(&quot;Reload File&quot;);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>setIconImage(Toolkit.getDefaultToolkit().getImage(MainFrame.class.getResource(ICON)));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>setLayout(new BorderLayout());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>setTitle(model.getTitle());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>splitPane.setResizeWeight(0.7);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>textArea.setEditable(false);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>textAreaPanel.add(createButtonsPanel(), BorderLayout.PAGE_END);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>textAreaPanel.add(textAreaScrollPane);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>textAreaPanel.setLayout(new BorderLayout());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>xpathAreaPanel.add(createXpathButtonsPanel(), BorderLayout.PAGE_END);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>xpathAreaPanel.add(xpathTextArea);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>xpathAreaPanel.setBorder(title);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>xpathAreaPanel.setLayout(new BorderLayout());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>xpathButtonsPanel.add(expandButton);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>xpathButtonsPanel.add(findNodeButton);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>xpathButtonsPanel.setLayout(new FlowLayout());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>xpathTextArea.setName(&quot;xpathTextArea&quot;);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>xpathTextArea.setVisible(!xpathTextArea.isVisible());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrame.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>xpathTextArea.setVisible(false);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTableModel.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>((TreeModelListener) listeners[i + 1]).treeStructureChanged(event);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTableModel.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>final Object[] listeners = listenerList.getListenerList();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTableModel.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>listenerList.add(TreeModelListener.class, listener);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTableModel.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>listenerList.remove(TreeModelListener.class, listener);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>LookAndFeel.installColorsAndFont(this, &quot;Tree.background&quot;,</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>Math.toIntExact(Math.round(getPreferredSize().getWidth() * 0.6));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>addMouseListener(new MouseAdapter() {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>final Class&lt;?&gt; editingClass = getColumnClass(editingColumn);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>final DetailAST ast = (DetailAST) tree.getLastSelectedPathComponent();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>final DetailAST rootAST = (DetailAST) tree.getModel().getRoot();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>final FontMetrics fontMetrics = getFontMetrics(getFont());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>final KeyStroke stroke = KeyStroke.getKeyStroke(&quot;ENTER&quot;);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>final MouseEvent newMouseEvent = new MouseEvent(tree, mouseEvent.getID(),</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>final String xpath = xpathEditor.getText();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>final TreePath selected = tree.getSelectionPath();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>final int height = getRowHeight();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>final int widthOfSixCharacterString = fontMetrics.stringWidth(&quot;XXXXXX&quot;);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>fontMetrics.stringWidth(&quot;XXXXXXXXXXXXXXXXXXXXXXXXXXXX&quot;);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>for (int counter = getColumnCount() - 1; counter &gt;= 0;</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>getActionMap().put(command, expand);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>getColumn(&quot;Column&quot;).setMaxWidth(widthOfColumnContainingSixCharacterString);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>getColumn(&quot;Line&quot;).setMaxWidth(widthOfColumnContainingSixCharacterString);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>getColumn(&quot;Tree&quot;).setPreferredWidth(preferredTreeColumnWidth);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>getColumn(&quot;Type&quot;).setPreferredWidth(preferredTypeColumnWidth);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>getInputMap().put(stroke, command);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>if (!tree.isExpanded(path)) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>if (getColumnClass(counter) == ParseTreeTableModel.class) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>if (tree != null &amp;&amp; tree.getRowHeight() != newRowHeight) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>if (tree.getLastSelectedPathComponent() instanceof DetailAST) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>if (tree.getRowHeight() &lt; 1) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>if (tree.isExpanded(selected)) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>mouseEvent.getWhen(), mouseEvent.getModifiersEx(),</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>mouseEvent.getX() - getCellRect(0, counter, true).x,</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>mouseEvent.getY(), mouseEvent.getClickCount(),</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>mouseEvent.isPopupTrigger());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>new CodeSelector(tree.getLastSelectedPathComponent(), editor, linePositionList).select();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>public TreeTable(ParseTreeTableModel treeTableModel) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>setDefaultEditor(ParseTreeTableModel.class, new TreeTableCellEditor());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>setDefaultRenderer(ParseTreeTableModel.class, tree);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>setIntercellSpacing(new Dimension(0, 0));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>setModel(new TreeTableModelAdapter(treeTableModel, tree));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>setSelectionModel(selectionWrapper.getListSelectionModel());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>setShowGrid(false);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>super.setRowHeight(newRowHeight);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>super.updateUI();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>tree.collapsePath(selected);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>tree.dispatchEvent(newMouseEvent);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>tree.expandPath(path);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>tree.expandPath(selected);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>tree.setRowHeight(getRowHeight());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>tree.setSelectionModel(selectionWrapper);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>tree.setSelectionPath(path);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>tree.setSelectionPath(selected);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>xpathEditor.setText(xpathEditor.getText() + NEWLINE + exception.getMessage());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTable.java</fileName>
     <specifier>override.effect.warning.inheritance</specifier>
     <message>method in com.puppycrawl.tools.checkstyle.gui.TreeTable.TreeTableCellEditor</message>
@@ -944,105 +944,105 @@
     </details>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableCellRenderer.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>&amp;&amp; treeTable.getRowHeight() != newRowHeight) {</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableCellRenderer.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>UIManager.getColor(COLOR_KEY_TABLE_SELECTION_BACKGROUND));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableCellRenderer.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>UIManager.getColor(COLOR_KEY_TABLE_SELECTION_FOREGROUND));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableCellRenderer.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>final TreeCellRenderer tcr = getCellRenderer();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableCellRenderer.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>graph.translate(0, -visibleRow * getRowHeight());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableCellRenderer.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>setBackground(UIManager.getColor(colorKey));</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableCellRenderer.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>super(model);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableCellRenderer.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>super.paint(graph);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableCellRenderer.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>super.setBounds(x, 0, w, treeTable.getHeight());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableCellRenderer.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>super.setRowHeight(newRowHeight);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableCellRenderer.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>super.updateUI();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableCellRenderer.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>treeTable.setRowHeight(getRowHeight());</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableModelAdapter.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>final TreePath treePath = tree.getPathForRow(row);</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableModelAdapter.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>
     <lineContent>return tree.getRowCount();</lineContent>
   </checkerFrameworkError>
 
-  <checkerFrameworkError unstable="false">
+  <checkerFrameworkError>
     <fileName>checkstyle/src/main/java/com/puppycrawl/tools/checkstyle/gui/TreeTableModelAdapter.java</fileName>
     <specifier>call.ui</specifier>
     <message>Calling a method with UIEffect effect from a context limited to SafeEffect effects.</message>

--- a/.github/workflows/checker-framework.yml
+++ b/.github/workflows/checker-framework.yml
@@ -29,6 +29,10 @@ jobs:
           java-version: 11
       - name: Install groovy
         run: sudo apt install groovy
+      - name: Print Version
+        run: |
+          java --version
+          groovy --version
       - name: Checkout
         uses: actions/checkout@v2
       - name: Execute checker framework


### PR DESCRIPTION
This PR contains:

- Replaces `temp-var-\\d+` with `temp-var` in `message` and `capture#\\d+` with `capture` in `details`