### PR TITLE
Issue #12625: validate wildcards on target classes

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -1128,6 +1128,22 @@ ci-temp-check)
     exit ${#FILES_NO_CONCURRENCY[@]}
     ;;
 
+check-wildcards-on-pitest-target-classes)
+  ALL_CLASSES=$(xmlstarlet sel \
+    -N x=http://maven.apache.org/POM/4.0.0 \
+    -t -v "/x:project/x:profiles/x:profile//x:targetClasses/x:param" \
+    -n pom.xml)
+
+  CLASSES_NO_WILDCARD=$(echo "$ALL_CLASSES" | grep -v ".*\*\$" | grep -v -e '^\s*$' || echo)
+  CLASSES_NO_WILDCARD_COUNT=$(echo "$CLASSES_NO_WILDCARD" | grep -v -e '^\s*$' | wc -l)
+
+  if [[ "$CLASSES_NO_WILDCARD_COUNT" -gt 0 ]]; then
+    echo "Append asterisks to the following pitest target classes in pom.xml:"
+    echo "$CLASSES_NO_WILDCARD"
+  fi
+  exit "$CLASSES_NO_WILDCARD_COUNT"
+  ;;
+
 *)
   echo "Unexpected argument: $1"
   sleep 5s

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,8 @@ jobs:
       - run:
           name: run << parameters.command >>
           command: |
+            sudo apt update
+            sudo apt install -y xmlstarlet --no-install-recommends apt-utils
             export PULL_REQUEST=$CIRCLE_PR_NUMBER
             export PR_HEAD_SHA=$CIRCLE_SHA1
             export PR_NUMBER=$CIRCLE_PR_NUMBER
@@ -239,6 +241,10 @@ workflows:
           name: "check-github-workflows-concurrency"
           command: "./.ci/validation.sh check-github-workflows-concurrency"
       - yamllint
+      - validate-with-script:
+          name: "check-wildcards-on-pitest-target-classes"
+          image-name: "cimg/base:2022.11"
+          command: "./.ci/validation.sh check-wildcards-on-pitest-target-classes"
 
   javac-validation:
     jobs:

--- a/pom.xml
+++ b/pom.xml
@@ -4202,16 +4202,16 @@
                 <param>com.puppycrawl.tools.checkstyle.ThreadModeSettings*</param>
                 <param>com.puppycrawl.tools.checkstyle.grammar.CrAwareLexerSimulator*</param>
                 <!-- interfaces -->
-                <param>com.puppycrawl.tools.checkstyle.AuditEventFormatter</param>
-                <param>com.puppycrawl.tools.checkstyle.XdocsPropertyType</param>
-                <param>com.puppycrawl.tools.checkstyle.PropertyType</param>
-                <param>com.puppycrawl.tools.checkstyle.FileStatefulCheck</param>
-                <param>com.puppycrawl.tools.checkstyle.ModuleFactory</param>
-                <param>com.puppycrawl.tools.checkstyle.PropertyResolver</param>
-                <param>com.puppycrawl.tools.checkstyle.StatelessCheck</param>
-                <param>com.puppycrawl.tools.checkstyle.TreeWalkerFilter</param>
-                <param>com.puppycrawl.tools.checkstyle.GlobalStatefulCheck</param>
-                <param>com.puppycrawl.tools.checkstyle.grammar.CommentListener</param>
+                <param>com.puppycrawl.tools.checkstyle.AuditEventFormatter*</param>
+                <param>com.puppycrawl.tools.checkstyle.XdocsPropertyType*</param>
+                <param>com.puppycrawl.tools.checkstyle.PropertyType*</param>
+                <param>com.puppycrawl.tools.checkstyle.FileStatefulCheck*</param>
+                <param>com.puppycrawl.tools.checkstyle.ModuleFactory*</param>
+                <param>com.puppycrawl.tools.checkstyle.PropertyResolver*</param>
+                <param>com.puppycrawl.tools.checkstyle.StatelessCheck*</param>
+                <param>com.puppycrawl.tools.checkstyle.TreeWalkerFilter*</param>
+                <param>com.puppycrawl.tools.checkstyle.GlobalStatefulCheck*</param>
+                <param>com.puppycrawl.tools.checkstyle.grammar.CommentListener*</param>
               </targetClasses>
               <targetTests>
                 <param>com.puppycrawl.tools.checkstyle.AuditEventDefaultFormatterTest</param>


### PR DESCRIPTION
Closes #12625

Link to example of failed run: https://app.circleci.com/pipelines/github/checkstyle/checkstyle/16973/workflows/1abde372-b58a-4607-9bb5-a51560e8edf2/jobs/231413/parallel-runs/0/steps/0-102 

```
Append asterisks to the following pitest target classes in pom.xml:
com.puppycrawl.tools.checkstyle.AuditEventFormatter
com.puppycrawl.tools.checkstyle.XdocsPropertyType
com.puppycrawl.tools.checkstyle.PropertyType
com.puppycrawl.tools.checkstyle.FileStatefulCheck
com.puppycrawl.tools.checkstyle.ModuleFactory
com.puppycrawl.tools.checkstyle.PropertyResolver
com.puppycrawl.tools.checkstyle.StatelessCheck
com.puppycrawl.tools.checkstyle.TreeWalkerFilter
com.puppycrawl.tools.checkstyle.GlobalStatefulCheck
com.puppycrawl.tools.checkstyle.grammar.CommentListener


Exited with code exit status 10
```
