### PR TITLE
Issue #11166: remove getFileContent() usage from FallThroughCheck

### DIFF
--- a/config/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
-    <sourceFile>FallThroughCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.FallThroughCheck</mutatedClass>
-    <mutatedMethod>matchesComment</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/regex/Matcher::start</description>
-    <lineContent>lineNo, matcher.start(), lineNo, matcher.end());</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>FinalLocalVariableCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck</mutatedClass>
     <mutatedMethod>leaveToken</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheck.java
@@ -19,14 +19,14 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
-import java.util.regex.Matcher;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 import com.puppycrawl.tools.checkstyle.StatelessCheck;
 import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.utils.CodePointUtil;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 /**
  * <p>
@@ -116,6 +116,11 @@ public class FallThroughCheck extends AbstractCheck {
         return getRequiredTokens();
     }
 
+    @Override
+    public boolean isCommentNodesRequired() {
+        return true;
+    }
+
     /**
      * Setter to define the RegExp to match the relief comment that suppresses
      * the warning about a fall through.
@@ -146,7 +151,7 @@ public class FallThroughCheck extends AbstractCheck {
             final DetailAST slist = ast.findFirstToken(TokenTypes.SLIST);
 
             if (slist != null && !isTerminated(slist, true, true)
-                && !hasFallThroughComment(ast, nextGroup)) {
+                && !hasFallThroughComment(ast)) {
                 if (isLastGroup) {
                     log(ast, MSG_FALL_THROUGH_LAST);
                 }
@@ -225,6 +230,11 @@ public class FallThroughCheck extends AbstractCheck {
             lastStmt = lastStmt.getPreviousSibling();
         }
 
+        while (TokenUtil.isOfType(lastStmt, TokenTypes.SINGLE_LINE_COMMENT,
+                TokenTypes.BLOCK_COMMENT_BEGIN)) {
+            lastStmt = lastStmt.getPreviousSibling();
+        }
+
         return lastStmt != null
             && isTerminated(lastStmt, useBreak, useContinue);
     }
@@ -240,13 +250,28 @@ public class FallThroughCheck extends AbstractCheck {
      */
     private boolean checkIf(final DetailAST ast, boolean useBreak,
                             boolean useContinue) {
-        final DetailAST thenStmt = ast.findFirstToken(TokenTypes.RPAREN)
-                .getNextSibling();
-        final DetailAST elseStmt = thenStmt.getNextSibling();
+        final DetailAST thenStmt = getNextNonCommentAst(ast.findFirstToken(TokenTypes.RPAREN));
+
+        final DetailAST elseStmt = getNextNonCommentAst(thenStmt);
 
         return elseStmt != null
                 && isTerminated(thenStmt, useBreak, useContinue)
-                && isTerminated(elseStmt.getFirstChild(), useBreak, useContinue);
+                && isTerminated(elseStmt.getLastChild(), useBreak, useContinue);
+    }
+
+    /**
+     * This method will skip the comment content while finding the next ast of current ast.
+     *
+     * @param ast current ast
+     * @return next ast after skipping comment
+     */
+    private static DetailAST getNextNonCommentAst(DetailAST ast) {
+        DetailAST nextSibling = ast.getNextSibling();
+        while (TokenUtil.isOfType(nextSibling, TokenTypes.SINGLE_LINE_COMMENT,
+                TokenTypes.BLOCK_COMMENT_BEGIN)) {
+            nextSibling = nextSibling.getNextSibling();
+        }
+        return nextSibling;
     }
 
     /**
@@ -365,46 +390,32 @@ public class FallThroughCheck extends AbstractCheck {
      * </pre>
      *
      * @param currentCase AST of the case that falls through to the next case.
-     * @param nextCase AST of the next case.
      * @return True if a relief comment was found
      */
