### PR TITLE
minor: replaces unncessary isTrue assertions with better ones

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/ConfigurationLoaderTest.java
@@ -158,14 +158,14 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         }
         catch (CheckstyleException ex) {
             assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage().contains("\"name\""))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .contains("\"name\"");
             assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage().contains("\"property\""))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .contains("\"property\"");
             assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage().endsWith(":8:41"))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .endsWith(":8:41");
         }
     }
 
@@ -180,14 +180,14 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         }
         catch (CheckstyleException ex) {
             assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage().contains("\"name\""))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .contains("\"name\"");
             assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage().contains("\"property\""))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .contains("\"property\"");
             assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage().endsWith(":8:41"))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .endsWith(":8:41");
         }
     }
 
@@ -199,14 +199,14 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         }
         catch (CheckstyleException ex) {
             assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage().contains("\"value\""))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .contains("\"value\"");
             assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage().contains("\"property\""))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .contains("\"property\"");
             assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage().endsWith(":8:43"))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .endsWith(":8:43");
         }
     }
 
@@ -218,14 +218,14 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         }
         catch (CheckstyleException ex) {
             assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage().contains("\"name\""))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .contains("\"name\"");
             assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage().contains("\"module\""))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .contains("\"module\"");
             assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage().endsWith(":7:23"))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .endsWith(":7:23");
         }
     }
 
@@ -237,14 +237,14 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
         }
         catch (CheckstyleException ex) {
             assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage().contains("\"property\""))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .contains("\"property\"");
             assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage().contains("\"module\""))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .contains("\"module\"");
             assertWithMessage("Invalid exception message: " + ex.getMessage())
-                    .that(ex.getMessage().endsWith(":8:38"))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .endsWith(":8:38");
         }
     }
 
@@ -315,8 +315,8 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
 
         final String expectedKey = "name.invalidPattern";
         assertWithMessage("Messages should contain key: " + expectedKey)
-                .that(grandchildren[0].getMessages().containsKey(expectedKey))
-                .isTrue();
+                .that(grandchildren[0].getMessages())
+                .containsKey(expectedKey);
     }
 
     private static void verifyConfigNode(

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavaParserTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavaParserTest.java
@@ -133,8 +133,8 @@ public class JavaParserTest extends AbstractModuleTestSupport {
             .that(commentContent.getColumnNo())
             .isEqualTo(2);
         assertWithMessage("Unexpected comment content")
-                .that(commentContent.getText().startsWith(" inline comment"))
-                .isTrue();
+                .that(commentContent.getText())
+                .startsWith(" inline comment");
     }
 
     @Test
@@ -173,8 +173,8 @@ public class JavaParserTest extends AbstractModuleTestSupport {
             .that(commentContent.getColumnNo())
             .isEqualTo(6);
         assertWithMessage("Unexpected comment content")
-                .that(commentContent.getText().startsWith(" indented comment"))
-                .isTrue();
+                .that(commentContent.getText())
+                .startsWith(" indented comment");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGeneratorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGeneratorTest.java
@@ -305,9 +305,8 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
         }
         catch (IllegalArgumentException ex) {
             assertWithMessage("Invalid error message")
-                    .that(ex.getMessage()
-                            .contains("mismatched input '<EOF>' expecting JAVADOC_INLINE_TAG_END"))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .contains("mismatched input '<EOF>' expecting JAVADOC_INLINE_TAG_END");
         }
         final long size = FileUtils.sizeOf(DESTFILE);
         assertWithMessage("File '" + DESTFILE + "' must be empty")
@@ -342,9 +341,8 @@ public class JavadocPropertiesGeneratorTest extends AbstractPathTestSupport {
         }
         catch (CheckstyleException ex) {
             assertWithMessage("Invalid error message")
-                    .that(ex.getMessage()
-                            .contains("InputJavadocPropertiesGeneratorParseError.java"))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .contains("InputJavadocPropertiesGeneratorParseError.java");
 
             final Throwable cause = ex.getCause();
             assertWithMessage("Invalid error message")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/MainTest.java
@@ -381,8 +381,8 @@ public class MainTest {
         final String cause = "com.puppycrawl.tools.checkstyle.api.CheckstyleException:"
                 + " cannot initialize module TreeWalker - ";
         assertWithMessage("Unexpected system error log")
-                .that(systemErr.getCapturedData().startsWith(cause))
-                .isTrue();
+                .that(systemErr.getCapturedData())
+                .startsWith(cause);
     }
 
     @Test
@@ -731,8 +731,8 @@ public class MainTest {
         final String errorOutput = "com.puppycrawl.tools.checkstyle.api."
             + "CheckstyleException: unable to parse configuration stream - ";
         assertWithMessage("Unexpected system error log")
-                .that(systemErr.getCapturedData().startsWith(errorOutput))
-                .isTrue();
+                .that(systemErr.getCapturedData())
+                .startsWith(errorOutput);
     }
 
     @Test
@@ -743,8 +743,8 @@ public class MainTest {
                 + "CheckstyleException: cannot initialize module RegexpSingleline"
                 + " - RegexpSingleline is not allowed as a child in RegexpSingleline";
         assertWithMessage("Unexpected system error log")
-                .that(systemErr.getCapturedData().startsWith(errorOutput))
-                .isTrue();
+                .that(systemErr.getCapturedData())
+                .startsWith(errorOutput);
     }
 
     @Test
@@ -756,8 +756,8 @@ public class MainTest {
                 + "cannot initialize module JavadocMethod - "
                 + "JavadocVariable is not allowed as a child in JavadocMethod";
         assertWithMessage("Unexpected system error log")
-                .that(systemErr.getCapturedData().startsWith(errorOutput))
-                .isTrue();
+                .that(systemErr.getCapturedData())
+                .startsWith(errorOutput);
     }
 
     @Test
@@ -795,8 +795,8 @@ public class MainTest {
                     .that(samePrefix || sameSuffix)
                     .isTrue();
             assertWithMessage("Invalid violation")
-                    .that(causeMessage.contains(".'"))
-                    .isTrue();
+                    .that(causeMessage)
+                    .contains(".'");
         }
     }
 
@@ -917,8 +917,8 @@ public class MainTest {
                 + "CheckstyleException: Exception was thrown while processing "
                 + new File(getNonCompilablePath("InputMainIncorrectClass.java")).getPath());
         assertWithMessage("Unexpected system error log")
-                .that(systemErr.getCapturedData().contains(exceptionMessage))
-                .isTrue();
+                .that(systemErr.getCapturedData())
+                .contains(exceptionMessage);
     }
 
     @Test
