### PR TITLE
Issue #11214: specified violation message for AnnotationUseStyleCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -101,7 +101,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.DescendantTokenCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.RequireThisCheck",
             "com.puppycrawl.tools.checkstyle.checks.metrics.JavaNCSSCheck",
-            "com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.PackageDeclarationCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckTest.java
@@ -106,18 +106,18 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "13:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
             "14:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "20:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "22:1: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
-            "28:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "21:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "23:1: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
             "29:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "33:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "39:1: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
-            "42:5: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
-            "50:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "52:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "56:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "84:32: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
-            "86:40: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "30:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "35:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "42:1: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "45:5: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "53:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "55:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "59:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "88:32: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "91:40: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
         };
 
         verifyWithInlineConfigParser(
@@ -134,9 +134,9 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
             "27:1: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_MISSING),
             "32:5: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_MISSING),
             "80:32: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_MISSING),
-            "82:40: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_MISSING),
-            "90:9: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_MISSING),
-            "90:31: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_MISSING),
+            "83:40: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_MISSING),
+            "91:9: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_MISSING),
+            "91:31: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_MISSING),
         };
 
         verifyWithInlineConfigParser(
@@ -150,10 +150,10 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
     public void testParensNever() throws Exception {
         final String[] expected = {
             "22:1: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
-            "39:1: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
-            "42:5: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
-            "84:32: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
-            "86:40: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "40:1: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "43:5: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "86:32: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
+            "89:40: " + getCheckMessage(MSG_KEY_ANNOTATION_PARENS_PRESENT),
         };
 
         verifyWithInlineConfigParser(
@@ -185,8 +185,8 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
             "52:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT"),
             "56:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT"),
             "76:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT"),
