### PR TITLE
Issue #12824: Add conditional to run on:push workflows only in checkstyle repository

### DIFF
--- a/.github/workflows/checker-framework.yml
+++ b/.github/workflows/checker-framework.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   check:
+    if: github.repository == 'checkstyle/checkstyle'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/error-prone.yml
+++ b/.github/workflows/error-prone.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   error-prone:
+    if: github.repository == 'checkstyle/checkstyle'
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 11

--- a/.github/workflows/no-exception-workflow.yml
+++ b/.github/workflows/no-exception-workflow.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   # this execution should stay on GitHub actions due to time/ memory limits in other CI
   no-exception-openjdk17:
+    if: github.repository == 'checkstyle/checkstyle'
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 11
@@ -30,6 +31,7 @@ jobs:
       - run: .ci/no-exception-test.sh openjdk17-with-checks-nonjavadoc-error
   # this execution should stay on GitHub actions due to time/ memory limits in other CI
   no-exception-openjdk19:
+    if: github.repository == 'checkstyle/checkstyle'
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 11

--- a/.github/workflows/no-old-refs.yml
+++ b/.github/workflows/no-old-refs.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   check_issues:
+    if: github.repository == 'checkstyle/checkstyle'
     runs-on: ubuntu-latest
     steps:
       - name: Download checkstyle

--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   test:
+    if: github.repository == 'checkstyle/checkstyle'
     strategy:
       matrix:
         profile:

--- a/.github/workflows/releasenotes-gen.yml
+++ b/.github/workflows/releasenotes-gen.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   generate:
+    if: github.repository == 'checkstyle/checkstyle'
     runs-on: ubuntu-latest
     steps:
       - name: Download checkstyle

--- a/.github/workflows/run-link-check.yml
+++ b/.github/workflows/run-link-check.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   check_issues:
+    if: github.repository == 'checkstyle/checkstyle'
     runs-on: ubuntu-latest
     steps:
       - name: Download checkstyle

--- a/.github/workflows/set-milestone-on-referenced-issue.yml
+++ b/.github/workflows/set-milestone-on-referenced-issue.yml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   set-milestone:
+    if: github.repository == 'checkstyle/checkstyle'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   # this execution should stay on GitHub actions due to time/ memory limits in other CI
   shellcheck:
+    if: github.repository == 'checkstyle/checkstyle'
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies


### PR DESCRIPTION
Resolves #12824

From [Example: Only run job for specific repository](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution#example-only-run-job-for-specific-repository)

codeql workflow already had such condition too:
https://github.com/checkstyle/checkstyle/blob/fd31119f2acdf8072e4205b6dd2abf5f118d4dd6/.github/workflows/codeql-analysis.yml#L23

Success commit with all skipped jobs: https://github.com/stoyanK7/checkstyle/commit/ff7b592585a695e20a693471e06a7b309e4bc6a9
![Screenshot from 2023-03-12 18-08-06](https://user-images.githubusercontent.com/23459549/224560577-c804ad8e-34ca-4b41-9bdb-3bfdcb2b378d.png)

