### PR TITLE
Multiple dependency bumps

### DIFF
--- a/config/pmd-main.xml
+++ b/config/pmd-main.xml
@@ -13,16 +13,13 @@
 
   <rule ref="category/java/design.xml/ImmutableField">
     <properties>
-      <!-- Fields with these annotations will have their value injected by picocli.
-           These fields should not be marked final. -->
-      <property name="ignoredAnnotations"
-               value="picocli.CommandLine$Option
-                     |picocli.CommandLine$Parameters"/>
       <!-- final modifier prevent us from reaching full test coverage,
-             we value full coverage more than final modifier. -->
+             we value full coverage more than final modifier.
+           Picocli fields will have their value injected and should not be marked final. -->
       <property name="violationSuppressXPath"
                value="//ClassOrInterfaceDeclaration[@SimpleName='FileText']
-                        //FieldDeclaration//VariableDeclarator[@Name='fullText']"/>
+                        //FieldDeclaration//VariableDeclarator[@Name='fullText']
+                    | //ClassOrInterfaceDeclaration[@SimpleName='CliOptions']"/>
     </properties>
   </rule>
   <rule ref="category/java/errorprone.xml/CloseResource">
@@ -44,14 +41,6 @@
                         //MethodDeclaration[@Name='getListeners' or @Name='createDefaultLogger']
                     | //ClassOrInterfaceDeclaration[@SimpleName='AbstractNode']
                         //MethodDeclaration[@Name='iterateAxis']"/>
-    </properties>
-  </rule>
-  <rule ref="category/java/design.xml/ExcessiveMethodLength">
-    <properties>
-      <!-- unfortunate cases -->
-      <property name="violationSuppressXPath"
-               value="//ClassOrInterfaceDeclaration[@SimpleName='PackageObjectFactory']
-                        //MethodDeclaration[@Name='fillChecksFromCodingPackage']"/>
     </properties>
   </rule>
 </ruleset>

--- a/config/pmd-test.xml
+++ b/config/pmd-test.xml
@@ -81,31 +81,6 @@
     </properties>
   </rule>
 
-  <rule ref="category/java/design.xml/ExcessiveMethodLength">
-    <properties>
-      <!-- GeneratedJavaTokenTypesTest.testTokenNumbering' is simple but long as it rechecks
-             each token one by one. Same goes for GeneratedJavadocTokenTypesTest#testTokenNumbers.
-           ParenPadCheckTest.testNospaceWithComplexInput is intended to keep all in one method.
-           JavadocTokenTypesTest.TokenValues contains several asserts as it checks each
-             token explicitly.
-          MainTest.testGenerateXpathSuppressionOptionOne requires a very long 'expected' string
-      -->
-      <property name="violationSuppressXPath"
-               value="//ClassOrInterfaceDeclaration[@SimpleName='GeneratedJavaTokenTypesTest']
-                        //MethodDeclaration[@Name='testTokenNumbering']
-                    | //ClassOrInterfaceDeclaration[@SimpleName='ParenPadCheckTest']
-                        //MethodDeclaration[@Name='testNospaceWithComplexInput']
-                    | //ClassOrInterfaceDeclaration[@SimpleName='ParenPadTest']
-                        //MethodDeclaration[@Name='testMethodParen']
-                    | //ClassOrInterfaceDeclaration[@SimpleName='JavadocTokenTypesTest']
-                        //MethodDeclaration[@Name='testTokenValues']
-                    | //ClassOrInterfaceDeclaration[@SimpleName='GeneratedJavadocTokenTypesTest']
-                        //MethodDeclaration[@Name='testTokenNumbers']
-                    | //ClassOrInterfaceDeclaration[@SimpleName='MainTest']
-                        //MethodDeclaration[@Name='testGenerateXpathSuppressionOptionOne']"/>
-    </properties>
-  </rule>
-
   <rule ref="category/java/bestpractices.xml/JUnitTestsShouldIncludeAssert">
     <!-- PMD cannot find assert if it is located in private method of this class called from
            the test method or method of another class. -->
@@ -120,7 +95,9 @@
            In XdocsPagesTest PMD does not find asserts in lambdas.
            All test classes which starts with XpathRegression have asserts inside parent's method.
            In ArchUnitTest, ArchUnitSuperClassTest, ImmutabilityTest, ArchUnitCyclesCheckTest
-           assertion calls are not required as they are called by the library -->
+           assertion calls are not required as they are called by the library.
+           In MainTest PMD does not find asserts in lambdas called in the method
+             invokeAndWait. -->
       <property name="violationSuppressXPath"
                value="//ClassOrInterfaceDeclaration[@SimpleName='AllChecksTest'
                      or @SimpleName='AstRegressionTest'
@@ -142,7 +119,9 @@
                    | //ClassOrInterfaceDeclaration[@SimpleName='ArchUnitCyclesCheckTest']
                        //MethodDeclaration
                    | //ClassOrInterfaceDeclaration[@SimpleName='SuppressionFilterTest']
