### PR TITLE
infra: migrate releasenotes-gen to codeship

### DIFF
--- a/.ci/jsoref-spellchecker/exclude.pl
+++ b/.ci/jsoref-spellchecker/exclude.pl
@@ -19,6 +19,7 @@ my @excludes=qw(
   ^.teamcity/
   ^.ci/checker-framework-suppressions/
   ^config/archunit-store/
+  ^codeship.encrypted$
 );
 my $exclude = join "|", @excludes;
 while (<>) {

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -2,3 +2,5 @@ system:
   image: checkstyle/maven-builder-image:latest
   volumes:
     - .:/usr/local/checkstyle
+  encrypted_env_file:
+    - codeship.encrypted

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -5,5 +5,6 @@
   # tag: master
   service: system
   steps:
-    # -  command: ./.ci/validation.sh site
     -  command: ls -la
+    -  command: if [ -z $READ_ONLY_TOKEN ]; then echo "token not found" && false; fi;
+    -  command: ./.ci/releasenotes-gen.sh

--- a/codeship.encrypted
+++ b/codeship.encrypted
@@ -1,0 +1,2 @@
+codeship:v2
+qEu3UX/OUVzRKHixymV7h0eNur13iFIyrLCkCLIN6AQRLL/aAwg4GVLPXUn8Jl7L3VSfLO6qW2dJyPOxqAeDdnxEXpbNcFArcJ/UlKla1o4Q7nRTkuQrYZLP+etp3f8pHxuRabWysQky

--- a/config/checkstyle_non_main_files_suppressions.xml
+++ b/config/checkstyle_non_main_files_suppressions.xml
@@ -52,6 +52,9 @@
   <suppress checks="NewlineAtEndOfFile"
             files="config[\\/]archunit-store[\\/]slices_should_be_free_of_cycles_suppressions"/>
 
+  <!-- encrypted file is generated, we should not append newline -->
+  <suppress checks="NewlineAtEndOfFile" files="codeship.encrypted"/>
+
   <!-- till https://issues.apache.org/jira/browse/MRELEASE-1008 -->
   <suppress id="lineLength" files="pom.xml"/>
   <!-- this file cannot be line wraped -->
@@ -108,6 +111,9 @@
 
   <!-- We will preserve formatting of archived release notes -->
   <suppress id="lineLength" files="[\\/]releasenotes_old_8\-0_8\-34\.xml"/>
+
+  <!-- encrypted secrets cannot be line wrapped -->
+  <suppress id="lineLength" files="codeship.encrypted"/>
 
   <!-- apply check numberOfTestCasesInXpath only for files in suppressionxpathfilter directory -->
   <suppress id="numberOfTestCasesInXpath"


### PR DESCRIPTION
As releasenotes-gen only runs on master, we can migrate this task to codeship. Currently, this job is failing in CircleCi due to missing github token: https://app.circleci.com/pipelines/github/checkstyle/checkstyle/16059/workflows/82c3e207-5f67-4958-84a0-c4428ea215c8/jobs/197310
