### PR TITLE
minor: extract Set declaration

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/AbstractCheckTest.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedSet;
 
 import org.junit.jupiter.api.Test;
@@ -397,7 +398,8 @@ public class AbstractCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testTokensAreUnmodifiable() {
         final DummyAbstractCheck check = new DummyAbstractCheck();
-        assertThrows(UnsupportedOperationException.class, () -> check.getTokenNames().add(""));
+        final Set<String> tokenNameSet = check.getTokenNames();
+        assertThrows(UnsupportedOperationException.class, () -> tokenNameSet.add(""));
     }
 
     public static final class DummyAbstractCheck extends AbstractCheck {


### PR DESCRIPTION
See https://sonarcloud.io/organizations/checkstyle/rules?open=java%3AS5778&rule_key=java%3AS5778 for details.

>When verifying that code raises a runtime exception, a good practice is to avoid having multiple method calls inside the tested code, to be explicit about which method call is expected to raise the exception.

![image](https://user-images.githubusercontent.com/31252532/203220389-8517cac4-756a-4403-aee1-e776ceb2f679.png)
