### PR TITLE
Pull #12909: Fail set-milestone if no milestone is found

### DIFF
--- a/.ci/set-milestone-on-referenced-issue.sh
+++ b/.ci/set-milestone-on-referenced-issue.sh
@@ -43,6 +43,12 @@ MILESTONE=$(curl --fail-with-body -s \
   https://api.github.com/repos/checkstyle/checkstyle/milestones)
 MILESTONE_NUMBER=$(echo "$MILESTONE" | jq .[0].number)
 MILESTONE_TITLE=$(echo "$MILESTONE" | jq -r .[0].title)
+
+if [ "$MILESTONE_NUMBER" == "null" ]; then
+  echo "[ERROR] No milestone is found."
+  exit 1
+fi
+
 echo "MILESTONE_NUMBER=$MILESTONE_NUMBER"
 echo "MILESTONE_TITLE=$MILESTONE_TITLE"
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ or set of validation rules (best practices).
 [![][closed issues img]][closed issues]
 [![][link check img]][link check]
 
+[![][milestone img]][milestone]
+
 Members chat: [![][gitter_mem img]][gitter_mem]
 Contributors chat: [![][gitter_con img]][gitter_con]
 
@@ -191,3 +193,6 @@ are in the file named "LICENSE.apache20" in this directory.
 
 [checker framework]:https://github.com/checkstyle/checkstyle/actions/workflows/checker-framework.yml
 [checker framework img]:https://github.com/checkstyle/checkstyle/actions/workflows/checker-framework.yml/badge.svg
+
+[milestone]:https://github.com/checkstyle/checkstyle/actions/workflows/set-milestone-on-referenced-issue.yml
+[milestone img]:https://github.com/checkstyle/checkstyle/actions/workflows/set-milestone-on-referenced-issue.yml/badge.svg


### PR DESCRIPTION
`set-milestone-on-referenced-issue` "failed" silently because there was no milestone created during release and it does not check for that. The milestone for `10.9.3` was missing for a few days.
https://github.com/checkstyle/checkstyle/actions/runs/4507589937/jobs/7935502024#step:3:53
```
Fetching latest milestone.
MILESTONE_NUMBER=null
MILESTONE_TITLE=null
Setting milestone null to issue #12898.
```

---
This PR adds a check to ensure failure if no milestone is found and also introduces a badge in the README. This way somebody can notice if milestone is missing.