-            "82:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT"),
-            "86:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT"),
+            "83:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT"),
+            "88:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT"),
         };
 
         verifyWithInlineConfigParser(
@@ -198,13 +198,13 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "13:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
             "14:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "20:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "28:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "21:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
             "29:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "33:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "50:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "30:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "35:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
             "52:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "56:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "54:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "58:1: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
         };
 
         verifyWithInlineConfigParser(
@@ -216,17 +216,17 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "12:20: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
             "15:30: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "19:40: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "22:44: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "25:54: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "33:22: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "33:36: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "35:21: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "35:30: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "38:39: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "38:49: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "41:21: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
-            "41:41: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "20:40: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "24:45: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "28:55: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "36:22: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "36:36: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "38:21: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "38:30: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "41:39: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "41:49: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "44:21: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
+            "44:41: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_MISSING),
         };
 
         verifyWithInlineConfigParser(
@@ -264,9 +264,9 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
     public void testTrailingArrayIgnore() throws Exception {
         final String[] expected = {
             "15:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "22:13: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "33:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
-            "39:9: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "23:13: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "35:5: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
+            "42:9: " + getCheckMessage(MSG_KEY_ANNOTATION_INCORRECT_STYLE, "COMPACT_NO_ARRAY"),
         };
 
         verifyWithInlineConfigParser(
@@ -276,14 +276,14 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testCommaNeverViolations() throws Exception {
         final String[] expected = {
-            "15:32: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT),
-            "19:42: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT),
-            "22:46: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT),
-            "25:56: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT),
-            "33:24: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT),
-            "33:39: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT),
-            "39:41: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT),
-            "39:52: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT),
+            "16:32: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT),
+            "21:42: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT),
+            "25:46: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT),
+            "29:56: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT),
+            "37:24: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT),
+            "37:39: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT),
+            "43:41: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT),
+            "43:52: " + getCheckMessage(MSG_KEY_ANNOTATION_TRAILING_COMMA_PRESENT),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleCompact.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleCompact.java
@@ -49,11 +49,11 @@ enum DOGS5 {
     String[] um() default {};
     @Another({""}) //compact
     String[] duh() default {};
-    @Another(value={""}) //expanded // violation
+    @Another(value={""}) //expanded // violation 'Annotation style must be 'COMPACT''
     DOGS[] pooches();
 }
 
-@Another(value={""}) //expanded // violation
+@Another(value={""}) //expanded // violation 'Annotation style must be 'COMPACT''
 enum E5 {
 
 }
@@ -73,17 +73,19 @@ enum E5 {
 class Closing5 {
     static final String UN_U = "UN_U";
 
-    @SuppressWarnings(value = UN_U) // violation
+    @SuppressWarnings(value = UN_U) // violation 'Annotation style must be 'COMPACT''
     int d;
 }
 
 @AnnotationWithAnnotationValue(@Another)
 class Example17 {}
-@AnnotationWithAnnotationValue(value = @Another) // violation
+// violation below 'Annotation style must be 'COMPACT''
+@AnnotationWithAnnotationValue(value = @Another)
 class Example18 {}
 @AnnotationWithAnnotationValue(@Another())
 class Example19 {}
-@AnnotationWithAnnotationValue(value = @Another()) // violation
+// violation below 'Annotation style must be 'COMPACT''
+@AnnotationWithAnnotationValue(value = @Another())
 class Example20 {}
 
 class Foo5 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleCompactNoArray.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleCompactNoArray.java
@@ -10,14 +10,15 @@ trailingArrayComma = ignore
 package com.puppycrawl.tools.checkstyle.checks.annotation.annotationusestyle;
 
 @Deprecated
-@SomeArrays(pooches={DOGS.LEO}) // violation
-@SuppressWarnings({""}) // violation
+@SomeArrays(pooches={DOGS.LEO}) // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
+@SuppressWarnings({""}) // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
 public class InputAnnotationUseStyleCompactNoArray
 {
 
 }
 
-@SomeArrays(pooches={DOGS.LEO}, um={}, duh={"bleh"}) // violation
+// violation below 'Annotation style must be 'COMPACT_NO_ARRAY''
+@SomeArrays(pooches={DOGS.LEO},um={}, duh={"bleh"})
 @SuppressWarnings("") //compact_no_array
 @Deprecated()
 class Dep6 {
@@ -25,12 +26,13 @@ class Dep6 {
 }
 
 @Deprecated
-@SomeArrays(pooches={DOGS.LEO}) // violation
-@SuppressWarnings({""}) // violation
+@SomeArrays(pooches={DOGS.LEO}) // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
+@SuppressWarnings({""}) // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
 enum SON6 {
 
     @Deprecated
-    @SomeArrays(pooches={DOGS.LEO}, um={""}, duh={"bleh"}) // violation
+    // violation below 'Annotation style must be 'COMPACT_NO_ARRAY''
+    @SomeArrays(pooches={DOGS.LEO},um={""}, duh={"bleh"})
     @APooch(dog=DOGS.HERBIE)
     @Another("") //compact_no_array
     ETHAN
@@ -47,13 +49,13 @@ enum DOGS6 {
 @interface SomeArrays6 {
     @Another("") //compact
     String[] um() default {};
-    @Another({""}) //compact // violation
+    @Another({""}) //compact // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
     String[] duh() default {};
-    @Another(value={""}) //expanded // violation
+    @Another(value={""}) //expanded // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
     DOGS[] pooches();
 }
 
-@Another(value={""}) //expanded // violation
+@Another(value={""}) //expanded // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
 enum E6 {
 
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleDifferentStyles.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleDifferentStyles.java
@@ -10,36 +10,39 @@ trailingArrayComma = (default)never
 package com.puppycrawl.tools.checkstyle.checks.annotation.annotationusestyle;
 
 @Deprecated
-@SomeArrays(pooches={DOGS.LEO}) // violation
-@SuppressWarnings({""}) // violation
+@SomeArrays(pooches={DOGS.LEO}) // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
+@SuppressWarnings({""}) // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
 public class InputAnnotationUseStyleDifferentStyles
 {
 
 }
 
-@SomeArrays(pooches={DOGS.LEO}, um={}, duh={"bleh"}) // violation
+// violation below 'Annotation style must be 'COMPACT_NO_ARRAY''
+@SomeArrays(pooches={DOGS.LEO},um={}, duh={"bleh"})
 @SuppressWarnings("") //compact_no_array
-@Deprecated() // violation
+@Deprecated() // violation 'Annotation cannot have closing parenthesis'
 class Dep {
 
 }
 
 @Deprecated
-@SomeArrays(pooches={DOGS.LEO}) // violation
-@SuppressWarnings({""}) // violation
+@SomeArrays(pooches={DOGS.LEO}) // violation 'Annotation style must be 'COMPACT_NO_ARRAY'
+@SuppressWarnings({""}) // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
 enum SON {
 
     @Deprecated
-    @SomeArrays(pooches={DOGS.LEO}, um={""}, duh={"bleh"}) // violation
+    // violation below 'Annotation style must be 'COMPACT_NO_ARRAY''
+    @SomeArrays(pooches={DOGS.LEO},um={""}, duh={"bleh"})
     @APooch(dog=DOGS.HERBIE)
     @Another("") //compact_no_array
     ETHAN
 }
 
-@InputAnnotationUseStyleCustomAnnotation3() // violation
+// violation below 'Annotation cannot have closing parenthesis'
+@InputAnnotationUseStyleCustomAnnotation3()
 enum DOGS {
 
-    @Deprecated() // violation
+    @Deprecated() // violation 'Annotation cannot have closing parenthesis'
     LEO,
     HERBIE
 }
@@ -47,13 +50,13 @@ enum DOGS {
 @interface SomeArrays {
     @Another("") //compact
     String[] um() default {};
-    @Another({""}) //compact // violation
+    @Another({""}) //compact // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
     String[] duh() default {};
-    @Another(value={""}) //expanded // violation
+    @Another(value={""}) //expanded // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
     DOGS[] pooches();
 }
 
-@Another(value={""}) //expanded // violation
+@Another(value={""}) //expanded // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
 enum E {
 
 }
@@ -81,9 +84,11 @@ class Closing {
 class Example1 {}
 @AnnotationWithAnnotationValue(value = @Another)
 class Example2 {}
-@AnnotationWithAnnotationValue(@Another()) // violation
+// violation below 'Annotation cannot have closing parenthesis'
+@AnnotationWithAnnotationValue(@Another())
 class Example3 {}
-@AnnotationWithAnnotationValue(value = @Another()) // violation
+// violation below 'Annotation cannot have closing parenthesis'
+@AnnotationWithAnnotationValue(value = @Another())
 class Example4 {}
 
 class Foo {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleExpanded.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleExpanded.java
@@ -11,14 +11,14 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.annotationusestyle;
 
 @Deprecated
 @SomeArrays(pooches={DOGS.LEO})
-@SuppressWarnings({""}) // violation
+@SuppressWarnings({""}) // violation 'Annotation style must be 'EXPANDED''
 public class InputAnnotationUseStyleExpanded
 {
 
 }
 
 @SomeArrays(pooches={DOGS.LEO}, um={}, duh={"bleh"})
-@SuppressWarnings("") //compact_no_array // violation
+@SuppressWarnings("") //compact_no_array // violation 'Annotation style must be 'EXPANDED''
 @Deprecated()
 class Dep4 {
 
@@ -26,13 +26,13 @@ class Dep4 {
 
 @Deprecated
 @SomeArrays(pooches={DOGS.LEO})
-@SuppressWarnings({""}) // violation
+@SuppressWarnings({""}) // violation 'Annotation style must be 'EXPANDED''
 enum SON4 {
 
     @Deprecated
     @SomeArrays(pooches={DOGS.LEO}, um={""}, duh={"bleh"})
     @APooch(dog=DOGS.HERBIE)
-    @Another("") //compact_no_array // violation
+    @Another("") //compact_no_array // violation 'Annotation style must be 'EXPANDED''
     ETHAN
 }
 
@@ -45,9 +45,9 @@ enum DOGS4 {
 }
 
 @interface SomeArrays4 {
-    @Another("") //compact // violation
+    @Another("") //compact // violation 'Annotation style must be 'EXPANDED''
     String[] um() default {};
-    @Another({""}) //compact // violation
+    @Another({""}) //compact // violation 'Annotation style must be 'EXPANDED''
     String[] duh() default {};
     @Another(value={""}) //expanded
     DOGS[] pooches();
@@ -64,12 +64,12 @@ enum E4 {
 
 @interface Another4 {
     String[] value() default {};
-    @Another({"foo", "bar"}) //compact style // violation
+    @Another({"foo", "bar"}) //compact style // violation 'Annotation style must be 'EXPANDED''
     String value1() default "";
 }
 
 @SomeArrays(pooches = {})
-@Another({}) // violation
+@Another({}) // violation 'Annotation style must be 'EXPANDED''
 class Closing4 {
     static final String UN_U = "UN_U";
 
@@ -77,11 +77,11 @@ class Closing4 {
     int d;
 }
 
-@AnnotationWithAnnotationValue(@Another) // violation
+@AnnotationWithAnnotationValue(@Another) // violation 'Annotation style must be 'EXPANDED''
 class Example13 {}
 @AnnotationWithAnnotationValue(value = @Another)
 class Example14 {}
-@AnnotationWithAnnotationValue(@Another()) // violation
+@AnnotationWithAnnotationValue(@Another()) // violation 'Annotation style must be 'EXPANDED''
 class Example15 {}
 @AnnotationWithAnnotationValue(value = @Another())
 class Example16 {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleNoParens.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleNoParens.java
@@ -19,7 +19,7 @@ public class InputAnnotationUseStyleNoParens
 
 @SomeArrays(pooches={DOGS.LEO}, um={}, duh={"bleh"})
 @SuppressWarnings("") //compact_no_array
-@Deprecated() // violation
+@Deprecated() // violation 'Annotation cannot have closing parenthesis'
 class Dep3 {
 
 }
@@ -36,10 +36,11 @@ enum SON3 {
     ETHAN
 }
 
-@InputAnnotationUseStyleCustomAnnotation6() // violation
+// violation below 'Annotation cannot have closing parenthesis'
+@InputAnnotationUseStyleCustomAnnotation6()
 enum DOGS3 {
 
-    @Deprecated() // violation
+    @Deprecated() // violation 'Annotation cannot have closing parenthesis'
     LEO,
     HERBIE
 }
@@ -81,9 +82,11 @@ class Closing3 {
 class Example9 {}
 @AnnotationWithAnnotationValue(value = @Another)
 class Example10 {}
-@AnnotationWithAnnotationValue(@Another()) // violation
+// violation below 'Annotation cannot have closing parenthesis'
+@AnnotationWithAnnotationValue(@Another())
 class Example11 {}
-@AnnotationWithAnnotationValue(value = @Another()) // violation
+// violation below 'Annotation cannot have closing parenthesis'
+@AnnotationWithAnnotationValue(value = @Another())
 class Example12 {}
 
 class Foo3 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleNoTrailingComma.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleNoTrailingComma.java
@@ -9,20 +9,23 @@ trailingArrayComma = ALWAYS
 
 package com.puppycrawl.tools.checkstyle.checks.annotation.annotationusestyle;
 
-@SuppressWarnings({}) // violation
+@SuppressWarnings({}) // violation 'Annotation array values must contain trailing comma'
 public class InputAnnotationUseStyleNoTrailingComma
 {
-  @SuppressWarnings({"common"}) // violation
+  @SuppressWarnings({"common"}) // violation 'Annotation array values must contain trailing comma'
   public void foo() {
 
       /** Suppress warnings */
-      @SuppressWarnings({"common","foo"}) // violation
+      // violation below 'Annotation array values must contain trailing comma'
+      @SuppressWarnings({"common","foo"})
       Object o = new Object() {
 
-          @SuppressWarnings(value={"common"}) // violation
+          // violation below 'Annotation array values must contain trailing comma'
+          @SuppressWarnings(value ={"common"})
           public String toString() {
 
-              @SuppressWarnings(value={"leo","herbie"}) // violation
+              // violation below 'Annotation array values must contain trailing comma'
+              @SuppressWarnings( value={"leo","herbie"})
               final String pooches = "leo.herbie";
 
               return pooches;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleWithParens.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleWithParens.java
@@ -9,7 +9,7 @@ trailingArrayComma = ignore
 
 package com.puppycrawl.tools.checkstyle.checks.annotation.annotationusestyle;
 
-@Deprecated // violation
+@Deprecated // violation 'Annotation must have closing parenthesis'
 @SomeArrays(pooches={DOGS.LEO})
 @SuppressWarnings({""})
 public class InputAnnotationUseStyleWithParens
@@ -24,12 +24,12 @@ class Dep2 {
 
 }
 
-@Deprecated // violation
+@Deprecated // violation 'Annotation must have closing parenthesis'
 @SomeArrays(pooches={DOGS.LEO})
 @SuppressWarnings({""})
 enum SON2 {
 
-    @Deprecated // violation
+    @Deprecated // violation 'Annotation must have closing parenthesis'
     @SomeArrays(pooches={DOGS.LEO}, um={""}, duh={"bleh"})
     @APooch(dog=DOGS.HERBIE)
     @Another("") //compact_no_array
@@ -77,9 +77,10 @@ class Closing2 {
     int d;
 }
 
-@AnnotationWithAnnotationValue(@Another) // violation
+@AnnotationWithAnnotationValue(@Another) // violation 'Annotation must have closing parenthesis'
 class Example5 {}
-@AnnotationWithAnnotationValue(value = @Another) // violation
+// violation below 'Annotation must have closing parenthesis'
+@AnnotationWithAnnotationValue(value = @Another)
 class Example6 {}
 @AnnotationWithAnnotationValue(@Another())
 class Example7 {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleWithTrailingCommaIgnore.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleWithTrailingCommaIgnore.java
@@ -12,14 +12,15 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.annotationusestyle;
 
 public class InputAnnotationUseStyleWithTrailingCommaIgnore
 {
-    @SuppressWarnings({"common",}) // violation
+    @SuppressWarnings({"common",}) // violation 'Annotation style must be 'COMPACT_NO_ARRAY''
     public void foo() {
 
 
         @SuppressWarnings({"common","foo",})
         Object o = new Object() {
 
-            @SuppressWarnings(value={"common",}) // violation
+            // violation below 'Annotation style must be 'COMPACT_NO_ARRAY''
+            @SuppressWarnings(value={"common",})
             public String toString() {
 
                 @SuppressWarnings(value={"leo","herbie",})
@@ -30,13 +31,15 @@ public class InputAnnotationUseStyleWithTrailingCommaIgnore
         };
     }
 
-    @Test3(value={"foo",}, more={"bar",}) // violation
+    // violation below 'Annotation style must be 'COMPACT_NO_ARRAY''
+    @Test3(value={"foo",}, more={"bar",})
     /**
 
     */
     enum P {
 
-        @Pooches3(tokens={Pooches3.class,},other={1,}) // violation
+        // violation below 'Annotation style must be 'COMPACT_NO_ARRAY''
+        @Pooches3(tokens={Pooches3.class,},other={1,})
         L,
 
         /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleWithTrailingCommaNever.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/annotation/annotationusestyle/InputAnnotationUseStyleWithTrailingCommaNever.java
@@ -12,17 +12,21 @@ package com.puppycrawl.tools.checkstyle.checks.annotation.annotationusestyle;
 
 public class InputAnnotationUseStyleWithTrailingCommaNever
 {
-    @SuppressWarnings({"common",}) // violation
+    // violation below 'Annotation array values cannot contain trailing comma'
+    @SuppressWarnings({"common",})
     public void foo() {
 
 
-        @SuppressWarnings({"common","foo",}) // violation
+        // violation below 'Annotation array values cannot contain trailing comma'
+        @SuppressWarnings({"common","foo",})
         Object o = new Object() {
 
-            @SuppressWarnings(value={"common",}) // violation
+            // violation below 'Annotation array values cannot contain trailing comma'
+            @SuppressWarnings(value={"common",})
             public String toString() {
 
-                @SuppressWarnings(value={"leo","herbie",}) // violation
+                // violation below 'Annotation array values cannot contain trailing comma'
+                @SuppressWarnings(value={"leo","herbie",})
                 final String pooches = "leo.herbie";
 
                 return pooches;


### PR DESCRIPTION
This is with reference to #11214 

I have made the respective changes but is unable to wrap the violation text to the next line. It keeps showing error when ever I wrap the long violation line to the next line. 

```
[ERROR] testStyleCompactNoArray  Time elapsed: 0.008 s  <<< ERROR!
com.puppycrawl.tools.checkstyle.api.CheckstyleException: Violation message should be specified on line 20 in C:\Users\shubh\OneDrive\Desktop\checkstyle\src\test\resources\com\puppycrawl\tools\checkstyle\checks\annotation\annotationusestyle\InputAnnotationUseStyleCompactNoArray.java
        at com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheckTest.testStyleCompactNoArray(AnnotationUseStyleCheckTest.java:210)
Caused by: com.puppycrawl.tools.checkstyle.api.CheckstyleException: Violation message should be specified on line 20
        at com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheckTest.testStyleCompactNoArray(AnnotationUseStyleCheckTest.java:210)

[ERROR] testParensAlways  Time elapsed: 0.002 s  <<< ERROR!
com.puppycrawl.tools.checkstyle.api.CheckstyleException: Violation message should be specified on line 82 in C:\Users\shubh\OneDrive\Desktop\checkstyle\src\test\resources\com\puppycrawl\tools\checkstyle\checks\annotation\annotationusestyle\InputAnnotationUseStyleWithParens.java
        at com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheckTest.testParensAlways(AnnotationUseStyleCheckTest.java:142)
Caused by: com.puppycrawl.tools.checkstyle.api.CheckstyleException: Violation message should be specified on line 82
        at com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheckTest.testParensAlways(AnnotationUseStyleCheckTest.java:142)

```

Hence, I have not wrapped the line therefore, it is giving me "longer than 100 character" error.

Kindly assist as to how can I wrap the line to the next line without triggering errors.