### PR TITLE
minor: ensure external repos are also cleaned and reset from previous

### DIFF
--- a/.ci/util.sh
+++ b/.ci/util.sh
@@ -31,9 +31,11 @@ function checkout_from {
   mkdir -p .ci-temp
   cd .ci-temp
   if [ -d "$PROJECT" ]; then
-    echo "Target project $PROJECT is already cloned, latest changes will be fetched"
+    echo "Target project $PROJECT is already cloned, latest changes will be fetched and reset"
     cd "$PROJECT"
     git fetch
+    git reset --hard HEAD
+    git clean -f -d
     cd ../
   else
     for i in 1 2 3 4 5; do git clone "$CLONE_URL" && break || sleep 15; done


### PR DESCRIPTION
identified from https://github.com/sevntu-checkstyle/sevntu.checkstyle/blob/master/.ci/validation.sh#L20 when trying to run locally and running into issues,

````
sevntu.checkstyle/.ci-temp/eclipse-cs/ $ git status

HEAD detached at 10.0.0
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

    modified:  docs/partials/releases/5.0.0final/release_notes.html
    modified:  docs/sitemap.xml

no changes added to commit (use "git add" and/or "git commit -a")
````

Even our checkout would not reset the repo and we assume we are getting a clean state of the repo we retrieve.