### PR TITLE
infra: migrate sonar to github actions

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -1129,6 +1129,7 @@ py
 qa
 qalab
 qaplug
+qualitygates
 Qube
 qux
 qw

--- a/.ci/sonar_break_build.sh
+++ b/.ci/sonar_break_build.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env sh
+set -e
+# inspired by https://github.com/viesure/blog-sonar-build-breaker
+
+SONAR_RESULT="target/sonar/report-task.txt"
+SONAR_SERVER="https://sonarcloud.io"
+
+if [ -z "$SONAR_API_TOKEN" ]; then
+  echo "Sonar API Token not set"
+  exit 1
+fi
+
+if [ ! -f $SONAR_RESULT ]; then
+  echo "Sonar result does not exist"
+  exit 1
+fi
+
+CE_TASK_ID=$(sed -n 's/ceTaskId=\(.*\)/\1/p' < $SONAR_RESULT)
+
+if [ -z "$CE_TASK_ID" ]; then
+  echo "ceTaskId is not set from sonar build"
+  exit 1
+fi
+
+TASK_URL="$SONAR_SERVER/api/ce/task\?id=$CE_TASK_ID"
+HTTP_STATUS=$(curl -s -o /dev/null -w '%{http_code}' \
+    -u "$SONAR_API_TOKEN": "$TASK_URL")
+
+if [  "$HTTP_STATUS" -ne 200 ]; then
+  echo "Sonar API Token has no access rights"
+  exit 1
+fi
+
+# While report is processed ANALYSIS_ID is not available and jq returns null
+ANALYSIS_ID=$(curl -X GET -s -u "$SONAR_API_TOKEN": "$TASK_URL" \
+    | jq -r .task.analysisId)
+I=1
+TIMEOUT=0
+while [ "$ANALYSIS_ID" = "null" ]; do
+  if [ "$TIMEOUT" -gt 30 ]; then
+    echo "Timeout of " + $TIMEOUT + " seconds exceeded for getting ANALYSIS_ID"
+    exit 1
+  fi
+  sleep $I
+  TIMEOUT=$((TIMEOUT+I))
+  I=$((I+1))
+  ANALYSIS_ID=$(curl -X GET -s -u "$SONAR_API_TOKEN": "$TASK_URL" \
+      | jq -r .task.analysisId)
+done
+
+ANALYSIS_URL="$SONAR_SERVER/api/qualitygates/project_status?analysisId=$ANALYSIS_ID"
+STATUS=$(curl -X GET -s -u "$SONAR_API_TOKEN": "$ANALYSIS_URL" \
+    | jq -r .projectStatus.status)
+
+if [ "$STATUS" = "ERROR" ]; then
+  echo "Quality gate failed."
+  exit 1
+fi
+
+echo "Sonar Quality gate is OK"
+exit 0

--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -597,14 +597,8 @@ sonarqube)
   echo "report-task.txt:"
   cat target/sonar/report-task.txt
   echo "Verification of sonar gate status"
-  checkout_from https://github.com/viesure/blog-sonar-build-breaker.git
-  sed -i'' "s|our.sonar.server|sonarcloud.io|" \
-    .ci-temp/blog-sonar-build-breaker/sonar_break_build.sh
-  sed -i'' "s|curl |curl --fail-with-body -k |" \
-    .ci-temp/blog-sonar-build-breaker/sonar_break_build.sh
   export SONAR_API_TOKEN=$SONAR_TOKEN
-  .ci-temp/blog-sonar-build-breaker/sonar_break_build.sh
-  removeFolderWithProtectedFiles .ci-temp/blog-sonar-build-breaker
+  .ci/sonar_break_build.sh
   ;;
 
 no-error-pgjdbc)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,8 @@ jobs:
       - image: << parameters.image-name >>
     steps:
       - checkout
+      - run:
+          command: apt-get install -y jq
       - restore_cache:
           name: Restore Maven repo cache
           keys:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,0 +1,28 @@
+name: SonarQube
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  check:
+    strategy:
+      fail-fast: true
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Execute sonar script
+        env:
+          MAVEN_OPTS: "-Xmx4g"
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./.ci/validation.sh sonarqube


### PR DESCRIPTION
For security reasons, we will migrate sonar to github actions. Also, I have copied the script from https://github.com/viesure/blog-sonar-build-breaker to our own repo, for several reasons:

1. External script could be modified by maintainer of https://github.com/viesure/blog-sonar-build-breaker to print our environment variables
2. External script does not use `set -e`, and thus will not fail build upon failure in script. 

Example: https://app.circleci.com/pipelines/github/checkstyle/checkstyle/16061/workflows/95872086-a4e9-4812-9a41-0900ae1bdfcb/jobs/197395

It is better for us to maintain control over scripts running in our CI.

We need to add our sonar token to github env variables.

---------------------

update: looks like sonar script has been failing for a long time, while not failing the build: https://app.circleci.com/pipelines/github/checkstyle/checkstyle/15593/workflows/f5f631b7-df87-4973-a670-1839874e29e3/jobs/186638

In fact, sonar script execution has probably been damaged for the entire time it has lived in CircleCI, since the image we use has not changed in quite some time.