@@ -1754,10 +1754,9 @@ public class MainTest {
                         + "TestRootModuleCheckerCheck");
         assertWithMessage(
                 "Unexpected system error log")
-                        .that(systemErr.getCapturedData()
-                                .startsWith(checkstylePackage + "api.CheckstyleException: "
-                                        + unableToInstantiateExceptionMessage.getMessage()))
-                        .isTrue();
+                        .that(systemErr.getCapturedData())
+                        .startsWith(checkstylePackage + "api.CheckstyleException: "
+                                + unableToInstantiateExceptionMessage.getMessage());
         assertWithMessage("Invalid checker state")
                 .that(TestRootModuleChecker.isProcessed())
                 .isFalse();
@@ -1771,8 +1770,8 @@ public class MainTest {
         final String cause = "com.puppycrawl.tools.checkstyle.api.CheckstyleException:"
                 + " cannot initialize module TreeWalker - ";
         assertWithMessage("Unexpected system error log")
-                .that(systemErr.getCapturedData().startsWith(cause))
-                .isTrue();
+                .that(systemErr.getCapturedData())
+                .startsWith(cause);
     }
 
     @Test
@@ -1784,11 +1783,11 @@ public class MainTest {
                 + " cannot initialize module TreeWalker - ";
         final String causeDetail = "it is not a boolean";
         assertWithMessage("Unexpected system error log")
-                .that(systemErr.getCapturedData().startsWith(cause))
-                .isTrue();
+                .that(systemErr.getCapturedData())
+                .startsWith(cause);
         assertWithMessage("Unexpected system error log")
-                .that(systemErr.getCapturedData().contains(causeDetail))
-                .isTrue();
+                .that(systemErr.getCapturedData())
+                .contains(causeDetail);
     }
 
     @Test
@@ -1829,8 +1828,8 @@ public class MainTest {
         final AuditListener listener = Main.OutputFormat.XML.createListener(out,
                 AutomaticBean.OutputStreamOptions.CLOSE);
         assertWithMessage("listener is XMLLogger")
-                .that(listener instanceof XMLLogger)
-                .isTrue();
+                .that(listener)
+                .isInstanceOf(XMLLogger.class);
     }
 
     @Test
