### PR TITLE
Pull #12799: Switch to PAT secret in set-milestone workflow

### DIFF
--- a/.github/workflows/set-milestone-on-referenced-issue.yml
+++ b/.github/workflows/set-milestone-on-referenced-issue.yml
@@ -2,7 +2,7 @@
 # GitHub action to set latest milestone on issue of merged PR.
 #
 #############################################################################
-name: 'Milestone for PR'
+name: 'Milestone issue closed by PR'
 
 on:
   pull_request:

--- a/.github/workflows/set-milestone-on-referenced-issue.yml
+++ b/.github/workflows/set-milestone-on-referenced-issue.yml
@@ -13,10 +13,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  issues: write
-  pull-requests: write
-
 jobs:
   set-milestone:
     name: '#${{ github.event.pull_request.number }}'
@@ -28,6 +24,6 @@ jobs:
 
       - name: Set milestone on issue
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
         run: |
           ./.ci/set-milestone-on-referenced-issue.sh ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Switches to `PAT` secret in `.github/workflows/set-milestone-on-referenced-issue.yml`.

From https://github.com/checkstyle/checkstyle/issues/12497#issuecomment-1455018698:
`GITHUB_TOKEN` does not receive write permissions for some reason.

Switching to `PAT` as suggested in https://github.com/checkstyle/checkstyle/issues/12497#issuecomment-1455130026
> as we have special logic in action `${{ github.event.pull_request.merged == true }}` that limits execution a lot, and content is trusty in this case. We should use PAT.