### PR TITLE
infra: test inspections on old commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,6 +215,10 @@ jobs:
   run-inspections:
     docker:
       - image: checkstyle/idea-docker:jdk11-idea2022.2.2
+    environment:
+      MAVEN_OPTS: "-Xmx6144m"
+      JAVA_OPTS: "-Xms6144m -Xmx6144m"
+    resource_class: large
 
     steps:
       - checkout

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/DetailAST.java
@@ -97,12 +97,8 @@ public interface DetailAST {
      *      Usage of this method is no longer accepted. We encourage
      *      traversal of subtrees to be written per the needs of each check
      *      to avoid unintended side effects.
-     * @noinspection DeprecatedIsStillUsed, RedundantSuppression
+     * @noinspection DeprecatedIsStillUsed
      * @noinspectionreason DeprecatedIsStillUsed - Method used in unit testing
-     * @noinspectionreason RedundantSuppression - Inspections shows false positive for
-     *      redundant suppression, see
-     *      <a href="https://github.com/checkstyle/checkstyle/issues/12359">here</a>
-     *      for more details.
      */
     @Deprecated(since = "8.43")
     boolean branchContains(int type);


### PR DESCRIPTION
This is a test to see if inspections still pass on old commit, if so, it means that there was probably some change on checkstyle side that caused new failure (dependency update, etc.)

DO NOT MERGE

One of the last passing inspections builds, from commit 7a75f4de6: 
First run (original run on master 18 days ago), successful: https://app.circleci.com/pipelines/github/checkstyle/checkstyle/15655/workflows/fb3432b8-e53f-49df-9fd4-84e67b3a6cc6/jobs/187987

Rerun (today) of same workflow after problems began, successful: https://app.circleci.com/pipelines/github/checkstyle/checkstyle/15655/workflows/24f32664-9bda-42f8-86b3-5c6731d903e0/jobs/192336

----------------------
inspections still passes on old base commit: https://github.com/checkstyle/checkstyle/pull/12362/commits/d437572109c83ac66ca6576751f16a8b010626b5

