### PR TITLE
Issue #12463: adds enforcement of executables in ci folder

### DIFF
--- a/config/checkstyle_non_main_files_checks.xml
+++ b/config/checkstyle_non_main_files_checks.xml
@@ -15,6 +15,16 @@
   </module>
   <!-- Miscellaneous -->
   <module name="NewlineAtEndOfFile" />
+
+  <module name="RegexpOnFilename">
+    <property name="id" value="executablesLocation"/>
+    <property name="folderPattern" value="[\\/].ci([\\/]|$)"/>
+    <property name="fileNamePattern" value="\.(bat|cmd|groovy|sh|md)$"/>
+    <property name="match" value="false"/>
+    <message key="regexp.filename.mismatch"
+      value="CI folder should only contain executables files"/>
+  </module>
+
   <module name="RegexpSingleline">
     <property name="id" value="lineLength"/>
     <!-- catch lines above 100 symbols -->


### PR DESCRIPTION
Issue #12463

Copied a file over to CI and ran this on my local:
````
[INFO] --- maven-antrun-plugin:3.1.0:run (ant-phase-verify) @ checkstyle ---
[INFO] Executing tasks
[INFO]      [echo] Checkstyle started (checkstyle_checks.xml): 28/11/2022 09:36:15 PM
[INFO] [checkstyle] Running Checkstyle  on 1496 files
[INFO]      [echo] Checkstyle finished (checkstyle_checks.xml) : 28/11/2022 09:36:18 PM
[INFO]      [echo] Checkstyle started (checkstyle_non_main_files_checks.xml): 28/11/2022 09:36:15 PM
[INFO] [checkstyle] Running Checkstyle  on 3500 files
[ERROR] [checkstyle] [ERROR] M:\checkstyleWorkspaceEclipse\checkstyle\.ci\catalog.xml:1: CI folder should only contain executables files [RegexpOnFilename]
````