### PR TITLE
Issue #12794: Diff-Report action does not post link to report in GitHub comment

### DIFF
--- a/.github/workflows/diff-report.yml
+++ b/.github/workflows/diff-report.yml
@@ -226,7 +226,13 @@ jobs:
 
       - name: Set output
         id: out
-        run: echo "::set-output name=message::$(cat message)"
+        run: |
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          {
+            echo "message<<$EOF"
+            cat message
+            echo "$EOF"
+          } >> "$GITHUB_OUTPUT"
 
   # should be always last step
   send_message:
@@ -256,7 +262,13 @@ jobs:
 
       - name: Set message
         id: out
-        run: echo "::set-output name=message::$(cat message)"
+        run: |
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          {
+            echo "message<<$EOF"
+            cat message
+            echo "$EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Comment PR
         uses: checkstyle/contribution/comment-action@master


### PR DESCRIPTION
Resolves #12794

Multiline strings should be handled differently. Taken from GitHub actions documentation: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string. We already applied the same solution in `site` workflow.

Before:
https://github.com/stoyanK7/checkstyle/pull/62#issuecomment-1493068289
![Screenshot from 2023-04-01 20-56-58](https://user-images.githubusercontent.com/23459549/229309292-bd372e7c-1ad5-4b9e-a29f-97829c8a1cca.png)

Now:
https://github.com/stoyanK7/checkstyle/pull/62#issuecomment-1493073677
![Screenshot from 2023-04-01 20-57-29](https://user-images.githubusercontent.com/23459549/229309326-52717162-c4ae-4ac7-9443-a529e251f108.png)
