### PR TITLE
minor: moves files generated by spellchecker to temp directory

### DIFF
--- a/.ci/test-spelling-unknown-words.sh
+++ b/.ci/test-spelling-unknown-words.sh
@@ -9,11 +9,12 @@ spellchecker='config/jsoref-spellchecker'
 temp='.ci-temp'
 whitelist_path="$spellchecker/whitelist.words"
 dict="$temp/english.words"
-word_splitter="$spellchecker/spelling-unknown-word-splitter.pl"
-run_output="$spellchecker/unknown.words"
+word_splitter="$temp/spelling-unknown-word-splitter.pl"
+run_output="$temp/unknown.words"
+
+mkdir -p $temp
 
 if [ ! -e "$dict" ]; then
-  mkdir -p $temp
   echo "Retrieve cached english.words from checkstyle.sourceforge.io"
   # english.words is taken from rpm:
   # https://rpmfind.net/linux/fedora/linux/development/rawhide/Everything/aarch64/os/Packages/w/"
@@ -72,6 +73,8 @@ diff_output=$(diff -U1 "$whitelist_path" "$run_output" |grep -v "$spellchecker" 
 if [ -z "$diff_output" ]; then
   echo "No new words and misspellings found."
   rm $dict
+  rm $word_splitter
+  rm $run_output
   exit 0
 fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -40,11 +40,6 @@ replay_pid*
 # temp folder for files/folders of ci validations
 .ci-temp
 
-#side effect of jsoref-spellchecker tools usage
-config/jsoref-spellchecker/spelling-unknown-word-splitter.pl
-config/jsoref-spellchecker/unknown.words
-config/jsoref-spellchecker/english.words
-
 # antlr4 grammar generates these
 **/gen
 **/JavaLanguageLexer.tokens


### PR DESCRIPTION
All temp files should be moved to `.ci-temp` as that is our temporary working directory when doing CI commands. It makes it easier to manage these files if they are separated from long term files managed by the git repository.