### PR TITLE
Issue #7608: Update doc for DesignForExtension

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
@@ -175,45 +175,89 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <pre>
  * &lt;module name=&quot;DesignForExtension&quot;/&gt;
  * </pre>
+ * <p>Example:</p>
+ * <pre>
+ * public abstract class Foo {
+ *   private int bar;
+ *
+ *   public int m1() {return 2;}  // Violation. No javadoc.
+ *
+ *   public int m2() {return 8;}  // Violation. No javadoc.
+ *
+ *   private void m3() {m4();}  // OK. Private method.
+ *
+ *   protected void m4() { }  // OK. No implementation.
+ *
+ *   public abstract void m5();  // OK. Abstract method.
+ *
+ *   &#47;**
+ *    * This implementation ...
+ *    &#64;return some int value.
+ *    *&#47;
+ *   public int m6() {return 1;}  // OK. Have javadoc on overridable method.
+ *
+ *   &#47;**
+ *    * Some comments ...
+ *    *&#47;
+ *   public int m7() {return 1;}  // OK. Have javadoc on overridable method.
+ *
+ *   &#47;**
+ *    * This
+ *    * implementation ...
+ *    *&#47;
+ *   public int m8() {return 2;}  // OK. Have javadoc on overridable method.
+ *
+ *   &#64;Override
+ *   public String toString() {  // Violation. No javadoc for @Override method.
+ *     return "";
+ *   }
+ * }
+ * </pre>
  * <p>
- * To configure the check to allow methods which have @Override and @Test annotations
+ * To configure the check to allow methods which have @Override annotations
  * to be designed for extension.
  * </p>
  * <pre>
  * &lt;module name=&quot;DesignForExtension&quot;&gt;
- *   &lt;property name=&quot;ignoredAnnotations&quot; value=&quot;Override, Test&quot;/&gt;
+ *   &lt;property name=&quot;ignoredAnnotations&quot; value=&quot;Override&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>Example:</p>
  * <pre>
