### PR TITLE
infra: move release note generation to github action

### DIFF
--- a/.github/workflows/releasenotes-gen.yml
+++ b/.github/workflows/releasenotes-gen.yml
@@ -1,0 +1,18 @@
+name: "Generate release notes"
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download checkstyle
+        uses: actions/checkout@v3
+
+      - name: Generate release notes
+        env:
+          READ_ONLY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./.ci/releasenotes-gen.sh

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ or set of validation rules (best practices).
 [![][mavenbadge img]][mavenbadge]
 [![][sonar img]][sonar]
 
+[![][release notes/version img]][release notes/version]
+
 [![][closed issues img]][closed issues]
 [![][link check img]][link check]
 
@@ -182,6 +184,9 @@ are in the file named "LICENSE.apache20" in this directory.
 
 [closed issues]:https://github.com/checkstyle/checkstyle/actions/workflows/no_old_refs.yml
 [closed issues img]:https://github.com/checkstyle/checkstyle/actions/workflows/no_old_refs.yml/badge.svg
+
+[release notes/version]:https://github.com/checkstyle/checkstyle/actions/workflows/releasenotes-gen.yml
+[release notes/version img]:https://github.com/checkstyle/checkstyle/actions/workflows/releasenotes-gen.yml
 
 [link check]:https://github.com/checkstyle/checkstyle/actions/workflows/run_link_check.yml
 [link check img]:https://github.com/checkstyle/checkstyle/actions/workflows/run_link_check.yml/badge.svg


### PR DESCRIPTION
Moving release note generation to github actions, as codeship UI is not great and codeship requires a bunch of extra steps to check repo out, etc.
BUT main problem is that codeship UI isnot mobile browser friendly that make it impossible to use, but unfortunately for this job we need good support to let us read printed content.

This PR is on a repo branch so that we can test it before merging.

------------------------
Results of testing: https://github.com/checkstyle/checkstyle/actions/workflows/releasenotes-gen.yml

We can see that runs 4 and 5 failed from PRs/issues that did not have a label (as expected), and run 6 succeeded after I added the labels.

