### PR TITLE
infra: bump starting and max heap size for report generation

### DIFF
--- a/.github/workflows/diff-report.yml
+++ b/.github/workflows/diff-report.yml
@@ -190,7 +190,7 @@ jobs:
           REF="origin/$BRANCH"
           REPO="../../checkstyle"
           BASE_BRANCH="upstream/master"
-          export MAVEN_OPTS="-Xmx2048m"
+          export MAVEN_OPTS="-Xmx5g"
           if [ -f new_module_config.xml ]; then
             groovy diff.groovy -r "$REPO" -p "$REF" -pc new_module_config.xml -m single\
               -l project.properties -xm "-Dcheckstyle.failsOnError=false"\


### PR DESCRIPTION
Noticed at https://github.com/checkstyle/checkstyle/pull/13008#issuecomment-1516224296:

```
Error:  Java heap space -> [Help 1]
java.lang.OutOfMemoryError: Java heap space

```

From a Github runner:
```
2023-04-20T12:43:16.7848766Z openjdk version "11.0.18" 2023-01-17
2023-04-20T12:43:16.7855021Z OpenJDK Runtime Environment Temurin-11.0.18+10 (build 11.0.18+10)
2023-04-20T12:43:16.7857637Z OpenJDK 64-Bit Server VM Temurin-11.0.18+10 (build 11.0.18+10, mixed mode)
2023-04-20T12:43:16.8054098Z    size_t ErgoHeapSizeLimit                        = 0                                         {product} {default}
2023-04-20T12:43:16.8096909Z    size_t HeapSizePerGCThread                      = 43620760                                  {product} {default}
2023-04-20T12:43:16.8097319Z    size_t InitialHeapSize                          = 115343360                                 {product} {ergonomic}
2023-04-20T12:43:16.8097704Z    size_t LargePageHeapSizeThreshold               = 134217728                                 {product} {default}
2023-04-20T12:43:16.8098078Z    size_t MaxHeapSize                              = 1820327936                                {product} {ergonomic}
2023-04-20T12:43:16.8098432Z     uintx NonNMethodCodeHeapSize                   = 5825164                                {pd product} {ergonomic}
2023-04-20T12:43:16.8098815Z     uintx NonProfiledCodeHeapSize                  = 122916538                              {pd product} {ergonomic}
2023-04-20T12:43:16.8099196Z     uintx ProfiledCodeHeapSize                     = 122916538                              {pd product} {ergonomic}
2023-04-20T12:43:16.8099587Z    size_t ShenandoahSoftMaxHeapSize                = 0                                      {manageable} {default}
```

 [Github runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) have 7GB of memory available. This PR bumps the max heap size from 1820MB to 5 GB. This still leaves about 2GB for the OS and other processes which should be fine on a headless Ubuntu system.