@@ -1839,8 +1838,8 @@ public class MainTest {
         final AuditListener listener = Main.OutputFormat.SARIF.createListener(out,
                 AutomaticBean.OutputStreamOptions.CLOSE);
         assertWithMessage("listener is SarifLogger")
-                .that(listener instanceof SarifLogger)
-                .isTrue();
+                .that(listener)
+                .isInstanceOf(SarifLogger.class);
     }
 
     @Test
@@ -1849,8 +1848,8 @@ public class MainTest {
         final AuditListener listener = Main.OutputFormat.PLAIN.createListener(out,
                 AutomaticBean.OutputStreamOptions.CLOSE);
         assertWithMessage("listener is DefaultLogger")
-                .that(listener instanceof DefaultLogger)
-                .isTrue();
+                .that(listener)
+                .isInstanceOf(DefaultLogger.class);
     }
 
     /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/TreeWalkerTest.java
@@ -251,9 +251,8 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         }
         catch (CheckstyleException exception) {
             assertWithMessage("Error message is unexpected")
-                    .that(exception.getMessage()
-                            .contains("TreeWalker is not allowed as a parent of"))
-                    .isTrue();
+                    .that(exception.getMessage())
+                    .contains("TreeWalker is not allowed as a parent of");
         }
     }
 
@@ -308,8 +307,8 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         }
         catch (CheckstyleException ex) {
             assertWithMessage("Error message is unexpected")
-                    .that(ex.getMessage().contains("isCommentNodesRequired"))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .contains("isCommentNodesRequired");
         }
     }
 
@@ -385,8 +384,8 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         }
         catch (CheckstyleException exception) {
             assertWithMessage("Error message is unexpected")
-                    .that(exception.getMessage().contains("occurred while parsing file"))
-                    .isTrue();
+                    .that(exception.getMessage())
+                    .contains("occurred while parsing file");
         }
     }
 
@@ -409,9 +408,8 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         }
         catch (CheckstyleException exception) {
             assertWithMessage("Error message is unexpected")
-                    .that(exception.getMessage()
-                            .contains("IllegalStateException occurred while parsing file"))
-                    .isTrue();
+                    .that(exception.getMessage())
+                    .contains("IllegalStateException occurred while parsing file");
         }
     }
 
@@ -466,8 +464,8 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
         catch (CheckstyleException exception) {
             final String message = "IllegalStateException occurred while parsing file";
             assertWithMessage("Error message is unexpected")
-                    .that(exception.getMessage().contains(message))
-                    .isTrue();
+                    .that(exception.getMessage())
+                    .contains(message);
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheckTest.java
@@ -335,8 +335,8 @@ public class AnnotationUseStyleCheckTest extends AbstractModuleTestSupport {
             final String messageStart = "unable to parse";
 
             assertWithMessage("Invalid exception message, should start with: " + messageStart)
-                    .that(ex.getMessage().startsWith(messageStart))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .startsWith(messageStart);
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckTest.java
@@ -184,8 +184,8 @@ public class IllegalTokenTextCheckTest
             assertWithMessage(TokenUtil.getTokenName(tokenType) + " should not be allowed"
                     + " in this check as its text is a constant"
                     + " (IllegalTokenCheck should be used for such cases).")
-                            .that(tokenTypesWithMutableText.contains(tokenType))
-                            .isTrue();
+                            .that(tokenTypesWithMutableText)
+                            .contains(tokenType);
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportControlCheckTest.java
@@ -348,8 +348,8 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
 
         final String contents = Files.readString(cacheFile.toPath());
         assertWithMessage("External resource is not present in cache")
-                .that(contents.contains("InputImportControlOneRegExp.xml"))
-                .isTrue();
+                .that(contents)
+                .contains("InputImportControlOneRegExp.xml");
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -598,8 +598,8 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
         }
         catch (IllegalStateException ex) {
             assertWithMessage("invalid exception message")
-                    .that(ex.getMessage().endsWith(": null"))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .endsWith(": null");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/AbstractJavadocCheckTest.java
@@ -300,8 +300,8 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
                     + "\"RETURN_LITERAL\" was not found in "
                     + "Acceptable javadoc tokens list in check";
             assertWithMessage("Invalid exception, should start with: " + expected)
-                    .that(ex.getMessage().startsWith(expected))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .startsWith(expected);
         }
     }
 
@@ -333,8 +333,8 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
                     + JavadocTokenTypes.RETURN_LITERAL + "\" from required"
                     + " javadoc tokens was not found in default javadoc tokens list in check";
             assertWithMessage("Invalid exception, should start with: " + expected)
-                    .that(ex.getMessage().startsWith(expected))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .startsWith(expected);
         }
     }
 
