### PR TITLE
minor: refactor to use 'ToIntFunction' interface

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/FinalClassCheck.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.ToIntFunction;
 
 import com.puppycrawl.tools.checkstyle.FileStatefulCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
@@ -271,7 +272,7 @@ public class FinalClassCheck
                                                            ClassDesc currentClass) {
         final String superClassName = getSuperClassName(currentClass.getTypeDeclarationAst());
         if (superClassName != null) {
-            final Function<ClassDesc, Integer> nestedClassCountProvider = classDesc -> {
+            final ToIntFunction<ClassDesc> nestedClassCountProvider = classDesc -> {
                 return CheckUtil.typeDeclarationNameMatchingCount(qualifiedClassName,
                                                                   classDesc.getQualifiedName());
             };
@@ -294,7 +295,7 @@ public class FinalClassCheck
                                                          String outerTypeDeclName) {
         final String superClassName = CheckUtil.getShortNameOfAnonInnerClass(literalNewAst);
 
-        final Function<ClassDesc, Integer> anonClassCountProvider = classDesc -> {
+        final ToIntFunction<ClassDesc> anonClassCountProvider = classDesc -> {
             return getAnonSuperTypeMatchingCount(outerTypeDeclName, classDesc.getQualifiedName());
         };
         getNearestClassWithSameName(superClassName, anonClassCountProvider)
@@ -342,9 +343,9 @@ public class FinalClassCheck
      *      pitest to fail
      */
     private Optional<ClassDesc> getNearestClassWithSameName(String className,
-        Function<ClassDesc, Integer> countProvider) {
+        ToIntFunction<ClassDesc> countProvider) {
         final String dotAndClassName = PACKAGE_SEPARATOR.concat(className);
-        final Comparator<ClassDesc> longestMatch = Comparator.comparingInt(countProvider::apply);
+        final Comparator<ClassDesc> longestMatch = Comparator.comparingInt(countProvider);
         return innerClasses.entrySet().stream()
                 .filter(entry -> entry.getKey().endsWith(dotAndClassName))
                 .map(Map.Entry::getValue)


### PR DESCRIPTION
See https://sonarcloud.io/project/issues?issues=AYFDh7epvqZP8r4qP3BS&open=AYFDh7epvqZP8r4qP3BS&id=org.checkstyle%3Acheckstyle for more details.

>The java.util.function package provides a large array of functional interface definitions for use in lambda expressions and method references. In general it is recommended to use the more specialised form to avoid auto-boxing. For instance IntFunction<Foo> should be preferred over Function<Integer, Foo>.

![image](https://user-images.githubusercontent.com/31252532/203221646-50727d05-991d-49db-a1b1-069d20199577.png)
