### PR TITLE
Issue #12726: Create new profile for gpg version 2 

### DIFF
--- a/.ci/maven-release-perform.sh
+++ b/.ci/maven-release-perform.sh
@@ -20,7 +20,7 @@ SKIP_OTHERS="-Dpmd.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -Dxml.skip=
 
 git checkout "checkstyle-$TARGET_VERSION"
 echo "Deploying jars to maven central (release:perform) ..."
-mvn -e --no-transfer-progress -Pgpg release:perform \
+mvn -e --no-transfer-progress -Pgpg -Pgpgv2 release:perform \
   -DconnectionUrl=scm:git:https://github.com/checkstyle/checkstyle.git \
   -Dtag=checkstyle-"$TARGET_VERSION" \
   -Darguments="$SKIP_TEST $SKIP_CHECKSTYLE $SKIP_OTHERS"

--- a/.ci/prepare-settings.sh
+++ b/.ci/prepare-settings.sh
@@ -18,7 +18,7 @@ replace() {
 replace SONATYPE_USER "$SONATYPE_USER"
 replace SONATYPE_PWD "$SONATYPE_PWD"
 replace GPG_PASSPHRASE "$GPG_PASSPHRASE"
-replace GPG_KEY "$GPG_KEYNAME"
+replace GPG_KEYNAME "$GPG_KEYNAME"
 
 mkdir -p ~/.m2
 TEMP_SETTING=./.ci-temp/release-settings.xml

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -502,6 +502,7 @@ googlesource
 govstrangefolder
 GPath
 gpg
+gpgv
 gradle
 gradlew
 graphicsenv
@@ -1027,6 +1028,7 @@ perl
 Perror
 pgjdbc
 Pgpg
+Pgpgv
 pguyot
 php
 picocli

--- a/pom.xml
+++ b/pom.xml
@@ -759,17 +759,6 @@
         <version>3.1.0</version>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>3.0.1</version>
-        <configuration>
-          <gpgArguments>
-            <arg>--pinentry-mode</arg>
-            <arg>loopback</arg>
-          </gpgArguments>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
         <version>${maven.versions.plugin.version}</version>
@@ -2381,6 +2370,26 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- Use only with GPG v2.1+ -->
+    <profile>
+      <id>gpgv2</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.0.1</version>
+            <configuration>
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Part of #12726 

---
Moves `maven-gpg-plugin` configuration to its own profile as requested in: https://github.com/checkstyle/checkstyle/issues/12762#issuecomment-1439393566
> My upgrade to 2.x will be not easy. Can we activate this plugin config by extra profile? To use it in environment with 2.x version, and work as before if not defined.

By default, the mode is used because GitHub runners use gpg v2.1+, but maintainer can remove it if they do release from local since not everybody can upgrade from v1.4 to v2.1 easily.


Job using new profile: https://github.com/stoyanK7/checkstyle/actions/runs/4246243945/jobs/7382806834
Expected fail without new profile: https://github.com/stoyanK7/checkstyle/actions/runs/4246287057/jobs/7382904938#step:6:1802
```
[INFO] --- maven-gpg-plugin:1.1:sign (sign-artifacts) @ checkstyle ---
    gpg: WARNING: "--no-use-agent" is an obsolete option - it has no effect
    gpg: signing failed: Inappropriate ioctl for device
    gpg: signing failed: Inappropriate ioctl for device
```