### PR TITLE
Issue#12393 : Added closing anchor tag

### DIFF
--- a/src/xdocs/cmdline.xml.vm
+++ b/src/xdocs/cmdline.xml.vm
@@ -145,9 +145,8 @@ java -D&lt;property&gt;=&lt;value&gt;  \
 
       <p>
         Note that the <code>-n packageNamesFile</code>
-        option has been dropped for Checkstyle 5.0, because of
-        significant changes regarding package name file handling. See <a
-        href="config.html#Packages"/> for details.
+        option has been dropped for Checkstyle 5.0, because of significant changes regarding
+        package name file handling. See <a href="config.html#Packages">this link</a> for details.
       </p>
 
       <p>


### PR DESCRIPTION
Fix to Issue #12393 : The closing anchor tag for the hyperlink was missing.
