### PR TITLE
Issue #12572: fix bump_license_year.yml not adding year to commit message

### DIFF
--- a/.github/workflows/bump_license_year.yml
+++ b/.github/workflows/bump_license_year.yml
@@ -20,14 +20,11 @@ jobs:
       - name: Checkout the latest code
         uses: actions/checkout@v3
       - name: Set Current Year
-        id: CURRENT_YEAR
         run: |
-          echo "year=$(date +'%Y')" >> "$GITHUB_OUTPUT"
+          echo "YEAR=$(date +'%Y')" >> "$GITHUB_ENV"
       - name: Modify Files
         run: |
           ./.ci/bump-license-year.sh $(("${{ env.YEAR }}" - 1)) ${{ env.YEAR }} .
-        env:
-          YEAR: ${{ steps.CURRENT_YEAR.outputs.year }}
       - name: Push commit
         run: |
           git config user.name 'github-actions[bot]'


### PR DESCRIPTION
Resolves #12572 

Source: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable

Proof of working: https://github.com/Vyom-Yadav/actions-test/commit/8ae3f4490e16f3bbba5f252f96b03e15198e8122