### PR TITLE
Issue #12186: Investigate change in behavior of ANTLR4 ErrorListener/Lexer

### DIFF
--- a/.ci/pitest-suppressions/pitest-common-2-suppressions.xml
+++ b/.ci/pitest-suppressions/pitest-common-2-suppressions.xml
@@ -180,13 +180,4 @@
     <lineContent>inputSource = super.resolveEntity(publicId, systemId);</lineContent>
   </mutation>
 
-  <!-- until https://github.com/checkstyle/checkstyle/issues/12186 -->
-  <mutation unstable="false">
-    <sourceFile>JavaParser.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.JavaParser</mutatedClass>
-    <mutatedMethod>parse</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/grammar/java/JavaLanguageLexer::removeErrorListeners</description>
-    <lineContent>lexer.removeErrorListeners();</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire.options />
     <projectVersion>${project.version}</projectVersion>
-    <antlr4.version>4.11.1</antlr4.version>
+    <antlr4.version>4.10.1</antlr4.version>
     <maven.site.plugin.version>3.12.1</maven.site.plugin.version>
     <maven.spotbugs.plugin.version>4.7.2.1</maven.spotbugs.plugin.version>
     <maven.pmd.plugin.version>3.19.0</maven.pmd.plugin.version>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/JavaParser.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/JavaParser.java
@@ -85,7 +85,6 @@ public final class JavaParser {
         final CharStream codePointCharStream = CharStreams.fromString(fullText);
         final JavaLanguageLexer lexer = new JavaLanguageLexer(codePointCharStream, true);
         lexer.setCommentListener(contents);
-        lexer.removeErrorListeners();
 
         final CommonTokenStream tokenStream = new CommonTokenStream(lexer);
         final JavaLanguageParser parser =


### PR DESCRIPTION
#12186 

Looks to be a bug on the ANTLR side, `line 2:2 token recognition error at: '#'` should still print if we do not remove error listeners. Some research in the antlr repo has not led to a clear reason why this error message doesn't print anymore.

https://github.com/antlr/antlr4/blob/b5648f405b746d87ec559132ad1939fb6d402053/runtime/Java/src/org/antlr/v4/runtime/ProxyErrorListener.java#L40

Need to investigate a bit more