### PR TITLE
infra: avoid travis package management

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,15 @@ cache:
   directories:
     - ~/.m2
 
-addons:
-  apt:
-    packages:
-      - groovy
-      - xsltproc
-      - xmlstarlet
-
 branches:
   only:
     - master
 
+before_install:
+  - sudo apt update
+
 install:
+  - sudo apt install -y groovy xsltproc xmlstarlet
   - ./.ci/travis.sh install-adoptium-jdk
   - ./.ci/travis.sh install-custom-mvn
 


### PR DESCRIPTION
Similar to https://github.com/checkstyle/contribution/pull/700#event-7956954470, avoidance of travis package management will hopefully help to stabilize travis build 