### PR TITLE
Issue #12522: Empty ErrorStream in checker-framework.groovy to prevent buffer exhaustion and external processes from blocking

### DIFF
--- a/.ci/checker-framework.groovy
+++ b/.ci/checker-framework.groovy
@@ -113,12 +113,24 @@ private static int checkCheckerFrameworkReport(final String profile) {
 private static List<List<String>> getCheckerFrameworkErrors(final String profile) {
     final List<String> checkerFrameworkLines = new ArrayList<>()
     final String command = "mvn -e --no-transfer-progress clean compile -P${profile}"
-    final Process process = getOsSpecificCmd(command).execute()
-    process.in.eachLine { final line ->
-        checkerFrameworkLines.add(line)
-        println(line)
+    final ProcessBuilder processBuilder = new ProcessBuilder(getOsSpecificCmd(command).split(' '))
+    processBuilder.redirectErrorStream(true)
+    final Process process = processBuilder.start()
+
+    BufferedReader reader = null
+    try {
+        reader = new BufferedReader(new InputStreamReader(process.inputStream))
+        String lineFromReader = reader.readLine()
+        while (lineFromReader != null) {
+            println(lineFromReader)
+            checkerFrameworkLines.add(lineFromReader)
+            lineFromReader = reader.readLine()
+        }
+        process.waitFor()
+    } finally {
+        reader.close()
     }
-    process.waitFor()
+
     final List<List<String>> checkerFrameworkErrors = new ArrayList<>()
     for (int index = 0; index < checkerFrameworkLines.size(); index++) {
         final String line = checkerFrameworkLines.get(index)


### PR DESCRIPTION
Resolves #12522