### PR TITLE
infra: remove --fail-with-body from no_old_refs.sh and add suppression

### DIFF
--- a/.ci/no_old_refs.sh
+++ b/.ci/no_old_refs.sh
@@ -38,7 +38,7 @@ for MENTIONED_ISSUES_GREP_OUTPUT_LINE in $(cat $MENTIONED_ISSUES_GREP_OUTPUT); d
 
   LINK="$GITHUB_HOST/$MAIN_REPO/blob/$DEFAULT_BRANCH/$FILE_PATH#L$LINE_NUMBER"
 
-  STATE=$(curl --fail-with-body -s -H \
+  STATE=$(curl -s -H \
    "Authorization: token $GITHUB_TOKEN" "$API_GITHUB_PREFIX/$ISSUE" \
    | jq '.state' | xargs)
   if [ "$STATE" = "closed" ]; then

--- a/config/checkstyle_non_main_files_suppressions.xml
+++ b/config/checkstyle_non_main_files_suppressions.xml
@@ -158,5 +158,6 @@
   <suppress id="properCurlCommand" files=".ci[\\/]run-link-check-plugin\.sh"/>
   <!-- other images that do not support newer curl commands -->
   <suppress id="properCurlCommand" files=".ci[\\/]sonar_break_build\.sh"/>
+  <suppress id="properCurlCommand" files=".ci[\\/]no_old_refs\.sh"/>
 
 </suppressions>


### PR DESCRIPTION
Noted at https://github.com/checkstyle/checkstyle/actions/runs/3474029994/jobs/5806727798, we found another old version of curl :)