### PR TITLE
minor: make inspections failure results more obvious

### DIFF
--- a/.ci/idea-inspection.sh
+++ b/.ci/idea-inspection.sh
@@ -49,7 +49,10 @@ echo "Checking results ..."
 PROBLEM_COUNT=$(grep -R "<problems" "$RESULTS_DIR"/ | cat | wc -l )
 
 if [[ $PROBLEM_COUNT -gt 0 ]] && [[ "$CIRCLECI" == "true" ]]; then
-    echo "There are inspection problems. Review results in 'ARTIFACTS' tab above."
+    echo -e "\n\n\n\n"
+    echo "ATTENTION GITHUB CONTRIBUTOR:"
+    echo "There are inspection problems."
+    echo "Review results in 'ARTIFACTS' tab in the CircleCI UI above."
     exit 1;
 elif [[ $PROBLEM_COUNT -gt 0 ]]; then
     echo "There are inspection problems. Review results at $RESULTS_DIR folder. Files:"


### PR DESCRIPTION
Related to https://github.com/checkstyle/checkstyle/pull/12835#issuecomment-1468275604, we need to make failure message and location of results more obvious.

Link to failure: https://app.circleci.com/pipelines/github/checkstyle/checkstyle/17709/workflows/0cdbc001-5bf5-4dd3-886a-5d7eb39f4933/jobs/259008?invite=true#step-103-100