### PR TITLE
Issue #7608: Update doc for DesignForExtension

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
@@ -76,7 +76,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * <blockquote>The class must document its self-use of overridable methods.
  * By convention, a method that invokes overridable methods contains a description
  * of these invocations at the end of its documentation comment. The description
- * begins with the phrase “This implementation.”
+ * begins with the phrase "This implementation."
  * </blockquote>
  * <blockquote>
  * The best solution to this problem is to prohibit subclassing in classes that
@@ -177,35 +177,43 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </pre>
  * <p>Example:</p>
  * <pre>
- * public abstract class Foo {
+ * public class A {
+ *   protected void foo1() {};  // OK. Abstract method.
+ *
+ *   protected static void foo2() {};  // OK. protected and static method.
+ *
+ *   protected final void foo3() {};  // OK. protected and final method.
+ *   }
+ *
+ * public class B extends A {
+ *   protected void foo1() { int arg; };  // Violation. The @Override annotation is missing.
+ *
+ *   protected static void foo2() { int arg; };  // Violation. The @Override annotation is missing.
+ *
+ *   protected final void foo3() { int arg; };  // Violation. The @Override annotation is missing.
+ *   }
+ *
+ * public class C {
  *   private int bar;
  *
- *   public int m1() {return 2;}  // Violation. No javadoc.
+ *   public int foo4() { return 1; }  // Violation, required javadoc phrase not in comment.
  *
- *   public int m2() {return 8;}  // Violation. No javadoc.
+ *   private void foo5() { foo6(); }  // OK. Private method.
  *
- *   private void m3() {m4();}  // OK. Private method.
+ *   protected void foo6() { }  // OK. No implementation.
  *
- *   protected void m4() { }  // OK. No implementation.
+ *   public abstract void foo7();  // OK. Abstract method.
  *
- *   public abstract void m5();  // OK. Abstract method.
+ *   /&#42;&#42;
+ *   &#42; This
+ *   &#42; implementation ...
+ *   &#42;/
+ *   public int foo8() {return 8;}  // OK. Required javadoc phrase in comment.
  *
- *   &#47;**
- *    * This implementation ...
- *    &#64;return some int value.
- *    *&#47;
- *   public int m6() {return 1;}  // OK. Have javadoc on overridable method.
- *
- *   &#47;**
- *    * Some comments ...
- *    *&#47;
- *   public int m7() {return 1;}  // OK. Have javadoc on overridable method.
- *
- *   &#47;**
- *    * This
- *    * implementation ...
- *    *&#47;
- *   public int m8() {return 2;}  // OK. Have javadoc on overridable method.
+ *   /&#42;&#42;
+ *   &#42; Do not extend ...
+ *   &#42;/
+ *   public int foo9() {return 9;}  // Violation, required javadoc phrase not in comment.
  *
  *   &#64;Override
  *   public String toString() {  // Violation. No javadoc for @Override method.
@@ -224,38 +232,46 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </pre>
  * <p>Example:</p>
  * <pre>
- * public abstract class Foo {
+ * public class A {
+ *   protected void foo1() {};  // OK. Abstract method.
+ *
+ *   protected static void foo2() {};  // OK. protected and static method.
+ *
+ *   protected final void foo3() {};  // OK. protected and final method.
+ *   }
+ *
+ * public class B extends A {
+ *   protected void foo1() { int arg; };  // Violation. The @Override annotation is missing.
+ *
+ *   protected static void foo2() { int arg; };  // Violation. The @Override annotation is missing.
+ *
+ *   protected final void foo3() { int arg; };  // Violation. The @Override annotation is missing.
+ *   }
+ *
+ * public class C {
  *   private int bar;
  *
- *   public int m1() {return 2;}  // Violation. No javadoc.
+ *   public int foo4() { return 1; }  // Violation, required javadoc phrase not in comment.
  *
- *   public int m2() {return 8;}  // Violation. No javadoc.
+ *   private void foo5() { foo6(); }  // OK. Private method.
  *
- *   private void m3() {m4();}  // OK. Private method.
+ *   protected void foo6() { }  // OK. No implementation.
  *
- *   protected void m4() { }  // OK. No implementation.
+ *   public abstract void foo7();  // OK. Abstract method.
  *
- *   public abstract void m5();  // OK. Abstract method.
+ *   /&#42;&#42;
+ *   &#42; This
+ *   &#42; implementation ...
+ *   &#42;/
+ *   public int foo8() {return 8;}  // OK. Required javadoc phrase in comment.
  *
- *   &#47;**
- *    * This implementation ...
- *    &#64;return some int value.
- *    *&#47;
- *   public int m6() {return 1;}  // OK. Have javadoc on overridable method.
- *
- *   &#47;**
- *    * Some comments ...
- *    *&#47;
- *   public int m7() {return 1;}  // OK. Have javadoc on overridable method.
- *
- *   &#47;**
- *    * This
- *    * implementation ...
- *    *&#47;
- *   public int m8() {return 2;}  // OK. Have javadoc on overridable method.
+ *   /&#42;&#42;
+ *   &#42; Do not extend ...
+ *   &#42;/
+ *   public int foo9() {return 9;}  // Violation, required javadoc phrase not in comment.
  *
  *   &#64;Override
- *   public String toString() {  // OK. Have javadoc on overridable method.
+ *   public String toString() {  // Violation. No javadoc for @Override method.
  *     return "";
  *   }
  * }
@@ -271,38 +287,46 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </pre>
  * <p>Example:</p>
  * <pre>
- * public abstract class Foo {
+ * public class A {
+ *   protected void foo1() {};  // OK. Abstract method.
+ *
+ *   protected static void foo2() {};  // OK. protected and static method.
+ *
+ *   protected final void foo3() {};  // OK. protected and final method.
+ *   }
+ *
+ * public class B extends A {
+ *   protected void foo1() { int arg; };  // Violation. The @Override annotation is missing.
+ *
+ *   protected static void foo2() { int arg; };  // Violation. The @Override annotation is missing.
+ *
+ *   protected final void foo3() { int arg; };  // Violation. The @Override annotation is missing.
+ *   }
+ *
+ * public class C {
  *   private int bar;
  *
- *   public int m1() {return 2;}  // Violation. No javadoc.
+ *   public int foo4() { return 1; }  // Violation, required javadoc phrase not in comment.
  *
- *   public int m2() {return 8;}  // Violation. No javadoc.
+ *   private void foo5() { foo6(); }  // OK. Private method.
  *
- *   private void m3() {m4();}  // OK. Private method.
+ *   protected void foo6() { }  // OK. No implementation.
  *
- *   protected void m4() { }  // OK. No implementation.
+ *   public abstract void foo7();  // OK. Abstract method.
  *
- *   public abstract void m5();  // OK. Abstract method.
+ *   /&#42;&#42;
+ *   &#42; This
+ *   &#42; implementation ...
+ *   &#42;/
+ *   public int foo8() {return 8;}  // OK. Required javadoc phrase in comment.
  *
- *   &#47;**
- *    * This implementation ...
- *    &#64;return some int value.
- *    *&#47;
- *   public int m6() {return 1;}  // OK. Have required javadoc.
- *
- *   &#47;**
- *    * Some comments ...
- *    *&#47;
- *   public int m7() {return 1;}  // Violation. No required javadoc.
- *
- *   &#47;**
- *    * This
- *    * implementation ...
- *    *&#47;
- *   public int m8() {return 2;}  // Violation. No required javadoc.
+ *   /&#42;&#42;
+ *   &#42; Do not extend ...
+ *   &#42;/
+ *   public int foo9() {return 9;}  // Violation, required javadoc phrase not in comment.
  *
  *   &#64;Override
- *   public String toString() {  // Violation. No required javadoc.
+ *   public String toString() {  // Violation. No javadoc for @Override method.
  *     return "";
  *   }
  * }
@@ -320,38 +344,46 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </pre>
  * <p>Example:</p>
  * <pre>
- * public abstract class Foo {
+ * public class A {
+ *   protected void foo1() {};  // OK. Abstract method.
+ *
+ *   protected static void foo2() {};  // OK. protected and static method.
+ *
+ *   protected final void foo3() {};  // OK. protected and final method.
+ *   }
+ *
+ * public class B extends A {
+ *   protected void foo1() { int arg; };  // Violation. The @Override annotation is missing.
+ *
+ *   protected static void foo2() { int arg; };  // Violation. The @Override annotation is missing.
+ *
+ *   protected final void foo3() { int arg; };  // Violation. The @Override annotation is missing.
+ *   }
+ *
+ * public class C {
  *   private int bar;
  *
- *   public int m1() {return 2;}  // Violation. No javadoc.
+ *   public int foo4() { return 1; }  // Violation, required javadoc phrase not in comment.
  *
- *   public int m2() {return 8;}  // Violation. No javadoc.
+ *   private void foo5() { foo6(); }  // OK. Private method.
  *
- *   private void m3() {m4();}
+ *   protected void foo6() { }  // OK. No implementation.
  *
- *   protected void m4() { }  // OK. No implementation.
+ *   public abstract void foo7();  // OK. Abstract method.
  *
- *   public abstract void m5();  // OK. Abstract method.
+ *   /&#42;&#42;
+ *   &#42; This
+ *   &#42; implementation ...
+ *   &#42;/
+ *   public int foo8() {return 8;}  // OK. Required javadoc phrase in comment.
  *
- *   &#47;**
- *    * This implementation ...
- *    &#64;return some int value.
- *    *&#47;
- *   public int m6() {return 1;}  // OK. Have required javadoc.
- *
- *   &#47;**
- *    * Some comments ...
- *    *&#47;
- *   public int m7() {return 1;}  // Violation. No required javadoc.
- *
- *   &#47;**
- *    * This
- *    * implementation ...
- *    *&#47;
- *   public int m8() {return 2;}  // OK. Have required javadoc.
+ *   /&#42;&#42;
+ *   &#42; Do not extend ...
+ *   &#42;/
+ *   public int foo9() {return 9;}  // Violation, required javadoc phrase not in comment.
  *
  *   &#64;Override
- *   public String toString() {  // Violation. No required javadoc.
+ *   public String toString() {  // Violation. No javadoc for @Override method.
  *     return "";
  *   }
  * }
@@ -383,7 +415,7 @@ public class DesignForExtensionCheck extends AbstractCheck {
      * Specify annotations which allow the check to skip the method from validation.
      */
     private Set<String> ignoredAnnotations = Arrays.stream(new String[] {"Test", "Before", "After",
-        "BeforeClass", "AfterClass", }).collect(Collectors.toSet());
+            "BeforeClass", "AfterClass", }).collect(Collectors.toSet());
 
     /**
      * Specify the comment text pattern which qualifies a method as designed for extension.
@@ -438,7 +470,7 @@ public class DesignForExtensionCheck extends AbstractCheck {
         if (!hasJavadocComment(ast)
                 && canBeOverridden(ast)
                 && (isNativeMethod(ast)
-                    || !hasEmptyImplementation(ast))
+                || !hasEmptyImplementation(ast))
                 && !hasIgnoredAnnotation(ast, ignoredAnnotations)
                 && !ScopeUtil.isInRecordBlock(ast)) {
             final DetailAST classDef = getNearestClassOrEnumDefinition(ast);
@@ -513,10 +545,10 @@ public class DesignForExtensionCheck extends AbstractCheck {
      */
     private boolean hasValidJavadocComment(DetailAST detailAST) {
         final String javadocString =
-            JavadocUtil.getBlockCommentContent(detailAST);
+                JavadocUtil.getBlockCommentContent(detailAST);
 
         final Matcher requiredJavadocPhraseMatcher =
-            requiredJavadocPhrase.matcher(javadocString);
+                requiredJavadocPhrase.matcher(javadocString);
 
         return requiredJavadocPhraseMatcher.find();
     }
@@ -545,10 +577,10 @@ public class DesignForExtensionCheck extends AbstractCheck {
         final DetailAST methodImplCloseBrace = methodImplOpenBrace.getLastChild();
         final Predicate<DetailAST> predicate = currentNode -> {
             return currentNode != methodImplCloseBrace
-                && !TokenUtil.isCommentType(currentNode.getType());
+                    && !TokenUtil.isCommentType(currentNode.getType());
         };
         final Optional<DetailAST> methodBody =
-            TokenUtil.findFirstTokenByPredicate(methodImplOpenBrace, predicate);
+                TokenUtil.findFirstTokenByPredicate(methodImplOpenBrace, predicate);
         if (methodBody.isPresent()) {
             hasEmptyBody = false;
         }
@@ -566,11 +598,11 @@ public class DesignForExtensionCheck extends AbstractCheck {
     private static boolean canBeOverridden(DetailAST methodDef) {
         final DetailAST modifiers = methodDef.findFirstToken(TokenTypes.MODIFIERS);
         return ScopeUtil.getSurroundingScope(methodDef).isIn(Scope.PROTECTED)
-            && !ScopeUtil.isInInterfaceOrAnnotationBlock(methodDef)
-            && modifiers.findFirstToken(TokenTypes.LITERAL_PRIVATE) == null
-            && modifiers.findFirstToken(TokenTypes.ABSTRACT) == null
-            && modifiers.findFirstToken(TokenTypes.FINAL) == null
-            && modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) == null;
+                && !ScopeUtil.isInInterfaceOrAnnotationBlock(methodDef)
+                && modifiers.findFirstToken(TokenTypes.LITERAL_PRIVATE) == null
+                && modifiers.findFirstToken(TokenTypes.ABSTRACT) == null
+                && modifiers.findFirstToken(TokenTypes.FINAL) == null
+                && modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) == null;
     }
 
     /**
@@ -583,10 +615,10 @@ public class DesignForExtensionCheck extends AbstractCheck {
     private static boolean hasIgnoredAnnotation(DetailAST methodDef, Set<String> annotations) {
         final DetailAST modifiers = methodDef.findFirstToken(TokenTypes.MODIFIERS);
         final Optional<DetailAST> annotation = TokenUtil.findFirstTokenByPredicate(modifiers,
-            currentToken -> {
-                return currentToken.getType() == TokenTypes.ANNOTATION
-                    && annotations.contains(getAnnotationName(currentToken));
-            });
+                currentToken -> {
+                    return currentToken.getType() == TokenTypes.ANNOTATION
+                            && annotations.contains(getAnnotationName(currentToken));
+                });
         return annotation.isPresent();
     }
 
@@ -612,7 +644,7 @@ public class DesignForExtensionCheck extends AbstractCheck {
     private static DetailAST getNearestClassOrEnumDefinition(DetailAST ast) {
         DetailAST searchAST = ast;
         while (searchAST.getType() != TokenTypes.CLASS_DEF
-               && searchAST.getType() != TokenTypes.ENUM_DEF) {
+                && searchAST.getType() != TokenTypes.ENUM_DEF) {
             searchAST = searchAST.getParent();
         }
         return searchAST;
@@ -627,8 +659,8 @@ public class DesignForExtensionCheck extends AbstractCheck {
     private static boolean canBeSubclassed(DetailAST classDef) {
         final DetailAST modifiers = classDef.findFirstToken(TokenTypes.MODIFIERS);
         return classDef.getType() != TokenTypes.ENUM_DEF
-            && modifiers.findFirstToken(TokenTypes.FINAL) == null
-            && hasDefaultOrExplicitNonPrivateCtor(classDef);
+                && modifiers.findFirstToken(TokenTypes.FINAL) == null
+                && hasDefaultOrExplicitNonPrivateCtor(classDef);
     }
 
     /**

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/design/DesignForExtensionCheck.java
@@ -415,7 +415,7 @@ public class DesignForExtensionCheck extends AbstractCheck {
      * Specify annotations which allow the check to skip the method from validation.
      */
     private Set<String> ignoredAnnotations = Arrays.stream(new String[] {"Test", "Before", "After",
-            "BeforeClass", "AfterClass", }).collect(Collectors.toSet());
+        "BeforeClass", "AfterClass", }).collect(Collectors.toSet());
 
     /**
      * Specify the comment text pattern which qualifies a method as designed for extension.

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -178,40 +178,48 @@ public abstract class Plant {
         </source>
         <p>Example:</p>
         <source>
-public abstract class Foo {
-  private int bar;
+public class A {
+    protected void foo1() {};  // OK. Abstract method.
 
-  public int m1() {return 2;}  // Violation. No javadoc.
+    protected static void foo2() {};  // OK. protected and static method.
 
-  public int m2() {return 8;}  // Violation. No javadoc.
+    protected final void foo3() {};  // OK. protected and final method.
+}
 
-  private void m3() {m4();}  // OK. Private method.
+public class B extends A {
+    protected void foo1() { int arg; };  // Violation. The @Override annotation is missing.
 
-  protected void m4() { }  // OK. No implementation.
+    protected static void foo2() { int arg; };  // Violation. The @Override annotation is missing.
 
-  public abstract void m5();  // OK. Abstract method.
+    protected final void foo3() { int arg; };  // Violation. The @Override annotation is missing.
+}
 
-  /**
-   * This implementation ...
-   @return some int value.
-   */
-  public int m6() {return 1;}  // OK. Have javadoc on overridable method.
+public class C {
+    private int bar;
 
-  /**
-   * Some comments ...
-   */
-  public int m7() {return 1;}  // OK. Have javadoc on overridable method.
+    public int foo4() { return 1; }  // Violation, required javadoc phrase not in comment.
 
-  /**
-   * This
-   * implementation ...
-   */
-  public int m8() {return 2;}  // OK. Have javadoc on overridable method.
+    private void foo5() { foo6(); }  // OK. Private method.
 
-  @Override
-  public String toString() {  // Violation. No javadoc for @Override method.
+    protected void foo6() { }  // OK. No implementation.
+
+    public abstract void foo7();  // OK. Abstract method.
+
+    /**
+    * This
+    * implementation ...
+    */
+    public int foo8() {return 8;}  // OK. Required javadoc phrase in comment.
+
+    /**
+    * Do not extend ...
+    */
+    public int foo9() {return 9;}  // Violation, required javadoc phrase not in comment.
+
+    @Override
+    public String toString() {  // Violation. No javadoc for @Override method.
     return "";
-  }
+    }
 }
         </source>
         <p>
@@ -225,40 +233,48 @@ public abstract class Foo {
         </source>
         <p>Example:</p>
         <source>
-public abstract class Foo {
-  private int bar;
+public class A {
+    protected void foo1() {};  // OK. Abstract method.
 
-  public int m1() {return 2;}  // Violation. No javadoc.
+    protected static void foo2() {};  // OK. protected and static method.
 
-  public int m2() {return 8;}  // Violation. No javadoc.
+    protected final void foo3() {};  // OK. protected and final method.
+}
 
-  private void m3() {m4();}  // OK. Private method.
+public class B extends A {
+    protected void foo1() { int arg; };  // Violation. The @Override annotation is missing.
 
-  protected void m4() { }  // OK. No implementation.
+    protected static void foo2() { int arg; };  // Violation. The @Override annotation is missing.
 
-  public abstract void m5();  // OK. Abstract method.
+    protected final void foo3() { int arg; };  // Violation. The @Override annotation is missing.
+}
 
-  /**
-   * This implementation ...
-   @return some int value.
-   */
-  public int m6() {return 1;}  // OK. Have javadoc on overridable method.
+public class C {
+    private int bar;
 
-  /**
-   * Some comments ...
-   */
-  public int m7() {return 1;}  // OK. Have javadoc on overridable method.
+    public int foo4() { return 1; }  // Violation, required javadoc phrase not in comment.
 
-  /**
-   * This
-   * implementation ...
-   */
-  public int m8() {return 2;}  // OK. Have javadoc on overridable method.
+    private void foo5() { foo6(); }  // OK. Private method.
 
-  @Override
-  public String toString() {  // OK. Have javadoc on overridable method.
+    protected void foo6() { }  // OK. No implementation.
+
+    public abstract void foo7();  // OK. Abstract method.
+
+    /**
+    * This
+    * implementation ...
+    */
+    public int foo8() {return 8;}  // OK. Required javadoc phrase in comment.
+
+    /**
+    * Do not extend ...
+    */
+    public int foo9() {return 9;}  // Violation, required javadoc phrase not in comment.
+
+    @Override
+    public String toString() {  // Violation. No javadoc for @Override method.
     return "";
-  }
+    }
 }
         </source>
         <p>To configure the check to allow methods which contain a specified comment text pattern in
@@ -271,40 +287,48 @@ public abstract class Foo {
         </source>
         <p>Example:</p>
         <source>
-public abstract class Foo {
-  private int bar;
+public class A {
+    protected void foo1() {};  // OK. Abstract method.
 
-  public int m1() {return 2;}  // Violation. No javadoc.
+    protected static void foo2() {};  // OK. protected and static method.
 
-  public int m2() {return 8;}  // Violation. No javadoc.
+    protected final void foo3() {};  // OK. protected and final method.
+}
 
-  private void m3() {m4();}  // OK. Private method.
+public class B extends A {
+    protected void foo1() { int arg; };  // Violation. The @Override annotation is missing.
 
-  protected void m4() { }  // OK. No implementation.
+    protected static void foo2() { int arg; };  // Violation. The @Override annotation is missing.
 
-  public abstract void m5();  // OK. Abstract method.
+    protected final void foo3() { int arg; };  // Violation. The @Override annotation is missing.
+}
 
-  /**
-   * This implementation ...
-   @return some int value.
-   */
-  public int m6() {return 1;}  // OK. Have required javadoc.
+public class C {
+    private int bar;
 
-  /**
-   * Some comments ...
-   */
-  public int m7() {return 1;}  // Violation. No required javadoc.
+    public int foo4() { return 1; }  // Violation, required javadoc phrase not in comment.
 
-  /**
-   * This
-   * implementation ...
-   */
-  public int m8() {return 2;}  // Violation. No required javadoc.
+    private void foo5() { foo6(); }  // OK. Private method.
 
-  @Override
-  public String toString() {  // Violation. No required javadoc.
+    protected void foo6() { }  // OK. No implementation.
+
+    public abstract void foo7();  // OK. Abstract method.
+
+    /**
+    * This
+    * implementation ...
+    */
+    public int foo8() {return 8;}  // OK. Required javadoc phrase in comment.
+
+    /**
+    * Do not extend ...
+    */
+    public int foo9() {return 9;}  // Violation, required javadoc phrase not in comment.
+
+    @Override
+    public String toString() {  // Violation. No javadoc for @Override method.
     return "";
-  }
+    }
 }
         </source>
         <p>
@@ -319,40 +343,48 @@ public abstract class Foo {
         </source>
         <p>Example:</p>
         <source>
-public abstract class Foo {
-  private int bar;
+public class A {
+    protected void foo1() {};  // OK. Abstract method.
 
-  public int m1() {return 2;}  // Violation. No javadoc.
+    protected static void foo2() {};  // OK. protected and static method.
 
-  public int m2() {return 8;}  // Violation. No javadoc.
+    protected final void foo3() {};  // OK. protected and final method.
+}
 
-  private void m3() {m4();}
+public class B extends A {
+    protected void foo1() { int arg; };  // Violation. The @Override annotation is missing.
 
-  protected void m4() { }  // OK. No implementation.
+    protected static void foo2() { int arg; };  // Violation. The @Override annotation is missing.
 
-  public abstract void m5();  // OK. Abstract method.
+    protected final void foo3() { int arg; };  // Violation. The @Override annotation is missing.
+}
 
-  /**
-   * This implementation ...
-   @return some int value.
-   */
-  public int m6() {return 1;}  // OK. Have required javadoc.
+public class C {
+    private int bar;
 
-  /**
-   * Some comments ...
-   */
-  public int m7() {return 1;}  // Violation. No required javadoc.
+    public int foo4() { return 1; }  // Violation, required javadoc phrase not in comment.
 
-  /**
-   * This
-   * implementation ...
-   */
-  public int m8() {return 2;}  // OK. Have required javadoc.
+    private void foo5() { foo6(); }  // OK. Private method.
 
-  @Override
-  public String toString() {  // Violation. No required javadoc.
+    protected void foo6() { }  // OK. No implementation.
+
+    public abstract void foo7();  // OK. Abstract method.
+
+    /**
+    * This
+    * implementation ...
+    */
+    public int foo8() {return 8;}  // OK. Required javadoc phrase in comment.
+
+    /**
+    * Do not extend ...
+    */
+    public int foo9() {return 9;}  // Violation, required javadoc phrase not in comment.
+
+    @Override
+    public String toString() {  // Violation. No javadoc for @Override method.
     return "";
-  }
+    }
 }
         </source>
       </subsection>

--- a/src/xdocs/config_design.xml
+++ b/src/xdocs/config_design.xml
@@ -56,7 +56,7 @@
         <blockquote>The class must document its self-use of overridable methods.
 By convention, a method that invokes overridable methods contains a description
 of these invocations at the end of its documentation comment. The description
-begins with the phrase “This implementation.”
+begins with the phrase "This implementation."
         </blockquote>
         <blockquote>The best solution to this problem is to prohibit subclassing in classes that
 are not designed and documented to be safely subclassed.


### PR DESCRIPTION
Issue #7608 : Code examples have been added to the original.

**How the website looks like after I add code example**
<img width="1071" alt="图1" src="https://user-images.githubusercontent.com/116325914/228914341-e29519a2-7156-4c15-98ff-1b653c0ec342.png">

<img width="1072" alt="图2" src="https://user-images.githubusercontent.com/116325914/228914379-14ee7df0-8a6e-4417-a69f-07b0fa3b29a2.png">

<img width="1071" alt="图3" src="https://user-images.githubusercontent.com/116325914/228914410-1250a4bb-1164-4384-9e6e-ae02de617522.png">

<img width="1075" alt="图4" src="https://user-images.githubusercontent.com/116325914/228914435-1b63140b-11a4-444f-8a5a-f2082b5db02f.png">

**output of default example:**

**Basic example for comparison**
```
C:\Users\SHD\Desktop\checkstyle-master>javac test.java
C:\Users\SHD\Desktop\checkstyle-master>type config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="DesignForExtension"/>
  </module>
</module>
C:\Users\SHD\Desktop\checkstyle-master>type test.java
 public class A {
    protected void foo1() {};  // OK. Abstract method.

   protected static void foo2() {};  // OK. protected and static method.

   protected final void foo3() {};  // OK. protected and final method.
   }

 public class B extends A {
   protected void foo1() {int arg; };  // Violation. The @Override annotation is missing.

    protected static void foo2() {int arg; };  // Violation. The @Override annotation is missing.

    protected final void foo3() {int arg; };  // Violation. The @Override annotation is missing.
    }

  public class C {
    private int bar;

    public int foo4() { return 1; }  // Violation, required javadoc phrase not in comment.

    private void foo5() {foo6();}  // OK. Private method.

    protected void foo6() { };  // OK. No implementation.

    public abstract void foo7();  // OK. Abstract method.

    /*
    * This
    * implementation ...
    */
    public int foo8() {return 8;}  // OK. Required javadoc phrase in comment.

    /*
    * Do not extend ...
    */
    public int foo9() {return 9;}  // Violation, required javadoc phrase not in comment.

    @Override
    public String toString() {  // Violation. No javadoc for @Override method.
      return "";
    }
  }
C:\Users\SHD\Desktop\checkstyle-master>set RUN_LOCALE="-Duser.language=en -Duser.country=US"

C:\Users\SHD\Desktop\checkstyle-master>java %RUN_LOCALE% -jar checkstyle-10.6.0-all.jar -c config.xml test.java
Starting audit...
[ERROR] C:\Users\SHD\Desktop\checkstyle-master\test.java:10:4: Class 'B' looks like designed for extension (can be subclassed), but the method 'foo1' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'B' final or making the method 'foo1' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] C:\Users\SHD\Desktop\checkstyle-master\test.java:20:5: Class 'C' looks like designed for extension (can be subclassed), but the method 'foo4' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'C' final or making the method 'foo4' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] C:\Users\SHD\Desktop\checkstyle-master\test.java:32:5: Class 'C' looks like designed for extension (can be subclassed), but the method 'foo8' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'C' final or making the method 'foo8' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] C:\Users\SHD\Desktop\checkstyle-master\test.java:37:5: Class 'C' looks like designed for extension (can be subclassed), but the method 'foo9' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'C' final or making the method 'foo9' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] C:\Users\SHD\Desktop\checkstyle-master\test.java:39:5: Class 'C' looks like designed for extension (can be subclassed), but the method 'toString' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'C' final or making the method 'toString' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
Audit done.
Checkstyle ends with 5 errors.
```

**Example for Config Property igonredAnnotations**
```
C:\Users\SHD\Desktop\checkstyle-master>javac test.java
C:\Users\SHD\Desktop\checkstyle-master>type config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="DesignForExtension">
      <property name="ignoredAnnotations" value="Override"/>
    </module>
  </module>
</module>
C:\Users\SHD\Desktop\checkstyle-master>type test.java
public class A {
    protected void foo1() {};

   protected static void foo2() {};

   protected final void foo3() {};
   }

 public class B extends A {
   protected void foo1() {int arg; };

    protected static void foo2() {int arg; };

    protected final void foo3() {int arg; };
    }

  public class C {
    private int bar;

    public int foo4() { return 1; }

    private void foo5() {foo6();}

    protected void foo6() { };

    public abstract void foo7();

    /*
    * This
    * implementation ...
    */
    public int foo8() {return 8;}

    /*
    * Do not extend ...
    */
    public int foo9() {return 9;}

    @Override
    public String toString() {
      return "";
    }
  }
C:\Users\SHD\Desktop\checkstyle-master>set RUN_LOCALE="-Duser.language=en -Duser.country=US"

C:\Users\SHD\Desktop\checkstyle-master>java %RUN_LOCALE% -jar checkstyle-10.6.0-all.jar -c config.xml test.java
Starting audit...
[ERROR] C:\Users\SHD\Desktop\checkstyle-master\test.java:10:4: Class 'B' looks like designed for extension (can be subclassed), but the method 'foo1' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'B' final or making the method 'foo1' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] C:\Users\SHD\Desktop\checkstyle-master\test.java:20:5: Class 'C' looks like designed for extension (can be subclassed), but the method 'foo4' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'C' final or making the method 'foo4' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] C:\Users\SHD\Desktop\checkstyle-master\test.java:32:5: Class 'C' looks like designed for extension (can be subclassed), but the method 'foo8' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'C' final or making the method 'foo8' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] C:\Users\SHD\Desktop\checkstyle-master\test.java:37:5: Class 'C' looks like designed for extension (can be subclassed), but the method 'foo9' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'C' final or making the method 'foo9' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
Audit done.
Checkstyle ends with 4 errors.
```

**Example for Config Property requiredJavadocPhrase (one line)**
```
C:\Users\SHD\Desktop\checkstyle-master>javac test.java
C:\Users\SHD\Desktop\checkstyle-master>type config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="DesignForExtension">
      <property name="requiredJavadocPhrase" value="This implementation"/>
    </module>
  </module>
</module>
C:\Users\SHD\Desktop\checkstyle-master>type test.java
public class A {
    protected void foo1() {};

   protected static void foo2() {};

   protected final void foo3() {};
   }

 public class B extends A {
   protected void foo1() {int arg; };

    protected static void foo2() {int arg; };

    protected final void foo3() {int arg; };
    }

  public class C {
    private int bar;

    public int foo4() { return 1; }

    private void foo5() {foo6();}

    protected void foo6() { };

    public abstract void foo7();

    /*
    * This
    * implementation ...
    */
    public int foo8() {return 8;}

    /*
    * Do not extend ...
    */
    public int foo9() {return 9;}

    @Override
    public String toString() {
      return "";
    }
  }
C:\Users\SHD\Desktop\checkstyle-master>set RUN_LOCALE="-Duser.language=en -Duser.country=US"

C:\Users\SHD\Desktop\checkstyle-master>java %RUN_LOCALE% -jar checkstyle-10.6.0-all.jar -c config.xml test.java
Starting audit...
[ERROR] C:\Users\SHD\Desktop\checkstyle-master\test.java:10:4: Class 'B' looks like designed for extension (can be subclassed), but the method 'foo1' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'B' final or making the method 'foo1' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] C:\Users\SHD\Desktop\checkstyle-master\test.java:20:5: Class 'C' looks like designed for extension (can be subclassed), but the method 'foo4' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'C' final or making the method 'foo4' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] C:\Users\SHD\Desktop\checkstyle-master\test.java:32:5: Class 'C' looks like designed for extension (can be subclassed), but the method 'foo8' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'C' final or making the method 'foo8' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] C:\Users\SHD\Desktop\checkstyle-master\test.java:37:5: Class 'C' looks like designed for extension (can be subclassed), but the method 'foo9' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'C' final or making the method 'foo9' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] C:\Users\SHD\Desktop\checkstyle-master\test.java:39:5: Class 'C' looks like designed for extension (can be subclassed), but the method 'toString' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'C' final or making the method 'toString' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
Audit done.
Checkstyle ends with 5 errors.
```

**Example for Config Property requiredJavadocPhrase (span in multiple line)**
```
C:\Users\SHD\Desktop\checkstyle-master>javac test.java
C:\Users\SHD\Desktop\checkstyle-master>type config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
  "https://checkstyle.org/dtds/configuration_1_3.dtd">
<module name="Checker">
  <module name="TreeWalker">
    <module name="DesignForExtension">
      <property name="requiredJavadocPhrase" value="This[\s\S]*implementation"/>
    </module>
  </module>
</module>
C:\Users\SHD\Desktop\checkstyle-master>type test.java
public class A {
    protected void foo1() {};

   protected static void foo2() {};

   protected final void foo3() {};
   }

 public class B extends A {
   protected void foo1() {int arg; };

    protected static void foo2() {int arg; };

    protected final void foo3() {int arg; };
    }

  public class C {
    private int bar;

    public int foo4() { return 1; }

    private void foo5() {foo6();}

    protected void foo6() { };

    public abstract void foo7();

    /*
    * This
    * implementation ...
    */
    public int foo8() {return 8;}

    /*
    * Do not extend ...
    */
    public int foo9() {return 9;}

    @Override
    public String toString() {
      return "";
    }
  }
C:\Users\SHD\Desktop\checkstyle-master>set RUN_LOCALE="-Duser.language=en -Duser.country=US"

C:\Users\SHD\Desktop\checkstyle-master>java %RUN_LOCALE% -jar checkstyle-10.6.0-all.jar -c config.xml test.java
Starting audit...
[ERROR] C:\Users\SHD\Desktop\checkstyle-master\test.java:10:4: Class 'B' looks like designed for extension (can be subclassed), but the method 'foo1' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'B' final or making the method 'foo1' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] C:\Users\SHD\Desktop\checkstyle-master\test.java:20:5: Class 'C' looks like designed for extension (can be subclassed), but the method 'foo4' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'C' final or making the method 'foo4' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] C:\Users\SHD\Desktop\checkstyle-master\test.java:32:5: Class 'C' looks like designed for extension (can be subclassed), but the method 'foo8' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'C' final or making the method 'foo8' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] C:\Users\SHD\Desktop\checkstyle-master\test.java:37:5: Class 'C' looks like designed for extension (can be subclassed), but the method 'foo9' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'C' final or making the method 'foo9' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
[ERROR] C:\Users\SHD\Desktop\checkstyle-master\test.java:39:5: Class 'C' looks like designed for extension (can be subclassed), but the method 'toString' does not have javadoc that explains how to do that safely. If class is not designed for extension consider making the class 'C' final or making the method 'toString' static/final/abstract/empty, or adding allowed annotation for the method. [DesignForExtension]
Audit done.
Checkstyle ends with 5 errors.
```