@@ -346,8 +346,8 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
         verify(checkConfig, getPath("InputAbstractJavadocLeaveToken.java"), expected);
         assertWithMessage("Javadoc visit count should be greater than zero")
-                .that(JavadocVisitLeaveCheck.visitCount > 0)
-                .isTrue();
+                .that(JavadocVisitLeaveCheck.visitCount)
+                .isGreaterThan(0);
         assertWithMessage("Javadoc visit and leave count should be equal")
             .that(JavadocVisitLeaveCheck.leaveCount)
             .isEqualTo(JavadocVisitLeaveCheck.visitCount);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/InlineTagUtilTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/utils/InlineTagUtilTest.java
@@ -111,8 +111,8 @@ public class InlineTagUtilTest {
         }
         catch (IllegalArgumentException ex) {
             assertWithMessage("Unexpected error message")
-                    .that(ex.getMessage().contains("newline"))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .contains("newline");
         }
     }
 
@@ -124,8 +124,8 @@ public class InlineTagUtilTest {
         }
         catch (IllegalArgumentException ex) {
             assertWithMessage("Invalid error message")
-                    .that(ex.getMessage().contains("newline"))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .contains("newline");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionsLoaderTest.java
@@ -143,14 +143,14 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         catch (CheckstyleException ex) {
             final String messageStart = "Unable to parse " + fn;
             assertWithMessage("Exception message should start with: " + messageStart)
-                    .that(ex.getMessage().startsWith("Unable to parse " + fn))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .startsWith("Unable to parse " + fn);
             assertWithMessage("Exception message should contain \"files\"")
-                    .that(ex.getMessage().contains("\"files\""))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .contains("\"files\"");
             assertWithMessage("Exception message should contain \"suppress\"")
-                    .that(ex.getMessage().contains("\"suppress\""))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .contains("\"suppress\"");
         }
     }
 
@@ -164,14 +164,14 @@ public class SuppressionsLoaderTest extends AbstractPathTestSupport {
         catch (CheckstyleException ex) {
             final String messageStart = "Unable to parse " + fn;
             assertWithMessage("Exception message should start with: " + messageStart)
-                    .that(ex.getMessage().startsWith(messageStart))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .startsWith(messageStart);
             assertWithMessage("Exception message should contain \"checks\"")
-                    .that(ex.getMessage().contains("\"checks\""))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .contains("\"checks\"");
             assertWithMessage("Exception message should contain \"suppress\"")
-                    .that(ex.getMessage().contains("\"suppress\""))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .contains("\"suppress\"");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElementTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/XpathFilterElementTest.java
@@ -139,8 +139,8 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
         }
         catch (IllegalArgumentException ex) {
             assertWithMessage("Message should be: Failed to initialise regular expression")
-                    .that(ex.getMessage().contains("Failed to initialise regular expression"))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .contains("Failed to initialise regular expression");
         }
     }
 
@@ -154,8 +154,8 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
         }
         catch (IllegalArgumentException ex) {
             assertWithMessage("Message should be: Incorrect xpath query")
-                    .that(ex.getMessage().contains("Incorrect xpath query"))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .contains("Incorrect xpath query");
         }
     }
 
