### PR TITLE
Pull #12857: Make twitter-releasenotes job depend on update-github-page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
 
   publish-releasenotes-twitter:
     uses: ./.github/workflows/release-publish-releasenotes-twitter.yml
-    needs: maven-perform
+    needs: update-github-page
     with:
       version: ${{ inputs.version }}
       concurrency-group: publish-releasenotes-twitter


### PR DESCRIPTION
Resolves twitter failure in release run: https://github.com/checkstyle/checkstyle/actions/runs/4438465653
Twitter job: https://github.com/checkstyle/checkstyle/actions/runs/4438465653/jobs/7790124616#step:4:124
```
TARGET_RELEASE_INDEX=
PREVIOUS_RELEASE_INDEX=1
```
Release on my fork: https://github.com/stoyanK7/checkstyle/actions/runs/4449215620
Twitter job : https://github.com/stoyanK7/checkstyle/actions/runs/4449215620/jobs/7813174923#step:4:125
```
TARGET_RELEASE_INDEX=0
PREVIOUS_RELEASE_INDEX=1
```

Twitter releasenotes job should be dependent on `update-github-page` because it expects the release to be there
https://github.com/checkstyle/checkstyle/blob/b2e5cb20d2f1b3aa0273579b05651404aa0234de/.ci/release-publish-releasenotes-twitter.sh#L32-L40

---
What happened in the fail run was that the twitter job ran before the release was on GitHub and it could not find it. [GitHub release was created at](https://github.com/checkstyle/checkstyle/actions/runs/4438465653/jobs/7790125303#step:4:150) 
```
Thu, 16 Mar 2023 15:22:11 GMT Creating Github release
```
but [twitter job started pulling releases](https://github.com/checkstyle/checkstyle/actions/runs/4438465653/jobs/7790124616#step:4:119) at
```
Thu, 16 Mar 2023 15:22:12 GMT   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
```