### PR TITLE
supplemental: changes to assembly profile for contribution#747

### DIFF
--- a/.ci/upload-all-jar.sh
+++ b/.ci/upload-all-jar.sh
@@ -18,7 +18,7 @@ echo TARGET_VERSION="$TARGET_VERSION"
 git checkout checkstyle-"$TARGET_VERSION"
 
 echo "Generating uber jar ...(no clean to keep site resources just in case)"
-mvn -e --no-transfer-progress -Passembly package
+mvn -e --no-transfer-progress -Passembly,no-validations package
 
 echo "Publishing 'all' jar to Github"
 UPLOAD_LINK=https://uploads.github.com/repos/checkstyle/checkstyle/releases

--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -436,7 +436,7 @@ release-dry-run)
   ;;
 
 assembly-run-all-jar)
-  mvn -e --no-transfer-progress clean package -Passembly
+  mvn -e --no-transfer-progress clean package -Passembly,no-validations
   CS_POM_VERSION="$(getCheckstylePomVersion)"
   echo version:"$CS_POM_VERSION"
   mkdir -p .ci-temp
@@ -565,7 +565,7 @@ javac17)
   ;;
 
 jdk14-assembly-site)
-  mvn -e --no-transfer-progress package -Passembly
+  mvn -e --no-transfer-progress package -Passembly,no-validations
   mvn -e --no-transfer-progress site -Pno-validations
   ;;
 
@@ -1071,7 +1071,7 @@ git-check-pull-number)
   ;;
 
 assembly-site)
-  mvn -e --no-transfer-progress package -Passembly
+  mvn -e --no-transfer-progress package -Passembly,no-validations
   mvn -e --no-transfer-progress site -Dlinkcheck.skip=true
   ;;
 

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -53,7 +53,7 @@ blocks:
                 - .ci/no-exception-test.sh no-exception-samples-ant
                 - .ci/validation.sh nondex
                 # until https://github.com/checkstyle/checkstyle/issues/9807
-                # - mvn -e --no-transfer-progress clean package -Passembly
+                # - mvn -e --no-transfer-progress clean package -Passembly,no-validations
                 #    && .ci/validation.sh no-violation-test-josm
           commands:
             - sem-version java 11

--- a/pom.xml
+++ b/pom.xml
@@ -2163,22 +2163,11 @@
 
     <profile>
       <!-- To be used during development. Run the command -->
-      <!-- mvn -Passembly package -->
+      <!-- mvn -Passembly,no-validations package -->
       <id>assembly</id>
       <properties>
-        <skipTests>true</skipTests>
-        <checkstyle.ant.skip>true</checkstyle.ant.skip>
-        <pmd.skip>true</pmd.skip>
-        <spotbugs.skip>true</spotbugs.skip>
-        <xml.skip>true</xml.skip>
-        <forbiddenapis.skip>true</forbiddenapis.skip>
-        <jacoco.skip>true</jacoco.skip>
-        <maven.javadoc.skip>true</maven.javadoc.skip>
-        <linkcheck.skip>true</linkcheck.skip>
-        <jdepend.skip>true</jdepend.skip>
-        <modernizer.skip>true</modernizer.skip>
-        <!-- difference from "no-validations" -->
         <maven.site.skip>true</maven.site.skip>
+        <assembly.skipAssembly>true</assembly.skipAssembly>
       </properties>
 
       <build>

--- a/release.sh
+++ b/release.sh
@@ -49,7 +49,7 @@ echo "Generating web site"
 mvn -e --no-transfer-progress site -Pno-validations -Dmaven.javadoc.skip=false
 
 echo "Generating uber jar ...(no clean to keep site resources just in case)"
-mvn -e --no-transfer-progress -Passembly package
+mvn -e --no-transfer-progress -Passembly,no-validations package
 
 echo "Come back repo folder"
 cd ../../

--- a/src/xdocs/cmdline.xml.vm
+++ b/src/xdocs/cmdline.xml.vm
@@ -239,7 +239,7 @@ java -D&lt;property&gt;=&lt;value&gt;  \
       </p>
       <div class="wrap-content">
         <source>
-          mvn clean package -Passembly
+          mvn clean package -Passembly,no-validations
           java -jar target/checkstyle-X.X-SNAPSHOT-all.jar -c /sun_checks.xml MyClass.java
         </source>
       </div>


### PR DESCRIPTION
Supplemental for https://github.com/checkstyle/contribution/pull/747#discussion_r1064284794

> let's combine no-validation and assembly.
> 
> But assembly should skip tests jaring and assembly plugin. So all 2 parameters should be part of assembly profile.
test jars assemble required only during release process. -Passembly was purely a profile to make "-all" jar that is not maven concept of jars.