### PR TITLE
Pull #12801: Fix 'set-milestone-on-referenced-issue'

### DIFF
--- a/.ci/set-milestone-on-referenced-issue.sh
+++ b/.ci/set-milestone-on-referenced-issue.sh
@@ -5,28 +5,24 @@ set -e
 source ./.ci/util.sh
 
 if [[ -z $1 ]]; then
-  echo "[ERROR] Pull request number is not set."
-  echo "Usage: $BASH_SOURCE <pull request number>"
+  echo "[ERROR] Commits array is not set."
+  echo "Usage: $BASH_SOURCE <commits array>"
   exit 1
 fi
 
-PULL_REQUEST_NUMBER=$1
-echo "PULL_REQUEST_NUMBER=$PULL_REQUEST_NUMBER"
-
 checkForVariable "GITHUB_TOKEN"
 
-echo "Fetching commit messages that match '^(Pull|Issue) #[0-9]+' from PR #$PULL_REQUEST_NUMBER."
-PULL_REQUEST_COMMITS=$(curl -s \
-  -H "Accept: application/vnd.github+json" \
-  -H "Authorization: Bearer $GITHUB_TOKEN"\
-  https://api.github.com/repos/checkstyle/checkstyle/pulls/"$PULL_REQUEST_NUMBER"/commits)
-PULL_REQUEST_COMMIT_MESSAGES=$(echo "$PULL_REQUEST_COMMITS" \
-  | jq -r .[].commit.message | grep -E "^(Pull|Issue) #[0-9]+")
-echo "PULL_REQUEST_COMMIT_MESSAGES=
-$PULL_REQUEST_COMMIT_MESSAGES"
+COMMITS_ARRAY=$1
+echo "COMMITS_ARRAY=$COMMITS_ARRAY"
+
+echo "Extracting commit messages from commits array that match '^(Pull|Issue) #[0-9]+'."
+COMMIT_MESSAGES=$(echo "$COMMITS_ARRAY" | jq -r .[].message \
+  | grep -E "^(Pull|Issue) #[0-9]+")
+echo "COMMIT_MESSAGES=
+$COMMIT_MESSAGES"
 
 echo "Extracting issue numbers from commit messages."
-ISSUE_NUMBERS=$(echo "$PULL_REQUEST_COMMIT_MESSAGES" | grep -oE "#[0-9]+" | cut -c2-)
+ISSUE_NUMBERS=$(echo "$COMMIT_MESSAGES" | grep -oE "#[0-9]+" | cut -c2-)
 echo "ISSUE_NUMBERS=
 $ISSUE_NUMBERS"
 

--- a/.github/workflows/set-milestone-on-referenced-issue.yml
+++ b/.github/workflows/set-milestone-on-referenced-issue.yml
@@ -5,18 +5,20 @@
 name: 'Milestone issue closed by PR'
 
 on:
-  pull_request:
-    types:
-      - closed
+  push:
+    branches:
+      - master
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   set-milestone:
-    name: '#${{ github.event.pull_request.number }}'
-    if: ${{ github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code
@@ -24,6 +26,6 @@ jobs:
 
       - name: Set milestone on issue
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ./.ci/set-milestone-on-referenced-issue.sh ${{ github.event.pull_request.number }}
+          ./.ci/set-milestone-on-referenced-issue.sh '${{ toJSON(github.event.commits) }}'


### PR DESCRIPTION
Moves from `pull-request:close` event trigger to a `push` trigger.

The issue with milestone: https://github.com/stoyanK7/checkstyle/issues/36
Job: https://github.com/stoyanK7/checkstyle/actions/runs/4346403881/jobs/7592443158

I believe this is the reason for our failure with making this job work yesterday: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflows-in-forked-repositories
> With the exception of `GITHUB_TOKEN`, secrets are not passed to the runner when a workflow is triggered from a forked repository. The `GITHUB_TOKEN` has read-only permissions in pull requests from forked repositories.