### PR TITLE
infra: re-enable nondex and upgrade to 2.1

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -88,7 +88,7 @@ nondex)
   mvn -e --no-transfer-progress --fail-never clean nondex:nondex -DargLine='-Xms1024m -Xmx2048m' \
     -Dtest=!JavadocPropertiesGeneratorTest#testNonExistentArgument
   mkdir -p .ci-temp
-  cat "$(grep -RlE 'td class=.x' .nondex/ | cat)" < /dev/null > .ci-temp/output.txt
+  grep -RlE 'td class=.x' .nondex/ | cat > .ci-temp/output.txt
   RESULT=$(cat .ci-temp/output.txt | wc -c)
   cat .ci-temp/output.txt
   echo 'Size of output:'"$RESULT"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -27,22 +27,6 @@ blocks:
               cache store m2 $HOME/.m2
             fi
       jobs:
-        # NonDex supports only Java 8 till https://github.com/TestingResearchIllinois/NonDex/pull/155
-        # - name: NonDex (openjdk11)
-        #   priority:
-        #     - value: 90
-        #       when: true
-        #   matrix:
-        #     - env_var: CMD
-        #       values:
-        #         - .ci/validation.sh nondex
-        #   commands:
-        #     - sem-version java 11
-        #     - echo "eval of CMD is starting";
-        #     - echo "CMD=$CMD";
-        #     - eval $CMD;
-        #     - echo "eval of CMD is completed";
-
         - name: Validation (openjdk11, fast pool)
           matrix:
             - env_var: CMD
@@ -53,6 +37,7 @@ blocks:
                 - .ci/validation.sh verify-regexp-id
                 - .ci/no-exception-test.sh guava-with-google-checks
                 - .ci/no-exception-test.sh guava-with-sun-checks
+                - .ci/validation.sh nondex
                 # until https://github.com/checkstyle/checkstyle/issues/9807
                 # - mvn -e --no-transfer-progress clean package -Passembly
                 #    && .ci/validation.sh no-violation-test-josm

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -6,5 +6,5 @@
   service: system
   steps:
     # -  command: ./.ci/validation.sh site
-    # -  command: ./.ci/validation.sh nondex
+    -  command: ./.ci/validation.sh nondex
     -  command: ls -la

--- a/pom.xml
+++ b/pom.xml
@@ -1833,7 +1833,7 @@
       <plugin>
         <groupId>edu.illinois</groupId>
         <artifactId>nondex-maven-plugin</artifactId>
-        <version>1.1.2</version>
+        <version>2.1</version>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
https://github.com/TestingResearchIllinois/NonDex/issues/175

https://github.com/TestingResearchIllinois/NonDex/compare/nondex-1.1.2...master (note, no tag for 2.1)

nondex 2.1 was released and should support Java 11.