### PR TITLE
Issue #12079: Github action "Release perform"

### DIFF
--- a/.ci/maven-release-perform.sh
+++ b/.ci/maven-release-perform.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+if [[ -z $1 ]]; then
+  echo "version is not set"
+  echo "Usage: $BASH_SCRIPT <version>"
+  exit 1
+fi
+
+TARGET_VERSION=$1
+echo TARGET_VERSION="$TARGET_VERSION"
+
+CURRENT_VERSION=$(xmlstarlet sel -N pom=http://maven.apache.org/POM/4.0.0 \
+                             -t -m pom:project -v pom:version pom.xml | sed "s/-SNAPSHOT//")
+echo CURRENT_VERSION="$CURRENT_VERSION"
+
+if [ "$TARGET_VERSION" != "$CURRENT_VERSION" ]; then
+  echo "Target Version and current Version do not match"
+  exit 1;
+fi
+
+SKIP_TEST="-DskipTests -DskipITs"
+SKIP_CHECKSTYLE="-Dcheckstyle.ant.skip=true -Dcheckstyle.skip=true"
+SKIP_OTHERS="-Dpmd.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -Dxml.skip=true"
+
+git checkout "checkstyle-$TARGET_VERSION"
+echo "Deploying jars to maven central (release:perform) ..."
+mvn -e --no-transfer-progress -Pgpg release:perform \
+  -DconnectionUrl=scm:git:git@github.com:checkstyle/checkstyle.git \
+  -Dtag=checkstyle-"$TARGET_VERSION" \
+  -Darguments="$SKIP_TEST $SKIP_CHECKSTYLE $SKIP_OTHERS"

--- a/.github/workflows/maven_release_perform.yml
+++ b/.github/workflows/maven_release_perform.yml
@@ -1,0 +1,45 @@
+#############################################################################
+# GitHub Action to Run Maven Release Perform.
+#
+#############################################################################
+name: "R: Maven Release Perform"
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Target Version without (-SNAPSHOT)'
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  perform:
+    name: Release perform {{ github.event.inputs.version }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the latest code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup local maven cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+      - name: Prepare release settings
+        env:
+          SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
+          SONATYPE_PWD: ${{ secrets.SONATYPE_PWD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_KEY: ${{ secrets.GPG_KEY }}
+        run: |
+          ./.ci/prepare-settings.sh
+      - name: Run Shell Script
+        run: |
+          ./.ci/maven-release-perform.sh ${{ github.event.inputs.version }}

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -286,6 +286,7 @@ davidwalsh
 DBFF
 Dcheckstyle
 dcm
+Dconnection
 Ddry
 declarationorder
 defau
@@ -346,6 +347,7 @@ dsm
 Dsonar
 Dspotbugs
 Dstrict
+Dtag
 Dtest
 Dubinin
 Duser


### PR DESCRIPTION
Resolves #12079 

---
I cannot wrap my head around how any of this realease/deploy works and I am stuck. This is my progress until now. I feel like I'm a just doing trial and error hoping something works at this point.

Running
```
 ./.ci/maven-release-perform.sh 10.5.1
```
yields
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:39 min
[INFO] Finished at: 2022-12-16T19:13:34+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:deploy
 (injected-nexus-deploy) on project checkstyle: Failed to deploy artifacts: Could not transfer artifact
 com.puppycrawl.tools:checkstyle:jar:test-sources:10.5.1-20221216.181333-36 
from/to sonatype-nexus-snapshots (https://oss.sonatype.org/content/repositories/snapshots/): 
Transfer failed for https://oss.sonatype.org/content/repositories/snapshots/com/puppycrawl
/tools/checkstyle/10.5.1-SNAPSHOT/checkstyle-10.5.1-20221216.181333-36-test-sources.jar 
401 Unauthorized -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal 
org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:deploy (injected-nexus-deploy) 
on project checkstyle: Failed to deploy artifacts: Could not transfer artifact 
com.puppycrawl.tools:checkstyle:jar:test-sources:10.5.1-20221216.181333-36 
from/to sonatype-nexus-snapshots (https://oss.sonatype.org/content/repositories/snapshots/):
 Transfer failed for https://oss.sonatype.org/content/repositories/snapshots/com/puppycrawl
/tools/checkstyle/10.5.1-SNAPSHOT/checkstyle-10.5.1-20221216.181333-36-test-sources.jar 401 Unauthorized

```