### PR TITLE
Issue #9994: LITERAL_SWITCH token support in RightCurlyCheck

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -1589,6 +1589,17 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java</fileName>
     <specifier>argument</specifier>
+    <message>incompatible argument for parameter nextToken of Details.</message>
+    <lineContent>return new Details(lcurly, rcurly, nextToken, true);</lineContent>
+    <details>
+      found   : @Initialized @Nullable DetailAST
+      required: @Initialized @NonNull DetailAST
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java</fileName>
+    <specifier>argument</specifier>
     <message>incompatible argument for parameter rcurly of Details.</message>
     <lineContent>return new Details(lcurly, rcurly, getNextToken(ast), true);</lineContent>
     <details>
@@ -1613,6 +1624,17 @@
     <specifier>argument</specifier>
     <message>incompatible argument for parameter rcurly of Details.</message>
     <lineContent>return new Details(lcurly, rcurly, nextToken, shouldCheckLastRcurly);</lineContent>
+    <details>
+      found   : @Initialized @Nullable DetailAST
+      required: @Initialized @NonNull DetailAST
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter rcurly of Details.</message>
+    <lineContent>return new Details(lcurly, rcurly, nextToken, true);</lineContent>
     <details>
       found   : @Initialized @Nullable DetailAST
       required: @Initialized @NonNull DetailAST

--- a/config/checkstyle-checks.xml
+++ b/config/checkstyle-checks.xml
@@ -319,6 +319,7 @@
       <property name="tokens" value="LITERAL_FINALLY"/>
       <property name="tokens" value="LITERAL_IF"/>
       <property name="tokens" value="LITERAL_TRY"/>
+      <property name="tokens" value="LITERAL_SWITCH"/>
       <property name="tokens" value="ANNOTATION_DEF"/>
       <property name="tokens" value="ENUM_DEF"/>
       <property name="tokens" value="RECORD_DEF"/>

--- a/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/RightCurlyTest.java
+++ b/src/it/java/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/RightCurlyTest.java
@@ -116,4 +116,18 @@ public class RightCurlyTest extends AbstractGoogleModuleTestSupport {
         verify(checkConfig, filePath, expected, warnList);
     }
 
+    @Test
+    public void testRightCurlySwitch() throws Exception {
+        final String[] expected = {
+            "12:24: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 24),
+            "19:27: " + getCheckMessage(RightCurlyCheck.class, MSG_KEY_LINE_ALONE, "}", 27),
+
+        };
+
+        final Configuration checkConfig = createTreeWalkerConfig(getModuleConfigsByIds(MODULES));
+        final String filePath = getPath("InputRightCurlySwitchCase.java");
+
+        final Integer[] warnList = getLinesWithWarn(filePath);
+        verify(checkConfig, filePath, expected, warnList);
+    }
 }

