### PR TITLE
Issue #13031: Upgrade aws-actions to v2

### DIFF
--- a/.github/workflows/diff-report.yml
+++ b/.github/workflows/diff-report.yml
@@ -163,7 +163,7 @@ jobs:
           sudo apt install groovy
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -82,7 +82,7 @@ jobs:
           fetch-depth: 0
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Solves https://github.com/checkstyle/checkstyle/issues/13031

Upgrading `aws-actions/configure-aws-credentials` to v2 upgrades `Node.js` to v16:

[aws-actions](https://github.com/aws-actions/configure-aws-credentials#:~:text=We%27ve%20recently%20released%20a%20v2%20of%20this%20action%20that%20uses%20the%20Node%2016%20runtime%20by%20default.%20You%20should%20update%20your%20action%20references%20to%20v2.%20We%20intend%20v2%20to%20be%20the%20new%20default%20for%20this%20action%20and%20will%20no%20longer%20be%20providing%20updates%20to%20the%20v1%20tag.)