### PR TITLE
Issue #12600: Modify javadocstyle check to work with inline return

### DIFF
--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocStyleCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocStyleCheck.xml
@@ -14,6 +14,9 @@
  &lt;li&gt;
  Ensures the first sentence ends with proper punctuation
  (That is a period, question mark, or exclamation mark, by default).
+ Note that this check is not applied to inline {@code @return} tags,
+ because the Javadoc tools automatically appends a period to the end of the tag
+ content.
  Javadoc automatically places the first sentence in the method summary
  table and index. Without proper punctuation the Javadoc may be malformed.
  All items eligible for the {@code {@inheritDoc}} tag are exempt from this

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheckTest.java
@@ -135,6 +135,15 @@ public class JavadocStyleCheckTest
     }
 
     @Test
+    public void testJavadocStyleDefaultSettingsFive()
+            throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWithInlineConfigParser(
+            getPath("InputJavadocStyleDefaultSettingsFive.java"), expected);
+    }
+
+    @Test
     public void testJavadocStyleFirstSentenceOne() throws Exception {
         final String[] expected = {
             "24: " + getCheckMessage(MSG_NO_PERIOD),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleDefaultSettingsFive.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/InputJavadocStyleDefaultSettingsFive.java
@@ -1,0 +1,62 @@
+/*
+JavadocStyle
+scope = (default)private
+excludeScope = (default)null
+checkFirstSentence = (default)true
+endOfSentenceFormat = (default)([.?!][ \t\n\r\f<])|([.?!]$)
+checkEmptyJavadoc = (default)false
+checkHtml = (default)true
+tokens = (default)ANNOTATION_DEF, ANNOTATION_FIELD_DEF, CLASS_DEF, CTOR_DEF, \
+         ENUM_CONSTANT_DEF, ENUM_DEF, INTERFACE_DEF, METHOD_DEF, PACKAGE_DEF, \
+         VARIABLE_DEF, RECORD_DEF, COMPACT_CTOR_DEF
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocstyle;
+
+public class InputJavadocStyleDefaultSettingsFive
+{
+   /**
+    * {@return a string}
+    */
+    public String foo()
+    {
+        return "Hello, world";
+    }
+
+   /**
+    *   This is the first sentence with leading and trailing spaces.   Second sentence.
+    */
+    public String foo2()
+    {
+        return "Hello, world";
+    }
+
+   /**
+    * {@return the Java language {@linkplain Modifier modifiers} for
+    * the executable represented by this object}
+    */
+    public int foo3()
+    {
+        return 0;
+    }
+
+   /**
+    * {@return {@code true} if this method is a bridge
+    * method; returns {@code false} otherwise}
+    */
+    public boolean foo4()
+    {
+        return true;
+    }
+
+    /**
+     * {@return {@code true} if this object has been {@linkplain #init
+     * initialized}, {@code false} otherwise}
+     */
+     public boolean foo5()
+     {
+       return true;
+     }
+}

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/Example1.txt
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocstyle/Example1.txt
@@ -13,6 +13,16 @@ public class Test {
      */
     private void methodWithValidCommentStyle() {}
 
+    // ok below, @return tag automatically inserts a period after the text
+    /**
+     * {@return {@code true} if this object
+     * has been initialized, {@code false} otherwise}
+     */
+    private boolean isInitialized()
+    {
+       return true;
+    }
+
     /**
      * Some description here // violation, the sentence must end with a proper punctuation
      */

--- a/src/xdocs/checks/javadoc/javadocstyle.xml
+++ b/src/xdocs/checks/javadoc/javadocstyle.xml
@@ -19,6 +19,9 @@
           <li>
             Ensures the first sentence ends with proper punctuation
             (That is a period, question mark, or exclamation mark, by default).
+            Note that this check is not applied to inline <code>@return</code> tags,
+            because the Javadoc tools automatically appends a period to the end of the tag
+            content.
             Javadoc automatically places the first sentence in the
             method summary table and index. Without proper punctuation
             the Javadoc may be malformed. All items eligible for the
@@ -197,6 +200,16 @@ public class Test {
      * Some description here. // OK
      */
     private void methodWithValidCommentStyle() {}
+
+    // ok below, @return tag automatically inserts a period after the text
+    /**
+     * {@return {@code true} if this object
+     * has been initialized, {@code false} otherwise}
+     */
+    private boolean isInitialized()
+    {
+       return true;
+    }
 
     /**
      * Some description here // violation, the sentence must end with a proper punctuation

--- a/src/xdocs/checks/javadoc/javadocstyle.xml.template
+++ b/src/xdocs/checks/javadoc/javadocstyle.xml.template
@@ -19,6 +19,9 @@
           <li>
             Ensures the first sentence ends with proper punctuation
             (That is a period, question mark, or exclamation mark, by default).
+            Note that this check is not applied to inline <code>@return</code> tags,
+            because the Javadoc tools automatically appends a period to the end of the tag
+            content.
             Javadoc automatically places the first sentence in the
             method summary table and index. Without proper punctuation
             the Javadoc may be malformed. All items eligible for the


### PR DESCRIPTION
Solves https://github.com/checkstyle/checkstyle/issues/12600

Since inline `@return` tag is the only inline tag that automatically inserts a period after the text, we can modify check method to determine if the first sentence was `{@return something}`

CLI:
```
$ cat config.xml
<?xml version="1.0"?>
<!DOCTYPE module PUBLIC
          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
          "https://checkstyle.org/dtds/configuration_1_3.dtd">

<module name="Checker">
    <module name="TreeWalker">
        <module name="JavadocStyle"/>
    </module>
</module>

$ cat Test.java
class Test {
    /**
     * {@return a string}
     */
    String foo() {
        return "Hello, world";
    }
}

$ java -jar checkstyle-10.10.1-SNAPSHOT-all.jar -c config.xml Test.java
Starting audit...
Audit done.
```

Diff Regression projects: https://gist.githubusercontent.com/0xbakry/7853843aa3d69aee301d7a8d62d08ebb/raw/2e52c13c579d1461e515394bbcbc752ee9c519cc/my_projects
Diff Regression config: https://gist.githubusercontent.com/0xbakry/a1fcb13eef42f29de8ff500892f34166/raw/6c59fb003381d5634486a2b908d1f0463515fb58/config_check.xml

Clean report:
https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/7324fc0_2023132220/reports/diff/index.html