### PR TITLE
Issue #11446: Updated SuppressWarningsHolderTest to use verifyWithInlineConfigParser method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1753,9 +1753,6 @@
                 <!-- content header is conflicting with Input inline header -->
                 <exclude>**/RegexpHeaderCheckTest.class</exclude>
 
-                <!-- remain test methods should be updated -->
-                <exclude>**/SuppressWarningsHolderTest.class</exclude>
-
                 <!-- test should be updated -->
                 <exclude>**/AbstractCheckTest.class</exclude>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -33,12 +33,9 @@ import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.Checker;
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.JavaParser;
-import com.puppycrawl.tools.checkstyle.TreeWalker;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.api.Violation;
@@ -47,7 +44,6 @@ import com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck;
 import com.puppycrawl.tools.checkstyle.checks.whitespace.TypecastParenPadCheck;
-import com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
@@ -83,53 +79,35 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
 
     @Test
     public void testOnComplexAnnotations() throws Exception {
-        final Configuration checkConfig = createModuleConfig(SuppressWarningsHolder.class);
-
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputSuppressWarningsHolder.java"), expected);
+        verifyWithInlineConfigParser(getPath("InputSuppressWarningsHolder.java"), expected);
     }
 
     @Test
     public void testOnComplexAnnotationsNonConstant() throws Exception {
-        final Configuration checkConfig = createModuleConfig(SuppressWarningsHolder.class);
-
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig,
+        verifyWithInlineConfigParser(
                 getNonCompilablePath("InputSuppressWarningsHolderNonConstant.java"), expected);
     }
 
     @Test
     public void testCustomAnnotation() throws Exception {
-        final Configuration checkConfig = createModuleConfig(SuppressWarningsHolder.class);
-
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputSuppressWarningsHolder5.java"), expected);
+        verifyWithInlineConfigParser(getPath("InputSuppressWarningsHolder5.java"), expected);
     }
 
     @Test
     public void testAll() throws Exception {
-        final Configuration checkConfig = createModuleConfig(SuppressWarningsHolder.class);
-        final DefaultConfiguration treeWalker = createModuleConfig(TreeWalker.class);
-        final Configuration filter = createModuleConfig(SuppressWarningsFilter.class);
-        final DefaultConfiguration violationCheck = createModuleConfig(TypecastParenPadCheck.class);
-        violationCheck.addProperty("option", "space");
-
-        treeWalker.addChild(checkConfig);
-        treeWalker.addChild(violationCheck);
-
-        final DefaultConfiguration root = createRootConfig(treeWalker);
-        root.addChild(filter);
-
         final String[] expected = {
-            "8:72: "
+            "21:23: "
                     + getCheckMessage(TypecastParenPadCheck.class,
                             AbstractParenPadCheck.MSG_WS_NOT_PRECEDED, ")"),
         };
 
-        verify(root, getPath("InputSuppressWarningsHolder6.java"), expected);
+        verifyWithInlineConfigParser(getPath("InputSuppressWarningsHolder6.java"), expected);
     }
 
     @Test
@@ -279,20 +257,16 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
 
     @Test
     public void testAnnotationInTry() throws Exception {
-        final Configuration checkConfig = createModuleConfig(SuppressWarningsHolder.class);
-
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputSuppressWarningsHolder2.java"), expected);
+        verifyWithInlineConfigParser(getPath("InputSuppressWarningsHolder2.java"), expected);
     }
 
     @Test
     public void testEmptyAnnotation() throws Exception {
-        final Configuration checkConfig = createModuleConfig(SuppressWarningsHolder.class);
-
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputSuppressWarningsHolder3.java"), expected);
+        verifyWithInlineConfigParser(getPath("InputSuppressWarningsHolder3.java"), expected);
     }
 
     @Test
