### PR TITLE
minor: remove drone badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ or set of validation rules (best practices).
 [![][snyk img]][snyk]
 [![][semaphoreci img]][semaphoreci]
 [![][azure img]][azure]
-[![][drone img]][drone]
 [![][error prone img]][error prone]
 [![][pitest img]][pitest]
 [![][checker framework img]][checker framework]
@@ -178,9 +177,6 @@ are in the file named "LICENSE.apache20" in this directory.
 
 [dependabot]:https://dependabot.com
 [dependabot img]:https://api.dependabot.com/badges/status?host=github&repo=checkstyle/checkstyle
-
-[drone]:https://cloud.drone.io/checkstyle/checkstyle
-[drone img]:https://cloud.drone.io/api/badges/checkstyle/checkstyle/status.svg
 
 [closed issues]:https://github.com/checkstyle/checkstyle/actions/workflows/no_old_refs.yml
 [closed issues img]:https://github.com/checkstyle/checkstyle/actions/workflows/no_old_refs.yml/badge.svg


### PR DESCRIPTION
Leftovers from https://github.com/checkstyle/checkstyle/commit/87cdbdc8aa3743ae61eab68ccf96aa2495635a4b and other drone migration related tasks

Also:
```
➜  checkstyle git:(master) ✗ ag -Q "drone"
src/xdocs/releasenotes.xml
1868:            minor: fix drone build by excluding archives from line length check.
1892:            Use cache for maven dependencies to speed up drone io builds.
4246:            Test more project on drone.io.

README.md
14:[![][drone img]][drone]
182:[drone]:https://cloud.drone.io/checkstyle/checkstyle
183:[drone img]:https://cloud.drone.io/api/badges/checkstyle/checkstyle/status.svg


```

```
➜  checkstyle git:(remove-badge) ✗ ag -Q "drone"               
src/xdocs/releasenotes.xml
1868:            minor: fix drone build by excluding archives from line length check.
1892:            Use cache for maven dependencies to speed up drone io builds.
4246:            Test more project on drone.io.
➜  checkstyle git:(remove-badge) ✗ 

```

