### PR TITLE
Issue #13095: kill mutation for VariableDeclarationUsageDistanceCheck 4

### DIFF
--- a/config/pitest-suppressions/pitest-coding-1-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-1-suppressions.xml
@@ -18,13 +18,4 @@
     <lineContent>return Collections.unmodifiableSet(methodCalls);</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
-    <mutatedMethod>isInitializationSequence</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>while (result</lineContent>
-  </mutation>
-
 </suppressedMutations>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -462,52 +462,34 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
         DetailAST currentSiblingAst = variableUsageAst;
         String initInstanceName = "";
 
-        while (result
-                && !isUsedVariableDeclarationFound
-                && currentSiblingAst != null) {
-            switch (currentSiblingAst.getType()) {
-                case TokenTypes.EXPR:
-                    final DetailAST methodCallAst = currentSiblingAst.getFirstChild();
-
-                    if (methodCallAst.getType() == TokenTypes.METHOD_CALL) {
-                        final String instanceName =
-                            getInstanceName(methodCallAst);
-                        // method is called without instance
-                        if (instanceName.isEmpty()) {
-                            result = false;
-                        }
-                        // differs from previous instance
-                        else if (!instanceName.equals(initInstanceName)) {
-                            if (initInstanceName.isEmpty()) {
-                                initInstanceName = instanceName;
-                            }
-                            else {
-                                result = false;
-                            }
-                        }
+        while (result && !isUsedVariableDeclarationFound && currentSiblingAst != null) {
+            if (currentSiblingAst.getType() == TokenTypes.EXPR
+                    && currentSiblingAst.getFirstChild().getType() == TokenTypes.METHOD_CALL) {
+                final DetailAST methodCallAst = currentSiblingAst.getFirstChild();
+                final String instanceName = getInstanceName(methodCallAst);
+                if (instanceName.isEmpty()) {
+                    result = false;
+                }
+                else if (!instanceName.equals(initInstanceName)) {
+                    if (initInstanceName.isEmpty()) {
+                        initInstanceName = instanceName;
                     }
                     else {
-                        // is not method call
                         result = false;
                     }
-                    break;
+                }
 
-                case TokenTypes.VARIABLE_DEF:
-                    final String currentVariableName = currentSiblingAst
-                        .findFirstToken(TokenTypes.IDENT).getText();
-                    isUsedVariableDeclarationFound = variableName.equals(currentVariableName);
-                    break;
-
-                case TokenTypes.SEMI:
-                    break;
-
-                default:
-                    result = false;
             }
-
+            else if (currentSiblingAst.getType() == TokenTypes.VARIABLE_DEF) {
+                final String currentVariableName =
+                        currentSiblingAst.findFirstToken(TokenTypes.IDENT).getText();
+                isUsedVariableDeclarationFound = variableName.equals(currentVariableName);
+            }
+            else {
+                result = currentSiblingAst.getType() == TokenTypes.SEMI;
+            }
             currentSiblingAst = currentSiblingAst.getPreviousSibling();
         }
-
         return result;
     }
 


### PR DESCRIPTION
Issue #13095: kill mutation for VariableDeclarationUsageDistanceCheck 4

# Check
https://checkstyle.org/config_coding.html#VariableDeclarationUsageDistance

# Mutation 
https://github.com/checkstyle/checkstyle/blob/81448ea434cda883b748d3d2c77b2f58a8b22bbe/config/pitest-suppressions/pitest-coding-1-suppressions.xml#L102-L109


4) Explanation:-
My thinking is that instead of removing the condition, we can continue if the token is SEMI and set the result to true. Now this won't have any problem as other branches can alter the result in the subsequent iterations and result is by default true.

A single dangling ; would be EMPTY_STAT and not SEMI. Please run regression on this method.


5)  Regression 

https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/2e4b5ad_2023084207/reports/diff/index.html

https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/2e4b5ad_2023213552/reports/diff/index.html

----------------------

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/12b3bfed9dcea32830f532159c5023c6/raw/1d2cf31a526f452572fc41bf922762ecc5c6b7d6/variable.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/21e3934e85f802e2fbd48af06d122364/raw/604256badd733d8568064f371d55657c04b00dfd/test-projects-2.properties
Report label: New-Regression-1