### PR TITLE
Issue #12524: Replace backward slash with forward slash while creating CheckerFrameworkError object in checker-framework.groovy

### DIFF
--- a/.ci/checker-framework.groovy
+++ b/.ci/checker-framework.groovy
@@ -184,7 +184,7 @@ private static List<CheckerFrameworkError> getErrorFromText(final List<List<Stri
         String lineContent = null
         int lineNumber = 0
         if (matcher.matches()) {
-            fileName = matcher.group(fileNameGroup)
+            fileName = matcher.group(fileNameGroup).replace('\\', '/')
             lineNumber = Integer.parseInt(matcher.group(lineNumberGroup))
             specifier = XmlUtil.escapeXml(matcher.group(specifierGroup).trim())
             message = XmlUtil.escapeXml(matcher.group(messageGroup).trim())


### PR DESCRIPTION
Resolves #12524 

Tested locally on windows as Checker Framework does not currently support windows properly, see https://github.com/checkstyle/checkstyle/pull/12366#issuecomment-1304441297 and the following comments.