-                       //MethodDeclaration[starts-with(@Name, 'testUseCache')]"/>
+                       //MethodDeclaration[starts-with(@Name, 'testUseCache')]
+                   | //ClassOrInterfaceDeclaration[@SimpleName='MainTest']
+                       //MethodDeclaration[starts-with(@Name, 'testMain')]"/>
     </properties>
   </rule>
 
@@ -212,6 +191,11 @@
                      //MethodDeclaration[@Name='verifyOutput']
                  | //ClassOrInterfaceDeclaration[@SimpleName='CommonUtilTest']
                      //MethodDeclaration[@Name='testClose']"/>
+    </properties>
+  </rule>
+  <rule ref="category/java/errorprone.xml/TestClassWithoutTestCases">
+    <properties>
+      <property name="testClassPattern" value="^[^$]*Test(s|Case)?$"/>
     </properties>
   </rule>
   <rule ref="category/java/multithreading.xml/DoNotUseThreads">

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -163,8 +163,6 @@
     <!-- That rule is not practical, no options to allow some magic numbers,
          we will use our implementation. -->
     <exclude name="AvoidLiteralsInIfCondition"/>
-    <!-- It is not our goal for now to keep all Serializable, maybe in the future. -->
-    <exclude name="BeanMembersShouldSerialize"/>
     <!-- We need compare by ref as Tree structure is immutable, we can easily
          rely on refs. -->
     <exclude name="CompareObjectsWithEquals"/>

--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,7 @@
     <dependency>
       <groupId>org.junit-pioneer</groupId>
       <artifactId>junit-pioneer</artifactId>
-      <version>1.7.1</version>
+      <version>2.0.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
     <dependency>
       <groupId>com.tngtech.archunit</groupId>
       <artifactId>archunit-junit5</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@
     <pitest.plugin.output.formats>HTML,XML</pitest.plugin.output.formats>
     <pitest.plugin.timeout.constant>50000</pitest.plugin.timeout.constant>
     <pitest.plugin.threads>4</pitest.plugin.threads>
-    <pitest.junit5.plugin.version>1.1.0</pitest.junit5.plugin.version>
+    <pitest.junit5.plugin.version>1.1.2</pitest.junit5.plugin.version>
     <pitest.accelerator.junit5.plugin.version>1.0.4</pitest.accelerator.junit5.plugin.version>
     <sonar.test.exclusions>**/test/resources/**/*,**/it/resources/**/*</sonar.test.exclusions>
     <junit.version>5.9.2</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
     <pitest.junit5.plugin.version>1.1.0</pitest.junit5.plugin.version>
     <pitest.accelerator.junit5.plugin.version>1.0.4</pitest.accelerator.junit5.plugin.version>
     <sonar.test.exclusions>**/test/resources/**/*,**/it/resources/**/*</sonar.test.exclusions>
-    <junit.version>5.9.1</junit.version>
+    <junit.version>5.9.2</junit.version>
     <forbiddenapis.version>3.4</forbiddenapis.version>
     <json-schema-validator.version>1.2.0</json-schema-validator.version>
     <error-prone.version>2.15.0</error-prone.version>

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
     <maven.site.plugin.version>3.12.1</maven.site.plugin.version>
     <maven.spotbugs.plugin.version>4.7.2.1</maven.spotbugs.plugin.version>
     <maven.pmd.plugin.version>3.20.0</maven.pmd.plugin.version>
-    <pmd.version>6.50.0</pmd.version>
+    <pmd.version>6.54.0</pmd.version>
     <maven.jacoco.plugin.version>0.8.8</maven.jacoco.plugin.version>
     <mockito.version>5.1.1</mockito.version>
     <saxon.version>12.0</saxon.version>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsUrlTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsUrlTest.java
@@ -102,7 +102,7 @@ public class XdocsUrlTest {
     public void testXdocsUrl() throws Exception {
         final SAXParserFactory parserFactory = SAXParserFactory.newInstance();
         final SAXParser parser = parserFactory.newSAXParser();
-        final CheckTest checkHandler = new CheckTest();
+        final DummyHandler checkHandler = new DummyHandler();
         try (InputStream input = Files.newInputStream(AVAILABLE_CHECKS_PATH)) {
             parser.parse(input, checkHandler);
         }
@@ -147,7 +147,7 @@ public class XdocsUrlTest {
         }
     }
 
-    public static final class CheckTest extends DefaultHandler {
+    public static final class DummyHandler extends DefaultHandler {
 
         private static final String SPLIT_CHECK_NAME_IN_ATTRIBUTE = "#";
 


### PR DESCRIPTION
Identified after noticing https://github.com/checkstyle/checkstyle/pull/12707#discussion_r1094701977 and running `mvn versions:display-dependency-updates`.

4-5 dependencies are out of date.

Based on below evidence, it looks like we stopped getting some updates around 10/25/2022 - 10/29/2022 .

`versions-maven-plugin` got an update around the same time.
https://mvnrepository.com/artifact/org.codehaus.mojo/versions-maven-plugin
2.13.0 release on 10/23.
It's latest release is 2.14.2 which was released on 12/24.

@romani ping