### PR TITLE
minor: move run key at last spot

### DIFF
--- a/.github/workflows/release-publish-releasenotes-twitter.yml
+++ b/.github/workflows/release-publish-releasenotes-twitter.yml
@@ -39,11 +39,11 @@ jobs:
           path: ~/.m2/repository
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}
       - name: Run Shell Script
-        run: |
-          ./.ci/release-publish-releasenotes-twitter.sh ${{ inputs.version }}
         env:
           GITHUB_READ_ONLY_TOKEN: ${{ secrets.READ_ONLY_TOKEN_GITHUB }}
           TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
           TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
           TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+        run: |
+          ./.ci/release-publish-releasenotes-twitter.sh ${{ inputs.version }}


### PR DESCRIPTION
We keep `run` key always at last spot. For example,
https://github.com/checkstyle/checkstyle/blob/665f58f178e282e5565b5782ab1b33237d32f547/.github/workflows/release-maven-perform.yml#L38-L54
https://github.com/checkstyle/checkstyle/blob/665f58f178e282e5565b5782ab1b33237d32f547/.github/workflows/release-update-github-page.yml#L41-L45
