### PR TITLE
infra: allow trigger action manually after version bump

### DIFF
--- a/.github/workflows/releasenotes-gen.yml
+++ b/.github/workflows/releasenotes-gen.yml
@@ -1,6 +1,7 @@
 name: "Generate release notes"
 
 on:
+  workflow_dispatch: null
   push:
     branches:
       - master


### PR DESCRIPTION
Release Notes action was skipped on commit of version bump 

https://github.com/checkstyle/checkstyle/actions/workflows/releasenotes-gen.yml


same as: https://github.com/checkstyle/contribution/commit/6c1e4973f94f63fbd70c4fd749dcbe19e3b08cd1#diff-3352b8e68cb99ef1d26fdb226a4caf7e9e5b524dee8dda727210453eec3d9b0dR10