### PR TITLE
Pull #12777: emphasize mutability of collectors

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -710,7 +710,7 @@
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java</fileName>
     <specifier>methodref.return</specifier>
     <message>Incompatible return type</message>
-    <lineContent>Collectors.mapping(Class::getCanonicalName, Collectors.toSet())));</lineContent>
+    <lineContent>Class::getCanonicalName,</lineContent>
     <details>
       found   : @Initialized @Nullable String
       required: @Initialized @NonNull String

--- a/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/PackageObjectFactory.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -305,7 +306,9 @@ public class PackageObjectFactory implements ModuleFactory {
         try {
             returnValue = ModuleReflectionUtil.getCheckstyleModules(packages, loader).stream()
                 .collect(Collectors.groupingBy(Class::getSimpleName,
-                    Collectors.mapping(Class::getCanonicalName, Collectors.toSet())));
+                    Collectors.mapping(
+                        Class::getCanonicalName,
+                        Collectors.toCollection(HashSet::new))));
         }
         catch (IOException ignore) {
             returnValue = Collections.emptyMap();

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalCatchCheck.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -154,7 +155,8 @@ public final class IllegalCatchCheck extends AbstractCheck {
     /** Specify exception class names to reject. */
     private final Set<String> illegalClassNames = Arrays.stream(new String[] {"Exception", "Error",
         "RuntimeException", "Throwable", "java.lang.Error", "java.lang.Exception",
-        "java.lang.RuntimeException", "java.lang.Throwable", }).collect(Collectors.toSet());
+        "java.lang.RuntimeException", "java.lang.Throwable", })
+            .collect(Collectors.toCollection(HashSet::new));
 
     /**
      * Setter to specify exception class names to reject.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalThrowsCheck.java
@@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -160,13 +161,13 @@ public final class IllegalThrowsCheck extends AbstractCheck {
 
     /** Specify names of methods to ignore. */
     private final Set<String> ignoredMethodNames =
-        Arrays.stream(new String[] {"finalize", }).collect(Collectors.toSet());
+        Arrays.stream(new String[] {"finalize", }).collect(Collectors.toCollection(HashSet::new));
 
     /** Specify throw class names to reject. */
     private final Set<String> illegalClassNames = Arrays.stream(
         new String[] {"Error", "RuntimeException", "Throwable", "java.lang.Error",
                       "java.lang.RuntimeException", "java.lang.Throwable", })
-        .collect(Collectors.toSet());
+        .collect(Collectors.toCollection(HashSet::new));
 
     /**
      * Allow to ignore checking overridden methods (marked with {@code Override}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -581,7 +581,7 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
     protected static String[] removeSuppressed(String[] actualViolations,
                                                String... suppressedViolations) {
         final List<String> actualViolationsList =
-            Arrays.stream(actualViolations).collect(Collectors.toList());
+            Arrays.stream(actualViolations).collect(Collectors.toCollection(ArrayList::new));
         actualViolationsList.removeAll(Arrays.asList(suppressedViolations));
         return actualViolationsList.toArray(CommonUtil.EMPTY_STRING_ARRAY);
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/JavaAstVisitorTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavaAstVisitorTest.java
@@ -19,6 +19,7 @@
 
 package com.puppycrawl.tools.checkstyle;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.truth.Truth.assertWithMessage;
 
 import java.io.File;
@@ -36,6 +37,7 @@ import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableSet;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.FileText;
@@ -107,14 +109,14 @@ public class JavaAstVisitorTest extends AbstractModuleTestSupport {
                 .map(Method::getName)
                 .collect(Collectors.toSet());
 
-        final Set<String> filteredVisitMethodNames = Arrays.stream(visitMethods)
+        final ImmutableSet<String> filteredVisitMethodNames = Arrays.stream(visitMethods)
                 .filter(method -> method.getName().contains("visit"))
+                // remove overridden 'visit' method from ParseTreeVisitor interface in
+                // JavaAstVisitor
+                .filter(method -> !"visit".equals(method.getName()))
                 .filter(method -> method.getModifiers() == Modifier.PUBLIC)
                 .map(Method::getName)
-                .collect(Collectors.toSet());
-
-        // remove overridden 'visit' method from ParseTreeVisitor interface in JavaAstVisitor
-        filteredVisitMethodNames.remove("visit");
+                .collect(toImmutableSet());
 
         final String message = "Visit methods in 'JavaLanguageParserBaseVisitor' generated from "
                 + "production rules and labeled alternatives in 'JavaLanguageParser.g4' should "

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XpathRegressionTest.java
@@ -193,7 +193,7 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
         final Set<Class<?>> abstractJavadocCheckNames = CheckUtil.getCheckstyleChecks()
                 .stream()
                 .filter(AbstractJavadocCheck.class::isAssignableFrom)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(HashSet::new));
         // add the extra checks
         abstractJavadocCheckNames.addAll(REGEXP_JAVADOC_CHECKS);
         final Set<String> abstractJavadocCheckSimpleNames =

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CheckUtil.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/CheckUtil.java
@@ -87,7 +87,7 @@ public final class CheckUtil {
             }
 
             return name;
-        }).collect(Collectors.toSet());
+        }).collect(Collectors.toCollection(HashSet::new));
     }
 
     /**


### PR DESCRIPTION
Consider the Javadoc of `Collectors#toSet`:

> Returns a Collector that accumulates the input elements into a new Set. There are no guarantees on the type, mutability, serializability, or thread-safety of the Set returned; if more control over the returned Set is required, use `toCollection(Supplier)`. 

The occurrences that do need a guarantee on mutability are updated to use the `toCollection(Supplier)` collector. There is also a similar `toList` occurrence that is fixed.

Our custom Error Prone check, [CollectorMutability](https://error-prone.picnic.tech/bugpatterns/CollectorMutability/), that we have in [Error Prone Support](https://github.com/picnicSupermarket/error-prone-support/) identified these occurrences.