### PR TITLE
Issue #12853: Generate site workflow should provide more specific links

### DIFF
--- a/.ci/generate-extra-site-links.sh
+++ b/.ci/generate-extra-site-links.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -e
+
+source ./.ci/util.sh
+
+PR_NUMBER=$1
+AWS_FOLDER_LINK=$2
+
+if [[ -z $PR_NUMBER || -z $AWS_FOLDER_LINK ]]; then
+  echo "not all parameters are set"
+  echo "Usage: $BASH_SCRIPT <pull request number> <aws folder link>"
+  exit 1
+fi
+
+checkForVariable "GITHUB_TOKEN"
+checkForVariable "REPOSITORY_OWNER"
+echo "PR_NUMBER=$PR_NUMBER"
+echo "AWS_FOLDER_LINK=$AWS_FOLDER_LINK"
+
+# Extract a list of the changed xdocs in the pull request. For example 'src/xdocs/config_misc.xml'.
+CHANGED_XDOCS_PATHS=$(curl --fail-with-body -Ls \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  "https://api.github.com/repos/$REPOSITORY_OWNER/checkstyle/pulls/$PR_NUMBER/files?per_page=100" |
+  jq -r ".[] | .filename" | grep src/xdocs/ || true)
+echo "CHANGED_XDOCS_PATHS=$CHANGED_XDOCS_PATHS"
+
+if [[ -z "$CHANGED_XDOCS_PATHS" ]]; then
+  echo "[WARN] No xdocs were changed in the pull request."
+  exit 0
+fi
+
+# Fetch the diff of the pull request.
+PR_DIFF=$(curl --fail-with-body -s \
+  "https://patch-diff.githubusercontent.com/raw/$REPOSITORY_OWNER/checkstyle/pull/$PR_NUMBER.diff")
+
+# Iterate through all changed xdocs files.
+while IFS= read -r CURRENT_XDOC_PATH
+do
+  # Extract the line number of the earliest change in the file, i.e. '90'.
+  EARLIEST_CHANGE_LINE_NUMBER=$(echo "$PR_DIFF" | grep -A 5 "diff.*$CURRENT_XDOC_PATH" | grep @@ |
+    head -1 | grep -oEi "[0-9]+" | head -1)
+  echo "EARLIEST_CHANGE_LINE_NUMBER=$EARLIEST_CHANGE_LINE_NUMBER"
+
+  # Find the id of the nearest subsection to the change.
+  while read -r CURRENT_LINE
+  do
+    # When the line contains 'id='.
+    if [[ $CURRENT_LINE =~ id\= ]]
+    then
+      # Extract the id value from the line.
+      SUBSECTION_ID=$(echo "$CURRENT_LINE" | grep -Eo 'id="[^"]+"' | sed 's/id="\([^"]*\)"/\1/')
+      echo "SUBSECTION_ID=$SUBSECTION_ID"
+      break
+    fi
+  # Read the file from the earliest change to the top. It would read first row 90, then 89, 88..1.
+  done < <(head -n "$EARLIEST_CHANGE_LINE_NUMBER" "$CURRENT_XDOC_PATH" | tac)
+
+  # Extract file name from path, i.e. 'config_misc'.
+  CURRENT_XDOC_NAME=$(echo "$CURRENT_XDOC_PATH" | sed 's/src\/xdocs\/\(.*\)\.xml/\1/')
+  echo "CURRENT_XDOC_NAME=$CURRENT_XDOC_NAME"
+
+  echo "" >> ../message # Add new line between each xdoc link.
+  echo "$AWS_FOLDER_LINK/$CURRENT_XDOC_NAME.html#$SUBSECTION_ID" >> ../message
+
+  # Reset variable.
+  SUBSECTION_ID=""
+done <<< "$CHANGED_XDOCS_PATHS"

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -101,6 +101,9 @@ jobs:
           mvn -e --no-transfer-progress clean site -Pno-validations -Dmaven.javadoc.skip=false
 
       - name: Copy site to AWS S3 Bucket
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
         run: |
           bash
           TIME=$(date +%Y%H%M%S)
@@ -109,10 +112,16 @@ jobs:
           LINK="https://${{env.AWS_BUCKET_NAME}}.s3.${{env.AWS_REGION}}.amazonaws.com"
           aws s3 cp "$SITE" "s3://${{env.AWS_BUCKET_NAME}}/$FOLDER/" --recursive
           echo "$LINK/$FOLDER/index.html" > message
+          cd checkstyle
+          ./.ci/generate-extra-site-links.sh ${{ github.event.issue.number }} "$LINK/$FOLDER"
 
       - name: Set output
         id: out
-        run: echo "message=$(cat message)" >> "$GITHUB_OUTPUT"
+        run: |
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "message<<$EOF" >> "$GITHUB_OUTPUT"
+          cat message >> "$GITHUB_OUTPUT"
+          echo "$EOF" >> "$GITHUB_OUTPUT"
 
   # should be always last step
   send_message:
@@ -141,7 +150,11 @@ jobs:
 
       - name: Set message
         id: out
-        run: echo "message=$(cat message)" >> "$GITHUB_OUTPUT"
+        run: |
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "message<<$EOF" >> "$GITHUB_OUTPUT"
+          cat message >> "$GITHUB_OUTPUT"
+          echo "$EOF" >> "$GITHUB_OUTPUT"
 
       - name: Comment PR
         uses: checkstyle/contribution/comment-action@master

--- a/config/jsoref-spellchecker/whitelist.words
+++ b/config/jsoref-spellchecker/whitelist.words
@@ -361,6 +361,7 @@ edb
 edef
 edu
 Eghj
+Ei
 ej
 ejb
 elasticsearch
@@ -1279,6 +1280,7 @@ Sys
 sysextensions
 sysprop
 systemout
+tac
 Taglib
 taglist
 taskdef
@@ -1363,6 +1365,7 @@ unusedlocalvariable
 uppercased
 upperell
 upsss
+urandom
 uri
 url
 userguide


### PR DESCRIPTION
Resolves #12853
Actions job: https://github.com/stoyanK7/checkstyle/actions/runs/4552768971/jobs/8028554421#step:3:19
Comment: https://github.com/stoyanK7/checkstyle/pull/62#issuecomment-1488315182

![Screenshot from 2023-03-29 12-00-21](https://user-images.githubusercontent.com/23459549/228499369-1b3561d0-988c-463f-baba-ac5ce72dd968.png)

---
The script is flexible enough to detect that multiple xdoc files were changed.

The script picks the earliest line that has been changed in the xdoc file. Let's say that lines 25 to 30 have been changed and lines 89 to 100. The script would pick line 25 and  start from it up (24, 23, 22, 21...) until it finds a row with an `id=".*"`(a (sub)section). Then it extracts the id and creates the link based on the name of the changed xdoc and the id.

Cases covered:
- New xdoc created (it would generate a link with `#` at the end which is valid)
- First line changed (there is no id above it so it would generate a link with `#` at the end which is valid)
- Deleted lines
- Added lines
- Changed lines