### PR TITLE
Issue #12081: Add Github action 'Copy site to sourceforge'

### DIFF
--- a/.ci/jsoref-spellchecker/whitelist.words
+++ b/.ci/jsoref-spellchecker/whitelist.words
@@ -769,6 +769,7 @@ KDoc
 keygen
 keyname
 keyrings
+keyscan
 Kochurkin
 konstantinos
 Kordas

--- a/.github/workflows/copy_site_to_sourceforge.yml
+++ b/.github/workflows/copy_site_to_sourceforge.yml
@@ -1,0 +1,33 @@
+#############################################################################
+# GitHub Action to Copy Site to SourceForge.
+#
+#############################################################################
+name: "R: Copy Site to SourceForge"
+on:
+  workflow_dispatch:
+    inputs:
+      release-version:
+        description: 'Release Version without (-SNAPSHOT)'
+        required: true
+jobs:
+  copy-site:
+    name: Copy site to sourceforge for ${{ github.event.inputs.release-version }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the latest code
+        uses: actions/checkout@v3
+
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh/
+          eval `ssh-agent -s`
+          echo "${{ secrets.SSH_KEY }}" > ~/.ssh/private_sourceforge_key
+          chmod 400 ~/.ssh/private_sourceforge_key
+          ssh-add ~/.ssh/private_sourceforge_key
+          ssh-keyscan -t ed25519 shell.sourceforge.net >> ~/.ssh/known_hosts
+
+      - name: Run Shell Script
+        env:
+          SF_USER: ${{ secrets.SF_USER }}
+        run: |
+          ./.ci/copy-site-to-sourceforge.sh ${{ github.event.inputs.release-version }}


### PR DESCRIPTION
Resolves #12081

---
The job: https://github.com/stoyanK7/checkstyle/actions/runs/3488545560/jobs/5837520525

Even though it failed, the files got uploaded and are accessible at https://stoyank-checkstyle.sourceforge.io.
The job failed on the archiving part since (I suspect) there is some internal folder structure that I need to set up manually once before running the script for the first time. `htdocs-version`, `htdocs/version` folders and so on..

We introduce two new secrets:
 - `SF_USER` - SourceForge username for login
 - `SSH_KEY`(Probably better to name it `SF_SSH_KEY`) - Private SSH key to access SourceForge. Public one has to be placed here https://sourceforge.net/auth/shell_services