### PR TITLE
Issue #12104: prepare order of execution for global locale issue

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -106,17 +106,6 @@
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/Checker.java</fileName>
-    <specifier>method.invocation</specifier>
-    <message>call to addListener(com.puppycrawl.tools.checkstyle.api.AuditListener) not allowed on the given receiver.</message>
-    <lineContent>addListener(counter);</lineContent>
-    <details>
-      found   : @UnderInitialization(com.puppycrawl.tools.checkstyle.AbstractAutomaticBean.class) @NonNull Checker
-      required: @Initialized @NonNull Checker
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/ConfigurationLoader.java</fileName>
     <specifier>argument</specifier>
     <message>incompatible argument for parameter arg0 of add.</message>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java
@@ -137,7 +137,7 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
      * The instance needs to be contextualized and configured.
      */
     public Checker() {
-        addListener(counter);
+        listeners.add(counter);
         log = LogFactory.getLog(Checker.class);
     }
 
@@ -469,11 +469,9 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
         try {
             child = moduleFactory.createModule(name);
 
-            if (child instanceof AbstractAutomaticBean) {
-                final AbstractAutomaticBean bean = (AbstractAutomaticBean) child;
-                bean.contextualize(childContext);
-                bean.configure(childConf);
-            }
+            final AbstractAutomaticBean bean = (AbstractAutomaticBean) child;
+            bean.contextualize(childContext);
+            bean.configure(childConf);
         }
         catch (final CheckstyleException ex) {
             throw new CheckstyleException("cannot initialize module " + name
@@ -482,19 +480,20 @@ public class Checker extends AbstractAutomaticBean implements MessageDispatcher,
         if (child instanceof FileSetCheck) {
             final FileSetCheck fsc = (FileSetCheck) child;
             fsc.init();
-            addFileSetCheck(fsc);
+            fsc.setMessageDispatcher(this);
+            fileSetChecks.add(fsc);
         }
         else if (child instanceof BeforeExecutionFileFilter) {
             final BeforeExecutionFileFilter filter = (BeforeExecutionFileFilter) child;
-            addBeforeExecutionFileFilter(filter);
+            beforeExecutionFileFilters.addBeforeExecutionFileFilter(filter);
         }
         else if (child instanceof Filter) {
             final Filter filter = (Filter) child;
-            addFilter(filter);
+            filters.addFilter(filter);
         }
         else if (child instanceof AuditListener) {
             final AuditListener listener = (AuditListener) child;
-            addListener(listener);
+            listeners.add(listener);
         }
         else {
             throw new CheckstyleException(name

--- a/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/CheckerTest.java
@@ -75,6 +75,7 @@ import com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck;
 import com.puppycrawl.tools.checkstyle.checks.TranslationCheck;
 import com.puppycrawl.tools.checkstyle.checks.coding.HiddenFieldCheck;
 import com.puppycrawl.tools.checkstyle.filters.SuppressionFilter;
+import com.puppycrawl.tools.checkstyle.filters.SuppressionXpathFilter;
 import com.puppycrawl.tools.checkstyle.internal.testmodules.DebugAuditAdapter;
 import com.puppycrawl.tools.checkstyle.internal.testmodules.DebugFilter;
 import com.puppycrawl.tools.checkstyle.internal.testmodules.TestBeforeExecutionFileFilter;
@@ -117,6 +118,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
     @Test
     public void testDestroy() throws Exception {
         final Checker checker = new Checker();
+        checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+        checker.finishLocalSetup();
         final DebugAuditAdapter auditAdapter = new DebugAuditAdapter();
         checker.addListener(auditAdapter);
         final TestFileSetCheck fileSet = new TestFileSetCheck();
@@ -154,6 +157,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
     public void testAddListener() throws Exception {
         final Checker checker = new Checker();
         final DebugAuditAdapter auditAdapter = new DebugAuditAdapter();
+        checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+        checker.finishLocalSetup();
         checker.addListener(auditAdapter);
 
         // Let's try fire some events
@@ -208,6 +213,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
     @Test
     public void testRemoveListener() throws Exception {
         final Checker checker = new Checker();
+        checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+        checker.finishLocalSetup();
         final DebugAuditAdapter auditAdapter = new DebugAuditAdapter();
         final DebugAuditAdapter aa2 = new DebugAuditAdapter();
         checker.addListener(auditAdapter);
@@ -266,6 +273,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
     @Test
     public void testAddBeforeExecutionFileFilter() throws Exception {
         final Checker checker = new Checker();
+        checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+        checker.finishLocalSetup();
         final TestBeforeExecutionFileFilter filter = new TestBeforeExecutionFileFilter();
 
         checker.addBeforeExecutionFileFilter(filter);
@@ -280,6 +289,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
     @Test
     public void testRemoveBeforeExecutionFileFilter() throws Exception {
         final Checker checker = new Checker();
+        checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+        checker.finishLocalSetup();
         final TestBeforeExecutionFileFilter filter = new TestBeforeExecutionFileFilter();
         final TestBeforeExecutionFileFilter f2 = new TestBeforeExecutionFileFilter();
         checker.addBeforeExecutionFileFilter(filter);
@@ -297,10 +308,11 @@ public class CheckerTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testAddFilter() {
+    public void testAddFilter() throws CheckstyleException {
         final Checker checker = new Checker();
         final DebugFilter filter = new DebugFilter();
-
+        checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+        checker.finishLocalSetup();
         checker.addFilter(filter);
 
         filter.resetFilter();
@@ -314,8 +326,10 @@ public class CheckerTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testRemoveFilter() {
+    public void testRemoveFilter() throws CheckstyleException {
         final Checker checker = new Checker();
+        checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+        checker.finishLocalSetup();
         final DebugFilter filter = new DebugFilter();
         final DebugFilter f2 = new DebugFilter();
         checker.addFilter(filter);
@@ -500,13 +514,15 @@ public class CheckerTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testSetupChildExceptions() {
+    public void testSetupChildExceptions() throws CheckstyleException {
         final Checker checker = new Checker();
         final PackageObjectFactory factory = new PackageObjectFactory(
             new HashSet<>(), Thread.currentThread().getContextClassLoader());
         checker.setModuleFactory(factory);
+        checker.finishLocalSetup();
 
-        final Configuration config = new DefaultConfiguration("java.lang.String");
+        final Configuration config = new DefaultConfiguration(
+                SuppressionXpathFilter.class.getName());
         try {
             checker.setupChild(config);
             assertWithMessage("Exception is expected").fail();
@@ -514,7 +530,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
         catch (CheckstyleException ex) {
             assertWithMessage("Error message is not expected")
                 .that(ex.getMessage())
-                .isEqualTo("java.lang.String is not allowed as a child in Checker");
+                .isEqualTo(SuppressionXpathFilter.class.getName()
+                        + " is not allowed as a child in Checker");
         }
     }
 
@@ -542,6 +559,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         final PackageObjectFactory factory = new PackageObjectFactory(
             new HashSet<>(), Thread.currentThread().getContextClassLoader());
         checker.setModuleFactory(factory);
+        checker.finishLocalSetup();
 
         final Configuration config = new DefaultConfiguration(
             DebugAuditAdapter.class.getCanonicalName());
@@ -951,6 +969,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
 
         final Checker checker = new Checker();
         checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+        checker.finishLocalSetup();
         checker.addFileSetCheck(check);
         checker.addFilter(new DummyFilterSet());
         checker.configure(checkerConfig);
@@ -1438,6 +1457,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
     public void testCheckerProcessCallAllNeededMethodsOfFileSets() throws Exception {
         final DummyFileSet fileSet = new DummyFileSet();
         final Checker checker = new Checker();
+        checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+        checker.finishLocalSetup();
         checker.addFileSetCheck(fileSet);
         checker.process(Collections.singletonList(new File("dummy.java")));
         final List<String> expected =
@@ -1448,9 +1469,11 @@ public class CheckerTest extends AbstractModuleTestSupport {
     }
 
     @Test
-    public void testSetFileSetCheckSetsMessageDispatcher() {
+    public void testSetFileSetCheckSetsMessageDispatcher() throws CheckstyleException {
         final DummyFileSet fileSet = new DummyFileSet();
         final Checker checker = new Checker();
+        checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+        checker.finishLocalSetup();
         checker.addFileSetCheck(fileSet);
         assertWithMessage("Message dispatcher was not expected")
             .that(fileSet.getInternalMessageDispatcher())
@@ -1473,6 +1496,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
             }
         };
         checker.setModuleFactory(factory);
+        checker.finishLocalSetup();
         checker.setupChild(createModuleConfig(DebugAuditAdapter.class));
         // Let's try fire some events
         checker.process(Collections.singletonList(new File("dummy.java")));
@@ -1497,6 +1521,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
             }
         };
         checker.setModuleFactory(factory);
+        checker.finishLocalSetup();
         checker.setupChild(createModuleConfig(TestBeforeExecutionFileFilter.class));
         checker.process(Collections.singletonList(new File("dummy.java")));
         assertWithMessage("Checker.acceptFileStarted() doesn't call listener")
@@ -1536,6 +1561,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
             CloseAndFlushTestByteArrayOutputStream testErrorOutputStream =
                 new CloseAndFlushTestByteArrayOutputStream()) {
             checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+            checker.finishLocalSetup();
             checker.addListener(new DefaultLogger(testInfoOutputStream,
                 OutputStreamOptions.CLOSE, testErrorOutputStream, OutputStreamOptions.CLOSE));
 
@@ -1566,6 +1592,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
         try (CloseAndFlushTestByteArrayOutputStream testInfoOutputStream =
                 new CloseAndFlushTestByteArrayOutputStream()) {
             checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+            checker.finishLocalSetup();
             checker.addListener(new XMLLogger(testInfoOutputStream, OutputStreamOptions.CLOSE));
 
             final File tmpFile = File.createTempFile("file", ".java", temporaryFolder);
@@ -1682,7 +1709,12 @@ public class CheckerTest extends AbstractModuleTestSupport {
         }
     }
 
-    public static class DummyFilter implements Filter {
+    public static class DummyFilter extends AbstractAutomaticBean implements Filter {
+
+        @Override
+        protected void finishLocalSetup() {
+            // no code
+        }
 
         @Override
         public boolean accept(AuditEvent event) {

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/testmodules/DebugAuditAdapter.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/testmodules/DebugAuditAdapter.java
@@ -21,8 +21,9 @@ package com.puppycrawl.tools.checkstyle.internal.testmodules;
 
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AuditListener;
+import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 
-public final class DebugAuditAdapter implements AuditListener {
+public final class DebugAuditAdapter extends AutomaticBean implements AuditListener {
 
     /** Keeps track whether this {@code AuditListener} was called. */
     private boolean called;
@@ -55,6 +56,11 @@ public final class DebugAuditAdapter implements AuditListener {
     public void resetListener() {
         called = false;
         passedEvent = false;
+    }
+
+    @Override
+    protected void finishLocalSetup() {
+        // no code
     }
 
     @Override

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/testmodules/TestBeforeExecutionFileFilter.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/testmodules/TestBeforeExecutionFileFilter.java
@@ -19,11 +19,18 @@
 
 package com.puppycrawl.tools.checkstyle.internal.testmodules;
 
+import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 import com.puppycrawl.tools.checkstyle.api.BeforeExecutionFileFilter;
 
-public final class TestBeforeExecutionFileFilter implements BeforeExecutionFileFilter {
+public final class TestBeforeExecutionFileFilter extends AutomaticBean
+        implements BeforeExecutionFileFilter {
 
     private boolean called;
+
+    @Override
+    protected void finishLocalSetup() {
+        // no code
+    }
 
     @Override
     public boolean accept(String uri) {


### PR DESCRIPTION
Issue #12104

This is the first PR to fix the overall issue. This is a sort of prep PR and is more minor and smaller. Unfortunately some context here might not make sense without the final product but I will try to explain as much as I can.

The point of this PR is:
* Ensure we are executing tests in the correct lifeycycle order. `configure`/`finishLocalSetup` should run first before `setupChild` which also should run before any custom "adds" to the root module. finishLocalSetup is executing before setupChild https://github.com/checkstyle/checkstyle/blob/b6301c189ef5d2d731a755fa9a2e84aa0677494a/src/main/java/com/puppycrawl/tools/checkstyle/AbstractAutomaticBean.java#L191-L207
 * I did this by adding custom code on the locale to print exceptions if things went out of order. It is not code that will remain for the PR.
* Ensure anything we are adding that is breaking the above bullet, is custom, to not interfere with the coming changes.
* Ensure everything we pull from the configuration extends `AutomaticBean` as we have declared all modules should be using it, which gives everything access to `contextualize`.
 * Source: https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/utils/ModuleReflectionUtil.java#L75-L76

------

### **Main point**

The changes I am planning for the bigger stage is anything going through `add*` in `Checker` (our root module) needs to call `contextualize` if allowed. I am planning to give all modules the `Locale` through the `contextualize` by adding this on [the end of `finishLocalSetup`](https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/Checker.java#L432). There are too many different types of areas that need the Locale in Checkstyle from Listeners to Filters, so this is the best way to spread the locale around in the current system.

---------

The lifecycle order is not a big deal as our Main is already following it. I confirmed maven-checkstyle is also following it.

A peek at the future PR can be seen at https://github.com/rnveach/checkstyle/commits/issue_12104 but it will be in some flux.

---------

how to install different locale on ubuntu host:
recheck installed locales:
```
$ locale -a
C
C.UTF-8
en_AG
en_AG.utf8
en_AU.utf8
en_BW.utf8
en_CA.utf8
en_DK.utf8
en_GB.utf8
en_HK.utf8
en_IE.utf8
en_IN
en_IN.utf8
en_NG
en_NG.utf8
en_NZ.utf8
en_PH.utf8
en_SG.utf8
en_US.utf8
en_ZA.utf8
en_ZM
en_ZM.utf8
en_ZW.utf8
POSIX
```

```
sudo apt-get install language-pack-ru
sudo update-locale LANG=ru_RU.utf8
reboot
```

all locales
```
$ locale -a
C
C.UTF-8
en_AG
en_AG.utf8
en_AU.utf8
en_BW.utf8
en_CA.utf8
en_DK.utf8
en_GB.utf8
en_HK.utf8
en_IE.utf8
en_IN
en_IN.utf8
en_NG
en_NG.utf8
en_NZ.utf8
en_PH.utf8
en_SG.utf8
en_US.utf8
en_ZA.utf8
en_ZM
en_ZM.utf8
en_ZW.utf8
POSIX
ru_RU.utf8
ru_UA.utf8
```

current locale
```
$ locale
LANG=ru_RU.utf8
LANGUAGE=ru
LC_CTYPE="ru_RU.utf8"
.....
$ mvn clean test -Dtest=CheckstyleAntTaskTest
.....
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTaskTest
[ERROR] Tests run: 42, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 0.838 s <<< FAILURE! - in com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTaskTest
[ERROR] com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTaskTest.testExecuteIgnoredModules  Time elapsed: 0.094 s  <<< FAILURE!
Content of file with violations differs from expected
expected: Starting audit...
but was : Начинаем проверку...
	at com.puppycrawl.tools.checkstyle.ant.CheckstyleAntTaskTest.testExecuteIgnoredModules(CheckstyleAntTaskTest.java:390)
	at [[Reflective call: 4 frames collapsed (https://goo.gl/aH3UyP)]].(:0)
	at [[Testing framework: 27 frames collapsed (https://goo.gl/aH3UyP)]].(:0)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at [[Testing framework: 9 frames collapsed (https://goo.gl/aH3UyP)]].(:0)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at [[Testing framework: 21 frames collapsed (https://goo.gl/aH3UyP)]].(:0)
	at org.apache.maven.surefire.junitplatform.LazyLauncher.execute(LazyLauncher.java:50)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:184)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:148)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:122)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
```

workaround (use existing/installed on your local "en" locale):
```
$ export LC_ALL=en_US.utf8
$ mvn verify
.... passes ...
```