### PR TITLE
infra: update diff report file download to use GitHub token and curl

### DIFF
--- a/.ci/diff-report.sh
+++ b/.ci/diff-report.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+
+source ./.ci/util.sh
+
+case $1 in
+
+# Downloads all files necessary to generate regression report.
+download-files)
+  checkForVariable "GITHUB_TOKEN"
+  echo "Downloading files..."
+
+  # check for projects link from PR, if not found use default from contribution repo
+  LINK="${LINK_FROM_PR:-$DEFAULT_PROJECTS_LINK}"
+
+  # get projects file
+  curl --fail-with-body -X GET "${LINK}" \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    -o project.properties
+
+  if [ -n "$NEW_MODULE_CONFIG_LINK" ]; then
+    curl --fail-with-body -X GET "${NEW_MODULE_CONFIG_LINK}" \
+      -H "Accept: application/vnd.github+json" \
+      -H "Authorization: token $GITHUB_TOKEN" \
+      -o new_module_config.xml
+  fi
+
+  if [ -n "$DIFF_CONFIG_LINK" ]; then
+    curl --fail-with-body -X GET "${DIFF_CONFIG_LINK}" \
+      -H "Accept: application/vnd.github+json" \
+      -H "Authorization: token $GITHUB_TOKEN" \
+      -o diff_config.xml
+  fi
+
+  if [ -n "$PATCH_CONFIG_LINK" ]; then
+    curl --fail-with-body -X GET "${PATCH_CONFIG_LINK}" \
+      -H "Accept: application/vnd.github+json" \
+      -H "Authorization: token $GITHUB_TOKEN" \
+      -o patch_config.xml
+  fi
+  ;;
+
+*)
+  echo "Unexpected argument: $1"
+  sleep 5s
+  false
+  ;;
+
+esac

--- a/.github/workflows/diff-report.yml
+++ b/.github/workflows/diff-report.yml
@@ -122,20 +122,9 @@ jobs:
           DIFF_CONFIG_LINK: ${{ needs.parse_body.outputs.config_link }}
           PATCH_CONFIG_LINK: ${{ needs.parse_body.outputs.patch_config_link }}
           LINK_FROM_PR: ${{ needs.parse_body.outputs.projects_link }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          LINK="${LINK_FROM_PR:-$DEFAULT_PROJECTS_LINK}"
-          wget -q "$LINK" -O project.properties
-          if [ -n "$NEW_MODULE_CONFIG_LINK" ]; then
-            wget -q "$NEW_MODULE_CONFIG_LINK" -O new_module_config.xml
-          fi
-
-          if [ -n "$DIFF_CONFIG_LINK" ]; then
-            wget -q "$DIFF_CONFIG_LINK" -O diff_config.xml
-          fi
-
-          if [ -n "$PATCH_CONFIG_LINK" ]; then
-            wget -q "$PATCH_CONFIG_LINK" -O patch_config.xml
-          fi
+          ./.ci/diff-report.sh download-files
 
       # fetch-depth - number of commits to fetch.
       # 0 indicates all history for all branches and tags.


### PR DESCRIPTION
Noticed at https://github.com/checkstyle/checkstyle/pull/12979#issuecomment-1509958270 and elsewhere, it looks like we are failing to download files for report generation. Example from logs:
```
...
2023-04-15T20:33:26.0038234Z   PATCH_CONFIG_LINK: 
2023-04-15T20:33:26.0038722Z   LINK_FROM_PR: https://gist.githubusercontent.com/0xbakry/7853843aa3d69aee301d7a8d62d08ebb/raw/65a7d6bee0ad8ad789c17f778ce7d8b0056ae28b/my_projects
2023-04-15T20:33:26.0039194Z ##[endgroup]
2023-04-15T20:33:26.1529944Z ##[error]Process completed with exit code 8.
...

```

exit code 8 from wget typically denotes a error response from the server, read more at https://stackoverflow.com/questions/65677320/what-does-server-issued-an-error-responseexit-status-8-mean-in-wget#:~:text=The%20man%20page%20of%20wget,types%20of%20errors%20are%20encountered..

We really need to begin to migrate complex steps for diff report generation to a script so that we can take advantage of our regular shellcheck exeuction (instead of built in actionlint one) and clean up the yaml. Issue is opened at https://github.com/checkstyle/checkstyle/issues/12991


-----------------------------------
Tested locally:
```
➜  checkstyle git:(fix-diff-report-action) export DEFAULT_PROJECTS_LINK=https://raw.githubusercontent.com/checkstyle/contribution/master/checkstyle-tester/projects-to-test-on-for-github-action.properties

➜  checkstyle git:(fix-diff-report-action) export DIFF_CONFIG_LINK=https://gist.githubusercontent.com/0xbakry/a1fcb13eef42f29de8ff500892f34166/raw/1b0af8d2da606b273e8ef9aaed6278020f876202/config_check.xml

➜  checkstyle git:(fix-diff-report-action) export LINK_FROM_PR=https://gist.githubusercontent.com/0xbakry/7853843aa3d69aee301d7a8d62d08ebb/raw/65a7d6bee0ad8ad789c17f778ce7d8b0056ae28b/my_projects

➜  checkstyle git:(fix-diff-report-action) ./.ci/diff-report.sh download-files
Downloading files...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   983  100   983    0     0    496      0  0:00:01  0:00:01 --:--:--   496
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1278  100  1278    0     0    955      0  0:00:01  0:00:01 --:--:--   955

➜  checkstyle git:(fix-diff-report-action) ✗ ls
appveyor.yml            config           LICENSE           project.properties  SECURITY.md
azure-pipelines.yml     diff_config.xml  LICENSE.apache20  README.md           src
cdg-pitest-licence.txt  gen              pom.xml           RIGHTS.antlr        target

➜  checkstyle git:(fix-diff-report-action) ✗ cat project.properties 
# List of GIT repositories to clone / pull for checking with Checkstyle
# File format: REPO_NAME|[local|git|hg]|URL|[COMMIT_ID]|[EXCLUDE FOLDERS]
# Please note that bash comments works in this file

guava|git|https://github.com/google/guava|v28.2||

infinispan|git|https://github.com/infinispan/infinispan|7.2.5.Final||
protonpack|git|https://github.com/poetix/protonpack|protonpack-1.7||
jOOL|git|https://github.com/jOOQ/jOOL|version-0.9.7||
lucene-solr|git|https://github.com/apache/lucene-solr|releases/lucene-solr/5.4.0||

tapestry-5|git|https://github.com/apache/tapestry-5|5.4.0|**/archetype-resources/**/*|
...
```

Note that we have set this report to be generated with a custom projects file, this is why i `cat`'d it to show that script works.