--- a/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlySwitchCase.java
+++ b/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule412nonemptyblocks/InputRightCurlySwitchCase.java
@@ -1,0 +1,50 @@
+package com.google.checkstyle.test.chapter4formatting.rule412nonemptyblocks;
+
+public class InputRightCurlySwitchCase {
+
+    public static void method0() {
+        int mode = 0;
+        switch (mode) {
+            case 1:
+                int x = 1;
+                break;
+            default :
+                x = 0; } // warn
+    }
+
+    public static void method1() {
+        int mode = 0;
+        switch (mode) {
+        default :
+               int x = 0; } // warn
+    }
+
+    public static void method2() {
+        int mode = 0;
+        switch (mode) {
+            case 1:
+                int x = 1;
+                break;
+            default:
+                x = 0;
+        } // ok
+    }
+
+    public static void method3() {
+        int mode = 0;
+        switch (mode) {
+        default :
+               int x = 0;
+        } // ok
+    }
+
+    public static void method4() {
+        int mode = 0;
+        switch (mode) {
+            case 1 :
+                int  y = 2;
+            default :
+               int x = 0;
+        } // ok
+    }
+}

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheck.java
@@ -32,7 +32,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 /**
  * <p>
  * Checks the placement of right curly braces ({@code '}'}) for code blocks. This check supports
- * if-else, try-catch-finally blocks, while-loops, for-loops,
+ * if-else, try-catch-finally blocks, switch statements, while-loops, for-loops,
  * method definitions, class definitions, constructor definitions,
  * instance, static initialization blocks, annotation definitions and enum definitions.
  * For right curly brace of expression blocks of arrays, lambdas and class instances
@@ -161,6 +161,43 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * }
  * </pre>
  * <p>
+ * To configure the check with policy {@code alone} for
+ * <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/switch.html">
+ * Switch</a> Statements:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;RightCurly&quot;&gt;
+ *  &lt;property name=&quot;option&quot; value=&quot;alone&quot;/&gt;
+ *  &lt;property name=&quot;tokens&quot; value=&quot;LITERAL_SWITCH&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <pre>
+ * class Test {
+ *
+ *     public void method0() {
+ *         int mode = 0;
+ *         switch (mode) {
+ *             case 1:
+ *                 int x = 1;
+ *                 break;
+ *             default:
+ *                 x = 0;
+ *         } // ok, RightCurly is alone
+ *     }
+ *
+ *     public void method0() {
+ *         int mode = 0;
+ *         switch (mode) {
+ *             case 1:
+ *                 int x = 1;
+ *                 break;
+ *             default:
+ *                 x = 0; } // violation, RightCurly should be alone on a line
+ *     }
+ *
+ * }
+ * </pre>
+ * <p>
  * To configure the check with policy {@code alone_or_singleline} for {@code if} and
  * <a href="https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
  * METHOD_DEF</a>
@@ -202,6 +239,47 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *   }                                // OK
  *
  *   public void violate() { bar(); } // OK , because singleline
+ * }
+ * </pre>
+ * <p>
+ * To configure the check with policy {@code alone_or_singleline} for
+ * <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/switch.html">
+ * Switch</a>
+ * Statements:
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;RightCurly&quot;&gt;
+ *  &lt;property name=&quot;option&quot; value=&quot;alone_or_singleline&quot;/&gt;
+ *  &lt;property name=&quot;tokens&quot; value=&quot;LITERAL_SWITCH&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <pre>
+ * class Test {
+ *
+ *     public void method0() {
+ *         int mode = 0;
+ *         switch (mode) {
+ *             case 1:
+ *                 int x = 1;
+ *                 break;
+ *             default:
+ *                 x = 0;
+ *         } // ok
+ *     }
+ *
+ *     public static void method7() {
+ *         int mode = 0;
+ *         int x;
+ *         switch (mode) { case 1: x = 5; } // ok, RightCurly is on the same line as LeftCurly
+ *     }
+ *
+ *     public void method() {
+ *         int mode = 0;
+ *         int x;
+ *         switch (mode) {
+ *             case 1:
+ *                 x = 1; } // violation, right curly should be alone on line
+ *         }
  * }
  * </pre>
  * <p>
@@ -292,6 +370,7 @@ public class RightCurlyCheck extends AbstractCheck {
             TokenTypes.INTERFACE_DEF,
             TokenTypes.RECORD_DEF,
             TokenTypes.COMPACT_CTOR_DEF,
+            TokenTypes.LITERAL_SWITCH,
         };
     }
 
@@ -559,11 +638,54 @@ public class RightCurlyCheck extends AbstractCheck {
                 case TokenTypes.LITERAL_DO:
                     details = getDetailsForDoLoops(ast);
                     break;
+                case TokenTypes.LITERAL_SWITCH:
+                    details = getDetailsForSwitch(ast);
+                    break;
                 default:
                     details = getDetailsForOthers(ast);
                     break;
             }
             return details;
+        }
+
+        /**
+         * Collects details about switch statements and expressions.
+         *
+         * @param switchNode switch statement or expression to gather details about
+         * @return new Details about given switch statement or expression
+         */
+        private static Details getDetailsForSwitch(DetailAST switchNode) {
+            final DetailAST lcurly = switchNode.findFirstToken(TokenTypes.LCURLY);
+            final DetailAST rcurly;
+            DetailAST nextToken = null;
+            // skipping switch expression as check only handles statements
+            if (isSwitchExpression(switchNode)) {
+                rcurly = null;
+            }
+            else {
+                rcurly = switchNode.getLastChild();
+                nextToken = getNextToken(switchNode);
+            }
+            return new Details(lcurly, rcurly, nextToken, true);
+        }
+
+        /**
+         * Check whether switch is expression or not.
+         *
+         * @param switchNode switch statement or expression to provide detail
+         * @return true if it is a switch expression
+         */
+        private static boolean isSwitchExpression(DetailAST switchNode) {
+            DetailAST currentNode = switchNode;
+            boolean ans = false;
+
+            while (currentNode != null) {
+                if (currentNode.getType() == TokenTypes.EXPR) {
+                    ans = true;
+                }
+                currentNode = currentNode.getParent();
+            }
+            return ans;
         }
 
         /**

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/blocks/RightCurlyCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/blocks/RightCurlyCheck.xml
@@ -6,7 +6,7 @@
               parent="com.puppycrawl.tools.checkstyle.TreeWalker">
          <description>&lt;p&gt;
  Checks the placement of right curly braces ({@code '}'}) for code blocks. This check supports
- if-else, try-catch-finally blocks, while-loops, for-loops,
+ if-else, try-catch-finally blocks, switch statements, while-loops, for-loops,
  method definitions, class definitions, constructor definitions,
  instance, static initialization blocks, annotation definitions and enum definitions.
  For right curly brace of expression blocks of arrays, lambdas and class instances

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -96,7 +96,7 @@
       <property name="tokens"
                value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
                     INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
-                    COMPACT_CTOR_DEF"/>
+                    COMPACT_CTOR_DEF, LITERAL_SWITCH"/>
     </module>
     <module name="SuppressionXpathSingleFilter">
       <!-- suppresion is required till https://github.com/checkstyle/checkstyle/issues/7541 -->

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/blocks/RightCurlyCheckTest.java
@@ -661,4 +661,164 @@ public class RightCurlyCheckTest extends AbstractModuleTestSupport {
         verifyWithInlineConfigParser(
                 getPath("InputRightCurlyTestIfElseAlone.java"), expected);
     }
+
+    @Test
+    public void testSwitchCase() throws Exception {
+        final String[] expected = {
+            "20:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
+            "27:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 27),
+            "51:46: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 46),
+            "69:68: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 68),
+            "75:74: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 74),
+            "112:17: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 17),
+            "116:21: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 21),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputRightCurlyTestSwitchCase.java"), expected);
+    }
+
+    @Test
+    public void testSwitchCase2() throws Exception {
+        final String[] expected = {
+            "20:24: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 24),
+            "27:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 27),
+            "114:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputRightCurlyTestSwitchCase2.java"), expected);
+    }
+
+    @Test
+    public void testSwitchCase3() throws Exception {
+        final String[] expected = {
+            "15:22: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 22),
+            "17:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "19:36: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 36),
+            "25:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "26:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
+            "28:22: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 22),
+            "29:22: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 22),
+            "37:26: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 26),
+            "37:27: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 27),
+            "43:40: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 40),
+            "43:41: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 41),
+            "48:46: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 46),
+            "50:32: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 32),
+            "50:33: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 33),
+            "52:13: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 13),
+            "52:14: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 14),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputRightCurlyTestSwitchCase3.java"), expected);
+    }
+
+    @Test
+    public void testSwitchCase4() throws Exception {
+        final String[] expected = {
+            "17:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "19:36: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 36),
+            "25:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "26:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
+            "28:22: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 22),
+            "35:41: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 41),
+            "35:42: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 42),
+            "40:46: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 46),
+            "42:32: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 32),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputRightCurlyTestSwitchCase4.java"), expected);
+    }
+
+    @Test
+    public void testSwitchCase5() throws Exception {
+        final String[] expected = {
+            "17:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "19:36: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 36),
+            "25:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "26:37: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 37),
+            "28:22: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 22),
+            "35:41: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 41),
+            "35:42: " + getCheckMessage(MSG_KEY_LINE_BREAK_BEFORE, "}", 42),
+            "40:46: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 46),
+            "42:32: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 32),
+            "65:49: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 49),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputRightCurlyTestSwitchCase5.java"), expected);
+    }
+
+    @Test
+    public void testSwitchExpression() throws Exception {
+        final String[] expected = {
+            "48:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "56:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "92:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputRightCurlyTestSwitchExpression.java"), expected);
+    }
+
+    @Test
+    public void testSwitchExpression2() throws Exception {
+        final String[] expected = {
+            "46:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "54:5: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 5),
+            "77:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+            "90:9: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 9),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputRightCurlyTestSwitchExpression2.java"), expected);
+    }
+
+    @Test
+    public void testSwitchExpression3() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputRightCurlyTestSwitchExpression3.java"), expected);
+    }
+
+    @Test
+    public void testSwitchExpression4() throws Exception {
+        final String[] expected = {
+            "117:28: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 28),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputRightCurlyTestSwitchExpression4.java"), expected);
+    }
+
+    @Test
+    public void testSwitchExpression5() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputRightCurlyTestSwitchExpression5.java"), expected);
+    }
+
+    @Test
+    public void testSwitchWithComment() throws Exception {
+        final String[] expected = {
+            "16:66: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 66),
+            "23:61: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 61),
+            "24:57: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 57),
+            "31:23: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 23),
+            "32:19: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 19),
+            "37:23: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 23),
+            "38:33: " + getCheckMessage(MSG_KEY_LINE_ALONE, "}", 33),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputRightCurlyTestWithComment.java"), expected);
+    }
+
+    @Test
+    public void testSwitchExpression6() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputRightCurlyTestSwitchExpression6.java"), expected);
+    }
+
+    @Test
+    public void testSwitchExpression7() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputRightCurlyTestSwitchExpression7.java"), expected);
+    }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression.java
@@ -1,0 +1,118 @@
+/*
+RightCurly
+option = ALONE
+tokens = LITERAL_SWITCH, LITERAL_IF
+
+
+*/
+
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyTestSwitchExpression {
+
+    public void test() {
+        int day = 3;
+        String check =
+            switch (day) {
+                case 1 -> "Monday";
+                case 2 -> "Tuesday";
+                case 3 -> "Wednesday";
+                default -> "Invalid day";
+            }; } // ok
+
+    public void test1() {
+        int day = 3;
+        String check =
+            switch (day) {
+                case 1 -> "Monday";
+                default -> "Invalid day";
+            }; // ok
+    }
+
+    public void test2() {
+        int day = 3;
+        String check =
+            switch (day) {
+                case 1 -> "Monday";
+                default -> "Invalid day";
+            }; System.out.println(check); // ok
+    }
+
+    public void test3() {
+        int num = 2;
+
+        switch (num) {
+            case 1 -> System.out.println("One");
+            default -> System.out.println("Other");
+    } int a; } // violation ''}' at column 5 should be alone on a line'
+
+    public void test4() {
+        int num = 2;
+
+        switch (num) {
+            case 1 -> System.out.println("One");
+            default -> System.out.println("Other");
+    } } // violation ''}' at column 5 should be alone on a line'
+
+    public void test5() {
+        int num = 0;
+        switch (num) {
+            case 1 -> System.out.println("One");
+            default -> System.out.println("Other");
+        } // ok
+    }
+
+    public void test6() {
+        int num = 2;
+
+        switch (num) {
+            //no case or default statement
+        } // ok
+    }
+
+    public void test7() {
+        int num = 2;
+
+        switch (num) {
+            //no case or default statement
+        } // ok
+    }
+
+    public void test8() {
+
+        int expression = 2;
+        switch (expression) {
+            case 1 -> {
+                Runnable result1 = () -> System.out.println("result1");
+            }
+            default -> {
+                Runnable defaultResult = () -> System.out.println("defaultResult");
+            }
+        } int a; // violation ''}' at column 9 should be alone on a line'
+    }
+
+    public void test9() {
+
+        int expression = 2;
+        switch (expression) {
+            case 1 -> {
+                Runnable result1 = () -> System.out.println("result1");
+            }
+            default -> {
+                Runnable defaultResult = () -> System.out.println("defaultResult");
+            }
+        } // ok
+    }
+
+    public void test10() {
+        int expression = 2;
+        switch (expression) { case 1 -> { Runnable result1 = () -> System.out.println("r1"); }
+        } // ok
+        switch (expression) {
+            case 1 -> {
+                Runnable result1 = () -> System.out.println("r1");
+            }
+        } // ok
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression2.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression2.java
@@ -1,0 +1,118 @@
+/*
+RightCurly
+option = ALONE_OR_SINGLELINE
+tokens = LITERAL_SWITCH, LITERAL_IF
+
+
+*/
+
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyTestSwitchExpression2 {
+
+    public void test() {
+        int day = 3;
+        String check =
+            switch (day) {
+                case 1 -> "Monday";
+                default -> "Invalid day";
+            }; } // ok
+
+    public void test1() {
+        int day = 3;
+        String check =
+            switch (day) {
+                case 1 -> "Monday";
+                default -> "Invalid day";
+            };
+    }
+
+    public void test2() {
+        int day = 3;
+        String check =
+            switch (day) {
+                case 1 -> "Monday";
+                default -> "Invalid day";
+            }; System.out.println(check); // ok
+    }
+
+    public void test3() {
+        int num = 2;
+
+        switch (num) {
+            case 1 -> System.out.println("One");
+            default -> System.out.println("Other");
+    } int a; } // violation ''}' at column 5 should be alone on a line'
+
+    public void test4() {
+        int num = 2;
+
+        switch (num) {
+            case 1 -> System.out.println("One");
+            default -> System.out.println("Other");
+    } } // violation ''}' at column 5 should be alone on a line'
+
+    public void test5() {
+        int num = 0;
+        switch (num) {
+            case 1 -> System.out.println("One");
+            default -> System.out.println("Other");
+        } // ok
+    }
+
+    public void test6() {
+        int num = 2;
+
+        switch (num) {
+            //no case or default statement
+        } // ok
+    }
+
+    public void test7() {
+        int num = 2;
+
+        switch (num) {
+            //no case or default statement
+        } int a; // violation ''}' at column 9 should be alone on a line'
+    }
+
+    public void test8() {
+
+        int expression = 2;
+        switch (expression) {
+            case 1 -> {
+                Runnable result1 = () -> System.out.println("result1");
+            }
+            default -> {
+                Runnable defaultResult = () -> System.out.println("defaultResult");
+            }
+        } int a; // violation ''}' at column 9 should be alone on a line'
+    }
+
+    public void test9() {
+
+        int expression = 2;
+        switch (expression) {
+            case 1 -> {
+                Runnable result1 = () -> System.out.println("result1");
+            }
+            default -> {
+                Runnable defaultResult = () -> System.out.println("defaultResult");
+            }
+        } // ok
+    }
+
+    public void test10() {
+        int expression = 2;
+        switch (expression)
+        { case 1 -> { Runnable result1 = () -> System.out.println("r1"); } } // ok
+        switch (expression)
+        { case 1 -> { Runnable result1 = () -> System.out.println("r1"); } } // ok
+        switch (expression) {
+            case 1 -> {
+                Runnable result1 = () -> System.out.println("r1");
+            }
+        } // ok
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression3.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression3.java
@@ -1,0 +1,29 @@
+/*
+RightCurly
+option = ALONE_OR_SINGLELINE
+tokens = LITERAL_SWITCH, LITERAL_IF
+
+
+*/
+
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyTestSwitchExpression3 {
+    int foo(int yield) {
+        return switch (yield) {
+            case 1 -> 2;
+            case 2 -> 3;
+            case 3 -> 4;
+            default -> 5;
+        };
+    }
+
+    int foo2(int yield) {
+        return switch (yield) {
+            case 1 -> 2;
+            case 2 -> 3;
+            case 3 -> 4;
+            default -> 5;
+        }; } // ok
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression4.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression4.java
@@ -1,0 +1,120 @@
+/*
+RightCurly
+option = ALONE
+tokens = LITERAL_SWITCH
+
+*/
+
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyTestSwitchExpression4 {
+
+    public class InputFinalLocalVariableCheckSwitchAssignment {
+        private static final int staticValue = 2;
+
+        public InputFinalLocalVariableCheckSwitchAssignment() throws Exception {
+            int a = 0;
+            final int b = 0;
+            int c = 10;
+            int d = 0;
+
+            c = switch (a) {
+                case 0 -> 5;
+                case 1 -> 10;
+                default -> switch (b) {
+                    case 2 -> {
+                        if (a == 0) {
+                            d = 1; // reassign d
+                        }
+                        throw new Exception();
+                    }
+                    default -> 2;
+                }; // ok
+            }; // ok
+        }
+
+        public void foo() throws Exception {
+            final int a = 0;
+
+            int b = switch (a) {
+                case 0 -> {
+                    int x = 5;
+                    int y = 6;
+                    if (a == 2) {
+                        y = 7;
+                    }
+                    throw new Exception();
+                }
+                default -> 2;
+            }; // ok
+
+            int c = switch (b) {
+                case 0 -> 1;
+                default -> 2;
+            }; // ok
+
+            c = switch (a) {
+                case 0 -> switch (b) {
+                    case 0 -> 1;
+                    case 1 -> 2;
+                    default -> 3;
+                }; // ok
+                default -> 1;
+            }; // ok
+        }
+    }
+}
+
+class InputMissingSwitchDefaultCheckSwitchExpressionsThree {
+    public enum Options {
+        ONE,
+        TWO,
+        THREE
+    }
+
+    public enum Day {
+        SUN,
+    }
+
+    public void foo2(Options option) {
+        assert Integer.valueOf(1).equals(switch (option) { // ok
+            case ONE -> 1;
+            case TWO -> 2;
+            case THREE -> 3;
+        }); // ok
+    }
+}
+
+class InputExecutableStatementCountRecords {
+
+      private int id(int i) {
+          return i;
+      }
+
+      private final int value = 2;
+
+      private final int field = id(switch(value) {
+          case 0 -> -1;
+          case 2 -> {
+              int temp = 0;
+              temp += 3;
+              yield temp;
+          }
+          default -> throw new IllegalStateException();
+      }); // ok
+
+    void commentBeforeRightCurly() {
+        int i = 20;
+        while (true) {
+            switch (i) {
+                case 0:
+                    i++;
+            } // ok
+            switch (i) {
+                case 0:
+                    i++;
+            /* fallthru */ } // violation ''}' at column 28 should be alone on a line'
+        }
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression5.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression5.java
@@ -1,0 +1,110 @@
+/*
+RightCurly
+option = ALONE
+tokens = LITERAL_SWITCH
+
+*/
+
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+import java.io.IOException;
+
+public class InputRightCurlyTestSwitchExpression5 {
+    public class InputFinalLocalVariableCheckSwitchAssignment {
+        private static final int staticValue = 2;
+
+        public InputFinalLocalVariableCheckSwitchAssignment() throws Exception {
+            int a = 0;
+            final int b = 0;
+            int c = 10;
+            int d = 0;
+
+            c = switch (a) {
+                case 0 -> 5;
+                case 1 -> 10;
+                default -> switch (b) {
+                    case 2 -> {
+                        if (a == 0) {
+                            d = 1; // reassign d
+                        }
+                        throw new Exception();
+                    }
+                    default -> 2;
+                };
+            }; // ok
+        }
+
+        public void foo() throws Exception {
+            final int a = 0;
+
+            int b = switch (a) {
+                case 0 -> {
+                    int x = 5;
+                    int y = 6;
+                    if (a == 2) {
+                        y = 7;
+                    }
+                    throw new Exception(); }
+                default -> 2; };
+
+            int c = switch (b) {
+                case 0 -> 1;
+                default -> 2;
+            };
+
+            c = switch (a) {
+                case 0 -> switch (b) {
+                    case 0 -> 1;
+                    case 1 -> 2;
+                    default -> 3; }; // ok
+                default -> 1; }; // ok
+        }
+    }
+}
+
+class InputMissingSwitchDefaultCheckSwitchExpressionsThree {
+    public enum Day {
+        SUN,
+    }
+    public enum Options { THREE }
+
+    public void foo2(Options option) {
+        assert Integer.valueOf(1).equals(switch (option) { // ok
+            case THREE -> 3;
+        }); // ok
+    }
+}
+
+class InputExecutableStatementCountRecords {
+
+    private int id(int i) {
+        return i;
+    }
+
+    private final int value = 2;
+
+    private final int field = id(switch (value) {
+        case 0 -> -1;
+        case 2 -> {
+            int temp = 0;
+            temp += 3;
+            yield temp;
+        }
+        default -> throw new IllegalStateException();
+    }); // ok
+
+    public static void method0() throws IOException {
+        int stValue = 0;
+        if (stValue > 0) {
+            try {
+                switch (stValue) {
+                    case 0:
+                        break;
+                } // ok
+            } catch (NumberFormatException e) {
+                throw new IOException(" value ");
+            }
+        }
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression6.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression6.java
@@ -1,0 +1,119 @@
+/*
+RightCurly
+option = ALONE
+tokens = LITERAL_SWITCH
+
+*/
+
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyTestSwitchExpression6 {
+     public void foo5() {
+         int x = 0;
+         final T e = T.B;
+
+         final boolean t8 = (switch (e) {
+         case A:
+             x = 1;
+         case B:
+         default:
+             yield false;
+         }) && x == 1; // ok
+
+         {
+             final T y = T.A;
+
+             final boolean t9 = (switch (y) {
+             case A:
+                 x = 1;
+                 yield true;
+             case B:
+                 yield (x = 1) == 1 || true;
+             default:
+                 yield false;
+             }) && x == 1; // ok
+         }
+
+         {
+             final T y = T.A;
+
+             final int v = switch (y) {
+             case A -> x = 0;
+             case B -> x = 0;
+             case C -> x = 0;
+             };
+
+             if (x != 0 || v != 0) {
+                 throw new IllegalStateException("Unexpected result.");
+             }
+        }
+
+         {
+             final T y = T.A;
+
+             final boolean tA = (switch (y) {
+            case A -> {
+                 x = 1;
+                 yield true;
+             }
+             case B -> {
+                 x = 1;
+                 yield true;
+             }
+             case C -> {
+                 x = 1;
+                 yield true;
+             }
+             }) && x == 1; // ok
+         }
+     }
+
+      public void bar2(Option option) {
+          assert 1 < switch (option) {
+              case ONE -> 1;
+              case TWO -> 2;
+              case THREE -> 3;
+          }; // ok
+      }
+
+      int usedOnBothSidesOfArithmeticExpression(Day day) {
+          return switch (day) {
+              case MON, TUE -> 0;
+              case WED -> 1;
+              default -> 2;
+          } * switch (day) {  // ok
+              case WED, THU -> 3;
+              case FRI -> 4;
+              default -> 5;
+          };
+      }
+
+      static {
+          int x = 0;
+          T e = T.B;
+
+          boolean t8 = (switch (e) {
+              case A
+                  :
+                  x = 1;
+                  yield true;
+              case B :
+                  yield (x = 1) == 1 || true;
+              default
+                      :yield false;
+          }) && x == 1; // ok
+     }
+}
+
+enum T {
+    A, B, C
+}
+
+enum Option {
+    ONE, TWO, THREE
+}
+
+enum Day {
+    MON, TUE, WED, THU, FRI
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression7.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchExpression7.java
@@ -1,0 +1,90 @@
+/*
+RightCurly
+option = ALONE
+tokens = LITERAL_SWITCH
+
+*/
+
+//non-compiled with javac: Compilable with Java14
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyTestSwitchExpression7 {
+
+      String isDayNameLong(Day day) {
+          return switch (day) {
+              case MON, FRI, SUN -> 6;
+              case TUE -> 7;
+              case THU, SAT -> 8;
+              case WED -> 9;
+          } > 7 ? "long" : "short"; // ok
+      }
+
+     int arithmetic(Day day) {
+         return switch (day) {
+             case MON, FRI, SUN -> 6;
+             case TUE -> 7;
+             case THU, SAT -> 8;
+             case WED -> 9;
+         } % 2; // ok
+     }
+
+     int signArithmetic(Day day) {
+         return -switch (day) {
+             case MON, FRI, SUN -> 6;
+             case TUE -> 7;
+             case THU, SAT -> 8;
+             case WED -> 9;
+         };
+     }
+
+     int usedOnBothSidesOfArithmeticExpression(Day day) {
+         return switch (day) {
+             case MON, TUE -> 0;
+             case WED -> 1;
+            default -> 2;
+         } * switch (day) { // ok
+             case WED, THU -> 3;
+             case FRI -> 4;
+             default -> 5;
+         }; // ok
+     }
+
+     static {
+         int i = 0;
+         int dummy = 1 + switch (i) {
+             case -1: yield 1;
+             default:
+                 i++;
+                 yield 1;
+         };
+         if (i != 1) {
+             throw new IllegalStateException("Side effects missing.");
+         }
+     }
+
+     static {
+         int x;
+
+         int t7 = new DefiniteAssignment1().id(switch (0) {
+             default -> isTrue();
+         } && (x = 1) == 1 && x == 1 ? 2 : -1);
+
+         if (t7 != 2) {
+             throw new IllegalStateException("Unexpected result.");
+         }
+     }
+
+    private static boolean isTrue() {
+          return true;
+    }
+}
+
+class DefiniteAssignment1 {
+    int id(int id) {
+        return id;
+    }
+}
+
+enum Day {
+    MON, TUE, WED, THU, FRI, SAT, SUN
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchCase.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchCase.java
@@ -1,0 +1,120 @@
+/*
+RightCurly
+option = ALONE
+tokens = LITERAL_SWITCH, LITERAL_IF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyTestSwitchCase {
+
+    public static void method0() {
+        int mode = 0;
+        switch (mode) {
+            case 1:
+                int x = 1;
+                break;
+            default :
+                x = 0; } // violation '}' at column 24 should be alone on a line'
+    }
+
+    public static void method1() {
+        int mode = 0;
+        switch (mode) {
+        default :
+               int x = 0; } // violation '}' at column 27 should be alone on a line'
+    }
+
+    public static void method2() {
+        int mode = 0;
+        switch (mode) {
+            case 1:
+                int x = 1;
+                break;
+            default:
+                x = 0;
+        } // ok
+    }
+
+    public static void method3() {
+        int mode = 0;
+        switch (mode) {
+        default :
+               int x = 0;
+        } // ok
+    }
+
+    public static void method4() {
+        int mode = 0;
+        switch (mode) { default : int x = 0; }
+        // violation above '}' at column 46 should be alone on a line'
+    }
+
+    public static void method5() {
+        int mode = 0;
+        switch (mode) { default : int x = 0;
+        } // ok
+    }
+
+    public static void method6() {
+        int mode = 0;
+        switch (mode) { case 0: int x = 1; break; default : x = 5;
+        } // ok
+    }
+
+    public static void method7() {
+        int mode = 0;
+        switch (mode) { case 0: int x = 1; break; default : x = 5; }
+        // violation above '}' at column 68 should be alone on a line'
+    }
+
+    public static void method8() {
+        int mode = 0;
+        switch (mode) { case 0: int x = 1; break; case 80: x = 1; break; }
+        // violation above '}' at column 74 should be alone on a line'
+    }
+
+    public static void method9() {
+        int mode = 0;
+        switch (mode) { case 0: int x = 1; break; default : x = 5;
+        } // ok
+    }
+
+    public static void method10() {
+        int mode = 0;
+        switch (mode) { case 0: int x = 1; break; case 80: x = 1; break;
+        } // ok
+    }
+
+    public static void method11() {
+        int mode = 0;
+        int x = 0;
+        switch (mode) {
+            case 0:
+                if(0>9) {
+                    x = 9;
+                }
+                break;
+            case 80:
+                x = 1;
+                break;
+        }
+    }
+    public static void method12() {
+        int mode = 0;
+        int x = 0;
+        switch (mode) {
+            case 0:
+                if(0>9) {
+                    x = 9;
+                } else { // violation ''}' at column 17 should be alone on a line'
+                }
+                break;
+        }
+        switch (x) {}; // violation ''}' at column 21 should be alone on a line'
+        switch (x) {
+        } // ok
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchCase2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchCase2.java
@@ -1,0 +1,118 @@
+/*
+RightCurly
+option = ALONE_OR_SINGLELINE
+tokens = LITERAL_SWITCH, LITERAL_IF, LITERAL_TRY, LITERAL_CATCH
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyTestSwitchCase2 {
+
+    public static void method0() {
+        int mode = 0;
+        switch (mode) {
+            case 1:
+                int x = 1;
+                break;
+            default :
+                x = 0; } // violation '}' at column 24 should be alone on a line'
+    }
+
+    public static void method1() {
+        int mode = 0;
+        switch (mode) {
+        default :
+               int x = 0; } // violation '}' at column 27 should be alone on a line'
+    }
+
+    public static void method2() {
+        int mode = 0;
+        switch (mode) {
+            case 1:
+                int x = 1;
+                break;
+            default:
+                x = 0;
+        } // ok
+    }
+
+    public static void method3() {
+        int mode = 0;
+        switch (mode) {
+        default :
+               int x = 0;
+        } // ok
+    }
+
+    public static void method4() {
+        int mode = 0;
+        switch (mode) { default : int x = 0; } // ok
+    }
+
+    public static void method5() {
+        int mode = 0;
+        switch (mode) { default : int x = 0;
+        } // ok
+    }
+
+    public static void method6() {
+        int mode = 0;
+        switch (mode) { case 0: int x = 1; break; default : x = 5;
+        } // ok
+    }
+
+    public static void method7() {
+        int mode = 0;
+        switch (mode) { case 0: int x = 1; break; default : x = 5; } // ok
+    }
+
+    public static void method8() {
+        int mode = 0;
+        switch (mode) { case 0: int x = 1; break; case 80: x = 1; break; } // ok
+    }
+
+    public static void method9() {
+        int mode = 0;
+        switch (mode) { case 0: int x = 1; break; default : x = 5;
+        } // ok
+    }
+
+    public static void method10() {
+        int mode = 0;
+        switch (mode) { case 0: int x = 1; break; case 80: x = 1; break;
+        } // ok
+    }
+
+    public static void method11() {
+        int mode = 0;
+        int x = 0;
+        switch (mode) {
+            case 0:
+                if(0>9) {
+                    x = 9;
+                }
+                break;
+            case 80:
+                x = 1;
+                break;
+        }
+    }
+
+    public static void method12() {
+        int num = 5;
+        try {
+            switch (num) {
+                case 1:
+                try {
+                        System.out.println("Number is 1");
+                        break;
+                }
+                catch (Exception ignored) {}
+            }
+        } catch (IllegalArgumentException e) { // violation 'at column 9 should be alone on a line'
+            System.err.println(e.getMessage());
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchCase3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchCase3.java
@@ -1,0 +1,60 @@
+/*
+RightCurly
+option = ALONE
+tokens = LITERAL_SWITCH, LITERAL_IF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyTestSwitchCase3 {
+
+    public void method() {
+        int x = 0;
+        switch (x) { } // violation ''}' at column 22 should be alone on a line'
+        switch (x) {
+        } int a; // violation ''}' at column 9 should be alone on a line'
+        switch (x) {
+            case(1): x = 0; break; } // violation ''}' at column 36 should be alone on a line'
+        switch (x)
+        {
+        } // ok
+        switch (x)
+        {case(1): x=1;break;
+        } int b; // violation ''}' at column 9 should be alone on a line'
+        switch (x) {case(2): break; } int c;
+        // violation above ''}' at column 37 should be alone on a line'
+        switch (x) { } int d; // violation ''}' at column 22 should be alone on a line'
+        switch (x) { } // violation ''}' at column 22 should be alone on a line'
+    }
+
+    public void someMethod() {
+        int x = 90;
+        if (7>x) {
+           switch (x) {
+               case(1):
+                   break;}} // 2 violations
+    }
+
+    public void someMethod2() {
+        int x = 90;
+        if (7>x) {
+           switch (x) { case(1): break;}} // 2 violations
+    }
+
+    public void someMethod3() {
+        int x = 90;
+        if (7>x) {switch (x) {case(1): break;}
+        } // violation above ''}' at column 46 should be alone on a line'
+        if (7>x) {switch (x) { }} // 2 violations
+        if (7>x) {switch (x) {
+            }} // 2 violations
+        if (7>x) {switch (x) {
+            }
+       }
+       if (7>x) {switch (x) {
+            }
+       }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchCase4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchCase4.java
@@ -1,0 +1,44 @@
+/*
+RightCurly
+option = ALONE_OR_SINGLELINE
+tokens = LITERAL_SWITCH, LITERAL_IF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyTestSwitchCase4 {
+
+    public void method() {
+        int x = 0;
+        switch (x) { } // ok
+        switch (x) {
+        } int a; // violation ''}' at column 9 should be alone on a line'
+        switch (x) {
+            case(1): x = 0; break; } // violation ''}' at column 36 should be alone on a line'
+        switch (x)
+        {
+        } // ok
+        switch (x)
+        {case(1): x=1;break;
+        } int b; // violation ''}' at column 9 should be alone on a line'
+        switch (x) {case(2): break; } int c;
+        // violation above ''}' at column 37 should be alone on a line'
+        switch (x) { } int d; // violation ''}' at column 22 should be alone on a line'
+        switch (x) { } // ok
+    }
+
+    public void someMethod2() {
+        int x = 90;
+        if (7>x) {
+            switch (x) { case(1): break;}} // 2 violations
+    }
+
+    public void someMethod3() {
+        int x = 90;
+        if (7>x) {switch (x) {case(1): break;}}
+        // violation above ''}' at column 46 should be alone on a line'
+        if (7>x) {switch (x) { }} // violation ''}' at column 32 should be alone on a line'
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchCase5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestSwitchCase5.java
@@ -1,0 +1,68 @@
+/*
+RightCurly
+option = SAME
+tokens = LITERAL_SWITCH, LITERAL_IF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyTestSwitchCase5 {
+
+    public void method() {
+        int x = 0;
+        switch (x) { } // ok
+        switch (x) {
+        } int a; // violation ''}' at column 9 should be alone on a line'
+        switch (x) {
+            case(1): x = 0; break; } // violation ''}' at column 36 should have line break before'
+        switch (x)
+        {
+        } // ok
+        switch (x)
+        {case(1): x=1;break;
+        } int b; // violation ''}' at column 9 should be alone on a line'
+        switch (x) {case(2): break; } int c;
+        // violation above ''}' at column 37 should be alone on a line'
+        switch (x) { } int d; // violation ''}' at column 22 should be alone on a line'
+        switch (x) { } // ok
+    }
+
+    public void someMethod2() {
+        int x = 90;
+        if (7>x) {
+            switch (x) { case(1): break;}} // 2 violations
+    }
+
+    public void someMethod3() {
+        int x = 90;
+        if (7>x) {switch (x) {case(1): break;}}
+        // violation above ''}' at column 46 should be alone on a line'
+        if (7>x) {switch (x) { }} // violation ''}' at column 32 should be alone on a line'
+    }
+}
+
+class NoViolationOnInputRightCurlyTestSwitchCase5 {
+    public void method() {
+        int x = 0;
+        switch (x) { } // ok
+        switch (x) { default: } // ok
+        switch (x) { case(1): x = 0; break; } // ok
+        switch (x)
+        {
+        } // ok
+        switch (x)
+        {case(1): x=1;break;
+        }
+        int b;
+        switch (x) {case(2): break; }
+        switch (x) { } // ok
+    }
+
+    public void someMethod2() {
+        int x = 90;
+        if (7>x) { switch (x) { case(1): break; } }
+        // violation above ''}' at column 49 should be alone on a line'
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestWithComment.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/blocks/rightcurly/InputRightCurlyTestWithComment.java
@@ -1,0 +1,39 @@
+/*
+RightCurly
+option = ALONE
+tokens = LITERAL_SWITCH, METHOD_DEF, LITERAL_WHILE, LITERAL_IF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.blocks.rightcurly;
+
+public class InputRightCurlyTestWithComment {
+    void m1(int mode) {
+        switch (mode) {
+            default:
+                int x = 0; // violation below ''}' at column 66 should be alone on a line'
+                /* block comment here is counted as violation */ }
+    }
+
+    void m2() {
+        int a = 0;
+        if (a > 2) {
+            System.out.println();  // violation below ''}' at column 61 should be alone on a line'
+            /* block comment here is counted as violation*/ }
+        /* block comment here is counted as violation*/ }
+        // violation above ''}' at column 57 should be alone on a line'
+
+    void method() {
+        int a = 0;
+        if (a > 2) {
+            System.out.println("no");
+        /* comment */ } // violation ''}' at column 23 should be alone on a line'
+    /* commrnt */ } // violation ''}' at column 19 should be alone on a line'
+
+    void loop() {
+        while(true) {
+            System.out.println("Checkstyle");
+        /* comment */ } // violation ''}' at column 23 should be alone on a line'
+    /* comment */ /* comment */ } // violation ''}' at column 33 should be alone on a line'
+}

--- a/src/xdocs/config_blocks.xml
+++ b/src/xdocs/config_blocks.xml
@@ -1250,8 +1250,8 @@ allowedFuture.addCallback(result -> {
       <subsection name="Description" id="RightCurly_Description">
         <p>
           Checks the placement of right curly braces (<code>'}'</code>) for code blocks.
-          This check supports if-else, try-catch-finally blocks, while-loops, for-loops,
-          method definitions, class definitions, constructor definitions,
+          This check supports if-else, try-catch-finally blocks, switch statements,
+          while-loops, for-loops, method definitions, class definitions, constructor definitions,
           instance, static initialization blocks, annotation definitions and enum definitions.
           For right curly brace of expression blocks of arrays, lambdas and class instances
           please follow issue
@@ -1318,6 +1318,8 @@ allowedFuture.addCallback(result -> {
                   RECORD_DEF</a>
                 ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#COMPACT_CTOR_DEF">
                   COMPACT_CTOR_DEF</a>
+                ,<a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#LITERAL_SWITCH">
+                  LITERAL_SWITCH</a>
                 .
               </td>
               <td>
@@ -1433,7 +1435,45 @@ public class Test {
   }                              // OK
 }
         </source>
+        <p>
+          To configure the check with policy <code>alone</code> for
+          <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/switch.html">
+          Switch</a>
+          Statements:
+        </p>
+        <source>
+&lt;module name=&quot;RightCurly&quot;&gt;
+  &lt;property name=&quot;option&quot; value=&quot;alone&quot;/&gt;
+  &lt;property name=&quot;tokens&quot; value=&quot;LITERAL_SWITCH&quot;/&gt;
+&lt;/module&gt;
+        </source>
 
+        <source>
+class Test {
+
+    public void method0() {
+        int mode = 0;
+        switch (mode) {
+            case 1:
+                int x = 1;
+                break;
+            default:
+                x = 0;
+        } // ok, RightCurly is alone
+    }
+
+    public void method0() {
+        int mode = 0;
+        switch (mode) {
+            case 1:
+                int x = 1;
+                break;
+            default:
+                x = 0; } // violation, RightCurly should be alone on a line
+    }
+
+}
+        </source>
         <p>
           To configure the check with policy <code>alone_or_singleline</code> for <code> if</code>
           and <a href="apidocs/com/puppycrawl/tools/checkstyle/api/TokenTypes.html#METHOD_DEF">
@@ -1475,6 +1515,47 @@ public class Test {
   }                                // OK
 
   public void violate() { bar(); } // OK , because singleline
+}
+        </source>
+        <p>
+          To configure the check with policy <code>alone_or_singleline</code> for
+          <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/switch.html">
+          Switch</a>
+          Statements:
+        </p>
+        <source>
+&lt;module name=&quot;RightCurly&quot;&gt;
+  &lt;property name=&quot;option&quot; value=&quot;alone_or_singleline&quot;/&gt;
+  &lt;property name=&quot;tokens&quot; value=&quot;LITERAL_SWITCH&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <source>
+class Test {
+
+    public void method0() {
+        int mode = 0;
+        switch (mode) {
+            case 1:
+                int x = 1;
+                break;
+            default:
+                x = 0;
+        } // ok
+    }
+
+    public static void method7() {
+        int mode = 0;
+        int x;
+        switch (mode) { case 1: x = 5; } // ok, RightCurly is on the same line as LeftCurly
+    }
+
+    public void method() {
+        int mode = 0;
+        int x;
+        switch (mode) {
+            case 1:
+                x = 1; } // violation, right curly should be alone on line
+    }
 }
         </source>
       </subsection>


### PR DESCRIPTION
Issue #9994: LITERAL_SWITCH token support in RightCurlyCheck


Diff Regression config: https://gist.githubusercontent.com/Kevin222004/75ac442a047d7fe25bedb544f9acd754/raw/52982ec6530ca6a4bfb5d24054bf816649cbe4fd/config.xml 

Diff Regression patch config: https://gist.githubusercontent.com/Kevin222004/7049aace77660fb0f0ac515ee7996c83/raw/1ef1a12723d35019f756bb0b11ed855e1d86ca92/patch_config.xml 