### PR TITLE
Issue #12182: Investigate why GITHUB token has no access to issues

### DIFF
--- a/.ci/update-github-page.sh
+++ b/.ci/update-github-page.sh
@@ -12,7 +12,6 @@ TARGET_VERSION=$1
 echo TARGET_VERSION="$TARGET_VERSION"
 
 checkForVariable "GITHUB_TOKEN"
-checkForVariable "BUILDER_GITHUB_TOKEN"
 
 checkout_from https://github.com/checkstyle/contribution
 
@@ -62,7 +61,7 @@ java -jar contribution/releasenotes-builder/target/releasenotes-builder-1.0-all.
      -startRef "$START_REF" \
      -endRef "$END_REF" \
      -releaseNumber "$TARGET_VERSION" \
-     -githubAuthToken "$BUILDER_GITHUB_TOKEN" \
+     -githubAuthToken "$GITHUB_TOKEN" \
      -generateGitHub \
      -gitHubTemplate $BUILDER_RESOURCE_DIR/templates/github_post.template
 
@@ -92,5 +91,5 @@ echo "Updating Github tag page"
 curl --fail-with-body \
   -X PATCH https://api.github.com/repos/checkstyle/checkstyle/releases/"$RELEASE_ID" \
   -H "Accept: application/vnd.github+json" \
-  -H "Authorization: token $BUILDER_GITHUB_TOKEN" \
+  -H "Authorization: token $GITHUB_TOKEN" \
   -d "${JSON}"

--- a/.github/workflows/publish_releasenotes_outside.yml
+++ b/.github/workflows/publish_releasenotes_outside.yml
@@ -13,12 +13,13 @@ jobs:
   publish:
     name: Publish releasenotes GitHub Page ${{ github.event.inputs.version }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout the latest code
         uses: actions/checkout@v3
       - name: Run Shell Script
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./.ci/update-github-page.sh ${{ github.event.inputs.version }}
-        env:
-          GITHUB_TOKEN : ${{ secrets.GITHUB_TOKEN }}
-          BUILDER_GITHUB_TOKEN : ${{ secrets.READ_ONLY_TOKEN_GITHUB }}


### PR DESCRIPTION
Resolves #12182

---
`.ci/update-github-page.sh` makes this `PATCH` request:
https://github.com/checkstyle/checkstyle/blob/c2e84c5bd0a5ac9169df7c056be9f13233efd651/.ci/update-github-page.sh#L92

This corresponds to [Update a release - `PATCH /repos/{owner}/{repo}/releases/{release_id}`](https://docs.github.com/en/rest/releases/releases#update-a-release)

Checking the [Permissions required for GitHub Apps for `Releases`](https://docs.github.com/en/rest/overview/permissions-required-for-github-apps#releases), this one in particular requires `write` access for `contents`. Supported by this [StackOverflow answer](https://stackoverflow.com/a/69941765/9553927):
![Screenshot from 2022-11-14 13-54-54](https://user-images.githubusercontent.com/23459549/201675331-b4838d8d-c241-4a32-ac0f-03ebd375cbd2.png)



Without `permissions`: https://github.com/stoyanK7/checkstyle/actions/runs/3461934840/jobs/5780172729#step:3:179
With `permissions`: https://github.com/stoyanK7/checkstyle/actions/runs/3461951248/jobs/5780209440#step:3:180
The release: https://github.com/stoyanK7/checkstyle/releases/tag/checkstyle-10.3