### PR TITLE
Issue #12720: Use input context instead of event context

### DIFF
--- a/.github/workflows/bump-version-and-update-milestone.yml
+++ b/.github/workflows/bump-version-and-update-milestone.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          echo "Latest Version: ${{ github.event.inputs.version }}"
+          echo "Latest Version: ${{ inputs.version }}"
   bump:
     name: Bump version
     runs-on: ubuntu-latest
@@ -37,15 +37,15 @@ jobs:
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}
       - name: Modify File
         run: |
-          ./.ci/bump-version.sh ${{ github.event.inputs.version }}
+          ./.ci/bump-version.sh ${{ inputs.version }}
       - name: Push commit
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git commit -am "minor: Bump version to ${{ github.event.inputs.version }}-SNAPSHOT"
+          git commit -am "minor: Bump version to ${{ inputs.version }}-SNAPSHOT"
           git push
       - name: GitHub Milestone
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          .ci/update-github-milestone.sh ${{ github.event.inputs.version }}
+          .ci/update-github-milestone.sh ${{ inputs.version }}

--- a/.github/workflows/maven-prepare.yml
+++ b/.github/workflows/maven-prepare.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   prepare:
-    name: Prepare Release ${{ github.event.inputs.version }}
+    name: Prepare Release ${{ inputs.version }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
@@ -38,7 +38,7 @@ jobs:
           git config user.email 'github-actions[bot]@users.noreply.github.com'
       - name: Run Shell Script
         run: |
-          ./.ci/maven-prepare.sh ${{ github.event.inputs.version }}
+          ./.ci/maven-prepare.sh ${{ inputs.version }}
       - name: Push commit
         run: |
           git push origin master --tags

--- a/.github/workflows/maven-release-perform.yml
+++ b/.github/workflows/maven-release-perform.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   perform:
-    name: Release perform {{ github.event.inputs.version }}
+    name: Release perform {{ inputs.version }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
@@ -42,4 +42,4 @@ jobs:
           ./.ci/prepare-settings.sh
       - name: Run Shell Script
         run: |
-          ./.ci/maven-release-perform.sh ${{ github.event.inputs.version }}
+          ./.ci/maven-release-perform.sh ${{ inputs.version }}

--- a/.github/workflows/new-milestone-and-issue-in-other-repo.yml
+++ b/.github/workflows/new-milestone-and-issue-in-other-repo.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   creation:
-    name: Creation-New Milestone/Issue" for ${{ github.event.inputs.version }}
+    name: Creation-New Milestone/Issue" for ${{ inputs.version }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
@@ -45,10 +45,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          ./.ci/upload-all-jar.sh ${{ github.event.inputs.version }}
+          ./.ci/upload-all-jar.sh ${{ inputs.version }}
 
       - name: Creation of issue in other Repositories
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
         run: |
-          ./.ci/creation-of-issue-in-other-repos.sh ${{ github.event.inputs.version }}
+          ./.ci/creation-of-issue-in-other-repos.sh ${{ inputs.version }}

--- a/.github/workflows/publish-releasenotes-for-twitter.yml
+++ b/.github/workflows/publish-releasenotes-for-twitter.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   publish:
-    name: Publish releasenotes tweet for ${{ github.event.inputs.version }}
+    name: Publish releasenotes tweet for ${{ inputs.version }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
@@ -30,7 +30,7 @@ jobs:
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}
       - name: Run Shell Script
         run: |
-          ./.ci/tweet-releasenotes.sh ${{ github.event.inputs.version }}
+          ./.ci/tweet-releasenotes.sh ${{ inputs.version }}
         env:
           GITHUB_READ_ONLY_TOKEN: ${{ secrets.READ_ONLY_TOKEN_GITHUB }}
           TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}

--- a/.github/workflows/publish-releasenotes-outside.yml
+++ b/.github/workflows/publish-releasenotes-outside.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   publish:
-    name: Publish releasenotes GitHub Page ${{ github.event.inputs.version }}
+    name: Publish releasenotes GitHub Page ${{ inputs.version }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -32,4 +32,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ./.ci/update-github-page.sh ${{ github.event.inputs.version }}
+          ./.ci/update-github-page.sh ${{ inputs.version }}

--- a/.github/workflows/update-github-io.yml
+++ b/.github/workflows/update-github-io.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   update:
-    name: update github.io ${{ github.event.inputs.version }}
+    name: update github.io ${{ inputs.version }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
@@ -31,7 +31,7 @@ jobs:
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}
       - name: Run Shell Script
         run: |
-          ./.ci/generate-website.sh ${{ github.event.inputs.version }}
+          ./.ci/generate-website.sh ${{ inputs.version }}
       - name: Checkout checkstyle.github.io repo
         uses: actions/checkout@v3
         with:
@@ -40,4 +40,4 @@ jobs:
           path: .ci-temp/checkstyle.github.io/
       - name: Commit and Push to checkstyle.github.io repo
         run: |
-          ./.ci/push-website-to-github-io.sh ${{ github.event.inputs.version }}
+          ./.ci/push-website-to-github-io.sh ${{ inputs.version }}

--- a/.github/workflows/update-sources.yml
+++ b/.github/workflows/update-sources.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   releasenotes:
-    name: Push releasenotes ${{ github.event.inputs.version }}
+    name: Push releasenotes ${{ inputs.version }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -35,10 +35,10 @@ jobs:
         env:
           READ_ONLY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ./.ci/update-releasenotesxml.sh ${{ github.event.inputs.version }}
+          ./.ci/update-releasenotesxml.sh ${{ inputs.version }}
       - name: Commit and Push
         run: |
             git config user.name 'github-actions[bot]'
             git config user.email 'github-actions[bot]@users.noreply.github.com'
-            git add . && git commit -m "doc: release notes for ${{ github.event.inputs.version }}"
+            git add . && git commit -m "doc: release notes for ${{ inputs.version }}"
             git push origin master

--- a/.github/workflows/upload-all-jar.yml
+++ b/.github/workflows/upload-all-jar.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   github:
-    name: Upload '-all' jar to Github for ${{ github.event.inputs.version }}
+    name: Upload '-all' jar to Github for ${{ inputs.version }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
@@ -35,4 +35,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          ./.ci/upload-all-jar.sh ${{ github.event.inputs.version }}
+          ./.ci/upload-all-jar.sh ${{ inputs.version }}


### PR DESCRIPTION
Part of #12720 

From https://github.com/checkstyle/checkstyle/pull/12741#discussion_r1106565550

> Is it possible to move such update on input usage in Separate PR, to let me merge it sooner and test in manual execution of each action in next release.
> It is huge milestone for us that release is fully in CI even there are few actions to run.
> 
> PR with workflow will take a bit more time to accept. I want it to has less changes to let me focus more details on actual workflow changes.

---
Reasoning: `inputs` context is accessible from both `workflow_dispatch` and `workflow_call`. We are going to use `workflow_call` to make the workflow reusable.

From: https://github.blog/changelog/2022-06-10-github-actions-inputs-unified-across-manual-and-reusable-workflows/

> 
> Workflows triggered by `workflow_dispatch` and `workflow_call` can now access their inputs using the inputs context.
> 
> Previously workflow_dispatch inputs were in the event payload. This made it difficult for workflow authors who wanted to have one workflow that was both reusable and manually triggered. Now a workflow author can write a single workflow triggered by `workflow_dispatch` and `workflow_call` and use the `inputs` context to access the input values.
> 
> For workflows triggered by `workflow_dispatch` inputs are still available in the `github.event.inputs` context to maintain compatibility.

---
Proof: I manually executed `R: Bump version/Update Milestone` in https://github.com/stoyanK7/checkstyle/actions/runs/4181886177/jobs/7244307869#step:2:5 and the output is printed:
```
Run echo "Latest Version: 10.7.2"
Latest Version: 10.7.2
```