### PR TITLE
Issue #11214: Add violation messages in JavadocTypeCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -103,7 +103,6 @@ public final class InlineConfigParser {
             "com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck",
             "com.puppycrawl.tools.checkstyle.checks.coding.PackageDeclarationCheck",
-            "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTypeCheckTest.java
@@ -250,9 +250,9 @@ public class JavadocTypeCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "21:4: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<D123>"),
             "25:1: " + getCheckMessage(MSG_MISSING_TAG, "@param <C456>"),
-            "58:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<C>"),
-            "61:5: " + getCheckMessage(MSG_MISSING_TAG, "@param <B>"),
-            "74:5: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "x"),
+            "59:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<C>"),
+            "62:5: " + getCheckMessage(MSG_MISSING_TAG, "@param <B>"),
+            "75:5: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "x"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputJavadocTypeTypeParamsTags_1.java"), expected);

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordComponents2.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecordComponents2.java
@@ -41,11 +41,11 @@ record MyRecord2(HashMap<String, String> myHashMap){}
 /**
  *
  */
-record MyRecord3<X>(){} // violation
+record MyRecord3<X>(){} // violation 'missing @param <X> tag.'
 
 /**
  *
- * @param x // violation
+ * @param x // violation 'Unused @param tag for 'x'.'
  */
 record MyRecord4(){}
 
@@ -56,26 +56,26 @@ record MyRecord4(){}
 record MyRecord5<X>(){}
 
 /**
- * @param notMyString // violation
+ * @param notMyString // violation 'Unused @param tag for 'notMyString'.'
  * @param <X>
  */
 record MyRecord6<X>(String myString, int myInt){} // 2 violations
 
 /**
  *
- * @param x // violation
+ * @param x // violation 'Unused @param tag for 'x'.'
  */
-record MyRecord7(List<String>myList){} // violation
+record MyRecord7(List<String>myList){} // violation 'missing @param myList tag.'
 
 /**
  * @author X
  * @param <X>
  * @param <T>
  */
-record MyRecord8<X, T>(String X){} // violation
+record MyRecord8<X, T>(String X){} // violation 'missing @param X tag.'
 
 /**
- * @param notMyString // violation
+ * @param notMyString // violation 'Unused @param tag for 'notMyString'.'
  * @param <X>
  */
 record MyRecord9<X, T>(String myString, int myInt){} // 3 violations

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecords.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeRecords.java
@@ -21,7 +21,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
  *
  * @version 8.35
  */
