### PR TITLE
Issue #12765: CommitValidationTest should ignore the release process

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CommitValidationTest.java
@@ -72,12 +72,15 @@ public class CommitValidationTest {
 
     private static final String ISSUE_COMMIT_MESSAGE_REGEX_PATTERN = "^Issue #\\d+: .*$";
     private static final String PR_COMMIT_MESSAGE_REGEX_PATTERN = "^Pull #\\d+: .*$";
+    private static final String RELEASE_COMMIT_MESSAGE_REGEX_PATTERN =
+            "^\\[maven-release-plugin] .*$";
     private static final String OTHER_COMMIT_MESSAGE_REGEX_PATTERN =
             "^(minor|config|infra|doc|spelling|dependency|supplemental): .*$";
 
     private static final String ACCEPTED_COMMIT_MESSAGE_REGEX_PATTERN =
               "(" + ISSUE_COMMIT_MESSAGE_REGEX_PATTERN + ")|"
               + "(" + PR_COMMIT_MESSAGE_REGEX_PATTERN + ")|"
+              + "(" + RELEASE_COMMIT_MESSAGE_REGEX_PATTERN + ")|"
               + "(" + OTHER_COMMIT_MESSAGE_REGEX_PATTERN + ")";
 
     private static final Pattern ACCEPTED_COMMIT_MESSAGE_PATTERN =
@@ -137,6 +140,19 @@ public class CommitValidationTest {
                 + "Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test Test "
                 + "Test Test Test Test Test Test Test  Test Test Test Test Test Test"))
             .isEqualTo(4);
+    }
+
+    @Test
+    public void testReleaseCommitMessage() {
+        assertWithMessage("should accept release commit message for preparing release")
+                .that(validateCommitMessage("[maven-release-plugin] "
+                        + "prepare release checkstyle-10.8.0"))
+                .isEqualTo(0);
+        assertWithMessage("should accept release commit message for preparing for "
+                + "next development iteration")
+                .that(validateCommitMessage("[maven-release-plugin] prepare for next "
+                        + "development iteration"))
+                .isEqualTo(0);
     }
 
     @Test


### PR DESCRIPTION
Resolves #12765

I identified only 2 types release commit messages:
- `[maven-release-plugin] prepare for next development iteration`
- `[maven-release-plugin] prepare release checkstyle-10.8.0`

Proof that it works. First I checkout to faulty commit and run test so it fails. Then I apply this commit on top and run test again:
[Screencast from 23-02-23 22:18:54.webm](https://user-images.githubusercontent.com/23459549/221034936-20b3995a-f985-45d6-8975-c9648deba270.webm)