- * public class A {
- *   &#64;Override
- *   public int foo() {
- *     return 2;
- *   }
+ * public abstract class Foo {
+ *   private int bar;
  *
- *   public int foo2() {return 8;} // violation
- * }
+ *   public int m1() {return 2;}  // Violation. No javadoc.
  *
- * public class B {
+ *   public int m2() {return 8;}  // Violation. No javadoc.
+ *
+ *   private void m3() {m4();}  // OK. Private method.
+ *
+ *   protected void m4() { }  // OK. No implementation.
+ *
+ *   public abstract void m5();  // OK. Abstract method.
+ *
  *   &#47;**
  *    * This implementation ...
- *      &#64;return some int value.
+ *    &#64;return some int value.
  *    *&#47;
- *   public int foo() {
- *     return 1;
+ *   public int m6() {return 1;}  // OK. Have javadoc on overridable method.
+ *
+ *   &#47;**
+ *    * Some comments ...
+ *    *&#47;
+ *   public int m7() {return 1;}  // OK. Have javadoc on overridable method.
+ *
+ *   &#47;**
+ *    * This
+ *    * implementation ...
+ *    *&#47;
+ *   public int m8() {return 2;}  // OK. Have javadoc on overridable method.
+ *
+ *   &#64;Override
+ *   public String toString() {  // OK. Have javadoc on overridable method.
+ *     return "";
  *   }
- *
- *   public int foo3() {return 3;} // violation
- * }
- *
- * public class FooTest {
- *   &#64;Test
- *   public void testFoo() {
- *     final B b = new A();
- *     assertEquals(2, b.foo());
- *   }
- *
- *   public int foo4() {return 4;} // violation
  * }
  * </pre>
  * <p>
@@ -222,23 +266,45 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </p>
  * <pre>
  * &lt;module name=&quot;DesignForExtension&quot;&gt;
- *   &lt;property name=&quot;requiredJavadocPhrase&quot;
- *     value=&quot;This implementation&quot;/&gt;
+ *   &lt;property name=&quot;requiredJavadocPhrase&quot; value=&quot;This implementation&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>Example:</p>
  * <pre>
- * public class A {
- *   /&#42;&#42;
- *   &#42; This implementation ...
- *   &#42;/
- *   public int foo() {return 2;} // ok, required javadoc phrase in comment
+ * public abstract class Foo {
+ *   private int bar;
  *
- *   /&#42;&#42;
- *   &#42; Do not extend ...
- *   &#42;/
- *   public int foo2() {return 8;} // violation, required javadoc phrase not in comment
+ *   public int m1() {return 2;}  // Violation. No javadoc.
  *
- *   public int foo3() {return 3;} // violation, required javadoc phrase not in comment
+ *   public int m2() {return 8;}  // Violation. No javadoc.
+ *
+ *   private void m3() {m4();}  // OK. Private method.
+ *
+ *   protected void m4() { }  // OK. No implementation.
+ *
+ *   public abstract void m5();  // OK. Abstract method.
+ *
+ *   &#47;**
+ *    * This implementation ...
+ *    &#64;return some int value.
+ *    *&#47;
+ *   public int m6() {return 1;}  // OK. Have required javadoc.
+ *
+ *   &#47;**
+ *    * Some comments ...
+ *    *&#47;
+ *   public int m7() {return 1;}  // Violation. No required javadoc.
+ *
+ *   &#47;**
+ *    * This
+ *    * implementation ...
+ *    *&#47;
+ *   public int m8() {return 2;}  // Violation. No required javadoc.
+ *
+ *   &#64;Override
+ *   public String toString() {  // Violation. No required javadoc.
+ *     return "";
+ *   }
  * }
  * </pre>
  * <p>
@@ -252,20 +318,42 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  *     value=&quot;This[\s\S]*implementation&quot;/&gt;
  * &lt;/module&gt;
  * </pre>
+ * <p>Example:</p>
  * <pre>
- * public class A {
- *   /&#42;&#42;
- *   &#42; This
- *   &#42; implementation ...
- *   &#42;/
- *   public int foo() {return 2;} // ok, required javadoc phrase in comment
+ * public abstract class Foo {
+ *   private int bar;
  *
- *   /&#42;&#42;
- *   &#42; Do not extend ...
- *   &#42;/
- *   public int foo2() {return 8;} // violation, required javadoc phrase not in comment
+ *   public int m1() {return 2;}  // Violation. No javadoc.
  *
- *   public int foo3() {return 3;} // violation, required javadoc phrase not in comment
+ *   public int m2() {return 8;}  // Violation. No javadoc.
+ *
+ *   private void m3() {m4();}
+ *
+ *   protected void m4() { }  // OK. No implementation.
+ *
+ *   public abstract void m5();  // OK. Abstract method.
+ *
+ *   &#47;**
+ *    * This implementation ...
+ *    &#64;return some int value.
+ *    *&#47;
+ *   public int m6() {return 1;}  // OK. Have required javadoc.
+ *
+ *   &#47;**
+ *    * Some comments ...
+ *    *&#47;
+ *   public int m7() {return 1;}  // Violation. No required javadoc.
+ *
+ *   &#47;**
+ *    * This
+ *    * implementation ...
+ *    *&#47;
+ *   public int m8() {return 2;}  // OK. Have required javadoc.
+ *
+ *   &#64;Override
+ *   public String toString() {  // Violation. No required javadoc.
+ *     return "";
+ *   }
  * }
  * </pre>
  * <p>

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -137,7 +137,6 @@ public abstract class Plant {
 }
         </source>
       </subsection>
-
       <subsection name="Properties" id="DesignForExtension_Properties">
         <div class="wrapper">
           <table>
@@ -170,108 +169,190 @@ public abstract class Plant {
           </table>
         </div>
       </subsection>
-
       <subsection name="Examples" id="DesignForExtension_Examples">
         <p>
           To configure the check:
         </p>
-
         <source>
 &lt;module name=&quot;DesignForExtension&quot;/&gt;
         </source>
-
-        <p>
-          To configure the check to allow methods which have @Override and @Test annotations to be
-          designed for extension.
-        </p>
-
+        <p>Example:</p>
         <source>
-&lt;module name=&quot;DesignForExtension&quot;&gt;
-  &lt;property name=&quot;ignoredAnnotations&quot; value=&quot;Override, Test&quot;/&gt;
-&lt;/module&gt;
-        </source>
+public abstract class Foo {
+  private int bar;
 
-        <source>
-public class A {
-  @Override
-  public int foo() {
-    return 2;
-  }
+  public int m1() {return 2;}  // Violation. No javadoc.
 
-  public int foo2() {return 8;} // violation
-}
+  public int m2() {return 8;}  // Violation. No javadoc.
 
-public class B {
+  private void m3() {m4();}  // OK. Private method.
+
+  protected void m4() { }  // OK. No implementation.
+
+  public abstract void m5();  // OK. Abstract method.
+
   /**
    * This implementation ...
-     @return some int value.
+   @return some int value.
    */
-  public int foo() {
-    return 1;
+  public int m6() {return 1;}  // OK. Have javadoc on overridable method.
+
+  /**
+   * Some comments ...
+   */
+  public int m7() {return 1;}  // OK. Have javadoc on overridable method.
+
+  /**
+   * This
+   * implementation ...
+   */
+  public int m8() {return 2;}  // OK. Have javadoc on overridable method.
+
+  @Override
+  public String toString() {  // Violation. No javadoc for @Override method.
+    return "";
   }
-
-  public int foo3() {return 3;} // violation
-}
-
-public class FooTest {
-  @Test
-  public void testFoo() {
-    final B b = new A();
-    assertEquals(2, b.foo());
-  }
-
-  public int foo4() {return 4;} // violation
 }
         </source>
         <p>
-          To configure the check to allow methods which contain a specified comment text
-          pattern in their javadoc to be designed for extension.
+          To configure the check to allow methods which have @Override annotations to be
+          designed for extension.
         </p>
         <source>
-&lt;module name=&quot;DesignForExtension&quot;&gt;
-  &lt;property name=&quot;requiredJavadocPhrase&quot; value=&quot;This implementation&quot;/&gt;
+&lt;module name="DesignForExtension"&gt;
+  &lt;property name="ignoredAnnotations" value="Override"/&gt;
 &lt;/module&gt;
         </source>
+        <p>Example:</p>
         <source>
-public class A {
-      /&#42;&#42;
-       &#42; This implementation ...
-       &#42;/
-      public int foo() {return 2;} // ok, required javadoc phrase in comment
+public abstract class Foo {
+  private int bar;
 
-      /&#42;&#42;
-       &#42; Do not extend ...
-       &#42;/
-      public int foo2() {return 8;} // violation, required javadoc phrase not in comment
+  public int m1() {return 2;}  // Violation. No javadoc.
 
-  public int foo3() {return 3;} // violation, required javadoc phrase not in comment
+  public int m2() {return 8;}  // Violation. No javadoc.
+
+  private void m3() {m4();}  // OK. Private method.
+
+  protected void m4() { }  // OK. No implementation.
+
+  public abstract void m5();  // OK. Abstract method.
+
+  /**
+   * This implementation ...
+   @return some int value.
+   */
+  public int m6() {return 1;}  // OK. Have javadoc on overridable method.
+
+  /**
+   * Some comments ...
+   */
+  public int m7() {return 1;}  // OK. Have javadoc on overridable method.
+
+  /**
+   * This
+   * implementation ...
+   */
+  public int m8() {return 2;}  // OK. Have javadoc on overridable method.
+
+  @Override
+  public String toString() {  // OK. Have javadoc on overridable method.
+    return "";
+  }
+}
+        </source>
+        <p>To configure the check to allow methods which contain a specified comment text pattern in
+          their javadoc to be designed for extension.
+        </p>
+        <source>
+&lt;module name="DesignForExtension"&gt;
+  &lt;property name="requiredJavadocPhrase" value="This implementation"/&gt;
+&lt;/module&gt;
+        </source>
+        <p>Example:</p>
+        <source>
+public abstract class Foo {
+  private int bar;
+
+  public int m1() {return 2;}  // Violation. No javadoc.
+
+  public int m2() {return 8;}  // Violation. No javadoc.
+
+  private void m3() {m4();}  // OK. Private method.
+
+  protected void m4() { }  // OK. No implementation.
+
+  public abstract void m5();  // OK. Abstract method.
+
+  /**
+   * This implementation ...
+   @return some int value.
+   */
+  public int m6() {return 1;}  // OK. Have required javadoc.
+
+  /**
+   * Some comments ...
+   */
+  public int m7() {return 1;}  // Violation. No required javadoc.
+
+  /**
+   * This
+   * implementation ...
+   */
+  public int m8() {return 2;}  // Violation. No required javadoc.
+
+  @Override
+  public String toString() {  // Violation. No required javadoc.
+    return "";
+  }
 }
         </source>
         <p>
-          To configure the check to allow methods which contain a specified comment text
-          pattern in their javadoc which can span multiple lines
-          to be designed for extension.
+          To configure the check to allow methods which contain a specified comment text pattern in
+          their javadoc which can span multiple lines to be designed for extension.
         </p>
         <source>
-&lt;module name=&quot;DesignForExtension&quot;&gt;
-  &lt;property name=&quot;requiredJavadocPhrase&quot;
-          value=&quot;This[\s\S]*implementation&quot;/&gt;
+&lt;module name="DesignForExtension"&gt;
+  &lt;property name="requiredJavadocPhrase"
+    value="This[\s\S]*implementation"/&gt;
 &lt;/module&gt;
         </source>
+        <p>Example:</p>
         <source>
-public class A {
-    /&#42;&#42;
-     &#42; This
-     &#42; implementation ...
-     &#42;/
-    public int foo() {return 2;} // ok, required javadoc phrase in comment
+public abstract class Foo {
+  private int bar;
 
-    /&#42;&#42;
-     &#42; Do not extend ...
-     &#42;/
-    public int foo2() {return 8;} // violation, required javadoc phrase not in comment
+  public int m1() {return 2;}  // Violation. No javadoc.
 
-    public int foo3() {return 3;} // violation, required javadoc phrase not in comment
+  public int m2() {return 8;}  // Violation. No javadoc.
+
+  private void m3() {m4();}
+
+  protected void m4() { }  // OK. No implementation.
+
+  public abstract void m5();  // OK. Abstract method.
+
+  /**
+   * This implementation ...
+   @return some int value.
+   */
+  public int m6() {return 1;}  // OK. Have required javadoc.
+
+  /**
+   * Some comments ...
+   */
+  public int m7() {return 1;}  // Violation. No required javadoc.
+
+  /**
+   * This
+   * implementation ...
+   */
+  public int m8() {return 2;}  // OK. Have required javadoc.
+
+  @Override
+  public String toString() {  // Violation. No required javadoc.
+    return "";
+  }
 }
         </source>
       </subsection>


### PR DESCRIPTION
# Issue #7608: Update doc for DesignForExtension

[x] Updated doc starts with default config and example, followed by properties and their examples
[x] Passed that command `mvn clean verify` pass without violations
[x] Screenshots of how website looks like are attached below
[x] CLI results of different examples are attached below

## Screenshots of website
<img width="616" alt="Screen Shot 2023-03-27 at 7 51 17 PM" src="https://user-images.githubusercontent.com/29494959/228149621-5dacdce9-66fb-4d39-a676-40602aeb5541.png">
<img width="630" alt="Screen Shot 2023-03-27 at 7 52 00 PM" src="https://user-images.githubusercontent.com/29494959/228149697-be09c0d8-ab6a-4b58-8c6b-e34aaf2c8be6.png">
<img width="691" alt="Screen Shot 2023-03-27 at 7 52 15 PM" src="https://user-images.githubusercontent.com/29494959/228149732-9ea905e2-8262-4c0d-9d97-7d706b565ee4.png">
<img width="841" alt="Screen Shot 2023-03-27 at 7 52 33 PM" src="https://user-images.githubusercontent.com/29494959/228149775-96fbbdc3-5bfe-4edd-a2b5-afbe997d43b4.png">

## CLI Results for Examples
### Example for Default Config
```terminal
(base) a9527@9527deMacBook-Pro java % javac Foo.java
(base) a9527@9527deMacBook-Pro java % cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="DesignForExtension"/>
  </module>
</module>
(base) a9527@9527deMacBook-Pro java % cat Foo.java  
public abstract class Foo {
  private int bar;

  public int method1() {return 2;}

  public int method2() {return 8;}

  private void method3() {method4();}

  protected void method4() { }

  public abstract void method5();
  /**
   * This implementation ...
   @return some int value.
   */
  public int method6() {return 1;}

  /**
   * Some comments ...
   */
  public int method7() {return 1;}

  /**
   * This
   * implementation ...
   */
  public int method8() {return 2;}

  @Override
  public String toString() {
    return "Foo{" +
        "bar=" + bar +
        '}';
  }
}
(base) a9527@9527deMacBook-Pro java % java -classpath ../../../out/artifacts/learn_checkstyle_jar/learn-checkstyle.jar:../../../../libcheckstyle-10.9.2-all.jar com.puppycrawl.tools.checkstyle.Main -c ./config.xml Foo.java 
Starting audit...
[ERROR] /Users/CS/learn-checkstyle/src/main/java/Foo.java:4:3: Class 'Foo' looks like designed for extension (can be subclassed), but the method 'method1' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'Foo' final or making the method 'method1' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] /Users/CS/learn-checkstyle/src/main/java/Foo.java:6:3: Class 'Foo' looks like designed for extension (can be subclassed), but the method 'method2' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'Foo' final or making the method 'method2' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] /Users/CS/learn-checkstyle/src/main/java/Foo.java:30:3: Class 'Foo' looks like designed for extension (can be subclassed), but the method 'toString' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'Foo' final or making the method 'toString' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
Audit done.
Checkstyle ends with 3 errors.      
```

### Example for Config Property `igonredAnnotations`
```
(base) a9527@9527deMacBook-Pro java % javac Foo.java                                                                                                                                                                          
(base) a9527@9527deMacBook-Pro java % cat config.xml                                                                                                                                                                          
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="DesignForExtension">
      <property name="ignoredAnnotations" value="Override"/>
    </module>
  </module>
</module>
(base) a9527@9527deMacBook-Pro java % cat Foo.java                                                                                                                                                                            
public abstract class Foo {
  private int bar;

  public int method1() {return 2;}

  public int method2() {return 8;}

  private void method3() {method4();}

  protected void method4() { }

  public abstract void method5();
  /**
   * This implementation ...
   @return some int value.
   */
  public int method6() {return 1;}

  /**
   * Some comments ...
   */
  public int method7() {return 1;}

  /**
   * This
   * implementation ...
   */
  public int method8() {return 2;}

  @Override
  public String toString() {
    return "Foo{" +
        "bar=" + bar +
        '}';
  }
}%                                                                                                                                                                                                                                      (base) a9527@9527deMacBook-Pro java % java -classpath ../../../out/artifacts/learn_checkstyle_jar/learn-checkstyle.jar:../../../../libcheckstyle-10.9.2-all.jar com.puppycrawl.tools.checkstyle.Main -c ./config.xml Foo.java 
Starting audit...
[ERROR] /Users/CS/learn-checkstyle/src/main/java/Foo.java:4:3: Class 'Foo' looks like designed for extension (can be subclassed), but the method 'method1' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'Foo' final or making the method 'method1' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] /Users/CS/learn-checkstyle/src/main/java/Foo.java:6:3: Class 'Foo' looks like designed for extension (can be subclassed), but the method 'method2' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'Foo' final or making the method 'method2' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
Audit done.
Checkstyle ends with 2 errors.
```

### Example for Config Property `requiredJavadocPhrase` (one line)
```
(base) a9527@9527deMacBook-Pro java % javac Foo.java                                                                                                                                                                          
(base) a9527@9527deMacBook-Pro java % cat config.xml                                                                                                                                                                          
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="DesignForExtension">
      <property name="requiredJavadocPhrase" value="This implementation"/>
    </module>
  </module>
</module>
(base) a9527@9527deMacBook-Pro java % cat Foo.java                                                                                                                                                                            
public abstract class Foo {
  private int bar;

  public int method1() {return 2;}

  public int method2() {return 8;}

  private void method3() {method4();}

  protected void method4() { }

  public abstract void method5();
  /**
   * This implementation ...
   @return some int value.
   */
  public int method6() {return 1;}

  /**
   * Some comments ...
   */
  public int method7() {return 1;}

  /**
   * This
   * implementation ...
   */
  public int method8() {return 2;}

  @Override
  public String toString() {
    return "Foo{" +
        "bar=" + bar +
        '}';
  }
}%                                                                                                                                                                                                                                      (base) a9527@9527deMacBook-Pro java % java -classpath ../../../out/artifacts/learn_checkstyle_jar/learn-checkstyle.jar:../../../../libcheckstyle-10.9.2-all.jar com.puppycrawl.tools.checkstyle.Main -c ./config.xml Foo.java 
Starting audit...
[ERROR] /Users/CS/learn-checkstyle/src/main/java/Foo.java:4:3: Class 'Foo' looks like designed for extension (can be subclassed), but the method 'method1' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'Foo' final or making the method 'method1' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] /Users/CS/learn-checkstyle/src/main/java/Foo.java:6:3: Class 'Foo' looks like designed for extension (can be subclassed), but the method 'method2' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'Foo' final or making the method 'method2' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] /Users/CS/learn-checkstyle/src/main/java/Foo.java:22:3: Class 'Foo' looks like designed for extension (can be subclassed), but the method 'method7' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'Foo' final or making the method 'method7' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] /Users/CS/learn-checkstyle/src/main/java/Foo.java:28:3: Class 'Foo' looks like designed for extension (can be subclassed), but the method 'method8' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'Foo' final or making the method 'method8' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] /Users/CS/learn-checkstyle/src/main/java/Foo.java:30:3: Class 'Foo' looks like designed for extension (can be subclassed), but the method 'toString' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'Foo' final or making the method 'toString' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
Audit done.
Checkstyle ends with 5 errors.
```

### Example for Config Property `requiredJavadocPhrase` (span in multiple line)
```
(base) a9527@9527deMacBook-Pro java % javac Foo.java                                                                                                                                                                          
(base) a9527@9527deMacBook-Pro java % cat config.xml                                                                                                                                                                          
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="DesignForExtension">
      <property name="requiredJavadocPhrase" value="This[\s\S]*implementation"/>
    </module>
  </module>
</module>
(base) a9527@9527deMacBook-Pro java % cat Foo.java                                                                                                                                                                            
public abstract class Foo {
  private int bar;

  public int method1() {return 2;}

  public int method2() {return 8;}

  private void method3() {method4();}

  protected void method4() { }

  public abstract void method5();
  /**
   * This implementation ...
   @return some int value.
   */
  public int method6() {return 1;}

  /**
   * Some comments ...
   */
  public int method7() {return 1;}

  /**
   * This
   * implementation ...
   */
  public int method8() {return 2;}

  @Override
  public String toString() {
    return "Foo{" +
        "bar=" + bar +
        '}';
  }
}%                                                                                                                                                                                                                                      (base) a9527@9527deMacBook-Pro java % java -classpath ../../../out/artifacts/learn_checkstyle_jar/learn-checkstyle.jar:../../../../libcheckstyle-10.9.2-all.jar com.puppycrawl.tools.checkstyle.Main -c ./config.xml Foo.java 
Starting audit...
[ERROR] /Users/CS/learn-checkstyle/src/main/java/Foo.java:4:3: Class 'Foo' looks like designed for extension (can be subclassed), but the method 'method1' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'Foo' final or making the method 'method1' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] /Users/CS/learn-checkstyle/src/main/java/Foo.java:6:3: Class 'Foo' looks like designed for extension (can be subclassed), but the method 'method2' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'Foo' final or making the method 'method2' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] /Users/CS/learn-checkstyle/src/main/java/Foo.java:22:3: Class 'Foo' looks like designed for extension (can be subclassed), but the method 'method7' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'Foo' final or making the method 'method7' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] /Users/CS/learn-checkstyle/src/main/java/Foo.java:30:3: Class 'Foo' looks like designed for extension (can be subclassed), but the method 'toString' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'Foo' final or making the method 'toString' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
Audit done.
Checkstyle ends with 4 errors.
```