### PR TITLE
minor: move sleep to main travis so all commands get chance to output

### DIFF
--- a/.ci/releasenotes-gen.sh
+++ b/.ci/releasenotes-gen.sh
@@ -9,7 +9,7 @@ set -e
 echo "PULL_REQUEST:""$PULL_REQUEST"
 if [[ $PULL_REQUEST =~ ^([0-9]+)$ ]]; then
   echo "Build is not for Pull Request";
-  sleep 5;
+  sleep 5s;
   exit 0;
 fi
 

--- a/.ci/sonar-wrapper.sh
+++ b/.ci/sonar-wrapper.sh
@@ -8,8 +8,9 @@ echo "Building docker image"
 docker pull sonarqube
 echo "Running docker container"
 docker run -dit -p 9000:9000 --name sonar sonarqube:latest
+
 echo "sleeping 60 sec to let sonar start up"
-sleep "60"
+sleep 60s
 
 ./.ci/sonar.sh
 

--- a/.ci/sonar.sh
+++ b/.ci/sonar.sh
@@ -15,7 +15,7 @@ mvn -e --no-transfer-progress sonar:sonar -P sonar -Dsonar.language=java \
 
 # get and parse response from sonar
 # give some time to sonar for report processing
-sleep "60"
+sleep 60s
 curl --fail-with-body -u admin:admin \
    -v http://localhost:9000/api/issues/search?componentRoots=com.puppycrawl.tools:checkstyle \
         > response.json

--- a/.ci/test-spelling-unknown-words.sh
+++ b/.ci/test-spelling-unknown-words.sh
@@ -85,7 +85,7 @@ if [ -z "$new_output" ]; then
   echo "$diff_output"
   echo "EOF"
   rm $dict
-  sleep 5
+  sleep 5s
   exit 1
 fi
 echo "New misspellings found, please review:"
@@ -95,5 +95,5 @@ echo "patch $whitelist_path <<EOF"
 echo "$diff_output"
 echo "EOF"
 rm $dict
-sleep 5
+sleep 5s
 exit 1

--- a/.ci/travis.sh
+++ b/.ci/travis.sh
@@ -108,7 +108,6 @@ deploy-snapshot)
       mvn -e --no-transfer-progress -s config/deploy-settings.xml -Pno-validations deploy;
       echo "deploy to maven snapshot repository is finished";
   fi
-  sleep 5s
   ;;
 
 ci-temp-check)

--- a/.ci/travis.sh
+++ b/.ci/travis.sh
@@ -144,7 +144,7 @@ quarterly-cache-cleanup)
   MVN_REPO=$(mvn -e --no-transfer-progress help:evaluate -Dexpression=settings.localRepository \
     -q -DforceStdout);
   if [[ -d ${MVN_REPO} ]]; then
-    find "$MVN_REPO" -maxdepth 4 -type d -mtime +90 -exec rm -rf {} \;
+    find "$MVN_REPO" -maxdepth 4 -type d -mtime +90 -exec rm -rf {} \; || true;
   else
     echo "Failed to find correct maven cache to clean. Quietly exiting."
   fi

--- a/.ci/util.sh
+++ b/.ci/util.sh
@@ -38,7 +38,7 @@ function checkout_from {
     git clean -f -d
     cd ../
   else
-    for i in 1 2 3 4 5; do git clone "$CLONE_URL" && break || sleep 15; done
+    for i in 1 2 3 4 5; do git clone "$CLONE_URL" && break || sleep 15s; done
   fi
   cd ../
 }

--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -92,7 +92,7 @@ nondex)
   RESULT=$(cat .ci-temp/output.txt | wc -c)
   cat .ci-temp/output.txt
   echo 'Size of output:'"$RESULT"
-  if [[ $RESULT != 0 ]]; then sleep 5s; false; fi
+  if [[ $RESULT != 0 ]]; then false; fi
   rm .ci-temp/output.txt
   ;;
 
@@ -115,7 +115,6 @@ pr-age)
   if (( $COMMITS_SINCE_MASTER > $MAX_ALLOWED ));
   then
     echo "This PR is too old and should be rebased on origin/master."
-    sleep 5s
     false
   fi
   ;;
@@ -184,7 +183,6 @@ versions)
     echo "New plugin versions:"
     grep -B 4 -A 7 "<nextVersion>" target/plugin-updates-report.xml | cat
     echo "Verification is failed."
-    sleep 5s
     false
   else
     echo "No new versions found"
@@ -487,7 +485,6 @@ check-since-version)
     CS_RELEASE_VERSION=$(echo "$CS_POM_VERSION" | cut -d '-' -f 1)
     echo "CS Release version: $CS_RELEASE_VERSION"
     echo "Grep for @since $CS_RELEASE_VERSION"
-    sleep 5s
     grep "* @since $CS_RELEASE_VERSION" "$NEW_CHECK_FILE"
   else
     echo "No new Check, all is good."

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,9 @@ script:
   - ./.ci/validation.sh git-diff
   - ./.ci/travis.sh ci-temp-check
   - ./.ci/travis.sh quarterly-cache-cleanup
+  - sleep 5s
 
 after_success:
   - ./.ci/travis.sh run-command-after-success
   - ./.ci/travis.sh deploy-snapshot
+  - sleep 5s


### PR DESCRIPTION
Identified at https://github.com/checkstyle/checkstyle/pull/12391#issuecomment-1312514908,

Moves all sleep commands to travis so we don't have to add sleep to everything and everyone gets a chance for output.

I left sleep commands near "exit"s as I wasn't sure if travis would still execute the rest.

I also organized all sleep commands so they were similar in pattern to do a search and find.