### PR TITLE
minor: upgrade actions/checkout to v3

### DIFF
--- a/.github/workflows/check-pr-description.yml
+++ b/.github/workflows/check-pr-description.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Do action
         env:

--- a/.github/workflows/checker-framework.yml
+++ b/.github/workflows/checker-framework.yml
@@ -39,7 +39,7 @@ jobs:
         run: sudo apt install groovy
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup local maven cache
         uses: actions/cache@v2

--- a/.github/workflows/diff-report.yml
+++ b/.github/workflows/diff-report.yml
@@ -166,7 +166,7 @@ jobs:
       # fetch-depth default: 1
       # Don't need history for all branches and tags here.
       - name: Download contribution
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: checkstyle/contribution
           ref: master

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -72,7 +72,7 @@ jobs:
       # 0, because we need access to all branches to create a report.
       # ref - branch to checkout.
       - name: Download checkstyle
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         env:
           USER_LOGIN: ${{ github.event.issue.user.login }}
         with:


### PR DESCRIPTION
Upgrades `actions/checkout` to v3
https://github.com/checkstyle/checkstyle/pull/12959#discussion_r1158548369
Upgrading to `v3` of action upgrades to node v16 runtime: https://stackoverflow.com/a/73474103/9553927. v2 uses node v12 which is out of support since April 2022 - https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/