### PR TITLE
minor: cat github output file in diff report generation

### DIFF
--- a/.github/workflows/diff_report.yml
+++ b/.github/workflows/diff_report.yml
@@ -86,7 +86,9 @@ jobs:
           echo "report_label=$(cat report_label)" >> "$GITHUB_OUTPUT"
 
           echo "GITHUB_OUTPUT:"
-          echo "$GITHUB_OUTPUT"
+          # need to 'echo' to see output in Github CI
+          # shellcheck disable=SC2005
+          echo "$(cat "$GITHUB_OUTPUT")"
 
       - name: Set branch
         id: branch


### PR DESCRIPTION
GITHUB_OUTPUT is a file, we need to `cat` it: https://github.com/checkstyle/checkstyle/actions/runs/3951129217/jobs/6764584414#:~:text=/home/runner/work,Set%20branch