### PR TITLE
Issue #12275: Resolve Pitest suppression for EmptyForInitializerPad-2

### DIFF
--- a/.ci/pitest-suppressions/pitest-whitespace-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-whitespace-suppressions.xml
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
-    <sourceFile>EmptyForInitializerPadCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck</mutatedClass>
-    <mutatedMethod>visitToken</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getNextSibling with receiver</description>
-    <lineContent>final DetailAST semi = ast.getNextSibling();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>EmptyLineSeparatorCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck</mutatedClass>
     <mutatedMethod>checkToken</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyForInitializerPadCheck.java
@@ -148,11 +148,9 @@ public class EmptyForInitializerPadCheck
     @Override
     public void visitToken(DetailAST ast) {
         if (!ast.hasChildren()) {
-            // empty for initializer. test pad before semi.
-            final DetailAST semi = ast.getNextSibling();
-            final int semiLineIdx = semi.getLineNo() - 1;
-            final int[] line = getLineCodePoints(semiLineIdx);
-            final int before = semi.getColumnNo() - 1;
+            final int lineIdx = ast.getLineNo() - 1;
+            final int[] line = getLineCodePoints(lineIdx);
+            final int before = ast.getColumnNo() - 1;
             // don't check if semi at beginning of line
             if (!CodePointUtil.hasWhitespaceBefore(before, line)) {
                 if (option == PadOption.NOSPACE


### PR DESCRIPTION
Issue #12275: Resolve Pitest suppression for EmptyForInitializerPad-2

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/a85bd5c1897e158b6495850ba792bf4b/raw/37385b138ced4f80b43ccf865900a812500f4f42/config.xml