### PR TITLE
Improve sonar failure message

### DIFF
--- a/.ci/sonar_break_build.sh
+++ b/.ci/sonar_break_build.sh
@@ -52,8 +52,11 @@ ANALYSIS_URL="$SONAR_SERVER/api/qualitygates/project_status?analysisId=$ANALYSIS
 STATUS=$(curl -X GET -s -u "$SONAR_API_TOKEN": "$ANALYSIS_URL" \
     | jq -r .projectStatus.status)
 
+DASHBOARD_URL=$(cat $SONAR_RESULT | sed -n 's/dashboardUrl=\(.*\)/\1/p')
+
 if [ "$STATUS" = "ERROR" ]; then
   echo "Quality gate failed."
+  echo "See sonar dashboard at '${DASHBOARD_URL}' for failures."
   exit 1
 fi
 

--- a/.ci/sonar_break_build.sh
+++ b/.ci/sonar_break_build.sh
@@ -15,7 +15,7 @@ if [ ! -f $SONAR_RESULT ]; then
   exit 1
 fi
 
-CE_TASK_ID=$(sed -n 's/ceTaskId=\(.*\)/\1/p' < $SONAR_RESULT)
+CE_TASK_ID=$(cat $SONAR_RESULT | sed -n 's/ceTaskId=\(.*\)/\1/p')
 
 if [ -z "$CE_TASK_ID" ]; then
   echo "ceTaskId is not set from sonar build"


### PR DESCRIPTION
Noticed at https://github.com/checkstyle/checkstyle/pull/12548#issuecomment-1368192527, how to diagnose sonar build failure is not obvious.

New failure message: https://app.circleci.com/pipelines/github/checkstyle/checkstyle/16821/workflows/4e9432ae-aef9-4286-aa5f-9ebc0d522bde/jobs/225458/parallel-runs/0/steps/0-103

```
Verification of sonar gate status
Quality gate failed.
See sonar dashboard at 'https://sonarcloud.io/dashboard?id=org.checkstyle%3Acheckstyle&pullRequest=12566' for failures.
```