### PR TITLE
Issue #7571: Update doc for AnnotationUseStyle

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/annotation/AnnotationUseStyleCheck.java
@@ -126,48 +126,107 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * Example:
  * </p>
  * <pre>
+ * &#64;SuppressWarnings("unchecked") // OK
  * &#64;Deprecated // OK
- * &#64;SomeArrays(pooches={DOGS.LEO}) // Violation - COMPACT_NO_ARRAY
- * &#64;SuppressWarnings({""}) // Violation - COMPACT_NO_ARRAY
+ * &#64;SomeArrays({"unchecked","unused"}) // OK
  * public class TestOne
  * {
  *
  * }
  *
- * &#64;SomeArrays(pooches={DOGS.LEO}, um={}, test={"bleh"}) // Violation - COMPACT_NO_ARRAY
- * &#64;SuppressWarnings("") // OK
- * &#64;Deprecated() // Violation - cannot have closing parenthesis
+ * &#64;SuppressWarnings(value={"unchecked"}) // Violation - parameter 'value' shouldn't be used
+ * &#64;Deprecated() // Violation - cannot have a closing parenthesis
+ * &#64;SomeArrays(value={"unchecked","unused",}) // Violation - cannot have a trailing array comma
  * class TestTwo {
  *
  * }
  * </pre>
  * <p>
  * To configure the check to enforce an {@code expanded} style,
- * with a trailing array comma set to {@code never}
- * and always including the closing parenthesis.
+ *             with a closing parenthesis and a trailing array comma set to {@code never}.
  * </p>
  * <pre>
  * &lt;module name=&quot;AnnotationUseStyle&quot;&gt;
- *   &lt;property name=&quot;elementStyle&quot; value=&quot;expanded&quot;/&gt;
- *   &lt;property name=&quot;trailingArrayComma&quot; value=&quot;never&quot;/&gt;
- *   &lt;property name=&quot;closingParens&quot; value=&quot;always&quot;/&gt;
+ *  &lt;property name=&quot;elementStyle&quot; value=&quot;expanded&quot;/&gt;
+ *  &lt;property name=&quot;closingParens&quot; value=&quot;never&quot;/&gt;
+ *  &lt;property name=&quot;trailingArrayComma&quot; value=&quot;never&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
  * <p>
  * Example:
  * </p>
  * <pre>
- * &#64;Deprecated // Violation - must have closing parenthesis
- * &#64;SomeArrays(pooches={DOGS.LEO}) // OK
- * &#64;SuppressWarnings({""}) // Violation - EXPANDED
+ * &#64;SuppressWarnings("unchecked") // Violation - parameters should be referenced
+ * &#64;Deprecated // OK
+ * &#64;SomeArrays({"unchecked","unused"}) // Violation - parameters should be referenced
  * public class TestOne
  * {
  *
  * }
  *
- * &#64;SomeArrays(pooches={DOGS.LEO}, um={}, test={"bleh"}) // OK
- * &#64;SuppressWarnings("") // Violation - EXPANDED
+ * &#64;SuppressWarnings(value={"unchecked"}) // OK
+ * &#64;Deprecated() // Violation - cannot have a closing parenthesis
+ * &#64;SomeArrays(value={"unchecked","unused",}) // Violation - cannot have a trailing array comma
+ * class TestTwo {
+ *
+ * }
+ * </pre>
+ * <p>
+ * To configure the check to enforce a {@code compact} style,
+ *             with always including a closing parenthesis and ignoring a trailing array comma.
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;AnnotationUseStyle&quot;&gt;
+ *  &lt;property name=&quot;elementStyle&quot; value=&quot;compact&quot;/&gt;
+ *  &lt;property name=&quot;closingParens&quot; value=&quot;always&quot;/&gt;
+ *  &lt;property name=&quot;trailingArrayComma&quot; value=&quot;ignore&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * &#64;SuppressWarnings("unchecked") // OK
+ * &#64;Deprecated // Violation - must have a closing parenthesis
+ * &#64;SomeArrays({"unchecked","unused"}) // OK
+ * public class TestOne
+ * {
+ *
+ * }
+ *
+ * &#64;SuppressWarnings(value={"unchecked"}) // Violation - parameter 'value' shouldn't be used
  * &#64;Deprecated() // OK
