### PR TITLE
Issue #12991: Improvements to diff report generation - parsing PR description and validation of URLs

### DIFF
--- a/.ci/diff-report.sh
+++ b/.ci/diff-report.sh
@@ -3,6 +3,36 @@ set -e
 
 source ./.ci/util.sh
 
+# Validates the URL, checks if it is a raw link, and exits if it is not. We
+# expect users to provide a raw gist or GitHub link.
+validate_url () {
+  URL=$1
+
+  VALID_URL_REGEX='^(https?|ftp|file)://[-A-Za-z0-9\+&@#/%?=~_|!:,.;]*[-A-Za-z0-9\+&@#/%=~_|]'
+  VALID_URL_REGEX+='\.[-A-Za-z0-9\+&@#/%?=~_|!:,.;]*[-A-Za-z0-9\+&@#/%=~_|]$'
+
+  if [[ -z "$URL" ]]; then
+    # It is ok for a URL to be empty, we use this later in the workflow
+    # to determine what "mode" we should generate report with.
+    echo "URL is empty."
+  elif [[ "$URL" == *: ]]; then
+    # We were not able to match in previous 'sed' command, so user has
+    # incorrectly supplied parameters in PR description.
+    echo "Parameter '${URL}' is incorrectly formatted, please use the following format:"
+    echo "'Parameter name: https://gist.githubusercontent.com/username/gist_id/raw/file'"
+    echo "Parameter name and URL must be separated by a colon and single space only."
+    exit 1
+  elif [[ "$URL" != *"raw"* ]]; then
+    echo "URL '${URL}' must be a direct raw link to a gist or GitHub file."
+    exit 1
+  elif ! [[ "$URL" =~ $VALID_URL_REGEX ]]; then
+    echo "URL '${URL}' is invalid."
+    exit 1
+  else
+    echo "URL '${URL}' is valid."
+  fi
+}
+
 case $1 in
 
 # Downloads all files necessary to generate regression report to the parent directory.
@@ -39,6 +69,55 @@ download-files)
       -H "Authorization: token $GITHUB_TOKEN" \
       -o ../patch_config.xml
   fi
+  ;;
+
+# Parses the text of the PR description, validates the URLs, and
+# sets the environment variables.
+# Expects PR description to be in a file called 'text'.
+parse-pr-description-text)
+
+  # parse parameters from PR description text
+  PROJECTS_FILE_PARAMETER=$(grep "^Diff Regression projects:" text || true)
+  CONFIG_PARAMETER=$(grep "^Diff Regression config:" text || true)
+  NEW_MODULE_CONFIG_PARAMETER=$(grep "^New module config:" text || true)
+  PATCH_CONFIG_PARAMETER=$(grep "^Diff Regression patch config:" text || true)
+  REPORT_LABEL_PARAMETER=$(grep "^Report label:" text || true)
+
+  echo "Parameters parsed from PR description:"
+  echo "PROJECTS_FILE_PARAMETER: '$PROJECTS_FILE_PARAMETER'"
+  echo "CONFIG_PARAMETER: '$CONFIG_PARAMETER'"
+  echo "NEW_MODULE_CONFIG_PARAMETER: '$NEW_MODULE_CONFIG_PARAMETER'"
+  echo "PATCH_CONFIG_PARAMETER: '$PATCH_CONFIG_PARAMETER'"
+  echo "REPORT_LABEL_PARAMETER: '$REPORT_LABEL_PARAMETER'"
+
+  # extract URLs from text
+  PROJECTS_LINK=$(echo "$PROJECTS_FILE_PARAMETER" | sed -E 's/Diff Regression projects: //')
+  CONFIG_LINK=$(echo "$CONFIG_PARAMETER" | sed -E 's/Diff Regression config: //')
+  NEW_MODULE_CONFIG_LINK=$(echo "$NEW_MODULE_CONFIG_PARAMETER" | sed -E 's/New module config: //')
+  PATCH_CONFIG_LINK=$(echo "$PATCH_CONFIG_PARAMETER" | sed -E 's/Diff Regression patch config: //')
+  REPORT_LABEL=$(echo "$REPORT_LABEL_PARAMETER" | sed -E 's/Report label: //')
+
+  echo "URLs extracted from parameters:"
+  echo "PROJECTS_LINK: '$PROJECTS_LINK'"
+  echo "CONFIG_LINK: '$CONFIG_LINK'"
+  echo "NEW_MODULE_CONFIG_LINK: '$NEW_MODULE_CONFIG_LINK'"
+  echo "PATCH_CONFIG_LINK: '$PATCH_CONFIG_LINK'"
+  echo "REPORT_LABEL: '$REPORT_LABEL'"
+
+  echo "Validating PROJECTS_LINK..."
+  validate_url "$PROJECTS_LINK"
+  echo "Validating CONFIG_LINK..."
+  validate_url "$CONFIG_LINK"
+  echo "Validating NEW_MODULE_CONFIG_LINK..."
+  validate_url "$NEW_MODULE_CONFIG_LINK"
+  echo "Validating PATCH_CONFIG_LINK..."
+  validate_url "$PATCH_CONFIG_LINK"
+
+  ./.ci/append-to-github-output.sh "projects_link" "$PROJECTS_LINK"
+  ./.ci/append-to-github-output.sh "config_link" "$CONFIG_LINK"
+  ./.ci/append-to-github-output.sh "new_module_config_link" "$NEW_MODULE_CONFIG_LINK"
+  ./.ci/append-to-github-output.sh "patch_config_link" "$PATCH_CONFIG_LINK"
+  ./.ci/append-to-github-output.sh "report_label" "$REPORT_LABEL"
   ;;
 
 *)

--- a/.github/workflows/diff-report.yml
+++ b/.github/workflows/diff-report.yml
@@ -83,25 +83,7 @@ jobs:
       - name: Parsing content of PR description
         id: parse
         run: |
-          grep "^Diff Regression projects:" text | cat > temp
-          sed 's/Diff Regression projects: //' temp > projects_link
-          ./.ci/append-to-github-output.sh "projects_link" "$(cat projects_link)"
-
-          grep "^Diff Regression config:" text | cat > temp
-          sed 's/Diff Regression config: //' temp > config_link
-          ./.ci/append-to-github-output.sh "config_link" "$(cat config_link)"
-
-          grep "^New module config:" text | cat > temp
-          sed 's/New module config: //' temp > new_module_config_link
-          ./.ci/append-to-github-output.sh "new_module_config_link" "$(cat new_module_config_link)"
-
-          grep "^Diff Regression patch config:" text | cat > temp
-          sed 's/Diff Regression patch config: //' temp > patch_config_link
-          ./.ci/append-to-github-output.sh "patch_config_link" "$(cat patch_config_link)"
-
-          grep "^Report label:" text | cat > temp
-          sed 's/Report label: //' temp > report_label
-          ./.ci/append-to-github-output.sh "report_label" "$(cat report_label)"
+          ./.ci diff-report.sh parse-pr-description-text
 
       - name: Set branch
         id: branch


### PR DESCRIPTION
Part of #12991

We want to fail fast and provide feedback about bad parameter/URL. Right now, a bad URL will still make it to the make-report job, where we just fail with a cryptic curl error. This wastes time and resources to re-clone the repo, etc. 

All of the issues that I see with report parameters are checked for in the `validate_url` function, namely:
1. newlines after `:` instead of single space
2. link to gist that is not a raw link
3. bad url in general
