### PR TITLE
minor: fix script path

### DIFF
--- a/.github/workflows/diff-report.yml
+++ b/.github/workflows/diff-report.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Parsing content of PR description
         id: parse
         run: |
-          ./.ci diff-report.sh parse-pr-description-text
+          ./.ci/diff-report.sh parse-pr-description-text
 
       - name: Set branch
         id: branch


### PR DESCRIPTION
Noticed at https://github.com/checkstyle/checkstyle/actions/runs/4770375164/jobs/8481564250, we have typo in script path