-class InputJavadocTypeRecords { // violation
+class InputJavadocTypeRecords { // violation 'missing @author tag.'
 }
 
 /**
@@ -30,7 +30,7 @@ class InputJavadocTypeRecords { // violation
  *
  * @version 8.37
  */
-record MyRecord1() { // violation
+record MyRecord1() { // violation 'missing @author tag.'
 
 }
 
@@ -39,7 +39,7 @@ record MyRecord1() { // violation
  * SomeText @author  Nick Mancuso
  * *@version 8.37
  */
-record MyRecord2() { // violation
+record MyRecord2() { // violation 'missing @author tag.'
 
     public MyRecord2 {
     }
@@ -52,7 +52,7 @@ record MyRecord2() { // violation
  * @author Nick Mancuso
  * @version 8.37
  */
-record MyRecord3() { // violation
+record MyRecord3() { // violation 'tag @author must match pattern 'ABC'.'
 
 }
 
@@ -62,7 +62,7 @@ record MyRecord3() { // violation
  *
  * @version 8.37
  */
-record MyRecord4() { // violation
+record MyRecord4() { // violation 'missing @author tag.'
 
 }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeBadTag.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeBadTag.java
@@ -16,7 +16,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
 
 /**
  * The following is a bad tag.
- * @mytag Hello   // violation
+ * @mytag Hello   // violation 'Unknown tag 'mytag'.'
  */
 public class InputJavadocTypeBadTag
 {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeInterfaceMemberScopeIsPublic.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeInterfaceMemberScopeIsPublic.java
@@ -16,12 +16,12 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
 
 public interface InputJavadocTypeInterfaceMemberScopeIsPublic {// ok
 
-    /** @param <T> unused */  // violation
+    /** @param <T> unused */  // violation 'Unused @param tag for '<T>'.'
     enum Enum {
 
     }
 
-    /** @param <T> unused */  // violation
+    /** @param <T> unused */  // violation 'Unused @param tag for '<T>'.'
     class Class {
 
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeJavadoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeJavadoc.java
@@ -28,7 +28,7 @@ class InputJavadocTypeJavadoc
  * SomeText @author Oliver Burn
  * *@version 1.0
  */
-class InputJavadocTypeJavadoc1 // violation
+class InputJavadocTypeJavadoc1 // violation 'missing @author tag'
 {
 }
 
@@ -64,7 +64,7 @@ enum InputJavadocTypeEnum
  * SomeText @author Oliver Burn
  * *@version 1.0
  */
-enum InputJavadocTypeEnum1 // violation
+enum InputJavadocTypeEnum1 // violation 'missing @author tag'
 {
 }
 
@@ -100,7 +100,7 @@ enum InputJavadocTypeEnum2
  * SomeText @author Oliver Burn
  * *@version 1.0
  */
-@interface InputJavadocInterface1 // violation
+@interface InputJavadocInterface1 // violation 'missing @author tag'
 {
 }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeJavadoc_1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeJavadoc_1.java
@@ -19,7 +19,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
  ****    @author Oliver Burn
  * @version 1.0
  */
-class InputJavadocTypeJavadoc_1 // violation
+class InputJavadocTypeJavadoc_1 // violation 'tag @author must match pattern 'ABC'.'
 {
 }
 
@@ -28,7 +28,7 @@ class InputJavadocTypeJavadoc_1 // violation
  * SomeText @author Oliver Burn
  * *@version 1.0
  */
-class InputJavadocTypeJavadoc_11 // violation
+class InputJavadocTypeJavadoc_11 // violation 'missing @author tag.'
 {
 }
 
@@ -37,7 +37,7 @@ class InputJavadocTypeJavadoc_11 // violation
  * tags are multi line ones
  * @author Oliver Burn
  * @version 1.0 */
-class InputJavadocTypeJavadoc_21 // violation
+class InputJavadocTypeJavadoc_21 // violation 'tag @author must match pattern 'ABC'.'
 {
 }
 
@@ -55,7 +55,7 @@ class InputJavadocType_1
  ****    @author Oliver Burn
  * @version 1.0
  */
-enum InputJavadocTypeEnum_1 // violation
+enum InputJavadocTypeEnum_1 // violation 'tag @author must match pattern 'ABC'.'
 {
 }
 
@@ -64,7 +64,7 @@ enum InputJavadocTypeEnum_1 // violation
  * SomeText @author Oliver Burn
  * *@version 1.0
  */
-enum InputJavadocTypeEnum_11 // violation
+enum InputJavadocTypeEnum_11 // violation 'missing @author tag.'
 {
 }
 
@@ -73,7 +73,7 @@ enum InputJavadocTypeEnum_11 // violation
  * tags are multi line ones
  * @author Oliver Burn
  * @version 1.0 */
-enum InputJavadocTypeEnum_21 // violation
+enum InputJavadocTypeEnum_21 // violation 'tag @author must match pattern 'ABC'.'
 {
 }
 
@@ -91,7 +91,7 @@ enum InputJavadocTypeEnum_21 // violation
  ****    @author Oliver Burn
  * @version 1.0
  */
-@interface InputJavadocInterface_1 // violation
+@interface InputJavadocInterface_1 // violation 'tag @author must match pattern 'ABC'.'
 {
 }
 
@@ -100,7 +100,7 @@ enum InputJavadocTypeEnum_21 // violation
  * SomeText @author Oliver Burn
  * *@version 1.0
  */
-@interface InputJavadocInterface_11 // violation
+@interface InputJavadocInterface_11 // violation 'missing @author tag.'
 {
 }
 
@@ -109,7 +109,7 @@ enum InputJavadocTypeEnum_21 // violation
  * tags are multi line ones
  * @author Oliver Burn
  * @version 1.0 */
-@interface InputJavadocInterface_21 // violation
+@interface InputJavadocInterface_21 // violation 'tag @author must match pattern 'ABC'.'
 {
 }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeJavadoc_2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeJavadoc_2.java
@@ -19,7 +19,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
  ****    @author Oliver Burn
  * @version 1.0
  */
-class InputJavadocTypeJavadoc_2 // violation
+class InputJavadocTypeJavadoc_2 // violation 'tag @version must match pattern'
 {
 }
 
@@ -28,7 +28,7 @@ class InputJavadocTypeJavadoc_2 // violation
  * SomeText @author Oliver Burn
  * *@version 1.0
  */
-class InputJavadocTypeJavadoc_12 // violation
+class InputJavadocTypeJavadoc_12 // violation 'missing @version tag'
 {
 }
 
@@ -37,7 +37,7 @@ class InputJavadocTypeJavadoc_12 // violation
  * tags are multi line ones
  * @author Oliver Burn
  * @version 1.0 */
-class InputJavadocTypeJavadoc_22 // violation
+class InputJavadocTypeJavadoc_22 // violation 'tag @version must match pattern'
 {
 }
 
@@ -46,7 +46,7 @@ class InputJavadocTypeJavadoc_22 // violation
 * @author ABC
 * @version 1.1
 */
-class InputJavadocType_2 // violation
+class InputJavadocType_2 // violation 'tag @version must match pattern'
 {
 }
 
@@ -55,7 +55,7 @@ class InputJavadocType_2 // violation
  ****    @author Oliver Burn
  * @version 1.0
  */
-enum InputJavadocTypeEnum_2 // violation
+enum InputJavadocTypeEnum_2 // violation 'tag @version must match pattern'
 {
 }
 
@@ -64,7 +64,7 @@ enum InputJavadocTypeEnum_2 // violation
  * SomeText @author Oliver Burn
  * *@version 1.0
  */
-enum InputJavadocTypeEnum_12 // violation
+enum InputJavadocTypeEnum_12 // violation 'missing @version tag.'
 {
 }
 
@@ -73,7 +73,7 @@ enum InputJavadocTypeEnum_12 // violation
  * tags are multi line ones
  * @author Oliver Burn
  * @version 1.0 */
-enum InputJavadocTypeEnum_22 // violation
+enum InputJavadocTypeEnum_22 // violation 'tag @version must match pattern'
 {
 }
 
@@ -82,7 +82,7 @@ enum InputJavadocTypeEnum_22 // violation
 * @author ABC
 * @version 1.1
 */
-@interface InputJavadocInterfaceType_2 // violation
+@interface InputJavadocInterfaceType_2 // violation 'tag @version must match pattern'
 {
 }
 
@@ -91,7 +91,7 @@ enum InputJavadocTypeEnum_22 // violation
  ****    @author Oliver Burn
  * @version 1.0
  */
-@interface InputJavadocInterface_2 // violation
+@interface InputJavadocInterface_2 // violation 'tag @version must match pattern'
 {
 }
 
@@ -100,7 +100,7 @@ enum InputJavadocTypeEnum_22 // violation
  * SomeText @author Oliver Burn
  * *@version 1.0
  */
-@interface InputJavadocInterface_12 // violation
+@interface InputJavadocInterface_12 // violation 'missing @version tag.'
 {
 }
 
@@ -109,7 +109,7 @@ enum InputJavadocTypeEnum_22 // violation
  * tags are multi line ones
  * @author Oliver Burn
  * @version 1.0 */
-@interface InputJavadocInterface_22 // violation
+@interface InputJavadocInterface_22 // violation 'tag @version must match pattern'
 {
 }
 
@@ -118,6 +118,6 @@ enum InputJavadocTypeEnum_22 // violation
 * @author ABC
 * @version 1.1
 */
-@interface InputJavadocInterfaceType_12 // violation
+@interface InputJavadocInterfaceType_12 // violation 'tag @version must match pattern'
 {
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeJavadoc_3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeJavadoc_3.java
@@ -28,7 +28,7 @@ class InputJavadocTypeJavadoc_3
  * SomeText @author Oliver Burn
  * *@version 1.0
  */
-class InputJavadocTypeJavadoc_13 // violation
+class InputJavadocTypeJavadoc_13 // violation 'missing @version tag.'
 {
 }
 
@@ -64,7 +64,7 @@ enum InputJavadocTypeEnum_3
  * SomeText @author Oliver Burn
  * *@version 1.0
  */
-enum InputJavadocTypeEnum_13 // violation
+enum InputJavadocTypeEnum_13 // violation 'missing @version tag.'
 {
 }
 
@@ -100,7 +100,7 @@ enum InputJavadocTypeEnum_23
  * SomeText @author Oliver Burn
  * *@version 1.0
  */
-@interface InputJavadocInterface_13 // violation
+@interface InputJavadocInterface_13 // violation 'missing @version tag.'
 {
 }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeNoJavadoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeNoJavadoc.java
@@ -15,7 +15,7 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
 
 /** */
-public class InputJavadocTypeNoJavadoc<T> // violation
+public class InputJavadocTypeNoJavadoc<T> // violation 'missing @param <T>.'
 {
     public int i1;
     protected int i2;
@@ -134,6 +134,6 @@ class PackageClass {
     void methodWithTwoStarComment() {}
 
     /** */
-    protected class ProtectedInner2<T> { // violation
+    protected class ProtectedInner2<T> { // violation 'missing @param <T>.'
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeNoJavadoc_1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeNoJavadoc_1.java
@@ -134,6 +134,6 @@ class PackageClass_1 {
     void methodWithTwoStarComment() {}
 
     /** */
-    protected class ProtectedInner2<T> { // violation
+    protected class ProtectedInner2<T> { // violation 'missing @param <T>.'
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeNoJavadoc_2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeNoJavadoc_2.java
@@ -15,7 +15,7 @@ tokens = (default)INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF, RECORD_DEF
 package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
 
 /** */
-public class InputJavadocTypeNoJavadoc_2<T> // violation
+public class InputJavadocTypeNoJavadoc_2<T> // violation 'missing @param <T>.'
 {
     public int i1;
     protected int i2;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeScopeInnerClasses.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeScopeInnerClasses.java
@@ -50,7 +50,7 @@ public class InputJavadocTypeScopeInnerClasses
         }
     }
     /** */
-    protected class InnerPublic2<T> // violation
+    protected class InnerPublic2<T> // violation 'missing @param <T> tag.'
     {
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeTestTrimProperty.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeTestTrimProperty.java
@@ -18,7 +18,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
  * Some explanation.
  * @param < A  > A type param
  * @param <B1> Another type param
- * @param <D123> The wrong type param   // violation
+ * @param <D123> The wrong type param   // violation 'Unused @param tag for '<D123>'.'
  * @author Nobody
  * @version 1.0
  */

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeTypeParamsTags.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeTypeParamsTags.java
@@ -18,7 +18,7 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
  * Some explanation.
  * @param <A> A type param
  * @param <B1> Another type param
- * @param <D123> The wrong type param   // violation
+ * @param <D123> The wrong type param   // violation 'Unused @param tag for '<D123>'.'
  * @author Nobody
  * @version 1.0
  */
@@ -55,7 +55,7 @@ public class InputJavadocTypeTypeParamsTags<A,B1,C456 extends Comparable>
     /**
      * Example inner class.
      * @param <A> documented parameter
-     * @param <C> extra parameter  // violation
+     * @param <C> extra parameter  // violation 'Unused @param tag for '<C>'.'
      */
 
     public static class InnerClass<A,B>
@@ -71,5 +71,5 @@ public class InputJavadocTypeTypeParamsTags<A,B1,C456 extends Comparable>
     }
 }
 
-/** @param x */ // violation
+/** @param x */ // violation 'Unused @param tag for 'x'.'
 class Test {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeTypeParamsTags_1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeTypeParamsTags_1.java
@@ -18,11 +18,12 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
  * Some explanation.
  * @param <A> A type param
  * @param <B1> Another type param
- * @param <D123> The wrong type param  // violation
+ * @param <D123> The wrong type param  // violation 'Unused @param tag for '<D123>'.'
  * @author Nobody
  * @version 1.0
  */
-public class InputJavadocTypeTypeParamsTags_1<A,B1,C456 extends Comparable> // violation
+public class InputJavadocTypeTypeParamsTags_1<A,B1,C456 extends Comparable>
+// violation above 'missing @param <C456> tag.'
 {
     /**
      * Some explanation.
@@ -55,10 +56,10 @@ public class InputJavadocTypeTypeParamsTags_1<A,B1,C456 extends Comparable> // v
     /**
      * Example inner class.
      * @param <A> documented parameter
-     * @param <C> extra parameter    // violation
+     * @param <C> extra parameter    // violation 'Unused @param tag for '<C>'.'
      */
 
-    public static class InnerClass_1<A,B> // violation
+    public static class InnerClass_1<A,B> // violation 'missing @param <B> tag.'
     {
     }
 
@@ -71,5 +72,5 @@ public class InputJavadocTypeTypeParamsTags_1<A,B1,C456 extends Comparable> // v
     }
 }
 
-/** @param x */  // violation
+/** @param x */  // violation 'Unused @param tag for 'x'.'
 class Test_1 {}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeUnusedParamInJavadocForClass.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeUnusedParamInJavadocForClass.java
@@ -17,8 +17,8 @@ package com.puppycrawl.tools.checkstyle.checks.javadoc.javadoctype;
 /**
  * InputJavadocTypeUnusedParamInJavadocForClass.
  *
- * @param BAD This is bad.   // violation
- * @param <BAD> This doesn't exist.   // violation
+ * @param BAD This is bad.   // violation 'Unused @param tag for 'BAD'.'
+ * @param <BAD> This doesn't exist.   // violation 'Unused @param tag for '<BAD>'.'
  * @param
  */
 public class InputJavadocTypeUnusedParamInJavadocForClass {

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeWhitespace.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeWhitespace.java
@@ -20,7 +20,7 @@ package com . puppycrawl
  * Class for testing javadoc issues.
  * violation missing author tag
  **/
-class InputJavadocTypeWhitespace // violation
+class InputJavadocTypeWhitespace // violation 'missing @author tag.'
 {
     /** another check */
     void donBradman(Runnable aRun)

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeWhitespace_1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeWhitespace_1.java
@@ -20,7 +20,7 @@ package com . puppycrawl
  * Class for testing javadoc issues.
  * violation missing author tag
  **/
-class InputJavadocTypeWhitespace_1 // violation
+class InputJavadocTypeWhitespace_1 // violation 'missing @version tag.'
 {
     /** another check */
     void donBradman(Runnable aRun)


### PR DESCRIPTION
Issue: #11214
I finished adding violation messages except for 2 parts.
The first part I have a trouble is this file.
`src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeJavadoc_2.java
`
In this file, I need to put `\$Revision.*\$` as a version format and I could not figure out how to do the escaping for special regex characters. I tried below patterns, but it did not work. Could you guide me how to fix it?

Things I tried
```
\\$Revision.*\\$
\\$Revision\.*\\$
\\$Revision.\*\\$
\\$Revision\.\*\\$
```

The second part I have a trouble is **25th** line of this file. 
`src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadoctype/InputJavadocTypeTypeParamsTags_1.java`
`public class InputJavadocTypeTypeParamsTags_1<A,B1,C456 extends Comparable> // violation 'missing'`
Since the class header is already long, I cannot put enough words to explain the violation message. Can I wrap it to 2nd line? If so, could you tell me how to wrap it? When I tested, the comment is not caught by tester and it failed the test.
