### PR TITLE
Issue #12995: Fix windows line endings in GitHub event text

### DIFF
--- a/.github/workflows/diff-report.yml
+++ b/.github/workflows/diff-report.yml
@@ -66,7 +66,9 @@ jobs:
           ISSUE_BODY: ${{ github.event.issue.body }}
           PULL_REQUEST_URL: ${{ github.event.issue.pull_request.url }}
         run: |
-          echo "$ISSUE_BODY" > text
+          # convert windows line endings to unix in event text
+          echo "$ISSUE_BODY" > windows.txt
+          tr -d '\15\32' < windows.txt > text
           echo "$USER_LOGIN" > user
           wget -q "$PULL_REQUEST_URL" -O info.json
           jq --raw-output .head.ref info.json > branch


### PR DESCRIPTION
closes #12995

-----------
Ok, here is the real issue: https://github.com/checkstyle-ci-tester/checkstyle/actions/runs/4739501477/jobs/8414388078#step:5:25

```
./text: ASCII text, with CRLF, LF line terminators
```

GitHub uses windows line endings in comments/descriptions, and when we get the text from the event it has windows line endings. Here is the line endings shown in a [tool](https://www.soscisurvey.de/tools/view-chars.php) that I found online:
![image](https://user-images.githubusercontent.com/31252532/232966815-c51e675a-9bb8-4858-8d5e-8602313e8fb9.png)

The problem is that when we grep and sed these lines from the text, we leave a single carriage return at the end of each line. Example:
```
curl --fail-with-body -X GET $'https://gist.githubusercontent.com/0xbakry/a1fcb13eef42f29de8ff500892f34166/raw/1b0af8d2da606b273e8ef9aaed6278020f876202/config_check.xml/r' -H 'Accept: application/vnd.github+json' -H 'Authorization: token ***' -o

```
It seems like we found this issue when we migrated to curl, since curl is less forgiving of weird urls than wget is, perhaps.

We should replace all windows line endings in event text with linux line endings to fix this issue.

-------------
Test, note that we have only a commit to replace line endings in event text on master: https://github.com/checkstyle-ci-tester/checkstyle/commits/master

Here is successful file download: https://github.com/checkstyle-ci-tester/checkstyle/actions/runs/4739619430/jobs/8414613676#step:3:1