### PR TITLE
Pull #12866: Ensure new-milestone-and-issues-in-other-repos always pulls latest commit

### DIFF
--- a/.github/workflows/release-new-milestone-and-issues-in-other-repos.yml
+++ b/.github/workflows/release-new-milestone-and-issues-in-other-repos.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: master
       - name: Download ncal
         run: |
           sudo apt-get install ncal


### PR DESCRIPTION
Resolves failure in release `10.9.2` https://github.com/checkstyle/checkstyle/actions/runs/4456286742/jobs/7826685717

`new-milestone-and-issues-in-other-repos` [failed by trying to create milestone `10.9.2`](https://github.com/checkstyle/checkstyle/actions/runs/4456286742/jobs/7826685717#step:5:112):
```
      "resource": "Milestone",
      "code": "already_exists",
      "field": "title"
```

It is supposed to get the new release number from pom. `10.9.3` in this case:
https://github.com/checkstyle/checkstyle/blob/c5e0f6fda7a48e38b9fbf45aa72f26a0b61b4cec/.ci/release-close-create-milestone.sh#L19-L22

The problem comes from `actions/checkout`. [It did not checkout to latest commit but rather to commit before release happened so the action pulled `10.9.2` from pom instead of `10.9.3`](https://github.com/checkstyle/checkstyle/actions/runs/4456286742/jobs/7826685717#step:2:613) 258c7928b3e09687eb0007387e752af53a14f821
```
/usr/bin/git log -1 --format='%H'
'258c7928b3e09687eb0007387e752af53a14f821'
```
The solution is taken from https://github.com/actions/checkout/issues/439#issuecomment-965968956. We already apply it in other release workflows.