### PR TITLE
Issue #12181: Fail 'Publish GitHub page' when curl fails

### DIFF
--- a/.ci/update-github-page.sh
+++ b/.ci/update-github-page.sh
@@ -89,7 +89,7 @@ EOF
 echo "$JSON"
 
 echo "Updating Github tag page"
-curl \
+curl --fail-with-body \
   -X PATCH https://api.github.com/repos/checkstyle/checkstyle/releases/"$RELEASE_ID" \
   -H "Accept: application/vnd.github+json" \
   -H "Authorization: token $BUILDER_GITHUB_TOKEN" \


### PR DESCRIPTION
Resolves #12181 

---
From curl docs:
> [--fail-with-body](https://curl.se/docs/manpage.html#--fail-with-body)
(HTTP) Return an error on server errors where the HTTP response code is 400 or greater). In normal cases when an HTTP server fails to deliver a document, it returns an HTML document stating so (which often also describes why and more). This flag will still allow curl to output and save that content but also to return error 22. 

---
Failed run: https://github.com/stoyanK7/checkstyle/actions/runs/3444671922/jobs/5747521215

```
curl: (22) The requested URL returned error: 404
{
  "message": "Not Found",
  "documentation_url": "https://docs.github.com/rest/reference/repos#update-a-release"
}
Error: Process completed with exit code 22.
```