### PR TITLE
Issue #7593: Update doc for translation

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -128,18 +128,35 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </li>
  * </ul>
  * <p>
+ * Note, that files with the same path and base name but which have different
+ * extensions will be considered as files that belong to different resource bundles.
+ * </p>
+ * <p>
  * To configure the check to check only files which have '.properties' and
  * '.translations' extensions:
  * </p>
  * <pre>
  * &lt;module name="Translation"&gt;
  *   &lt;property name="fileExtensions" value="properties, translations"/&gt;
+ *   &lt;property name="requiredTranslations" value="fr"/&gt;
  * &lt;/module&gt;
  * </pre>
  * <p>
- * Note, that files with the same path and base name but which have different
- * extensions will be considered as files that belong to different resource bundles.
+ * Example:
  * </p>
+ * <pre>
+ * #messages.properties
+ * hello=Hello
+ * cancel=Cancel
+ *
+ * #messages.translations
+ * hello=Hallo
+ * ok=OK
+ * </pre>
+ * <pre>
+ * messages.properties: Properties file 'messages_fr.properties' is missing.
+ * messages.translations: Properties file 'messages_fr.translations' is missing.
+ * </pre>
  * <p>
  * An example of how to configure the check to validate only bundles which base
  * names start with "ButtonLabels":
@@ -147,7 +164,24 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * <pre>
  * &lt;module name="Translation"&gt;
  *   &lt;property name="baseName" value="^ButtonLabels.*$"/&gt;
+ *   &lt;property name="requiredTranslations" value="fr"/&gt;
  * &lt;/module&gt;
+ * </pre>
+ * <p>
+ * Example:
+ * </p>
+ * <pre>
+ * #ButtonLabels.properties
+ * hello=Hello
+ * cancel=Cancel
+ *
+ * #ButtonLabels_fr.properties
+ * hello=Bonjour
+ * name=Nom
+ * </pre>
+ * <pre>
+ * ButtonLabels.properties: Key 'name' is missing.
+ * ButtonLabels_fr.properties: Key 'cancel' is missing.
  * </pre>
  * <p>
  * To configure the check to check existence of Japanese and French translations:
@@ -158,29 +192,29 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * &lt;/module&gt;
  * </pre>
  * <p>
- * The following example shows how the check works if there is a message bundle
- * which element name contains language code, county code, platform name.
- * Consider that we have the below configuration:
+ * Example:
  * </p>
  * <pre>
- * &lt;module name="Translation"&gt;
- *   &lt;property name="requiredTranslations" value="es, fr, de"/&gt;
- * &lt;/module&gt;
+ * #messages.properties
+ * hello=Hello
+ * cancel=Cancel
+ *
+ * #messages_ja.properties
+ * greeting=こんにちは
+ * age=年齢
+ *
+ * #messages_fr.properties
+ * greeting=Bonjour
+ * name=Nom
  * </pre>
- * <p>
- * As we can see from the configuration, the TranslationCheck was configured
- * to check an existence of 'es', 'fr' and 'de' translations. Let's assume that
- * we have the resource bundle:
- * </p>
  * <pre>
- * messages_home.properties
- * messages_home_es_US.properties
- * messages_home_fr_CA_UNIX.properties
+ * messages.properties: Key 'age' missing.
+ * messages.properties: Key 'name' missing.
+ * messages_fr.properties: Key 'age' missing.
+ * messages_fr.properties: Key 'cancel' missing.
+ * messages_ja.properties: Key 'cancel' missing.
+ * messages_ja.properties: Key 'name' missing.
  * </pre>
- * <p>
- * Than the check will rise the following violation: "0: Properties file
- * 'messages_home_de.properties' is missing."
- * </p>
  * <p>
  * Parent is {@code com.puppycrawl.tools.checkstyle.Checker}
  * </p>

--- a/src/xdocs/config_misc.xml
+++ b/src/xdocs/config_misc.xml
@@ -2341,18 +2341,35 @@ messages.properties: Key 'ok' missing.
 
       <subsection name="Examples" id="Translation_Examples">
         <p>
