### PR TITLE
Issue #12878: Resolve pitest suppression for BeforeExecutionFileFilterSet

### DIFF
--- a/config/pitest-suppressions/pitest-api-suppressions.xml
+++ b/config/pitest-suppressions/pitest-api-suppressions.xml
@@ -10,15 +10,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>BeforeExecutionFileFilterSet.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.BeforeExecutionFileFilterSet</mutatedClass>
-    <mutatedMethod>toString</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator</mutator>
-    <description>replaced return value with &quot;&quot; for com/puppycrawl/tools/checkstyle/api/BeforeExecutionFileFilterSet::toString</description>
-    <lineContent>return beforeExecutionFileFilters.toString();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>FileContents.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.api.FileContents</mutatedClass>
     <mutatedMethod>getBlockComments</mutatedMethod>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/BeforeExecutionFileFilterSetTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/BeforeExecutionFileFilterSetTest.java
@@ -115,4 +115,16 @@ public class BeforeExecutionFileFilterSetTest {
             () -> filterSet.getBeforeExecutionFileFilters().add(filter));
     }
 
+    /*
+      Input based test does not call toString, but this method might be
+      useful for third party integrations.
+    */
+    @Test
+    public void testEmptyToString() {
+        final BeforeExecutionFileFilterSet filterSet = new BeforeExecutionFileFilterSet();
+        assertWithMessage("toString() result shouldn't be an empty string")
+                .that(filterSet.toString())
+                .isNotEmpty();
+    }
+
 }


### PR DESCRIPTION
Related to #12878

@romani 
Surviving mutation has been killed.
Pure JUnit testing has been used here as well.
Reason for which has been stated in a multiline comment .


