### PR TITLE
Issue #11214: Specify violation messages for MethodParamPadCheck

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/bdd/InlineConfigParser.java
@@ -97,7 +97,6 @@ public final class InlineConfigParser {
      * Until <a href="https://github.com/checkstyle/checkstyle/issues/11214">#11214</a>
      */
     private static final Set<String> SUPPRESSED_CHECKS = new HashSet<>(Arrays.asList(
-            "com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCheck",
             "com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck",
             "com.puppycrawl.tools.checkstyle.checks.regexp.RegexpCheck",
             "com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyForInitializerPadCheck",

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/MethodParamPadCheckTest.java
@@ -124,16 +124,16 @@ public class MethodParamPadCheckTest
     @Test
     public void testMethodParamPadRecords() throws Exception {
         final String[] expected = {
-            "19:25: " + getCheckMessage(MSG_WS_PRECEDED, "("),
+            "19:16: " + getCheckMessage(MSG_WS_PRECEDED, "("),
             "20:34: " + getCheckMessage(MSG_WS_PRECEDED, "("),
-            "31:26: " + getCheckMessage(MSG_WS_PRECEDED, "("),
-            "32:23: " + getCheckMessage(MSG_WS_PRECEDED, "("),
-            "37:26: " + getCheckMessage(MSG_WS_PRECEDED, "("),
+            "31:17: " + getCheckMessage(MSG_WS_PRECEDED, "("),
+            "32:14: " + getCheckMessage(MSG_WS_PRECEDED, "("),
+            "37:17: " + getCheckMessage(MSG_WS_PRECEDED, "("),
             "38:33: " + getCheckMessage(MSG_WS_PRECEDED, "("),
-            "44:26: " + getCheckMessage(MSG_WS_PRECEDED, "("),
+            "44:17: " + getCheckMessage(MSG_WS_PRECEDED, "("),
             "45:18: " + getCheckMessage(MSG_WS_PRECEDED, "("),
-            "51:34: " + getCheckMessage(MSG_WS_PRECEDED, "("),
-            "57:34: " + getCheckMessage(MSG_WS_PRECEDED, "("),
+            "51:25: " + getCheckMessage(MSG_WS_PRECEDED, "("),
+            "57:25: " + getCheckMessage(MSG_WS_PRECEDED, "("),
         };
         verifyWithInlineConfigParser(
                 getNonCompilablePath("InputMethodParamPadRecords.java"), expected);

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/methodparampad/InputMethodParamPadRecords.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/methodparampad/InputMethodParamPadRecords.java
@@ -16,8 +16,8 @@ import org.w3c.dom.Node;
 public class InputMethodParamPadRecords {
 
     // in record def
-    record MyTestRecord (String string, Record rec){ // violation
-        private boolean inRecord (Object obj) { // violation
+    record Mtr (String string, Record rec){ // violation ''(' is preceded with whitespace'
+        private boolean inRecord (Object obj) { // violation ''(' is preceded with whitespace'
             int value = 0;
             if(obj instanceof Integer i) {
                 value = i;
@@ -28,32 +28,32 @@ public class InputMethodParamPadRecords {
     }
 
     //in ctor
-    record MyTestRecord2 () { // violation
-        MyTestRecord2 (String one, String two, String three){ // violation
-            this ();// ok
+    record Mtr2 () { // violation ''(' is preceded with whitespace'
+        Mtr2 (String s1, String s2, String s3){ // violation ''(' is preceded with whitespace'
+            this ();
         }
     }
 
-    record MyTestRecord3 (Integer i, Node node) { // violation
-        public static void main (String... args) { // violation
+    record Mtr3 (Integer i, Node node) { // violation ''(' is preceded with whitespace'
+        public static void main (String... args) { // violation ''(' is preceded with whitespace'
             System.out.println("works!");
         }
     }
 
     //in method def
-    record MyTestRecord4 () { // violation
-        void foo (){} // violation
+    record Mtr4 () { // violation ''(' is preceded with whitespace'
+        void foo (){} // violation ''(' is preceded with whitespace'
     }
 
     //in ctor invocation
-    record MyTestRecord5() {
-        static MyTestRecord mtr =
-                new MyTestRecord ("my string", new MyTestRecord4()); // violation
+    record Mtr5() {
+        static Mtr mtr =
+                new Mtr ("my string", new Mtr4()); // violation ''(' is preceded with whitespace'
     }
 
     //in ctor invocation
     class MyTestClass {
-        private MyTestRecord mtr =
-                new MyTestRecord ("my string", new MyTestRecord4()); // violation
+        private Mtr mtr =
+                new Mtr ("my string", new Mtr4()); // violation ''(' is preceded with whitespace'
     }
 }


### PR DESCRIPTION
Solves issue #11214 for MethodParamPadCheck

- Build successful with `mvn clean verify`
- Removed MethodParamPadCheck from suppression list
- Added violation messages for InputMethodParamPadRecords
