### PR TITLE
Issue #11604: allow 3rd party checks to print their own custom asts

### DIFF
--- a/config/checker-framework-suppressions/checker-methods-resource-fenum-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-methods-resource-fenum-suppressions.xml
@@ -2,6 +2,17 @@
 <suppressedErrors>
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
+    <specifier>method.invocation</specifier>
+    <message>call to printFileAst(java.io.File) not allowed on the given receiver.</message>
+    <lineContent>.printFileAst(file);</lineContent>
+    <details>
+      found   : @FenumTop TreeStringPrinter
+      required: @FenumUnqualified TreeStringPrinter
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
     <specifier>required.method.not.called</specifier>
     <message>@MustCall method close may not have been invoked on out or any of its aliases.</message>
     <lineContent>final OutputStream out = getOutputStream(outputLocation);</lineContent>

--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -627,6 +627,13 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
+    <message>the default constructor does not initialize field customTreePrinterClass</message>
+    <lineContent>private String customTreePrinterClass;</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
+    <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field files</message>
     <lineContent>private List&lt;File&gt; files;</lineContent>
   </checkerFrameworkError>

--- a/config/checker-framework-suppressions/checker-signature-gui-units-init-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-signature-gui-units-init-suppressions.xml
@@ -23,6 +23,17 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/Main.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter className of forName.</message>
+    <lineContent>Class.forName(options.customTreePrinterClass));</lineContent>
+    <details>
+      found   : @SignatureUnknown String
+      required: @ClassGetName String
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter name of forName.</message>

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -357,7 +357,9 @@
       <!-- Till https://github.com/checkstyle/checkstyle/issues/10064 -->
       <property name="violationSuppressXPath"
                 value="//ClassOrInterfaceDeclaration[@SimpleName='XdocsPagesTest']
-                    //MethodDeclaration[@Name='getModulePropertyExpectedValue']"/>
+                    //MethodDeclaration[@Name='getModulePropertyExpectedValue']
+                  | //ClassOrInterfaceDeclaration[@SimpleName='Main']
+                    //MethodDeclaration[@Name='runCli']"/>
     </properties>
   </rule>
 

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -76,7 +76,7 @@
                     |AbstractCheckTest)\.java"/>
   <suppress checks="ClassDataAbstractionCoupling"
              files="XpathFileGeneratorAuditListenerTest\.java"/>
-  <suppress checks="ClassFanOutComplexity" files="[\\/]Main\.java"/>
+  <suppress checks="ClassFanOutComplexity|CyclomaticComplexity" files="[\\/]Main\.java"/>
   <suppress checks="ClassFanOutComplexity" files="CheckerTest\.java"/>
   <suppress checks="ClassFanOutComplexity" files="Checker\.java"/>
   <suppress checks="ClassFanOutComplexity" files="XdocsPagesTest\.java"/>

--- a/pom.xml
+++ b/pom.xml
@@ -4452,7 +4452,9 @@
               <targetClasses>
                 <param>com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser*</param>
                 <param>com.puppycrawl.tools.checkstyle.DetailNodeTreeStringPrinter*</param>
+                <param>com.puppycrawl.tools.checkstyle.AstAndDetailNodeTreeStringPrinter*</param>
                 <param>com.puppycrawl.tools.checkstyle.AstTreeStringPrinter*</param>
+                <param>com.puppycrawl.tools.checkstyle.AstWithCommentsTreeStringPrinter*</param>
                 <param>com.puppycrawl.tools.checkstyle.SuppressionsStringPrinter*</param>
                 <param>com.puppycrawl.tools.checkstyle.TreeWalker*</param>
                 <param>com.puppycrawl.tools.checkstyle.TreeWalkerAuditEvent*</param>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/AstAndDetailNodeTreeStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/AstAndDetailNodeTreeStringPrinter.java
