### PR TITLE
Issue #12887: Kill surviving mutation in FilterSet.java

### DIFF
--- a/config/pitest-suppressions/pitest-api-suppressions.xml
+++ b/config/pitest-suppressions/pitest-api-suppressions.xml
@@ -100,15 +100,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>FilterSet.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.FilterSet</mutatedClass>
-    <mutatedMethod>toString</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator</mutator>
-    <description>replaced return value with &quot;&quot; for com/puppycrawl/tools/checkstyle/api/FilterSet::toString</description>
-    <lineContent>return filters.toString();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>FullIdent.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.api.FullIdent</mutatedClass>
     <mutatedMethod>createFullIdentBelow</mutatedMethod>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FilterSetTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FilterSetTest.java
@@ -117,6 +117,18 @@ public class FilterSetTest {
             () -> filterSet.getFilters().add(filter));
     }
 
+    /*
+      Input based test does not call toString, but this method might
+      be useful for third party integrations
+    */
+    @Test
+    public void testEmptyToString() {
+        final FilterSet filterSet = new FilterSet();
+        assertWithMessage("toString() result shouldn't be an empty string")
+                .that(filterSet.toString())
+                .isNotEmpty();
+    }
+
     private static final class DummyFilter implements Filter {
 
         private final boolean acceptValue;


### PR DESCRIPTION
Related to #12887 

Surviving mutation has been killed. 
Pure JUnit test used here. reason mentioned in the testing suite.
