### PR TITLE
Issue #7593: Add example for Transaltion's each existing config

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -137,6 +137,15 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * &lt;/module&gt;
  * </pre>
  * <p>
+ *Example:
+ * </p>
+ * <pre>
+ *baseName.properties //ok
+ *baseName.translations  //ok
+ *baseName.text //violation  , extension without translations or properties
+ *baseName.word  // violation , extension without translations or properties
+ * </pre>
+ * <p>
  * Note, that files with the same path and base name but which have different
  * extensions will be considered as files that belong to different resource bundles.
  * </p>
@@ -148,6 +157,13 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * &lt;module name="Translation"&gt;
  *   &lt;property name="baseName" value="^ButtonLabels.*$"/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * ButtonLabels.properties  //ok
+ * another.properties   //violation , the basename is not ButtonLabels
  * </pre>
  * <p>
  * To configure the check to check existence of Japanese and French translations:
@@ -168,6 +184,14 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * &lt;/module&gt;
  * </pre>
  * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * baseName-ja.properties//ok
+ * baseName-fr.properties  //ok
+ * baseName-ar.properties  //voilation , arabic translation
+ *</pre>
+ * <p>
  * As we can see from the configuration, the TranslationCheck was configured
  * to check an existence of 'es', 'fr' and 'de' translations. Let's assume that
  * we have the resource bundle:
@@ -176,6 +200,20 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * messages_home.properties
  * messages_home_es_US.properties
  * messages_home_fr_CA_UNIX.properties
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * messages_home_de.properties
+ * messages_home_es_US.properties
+ * messages_home_fr_CA_UNIX.properties
+ * /ok
+ *
+ * messages_home_de.properties
+ * messages_home.properties
+ * messages_home_fr_CA_UNIX.properties
+ * //voilation , es is missing
  * </pre>
  * <p>
  * Than the check will rise the following violation: "0: Properties file

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -52,7 +52,7 @@ import com.puppycrawl.tools.checkstyle.api.MessageDispatcher;
 import com.puppycrawl.tools.checkstyle.api.Violation;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
-/**
+/* *
  * <p>
  * Ensures the correct translation of code by checking property files for consistency
  * regarding their keys. Two property files describing one and the same context
@@ -137,13 +137,13 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * &lt;/module&gt;
  * </pre>
  * <p>
- *Example:
+ * Example:
  * </p>
  * <pre>
- *baseName.properties //ok
- *baseName.translations  //ok
- *baseName.text //violation  , extension without translations or properties
- *baseName.word  // violation , extension without translations or properties
+ * baseName.properties //ok
+ * baseName.translations  //ok
+ * baseName.text //violation  , extension without translations or properties
+ * baseName.word  // violation , extension without translations or properties
  * </pre>
  * <p>
  * Note, that files with the same path and base name but which have different
@@ -190,7 +190,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * baseName-ja.properties//ok
  * baseName-fr.properties  //ok
  * baseName-ar.properties  //voilation , arabic translation
- *</pre>
+ * </pre>
  * <p>
  * As we can see from the configuration, the TranslationCheck was configured
  * to check an existence of 'es', 'fr' and 'de' translations. Let's assume that

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -2350,13 +2350,13 @@ messages.properties: Key 'ok' missing.
 &lt;/module&gt;
         </source>
         <p>
-              Example:
+          Example:
         </p>
         <source>
 baseName.properties //ok
 baseName.translations  //ok
-baseName.text //violation  , extension without translations or properties
-baseName.word  // violation , extension without translations or properties
+baseName.text //violation , extension without translations or properties
+baseName.word // violation,extension without translations or properties
         </source>
         <p>
           Note, that files with the same path and base name but which have different
@@ -2375,10 +2375,9 @@ baseName.word  // violation , extension without translations or properties
               Example:
         </p>
         <source>
-ButtonLabels.properties  //ok
-another.properties   //violation , the basename is not ButtonLabels
+ButtonLabels.properties//ok
+another.properties  //violation, the basename is not ButtonLabels
         </source>
-
 
         <p>
           To configure the check to check existence of Japanese and French translations:
@@ -2407,12 +2406,12 @@ baseName-ar.properties  //voilation , arabic translation
 &lt;/module&gt;
         </source>
         <p>
-              Example:
+            Example:
         </p>
         <source>
-messages_home_de.properties
-messages_home_es_US.properties
-messages_home_fr_CA_UNIX.properties
+messages_de.properties
+messages_es_US.properties
+messages_fr_CA_UNIX.properties
         //ok
 
 messages_home_de.properties
@@ -2424,8 +2423,6 @@ messages_home_fr_CA_UNIX.properties
           As we can see from the configuration, the TranslationCheck was configured to check
           an existence of 'es', 'fr' and 'de' translations. Let's assume that we have the resource
           bundle:
-
-
         </p>
         <source>
 messages_home.properties

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -2349,6 +2349,13 @@ messages.properties: Key 'ok' missing.
   &lt;property name=&quot;fileExtensions&quot; value=&quot;properties, translations&quot;/&gt;
 &lt;/module&gt;
         </source>
+        <p>Example:</p>
+          <source>
+              public class FirstClass {} /*OK*/
+              private class SecondClass {} /*OK*/
+              class ThirdClass {} /*OK,Default translation is present*/
+              protected class FourthClass {} /*OK*/
+          </source>
         <p>
           Note, that files with the same path and base name but which have different
           extensions will be considered as files that belong to different resource bundles.