+          Note, that files with the same path and base name but which have different
+          extensions will be considered as files that belong to different resource bundles.
+        </p>
+        <p>
           To configure the check to check only files which have '.properties' and '.translations'
           extensions:
         </p>
         <source>
 &lt;module name=&quot;Translation&quot;&gt;
   &lt;property name=&quot;fileExtensions&quot; value=&quot;properties, translations&quot;/&gt;
+  &lt;property name=&quot;requiredTranslations&quot; value=&quot;fr&quot;/&gt;
 &lt;/module&gt;
         </source>
         <p>
-          Note, that files with the same path and base name but which have different
-          extensions will be considered as files that belong to different resource bundles.
+          Example:
         </p>
+        <source>
+#messages.properties
+hello=Hello
+cancel=Cancel
+
+#messages.translations
+hello=Hallo
+ok=OK
+        </source>
+        <source>
+messages.properties: Properties file 'messages_fr.properties' is missing.
+messages.translations: Properties file 'messages_fr.translations' is missing.
+        </source>
         <p>
           An example of how to configure the check to validate only bundles which base names
           start with "ButtonLabels":
@@ -2360,9 +2377,25 @@ messages.properties: Key 'ok' missing.
         <source>
 &lt;module name=&quot;Translation&quot;&gt;
   &lt;property name=&quot;baseName&quot; value=&quot;^ButtonLabels.*$&quot;/&gt;
+  &lt;property name=&quot;requiredTranslations&quot; value=&quot;fr&quot;/&gt;
 &lt;/module&gt;
         </source>
+        <p>
+          Example:
+        </p>
+        <source>
+#ButtonLabels.properties
+hello=Hello
+cancel=Cancel
 
+#ButtonLabels_fr.properties
+hello=Bonjour
+name=Nom
+        </source>
+        <source>
+ButtonLabels.properties: Key 'name' is missing.
+ButtonLabels_fr.properties: Key 'cancel' is missing.
+        </source>
         <p>
           To configure the check to check existence of Japanese and French translations:
         </p>
@@ -2372,29 +2405,29 @@ messages.properties: Key 'ok' missing.
 &lt;/module&gt;
         </source>
         <p>
-          The following example shows how the check works if there is a message bundle which
-          element name contains language code, county code, platform name.
-          Consider that we have the below configuration:
+          Example:
         </p>
         <source>
-&lt;module name=&quot;Translation&quot;&gt;
-  &lt;property name=&quot;requiredTranslations&quot; value=&quot;es, fr, de&quot;/&gt;
-&lt;/module&gt;
+#messages.properties
+hello=Hello
+cancel=Cancel
+
+#messages_ja.properties
+greeting=こんにちは
+age=年齢
+
+#messages_fr.properties
+greeting=Bonjour
+name=Nom
         </source>
-        <p>
-          As we can see from the configuration, the TranslationCheck was configured to check
-          an existence of 'es', 'fr' and 'de' translations. Let's assume that we have the resource
-          bundle:
-        </p>
         <source>
-messages_home.properties
-messages_home_es_US.properties
-messages_home_fr_CA_UNIX.properties
+messages.properties: Key 'age' missing.
+messages.properties: Key 'name' missing.
+messages_fr.properties: Key 'age' missing.
+messages_fr.properties: Key 'cancel' missing.
+messages_ja.properties: Key 'cancel' missing.
+messages_ja.properties: Key 'name' missing.
         </source>
-        <p>
-          Than the check will rise the following violation:
-          "0: Properties file 'messages_home_de.properties' is missing."
-        </p>
       </subsection>
 
       <subsection name="Example of Usage" id="Translation_Example_of_Usage">


### PR DESCRIPTION
Issue: #7593
Example added.
``` mvn clean verify ``` Passed. 

Website image:

Example 1:


CLI o/p:
```
$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="Translation">
        <property name="fileExtensions" value="properties, translations"/>
        <property name="requiredTranslations" value="ja, fr"/>
    </module>
</module>
```

