### PR TITLE
Issue #13095: kill mutation for VariableDeclarationUsageDistanceCheck 3

### DIFF
--- a/config/pitest-suppressions/pitest-coding-1-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-1-suppressions.xml
@@ -120,15 +120,6 @@
   <mutation unstable="false">
     <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
-    <mutatedMethod>getDistToVariableUsageInChildNode</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_1</mutator>
-    <description>RemoveSwitch 1 (case value 10)</description>
-    <lineContent>switch (examineNode.getType()) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
     <mutatedMethod>isInitializationSequence</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
     <description>removed conditional - replaced equality check with true</description>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -566,9 +566,6 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
 
         int resultDist = currentDistToVarUsage;
         switch (examineNode.getType()) {
-            case TokenTypes.VARIABLE_DEF:
-                resultDist++;
-                break;
             case TokenTypes.SLIST:
                 resultDist = 0;
                 break;


### PR DESCRIPTION
 **1**  Issue #13095: kill mutation for VariableDeclarationUsageDistanceCheck 3


 **2** Link to Check Documentation :-
 https://checkstyle.org/config_coding.html#VariableDeclarationUsageDistance


**3** covering 
https://github.com/checkstyle/checkstyle/blob/6f451fbb49afc21b0e04b46c0576c7a984419a88/config/pitest-suppressions/pitest-coding-1-suppressions.xml#L129-L136


**4** Logic behind mutation removal
I don't find any test case which can kill this mutation.

https://github.com/Kevin222004/checkstyle/blob/d60bae5293a4221f4e5b28da1300441a90be5d44/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java#L569-L571
whenever the token type is off `TokenTypes.VARIABLE_DEF` then `resultDist++;` will increment by 1.

In default case 
https://github.com/Kevin222004/checkstyle/blob/d60bae5293a4221f4e5b28da1300441a90be5d44/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java#L589-L595
 `if (examineNode.findFirstToken(TokenTypes.SLIST) == null) {`  here if the `if` statment is been executing then similarly `resultDist++;` will increment by 1 their is no case possible where `SLIST` become the child of `VARIABLE_DEF` so it is always going to be null and every time only if will execute.


**5**  Reports :- 
https://kevin222004.github.io/reports/M3/2023-05-31-T-09-24-56/test-report/index.html