### PR TITLE
Issue #12876: Resolve pitest suppression for AbstractViolationReporter

### DIFF
--- a/config/pitest-suppressions/pitest-api-suppressions.xml
+++ b/config/pitest-suppressions/pitest-api-suppressions.xml
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
-    <sourceFile>AbstractViolationReporter.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.AbstractViolationReporter</mutatedClass>
-    <mutatedMethod>setSeverity</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable severityLevel</description>
-    <lineContent>severityLevel = SeverityLevel.getInstance(severity);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>FileContents.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.api.FileContents</mutatedClass>
     <mutatedMethod>getBlockComments</mutatedMethod>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheckTest.java
@@ -242,6 +242,15 @@ public class UnusedLocalVariableCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testUnusedLocalVarTestWarningSeverity() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWithInlineConfigParser(
+                getPath("InputUnusedLocalVariableTestWarningSeverity.java"),
+                expected);
+    }
+
+    @Test
     public void testUnusedLocalVarEnum() throws Exception {
         final String[] expected = {
             "22:9: " + getCheckMessage(MSG_UNUSED_LOCAL_VARIABLE, "a"),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableTestWarningSeverity.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unusedlocalvariable/InputUnusedLocalVariableTestWarningSeverity.java
@@ -1,0 +1,18 @@
+/*
+UnusedLocalVariable
+severity = warning
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.unusedlocalvariable;
+
+public class InputUnusedLocalVariableTestWarningSeverity {
+
+    void m() {
+     @Test.A Outer p1 = new @Test.A Outer();
+     @Test.A Outer.@Test.B Inner p2 = p1.new @Test.B Inner();
+     // ok above until https://github.com/checkstyle/checkstyle/issues/12980
+    }
+
+}


### PR DESCRIPTION
Resolves #12876 

@romani @nrmancuso 

Surviving mutation has been killed. 
Note that pure JUnit test has been used to kill the mutation. Reason for this is mentioned as a multiline comment above the test suite in ``AbstractViolationReportertest.java``.

