### PR TITLE
Issue #11637: Resolve shellcheck SC701

### DIFF
--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -75,7 +75,7 @@ function should_run_job {
          # Identifies if the files involved in the commits between head and previous
          # is more than the list of skippable files
          if [[ $(git diff --name-only "$HEAD" "$PREVIOUS_COMMIT" \
-                    | grep -vE "$SKIP_FILES" | cat | wc -c | sed 's/^ *//' ) > 0 ]]; then
+                    | grep -vE "$SKIP_FILES" | cat | wc -c | sed 's/^ *//' ) -gt 0 ]]; then
               SKIP_JOB_BY_FILES="false"
          else
               SKIP_JOB_BY_FILES="true"

--- a/.ci/idea_inspection.sh
+++ b/.ci/idea_inspection.sh
@@ -48,10 +48,10 @@ fi
 echo "Checking results ..."
 PROBLEM_COUNT=$(grep -R "<problems" "$RESULTS_DIR"/ | cat | wc -l )
 
-if [[ $PROBLEM_COUNT > 0 ]] && [[ "$CIRCLECI" == "true" ]]; then
+if [[ $PROBLEM_COUNT -gt 0 ]] && [[ "$CIRCLECI" == "true" ]]; then
     echo "There are inspection problems. Review results in 'ARTIFACTS' tab above."
     exit 1;
-elif [[ $PROBLEM_COUNT > 0 ]]; then
+elif [[ $PROBLEM_COUNT -gt 0 ]]; then
     echo "There are inspection problems. Review results at $RESULTS_DIR folder. Files:"
     grep -Rl "<problems" "$RESULTS_DIR"/
     exit 1;

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -7,7 +7,6 @@ disable=SC2035 # (info): Use ./glob or -- glob so names with dashes won't become
 disable=SC2016 # (info): Expressions don't expand in single quotes, use double quotes for that.
 disable=SC2185 # (info): Some finds don't have a default path. Specify '.' explicitly.
 disable=SC2155 # (warning): Declare and assign separately to avoid masking return values.
-disable=SC2071 # (error): > is for string comparisons. Use -gt instead.
 disable=SC2034 # (warning): RUN_JOB appears unused. Verify use (or export if used externally).
 disable=SC2216 # (warning): Piping to 'true', a command that doesn't read stdin.
 disable=SC2013 # (info): To read lines rather than words, pipe/redirect to a 'while read' loop.


### PR DESCRIPTION
Part Of #11637 : 

Resolves : 

```
SC2071 # (error): > is for string comparisons. Use -gt instead.
```