### PR TITLE
infra: added quarterly cache clean up (travis)

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -830,6 +830,7 @@ markdownlint
 Massol
 matchxpath
 mavenbadge
+maxdepth
 maxmem
 maxmethods
 mct
@@ -878,6 +879,7 @@ mozilla
 MRELEASE
 mstudman
 MTAGLIST
+mtime
 MUI
 multicharacter
 multiline

--- a/.ci/travis.sh
+++ b/.ci/travis.sh
@@ -138,6 +138,10 @@ jacoco)
   fi
   ;;
 
+quarterly-cache-cleanup)
+  find ~/.m2 -maxdepth 4 -type d -mtime +90 -exec rm -rf {} \;
+  ;;
+
 *)
   echo "Unexpected argument: $1"
   sleep 5s

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ script:
 #  - ./.ci/travis.sh remove-adoptium-jdk
   - ./.ci/validation.sh git-diff
   - ./.ci/travis.sh ci-temp-check
+  - ./.ci/travis.sh quarterly-cache-cleanup
 
 after_success:
   - ./.ci/travis.sh run-command-after-success


### PR DESCRIPTION
After thinking about random things late at night, and then seeing sevntu has a 2 gig cache file. Checkstyle seems to be around 600 megs.

https://app.travis-ci.com/github/sevntu-checkstyle/sevntu.checkstyle/caches
https://app.travis-ci.com/github/checkstyle/checkstyle/caches

Command from https://www.howtogeek.com/howto/ubuntu/delete-files-older-than-x-days-on-linux .

This won't be perfect as we could removing dependencies that are still used but have not updated in this timeframe.