@@ -338,8 +338,8 @@ public class XpathFilterElementTest extends AbstractModuleTestSupport {
         }
         catch (IllegalStateException ex) {
             assertWithMessage("Exception message does not match expected one")
-                    .that(ex.getMessage().contains("Cannot initialize context and evaluate query"))
-                    .isTrue();
+                    .that(ex.getMessage())
+                    .contains("Cannot initialize context and evaluate query");
         }
     }
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModelTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModelTest.java
@@ -196,8 +196,8 @@ public class MainFrameModelTest extends AbstractModuleTestSupport {
 
         final String testDataFileNameWithoutPostfix = FILE_NAME_TEST_DATA.replace(".java", "");
         assertWithMessage("Invalid model text: " + model.getText())
-                .that(model.getText().contains(testDataFileNameWithoutPostfix))
-                .isTrue();
+                .that(model.getText())
+                .contains(testDataFileNameWithoutPostfix);
 
         final File expectedLastDirectory = new File(getPath(""));
         assertWithMessage("Invalid model last directory")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/gui/ParseTreeTablePresentationTest.java
@@ -83,8 +83,8 @@ public class ParseTreeTablePresentationTest extends AbstractPathTestSupport {
     public void testChild() {
         final Object child = new ParseTreeTablePresentation(null).getChild(tree, 1);
         assertWithMessage("Invalid child type")
-                .that(child instanceof DetailAST)
-                .isTrue();
+                .that(child)
+                .isInstanceOf(DetailAST.class);
         final int type = ((DetailAST) child).getType();
         assertWithMessage("Invalid child token type")
             .that(type)
@@ -97,8 +97,8 @@ public class ParseTreeTablePresentationTest extends AbstractPathTestSupport {
         parseTree.setParseMode(ParseMode.JAVA_WITH_JAVADOC_AND_COMMENTS);
         final Object child = parseTree.getChild(tree, 1);
         assertWithMessage("Invalid child type")
-                .that(child instanceof DetailAST)
-                .isTrue();
+                .that(child)
+                .isInstanceOf(DetailAST.class);
         final int type = ((DetailAST) child).getType();
         assertWithMessage("Invalid child token type")
             .that(type)
@@ -162,8 +162,8 @@ public class ParseTreeTablePresentationTest extends AbstractPathTestSupport {
         parseTree.setParseMode(ParseMode.JAVA_WITH_JAVADOC_AND_COMMENTS);
         final Object child = parseTree.getChild(commentContentNode, 0);
         assertWithMessage("Invalid child type")
-                .that(child instanceof DetailNode)
-                .isTrue();
+                .that(child)
+                .isInstanceOf(DetailNode.class);
         final int type = ((DetailNode) child).getType();
         assertWithMessage("Invalid child token type")
             .that(type)
@@ -171,8 +171,8 @@ public class ParseTreeTablePresentationTest extends AbstractPathTestSupport {
         // get Child one more time to test cache of PModel
         final Object childSame = parseTree.getChild(commentContentNode, 0);
         assertWithMessage("Invalid child type")
-                .that(childSame instanceof DetailNode)
-                .isTrue();
+                .that(childSame)
+                .isInstanceOf(DetailNode.class);
         final int sameType = ((DetailNode) childSame).getType();
         assertWithMessage("Invalid child token type")
             .that(sameType)
@@ -186,8 +186,8 @@ public class ParseTreeTablePresentationTest extends AbstractPathTestSupport {
         parseTree.setParseMode(ParseMode.JAVA_WITH_JAVADOC_AND_COMMENTS);
         final Object javadoc = parseTree.getChild(commentContentNode, 0);
         assertWithMessage("Invalid child type")
-                .that(javadoc instanceof DetailNode)
-                .isTrue();
+                .that(javadoc)
+                .isInstanceOf(DetailNode.class);
         final int type = ((DetailNode) javadoc).getType();
         assertWithMessage("Invalid child token type")
             .that(type)
@@ -205,16 +205,16 @@ public class ParseTreeTablePresentationTest extends AbstractPathTestSupport {
         parseTree.setParseMode(ParseMode.JAVA_WITH_JAVADOC_AND_COMMENTS);
         final Object javadoc = parseTree.getChild(commentContentNode, 0);
         assertWithMessage("Invalid child type")
-                .that(javadoc instanceof DetailNode)
-                .isTrue();
+                .that(javadoc)
+                .isInstanceOf(DetailNode.class);
         final int type = ((DetailNode) javadoc).getType();
         assertWithMessage("Invalid child token type")
             .that(type)
             .isEqualTo(JavadocTokenTypes.JAVADOC);
         final Object javadocChild = parseTree.getChild(javadoc, 2);
         assertWithMessage("Invalid child type")
-                .that(javadocChild instanceof DetailNode)
-                .isTrue();
+                .that(javadocChild)
+                .isInstanceOf(DetailNode.class);
         final int childType = ((DetailNode) javadocChild).getType();
         assertWithMessage("Invalid child token type")
             .that(childType)

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java
@@ -507,8 +507,8 @@ public class AllChecksTest extends AbstractModuleTestSupport {
         moduleNames.removeAll(INTERNAL_MODULES);
         for (String moduleName : moduleNames) {
             assertWithMessage("checkstyle_checks.xml is missing module: " + moduleName)
-                    .that(configChecks.contains(moduleName))
-                    .isTrue();
+                    .that(configChecks)
+                    .contains(moduleName);
         }
     }
 
@@ -568,8 +568,8 @@ public class AllChecksTest extends AbstractModuleTestSupport {
 
                 assertWithMessage("property '" + key + "' isn't used by any check in package '"
                                       + entry.getKey() + "'")
-                        .that(entry.getValue().contains(key.toString()))
-                        .isTrue();
+                        .that(entry.getValue())
+                        .contains(key.toString());
             }
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllTestsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllTestsTest.java
@@ -226,8 +226,8 @@ public class AllTestsTest {
 
                     assertWithMessage("Test must be named after a production class "
                                + "and must be in the same package of the production class: " + path)
-                            .that(classes != null && classes.contains(fileName))
-                            .isTrue();
+                            .that(classes)
+                            .contains(fileName);
                 }
             }
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
@@ -96,8 +96,8 @@ public class CommitValidationTest {
         final List<RevCommit> lastCommits = getCommitsToCheck();
 
         assertWithMessage("must have at least one commit to validate")
-                .that(lastCommits != null && !lastCommits.isEmpty())
-                .isTrue();
+                .that(lastCommits)
+                .isNotEmpty();
     }
 
     @Test

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsMobileWrapperTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsMobileWrapperTest.java
@@ -76,8 +76,8 @@ public class XdocsMobileWrapperTest {
                         + child.getNodeName() + "' in '" + node.getNodeName()
                         + "' needs a wrapping <span> or <div> with the class 'wrapper'.";
                 assertWithMessage(wrapperMessage)
-                        .that("div".equals(node.getNodeName()) || "span".equals(node.getNodeName()))
-                        .isTrue();
+                        .that(node.getNodeName())
+                        .isAnyOf("div", "span");
                 assertWithMessage(wrapperMessage)
                         .that(node.hasAttributes())
                         .isTrue();
@@ -86,8 +86,8 @@ public class XdocsMobileWrapperTest {
                         .isNotNull();
                 assertWithMessage(wrapperMessage)
                         .that(node.getAttributes().getNamedItem("class")
-                                .getNodeValue().contains("wrapper"))
-                        .isTrue();
+                                .getNodeValue())
+                        .contains("wrapper");
 
                 if ("table".equals(child.getNodeName())) {
                     iterateNode(child, fileName, sectionName);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -605,14 +605,14 @@ public class XdocsPagesTest {
         if ("Checker".equals(sectionName)) {
             assertWithMessage(fileName + " section '" + sectionName
                     + "' should contain up to 'Package' sub-section")
-                    .that(subSectionPos >= 6)
-                    .isTrue();
+                    .that(subSectionPos)
+                    .isGreaterThan(5);
         }
         else {
             assertWithMessage(fileName + " section '" + sectionName
                     + "' should contain up to 'Parent' sub-section")
-                    .that(subSectionPos >= 7)
-                    .isTrue();
+                    .that(subSectionPos)
+                    .isGreaterThan(6);
         }
     }
 
@@ -712,9 +712,8 @@ public class XdocsPagesTest {
                 .that(div.getAttributes().getNamedItem("class").getNodeValue())
                 .isNotNull();
             assertWithMessage(wrapperMessage)
-                    .that(div.getAttributes().getNamedItem("class").getNodeValue()
-                                    .contains("wrapper"))
-                    .isTrue();
+                    .that(div.getAttributes().getNamedItem("class").getNodeValue())
+                    .contains("wrapper");
 
             final Node table = XmlUtil.getFirstChildElement(div);
             assertWithMessage(fileName + " section '" + sectionName
@@ -1255,9 +1254,8 @@ public class XdocsPagesTest {
             assertWithMessage(
                     fileName + " section '" + sectionName + "' could not find field "
                             + propertyName)
-                    .that(PROPERTIES_ALLOWED_GET_TYPES_FROM_METHOD
-                            .contains(sectionName + "." + propertyName))
-                    .isTrue();
+                    .that(PROPERTIES_ALLOWED_GET_TYPES_FROM_METHOD)
+                    .contains(sectionName + "." + propertyName);
 
             final PropertyDescriptor descriptor = PropertyUtils.getPropertyDescriptor(instance,
                     propertyName);
@@ -1395,8 +1393,8 @@ public class XdocsPagesTest {
 
                 assertWithMessage(fileName + " section '" + sectionName
                             + "' should be in google_checks.xml or not reference 'Google Style'")
-                        .that(GOOGLE_MODULES.contains(sectionName))
-                        .isTrue();
+                        .that(GOOGLE_MODULES)
+                        .contains(sectionName);
             }
             else if ("Sun Style".equals(linkText)) {
                 hasSun = true;
@@ -1407,8 +1405,8 @@ public class XdocsPagesTest {
 
                 assertWithMessage(fileName + " section '" + sectionName
                             + "' should be in sun_checks.xml or not reference 'Sun Style'")
-                        .that(SUN_MODULES.contains(sectionName))
-                        .isTrue();
+                        .that(SUN_MODULES)
+                        .contains(sectionName);
             }
 
             assertWithMessage(fileName + " section '" + sectionName
@@ -1703,14 +1701,14 @@ public class XdocsPagesTest {
                 else if ("test".equals(configName)) {
                     assertWithMessage(styleName + "_style.xml rule '" + ruleName + "' module '"
                                 + moduleName + "' should have matching " + configName + " url")
-                            .that(configUrl.startsWith("https://github.com/checkstyle/checkstyle/"
-                                            + "blob/master/src/it/java/com/" + styleName
-                                            + "/checkstyle/test/"))
-                            .isTrue();
+                            .that(configUrl)
+                            .startsWith("https://github.com/checkstyle/checkstyle/"
+                                    + "blob/master/src/it/java/com/" + styleName
+                                    + "/checkstyle/test/");
                     assertWithMessage(styleName + "_style.xml rule '" + ruleName + "' module '"
                                 + moduleName + "' should have matching " + configName + " url")
-                            .that(configUrl.endsWith("/" + moduleName + "Test.java"))
-                            .isTrue();
+                            .that(configUrl)
+                            .endsWith("/" + moduleName + "Test.java");
 
                     assertWithMessage(styleName + "_style.xml rule '" + ruleName + "' module '"
                                 + moduleName + "' should have a test that exists")

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsUrlTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsUrlTest.java
@@ -139,14 +139,10 @@ public class XdocsUrlTest {
                 assertWithMessage(moduleNameErrorMsg)
                         .that(moduleFileNames)
                         .isNotNull();
-                boolean match = false;
                 final String checkNameWithSuffix = checkNameInAttribute + SUFFIX_CHECK;
-                if (moduleFileNames.contains(checkNameWithSuffix)) {
-                    match = true;
-                }
                 assertWithMessage(checkNameModuleErrorMsg)
-                        .that(match)
-                        .isTrue();
+                        .that(moduleFileNames)
+                        .contains(checkNameWithSuffix);
             }
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -227,8 +227,8 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
 
                 final String check = matcher.group(1);
                 assertWithMessage("Unknown check '" + check + "' in test file: " + filename)
-                        .that(SIMPLE_CHECK_NAMES.contains(check))
-                        .isTrue();
+                        .that(SIMPLE_CHECK_NAMES)
+                        .contains(check);
 
                 assertWithMessage(
                             "Check '" + check + "' is now tested. Please update the todo list in"
@@ -271,8 +271,8 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
                         .isTrue();
                 final String dirName = dir.toFile().getName();
                 assertWithMessage("Invalid directory name: " + dirName)
-                        .that(ALLOWED_DIRECTORY_AND_CHECKS.containsKey(dirName))
-                        .isTrue();
+                        .that(ALLOWED_DIRECTORY_AND_CHECKS)
+                        .containsKey(dirName);
 
                 // input directory must be connected to an existing test
                 final String check = ALLOWED_DIRECTORY_AND_CHECKS.get(dirName);
@@ -305,8 +305,8 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
                     final String remaining = matcher.group(1);
                     assertWithMessage("Check name '" + check
                                 + "' should be included in input file: " + inputPath)
-                            .that(remaining.startsWith(check))
-                            .isTrue();
+                            .that(remaining)
+                            .startsWith(check);
                 }
             }
         }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReaderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReaderTest.java
@@ -97,7 +97,7 @@ public class XmlMetaReaderTest extends AbstractPathTestSupport {
             assertThat(violationMessageKeys).hasSize(2);
             assertThat(violationMessageKeys.get(0)).isEqualTo("test.key1");
             assertThat(violationMessageKeys.get(1)).isEqualTo("test.key2");
-            assertThat(result.getProperties().isEmpty()).isTrue();
+            assertThat(result.getProperties()).isEmpty();
         }
     }
 
@@ -110,7 +110,7 @@ public class XmlMetaReaderTest extends AbstractPathTestSupport {
                 "com.puppycrawl.tools.checkstyle.filters.SomeFilter",
                 "com.puppycrawl.tools.checkstyle.TreeWalker");
             assertThat(result.getName()).isEqualTo("SomeFilter");
-            assertThat(result.getViolationMessageKeys().isEmpty()).isTrue();
+            assertThat(result.getViolationMessageKeys()).isEmpty();
             final List<ModulePropertyDetails> props = result.getProperties();
             assertThat(props).hasSize(1);
             final ModulePropertyDetails prop1 = props.get(0);
@@ -130,7 +130,7 @@ public class XmlMetaReaderTest extends AbstractPathTestSupport {
                 "com.puppycrawl.tools.checkstyle.filefilters.FileFilter",
                 "com.puppycrawl.tools.checkstyle.Checker");
             assertThat(result.getName()).isEqualTo("FileFilter");
-            assertThat(result.getViolationMessageKeys().isEmpty()).isTrue();
+            assertThat(result.getViolationMessageKeys()).isEmpty();
             final List<ModulePropertyDetails> props = result.getProperties();
             assertThat(props).hasSize(1);
             final ModulePropertyDetails prop1 = props.get(0);

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/ElementNodeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/ElementNodeTest.java
@@ -135,8 +135,8 @@ public class ElementNodeTest extends AbstractPathTestSupport {
             .that(root.getTokenType())
             .isEqualTo(TokenTypes.COMPILATION_UNIT);
         assertWithMessage("Should return true, because selected node is RootNode")
-                .that(root instanceof RootNode)
-                .isTrue();
+                .that(root)
+                .isInstanceOf(RootNode.class);
     }
 
     @Test
@@ -235,13 +235,13 @@ public class ElementNodeTest extends AbstractPathTestSupport {
         final ElementNode elementNode = new ElementNode(rootNode, rootNode, detailAST, 1, 0);
         try (AxisIterator iterator = elementNode.iterateAxis(AxisInfo.CHILD)) {
             assertWithMessage("Invalid iterator")
-                    .that(iterator instanceof EmptyIterator)
-                    .isTrue();
+                    .that(iterator)
+                    .isInstanceOf(EmptyIterator.class);
         }
         try (AxisIterator iterator = elementNode.iterateAxis(AxisInfo.DESCENDANT)) {
             assertWithMessage("Invalid iterator")
-                    .that(iterator instanceof EmptyIterator)
-                    .isTrue();
+                    .that(iterator)
+                    .isInstanceOf(EmptyIterator.class);
         }
     }
 
@@ -255,13 +255,13 @@ public class ElementNodeTest extends AbstractPathTestSupport {
         final ElementNode elementNode = new ElementNode(rootNode, rootNode, detailAST, 1, 0);
         try (AxisIterator iterator = elementNode.iterateAxis(AxisInfo.CHILD)) {
             assertWithMessage("Invalid iterator")
-                    .that(iterator instanceof ArrayIterator)
-                    .isTrue();
+                    .that(iterator)
+                    .isInstanceOf(ArrayIterator.class);
         }
         try (AxisIterator iterator = elementNode.iterateAxis(AxisInfo.DESCENDANT)) {
             assertWithMessage("Invalid iterator")
-                    .that(iterator instanceof DescendantIterator)
-                    .isTrue();
+                    .that(iterator)
+                    .isInstanceOf(DescendantIterator.class);
         }
     }
 
@@ -278,13 +278,13 @@ public class ElementNodeTest extends AbstractPathTestSupport {
         final AbstractNode elementNode = parentNode.getChildren().get(0);
         try (AxisIterator iterator = elementNode.iterateAxis(AxisInfo.FOLLOWING_SIBLING)) {
             assertWithMessage("Invalid iterator")
-                    .that(iterator instanceof EmptyIterator)
-                    .isTrue();
+                    .that(iterator)
+                    .isInstanceOf(EmptyIterator.class);
         }
         try (AxisIterator iterator = elementNode.iterateAxis(AxisInfo.PRECEDING_SIBLING)) {
             assertWithMessage("Invalid iterator")
-                    .that(iterator instanceof EmptyIterator)
-                    .isTrue();
+                    .that(iterator)
+                    .isInstanceOf(EmptyIterator.class);
         }
     }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/xpath/RootNodeTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/xpath/RootNodeTest.java
@@ -75,8 +75,8 @@ public class RootNodeTest extends AbstractPathTestSupport {
             .hasSize(1);
         final NodeInfo firstNode = nodes.get(0);
         assertWithMessage("Should return true, because selected node is RootNode")
-                .that(firstNode instanceof RootNode)
-                .isTrue();
+                .that(firstNode)
+                .isInstanceOf(RootNode.class);
         assertWithMessage("Result node should have same reference as expected")
             .that(rootNode)
             .isEqualTo(firstNode);


### PR DESCRIPTION
The `isTrue` were starting to annoy me.

The same cannot be done with `isFalse`. For example there is no `doesNotStartWith`.