### PR TITLE
Issue #12326: Resolve Pitest suppression for AccessModifierOption

### DIFF
--- a/.ci/pitest-suppressions/pitest-naming-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-naming-suppressions.xml
@@ -10,15 +10,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>AccessModifierOption.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption</mutatedClass>
-    <mutatedMethod>getInstance</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/lang/String::trim with receiver</description>
-    <lineContent>return valueOf(AccessModifierOption.class, modifierName.trim().toUpperCase(Locale.ENGLISH));</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>ParameterNameCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.naming.ParameterNameCheck</mutatedClass>
     <mutatedMethod>setAccessModifiers</mutatedMethod>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheckTest.java
@@ -69,6 +69,17 @@ public class ParameterNameCheckTest
     }
 
     @Test
+    public void testWhitespaceInAccessModifierProperty() throws Exception {
+        final String pattern = "^h$";
+        final String[] expected = {
+            "14:69: " + getCheckMessage(MSG_INVALID_PATTERN, "parameter1", pattern),
+            "18:31: " + getCheckMessage(MSG_INVALID_PATTERN, "parameter2", pattern),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputParameterNameWhitespaceInAccessModifierProperty.java"), expected);
+    }
+
+    @Test
     public void testDefault()
             throws Exception {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/InputParameterNameWhitespaceInAccessModifierProperty.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/naming/parametername/InputParameterNameWhitespaceInAccessModifierProperty.java
@@ -1,0 +1,23 @@
+/*
+ParameterName
+format = ^h$
+ignoreOverridden = (default)false
+accessModifiers = \tpublic
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.naming.parametername;
+
+public class InputParameterNameWhitespaceInAccessModifierProperty {
+
+    public InputParameterNameWhitespaceInAccessModifierProperty(int parameter1) {} // violation
+
+    public void v1(int h) { // ok
+        new Object () {
+            public void i(int parameter2) {} // violation
+        };
+    }
+
+    void method2(int V3) {}
+}


### PR DESCRIPTION
Referencing from #12326 
also related to #12341

![image](https://user-images.githubusercontent.com/90137881/197394901-f66a41a2-3f7e-43d2-94a2-bc9705c5697c.png)

