### PR TITLE
infra: remove 'fail-with-body' option from link check

### DIFF
--- a/.ci/run-link-check-plugin.sh
+++ b/.ci/run-link-check-plugin.sh
@@ -6,7 +6,7 @@ set -e
 pwd
 uname -a
 mvn --version
-curl --fail-with-body -I https://sourceforge.net/projects/checkstyle/
+curl -I https://sourceforge.net/projects/checkstyle/
 mvn -e --no-transfer-progress clean site -Dcheckstyle.ant.skip=true -DskipTests -DskipITs \
    -Dpmd.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -Dcheckstyle.skip=true
 echo "------------ grep of linkcheck.html--BEGIN"

--- a/config/checkstyle_non_main_files_suppressions.xml
+++ b/config/checkstyle_non_main_files_suppressions.xml
@@ -152,4 +152,5 @@
   <suppress id="properCurlCommand" files=".ci[\\/]validation\.sh"/>
   <!-- azure does not support this curl command -->
   <suppress id="properCurlCommand" files=".ci[\\/]test-spelling-unknown-words\.sh"/>
+  <suppress id="properCurlCommand" files=".ci[\\/]run-link-check-plugin\.sh"/>
 </suppressions>


### PR DESCRIPTION
fixes failure and adds suppression for https://github.com/checkstyle/checkstyle/actions/runs/3453488392/jobs/5764121711

Failure occurred in master after merge since link check runs only there.