### PR TITLE
Pull #12942: Fix concurrency group for site action

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -24,7 +24,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Resolves https://github.com/checkstyle/checkstyle/issues/12853#issuecomment-1490493226

> The workflow uses this group
>`group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`
>
>But this workflow context does not have `github.event.pull_request.number`, rather `github.event.issue.number` so it falls back to `github.ref`.

Print of new concurrency group:
https://github.com/stoyanK7/checkstyle/actions/runs/4578224927/jobs/8084568564#step:4:8
```
Site-62
```
Old one was `Site-refs/heads/master`.