### PR TITLE
Issue #12479: 'R: Push Release Notes' failing on push

### DIFF
--- a/.github/workflows/update_sources.yml
+++ b/.github/workflows/update_sources.yml
@@ -13,6 +13,8 @@ jobs:
   releasenotes:
     name: Push releasenotes ${{ github.event.inputs.version }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout the latest code
         uses: actions/checkout@v3


### PR DESCRIPTION
Resolves #12479 

---
Without permissions: https://github.com/stoyanK7/checkstyle/actions/runs/3586321134/jobs/6035377211#step:5:11
With permissions: https://github.com/stoyanK7/checkstyle/actions/runs/3586454916/jobs/6035663797#step:5:1