### PR TITLE
infra: mostly disable codeship

### DIFF
--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -2,5 +2,3 @@ system:
   image: checkstyle/jdk-11-groovy-git-mvn:11.0.13__3.0.9__2.25.1__3.6.3
   volumes:
     - .:/usr/local/checkstyle
-  encrypted_env_file:
-    - codeship.encrypted

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -6,4 +6,3 @@
   service: system
   steps:
     -  command: ls -la
-    -  command: ./.ci/releasenotes-gen.sh

--- a/codeship.encrypted
+++ b/codeship.encrypted
@@ -1,2 +1,0 @@
-codeship:v2
-qEu3UX/OUVzRKHixymV7h0eNur13iFIyrLCkCLIN6AQRLL/aAwg4GVLPXUn8Jl7L3VSfLO6qW2dJyPOxqAeDdnxEXpbNcFArcJ/UlKla1o4Q7nRTkuQrYZLP+etp3f8pHxuRabWysQky

--- a/config/checkstyle_non_main_files_suppressions.xml
+++ b/config/checkstyle_non_main_files_suppressions.xml
@@ -52,9 +52,6 @@
   <suppress checks="NewlineAtEndOfFile"
             files="config[\\/]archunit-store[\\/]slices_should_be_free_of_cycles_suppressions"/>
 
-  <!-- encrypted file is generated, we should not append newline -->
-  <suppress checks="NewlineAtEndOfFile" files="codeship.encrypted"/>
-
   <!-- till https://issues.apache.org/jira/browse/MRELEASE-1008 -->
   <suppress id="lineLength" files="pom.xml"/>
   <!-- this file cannot be line wraped -->
@@ -111,9 +108,6 @@
 
   <!-- We will preserve formatting of archived release notes -->
   <suppress id="lineLength" files="[\\/]releasenotes_old_8\-0_8\-34\.xml"/>
-
-  <!-- encrypted secrets cannot be line wrapped -->
-  <suppress id="lineLength" files="codeship.encrypted"/>
 
   <!-- apply check numberOfTestCasesInXpath only for files in suppressionxpathfilter directory -->
   <suppress id="numberOfTestCasesInXpath"


### PR DESCRIPTION
Codeship is painful to deal with for a number of reasons (bad UI, etc.). We have moved release notes generation to github action at https://github.com/checkstyle/checkstyle/pull/12421, so we should clean up and remove it and related changes from codeship. We will keep `ls -la` running to make sure we keep resources available if we need them.