### PR TITLE
Issue #12451: Restore curl --fail-with-body

### DIFF
--- a/.ci/no-old-refs.sh
+++ b/.ci/no-old-refs.sh
@@ -38,7 +38,7 @@ for MENTIONED_ISSUES_GREP_OUTPUT_LINE in $(cat $MENTIONED_ISSUES_GREP_OUTPUT); d
 
   LINK="$GITHUB_HOST/$MAIN_REPO/blob/$DEFAULT_BRANCH/$FILE_PATH#L$LINE_NUMBER"
 
-  STATE=$(curl -s -H \
+  STATE=$(curl --fail-with-body -s -H \
    "Authorization: token $GITHUB_TOKEN" "$API_GITHUB_PREFIX/$ISSUE" \
    | jq '.state' | xargs)
   if [ "$STATE" = "closed" ]; then

--- a/.ci/pr-description.sh
+++ b/.ci/pr-description.sh
@@ -4,7 +4,7 @@ set -e
 
 if [[ ! $PULL_REQUEST =~ ^([0-9]*)$ ]]; then exit 0; fi
 LINK_COMMITS=https://api.github.com/repos/checkstyle/checkstyle/pulls/$PULL_REQUEST/commits
-COMMITS=$(curl -s -H "Authorization: token $READ_ONLY_TOKEN" "$LINK_COMMITS" \
+COMMITS=$(curl --fail-with-body -s -H "Authorization: token $READ_ONLY_TOKEN" "$LINK_COMMITS" \
              | jq '.[0] | .commit.message')
 echo 'Commit messages from github: '"${COMMITS:0:60}"...
 ISSUE_NUMBER=$(echo "$COMMITS" | sed -e 's/^.*Issue //' | sed -e 's/:.*//')
@@ -13,7 +13,7 @@ if [[ $ISSUE_NUMBER =~ ^#[0-9]+$ ]]; then
     LINK_PR=https://api.github.com/repos/checkstyle/checkstyle/pulls/$PULL_REQUEST
     LINK_ISSUE=https://api.github.com/repos/checkstyle/checkstyle/issues/${ISSUE_NUMBER:1}
     REGEXP=($ISSUE_NUMBER\|https://github.com/checkstyle/checkstyle/issues/${ISSUE_NUMBER:1})
-    PR_DESC=$(curl -s -H "Authorization: token $READ_ONLY_TOKEN" "$LINK_PR" \
+    PR_DESC=$(curl --fail-with-body -s -H "Authorization: token $READ_ONLY_TOKEN" "$LINK_PR" \
                 | jq '.body' | grep -E "$REGEXP" | cat )
     echo 'PR Description grepped:'"${PR_DESC:0:80}"
     if [[ -z $PR_DESC ]]; then
@@ -21,7 +21,7 @@ if [[ $ISSUE_NUMBER =~ ^#[0-9]+$ ]]; then
          echo 'this will bind the Issue to your PR in Github'
          RESULT=1;
        fi
-    LABEL_APRV=$(curl -s -H "Authorization: token $READ_ONLY_TOKEN" "$LINK_ISSUE" \
+    LABEL_APRV=$(curl --fail-with-body -s -H "Authorization: token $READ_ONLY_TOKEN" "$LINK_ISSUE" \
                    | jq '.labels [] | .name' | grep approved | cat | wc -l )
     if [[ $LABEL_APRV == 0 ]]; then
          echo 'You are providing a PR for an Issue that is not approved yet,'

--- a/.ci/release-close-create-milestone.sh
+++ b/.ci/release-close-create-milestone.sh
@@ -7,11 +7,11 @@ source ./.ci/util.sh
 checkForVariable "GITHUB_TOKEN"
 
 echo "Close previous milestone at github"
-MILESTONE_NUMBER=$(curl -s \
+MILESTONE_NUMBER=$(curl --fail-with-body -s \
                 -H "Authorization: token $GITHUB_TOKEN" \
                 -X GET https://api.github.com/repos/checkstyle/checkstyle/milestones?state=open \
                 | jq ".[0] | .number")
-curl -i -H "Authorization: token $GITHUB_TOKEN" \
+curl --fail-with-body -i -H "Authorization: token $GITHUB_TOKEN" \
   -d "{ \"state\": \"closed\" }" \
   -X PATCH https://api.github.com/repos/checkstyle/checkstyle/milestones/"$MILESTONE_NUMBER"
 
@@ -26,7 +26,7 @@ LAST_SUNDAY_DAY=$(cal -d "$(date -d "next month" +"%Y-%m")" \
 LAST_SUNDAY_DATETIME=$(date -d "next month" +"%Y-%m")"-$LAST_SUNDAY_DAY""T08:00:00Z"
 echo "$LAST_SUNDAY_DATETIME"
 
-curl -i -H "Authorization: token $GITHUB_TOKEN" \
+curl --fail-with-body -i -H "Authorization: token $GITHUB_TOKEN" \
   -d "{ \"title\": \"$CURRENT_VERSION\", \
         \"state\": \"open\", \
         \"description\": \"\", \

--- a/.ci/release-create-issues-in-other-repos.sh
+++ b/.ci/release-create-issues-in-other-repos.sh
@@ -16,14 +16,14 @@ TARGET_VERSION=$1
 echo TARGET_VERSION="$TARGET_VERSION"
 
 echo "Creation of issue in eclipse-cs repo ..."
-curl -i -H "Authorization: token $GITHUB_TOKEN" \
+curl --fail-with-body -i -H "Authorization: token $GITHUB_TOKEN" \
   -d "{ \"title\": \"upgrade to checkstyle $TARGET_VERSION\", \
         \"body\": \"https://checkstyle.org/releasenotes.html#Release_$TARGET_VERSION\" \
         }" \
   -X POST https://api.github.com/repos/checkstyle/eclipse-cs/issues
 
 echo "Creation of issue in sonar-checkstyle repo ..."
-curl -i -H "Authorization: token $GITHUB_TOKEN" \
+curl --fail-with-body -i -H "Authorization: token $GITHUB_TOKEN" \
   -d "{ \"title\": \"upgrade to checkstyle $TARGET_VERSION\", \
         \"body\": \"https://checkstyle.org/releasenotes.html#Release_$TARGET_VERSION\" \
         }" \

--- a/.ci/release-publish-releasenotes-twitter.sh
+++ b/.ci/release-publish-releasenotes-twitter.sh
@@ -29,7 +29,7 @@ fi
 
 cd .ci-temp/checkstyle
 
-curl https://api.github.com/repos/checkstyle/checkstyle/releases \
+curl --fail-with-body https://api.github.com/repos/checkstyle/checkstyle/releases \
  -H "Authorization: token $GITHUB_READ_ONLY_TOKEN" \
  -o /var/tmp/cs-releases.json
 

--- a/.ci/release-update-github-page.sh
+++ b/.ci/release-update-github-page.sh
@@ -33,7 +33,7 @@ fi
 
 cd .ci-temp/checkstyle
 
-curl https://api.github.com/repos/checkstyle/checkstyle/releases \
+curl --fail-with-body https://api.github.com/repos/checkstyle/checkstyle/releases \
  -H "Authorization: token $GITHUB_TOKEN" \
  -o /var/tmp/cs-releases.json
 
@@ -82,7 +82,7 @@ echo "JSON Body"
 cat body.json
 
 echo "Creating Github release"
-curl \
+curl --fail-with-body \
   -X POST https://api.github.com/repos/checkstyle/checkstyle/releases \
   -H "Accept: application/vnd.github+json" \
   -H "Authorization: token $GITHUB_TOKEN" \

--- a/.ci/release-upload-all-jar.sh
+++ b/.ci/release-upload-all-jar.sh
@@ -22,13 +22,13 @@ mvn -e --no-transfer-progress -Passembly,no-validations package
 
 echo "Publishing 'all' jar to Github"
 UPLOAD_LINK=https://uploads.github.com/repos/checkstyle/checkstyle/releases
-RELEASE_ID=$(curl -s -X GET \
+RELEASE_ID=$(curl --fail-with-body -s -X GET \
   -H "Authorization: token $GITHUB_TOKEN" \
   https://api.github.com/repos/checkstyle/checkstyle/releases/tags/checkstyle-"$TARGET_VERSION" \
   | jq ".id")
 
 
-curl -i -H "Authorization: token $GITHUB_TOKEN" \
+curl --fail-with-body -i -H "Authorization: token $GITHUB_TOKEN" \
   -H "Content-Type: application/java-archive" \
   --data-binary @"target/checkstyle-$TARGET_VERSION-all.jar" \
   -X POST "$UPLOAD_LINK"/"$RELEASE_ID"/assets?name=checkstyle-"$TARGET_VERSION"-all.jar

--- a/.ci/releasenotes-gen-xdoc-push.sh
+++ b/.ci/releasenotes-gen-xdoc-push.sh
@@ -32,7 +32,7 @@ else
 fi
 
 cd .ci-temp/checkstyle
-LATEST_RELEASE_TAG=$(curl -s -H "Authorization: token $READ_ONLY_TOKEN" \
+LATEST_RELEASE_TAG=$(curl --fail-with-body -s -H "Authorization: token $READ_ONLY_TOKEN" \
                        https://api.github.com/repos/checkstyle/checkstyle/releases/latest \
                        | jq ".tag_name")
 echo LATEST_RELEASE_TAG="$LATEST_RELEASE_TAG"

--- a/.ci/run-link-check-plugin.sh
+++ b/.ci/run-link-check-plugin.sh
@@ -6,7 +6,7 @@ set -e
 pwd
 uname -a
 mvn --version
-curl -I https://sourceforge.net/projects/checkstyle/
+curl --fail-with-body -I https://sourceforge.net/projects/checkstyle/
 mvn -e --no-transfer-progress clean site -Dcheckstyle.ant.skip=true -DskipTests -DskipITs \
    -Dpmd.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -Dcheckstyle.skip=true
 echo "------------ grep of linkcheck.html--BEGIN"

--- a/.ci/set-milestone-on-referenced-issue.sh
+++ b/.ci/set-milestone-on-referenced-issue.sh
@@ -37,7 +37,7 @@ if [ -z "$ISSUE_NUMBERS" ]; then
 fi
 
 echo "Fetching latest milestone."
-MILESTONE=$(curl -s \
+MILESTONE=$(curl --fail-with-body -s \
   -H "Accept: application/vnd.github+json" \
   -H "Authorization: Bearer $GITHUB_TOKEN"\
   https://api.github.com/repos/checkstyle/checkstyle/milestones)
@@ -50,7 +50,7 @@ function setMilestoneOnIssue {
   ISSUE_NUMBER=$1
   echo "Setting milestone $MILESTONE_TITLE to issue #$ISSUE_NUMBER."
   BODY="{\"milestone\": $MILESTONE_NUMBER}"
-  curl -s \
+  curl --fail-with-body -s \
     -X PATCH \
     -H "Accept: application/vnd.github+json" \
     -H "Authorization: Bearer $GITHUB_TOKEN"\

--- a/.ci/test-spelling-unknown-words.sh
+++ b/.ci/test-spelling-unknown-words.sh
@@ -19,13 +19,13 @@ if [ ! -e "$dict" ]; then
   # english.words is taken from rpm:
   # https://rpmfind.net/linux/fedora/linux/development/rawhide/Everything/aarch64/os/Packages/w/"
   # "words-.*.noarch.rpm"
-  curl -k https://checkstyle.sourceforge.io/reports/english.words -o $dict
+  curl --fail-with-body -k https://checkstyle.sourceforge.io/reports/english.words -o $dict
 fi
 
 if [ ! -e "$word_splitter" ]; then
   echo "Retrieve w"
   w_location='https://raw.githubusercontent.com/jsoref/spelling/master/w'
-  curl -s "$w_location" |\
+  curl --fail-with-body -s "$w_location" |\
     perl -p -n -e "s</usr/share/dict/words><$dict>" > "$word_splitter"
   get_word_splitter_status="${PIPESTATUS[0]} ${PIPESTATUS[1]}"
   if [ "$get_word_splitter_status" != '0 0' ]; then

--- a/.ci/update-github-milestone.sh
+++ b/.ci/update-github-milestone.sh
@@ -16,7 +16,7 @@ TARGET_VERSION=$1
 echo TARGET_VERSION="$TARGET_VERSION"
 
 echo "Updating milestone at github"
-MILESTONE_ID=$(curl -s \
+MILESTONE_ID=$(curl --fail-with-body -s \
                 -H "Authorization: token $GITHUB_TOKEN" \
                 -X GET https://api.github.com/repos/checkstyle/checkstyle/milestones?state=open \
                 | jq ".[0] | .number")
@@ -24,7 +24,7 @@ MILESTONE_ID=$(curl -s \
 echo TARGET_VERSION="$TARGET_VERSION"
 echo MILESTONE_ID="$MILESTONE_ID"
 
-curl \
+curl --fail-with-body \
   -X PATCH https://api.github.com/repos/checkstyle/checkstyle/milestones/"$MILESTONE_ID" \
   -H "Authorization: token $GITHUB_TOKEN" \
   -d "{ \"title\": \"$TARGET_VERSION\" }"

--- a/.github/workflows/check-pr-description.yml
+++ b/.github/workflows/check-pr-description.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/no-old-refs.yml
+++ b/.github/workflows/no-old-refs.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   check_issues:
     if: github.repository == 'checkstyle/checkstyle'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Download checkstyle
         uses: actions/checkout@v3

--- a/.github/workflows/release-new-milestone-and-issues-in-other-repos.yml
+++ b/.github/workflows/release-new-milestone-and-issues-in-other-repos.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   new-milestone-and-issues-in-other-repos:
     name: New Milestone, Create issues for ${{ inputs.version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout the latest code
         uses: actions/checkout@v3

--- a/.github/workflows/release-publish-releasenotes-twitter.yml
+++ b/.github/workflows/release-publish-releasenotes-twitter.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   publish-releasenotes-twitter:
     name: Publish Release Notes on Twitter ${{ inputs.version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout the latest code
         uses: actions/checkout@v3

--- a/.github/workflows/release-update-github-page.yml
+++ b/.github/workflows/release-update-github-page.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   update-github-page:
     name: Update GitHub Page ${{ inputs.version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release-upload-all-jar.yml
+++ b/.github/workflows/release-upload-all-jar.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   upload-all-jar:
     name: Upload '-all' jar ${{ inputs.version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout the latest code
         uses: actions/checkout@v3

--- a/.github/workflows/releasenotes-gen.yml
+++ b/.github/workflows/releasenotes-gen.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   generate:
     if: github.repository == 'checkstyle/checkstyle'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Download checkstyle
         uses: actions/checkout@v3

--- a/.github/workflows/run-link-check.yml
+++ b/.github/workflows/run-link-check.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   check_issues:
     if: github.repository == 'checkstyle/checkstyle'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Download checkstyle
         uses: actions/checkout@v3

--- a/.github/workflows/set-milestone-on-referenced-issue.yml
+++ b/.github/workflows/set-milestone-on-referenced-issue.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   set-milestone:
     if: github.repository == 'checkstyle/checkstyle'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout the latest code
         uses: actions/checkout@v3

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ strategy:
 
     # spelling
     'spelling':
-      image: 'ubuntu-20.04'
+      image: 'ubuntu-22.04'
       cmd: "./.ci/test-spelling-unknown-words.sh"
       skipCache: true
 

--- a/config/checkstyle-non-main-files-suppressions.xml
+++ b/config/checkstyle-non-main-files-suppressions.xml
@@ -154,21 +154,7 @@
 
   <!-- not a curl command but a text replacement -->
   <suppress id="properCurlCommand" files=".ci[\\/]validation\.sh"/>
-  <!-- azure does not support this curl command -->
-  <suppress id="properCurlCommand" files=".ci[\\/]test-spelling-unknown-words\.sh"/>
-  <suppress id="properCurlCommand" files=".ci[\\/]run-link-check-plugin\.sh"/>
-  <!-- other images that do not support newer curl commands until #12451 -->
+  <!-- other images that do not support newer curl commands -->
   <suppress id="properCurlCommand" files=".ci[\\/]sonar-break-build\.sh"/>
-  <suppress id="properCurlCommand" files=".ci[\\/]no-old-refs\.sh"/>
-  <suppress id="properCurlCommand" files=".ci[\\/]pr-description\.sh"/>
-  <suppress id="properCurlCommand" files=".ci[\\/]release-close-create-milestone\.sh"/>
-  <suppress id="properCurlCommand" files=".ci[\\/]release-publish-releasenotes-twitter\.sh"/>
-  <suppress id="properCurlCommand" files=".ci[\\/]release-upload-all-jar\.sh"/>
-  <suppress id="properCurlCommand" files=".ci[\\/]release-update-github-page\.sh"/>
-  <suppress id="properCurlCommand" files=".ci[\\/]update-github-milestone\.sh"/>
-  <suppress id="properCurlCommand" files=".ci[\\/]releasenotes-gen-xdoc-push\.sh"/>
-  <suppress id="properCurlCommand" files=".ci[\\/]release-create-issues-in-other-repos\.sh"/>
-  <suppress id="properCurlCommand" files=".ci[\\/]set-milestone-on-referenced-issue\.sh"/>
-  <suppress id="properCurlCommand" files="release\.sh"/>
 
 </suppressions>


### PR DESCRIPTION
Resolves #12451

---
Proof that `--fail-with-body` is now supported. It was released in `7.76.0`:
 - Run: https://github.com/stoyanK7/checkstyle/actions/runs/4449397732/jobs/7813529479#step:3:6
    ```
    curl --version
    curl 7.81.0 (x86_64-pc-linux-gnu) ...
   ```
 - https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#installed-apt-packages