+ * &#64;SomeArrays(value={"unchecked","unused",}) // Violation - parameter 'value' shouldn't be used
+ * class TestTwo {
+ *
+ * }
+ * </pre>
+ * <p>
+ * To configure the check to enforce a trailing array comma,
+ *             with ignoring the elementStyle and a closing parenthesis.
+ * </p>
+ * <pre>
+ * &lt;module name=&quot;AnnotationUseStyle&quot;&gt;
+ *  &lt;property name=&quot;elementStyle&quot; value=&quot;ignore&quot;/&gt;
+ *  &lt;property name=&quot;closingParens&quot; value=&quot;ignore&quot;/&gt;
+ *  &lt;property name=&quot;trailingArrayComma&quot; value=&quot;always&quot;/&gt;
+ * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * &#64;SuppressWarnings("unchecked") // OK
+ * &#64;Deprecated // OK
+ * &#64;SomeArrays({"unchecked","unused"}) // Violation - must have a trailing array comma
+ * public class TestOne
+ * {
+ *
+ * }
+ *
+ * &#64;SuppressWarnings(value={"unchecked"}) // Violation - must have a trailing array comma
+ * &#64;Deprecated() // OK
+ * &#64;SomeArrays(value={"unchecked","unused",})  // OK
  * class TestTwo {
  *
  * }

