### PR TITLE
Issue 12705: remove .m2 for codenarc execution to make it more stable on download

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -33,6 +33,7 @@ blocks:
 
         - name: codenarc analysis
           commands:
+            - rm -rf $HOME/.m2
             - ./.ci/codenarc.sh
 
         - name: ensure that all modules are used in no exception configs


### PR DESCRIPTION
Issue #12705
