### PR TITLE
Issue #12809: Improve performance of lambda processing

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/grammar/java/JavaLanguageParser.g4
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/grammar/java/JavaLanguageParser.g4
@@ -720,16 +720,11 @@ expr
         | BAND_ASSIGN | BOR_ASSIGN | BXOR_ASSIGN | SR_ASSIGN | BSR_ASSIGN
         | SL_ASSIGN | MOD_ASSIGN)
       expr                                                                 #binOp
-    | lambdaExpression                                                     #lambdaExp
+    | lambdaParameters LAMBDA (expr | block)                               #lambdaExp
     ;
 
 typeCastParameters
     : typeType[true] (BAND typeType[true])*
-    ;
-
-// Java8
-lambdaExpression
-    : lambdaParameters LAMBDA lambdaBody
     ;
 
 // Java8
@@ -741,12 +736,6 @@ lambdaParameters
 
 multiLambdaParams
     : id (COMMA id)*
-    ;
-
-// Java8
-lambdaBody
-    : expression
-    | block
     ;
 
 primary


### PR DESCRIPTION
Closes #12809 

-------------------------
Reports:

AST regression test report:
https://nrmancuso.github.io/reports/issue-12809/2023-03-18-T-00-03-28/antlr-report/index.html

 - Difference is in stack trace of non-compilable files only

Check regression reports:
https://nrmancuso.github.io/reports/issue-12809/2023-03-18-T-00-03-28/part2-report/index.html

https://nrmancuso.github.io/reports/issue-12809/2023-03-18-T-00-03-28/part4-report/index.html

https://nrmancuso.github.io/reports/issue-12809/2023-03-18-T-00-03-28/sevntu-check-regression_part_1-report/index.html

https://nrmancuso.github.io/reports/issue-12809/2023-03-18-T-00-03-28/part6-report/index.html

https://nrmancuso.github.io/reports/issue-12809/2023-03-18-T-00-03-28/part3-report/index.html

https://nrmancuso.github.io/reports/issue-12809/2023-03-18-T-00-03-28/sevntu-check-regression_part_2-report/index.html

https://nrmancuso.github.io/reports/issue-12809/2023-03-18-T-00-03-28/part5-report/index.html

https://nrmancuso.github.io/reports/issue-12809/2023-03-18-T-00-03-28/part1-report/index.html

 - No differences