### PR TITLE
Issue #12169: Fix failure to publish github release notes ' R: Publish GitHub Page'

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -1193,6 +1193,7 @@ rpmfind
 rq
 Rrridden
 RRRR
+Rsa
 rtc
 Rtl
 ru

--- a/.ci/update-github-page.sh
+++ b/.ci/update-github-page.sh
@@ -72,24 +72,24 @@ CONTENT=$(cat github_post.txt)
 echo "$CONTENT"
 
 echo 'Updating content to be be json value friendly'
-UPDATED_CONTENT=$(awk '{printf "%s\\n", $0}' github_post.txt |  sed "s/\`/'/g")
+UPDATED_CONTENT=$(awk '{printf "%s\n", $0}' github_post.txt | jq -Rsa .)
 echo "$UPDATED_CONTENT"
 
 RELEASE_ID=$(cat /var/tmp/cs-releases.json | jq -r ".[$TARGET_RELEASE_INDEX].id")
 echo RELEASE_ID="$RELEASE_ID"
 
-JSON=$(cat <<EOF
+cat <<EOF > body.json
 {
 "tag_name": "checkstyle-${TARGET_VERSION}",
-"body": "${UPDATED_CONTENT}"
+"body": ${UPDATED_CONTENT}
 }
 EOF
-)
-echo "$JSON"
+echo "JSON Body"
+cat body.json
 
 echo "Updating Github tag page"
 curl --fail-with-body \
   -X PATCH https://api.github.com/repos/checkstyle/checkstyle/releases/"$RELEASE_ID" \
   -H "Accept: application/vnd.github+json" \
   -H "Authorization: token $GITHUB_TOKEN" \
-  -d "${JSON}"
+  --data @body.json


### PR DESCRIPTION
Resolves #12169 and in particular https://github.com/checkstyle/checkstyle/issues/12169#issuecomment-1239374997

---
[The JSON](https://github.com/checkstyle/checkstyle/actions/runs/3007875786/jobs/4830931730#step:3:193) had unescaped `"` characters:
![Screenshot from 2022-11-14 21-11-43](https://user-images.githubusercontent.com/23459549/201756183-6e6076d6-dff6-4ed6-87eb-09b9ebe39299.png)

We just swap them with single-quote `'` like with backticks.
