### PR TITLE
Issue #12840: Add repository owner environment variable in release process

### DIFF
--- a/.ci/release-close-create-milestone.sh
+++ b/.ci/release-close-create-milestone.sh
@@ -5,15 +5,16 @@ set -e
 source ./.ci/util.sh
 
 checkForVariable "GITHUB_TOKEN"
+checkForVariable "REPOSITORY_OWNER"
 
 echo "Close previous milestone at github"
 MILESTONE_NUMBER=$(curl --fail-with-body -s \
                 -H "Authorization: token $GITHUB_TOKEN" \
-                -X GET https://api.github.com/repos/checkstyle/checkstyle/milestones?state=open \
+                -X GET https://api.github.com/repos/"$REPOSITORY_OWNER"/checkstyle/milestones?state=open \
                 | jq ".[0] | .number")
 curl --fail-with-body -i -H "Authorization: token $GITHUB_TOKEN" \
   -d "{ \"state\": \"closed\" }" \
-  -X PATCH https://api.github.com/repos/checkstyle/checkstyle/milestones/"$MILESTONE_NUMBER"
+  -X PATCH https://api.github.com/repos/"$REPOSITORY_OWNER"/checkstyle/milestones/"$MILESTONE_NUMBER"
 
 
 echo "Creation of new milestone ..."
@@ -32,4 +33,4 @@ curl --fail-with-body -i -H "Authorization: token $GITHUB_TOKEN" \
         \"description\": \"\", \
         \"due_on\": \"$LAST_SUNDAY_DATETIME\" \
         }" \
-  -X POST https://api.github.com/repos/checkstyle/checkstyle/milestones
+  -X POST https://api.github.com/repos/"$REPOSITORY_OWNER"/checkstyle/milestones

--- a/.ci/release-create-issues-in-other-repos.sh
+++ b/.ci/release-create-issues-in-other-repos.sh
@@ -5,6 +5,7 @@ set -e
 source ./.ci/util.sh
 
 checkForVariable "GITHUB_TOKEN"
+checkForVariable "REPOSITORY_OWNER"
 
 if [[ -z $1 ]]; then
   echo "version is not set"
@@ -20,11 +21,11 @@ curl --fail-with-body -i -H "Authorization: token $GITHUB_TOKEN" \
   -d "{ \"title\": \"upgrade to checkstyle $TARGET_VERSION\", \
         \"body\": \"https://checkstyle.org/releasenotes.html#Release_$TARGET_VERSION\" \
         }" \
-  -X POST https://api.github.com/repos/checkstyle/eclipse-cs/issues
+  -X POST https://api.github.com/repos/"$REPOSITORY_OWNER"/eclipse-cs/issues
 
 echo "Creation of issue in sonar-checkstyle repo ..."
 curl --fail-with-body -i -H "Authorization: token $GITHUB_TOKEN" \
   -d "{ \"title\": \"upgrade to checkstyle $TARGET_VERSION\", \
         \"body\": \"https://checkstyle.org/releasenotes.html#Release_$TARGET_VERSION\" \
         }" \
-  -X POST https://api.github.com/repos/checkstyle/sonar-checkstyle/issues
+  -X POST https://api.github.com/repos/"$REPOSITORY_OWNER"/sonar-checkstyle/issues

--- a/.ci/release-maven-perform.sh
+++ b/.ci/release-maven-perform.sh
@@ -10,6 +10,8 @@ if [[ -z $1 ]]; then
   exit 1
 fi
 
+checkForVariable "REPOSITORY_OWNER"
+
 TARGET_VERSION=$1
 echo TARGET_VERSION="$TARGET_VERSION"
 
@@ -21,6 +23,6 @@ SKIP_OTHERS="-Dpmd.skip=true -Dspotbugs.skip=true -Djacoco.skip=true -Dxml.skip=
 git checkout "checkstyle-$TARGET_VERSION"
 echo "Deploying jars to maven central (release:perform) ..."
 mvn -e --no-transfer-progress -Pgpg -Pgpgv2 release:perform \
