### PR TITLE
Pull #12793: Remove execution of upload -all jar from new-milestone-and-issue-in-other-repo

### DIFF
--- a/.github/workflows/new-milestone-and-issue-in-other-repo.yml
+++ b/.github/workflows/new-milestone-and-issue-in-other-repo.yml
@@ -2,8 +2,8 @@
 # GitHub Action to Create New Milestone and issue in Other Repositories.
 #
 #############################################################################
-name: "R: Close/Create Milestone, Upload '-all' jar, Create issues"
-run-name: "R: Close/Create Milestone, Upload '-all' jar, Create issues ${{ inputs.version }}"
+name: "R: Close/Create Milestone, Create issues"
+run-name: "R: Close/Create Milestone, Create issues ${{ inputs.version }}"
 on:
   workflow_dispatch:
     inputs:
@@ -50,12 +50,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           ./.ci/close-create-milestone.sh
-
-      - name: Upload '-all' jar
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          ./.ci/upload-all-jar.sh ${{ inputs.version }}
 
       - name: Creation of issue in other Repositories
         env:


### PR DESCRIPTION
Removes execution of `upload-all-jar.sh` from `new-milestone-and-issue-in-other-repo.yml`. The workflow was doing too much and the upload of `-jar` is an important part of the release process. We already have a separate workflow for uploading all jar:
https://github.com/checkstyle/checkstyle/blob/master/.github/workflows/upload-all-jar.yml

After merging PR, https://github.com/checkstyle/checkstyle/wiki/Semi-automated-release has to be updated.