### PR TITLE
Issue #11055: rewrites code to avoid possible NPE

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/indentation/AbstractExpressionHandler.java
@@ -431,7 +431,7 @@ public abstract class AbstractExpressionHandler {
 
         DetailAST curNode = ast;
         DetailAST realStart = ast;
-        while (curNode != null) {
+        do {
             if (curNode.getLineNo() < realStart.getLineNo()
                     || curNode.getLineNo() == realStart.getLineNo()
                     && curNode.getColumnNo() < realStart.getColumnNo()) {
@@ -443,7 +443,7 @@ public abstract class AbstractExpressionHandler {
                 curNode = curNode.getParent();
             }
             curNode = toVisit;
-        }
+        } while (curNode != null);
         return realStart;
     }
 


### PR DESCRIPTION
Issue #11055

There is no surviving mutations on this, so a lot of our tests says it has to be like this. The code is identical to our TreeWalker code. The code is looking for a node by line/column, and since we don't keep our nodes ordered in source order, doing a random scan is really the only way. There are times we do go to null in this code. There are times were we going through multiple ASTs before we exit with our "answer". I don't see any "find by..." AST here then we already have.

If anything, having this as a do/while shows us we don't need to do the condition check first as long as regression shows differences.