### PR TITLE
Issue #12678: Re-enable action lint

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -3,8 +3,12 @@ on:
   push:
     branches:
       - master
+    paths:
+      - '.github/workflows/**'
   pull_request:
     branches: '*'
+    paths:
+      - '.github/workflows/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -14,8 +18,11 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Check workflow files
         uses: docker://rhysd/actionlint:latest
         with:
-          args: -color
+          # Until https://github.com/checkstyle/checkstyle/issues/12696
+          args: -ignore ".* was deprecated.*"

--- a/.github/workflows/release-new-milestone-and-issues-in-other-repos.yml
+++ b/.github/workflows/release-new-milestone-and-issues-in-other-repos.yml
@@ -15,9 +15,6 @@ on:
       version:
         type: string
         required: true
-      concurrency-group:
-        type: string
-        required: true
 
 permissions:
   contents: write
@@ -25,7 +22,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}
-    -${{ github.event.pull_request.number || github.ref }}-${{ inputs.concurrency-group }}
+    -${{ github.event.pull_request.number || github.ref }}-new-milestone-and-issues-in-other-repos
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release-publish-releasenotes-twitter.yml
+++ b/.github/workflows/release-publish-releasenotes-twitter.yml
@@ -15,13 +15,10 @@ on:
       version:
         type: string
         required: true
-      concurrency-group:
-        type: string
-        required: true
 
 concurrency:
   group: ${{ github.workflow }}
-    -${{ github.event.pull_request.number || github.ref }}-${{ inputs.concurrency-group }}
+    -${{ github.event.pull_request.number || github.ref }}-publish-releasenotes-twitter
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release-update-github-io.yml
+++ b/.github/workflows/release-update-github-io.yml
@@ -15,13 +15,10 @@ on:
       version:
         type: string
         required: true
-      concurrency-group:
-        type: string
-        required: true
 
 concurrency:
   group: ${{ github.workflow }}
-    -${{ github.event.pull_request.number || github.ref }}-${{ inputs.concurrency-group }}
+    -${{ github.event.pull_request.number || github.ref }}-update-github-io
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release-update-github-page.yml
+++ b/.github/workflows/release-update-github-page.yml
@@ -15,13 +15,10 @@ on:
       version:
         type: string
         required: true
-      concurrency-group:
-        type: string
-        required: true
 
 concurrency:
   group: ${{ github.workflow }}
-    -${{ github.event.pull_request.number || github.ref }}-${{ inputs.concurrency-group }}
+    -${{ github.event.pull_request.number || github.ref }}-update-github-page
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release-upload-all-jar.yml
+++ b/.github/workflows/release-upload-all-jar.yml
@@ -15,16 +15,13 @@ on:
       version:
         type: string
         required: true
-      concurrency-group:
-        type: string
-        required: true
 
 permissions:
   contents: write
 
 concurrency:
   group: ${{ github.workflow }}
-    -${{ github.event.pull_request.number || github.ref }}-${{ inputs.concurrency-group }}
+    -${{ github.event.pull_request.number || github.ref }}-upload-all-jar
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,6 @@ jobs:
     needs: maven-perform
     with:
       version: ${{ inputs.version }}
-      concurrency-group: update-github-page
     secrets: inherit
     permissions:
       contents: write
@@ -55,7 +54,6 @@ jobs:
     needs: update-github-page
     with:
       version: ${{ inputs.version }}
-      concurrency-group: upload-all-jar
     secrets: inherit
     permissions:
       contents: write
@@ -65,7 +63,6 @@ jobs:
     needs: update-github-page
     with:
       version: ${{ inputs.version }}
-      concurrency-group: new-milestone-and-issues-in-other-repos
     secrets: inherit
     permissions:
       contents: write
@@ -76,7 +73,6 @@ jobs:
     needs: update-github-page
     with:
       version: ${{ inputs.version }}
-      concurrency-group: publish-releasenotes-twitter
     secrets: inherit
 
   update-github-io:
@@ -84,7 +80,6 @@ jobs:
     needs: maven-perform
     with:
       version: ${{ inputs.version }}
-      concurrency-group: update-github-io
     secrets: inherit
 
   copy-github-io-to-sourceforge:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -119,9 +119,11 @@ jobs:
         id: out
         run: |
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "message<<$EOF" >> "$GITHUB_OUTPUT"
-          cat message >> "$GITHUB_OUTPUT"
-          echo "$EOF" >> "$GITHUB_OUTPUT"
+          {
+            echo "message<<$EOF"
+            cat message
+            echo "$EOF"
+          } >> "$GITHUB_OUTPUT"
 
   # should be always last step
   send_message:
@@ -152,9 +154,11 @@ jobs:
         id: out
         run: |
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "message<<$EOF" >> "$GITHUB_OUTPUT"
-          cat message >> "$GITHUB_OUTPUT"
-          echo "$EOF" >> "$GITHUB_OUTPUT"
+          {
+            echo "message<<$EOF"
+            cat message
+            echo "$EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Comment PR
         uses: checkstyle/contribution/comment-action@master


### PR DESCRIPTION
Resolves #12678

https://github.com/checkstyle/checkstyle/issues/12678#issuecomment-1488545090

---
The following errors were present:
https://github.com/stoyanK7/checkstyle/actions/runs/4553573127/jobs/8030294702#step:4:6
```
.github/workflows/release-new-milestone-and-issues-in-other-repos.yml:27:92: property "concurrency-group" is not defined in object type {version: any} [expression]
.github/workflows/release-publish-releasenotes-twitter.yml:23:92: property "concurrency-group" is not defined in object type {version: any} [expression]
.github/workflows/release-update-github-io.yml:23:92: property "concurrency-group" is not defined in object type {version: any} [expression]
.github/workflows/release-update-github-page.yml:23:92: property "concurrency-group" is not defined in object type {version: any} [expression]
.github/workflows/release-upload-all-jar.yml:26:92: property "concurrency-group" is not defined in object type {version: any} [expression]
```
Success run after they were fixed: https://github.com/stoyanK7/checkstyle/actions/runs/4566213905/jobs/8058397704#step:4:5