### PR TITLE
Issue #12464: Fix 'R: Push Release Notes' failing

### DIFF
--- a/.github/workflows/update_sources.yml
+++ b/.github/workflows/update_sources.yml
@@ -20,6 +20,8 @@ jobs:
         run: |
           sudo apt-get install xmlstarlet
       - name: Run Shell Script
+        env:
+          READ_ONLY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./.ci/update-releasenotesxml.sh ${{ github.event.inputs.version }}
       - name: Commit and Push


### PR DESCRIPTION
Resolves #12464

---
Without env variable: https://github.com/stoyanK7/checkstyle/actions/runs/3577041042/jobs/6015570073#step:4:7
With env variable: https://github.com/stoyanK7/checkstyle/actions/runs/3577075268/jobs/6015645427#step:4:8