### PR TITLE
issue #7601: Update JavadocType check example #8012

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -140,7 +140,8 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <p>Example:</p>
  * <pre>
  * &#47;**
- * * &#64;author 	xyz  // violation, No tabs or whitespaces before author name
+ * * &#64;author 	
+                  xyz  // violation, no newline,tabs,spaces before xyz
  * * &#64;author xyz // OK
  * *&#47;
  * public class test{

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheck.java
@@ -137,6 +137,15 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *   &lt;property name="authorFormat" value="\S"/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * &#47;**
+ * * &#64;author 	xyz  // violation, No tabs or whitespaces before author name
+ * * &#64;author xyz // OK
+ * *&#47;
+ * public class test{
+ * }
+ * </pre>
  * <p>
  * To configure the check for a CVS revision version tag:
  * </p>


### PR DESCRIPTION
add example for JavadocType check with property-authorFormat

### Input:
```
/**
 * @author 
 *          xyz  // violation, must match with pattern "\S"
 */
class test{
}
```

```
<module name="Checker">
	<module name="TreeWalker">
<module name="JavadocType">
  <property name="authorFormat" value="\S"/>
</module>
</module>
</module>
```

### Output:

> C:\Users\HP\Downloads>java -jar checkstyle-10.5.0-all.jar -c C:\Users\HP\Downloads\checkstyle-9.1-all\mynew.xml C:\untitled\src\car.java
> Starting audit...
> [ERROR] C:\untitled\src\car.java:6:1: Type Javadoc tag @author must match pattern '\S'. [JavadocType]
> Audit done.
> Checkstyle ends with 1 errors.