-  -DconnectionUrl=scm:git:https://github.com/checkstyle/checkstyle.git \
+  -DconnectionUrl=scm:git:https://github.com/"$REPOSITORY_OWNER"/checkstyle.git \
   -Dtag=checkstyle-"$TARGET_VERSION" \
   -Darguments="$SKIP_TEST $SKIP_CHECKSTYLE $SKIP_OTHERS"

--- a/.ci/release-publish-releasenotes-twitter.sh
+++ b/.ci/release-publish-releasenotes-twitter.sh
@@ -8,6 +8,7 @@ checkForVariable "TWITTER_CONSUMER_SECRET"
 checkForVariable "TWITTER_ACCESS_TOKEN"
 checkForVariable "TWITTER_ACCESS_TOKEN_SECRET"
 checkForVariable "GITHUB_READ_ONLY_TOKEN"
+checkForVariable "REPOSITORY_OWNER"
 
 checkout_from https://github.com/checkstyle/contribution
 
@@ -23,13 +24,13 @@ if [ -d .ci-temp/checkstyle ]; then
   cd ../../
 else
   cd .ci-temp/
-  git clone https://github.com/checkstyle/checkstyle
+  git clone https://github.com/"$REPOSITORY_OWNER"/checkstyle
   cd ../
 fi
 
 cd .ci-temp/checkstyle
 
-curl --fail-with-body https://api.github.com/repos/checkstyle/checkstyle/releases \
+curl --fail-with-body https://api.github.com/repos/"$REPOSITORY_OWNER"/checkstyle/releases \
  -H "Authorization: token $GITHUB_READ_ONLY_TOKEN" \
  -o /var/tmp/cs-releases.json
 
@@ -52,7 +53,7 @@ cd ../
 BUILDER_RESOURCE_DIR="contribution/releasenotes-builder/src/main/resources/com/github/checkstyle"
 
 java -jar contribution/releasenotes-builder/target/releasenotes-builder-1.0-all.jar \
-     -remoteRepoPath checkstyle/checkstyle \
+     -remoteRepoPath "$REPOSITORY_OWNER"/checkstyle \
      -localRepoPath checkstyle \
      -startRef "$START_REF" \
      -endRef "$END_REF" \

--- a/.ci/release-update-github-page.sh
+++ b/.ci/release-update-github-page.sh
@@ -12,6 +12,7 @@ TARGET_VERSION=$1
 echo TARGET_VERSION="$TARGET_VERSION"
 
 checkForVariable "GITHUB_TOKEN"
+checkForVariable "REPOSITORY_OWNER"
 
 checkout_from https://github.com/checkstyle/contribution
 
@@ -27,13 +28,13 @@ if [ -d .ci-temp/checkstyle ]; then
   cd ../../
 else
   cd .ci-temp/
-  git clone https://github.com/checkstyle/checkstyle
+  git clone https://github.com/"$REPOSITORY_OWNER"/checkstyle
   cd ../
 fi
 
 cd .ci-temp/checkstyle
 
-curl --fail-with-body https://api.github.com/repos/checkstyle/checkstyle/releases \
+curl --fail-with-body https://api.github.com/repos/"$REPOSITORY_OWNER"/checkstyle/releases \
  -H "Authorization: token $GITHUB_TOKEN" \
  -o /var/tmp/cs-releases.json
 
@@ -50,7 +51,7 @@ BUILDER_RESOURCE_DIR="contribution/releasenotes-builder/src/main/resources/com/g
 
 java -jar contribution/releasenotes-builder/target/releasenotes-builder-1.0-all.jar \
      -localRepoPath checkstyle \
-     -remoteRepoPath checkstyle/checkstyle \
+     -remoteRepoPath "$REPOSITORY_OWNER"/checkstyle \
      -startRef "$START_REF" \
      -endRef "$END_REF" \
      -releaseNumber "$TARGET_VERSION" \
@@ -83,7 +84,7 @@ cat body.json
 
 echo "Creating Github release"
 curl --fail-with-body \
-  -X POST https://api.github.com/repos/checkstyle/checkstyle/releases \
+  -X POST https://api.github.com/repos/"$REPOSITORY_OWNER"/checkstyle/releases \
   -H "Accept: application/vnd.github+json" \
   -H "Authorization: token $GITHUB_TOKEN" \
   --data @body.json

