### PR TITLE
infra: move token check into releasenotes-gen.sh

### DIFF
--- a/.ci/releasenotes-gen.sh
+++ b/.ci/releasenotes-gen.sh
@@ -6,6 +6,12 @@
 
 set -e
 
+if [ -z "$READ_ONLY_TOKEN" ]; then
+  echo "'READ_ONLY_TOKEN' not found, exiting..."
+  sleep 5s;
+  exit 1;
+fi
+
 echo "PULL_REQUEST:""$PULL_REQUEST"
 if [[ $PULL_REQUEST =~ ^([0-9]+)$ ]]; then
   echo "Build is not for Pull Request";

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -6,5 +6,4 @@
   service: system
   steps:
     -  command: ls -la
-    -  command: if [ -z $READ_ONLY_TOKEN ]; then echo "token not found" && false; fi;
     -  command: ./.ci/releasenotes-gen.sh


### PR DESCRIPTION
codeship does not like `if` command in yaml file, this PR moves it to release notes script (it should be there anyway to check for existence of token before proceeding). See https://app.codeship.com/projects/67b814a0-8fee-0133-9b59-02a170289b8c/builds/d1f69a08-b1da-46aa-a7f7-6780a76fc829?component=step_parallel_.%2F.ci%2Freleasenotes-gen.sh