### PR TITLE
Issue #12978: Upgrade actions/cache to v3

### DIFF
--- a/.github/workflows/bump-version-and-update-milestone.yml
+++ b/.github/workflows/bump-version-and-update-milestone.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup local maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/checker-framework.yml
+++ b/.github/workflows/checker-framework.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup local maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup local maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/diff-report.yml
+++ b/.github/workflows/diff-report.yml
@@ -154,7 +154,7 @@ jobs:
           cd ../
 
       - name: Setup local maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/error-prone.yml
+++ b/.github/workflows/error-prone.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup local maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -61,7 +61,7 @@ jobs:
           sudo apt install groovy
 
       - name: Setup local maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/release-maven-perform.yml
+++ b/.github/workflows/release-maven-perform.yml
@@ -32,7 +32,7 @@ jobs:
           ref: master
 
       - name: Setup local maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/release-maven-prepare.yml
+++ b/.github/workflows/release-maven-prepare.yml
@@ -35,7 +35,7 @@ jobs:
           ref: master
 
       - name: Setup local maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/release-new-milestone-and-issues-in-other-repos.yml
+++ b/.github/workflows/release-new-milestone-and-issues-in-other-repos.yml
@@ -41,7 +41,7 @@ jobs:
           sudo apt-get install ncal
 
       - name: Setup local maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/release-publish-releasenotes-twitter.yml
+++ b/.github/workflows/release-publish-releasenotes-twitter.yml
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup local maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/release-update-github-io.yml
+++ b/.github/workflows/release-update-github-io.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup local maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/release-update-github-page.yml
+++ b/.github/workflows/release-update-github-page.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup local maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/release-update-xdoc-with-releasenotes.yml
+++ b/.github/workflows/release-update-xdoc-with-releasenotes.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup local maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/release-upload-all-jar.yml
+++ b/.github/workflows/release-upload-all-jar.yml
@@ -36,7 +36,7 @@ jobs:
           ref: master
 
       - name: Setup local maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/releasenotes-gen.yml
+++ b/.github/workflows/releasenotes-gen.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup local maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/run-link-check.yml
+++ b/.github/workflows/run-link-check.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup local maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -89,7 +89,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Setup local maven cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: checkstyle-maven-cache-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
Solves https://github.com/checkstyle/checkstyle/issues/12978

Upgradeing `actions/cache` to v3 upgrades `Node.js` to v16:
https://github.com/marketplace/actions/cache