### PR TITLE
Issue #12923: UnusedImports does not report unused static imports whe…

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -285,10 +285,14 @@ public class UnusedImportsCheck extends AbstractCheck {
                 && !TokenUtil.isOfType(ast.getPreviousSibling(), TokenTypes.DOT)
                 && ast.getNextSibling() != null;
 
+        final boolean isPossibleDotMethodRefMethodName = parentType == TokenTypes.METHOD_REF
+                && ast.getPreviousSibling() != null;
+
         if (TokenUtil.isTypeDeclaration(parentType)) {
             currentFrame.addDeclaredType(ast.getText());
         }
-        else if (!isPossibleDotClassOrInMethod || isQualifiedIdent) {
+        else if (!isPossibleDotMethodRefMethodName
+                && (!isPossibleDotClassOrInMethod || isQualifiedIdent)) {
             currentFrame.addReferencedType(ast.getText());
         }
     }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
@@ -297,6 +297,7 @@ public class UnusedImportsCheckTest extends AbstractModuleTestSupport {
             "13:8: " + getCheckMessage(MSG_KEY, "java.util.Set"),
             "16:8: " + getCheckMessage(MSG_KEY, "com.puppycrawl.tools.checkstyle.checks.imports."
                     + "unusedimports.InputUnusedImportsShadowed"),
+            "22:15: " + getCheckMessage(MSG_KEY, "java.lang.String.format"),
         };
         verifyWithInlineConfigParser(
                 getPath("InputUnusedImportsShadowed.java"), expected);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsShadowed.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImportsShadowed.java
@@ -19,6 +19,10 @@ import com.puppycrawl.tools.checkstyle.checks.imports.unusedimports.InputUnusedI
 import com.puppycrawl.tools.checkstyle.checks.imports.unusedimports.InputUnusedImportsShadowed.Inner; // ok
 import com.puppycrawl.tools.checkstyle.checks.imports.unusedimports.InputUnusedImportsShadowed.Nested; // ok
 import com.puppycrawl.tools.checkstyle.checks.imports.unusedimports.InputUnusedImportsShadowed.Nested.List.Map.Entry; // ok
+import static java.lang.String.format; // violation
+import java.util.Objects; // ok
+import java.util.Optional; //ok
+
 
 @Deprecated(foo = Foo.class, classes = {Inner.class})
 public class InputUnusedImportsShadowed
@@ -88,6 +92,18 @@ public class InputUnusedImportsShadowed
             class List {
             }
         }
+    }
+
+    void testMethodRef()
+    {
+        Optional<String> test = Optional.empty();
+        test.map(String::format);
+    }
+
+    void testMethodRefWithClass()
+    {
+        Optional<String> test = Optional.empty();
+        test.map(Objects::nonNull);
     }
 
 }


### PR DESCRIPTION
…n the method is used as a method reference

Added an additional check to not include method ref into referenced types.

