### PR TITLE
Update Test Configuration To Support Adding TreeWalker Property

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputConfiguration.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/TestInputConfiguration.java
@@ -84,9 +84,8 @@ public final class TestInputConfiguration {
 
     public DefaultConfiguration createConfiguration() {
         final DefaultConfiguration root = new DefaultConfiguration(ROOT_MODULE_NAME);
-        final DefaultConfiguration treeWalker =
-                new DefaultConfiguration(TreeWalker.class.getName());
         root.addProperty("charset", StandardCharsets.UTF_8.name());
+        final DefaultConfiguration treeWalker = createTreeWalker();
         childrenModules
                 .stream()
                 .map(ModuleInputConfiguration::createConfiguration)
@@ -94,7 +93,7 @@ public final class TestInputConfiguration {
                     if (CHECKER_CHILDREN.contains(moduleConfig.getName())) {
                         root.addChild(moduleConfig);
                     }
-                    else {
+                    else if (!treeWalker.getName().equals(moduleConfig.getName())) {
                         treeWalker.addChild(moduleConfig);
                     }
                 });
@@ -104,9 +103,8 @@ public final class TestInputConfiguration {
 
     public DefaultConfiguration createConfigurationWithoutFilters() {
         final DefaultConfiguration root = new DefaultConfiguration(ROOT_MODULE_NAME);
-        final DefaultConfiguration treeWalker =
-                new DefaultConfiguration(TreeWalker.class.getName());
         root.addProperty("charset", StandardCharsets.UTF_8.name());
+        final DefaultConfiguration treeWalker = createTreeWalker();
         childrenModules
                 .stream()
                 .map(ModuleInputConfiguration::createConfiguration)
@@ -115,12 +113,23 @@ public final class TestInputConfiguration {
                     if (CHECKER_CHILDREN.contains(moduleConfig.getName())) {
                         root.addChild(moduleConfig);
                     }
-                    else {
+                    else if (!treeWalker.getName().equals(moduleConfig.getName())) {
                         treeWalker.addChild(moduleConfig);
                     }
                 });
         root.addChild(treeWalker);
         return root;
+    }
+
+    private DefaultConfiguration createTreeWalker() {
+        final DefaultConfiguration treeWalker;
+        if (childrenModules.get(0).getModuleName().equals(TreeWalker.class.getName())) {
+            treeWalker = childrenModules.get(0).createConfiguration();
+        }
+        else {
+            treeWalker = new DefaultConfiguration(TreeWalker.class.getName());
+        }
+        return treeWalker;
     }
 
     public static final class Builder {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
@@ -423,17 +423,12 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
 
     @Test
     public void testFileNameNoExtension() throws Exception {
-        final DefaultConfiguration checkConfig = createModuleConfig(ImportControlCheck.class);
-        checkConfig.addProperty("file",
-                getResourcePath("InputImportControlFileNameNoExtension.xml"));
-        final DefaultConfiguration treewalkerConfig = createModuleConfig(TreeWalker.class);
-        treewalkerConfig.addProperty("fileExtensions", "");
-        treewalkerConfig.addChild(checkConfig);
         final String[] expected = {
-            "11:1: " + getCheckMessage(MSG_DISALLOWED, "java.awt.Image"),
+            "13:1: " + getCheckMessage(MSG_DISALLOWED, "java.awt.Image"),
         };
 
-        verify(treewalkerConfig, getPath("InputImportControlFileNameNoExtension"), expected);
+        verifyWithInlineConfigParser(
+                getPath("InputImportControlFileNameNoExtension"), expected);
     }
 
     /**

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControlFileNameNoExtension
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importcontrol/InputImportControlFileNameNoExtension
@@ -1,14 +1,16 @@
 /*
-ImportControl
-file = InputImportControlFileNameNoExtension.xml
-path = (default).*
+com.puppycrawl.tools.checkstyle.TreeWalker
+fileExtensions =
 
+ImportControl
+file = (file)InputImportControlFileNameNoExtension.xml
+path = (default).*
 
 */
 
 package com.puppycrawl.tools.checkstyle.checks.imports.importcontrol;
 
-import java.awt.Image; // violation
+import java.awt.Image; // violation 'Disallowed import - java.awt.Image'
 
 public @interface InputImportControlFileNameNoExtension {
 }


### PR DESCRIPTION
In test Input Files, Checks Modules and Properties are passed in comments at the top file and all these modules are added as child of TreeWalker.

But There is no way to configure the property of TreeWalker from Input Files Comments. So I added the function which will set the property of treeWalker.

For ref, #12386
