### PR TITLE
Pull #12940: Add 3 to earliest change variable to compensate for diff context

### DIFF
--- a/.ci/generate-extra-site-links.sh
+++ b/.ci/generate-extra-site-links.sh
@@ -41,6 +41,8 @@ do
   # Extract the line number of the earliest change in the file, i.e. '90'.
   EARLIEST_CHANGE_LINE_NUMBER=$(echo "$PR_DIFF" | grep -A 5 "diff.*$CURRENT_XDOC_PATH" | grep @@ |
     head -1 | grep -oEi "[0-9]+" | head -1)
+  # Add 3 to the number because diffs contain 3 lines of context.
+  EARLIEST_CHANGE_LINE_NUMBER=$((EARLIEST_CHANGE_LINE_NUMBER + 3))
   echo "EARLIEST_CHANGE_LINE_NUMBER=$EARLIEST_CHANGE_LINE_NUMBER"
 
   # Find the id of the nearest subsection to the change.


### PR DESCRIPTION
Resolves issues found in https://github.com/checkstyle/checkstyle/pull/12937#issuecomment-1490596614

Adds 3 to variable `EARLIEST_CHANGE_LINE_NUMBER` to compensate for the diff context:
![Screenshot from 2023-03-31 20-00-16](https://user-images.githubusercontent.com/23459549/229195556-4106694a-b039-40a5-8f91-1e2dbebf9511.png)


We expect `http://checkstyle-docs.org/asda123/sun_style.html#Sun_Suppressions`
Local run:
```
__________________________________________________________________________________________________________________________________________________
 stoyan @  zenbook:  ~/open-source/checkstyle                                                                       pull/12940-fix-extra-links
$ git log -1
commit c8e96ab989a5e2e57ebccfba266c09b6d02ca3af (HEAD -> pull/12940-fix-extra-links, origin/pull/12940-fix-extra-links)
Author: stoyanK7 <stoyank127@gmail.com>
Date:   Fri Mar 31 19:43:56 2023 +0200

    Pull #12940: Add 3 to earliest change variable to compensate for diff context
__________________________________________________________________________________________________________________________________________________
 stoyan @  zenbook:  ~/open-source/checkstyle                                                                       pull/12940-fix-extra-links
$ ./.ci/generate-extra-site-links.sh 12937 http://checkstyle-docs.org/asda123
PR_NUMBER=12937
AWS_FOLDER_LINK=http://checkstyle-docs.org/asda123
CHANGED_XDOCS_PATHS=src/xdocs/config_header.xml
src/xdocs/config_modifier.xml
src/xdocs/sun_style.xml
src/xdocs/test.xml
EARLIEST_CHANGE_LINE_NUMBER=93
SUBSECTION_ID=Header_Properties
CURRENT_XDOC_NAME=config_header
EARLIEST_CHANGE_LINE_NUMBER=514
SUBSECTION_ID=ModifierOrder_Violation_Messages
CURRENT_XDOC_NAME=config_modifier
EARLIEST_CHANGE_LINE_NUMBER=1003
SUBSECTION_ID=Sun_Suppressions
CURRENT_XDOC_NAME=sun_style
EARLIEST_CHANGE_LINE_NUMBER=3
CURRENT_XDOC_NAME=test
__________________________________________________________________________________________________________________________________________________
 stoyan @  zenbook:  ~/open-source/checkstyle                                                                       pull/12940-fix-extra-links
$ cat ../message 

http://checkstyle-docs.org/asda123/config_header.html#Header_Properties

http://checkstyle-docs.org/asda123/config_modifier.html#ModifierOrder_Violation_Messages

http://checkstyle-docs.org/asda123/sun_style.html#Sun_Suppressions

http://checkstyle-docs.org/asda123/test.html#


```