### PR TITLE
infra: fix concurrency block in diff report workflow

### DIFF
--- a/.github/workflows/diff_report.yml
+++ b/.github/workflows/diff_report.yml
@@ -28,7 +28,9 @@ permissions:
   pull-requests: write
 
 # allow diff reports to run concurrently
-concurrency: null
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   # Parse PR Body, search for links to .properties and .xml files


### PR DESCRIPTION
Noticed at https://github.com/checkstyle/checkstyle/actions/runs/4012370020:

`The workflow is not valid. .github/workflows/diff_report.yml (Line: 31, Col: 14): Concurrency group name cannot be empty`

diff report generation is now completely broken.