-    private boolean hasFallThroughComment(DetailAST currentCase, DetailAST nextCase) {
-        boolean allThroughComment = false;
-        final int endLineNo = nextCase.getLineNo();
-
-        if (matchesComment(reliefPattern, endLineNo)) {
-            allThroughComment = true;
+    private boolean hasFallThroughComment(DetailAST currentCase) {
+        final DetailAST nextSibling = currentCase.getNextSibling();
+        final DetailAST ast;
+        if (nextSibling.getType() == TokenTypes.CASE_GROUP) {
+            ast = nextSibling.getFirstChild();
         }
         else {
-            final int startLineNo = currentCase.getLineNo();
-            for (int i = endLineNo - 2; i > startLineNo - 1; i--) {
-                final int[] line = getLineCodePoints(i);
-                if (!CodePointUtil.isBlank(line)) {
-                    allThroughComment = matchesComment(reliefPattern, i + 1);
-                    break;
-                }
-            }
+            ast = currentCase;
         }
-        return allThroughComment;
+        return hasReliefComment(ast);
     }
 
     /**
-     * Does a regular expression match on the given line and checks that a
-     * possible match is within a comment.
+     * Check if there is any fall through comment.
      *
-     * @param pattern The regular expression pattern to use.
-     * @param lineNo The line number in the file.
-     * @return True if a match was found inside a comment.
+     * @param ast ast to check
+     * @return true if relief comment found
      */
-    // suppress deprecation until https://github.com/checkstyle/checkstyle/issues/11166
-    @SuppressWarnings("deprecation")
-    private boolean matchesComment(Pattern pattern, int lineNo) {
-        final String line = getLine(lineNo - 1);
-
-        final Matcher matcher = pattern.matcher(line);
-        return matcher.find()
-                && getFileContents().hasIntersectionWithComment(
-                        lineNo, matcher.start(), lineNo, matcher.end());
+    private boolean hasReliefComment(DetailAST ast) {
+        return Optional.ofNullable(getNextNonCommentAst(ast))
+                .map(DetailAST::getPreviousSibling)
+                .map(previous -> previous.getFirstChild().getText())
+                .map(text -> reliefPattern.matcher(text).find())
+                .orElse(Boolean.FALSE);
     }
 
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/FallThroughCheckTest.java
@@ -124,8 +124,6 @@ public class FallThroughCheckTest extends AbstractModuleTestSupport {
             "432:9: " + getCheckMessage(MSG_FALL_THROUGH),
             "444:9: " + getCheckMessage(MSG_FALL_THROUGH),
             "454:9: " + getCheckMessage(MSG_FALL_THROUGH),
-            // line 490 violation expected till https://github.com/checkstyle/checkstyle/pull/12966
-            "490:9: " + getCheckMessage(MSG_FALL_THROUGH),
             "491:9: " + getCheckMessage(MSG_FALL_THROUGH),
             "492:9: " + getCheckMessage(MSG_FALL_THROUGH),
         };
@@ -254,6 +252,7 @@ public class FallThroughCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "48:11: " + getCheckMessage(MSG_FALL_THROUGH_LAST),
             "83:11: " + getCheckMessage(MSG_FALL_THROUGH_LAST),
+            "112:11: " + getCheckMessage(MSG_FALL_THROUGH_LAST),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFallThrough4.java"),
@@ -273,13 +272,8 @@ public class FallThroughCheckTest extends AbstractModuleTestSupport {
     @Test
     public void testFallThrough() throws Exception {
         final String[] expected = {
-            "16:13: " + getCheckMessage(MSG_FALL_THROUGH),
-            "18:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "23:13: " + getCheckMessage(MSG_FALL_THROUGH),
-            "25:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "27:13: " + getCheckMessage(MSG_FALL_THROUGH),
-            // line 37 needs consideration https://github.com/checkstyle/checkstyle/pull/12966
-            "37:10: " + getCheckMessage(MSG_FALL_THROUGH),
             "52:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "65:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "80:13: " + getCheckMessage(MSG_FALL_THROUGH),
@@ -337,7 +331,11 @@ public class FallThroughCheckTest extends AbstractModuleTestSupport {
     public void testLastLine() throws Exception {
         final String[] expected = {
             "21:13: " + getCheckMessage(MSG_FALL_THROUGH),
+            // until https://github.com/checkstyle/checkstyle/issues/13553
+            "33:13: " + getCheckMessage(MSG_FALL_THROUGH),
             "99:39: " + getCheckMessage(MSG_FALL_THROUGH_LAST),
+            // until https://github.com/checkstyle/checkstyle/issues/13553
+            "107:11: " + getCheckMessage(MSG_FALL_THROUGH_LAST),
         };
         verifyWithInlineConfigParser(
                 getPath("InputFallThroughLastLineCommentCheck.java"),
@@ -349,10 +347,22 @@ public class FallThroughCheckTest extends AbstractModuleTestSupport {
         final String[] expected = {
             "19:13: " + getCheckMessage(MSG_FALL_THROUGH_LAST),
             "22:13: " + getCheckMessage(MSG_FALL_THROUGH_LAST),
-            "25:13: " + getCheckMessage(MSG_FALL_THROUGH_LAST),
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputFallThrough5.java"),
+                expected);
+    }
+
+    @Test
+    public void testReliefCommentBetweenMultipleComment() throws Exception {
+        final String[] expected = {
+            // until https://github.com/checkstyle/checkstyle/issues/13553
+            "25:17: " + getCheckMessage(MSG_FALL_THROUGH),
+            // until https://github.com/checkstyle/checkstyle/issues/13553
+            "34:13: " + getCheckMessage(MSG_FALL_THROUGH_LAST),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputFallThrough8.java"),
                 expected);
     }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThrough5.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThrough5.java
@@ -21,7 +21,7 @@ public class InputFallThrough5 {
         switch (o) { // violation below 'Fall .* from the last branch of the switch statement'
             case Object obj, null: ;
         }
-        switch (o) { // violation below 'Fall .* from the last branch of the switch statement'
+        switch (o) {
             case Object obj, null: ; // fall thru
         }
     }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThrough.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThrough.java
@@ -487,7 +487,7 @@ public class InputFallThrough
         int i = 0;
         switch (i) {
         case 0: case 1: i *= i; // fall through
-        case 2: case 3: i *= i; // violation 'Fall through from prev.* br.* switch statement.'
+        case 2: case 3: i *= i;
         case 4: case 5: i *= i; // violation 'Fall through from prev.* br.* switch statement.'
         case 6: case 7: i *= i; // violation 'Fall through from prev.* br.* switch statement.'
             break;

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThrough4.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThrough4.java
@@ -109,7 +109,7 @@ public class InputFallThrough4 {
    void method5(int i, int j, boolean cond) {
       while (true) {
           switch (i){
-          case 5:
+          case 5: // violation 'Fall through from the last branch of the switch statement'
               i++;
               /* block */ /* fallthru */ // comment
           }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThrough6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThrough6.java
@@ -13,16 +13,16 @@ public class InputFallThrough6 {
         switch(i) {
             case 1:
                  int fallthru = 2; // fallthru
-            case 2: // violation 'Fall through from previous branch of the switch statement'
+            case 2:
                  int fallthrough = 2; //            fall thru
-            case 3: // violation 'Fall through from previous branch of the switch statement'
+            case 3:
                  break;
             case 4:
                  int fallthru2 = 3;
                  //     fall   -   thru
             case 5: // violation 'Fall through from previous branch of the switch statement.'
                  int fallthru3 = 4; // This is a fallthru comment
-            case 6: // violation 'Fall through from previous branch of the switch statement'
+            case 6:
                  int fallthru4 = 5; // falldown
             default: // violation 'Fall through from previous branch of the switch statement.'
             }
@@ -35,7 +35,7 @@ public class InputFallThrough6 {
          case 2: case 3: i *= i; // fall through
          case 4: case 5: i *= i; // fall through
          case 6: case 7: i *= i;
-             break; // violation above 'Fall through from previous branch of the switch statement'
+             break;
          default:
              throw new RuntimeException();
          }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThrough8.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThrough8.java
@@ -1,0 +1,48 @@
+/*
+FallThrough
+checkLastCaseGroup = true
+reliefPattern = (default)falls?[ -]?thr(u|ough)
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.fallthrough;
+
+public class InputFallThrough8 {
+    void methodLastLine(int i) {
+        while (true) {
+            switch (i) {
+                case 0:
+                    i++;
+                    /* block */ // comment
+                    // fall thru
+                case 1:
+                    i++;
+                    break;
+                case 2:
+                    i++;
+                    /* comment */ /* fall thru */ /* comment */
+                case 3: // violation 'Fall through from previous branch of the switch statement'
+                    i--;
+                    break;
+            }
+        }
+    }
+
+    void testLastCase(int i) {
+        switch (i) {
+            case 0: // violation 'Fall through from the last branch of the switch statement'
+                i++;
+                /* comment */ /* fall thru */ /* comment */
+        }
+    }
+
+    void testLastCase2(int i) {
+        switch (i) {
+            case 0:
+                i++;
+                /* comment */ /* comment */
+                /* fall thru */
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThroughLastLineCommentCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/fallthrough/InputFallThroughLastLineCommentCheck.java
@@ -30,7 +30,7 @@ public class InputFallThroughLastLineCommentCheck {
             case 1:
                 i++;
                 /* block */ /* fallthru */ // comment
-            case 2:
+            case 2: // violation 'Fall through from previous branch of the switch statement'
                 // this is comment
                 i++;
                 // fall through
@@ -104,7 +104,7 @@ public class InputFallThroughLastLineCommentCheck {
    void method7(int i, int j, boolean cond) {
       while (true) {
           switch (i){
-          case 5:
+          case 5: // violation 'Fall through from the last branch of the switch statement'
               i++;
               /* block */ i++; /* fallthru */ // comment
           }


### PR DESCRIPTION
Resolves https://github.com/checkstyle/checkstyle/issues/12948

partial for Issue #11166: remove getFileContent() usage from FallThroughCheck

--------------------

# Regression

final report :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/b242e7a_2023192425/reports/diff/index.html

final report 2 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/b242e7a_2023213303/reports/diff/index.html

-----------------------------------------------------------------------------

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/ebc8a446892fe0a9aaf746b1b1b43c05/raw/4e77df9181e2cbd8dd9e227169310190e2eb8f5b/fall.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: final-report-2.1