### PR TITLE
infra: remove --fail-with-body from pr-description.sh

### DIFF
--- a/.ci/pr-description.sh
+++ b/.ci/pr-description.sh
@@ -4,7 +4,7 @@ set -e
 
 if [[ ! $PULL_REQUEST =~ ^([0-9]*)$ ]]; then exit 0; fi
 LINK_COMMITS=https://api.github.com/repos/checkstyle/checkstyle/pulls/$PULL_REQUEST/commits
-COMMITS=$(curl --fail-with-body -s -H "Authorization: token $READ_ONLY_TOKEN" "$LINK_COMMITS" \
+COMMITS=$(curl -s -H "Authorization: token $READ_ONLY_TOKEN" "$LINK_COMMITS" \
              | jq '.[0] | .commit.message')
 echo 'Commit messages from github: '"${COMMITS:0:60}"...
 ISSUE_NUMBER=$(echo "$COMMITS" | sed -e 's/^.*Issue //' | sed -e 's/:.*//')
@@ -13,7 +13,7 @@ if [[ $ISSUE_NUMBER =~ ^#[0-9]+$ ]]; then
     LINK_PR=https://api.github.com/repos/checkstyle/checkstyle/pulls/$PULL_REQUEST
     LINK_ISSUE=https://api.github.com/repos/checkstyle/checkstyle/issues/${ISSUE_NUMBER:1}
     REGEXP=($ISSUE_NUMBER\|https://github.com/checkstyle/checkstyle/issues/${ISSUE_NUMBER:1})
-    PR_DESC=$(curl --fail-with-body -s -H "Authorization: token $READ_ONLY_TOKEN" "$LINK_PR" \
+    PR_DESC=$(curl -s -H "Authorization: token $READ_ONLY_TOKEN" "$LINK_PR" \
                 | jq '.body' | grep -E "$REGEXP" | cat )
     echo 'PR Description grepped:'"${PR_DESC:0:80}"
     if [[ -z $PR_DESC ]]; then
@@ -21,7 +21,7 @@ if [[ $ISSUE_NUMBER =~ ^#[0-9]+$ ]]; then
          echo 'this will bind the Issue to your PR in Github'
          RESULT=1;
        fi
-    LABEL_APRV=$(curl --fail-with-body -s -H "Authorization: token $READ_ONLY_TOKEN" "$LINK_ISSUE" \
+    LABEL_APRV=$(curl -s -H "Authorization: token $READ_ONLY_TOKEN" "$LINK_ISSUE" \
                    | jq '.labels [] | .name' | grep approved | cat | wc -l )
     if [[ $LABEL_APRV == 0 ]]; then
          echo 'You are providing a PR for an Issue that is not approved yet,'

--- a/config/checkstyle_non_main_files_suppressions.xml
+++ b/config/checkstyle_non_main_files_suppressions.xml
@@ -156,8 +156,9 @@
   <!-- azure does not support this curl command -->
   <suppress id="properCurlCommand" files=".ci[\\/]test-spelling-unknown-words\.sh"/>
   <suppress id="properCurlCommand" files=".ci[\\/]run-link-check-plugin\.sh"/>
-  <!-- other images that do not support newer curl commands -->
+  <!-- other images that do not support newer curl commands until #12451 -->
   <suppress id="properCurlCommand" files=".ci[\\/]sonar_break_build\.sh"/>
   <suppress id="properCurlCommand" files=".ci[\\/]no_old_refs\.sh"/>
+  <suppress id="properCurlCommand" files=".ci[\\/]pr-description\.sh"/>
 
 </suppressions>


### PR DESCRIPTION
Noticed at https://github.com/checkstyle/checkstyle/actions/runs/3531403281/jobs/5924533074, check of PR description was silently failing.

```
0s
Run ./.ci/pr-description.sh
curl: option --fail-with-body: is unknown
curl: try 'curl --help' or 'curl --manual' for more information
Commit messages from github: ...
Issue number: 
PR validation succeeded.
```