### PR TITLE
Pull #12776: Keep workflow input descriptions consistent

### DIFF
--- a/.github/workflows/bump-version-and-update-milestone.yml
+++ b/.github/workflows/bump-version-and-update-milestone.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'New Version (without "-SNAPSHOT")'
+        description: 'Target Version without (-SNAPSHOT)'
         required: true
 permissions:
   contents: write

--- a/.github/workflows/copy-site-to-sourceforge.yml
+++ b/.github/workflows/copy-site-to-sourceforge.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release Version without (-SNAPSHOT)'
+        description: 'Target Version without (-SNAPSHOT)'
         required: true
 
 concurrency:


### PR DESCRIPTION
All descriptions use `Target Version without (-SNAPSHOT)` except those two files.