### PR TITLE
infra: update codeship image to latest jdk-11-groovy-git-mvn

### DIFF
--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -1,5 +1,5 @@
 system:
-  image: checkstyle/maven-builder-image:latest
+  image: checkstyle/jdk-11-groovy-git-mvn:11.0.13__3.0.9__2.25.1__3.6.3
   volumes:
     - .:/usr/local/checkstyle
   encrypted_env_file:


### PR DESCRIPTION
Noticed at https://app.codeship.com/projects/67b814a0-8fee-0133-9b59-02a170289b8c/builds/6cdaaf52-f4fc-428d-b94e-0bfd445160bf?component=step_parallel_.%2F.ci%2Freleasenotes-gen.sh&log=8c83cc9d-c27e-4bf8-9808-411b9bb6274e_8, it looks like job is failing since image specified is based on jdk8