@@ -417,20 +391,16 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
 
     @Test
     public void testAnnotationWithFullName() throws Exception {
-        final Configuration checkConfig = createModuleConfig(SuppressWarningsHolder.class);
-
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputSuppressWarningsHolder4.java"), expected);
+        verifyWithInlineConfigParser(getPath("InputSuppressWarningsHolder4.java"), expected);
     }
 
     @Test
     public void testSuppressWarningsAsAnnotationProperty() throws Exception {
-        final Configuration checkConfig = createModuleConfig(SuppressWarningsHolder.class);
-
         final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
 
-        verify(checkConfig, getPath("InputSuppressWarningsHolder7.java"), expected);
+        verifyWithInlineConfigParser(getPath("InputSuppressWarningsHolder7.java"), expected);
     }
 
     @Test
@@ -480,52 +450,31 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
 
     @Test
     public void testSuppressWarningsTextBlocks() throws Exception {
-        final Configuration checkConfig = createModuleConfig(SuppressWarningsHolder.class);
-        final DefaultConfiguration treeWalker = createModuleConfig(TreeWalker.class);
-        final Configuration filter = createModuleConfig(SuppressWarningsFilter.class);
-        final DefaultConfiguration violationCheck = createModuleConfig(MemberNameCheck.class);
-
-        treeWalker.addChild(checkConfig);
-        treeWalker.addChild(violationCheck);
-
-        final DefaultConfiguration root = createRootConfig(treeWalker);
-        root.addChild(filter);
-
         final String pattern = "^[a-z][a-zA-Z0-9]*$";
 
         final String[] expected = {
-            "15:12: " + getCheckMessage(MemberNameCheck.class,
+            "31:12: " + getCheckMessage(MemberNameCheck.class,
                 AbstractNameCheck.MSG_INVALID_PATTERN, "STRING3", pattern),
-            "17:12: " + getCheckMessage(MemberNameCheck.class,
+            "33:12: " + getCheckMessage(MemberNameCheck.class,
                 AbstractNameCheck.MSG_INVALID_PATTERN, "STRING4", pattern),
-            "46:12: " + getCheckMessage(MemberNameCheck.class,
+            "61:12: " + getCheckMessage(MemberNameCheck.class,
                 AbstractNameCheck.MSG_INVALID_PATTERN, "STRING8", pattern),
             };
 
-        verify(root,
-            getNonCompilablePath("InputSuppressWarningsHolderTextBlocks.java"), expected);
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputSuppressWarningsHolderTextBlocks.java"), expected);
+
     }
 
     @Test
     public void testWithAndWithoutCheckSuffixDifferentCases() throws Exception {
-        final Configuration checkConfig = createModuleConfig(SuppressWarningsHolder.class);
-        final DefaultConfiguration treeWalker = createModuleConfig(TreeWalker.class);
-        final Configuration filter = createModuleConfig(SuppressWarningsFilter.class);
-        final DefaultConfiguration violationCheck = createModuleConfig(ConstantNameCheck.class);
-
-        treeWalker.addChild(checkConfig);
-        treeWalker.addChild(violationCheck);
-
-        final DefaultConfiguration root = createRootConfig(treeWalker);
-        root.addChild(filter);
-
         final String pattern = "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$";
         final String[] expected = {
-            "4:30: " + getCheckMessage(ConstantNameCheck.class,
+            "16:30: " + getCheckMessage(ConstantNameCheck.class,
                 AbstractNameCheck.MSG_INVALID_PATTERN, "a", pattern),
         };
 
-        verify(root,
+        verifyWithInlineConfigParser(
                 getPath("InputSuppressWarningsHolderWithAndWithoutCheckSuffixDifferentCases.java"),
                 expected);
     }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderNonConstant.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderNonConstant.java
@@ -1,3 +1,10 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder
+aliasList = (default)
+
+
+*/
+
 //non-compiled with eclipse: The value for annotation attribute must be a constant expression
 package com.puppycrawl.tools.checkstyle.checks.suppresswarningsholder;
 public class InputSuppressWarningsHolderNonConstant {

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderTextBlocks.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderTextBlocks.java
@@ -1,3 +1,19 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder
+aliasList = (default)
+
+com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter
+
+com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck
+format = (default)^[a-z][a-zA-Z0-9]*$
+applyToPublic = (default)true
+applyToProtected = (default)true
+applyToPackage = (default)true
+applyToPrivate = (default)true
+
+
+*/
+
 //non-compiled with javac: Compilable with Java14
 package com.puppycrawl.tools.checkstyle.checks.suppresswarningsholder;
 
@@ -12,10 +28,9 @@ public class InputSuppressWarningsHolderTextBlocks {
     String STRING2 = """
             string"""; // ok, suppressed
 
-    String STRING3 = "string"; // violation
+    String STRING3 = "string"; // violation ''STRING3' must match pattern'
 
-    String STRING4 = """
-            string"""; // violation
+    String STRING4 = "string"; // violation ''STRING4' must match pattern'
 
     @SuppressWarnings({"""
             membername"""})
@@ -43,6 +58,5 @@ public class InputSuppressWarningsHolderTextBlocks {
                 checkstyle:misspelled
         """
     })
-    String STRING8 = """
-        string"""; // violation
+    String STRING8 = "string"; // violation ''STRING8' must match pattern'
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder.java
@@ -1,3 +1,10 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder
+aliasList = (default)
+
+
+*/
+
 package com.puppycrawl.tools.checkstyle.checks.suppresswarningsholder;
 
 public class InputSuppressWarningsHolder {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder2.java
@@ -1,3 +1,10 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder
+aliasList = (default)
+
+
+*/
+
 package com.puppycrawl.tools.checkstyle.checks.suppresswarningsholder;
 
 public class InputSuppressWarningsHolder2

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder3.java
@@ -1,3 +1,10 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder
+aliasList = (default)
+
+
+*/
+
 package com.puppycrawl.tools.checkstyle.checks.suppresswarningsholder;
 
 public class InputSuppressWarningsHolder3 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder4.java
@@ -1,3 +1,10 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder
+aliasList = (default)
+
+
+*/
+
 package com.puppycrawl.tools.checkstyle.checks.suppresswarningsholder;
 
 public class InputSuppressWarningsHolder4 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder5.java
@@ -1,3 +1,10 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder
+aliasList = (default)
+
+
+*/
+
 package com.puppycrawl.tools.checkstyle.checks.suppresswarningsholder;
 
 import java.lang.annotation.ElementType;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder6.java
@@ -1,3 +1,15 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder
+aliasList = (default)
+
+com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter
+
+com.puppycrawl.tools.checkstyle.checks.whitespace.TypecastParenPadCheck
+option = space
+
+
+*/
+
 package com.puppycrawl.tools.checkstyle.checks.suppresswarningsholder;
 
 import java.lang.annotation.ElementType;
@@ -5,7 +17,8 @@ import java.lang.annotation.Target;
 
 public class InputSuppressWarningsHolder6 {
     public static void foo1(Object str) {
-        String myString = (@SuppressWarnings("TypecastParenPad") String) str;
+        String myString = (@SuppressWarnings("TypecastParenPad")
+                String) str; // violation '')' is not preceded with whitespace'
     }
 
     @Target(ElementType.TYPE_USE)

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder7.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder7.java
@@ -1,3 +1,10 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder
+aliasList = (default)
+
+
+*/
+
 package com.puppycrawl.tools.checkstyle.checks.suppresswarningsholder;
 
 import java.lang.annotation.*;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderWithAndWithoutCheckSuffixDifferentCases.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolderWithAndWithoutCheckSuffixDifferentCases.java
@@ -1,7 +1,19 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder
+aliasList = (default)
+
+com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter
+
+com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck
+format = (default)^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$
+
+
+*/
+
 package com.puppycrawl.tools.checkstyle.checks.suppresswarningsholder;
 
 public class InputSuppressWarningsHolderWithAndWithoutCheckSuffixDifferentCases {
-    private static final int a = 0; // violation 'invalid pattern'
+    private static final int a = 0; // violation 'Name 'a' must match pattern'
 
     @SuppressWarnings("checkstyle:constantnamecheck") // filtered violation 'invalid pattern'
     private static final int b = 0;


### PR DESCRIPTION
Issue #11446
SuppressWarningsHolder is Annotation check. [documentation](https://checkstyle.org/config_annotation.html#SuppressWarningsHolder)
I don't know how to replace the configs in methods `testAll()`, `testSuppressWarningsTextBlocks()`, `testWithAndWithoutCheckSuffixDifferentCases()` with inlined comment configs. Thanks.