### PR TITLE
Issue #13102: kill mutation for DeclarationOrderCheck

### DIFF
--- a/config/pitest-suppressions/pitest-coding-1-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-1-suppressions.xml
@@ -19,15 +19,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>DeclarationOrderCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.DeclarationOrderCheck</mutatedClass>
-    <mutatedMethod>processModifiersState</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable declarationAccess</description>
-    <lineContent>state.declarationAccess = Scope.PUBLIC;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>EqualsAvoidNullCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheck</mutatedClass>
     <mutatedMethod>isStringFieldOrVariableFromClass</mutatedMethod>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheckTest.java
@@ -33,6 +33,7 @@ import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.api.Violation;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class DeclarationOrderCheckTest
     extends AbstractModuleTestSupport {
@@ -233,6 +234,14 @@ public class DeclarationOrderCheckTest
         };
         verifyWithInlineConfigParser(
                 getPath("InputDeclarationOrderAvoidDuplicatesInStaticFinalFields.java"),
+                expected);
+    }
+
+    @Test
+    public void test() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputDeclarationOrder2.java"),
                 expected);
     }
 

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/declarationorder/InputDeclarationOrder2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/declarationorder/InputDeclarationOrder2.java
@@ -1,0 +1,22 @@
+/*
+DeclarationOrder
+ignoreConstructors = (default)false
+ignoreModifiers = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.declarationorder;
+
+public class InputDeclarationOrder2 {
+    private static char[] sHexChars = {
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+            'A', 'B', 'C', 'D', 'E', 'F' }; // ok
+
+    int[] array = new int[] {1, 2, 3}; // ok
+
+    int[] array2 = new int[] {
+            1, 2, 3
+    }; // ok
+
+}


### PR DESCRIPTION
Issue #13102: kill mutation for DeclarationOrderCheck

covering 
https://github.com/checkstyle/checkstyle/blob/d7f62fc0f643eb54c3b20d9e9243ec72faea637f/config/pitest-suppressions/pitest-coding-1-suppressions.xml#L21-L28