### PR TITLE
 Issue #7616: Add code example for VisibilityModifier check #7616

### DIFF
--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -981,7 +981,24 @@ public class Foo{
         <source>
 &lt;module name=&quot;VisibilityModifier&quot;/&gt;
         </source>
+        <p>Example with default values:</p>
+        <source>
+public class MyClass 
+{	
+ private int myPrivateField1; // Ok, has a visibility modifier
+ private final int myPrivateField2; // Ok, has a private visibility
+ public long serialVersionUID = 123456789L; // Ok, matches the patern ^serialVersionUID$
+ public static final int MY_CONSTANT = 42; // Ok, static final 
+}
 
+public class MyClass 
+{	
+ int myPrivateField; // Violation, must have a visibility modifier 
+ protected String myProtectedField; // Violation, protected visibility is not allowed
+ public final int MY_CONSTANT = 42; // Violation, public final fields are not allowed 
+ public int NOT_CONSTANT = 42; // Violation, not static final, immutable, nor matching the patteern
+}	  
+        </source>
         <p>
           To configure the check so that it allows package visible members:
         </p>


### PR DESCRIPTION
Issue:  #7616

This PR adds a code example to the documentation of the VisibilityModifier check.

Example 1: With default properties of VisibilityModifier.

Web Page:

![Screenshot from 2023-03-02 20-32-24](https://user-images.githubusercontent.com/67487202/222539500-191ae5d6-3732-4d4e-ba8c-434f12080c66.png)


CLI:

![Screenshot from 2023-03-02 20-31-11](https://user-images.githubusercontent.com/67487202/222539580-37ac01d9-109d-4408-aa3b-7f7b486bc8cb.png)

