### PR TITLE
Pull #12796: Add forgotten secret inherit in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
     with:
       version: ${{ inputs.version }}
       concurrency-group: new-milestone-and-issue-in-other-repo
+    secrets: inherit
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
`new-milestone-and-issue-in-other-repo` uses `secrets` context. When called from caller workflow, it needs to inherit that context. We do that with most other jobs in `release.yml` but I forgot this one. My bad.
https://github.com/checkstyle/checkstyle/blob/e00da2f769452ca4d01e05b94d162210e9d854a0/.github/workflows/new-milestone-and-issue-in-other-repo.yml#L60-L64

Noticed in:
https://github.com/stoyanK7/checkstyle/actions/runs/4326216948/jobs/7553449274#step:6:5
 ```
 ./.ci/creation-of-issue-in-other-repos.sh 10.8.1
  shell: /usr/bin/bash -e {0}
  env:
    GITHUB_TOKEN: 
Error: Set not empty value to GITHUB_TOKEN environment variable
Error: Process completed with exit code 1.
```

Success run with applied fix:
https://github.com/stoyanK7/checkstyle/actions/runs/4326378052/jobs/7553782567#step:6:5
https://github.com/stoyanK7/checkstyle/commit/6e86409f35042378cc8e140e5aa18d09681293fd
```
  ./.ci/creation-of-issue-in-other-repos.sh 10.8.1
  shell: /usr/bin/bash -e {0}
  env:
    GITHUB_TOKEN: ***
```