### PR TITLE
config: Remove RecordComponentNumberCheck from pitest-misc profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2918,9 +2918,6 @@
                 <param>com.puppycrawl.tools.checkstyle.checks.NoCodeInFileCheck*</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck*</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck*</param>
-                <param>
-                  com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheck*
-                </param>
                 <param>com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder*</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck*</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheck*</param>
@@ -2940,9 +2937,6 @@
                 <param>com.puppycrawl.tools.checkstyle.checks.NoCodeInFileCheckTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheckTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheckTest</param>
-                <param>
-                  com.puppycrawl.tools.checkstyle.checks.sizes.RecordComponentNumberCheckTest
-                </param>
                 <param>com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolderTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.TodoCommentCheckTest</param>
                 <param>com.puppycrawl.tools.checkstyle.checks.TrailingCommentCheckTest</param>


### PR DESCRIPTION
Identified at https://github.com/checkstyle/checkstyle/pull/12593#issuecomment-1372990203

`RecordComponentNumberCheck` is covered at:
https://github.com/checkstyle/checkstyle/blob/098d9c0d764f1d1d92cdcf192e71f56e40e0b68c/pom.xml#L3965-L3970