--- a/src/xdocs/config_annotation.xml
+++ b/src/xdocs/config_annotation.xml
@@ -608,48 +608,107 @@ class Bar implements Foo {
           Example:
         </p>
         <source>
+@SuppressWarnings("unchecked") // OK
 @Deprecated // OK
-@SomeArrays(pooches={DOGS.LEO}) // Violation - COMPACT_NO_ARRAY
-@SuppressWarnings({""}) // Violation - COMPACT_NO_ARRAY
+@SomeArrays({"unchecked","unused"}) // OK
 public class TestOne
 {
 
 }
 
-@SomeArrays(pooches={DOGS.LEO}, um={}, test={"bleh"}) // Violation - COMPACT_NO_ARRAY
-@SuppressWarnings("") // OK
-@Deprecated() // Violation - cannot have closing parenthesis
+@SuppressWarnings(value={"unchecked"}) // Violation - parameter 'value' shouldn't be used
+@Deprecated() // Violation - cannot have a closing parenthesis
+@SomeArrays(value={"unchecked","unused",}) // Violation - cannot have a trailing array comma
 class TestTwo {
 
 }
         </source>
         <p>
           To configure the check to enforce an <code>expanded</code> style,
-          with a trailing array comma set to <code>never</code>
-          and always including the closing parenthesis.
+            with a closing parenthesis and a trailing array comma set to <code>never</code>.
         </p>
         <source>
 &lt;module name=&quot;AnnotationUseStyle&quot;&gt;
   &lt;property name=&quot;elementStyle&quot; value=&quot;expanded&quot;/&gt;
+  &lt;property name=&quot;closingParens&quot; value=&quot;never&quot;/&gt;
   &lt;property name=&quot;trailingArrayComma&quot; value=&quot;never&quot;/&gt;
-  &lt;property name=&quot;closingParens&quot; value=&quot;always&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>
           Example:
         </p>
         <source>
-@Deprecated // Violation - must have closing parenthesis
-@SomeArrays(pooches={DOGS.LEO}) // OK
-@SuppressWarnings({""}) // Violation - EXPANDED
+@SuppressWarnings("unchecked") // Violation - parameters should be referenced
+@Deprecated // OK
+@SomeArrays({"unchecked","unused"}) // Violation - parameters should be referenced
 public class TestOne
 {
 
 }
 
-@SomeArrays(pooches={DOGS.LEO}, um={}, test={"bleh"}) // OK
-@SuppressWarnings("") // Violation - EXPANDED
+@SuppressWarnings(value={"unchecked"}) // OK
+@Deprecated() // Violation - cannot have a closing parenthesis
+@SomeArrays(value={"unchecked","unused",}) // Violation - cannot have a trailing array comma
+class TestTwo {
+
+}
+        </source>
+        <p>
+          To configure the check to enforce a <code>compact</code> style,
+            with always including a closing parenthesis and ignoring a trailing array comma.
+        </p>
+        <source>
+&lt;module name=&quot;AnnotationUseStyle&quot;&gt;
+  &lt;property name=&quot;elementStyle&quot; value=&quot;compact&quot;/&gt;
+  &lt;property name=&quot;closingParens&quot; value=&quot;always&quot;/&gt;
+  &lt;property name=&quot;trailingArrayComma&quot; value=&quot;ignore&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+@SuppressWarnings("unchecked") // OK
+@Deprecated // Violation - must have a closing parenthesis
+@SomeArrays({"unchecked","unused"}) // OK
+public class TestOne
+{
+
+}
+
+@SuppressWarnings(value={"unchecked"}) // Violation - parameter 'value' shouldn't be used
 @Deprecated() // OK
+@SomeArrays(value={"unchecked","unused",}) // Violation - parameter 'value' shouldn't be used
+class TestTwo {
+
+}
+        </source>
+        <p>
+          To configure the check to enforce a trailing array comma,
+            with ignoring the elementStyle and a closing parenthesis.
+        </p>
+        <source>
+&lt;module name=&quot;AnnotationUseStyle&quot;&gt;
+  &lt;property name=&quot;elementStyle&quot; value=&quot;ignore&quot;/&gt;
+  &lt;property name=&quot;closingParens&quot; value=&quot;ignore&quot;/&gt;
+  &lt;property name=&quot;trailingArrayComma&quot; value=&quot;always&quot;/&gt;
+&lt;/module&gt;
+        </source>
+        <p>
+          Example:
+        </p>
+        <source>
+@SuppressWarnings("unchecked") // OK
+@Deprecated // OK
+@SomeArrays({"unchecked","unused"}) // Violation - must have a trailing array comma
+public class TestOne
+{
+
+}
+
+@SuppressWarnings(value={"unchecked"}) // Violation - must have a trailing array comma
+@Deprecated() // OK
+@SomeArrays(value={"unchecked","unused",}) // OK
 class TestTwo {
 
 }


### PR DESCRIPTION
Closes #7571

**The default value properties**
Web Page:
<img width="670" alt="Screen Shot 2023-03-05 at 4 30 04 PM" src="https://user-images.githubusercontent.com/61718025/222995882-352b701d-8dee-4c0c-ad84-535355a41118.png">
CLI:
```
naotokuwayama@NaotonoMacBook-Air test % cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="AnnotationUseStyle"/>
  </module>
</module>
naotokuwayama@NaotonoMacBook-Air test % cat Test.java 
@SuppressWarnings("unchecked") // OK
@Deprecated // OK
@SomeArrays({"unchecked","unused"}) // OK
public class TestOne
{

}

@SuppressWarnings(value={"unchecked"}) // Violation - parameter 'value' shouldn't be used
@Deprecated() // Violation - cannot have a closing parenthesis
@SomeArrays(value={"unchecked","unused",}) // Violation - cannot have a trailing array comma
class TestTwo {

}
naotokuwayama@NaotonoMacBook-Air test %  java $RUN_LOCALE -jar checkstyle-10.8.0-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /Users/naotokuwayama/open_source/test/Test.java:9:1: Annotation style must be 'COMPACT_NO_ARRAY'. [AnnotationUseStyle]
[ERROR] /Users/naotokuwayama/open_source/test/Test.java:10:1: Annotation cannot have closing parenthesis. [AnnotationUseStyle]
[ERROR] /Users/naotokuwayama/open_source/test/Test.java:11:40: Annotation array values cannot contain trailing comma. [AnnotationUseStyle]
Audit done.
Checkstyle ends with 3 errors.
```

**To configure the check to enforce an expanded style, with a closing parenthesis and a trailing array comma set to never.**
WebPage:
<img width="683" alt="2" src="https://user-images.githubusercontent.com/61718025/222829730-71d578fa-c10c-4dda-b864-96a59fe2a1ad.png">
CLI:
```
naotokuwayama@NaotonoMacBook-Air test % cat config.xml                                                          
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="AnnotationUseStyle">
        <property name="elementStyle" value="expanded"/>
        <property name="closingParens" value="never"/>
        <property name="trailingArrayComma" value="never"/>
    </module>
  </module>
</module>
naotokuwayama@NaotonoMacBook-Air test % cat Test.java                                                           
@SuppressWarnings("unchecked") // Violation - parameters should be referenced
@Deprecated // OK
@SomeArrays({"unchecked","unused"}) // Violation - parameters should be referenced
public class TestOne
{

}

@SuppressWarnings(value={"unchecked"}) // OK
@Deprecated() // Violation - cannot have a closing parenthesis
@SomeArrays(value={"unchecked","unused",}) // Violation - cannot have a trailing array comma
class TestTwo {

}

naotokuwayama@NaotonoMacBook-Air test %  java $RUN_LOCALE -jar checkstyle-10.8.0-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /Users/naotokuwayama/open_source/test/Test.java:1:1: Annotation style must be 'EXPANDED'. [AnnotationUseStyle]
[ERROR] /Users/naotokuwayama/open_source/test/Test.java:3:1: Annotation style must be 'EXPANDED'. [AnnotationUseStyle]
[ERROR] /Users/naotokuwayama/open_source/test/Test.java:10:1: Annotation cannot have closing parenthesis. [AnnotationUseStyle]
[ERROR] /Users/naotokuwayama/open_source/test/Test.java:11:40: Annotation array values cannot contain trailing comma. [AnnotationUseStyle]
Audit done.
Checkstyle ends with 4 errors.
```
**To configure the check to enforce a compact style, with always including a closing parenthesis and ignoring a trailing array comma.**
WebPage:
<img width="658" alt="Screen Shot 2023-03-05 at 4 30 16 PM" src="https://user-images.githubusercontent.com/61718025/222995967-6a9ea6b7-e9fb-4dee-8c88-e58d3e13fa24.png">

CLI:
```
naotokuwayama@NaotonoMacBook-Air test % cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="AnnotationUseStyle">
      <property name="elementStyle" value="compact"/>
      <property name="closingParens" value="always"/>
      <property name="trailingArrayComma" value="ignore"/>
    </module>
  </module>
</module>
naotokuwayama@NaotonoMacBook-Air test % cat Test.java
@SuppressWarnings("unchecked") // OK
@Deprecated // Violation - must have a closing parenthesis
@SomeArrays({"unchecked","unused"}) // OK
public class TestOne
{

}

@SuppressWarnings(value={"unchecked"}) // Violation - parameter 'value' shouldn't be used
@Deprecated() // OK
@SomeArrays(value={"unchecked","unused",}) // Violation - parameter 'value' shouldn't be used
class TestTwo {

}
naotokuwayama@NaotonoMacBook-Air test %  java $RUN_LOCALE -jar checkstyle-10.8.0-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /Users/naotokuwayama/open_source/test/Test.java:2:1: Annotation must have closing parenthesis. [AnnotationUseStyle]
[ERROR] /Users/naotokuwayama/open_source/test/Test.java:9:1: Annotation style must be 'COMPACT'. [AnnotationUseStyle]
[ERROR] /Users/naotokuwayama/open_source/test/Test.java:11:1: Annotation style must be 'COMPACT'. [AnnotationUseStyle]
Audit done.
```
**To configure the check to enforce a trailing array comma, with ignoring the elementStyle and a closing parenthesis.**
WebPage:
<img width="663" alt="4" src="https://user-images.githubusercontent.com/61718025/222996159-d518cc86-5475-4479-bb21-55be6c6a8dde.png">

CLI:
```
naotokuwayama@NaotonoMacBook-Air test % cat config.xml                                                          
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="AnnotationUseStyle">
        <property name="elementStyle" value="ignore"/>
        <property name="closingParens" value="ignore"/>
        <property name="trailingArrayComma" value="always"/>
    </module>
  </module>
</module>
naotokuwayama@NaotonoMacBook-Air test % cat Test.java                                                           
@SuppressWarnings("unchecked") // OK
@Deprecated // OK
@SomeArrays({"unchecked","unused"}) // Violation - must have a trailing array comma
public class TestOne
{

}

@SuppressWarnings(value={"unchecked"}) // Violation - must have a trailing array comma
@Deprecated() // OK
@SomeArrays(value={"unchecked","unused",}) // OK
class TestTwo {

}
naotokuwayama@NaotonoMacBook-Air test %  java $RUN_LOCALE -jar checkstyle-10.8.0-all.jar -c config.xml Test.java
Starting audit...
[ERROR] /Users/naotokuwayama/open_source/test/Test.java:3:34: Annotation array values must contain trailing comma. [AnnotationUseStyle]
[ERROR] /Users/naotokuwayama/open_source/test/Test.java:9:37: Annotation array values must contain trailing comma. [AnnotationUseStyle]
Audit done.
Checkstyle ends with 2 errors.
```
