### PR TITLE
infra: migrate travis jobs to semaphore

### DIFF
--- a/.ci/travis.sh
+++ b/.ci/travis.sh
@@ -110,21 +110,6 @@ deploy-snapshot)
   fi
   ;;
 
-ci-temp-check)
-    fail=0
-    mkdir -p .ci-temp
-    if [ -z "$(ls -A .ci-temp)" ]; then
-        echo "Folder .ci-temp/ is empty."
-    else
-        echo "Folder .ci-temp/ is not empty. Verification failed."
-        echo "Contents of .ci-temp/:"
-        fail=1
-    fi
-    ls -A .ci-temp
-    sleep 5s
-    exit $fail
-  ;;
-
 quarterly-cache-cleanup)
   MVN_REPO=$(mvn -e --no-transfer-progress help:evaluate -Dexpression=settings.localRepository \
     -q -DforceStdout);

--- a/.ci/travis.sh
+++ b/.ci/travis.sh
@@ -125,21 +125,6 @@ ci-temp-check)
     exit $fail
   ;;
 
-jacoco)
-  export MAVEN_OPTS='-Xmx2000m'
-  mvn -e --no-transfer-progress clean test \
-    jacoco:restore-instrumented-classes \
-    jacoco:report@default-report \
-    jacoco:check@default-check
-  # if launch is not from CI, we skip this step
-  if [[ $TRAVIS == 'true' ]]; then
-    echo "Reporting to codecov"
-    bash <(curl --fail-with-body -s https://codecov.io/bash)
-  else
-    echo "No reporting to codecov outside CI"
-  fi
-  ;;
-
 quarterly-cache-cleanup)
   MVN_REPO=$(mvn -e --no-transfer-progress help:evaluate -Dexpression=settings.localRepository \
     -q -DforceStdout);

--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -1075,6 +1075,21 @@ assembly-site)
   mvn -e --no-transfer-progress site -Dlinkcheck.skip=true
   ;;
 
+jacoco)
+  export MAVEN_OPTS='-Xmx2000m'
+  mvn -e --no-transfer-progress clean test \
+    jacoco:restore-instrumented-classes \
+    jacoco:report@default-report \
+    jacoco:check@default-check
+  # if launch is not from CI, we skip this step
+  if [[ $CI == 'true' ]]; then
+    echo "Reporting to codecov"
+    bash <(curl --fail-with-body -s https://codecov.io/bash)
+  else
+    echo "No reporting to codecov outside CI"
+  fi
+  ;;
+
 *)
   echo "Unexpected argument: $1"
   sleep 5s

--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -1090,6 +1090,21 @@ jacoco)
   fi
   ;;
 
+ci-temp-check)
+    fail=0
+    mkdir -p .ci-temp
+    if [ -z "$(ls -A .ci-temp)" ]; then
+        echo "Folder .ci-temp/ is empty."
+    else
+        echo "Folder .ci-temp/ is not empty. Verification failed."
+        echo "Contents of .ci-temp/:"
+        fail=1
+    fi
+    ls -A .ci-temp
+    sleep 5s
+    exit $fail
+  ;;
+
 *)
   echo "Unexpected argument: $1"
   sleep 5s

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,9 @@ jobs:
       - run:
           command: << parameters.command >>
       - run:
-          command: ./.ci/validation.sh git-diff
+          command: |
+            ./.ci/validation.sh git-diff
+            ./.ci/validation.sh ci-temp-check
       - save_cache:
           name: Save Maven repo cache
           key: mvn-cache-{{ checksum "pom.xml" }}

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -103,3 +103,4 @@ blocks:
             - eval $CMD;
             - echo "eval of CMD is completed";
             - ./.ci/validation.sh git-diff
+            - ./.ci/validation.sh ci-temp-check

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -27,6 +27,19 @@ blocks:
               cache store m2 $HOME/.m2
             fi
       jobs:
+        - name: sevntu
+          commands:
+            - mvn -e --no-transfer-progress compile antrun:run@ant-phase-verify-sevntu -Psevntu
+
+        - name: codenarc analysis
+          commands:
+            - ./.ci/codenarc.sh
+
+        - name: ensure that all modules are used in no exception configs
+          commands:
+            - export PULL_REQUEST=$SEMAPHORE_GIT_PR_NUMBER
+            - ./.ci/validation.sh verify-no-exception-configs
+
         - name: Validation (openjdk11, fast pool)
           matrix:
             - env_var: CMD
@@ -37,6 +50,7 @@ blocks:
                 - .ci/validation.sh verify-regexp-id
                 - .ci/no-exception-test.sh guava-with-google-checks
                 - .ci/no-exception-test.sh guava-with-sun-checks
+                - .ci/no-exception-test.sh no-exception-samples-ant
                 - .ci/validation.sh nondex
                 # until https://github.com/checkstyle/checkstyle/issues/9807
                 # - mvn -e --no-transfer-progress clean package -Passembly
@@ -61,6 +75,7 @@ blocks:
                 - .ci/validation.sh no-error-methods-distance
                 - .ci/validation.sh no-error-spring-cloud-gcp
                 - .ci/validation.sh no-error-equalsverifier
+                - .ci/validation.sh jacoco
 
           commands:
             - sem-version java 11

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,38 +35,6 @@ jobs:
         - DEPLOY="true"
         - USE_MAVEN_REPO="true"
 
-    # sevntu (openjdk11)
-    - jdk: openjdk11
-      env:
-        - DESC="sevntu"
-        - CMD="mvn -e --no-transfer-progress compile antrun:run@ant-phase-verify-sevntu -Psevntu"
-        - DEPLOY="true"
-        - USE_MAVEN_REPO="true"
-
-    # codecov
-    - jdk: openjdk11
-      env:
-        - DESC="codecov"
-        - USE_MAVEN_REPO="true"
-        - CMD="./.ci/travis.sh jacoco"
-
-    - jdk: openjdk11
-      env:
-        - DESC="codenarc analysis"
-        - CMD="./.ci/codenarc.sh"
-
-    - jdk: openjdk11
-      env:
-        - DESC="no-exception-samples-ant"
-        - CMD="./.ci/no-exception-test.sh no-exception-samples-ant"
-
-    # Ensure that all modules are used in no exception configs
-    - env:
-        - DESC="ensure that all modules are used in no exception configs"
-        - CMD1="export PULL_REQUEST=$TRAVIS_PULL_REQUEST"
-        - CMD2="./.ci/validation.sh verify-no-exception-configs"
-        - CMD="$CMD1 && $CMD2"
-
 before_script:
   - |
     if [[ $TRAVIS_CPU_ARCH == 'ppc64le' ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ script:
   # - ./.ci/travis.sh remove-custom-mvn
   # - ./.ci/travis.sh remove-adoptium-jdk
   - ./.ci/validation.sh git-diff
-  - ./.ci/travis.sh ci-temp-check
+  - ./.ci/validation.sh ci-temp-check
   - ./.ci/travis.sh quarterly-cache-cleanup
   - sleep 5s
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -165,6 +165,7 @@ steps:
       echo "cmd: "$(cmd)
       eval "$(cmd)"
       ./.ci/validation.sh git-diff
+      ./.ci/validation.sh ci-temp-check
     condition: |
         or (
             ne(variables.ON_CRON_ONLY, 'true'),


### PR DESCRIPTION
Migrates most travis jobs to semaphore, travis has been failing for quite awhile now. We will keep "test and deploy" and snapshot deployment in travis on master branch until at least https://github.com/checkstyle/checkstyle/issues/12620