### PR TITLE
dependency: bump versions-maven-plugin to 2.14.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
     <maven.sevntu-checkstyle-check.checkstyle.version>
       10.4
     </maven.sevntu-checkstyle-check.checkstyle.version>
-    <maven.versions.plugin.version>2.13.0</maven.versions.plugin.version>
+    <maven.versions.plugin.version>2.14.2</maven.versions.plugin.version>
     <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
     <java.version>11</java.version>
     <pitest.plugin.version>1.9.9</pitest.plugin.version>


### PR DESCRIPTION
Missed from https://github.com/checkstyle/checkstyle/pull/12710 as it seems versions-maven-plugin does not look to bump itself. Edit: It seems this is only reported by `display-plugin-updates`.

https://mvnrepository.com/artifact/org.codehaus.mojo/versions-maven-plugin
2.14.2 released on 12/24. *(Missed)*
2.14.0 released on 12/14. *(Missed)*
2.13.0 released on 10/23.