@@ -2362,6 +2369,13 @@ messages.properties: Key 'ok' missing.
   &lt;property name=&quot;baseName&quot; value=&quot;^ButtonLabels.*$&quot;/&gt;
 &lt;/module&gt;
         </source>
+        <p>Example:</p>
+          <source>
+              public class FirstClass {} /*OK*/
+              private class SecondClass {} /*OK*/
+              protected class ThirdClass {} /*OK*/
+              class FourthClass {} /*OK*/
+          </source>
 
         <p>
           To configure the check to check existence of Japanese and French translations:
@@ -2391,6 +2405,13 @@ messages_home.properties
 messages_home_es_US.properties
 messages_home_fr_CA_UNIX.properties
         </source>
+        <p>Example:</p>
+          <source>
+              public class FirstClass {} /*violation,should match pattern "^$"*/
+              private class SecondClass {} /*OK*/
+              protected class ThirdClass {} /*OK*/
+              class FourthClass {} /*OK*/
+          </source>
         <p>
           Than the check will rise the following violation:
           "0: Properties file 'messages_home_de.properties' is missing."

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -2349,13 +2349,15 @@ messages.properties: Key 'ok' missing.
   &lt;property name=&quot;fileExtensions&quot; value=&quot;properties, translations&quot;/&gt;
 &lt;/module&gt;
         </source>
-        <p>Example:</p>
-          <source>
-              public class FirstClass {} /*OK*/
-              private class SecondClass {} /*OK*/
-              class ThirdClass {} /*OK,Default translation is present*/
-              protected class FourthClass {} /*OK*/
-          </source>
+        <p>
+              Example:
+        </p>
+        <source>
+baseName.properties //ok
+baseName.translations  //ok
+baseName.text //violation  , extension without translations or properties
+baseName.word  // violation , extension without translations or properties
+        </source>
         <p>
           Note, that files with the same path and base name but which have different
           extensions will be considered as files that belong to different resource bundles.
@@ -2369,13 +2371,14 @@ messages.properties: Key 'ok' missing.
   &lt;property name=&quot;baseName&quot; value=&quot;^ButtonLabels.*$&quot;/&gt;
 &lt;/module&gt;
         </source>
-        <p>Example:</p>
-          <source>
-              public class FirstClass {} /*OK*/
-              private class SecondClass {} /*OK*/
-              protected class ThirdClass {} /*OK*/
-              class FourthClass {} /*OK*/
-          </source>
+        <p>
+              Example:
+        </p>
+        <source>
+ButtonLabels.properties  //ok
+another.properties   //violation , the basename is not ButtonLabels
+        </source>
+
 
         <p>
           To configure the check to check existence of Japanese and French translations:
@@ -2384,6 +2387,14 @@ messages.properties: Key 'ok' missing.
 &lt;module name=&quot;Translation&quot;&gt;
   &lt;property name=&quot;requiredTranslations&quot; value=&quot;ja, fr&quot;/&gt;
 &lt;/module&gt;
+        </source>
+        <p>
+           Example:
+        </p>
+        <source>
+baseName-ja.properties//ok
+baseName-fr.properties  //ok
+baseName-ar.properties  //voilation , arabic translation
         </source>
         <p>
           The following example shows how the check works if there is a message bundle which
@@ -2396,22 +2407,32 @@ messages.properties: Key 'ok' missing.
 &lt;/module&gt;
         </source>
         <p>
+              Example:
+        </p>
+        <source>
+messages_home_de.properties
+messages_home_es_US.properties
+messages_home_fr_CA_UNIX.properties
+        //ok
+
+messages_home_de.properties
+messages_home.properties
+messages_home_fr_CA_UNIX.properties
+        //voilation , es is missing
+        </source>
+        <p>
           As we can see from the configuration, the TranslationCheck was configured to check
           an existence of 'es', 'fr' and 'de' translations. Let's assume that we have the resource
           bundle:
+
+
         </p>
         <source>
 messages_home.properties
 messages_home_es_US.properties
 messages_home_fr_CA_UNIX.properties
         </source>
-        <p>Example:</p>
-          <source>
-              public class FirstClass {} /*violation,should match pattern "^$"*/
-              private class SecondClass {} /*OK*/
-              protected class ThirdClass {} /*OK*/
-              class FourthClass {} /*OK*/
-          </source>
+
         <p>
           Than the check will rise the following violation:
           "0: Properties file 'messages_home_de.properties' is missing."


### PR DESCRIPTION
Issue https://github.com/checkstyle/checkstyle/issues/7593 : Add example 

![TranslationCheck](https://user-images.githubusercontent.com/105888506/220480288-0ea75169-48dc-443c-805e-e759e27a07dc.png)
 output:

![CL1Translation](https://user-images.githubusercontent.com/105888506/220480376-bafd69d4-692a-434e-bd55-c27c02cb3001.png)


![CL2Translation](https://user-images.githubusercontent.com/105888506/220480420-d01c2118-e60a-424e-9a52-183109b9748a.png)

