### PR TITLE
minor: exclude annoying link that results in 500 http code frequently

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2006,6 +2006,8 @@
             <excludedLink>http://dl.acm.org/*</excludedLink>
             <!-- permanent SSLException -->
             <excludedLink>https://git-scm.com</excludedLink>
+            <!-- too frequent to return 500 -->
+            <excludedLink>https://docs.oracle.com/javase/specs/jls/se17/html/jls-15.html#jls-15.28</excludedLink>
             <!-- I do not know how to resolve this "302 Found" response -->
             <excludedLink>https://plus.google.com/+CheckstyleJava</excludedLink>
             <!-- 302 redirect to


### PR DESCRIPTION
I do not know why only this page is problematic
https://github.com/checkstyle/checkstyle/actions/runs/4621172724/jobs/8172260574#step:4:2383
```
 ------------ grep of linkcheck.html--BEGIN
<td><i><a class="externalLink" 
href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-15.html#jls-15.28">
https://docs.oracle.com/javase/specs/jls/se17/html/jls-15.html#jls-15.28</a>
: 500 Internal Server Error</i></td></tr></table></td></tr>
<td><i><a class="externalLink" 
href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-15.html#jls-15.28">
https://docs.oracle.com/javase/specs/jls/se17/html/jls-15.html#jls-15.28</a>
: 500 Internal Server Error</i></td></tr></table></td></tr>
------------ grep of linkcheck.html--END
```


it is not single usage of this jdk docs
```
~/java/github/romani/checkstyle [master|✔] 
$ ag "specs/jls/se17"
src/main/java/com/puppycrawl/tools/checkstyle/api/TokenTypes.java
6207:     * @see <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-14.html#jls-14.30">
6263:     * @see <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-14.html#jls-14.30">

src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MissingSwitchDefaultCheck.java
53: * See the <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-15.html#jls-15.28">

src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
46: * <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-14.html#jls-14.30">
49: * <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-4.html#jls-4.12.3">
52: * <a href="https://docs.oracle.com/javase/specs/jls/se17/html/index.html">JLS</a>.

src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/MissingSwitchDefaultCheck.xml
31: See the &lt;a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-15.html#jls-15.28"&gt;

src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/UnusedLocalVariableCheck.xml
10: &lt;a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-14.html#jls-14.30"&gt;
13: &lt;a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-4.html#jls-4.12.3"&gt;
16: &lt;a href="https://docs.oracle.com/javase/specs/jls/se17/html/index.html"&gt;&lt;/a&gt;.

src/xdocs/config_coding.xml
4202:          <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-15.html#jls-15.28">
7998:          Doesn't support <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-14.html#jls-14.30">pattern variables yet</a>.
7999:          Doesn't check <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-4.html#jls-4.12.3">array components</a> as array
8000:          components are classified as different kind of variables by <a href="https://docs.oracle.com/javase/specs/jls/se17/html/index.html">JLS</a>.
```