### PR TITLE
Update Xpath suppression example

### DIFF
--- a/src/xdocs/config_filters.xml
+++ b/src/xdocs/config_filters.xml
@@ -1562,7 +1562,7 @@ public class FileOne {}
           <pre>
 &lt;module name="SuppressionXpathSingleFilter"&gt;
   &lt;property name="checks" value="RedundantModifier"/&gt;
-  &lt;property name="query" value="/INTERFACE_DEF//*"/&gt;
+  &lt;property name="query" value="//INTERFACE_DEF//*"/&gt;
 &lt;module/&gt;
           </pre>
         </div>


### PR DESCRIPTION
In local testing it was found that SuppressionXpathSingleFilter for suppressing RedundantModifier in interface definitions did not work. A variant with leading double slash does work.

