### PR TITLE
infra: remove releasenotes-gen from circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,9 +201,6 @@ workflows:
       - validate-with-script:
           name: "checkchmod"
           command: "./.ci/checkchmod.sh"
-      - validate-with-script:
-          name: "releasenotes-gen"
-          command: "./.ci/releasenotes-gen.sh"
 
   javac-validation:
     jobs:


### PR DESCRIPTION
releasenotes-gen job is failing without github token, we have a PR to re-enable this job in another CI at https://github.com/checkstyle/checkstyle/pull/12401, but that PR may take some time. Better to disable this since it will constantly fail anyway in repo branches (master, dependabot, etc., not from forked PRs).