### PR TITLE
Issue #12720: Create release in update github page script 

### DIFF
--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -1282,7 +1282,6 @@ sysprop
 systemout
 Taglib
 taglist
-tagname
 taskdef
 tbody
 tcr


### PR DESCRIPTION
Part of #12720 
The purpose of this PR is to divide #12741 into smaller chunks

---
> Please explain why this shell script is required.
I was under impression that we did not miss any steps from release process.

Answer(same as https://github.com/checkstyle/checkstyle/pull/12741#discussion_r1116005992): 
The purpose of this script is to create the release on GitHub. Nowhere in the release process are we doing that:
![image](https://user-images.githubusercontent.com/23459549/220980019-fd0ba551-051d-4708-92e2-3a57b5b413a4.png)


After it is created, `R: Close/Create Milestone, Upload '-all' jar, Create issues` and `R: Publish GitHub Page` search for that release by tag `checkstyle-<release target version>`
https://github.com/checkstyle/checkstyle/blob/fb9ff40ef7679342afcc6dc62cd059255c673dbb/.ci/update-github-page.sh#L36-L42
https://github.com/checkstyle/checkstyle/blob/fb9ff40ef7679342afcc6dc62cd059255c673dbb/.ci/upload-all-jar.sh#L23-L28

After both of these jobs update the release, this is how it looks:
![image](https://user-images.githubusercontent.com/23459549/220980042-ec0f0ef2-9d82-4d94-b7ff-8f03bf010acb.png)


Here is a successful run with the job that creates the GitHub release:
https://github.com/stoyanK7/checkstyle/actions/runs/4254777591

And here is a failing run when we do not use that job: https://github.com/stoyanK7/checkstyle/actions/runs/4254920912
 - https://github.com/stoyanK7/checkstyle/actions/runs/4254920912/jobs/7401938612#step:4:121
   ```
   TARGET_RELEASE_INDEX=
   PREVIOUS_RELEASE_INDEX=1
   START_REF=checkstyle-10.6.0
   END_REF=checkstyle-10.7.0
   ...
   Exception in thread "main" org.eclipse.jgit.errors.RevisionSyntaxException: Invalid ref name: checkstyle-10.7.0
   ```
 - https://github.com/stoyanK7/checkstyle/actions/runs/4254920912/jobs/7401938788#step:6:243
   ```
   HTTP/2 404 
   ...
   {"message":"Not Found","request_id":"1BC5:0714:6AADEC:889F39:63F79B70","documentation_url":"https://docs.github.com/rest"}Jar Published for 10.8.0
   ```
Moreover, same thing is done in `release.sh`:
https://github.com/checkstyle/checkstyle/blob/fb9ff40ef7679342afcc6dc62cd059255c673dbb/release.sh#L67-L74