### PR TITLE
infra: fix indentation and add echo of output

### DIFF
--- a/.github/workflows/diff_report.yml
+++ b/.github/workflows/diff_report.yml
@@ -85,6 +85,9 @@ jobs:
           sed 's/Report label: //' temp > report_label
           echo "report_label=$(cat report_label)" >> "$GITHUB_OUTPUT"
 
+          echo "GITHUB_OUTPUT:"
+          echo "$GITHUB_OUTPUT"
+
       - name: Set branch
         id: branch
         run: |
@@ -106,19 +109,20 @@ jobs:
           PATCH_CONFIG_LINK: ${{ needs.parse_body.outputs.patch_config_link }}
           LINK_FROM_PR: ${{ needs.parse_body.outputs.projects_link }}
         run: |
-         LINK="${LINK_FROM_PR:-$DEFAULT_PROJECTS_LINK}"
-         wget -q "$LINK" -O project.properties
-         if [ -n "$NEW_MODULE_CONFIG_LINK" ]; then
-           wget -q "$NEW_MODULE_CONFIG_LINK" -O new_module_config.xml
-         fi
+          LINK="${LINK_FROM_PR:-$DEFAULT_PROJECTS_LINK}"
+          echo "PROJECTS LINK: ${LINK}"
+          wget -q "$LINK" -O project.properties
+          if [ -n "$NEW_MODULE_CONFIG_LINK" ]; then
+            wget -q "$NEW_MODULE_CONFIG_LINK" -O new_module_config.xml
+          fi
 
-         if [ -n "$DIFF_CONFIG_LINK" ]; then
-           wget -q "$DIFF_CONFIG_LINK" -O diff_config.xml
-         fi
+          if [ -n "$DIFF_CONFIG_LINK" ]; then
+            wget -q "$DIFF_CONFIG_LINK" -O diff_config.xml
+          fi
 
-         if [ -n "$PATCH_CONFIG_LINK" ]; then
-           wget -q "$PATCH_CONFIG_LINK" -O patch_config.xml
-         fi
+          if [ -n "$PATCH_CONFIG_LINK" ]; then
+            wget -q "$PATCH_CONFIG_LINK" -O patch_config.xml
+          fi
 
       # fetch-depth - number of commits to fetch.
       # 0 indicates all history for all branches and tags.


### PR DESCRIPTION
We have a failure to generate diff report when we use more than one parameter. See examples below.

Ok, we need to merge this to see results from `echo`.

My guess is that we are appending to GITHUB_OUTPUT in such a way as to cause issues when we later retrieve this information.

Diff Regression config: https://gist.githubusercontent.com/nrmancuso/51b18335d59bc81bb09370564e258f51/raw/5dbbab498fceb4b15f5395cebcf133f2d7a02ba4/config.xml
