### PR TITLE
infra: add "Print versions" to 'run-inspections' job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,6 +219,15 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Print versions
+          command: |
+            echo "Maven version:"
+            mvn --version
+            echo "Java version:"
+            java --version
+            echo "IDEA version:"
+            echo $IDEA_VERSION
+      - run:
           name: Run inspections
           command: |
             mkdir .idea


### PR DESCRIPTION
Requested at https://github.com/checkstyle/checkstyle/pull/12354#issuecomment-1298624070

>IDEA_VERSION
JAVA_VERSION
MAVEN_VERSION

Done

>print sha of the downloaded file

Downloaded file is not in the final image, and in fact it is piped directly to `tar`. In order to keep the size of the image as small as possible, we do not store this.