### PR TITLE
Issue #13063: fix listing pitest profiles on Mac

### DIFF
--- a/.ci/pitest.sh
+++ b/.ci/pitest.sh
@@ -4,7 +4,7 @@ set -e
 
 function list_profiles() {
   POM_PATH="$(dirname "${0}")/../pom.xml"
-  cat "$POM_PATH" | sed -n -e 's/^.*<id>\(pitest-[^<]\+\)<\/id>.*$/\1/p' | sort
+  cat "$POM_PATH" | sed -E -n 's/^.*<id>(pitest-[^<]+)<\/id>.*$/\1/p' | sort
 }
 
 case $1 in


### PR DESCRIPTION
Issue #13063 

Fix tested on Mac, Fedora and Ubuntu as follows:

Mac
```
/var/tmp/checkstyle[issue-13063 L|✔] [20:56:18]% uname -v
Darwin Kernel Version 22.4.0: Mon Mar  6 20:59:28 PST 2023; root:xnu-8796.101.5~3/RELEASE_ARM64_T6000
/var/tmp/checkstyle[issue-13063 L|✔] [20:56:24]% ./.ci/pitest.sh --list
Supported profiles:
pitest-annotation
pitest-ant
pitest-api
pitest-blocks
pitest-coding-1
pitest-coding-2
pitest-coding-require-this-check
pitest-common
pitest-common-2
pitest-design
pitest-filters
pitest-gui
pitest-header
pitest-imports
pitest-indentation
pitest-java-ast-visitor
pitest-javadoc
pitest-main
pitest-metrics
pitest-misc
pitest-modifier
pitest-naming
pitest-packagenamesloader
pitest-regexp
pitest-sizes
pitest-tree-walker
pitest-utils
pitest-whitespace
pitest-xpath
```

Fedora
```
/var/tmp/checkstyle[issue-13063 L|✔] [20:59:51]% docker run -it -v /var/tmp/checkstyle:/var/tmp/checkstyle fedora bash -c "cd /var/tmp/checkstyle && .ci/pitest.sh --list"
Supported profiles:
pitest-annotation
pitest-ant
pitest-api
pitest-blocks
pitest-coding-1
pitest-coding-2
pitest-coding-require-this-check
pitest-common
pitest-common-2
pitest-design
pitest-filters
pitest-gui
pitest-header
pitest-imports
pitest-indentation
pitest-java-ast-visitor
pitest-javadoc
pitest-main
pitest-metrics
pitest-misc
pitest-modifier
pitest-naming
pitest-packagenamesloader
pitest-regexp
pitest-sizes
pitest-tree-walker
pitest-utils
pitest-whitespace
pitest-xpath
```

Ubuntu
```
/var/tmp/checkstyle[issue-13063 L|✔] [21:00:07]% docker run -it -v /var/tmp/checkstyle:/var/tmp/checkstyle ubuntu bash -c "cd /var/tmp/checkstyle && .ci/pitest.sh --list"
Supported profiles:
pitest-annotation
pitest-ant
pitest-api
pitest-blocks
pitest-coding-1
pitest-coding-2
pitest-coding-require-this-check
pitest-common
pitest-common-2
pitest-design
pitest-filters
pitest-gui
pitest-header
pitest-imports
pitest-indentation
pitest-java-ast-visitor
pitest-javadoc
pitest-main
pitest-metrics
pitest-misc
pitest-modifier
pitest-naming
pitest-packagenamesloader
pitest-regexp
pitest-sizes
pitest-tree-walker
pitest-utils
pitest-whitespace
pitest-xpath
```