### PR TITLE
infra: fix site generation

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -52,8 +52,8 @@ jobs:
       - name: Set branch
         id: branch
         run: |
-          run: echo "ref=$(xargs < branch)" >> "$GITHUB_OUTPUT"
-          run: echo "commit_sha=$(xargs < commit_sha | cut -c 1-7)" >> "$GITHUB_OUTPUT"
+          echo "ref=$(xargs < branch)" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=$(xargs < commit_sha | cut -c 1-7)" >> "$GITHUB_OUTPUT"
 
   generate_site:
     needs: parse_pr_info


### PR DESCRIPTION
Noticed at https://github.com/checkstyle/checkstyle/actions/runs/3794382250, site generation is failing from commands in `run` continuation block prefaced with `run:` (bad copy/paste on my part).

This was not caught since github actions do not use yml from the PR branch to run (forgot about this when "testing")