@@ -1,0 +1,38 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2022 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import java.io.File;
+import java.io.IOException;
+
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.TreeStringPrinter;
+
+/**
+ * Class for printing AST combined with DetailNode to String.
+ */
+public class AstAndDetailNodeTreeStringPrinter implements TreeStringPrinter {
+
+    @Override
+    public String printFileAst(File file) throws IOException, CheckstyleException {
+        return AstTreeStringPrinter.printJavaAndJavadocTree(file);
+    }
+
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinter.java
@@ -28,13 +28,14 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.api.TreeStringPrinter;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
  * Class for printing AST to String.
  */
-public final class AstTreeStringPrinter {
+public final class AstTreeStringPrinter implements TreeStringPrinter {
 
     /** Newline pattern. */
     private static final Pattern NEWLINE = Pattern.compile("\n");
@@ -46,9 +47,9 @@ public final class AstTreeStringPrinter {
     /** OS specific line separator. */
     private static final String LINE_SEPARATOR = System.lineSeparator();
 
-    /** Prevent instances. */
-    private AstTreeStringPrinter() {
-        // no code
+    @Override
+    public String printFileAst(File file) throws IOException, CheckstyleException {
+        return printFileAst(file, JavaParser.Options.WITHOUT_COMMENTS);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/AstWithCommentsTreeStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/AstWithCommentsTreeStringPrinter.java
@@ -1,0 +1,38 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2022 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle;
+
+import java.io.File;
+import java.io.IOException;
+
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.TreeStringPrinter;
+
+/**
+ * Class for printing AST with Comments to String.
+ */
+public class AstWithCommentsTreeStringPrinter implements TreeStringPrinter {
+
+    @Override
+    public String printFileAst(File file) throws IOException, CheckstyleException {
+        return AstTreeStringPrinter.printFileAst(file, JavaParser.Options.WITH_COMMENTS);
+    }
+
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinter.java
@@ -29,20 +29,21 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.DetailNode;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
+import com.puppycrawl.tools.checkstyle.api.TreeStringPrinter;
 import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
 import com.puppycrawl.tools.checkstyle.utils.ParserUtil;
 
 /**
  * Parses file as javadoc DetailNode tree and prints to system output stream.
  */
-public final class DetailNodeTreeStringPrinter {
+public final class DetailNodeTreeStringPrinter implements TreeStringPrinter {
 
     /** OS specific line separator. */
     private static final String LINE_SEPARATOR = System.getProperty("line.separator");
 
-    /** Prevent instances. */
-    private DetailNodeTreeStringPrinter() {
-        // no code
+    @Override
+    public String printFileAst(File file) throws IOException {
+        return printFileAstEx(file);
     }
 
     /**
@@ -52,7 +53,7 @@ public final class DetailNodeTreeStringPrinter {
      * @return parse tree as a string
      * @throws IOException if the file could not be read.
      */
-    public static String printFileAst(File file) throws IOException {
+    public static String printFileAstEx(File file) throws IOException {
         return printTree(parseFile(file), "", "");
     }
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/TreeStringPrinter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/TreeStringPrinter.java
@@ -1,0 +1,41 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2022 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.api;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Interface for printing ASTs to String.
+ */
+@FunctionalInterface
+public interface TreeStringPrinter {
+
+    /**
+     * Prints AST of the provided file.
+     *
+     * @param file the file to parse.
+     * @return Full tree
+     * @throws IOException Failed to open a file
+     * @throws CheckstyleException error while parsing the file
+     */
+    String printFileAst(File file) throws IOException, CheckstyleException;
+
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractTreeTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractTreeTestSupport.java
@@ -110,7 +110,7 @@ public abstract class AbstractTreeTestSupport extends AbstractPathTestSupport {
                                             String actualJavadocFilename) throws Exception {
         final String expectedContents = readFile(expectedTextPrintFilename);
 
-        final String actualContents = toLfLineEnding(DetailNodeTreeStringPrinter.printFileAst(
+        final String actualContents = toLfLineEnding(DetailNodeTreeStringPrinter.printFileAstEx(
                 new File(actualJavadocFilename)));
 
         assertWithMessage("Generated tree from the javadoc file should match the pre-defined tree")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
@@ -20,7 +20,6 @@
 package com.puppycrawl.tools.checkstyle;
 
 import static com.google.common.truth.Truth.assertWithMessage;
-import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -39,13 +38,6 @@ public class AstTreeStringPrinterTest extends AbstractTreeTestSupport {
     @Override
     protected String getPackageLocation() {
         return "com/puppycrawl/tools/checkstyle/asttreestringprinter";
-    }
-
-    @Test
-    public void testIsProperUtilsClass() throws ReflectiveOperationException {
-        assertWithMessage("Constructor is not private")
-                .that(isUtilsClassHasPrivateConstructor(AstTreeStringPrinter.class))
-                .isTrue();
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/DetailNodeTreeStringPrinterTest.java
@@ -23,7 +23,6 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.MSG_JAVADOC_MISSED_HTML_CLOSE;
 import static com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.MSG_JAVADOC_PARSE_RULE_ERROR;
 import static com.puppycrawl.tools.checkstyle.JavadocDetailNodeParser.MSG_JAVADOC_WRONG_SINGLETON_TAG;
-import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
 
 import java.io.File;
 
@@ -40,13 +39,6 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
     }
 
     @Test
-    public void testIsProperUtilsClass() throws ReflectiveOperationException {
-        assertWithMessage("Constructor is not private")
-                .that(isUtilsClassHasPrivateConstructor(DetailNodeTreeStringPrinter.class))
-                .isTrue();
-    }
-
-    @Test
     public void testParseFile() throws Exception {
         verifyJavadocTree(getPath("ExpectedDetailNodeTreeStringPrinterJavadocComment.txt"),
                 getPath("InputDetailNodeTreeStringPrinterJavadocComment.javadoc"));
@@ -57,7 +49,7 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
         final File file = new File(
                 getPath("InputDetailNodeTreeStringPrinterJavadocWithError.javadoc"));
         try {
-            DetailNodeTreeStringPrinter.printFileAst(file);
+            DetailNodeTreeStringPrinter.printFileAstEx(file);
             assertWithMessage("Javadoc parser didn't fail on missing end tag").fail();
         }
         catch (IllegalArgumentException ex) {
@@ -138,7 +130,7 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
                 getPath("InputDetailNodeTreeStringPrinter"
                         + "UnescapedJavaCodeWithGenericsInJavadoc.javadoc"));
         try {
-            DetailNodeTreeStringPrinter.printFileAst(file);
+            DetailNodeTreeStringPrinter.printFileAstEx(file);
             assertWithMessage("Exception is expected").fail();
         }
         catch (IllegalArgumentException ex) {
@@ -156,7 +148,7 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
         final File file = new File(
                 getPath("InputDetailNodeTreeStringPrinterNoViableAltException.javadoc"));
         try {
-            DetailNodeTreeStringPrinter.printFileAst(file);
+            DetailNodeTreeStringPrinter.printFileAstEx(file);
             assertWithMessage("Exception is expected").fail();
         }
         catch (IllegalArgumentException ex) {
@@ -175,7 +167,7 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
         final File file = new File(
                 getPath("InputDetailNodeTreeStringPrinterHtmlTagCloseBeforeTagOpen.javadoc"));
         try {
-            DetailNodeTreeStringPrinter.printFileAst(file);
+            DetailNodeTreeStringPrinter.printFileAstEx(file);
             assertWithMessage("Exception is expected").fail();
         }
         catch (IllegalArgumentException ex) {
@@ -194,7 +186,7 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
         final File file = new File(
                 getPath("InputDetailNodeTreeStringPrinterWrongHtmlTagOrder.javadoc"));
         try {
-            DetailNodeTreeStringPrinter.printFileAst(file);
+            DetailNodeTreeStringPrinter.printFileAstEx(file);
             assertWithMessage("Exception is expected").fail();
         }
         catch (IllegalArgumentException ex) {
@@ -212,7 +204,7 @@ public class DetailNodeTreeStringPrinterTest extends AbstractTreeTestSupport {
         final File file = new File(
                 getPath("InputDetailNodeTreeStringPrinterOmittedStartTagForHtmlElement.javadoc"));
         try {
-            DetailNodeTreeStringPrinter.printFileAst(file);
+            DetailNodeTreeStringPrinter.printFileAstEx(file);
             assertWithMessage("Exception is expected").fail();
         }
         catch (IllegalArgumentException ex) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CliOptionsXdocsSyncTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CliOptionsXdocsSyncTest.java
@@ -52,7 +52,18 @@ public class CliOptionsXdocsSyncTest {
         final Set<String> cmdOptions = getListById(sections.item(2), "CLI_Options");
         for (String option : cmdOptions) {
             final String text = option.trim().replaceAll("\\s+", " ");
-            cmdDesc.put(text.substring(0, 2), text.substring(text.indexOf(" - ") + 3));
+            final int descSplit = text.indexOf(" - ");
+            final int firstSpace = text.indexOf(' ');
+            int commandSplit = text.indexOf(',');
+
+            if (commandSplit == -1 || commandSplit > descSplit) {
+                commandSplit = descSplit;
+            }
+            if (commandSplit > firstSpace) {
+                commandSplit = firstSpace;
+            }
+
+            cmdDesc.put(text.substring(0, commandSplit), text.substring(descSplit + 3));
         }
 
         final Class<?> cliOptions = Class.forName("com.puppycrawl.tools.checkstyle"
@@ -90,7 +101,7 @@ public class CliOptionsXdocsSyncTest {
         final Node usageSource = XmlUtil.getFirstChildElement(sections.item(2));
         final String usageText = XmlUtil.getFirstChildElement(usageSource).getTextContent();
 
-        final Set<String> shortParamsXdoc = getParameters(usageText, "-[a-zA-CE-X]\\b");
+        final Set<String> shortParamsXdoc = getParameters(usageText, "-[a-zA-CE-X]{1,2}\\b");
         final Set<String> longParamsXdoc = getParameters(usageText, "-(-\\w+)+");
 
         final Class<?> cliOptions = Class.forName("com.puppycrawl.tools.checkstyle"

--- a/src/xdocs/cmdline.xml.vm
+++ b/src/xdocs/cmdline.xml.vm
@@ -35,6 +35,7 @@ java -D&lt;property&gt;=&lt;value&gt;  \
      [-f &lt;format&gt;] [-p &lt;propertiesFile&gt;] [-o &lt;file&gt;] \
      [-s &lt;line:column&gt;] [-g | --generate-xpath-suppression] [-w | --tabWidth &lt;length&gt;] \
      [-t | --tree] [-T | --treeWithComments] [-J | --treeWithJavadoc] [-j | --javadocTree] \
+     [-pc | --printWithCustomTree &lt;customTreePrinterClass&gt;] \
      [-V | --version] [-b | --branch-matching-xpath &lt;xpathQuery&gt;] [-h | --help] \
      [-e | --exclude &lt;excludedPath&gt;] [-E | --executeIgnoredModules] [-d | --debug] \
      [-x | --exclude-regexp &lt;excludedPathPattern&gt;] \ file...
@@ -115,6 +116,10 @@ java -D&lt;property&gt;=&lt;value&gt;  \
           The file have to contain <b>only Javadoc comment content</b> without including '/**' and
           '*/' at the beginning and at the end respectively. The option
           cannot be used other options and requires exactly one file to run on to be specified.
+        </li>
+        <li>
+          <code>-pc, --printWithCustomTree customTreePrinterClass</code> - Prints Tree based on the
+          provided custom class.
         </li>
         <li>
           <code>-d, --debug</code> - Prints all debug logging of CheckStyle utility.


### PR DESCRIPTION
Issue #11604

Currently 3rd parties have no way to provide their own AST to do some of the basics that Checkstyle does like printing the ASTs for users to understand it.

This provides a new option in the CLI so custom printers can be used. Other printers were very slightly reworked to this new method to show its usage.

It is hoped to use this method for other CLI functionality like `printXpathBranch` and `printSuppressions`.