### PR TITLE
Issue #12441: Resolve Pitest suppression for RightCurlyCheck

### DIFF
--- a/config/pitest-suppressions/pitest-blocks-suppressions.xml
+++ b/config/pitest-suppressions/pitest-blocks-suppressions.xml
@@ -138,15 +138,6 @@
   <mutation unstable="false">
     <sourceFile>RightCurlyCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck$Details</mutatedClass>
-    <mutatedMethod>getDetailsForIfElse</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck$Details::getNextToken</description>
-    <lineContent>nextToken = getNextToken(ast);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>RightCurlyCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyCheck$Details</mutatedClass>
     <mutatedMethod>getDetailsForOthers</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
     <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getFirstChild with receiver</description>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
@@ -649,4 +649,14 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         verifyWithInlineConfigParser(
                 getPath("InputRightCurlyWithUppercaseOptionProperty.java"), expected);
     }
+
+    @Test
+    public void testRightCurlyWithIfElseAlone() throws Exception {
+        final String[] expected = {
+            "19:12: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 12),
+            "27:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputRightCurlyTestIfElseAlone.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestIfElseAlone.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestIfElseAlone.java
@@ -1,0 +1,32 @@
+/*
+RightCurly
+option = ALONE
+tokens = LITERAL_IF, LITERAL_ELSE
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyTestIfElseAlone {
+
+    public void test() {
+       int id = 0;
+       switch (id) {
+           case 0: break;
+           case 1: if (1 == 0) {
+               break;
+           }; // violation ''}' at column 12 should be alone on a line.'
+           case 2: break;
+       }
+    }
+
+    public void test2() {
+        if(true) {
+
+        } if(false) { // violation ''}' at column 9 should be alone on a line.'
+
+        }
+    }
+
+}


### PR DESCRIPTION
Issue #12441: Resolve Pitest suppression for RightCurlyCheck

Diff Regression config: https://gist.githubusercontent.com/arinmodi/3cf085f17de7e31a5089c43182f45eec/raw/37bb6fa0f32abfc98f35ebad85ec603fb89e665e/config2.xml