### PR TITLE
Issue #12456: Remove new curl parameter from all GitHub actions for release

### DIFF
--- a/.ci/close-create-milestone.sh
+++ b/.ci/close-create-milestone.sh
@@ -7,10 +7,10 @@ source ./.ci/util.sh
 checkForVariable "GITHUB_TOKEN"
 
 echo "Close previous milestone at github"
-MILESTONE_ID=$(curl --fail-with-body -s \
+MILESTONE_ID=$(curl -s \
                 -X GET https://api.github.com/repos/checkstyle/checkstyle/milestones?state=open \
                 | jq ".[0] | .number")
-curl --fail-with-body -i -H "Authorization: token $GITHUB_TOKEN" \
+curl -i -H "Authorization: token $GITHUB_TOKEN" \
   -d "{ \"state\": \"closed\" }" \
   -X PATCH https://api.github.com/repos/checkstyle/checkstyle/milestones/"$MILESTONE_ID"
 
@@ -26,7 +26,7 @@ LAST_SUNDAY_DAY=$(cal -d "$(date -d "next month" +"%Y-%m")" \
 LAST_SUNDAY_DATETIME=$(date -d "next month" +"%Y-%m")"-$LAST_SUNDAY_DAY""T08:00:00Z"
 echo "$LAST_SUNDAY_DATETIME"
 
-curl --fail-with-body -i -H "Authorization: token $GITHUB_TOKEN" \
+curl -i -H "Authorization: token $GITHUB_TOKEN" \
   -d "{ \"title\": \"$CURRENT_VERSION\", \
         \"state\": \"open\", \
         \"description\": \"\", \

--- a/.ci/creation-of-issue-in-other-repos.sh
+++ b/.ci/creation-of-issue-in-other-repos.sh
@@ -16,14 +16,14 @@ TARGET_VERSION=$1
 echo TARGET_VERSION="$TARGET_VERSION"
 
 echo "Creation of issue in eclipse-cs repo ..."
-curl --fail-with-body -i -H "Authorization: token $GITHUB_TOKEN" \
+curl -i -H "Authorization: token $GITHUB_TOKEN" \
   -d "{ \"title\": \"upgrade to checkstyle $TARGET_VERSION\", \
         \"body\": \"https://checkstyle.org/releasenotes.html#Release_$TARGET_VERSION\" \
         }" \
   -X POST https://api.github.com/repos/checkstyle/eclipse-cs/issues
 
 echo "Creation of issue in sonar-checkstyle repo ..."
-curl --fail-with-body -i -H "Authorization: token $GITHUB_TOKEN" \
+curl -i -H "Authorization: token $GITHUB_TOKEN" \
   -d "{ \"title\": \"upgrade to checkstyle $TARGET_VERSION\", \
         \"body\": \"https://checkstyle.org/releasenotes.html#Release_$TARGET_VERSION\" \
         }" \

--- a/.ci/releasenotes-gen-xdoc-push.sh
+++ b/.ci/releasenotes-gen-xdoc-push.sh
@@ -26,7 +26,7 @@ CS_RELEASE_VERSION="$(getCheckstylePomVersion)"
 echo CS_RELEASE_VERSION="$CS_RELEASE_VERSION"
 
 cd .ci-temp/checkstyle
-LATEST_RELEASE_TAG=$(curl --fail-with-body -s \
+LATEST_RELEASE_TAG=$(curl -s \
                        https://api.github.com/repos/checkstyle/checkstyle/releases/latest \
                        | jq ".tag_name")
 echo LATEST_RELEASE_TAG="$LATEST_RELEASE_TAG"

--- a/.ci/tweet-releasenotes.sh
+++ b/.ci/tweet-releasenotes.sh
@@ -29,8 +29,7 @@ fi
 
 cd .ci-temp/checkstyle
 
-curl --fail-with-body \
- https://api.github.com/repos/checkstyle/checkstyle/releases \
+curl https://api.github.com/repos/checkstyle/checkstyle/releases \
  -H "Authorization: token $GITHUB_READ_ONLY_TOKEN" \
  -o /var/tmp/cs-releases.json
 

--- a/.ci/update-github-milestone.sh
+++ b/.ci/update-github-milestone.sh
@@ -16,14 +16,14 @@ TARGET_VERSION=$1
 echo TARGET_VERSION="$TARGET_VERSION"
 
 echo "Updating milestone at github"
-MILESTONE_ID=$(curl --fail-with-body -s \
+MILESTONE_ID=$(curl -s \
                 -X GET https://api.github.com/repos/checkstyle/checkstyle/milestones?state=open \
                 | jq ".[0] | .number")
 
 echo TARGET_VERSION="$TARGET_VERSION"
 echo MILESTONE_ID="$MILESTONE_ID"
 
-curl --fail-with-body \
+curl \
   -X PATCH https://api.github.com/repos/checkstyle/checkstyle/milestones/"$MILESTONE_ID" \
   -H "Authorization: token $GITHUB_TOKEN" \
   -d "{ \"title\": \"$TARGET_VERSION\" }"

--- a/.ci/update-github-page.sh
+++ b/.ci/update-github-page.sh
@@ -33,8 +33,7 @@ fi
 
 cd .ci-temp/checkstyle
 
-curl --fail-with-body \
- https://api.github.com/repos/checkstyle/checkstyle/releases \
+curl https://api.github.com/repos/checkstyle/checkstyle/releases \
  -H "Authorization: token $GITHUB_TOKEN" \
  -o /var/tmp/cs-releases.json
 
@@ -88,7 +87,7 @@ echo "JSON Body"
 cat body.json
 
 echo "Updating Github tag page"
-curl --fail-with-body \
+curl \
   -X PATCH https://api.github.com/repos/checkstyle/checkstyle/releases/"$RELEASE_ID" \
   -H "Accept: application/vnd.github+json" \
   -H "Authorization: token $GITHUB_TOKEN" \

--- a/.ci/upload-all-jar.sh
+++ b/.ci/upload-all-jar.sh
@@ -22,12 +22,12 @@ mvn -e --no-transfer-progress -Passembly package
 
 echo "Publishing 'all' jar to Github"
 UPLOAD_LINK=https://uploads.github.com/repos/checkstyle/checkstyle/releases
-RELEASE_ID=$(curl --fail-with-body -s -X GET \
+RELEASE_ID=$(curl -s -X GET \
   https://api.github.com/repos/checkstyle/checkstyle/releases/tags/checkstyle-"$TARGET_VERSION" \
   | jq ".id")
 
 
-curl --fail-with-body -i -H "Authorization: token $GITHUB_TOKEN" \
+curl -i -H "Authorization: token $GITHUB_TOKEN" \
   -H "Content-Type: application/zip" \
   --data-binary @"target/checkout/target/checkstyle-$TARGET_VERSION-all.jar" \
   -X POST "$UPLOAD_LINK"/"$RELEASE_ID"/assets?name=checkstyle-"$TARGET_VERSION"-all.jar

--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -351,7 +351,7 @@ verify-no-exception-configs)
     if [[ $PULL_REQUEST =~ ^([0-9]+)$ ]]; then
       LINK_PR=https://api.github.com/repos/checkstyle/checkstyle/pulls/$PULL_REQUEST
       REGEXP="https://github.com/checkstyle/contribution/pull/"
-      PR_DESC=$(curl --fail-with-body -s -H "Authorization: token $READ_ONLY_TOKEN" "$LINK_PR" \
+      PR_DESC=$(curl -s -H "Authorization: token $READ_ONLY_TOKEN" "$LINK_PR" \
                   | jq '.body' | grep $REGEXP | cat )
       echo 'PR Description grepped:'"${PR_DESC:0:180}"
       if [[ -z $PR_DESC ]]; then

--- a/config/checkstyle_non_main_files_suppressions.xml
+++ b/config/checkstyle_non_main_files_suppressions.xml
@@ -160,5 +160,12 @@
   <suppress id="properCurlCommand" files=".ci[\\/]sonar_break_build\.sh"/>
   <suppress id="properCurlCommand" files=".ci[\\/]no_old_refs\.sh"/>
   <suppress id="properCurlCommand" files=".ci[\\/]pr-description\.sh"/>
+  <suppress id="properCurlCommand" files=".ci[\\/]close-create-milestone\.sh"/>
+  <suppress id="properCurlCommand" files=".ci[\\/]tweet-releasenotes\.sh"/>
+  <suppress id="properCurlCommand" files=".ci[\\/]upload-all-jar\.sh"/>
+  <suppress id="properCurlCommand" files=".ci[\\/]update-github-page\.sh"/>
+  <suppress id="properCurlCommand" files=".ci[\\/]update-github-milestone\.sh"/>
+  <suppress id="properCurlCommand" files=".ci[\\/]releasenotes-gen-xdoc-push\.sh"/>
+  <suppress id="properCurlCommand" files=".ci[\\/]creation-of-issue-in-other-repos\.sh"/>
 
 </suppressions>


### PR DESCRIPTION
Resolves #12456 

---
I have left `sonar`, `drone-io`, `travis` and `release` untouched:
![Screenshot from 2022-11-26 09-10-10](https://user-images.githubusercontent.com/23459549/204079901-4fa9e592-89df-4856-97ca-bc168cf785e4.png)
