### PR TITLE
infra: run one checker to maintain windows compatibility

### DIFF
--- a/.ci/checker-framework.groovy
+++ b/.ci/checker-framework.groovy
@@ -112,7 +112,7 @@ private static int checkCheckerFrameworkReport(final String profile) {
  */
 private static List<List<String>> getCheckerFrameworkErrors(final String profile) {
     final List<String> checkerFrameworkLines = new ArrayList<>()
-    final String command = "mvn -e --no-transfer-progress clean compile -P${profile}"
+    final String command = "mvn -X -e --no-transfer-progress clean compile -P${profile}"
     final Process process = getOsSpecificCmd(command).execute()
     process.in.eachLine { final line ->
         checkerFrameworkLines.add(line)

--- a/.ci/validate-checker.cmd
+++ b/.ci/validate-checker.cmd
@@ -1,0 +1,2 @@
+@echo on
+groovy ./.ci/checker-framework.groovy checker-signature-gui-units-init

--- a/.ci/validate-checker.cmd
+++ b/.ci/validate-checker.cmd
@@ -1,2 +1,3 @@
 @echo on
+JAVA_HOME="C:\Program Files\OpenJDK\jdk-17"
 mvn -X -e --no-transfer-progress clean compile -Pchecker-signature-gui-units-init

--- a/.ci/validate-checker.cmd
+++ b/.ci/validate-checker.cmd
@@ -1,2 +1,2 @@
 @echo on
-groovy ./.ci/checker-framework.groovy checker-signature-gui-units-init
+mvn -X -e --no-transfer-progress clean compile -Pchecker-signature-gui-units-init

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -49,6 +49,7 @@ task:
     - java --version
     - mvn --version
     - groovy --version
+    - echo %JAVA_HOME%
     # - xsltproc --version
     # - xml --version
   validate_checker_windows_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,6 +22,7 @@ task:
       env:
         OPENJDK_VERSION: "17.0.0"
         OPENJDK_PATH: "jdk-17"
+        GROOVY_VERSION: "3.0.11"
   env:
     # disable ANSI output for picocli (may affect tests)
     NO_COLOR: "1"
@@ -32,13 +33,14 @@ task:
     MAVEN_VERSION: "3.8.4"
     PATH: "%PATH%;C:/Program Files/OpenJDK/%OPENJDK_PATH%/bin;\
       C:/ProgramData/chocolatey/lib/maven/apache-maven-%MAVEN_VERSION%/bin;\
-      C:/ProgramData/chocolatey/bin"
+      C:/ProgramData/chocolatey/bin;C:/tools/groovy-%GROOVY_VERSION%/bin"
   install_script:
     - choco config set cacheLocation %CIRRUS_WORKING_DIR%/.chocolatey
     - choco upgrade -y chocolatey
     - choco install -y --no-progress ant
     - choco install -y --no-progress maven --version %MAVEN_VERSION%
     - choco install -y --no-progress openjdk --version %OPENJDK_VERSION%
+    - choco install -y --no-progress groovy --version %GROOVY_VERSION%
     # - choco install -y --no-progress xsltproc
     # - choco install -y --no-progress xmlstarlet
   version_script:
@@ -46,8 +48,13 @@ task:
     - ant -version
     - java --version
     - mvn --version
+    - groovy --version
     # - xsltproc --version
     # - xml --version
+  validate_checker_windows_script:
+    - cd ci
+    # ' || VER>NUL' below until https://github.com/checkstyle/checkstyle/issues/12221
+    - .ci/validate-checker.cmd || VER>NUL
   sevntu_script:
     - cd ci
     - .ci/validation.cmd sevntu


### PR DESCRIPTION
In order to prove resolution of #12221 and https://github.com/checkstyle/checkstyle/issues/12243, we should keep one checker execution in windows CI. I have added `|| VER>NUL` to the end of the checker command to allow checker execution to fail and CI still pass, until we resolve the above issues. `|| VER>NUL` should be removed in the scope of the above issues.