### PR TITLE
Issue #12261: Resolve Pitest suppression for EmptyForIteratorPadCheck

### DIFF
--- a/.ci/pitest-suppressions/pitest-whitespace-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-whitespace-suppressions.xml
@@ -37,24 +37,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>EmptyForIteratorPadCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIteratorPadCheck</mutatedClass>
-    <mutatedMethod>setOption</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/lang/String::toUpperCase with receiver</description>
-    <lineContent>option = PadOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>EmptyForIteratorPadCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForIteratorPadCheck</mutatedClass>
-    <mutatedMethod>setOption</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/lang/String::trim with receiver</description>
-    <lineContent>option = PadOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>EmptyLineSeparatorCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck</mutatedClass>
     <mutatedMethod>checkToken</mutatedMethod>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForIteratorPadCheckTest.java
@@ -107,4 +107,25 @@ public class EmptyForIteratorPadCheckTest
         }
     }
 
+    @Test
+    public void testTrimOptionProperty() throws Exception {
+        final String[] expected = {
+            "20:31: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, ";"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputEmptyForIteratorPadToCheckTrimFunctionInOptionProperty.java"),
+                expected);
+
+    }
+
+    @Test
+    public void testUppercaseOptionProperty() throws Exception {
+        final String[] expected = {
+            "20:31: " + getCheckMessage(MSG_WS_NOT_FOLLOWED, ";"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputEmptyForIteratorPadToCheckUppercaseFunctionInOptionProperty.java"),
+                expected);
+
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforiteratorpad/InputEmptyForIteratorPadToCheckTrimFunctionInOptionProperty.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforiteratorpad/InputEmptyForIteratorPadToCheckTrimFunctionInOptionProperty.java
@@ -1,0 +1,28 @@
+/*
+EmptyForIteratorPad
+option = \tSPACE
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptyforiteratorpad;
+
+class InputEmptyForIteratorPadToCheckTrimFunctionInOptionProperty {
+
+    void method() {
+
+        for (int i = 0; i < 1;i++ ) {
+        }
+
+        for (int i = 0; i < 1; i++ ) {
+        }
+
+        for (int i = 0; i < 1;) { // violation '';' is not followed by whitespace'
+            i++;
+        }
+
+        for (int i = 0; i < 1; ) { // ok
+            i++;
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforiteratorpad/InputEmptyForIteratorPadToCheckUppercaseFunctionInOptionProperty.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/emptyforiteratorpad/InputEmptyForIteratorPadToCheckUppercaseFunctionInOptionProperty.java
@@ -1,0 +1,28 @@
+/*
+EmptyForIteratorPad
+option = space
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptyforiteratorpad;
+
+public class InputEmptyForIteratorPadToCheckUppercaseFunctionInOptionProperty {
+
+    void method() {
+
+        for (int i = 0; i < 1;i++ ) {
+        }
+
+        for (int i = 0; i < 1; i++ ) {
+        }
+
+        for (int i = 0; i < 1;) { // violation '';' is not followed by whitespace'
+            i++;
+        }
+
+        for (int i = 0; i < 1; ) { // ok
+            i++;
+        }
+    }
+}


### PR DESCRIPTION
Issue #12261: Resolve Pitest suppression for EmptyForIteratorPadCheck

killed two surviving mutation

https://github.com/checkstyle/checkstyle/blob/ba8efc21659a66600a25ed662b62d1b1cb7611ea/.ci/pitest-suppressions/pitest-whitespace-suppressions.xml#L44
and 
https://github.com/checkstyle/checkstyle/blob/ba8efc21659a66600a25ed662b62d1b1cb7611ea/.ci/pitest-suppressions/pitest-whitespace-suppressions.xml#L53