### PR TITLE
Issue #12694: Push 'all' jar action is not working and not failing execution

### DIFF
--- a/.ci/close-create-milestone.sh
+++ b/.ci/close-create-milestone.sh
@@ -8,6 +8,7 @@ checkForVariable "GITHUB_TOKEN"
 
 echo "Close previous milestone at github"
 MILESTONE_NUMBER=$(curl -s \
+                -H "Authorization: token $GITHUB_TOKEN" \
                 -X GET https://api.github.com/repos/checkstyle/checkstyle/milestones?state=open \
                 | jq ".[0] | .number")
 curl -i -H "Authorization: token $GITHUB_TOKEN" \

--- a/.ci/update-github-milestone.sh
+++ b/.ci/update-github-milestone.sh
@@ -17,6 +17,7 @@ echo TARGET_VERSION="$TARGET_VERSION"
 
 echo "Updating milestone at github"
 MILESTONE_ID=$(curl -s \
+                -H "Authorization: token $GITHUB_TOKEN" \
                 -X GET https://api.github.com/repos/checkstyle/checkstyle/milestones?state=open \
                 | jq ".[0] | .number")
 

--- a/.ci/upload-all-jar.sh
+++ b/.ci/upload-all-jar.sh
@@ -23,6 +23,7 @@ mvn -e --no-transfer-progress -Passembly,no-validations package
 echo "Publishing 'all' jar to Github"
 UPLOAD_LINK=https://uploads.github.com/repos/checkstyle/checkstyle/releases
 RELEASE_ID=$(curl -s -X GET \
+  -H "Authorization: token $GITHUB_TOKEN" \
   https://api.github.com/repos/checkstyle/checkstyle/releases/tags/checkstyle-"$TARGET_VERSION" \
   | jq ".id")
 


### PR DESCRIPTION
Resolves #12694

---
Adds `GITHUB_TOKEN` authorization header where it was missing. I checked all actions jobs and the `.sh` files they are calling.

---
The reason for [the main issue was different](https://github.com/checkstyle/checkstyle/issues/12694#issuecomment-1410750115) but I am adding the headers anyways to keep things consistent.