### PR TITLE
Issue #12878: Resolve pitest suppression for BeforeExecutionFileFilterSet

### DIFF
--- a/config/pitest-suppressions/pitest-api-suppressions.xml
+++ b/config/pitest-suppressions/pitest-api-suppressions.xml
@@ -12,15 +12,6 @@
   <mutation unstable="false">
     <sourceFile>BeforeExecutionFileFilterSet.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.api.BeforeExecutionFileFilterSet</mutatedClass>
-    <mutatedMethod>getBeforeExecutionFileFilters</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to java/util/Collections::unmodifiableSet with argument</description>
-    <lineContent>return Collections.unmodifiableSet(beforeExecutionFileFilters);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>BeforeExecutionFileFilterSet.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.BeforeExecutionFileFilterSet</mutatedClass>
     <mutatedMethod>toString</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator</mutator>
     <description>replaced return value with &quot;&quot; for com/puppycrawl/tools/checkstyle/api/BeforeExecutionFileFilterSet::toString</description>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/BeforeExecutionFileFilterSetTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/BeforeExecutionFileFilterSetTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.api;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.regex.Pattern;
 
@@ -98,6 +99,20 @@ public class BeforeExecutionFileFilterSetTest {
         assertWithMessage("Invalid filter set size")
                 .that(filterSet.getBeforeExecutionFileFilters())
                 .isEmpty();
+    }
+
+    /*
+      Due to low level configuration setup of BeforeExecutionFileFilterSet, conventional
+      input validation cannot be done here hence, pure JUnit testing has been
+      done for the time being
+    */
+    @Test
+    public void testUnmodifiableSet() {
+        final BeforeExecutionFileFilterSet filterSet = new BeforeExecutionFileFilterSet();
+        final BeforeExecutionFileFilter filter = new BeforeExecutionExclusionFileFilter();
+        filterSet.addBeforeExecutionFileFilter(filter);
+        assertThrows(UnsupportedOperationException.class,
+            () -> filterSet.getBeforeExecutionFileFilters().add(filter));
     }
 
 }


### PR DESCRIPTION
Related to #12877.

Surviving mutation has been killed.
