### PR TITLE
Issue #12667: disables picocli's colors for tests

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGeneratorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGeneratorTest.java
@@ -79,6 +79,7 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
      * <p>Configures the environment for each test.</p>
      * <ul>
      * <li>Start output capture for {@link System#err} and {@link System#out}</li>
+     * <li>Turn off colors for picocli to not conflict with tests if they are auto turned on.</li>
      * </ul>
      *
      * @param systemErr wrapper for {@code System.err}
@@ -88,6 +89,8 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
     public void setUp(@SysErr Capturable systemErr, @SysOut Capturable systemOut) {
         systemErr.captureMuted();
         systemOut.captureMuted();
+
+        System.setProperty("picocli.ansi", "false");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -213,6 +213,7 @@ public class MainTest {
      * <p>Configures the environment for each test.</p>
      * <ul>
      * <li>Restore original logging level and HANDLERS to prevent bleeding into other tests;</li>
+     * <li>Turn off colors for picocli to not conflict with tests if they are auto turned on.</li>
      * <li>Start output capture for {@link System#err} and {@link System#out}</li>
      * </ul>
      *
@@ -223,6 +224,8 @@ public class MainTest {
     public void setUp(@SysErr Capturable systemErr, @SysOut Capturable systemOut) {
         systemErr.captureMuted();
         systemOut.captureMuted();
+
+        System.setProperty("picocli.ansi", "false");
 
         LOG.setLevel(ORIGINAL_LOG_LEVEL);
 


### PR DESCRIPTION
Issue #12667

As discussed at https://github.com/checkstyle/checkstyle/issues/12667#issuecomment-1397649608 .

I confirmed that test pass now in Git Bash on Windows.