### PR TITLE
doc: describe in cli doc that folder can be used

### DIFF
--- a/src/xdocs/cmdline.xml.vm
+++ b/src/xdocs/cmdline.xml.vm
@@ -37,7 +37,8 @@ java -D&lt;property&gt;=&lt;value&gt;  \
      [-t | --tree] [-T | --treeWithComments] [-J | --treeWithJavadoc] [-j | --javadocTree] \
      [-V | --version] [-b | --branch-matching-xpath &lt;xpathQuery&gt;] [-h | --help] \
      [-e | --exclude &lt;excludedPath&gt;] [-E | --executeIgnoredModules] [-d | --debug] \
-     [-x | --exclude-regexp &lt;excludedPathPattern&gt;] \ file...
+     [-x | --exclude-regexp &lt;excludedPathPattern&gt;] \
+     file(s) or folder(s) ...
         </source>
       </p>
 


### PR DESCRIPTION
issue detected while helping at https://github.com/checkstyle/checkstyle/pull/12870

existing doc is incorrect as after `\` should be nothing, as it is line end wrapper symbol in linux.