### PR TITLE
infra: remove nondex from codeship

### DIFF
--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -6,5 +6,4 @@
   service: system
   steps:
     # -  command: ./.ci/validation.sh site
-    -  command: ./.ci/validation.sh nondex
     -  command: ls -la


### PR DESCRIPTION
We do not need redundancy in nondex, build is failing in codeship on master branch now: https://app.codeship.com/projects/67b814a0-8fee-0133-9b59-02a170289b8c/builds/41483c48-ab4c-46ea-a410-46a750e6a5d0?component=step_parallel_.%2F.ci%2Fvalidation.sh_nondex