```
$ cat messages.properties
hello=Hello
cancel=Cancel
```
```
$ cat messages.translations
hello=Hallo
ok=OK
```
```
$ java -jar target/checkstyle-10.9.3-SNAPSHOT-all.jar -c config.xml messages.properties messages.translations
Starting audit...
[ERROR] D:\checkstyle:1: Properties file 'messages_ja.translations' is missing. [Translation]
[ERROR] D:\checkstyle:1: Properties file 'messages_fr.translations' is missing. [Translation]
[ERROR] D:\checkstyle:1: Properties file 'messages_ja.properties' is missing. [Translation]
[ERROR] D:\checkstyle:1: Properties file 'messages_fr.properties' is missing. [Translation]
Audit done.
Checkstyle ends with 4 errors.

```

Example 2:

CLI o/p:
```
$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
      "-//Checkstyle//DTD Check Configuration 1.3//EN"
      "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="Translation">     
        <property name="fileExtensions" value="properties, translations"/>
        <property name="baseName" value="^ButtonLabels.*$"/>
        <property name="requiredTranslations" value="ja, fr"/>
  </module>
</module>
```
```
$ cat ButtonLabels.properties
save=Save
cancel=Cancel
```
```
$ cat ButtonLabels.translations
save=Speichern
ok=OK
```
```
$ java -jar target/checkstyle-10.9.3-SNAPSHOT-all.jar -c config.xml ButtonLabels.properties ButtonLabels.translations
Starting audit...
[ERROR] D:\checkstyle:1: Properties file 'ButtonLabels_ja.properties' is missing. [Translation]
[ERROR] D:\checkstyle:1: Properties file 'ButtonLabels_fr.properties' is missing. [Translation]
[ERROR] D:\checkstyle:1: Properties file 'ButtonLabels_ja.translations' is missing. [Translation]
[ERROR] D:\checkstyle:1: Properties file 'ButtonLabels_fr.translations' is missing. [Translation]
Audit done.
Checkstyle ends with 4 errors.
```

Example 3:

CLI o/p:
```
$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="Translation">
        <property name="fileExtensions" value="properties, translations"/>
        <property name="requiredTranslations" value="ja,  fr"/>
    </module>
</module>
```
```
$ cat messages_fr.properties
greeting=Bonjour
name=Nom
```
```
$ cat messages_ja.properties
greeting=こんにちは
age=年齢
```
```
$ java -jar target/checkstyle-10.9.3-SNAPSHOT-all.jar -c config.xml messages_ja.properties messages_fr.properties
Starting audit...
[ERROR] D:\checkstyle:1: Properties file 'messages.properties' is missing. [Translation]
[ERROR] D:\checkstyle\messages_fr.properties:1: Key 'age' missing. [Translation]
[ERROR] D:\checkstyle\messages_ja.properties:1: Key 'name' missing. [Translation]
Audit done.
Checkstyle ends with 3 errors.

```
Example 4:



CLI o/p:

```
$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="Translation">
        <property name="fileExtensions" value="properties, translations"/>
        <property name="requiredTranslations" value="es, fr, de"/>
    </module>
</module>
```
```
$ cat messages_de.properties
hello=Hallo
bye=Tschüss
ok=OK
```
```
$ cat messages_es.properties
hello=Hola
bye=Adiós
ok=Aceptar
```
```
$ cat messages_fr.properties
hello=Bonjour
cancel=Annuler
```
```
$  java -jar target/checkstyle-10.9.3-SNAPSHOT-all.jar -c config.xml messages_es.properties messages_fr.properties messages_de.properties
Starting audit...
[ERROR] D:\checkstyle:1: Properties file 'messages.properties' is missing. [Translation]
[ERROR] D:\checkstyle\messages_de.properties:1: Key 'cancel' missing. [Translation]
[ERROR] D:\checkstyle\messages_es.properties:1: Key 'cancel' missing. [Translation]
[ERROR] D:\checkstyle\messages_fr.properties:1: Key 'bye' missing. [Translation]
[ERROR] D:\checkstyle\messages_fr.properties:1: Key 'ok' missing. [Translation]
Audit done.
Checkstyle ends with 5 errors.

```