--- a/.ci/release-upload-all-jar.sh
+++ b/.ci/release-upload-all-jar.sh
@@ -5,6 +5,7 @@ set -e
 source ./.ci/util.sh
 
 checkForVariable "GITHUB_TOKEN"
+checkForVariable "REPOSITORY_OWNER"
 
 if [[ -z $1 ]]; then
   echo "version is not set"
@@ -21,10 +22,10 @@ echo "Generating uber jar ...(no clean to keep site resources just in case)"
 mvn -e --no-transfer-progress -Passembly,no-validations package
 
 echo "Publishing 'all' jar to Github"
-UPLOAD_LINK=https://uploads.github.com/repos/checkstyle/checkstyle/releases
+UPLOAD_LINK=https://uploads.github.com/repos/"$REPOSITORY_OWNER"/checkstyle/releases
 RELEASE_ID=$(curl --fail-with-body -s -X GET \
   -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/checkstyle/checkstyle/releases/tags/checkstyle-"$TARGET_VERSION" \
+  https://api.github.com/repos/"$REPOSITORY_OWNER"/checkstyle/releases/tags/checkstyle-"$TARGET_VERSION" \
   | jq ".id")
 
 

--- a/.github/workflows/release-maven-perform.yml
+++ b/.github/workflows/release-maven-perform.yml
@@ -57,5 +57,7 @@ jobs:
           ./.ci/release-create-maven-settings-xml.sh
 
       - name: Run Shell Script
+        env:
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
         run: |
           ./.ci/release-maven-perform.sh ${{ inputs.version }}

--- a/.github/workflows/release-new-milestone-and-issues-in-other-repos.yml
+++ b/.github/workflows/release-new-milestone-and-issues-in-other-repos.yml
@@ -52,11 +52,13 @@ jobs:
       - name: Close/Create Milestone
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
         run: |
           ./.ci/release-close-create-milestone.sh
 
       - name: Creation of issue in other Repositories
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
         run: |
           ./.ci/release-create-issues-in-other-repos.sh ${{ inputs.version }}

--- a/.github/workflows/release-publish-releasenotes-twitter.yml
+++ b/.github/workflows/release-publish-releasenotes-twitter.yml
@@ -47,5 +47,6 @@ jobs:
           TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
           TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
           TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
         run: |
           ./.ci/release-publish-releasenotes-twitter.sh ${{ inputs.version }}

--- a/.github/workflows/release-update-github-io.yml
+++ b/.github/workflows/release-update-github-io.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout the latest code
         uses: actions/checkout@v3
         with:
-          repository: checkstyle/checkstyle
+          repository: ${{ github.repository_owner }}/checkstyle
           fetch-depth: 0
 
       - name: Setup local maven cache
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout checkstyle.github.io repo
         uses: actions/checkout@v3
         with:
-          repository: checkstyle/checkstyle.github.io
+          repository: ${{ github.repository_owner }}/checkstyle.github.io
           token: ${{ secrets.PAT }}
           path: .ci-temp/checkstyle.github.io/
 

--- a/.github/workflows/release-update-github-page.yml
+++ b/.github/workflows/release-update-github-page.yml
@@ -43,5 +43,6 @@ jobs:
       - name: Run Shell Script
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
         run: |
           ./.ci/release-update-github-page.sh ${{ inputs.version }}

--- a/.github/workflows/release-upload-all-jar.yml
+++ b/.github/workflows/release-upload-all-jar.yml
@@ -47,5 +47,6 @@ jobs:
       - name: Run GitHub Update Script
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
         run: |
           ./.ci/release-upload-all-jar.sh ${{ inputs.version }}


### PR DESCRIPTION
Resolves #12840 

---
Workflow run: https://github.com/stoyanK7/checkstyle/actions/runs/4520382682
The run fails, but that is because I do not have Twitter credentials. I had to manually point to my Sourceforge project, but that is not tied with GitHub so nothing can be done there.

What I noticed is that we can maybe make `release-maven-perform` have a different profile (https://github.com/stoyanK7/checkstyle/commit/08f79b22ba7c8f381be22b968ca01b3409ba272b) to deploy to local if `$REPOSITORY_OWNER` is not `checkstyle`. That way anyone can run/debug the whole release process on their fork. This is a separate issue from this one though.