### PR TITLE
Issue #13095: kill mutation for VariableDeclarationUsageDistanceCheck 5

### DIFF
--- a/config/pitest-suppressions/pitest-coding-1-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-1-suppressions.xml
@@ -93,15 +93,6 @@
   <mutation unstable="false">
     <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
-    <mutatedMethod>calculateDistanceBetweenScopes</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to java/util/Objects::requireNonNullElse with argument</description>
-    <lineContent>Objects.requireNonNullElse(exprWithVariableUsage, blockWithVariableUsage);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
     <mutatedMethod>isInitializationSequence</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
     <description>removed conditional - replaced equality check with true</description>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java
@@ -23,7 +23,6 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -653,8 +652,7 @@ public class VariableDeclarationUsageDistanceCheck extends AbstractCheck {
                         exprWithVariableUsage = blockWithVariableUsage.getFirstChild();
                 }
                 currentScopeAst = exprWithVariableUsage;
-                variableUsageAst =
-                        Objects.requireNonNullElse(exprWithVariableUsage, blockWithVariableUsage);
+                variableUsageAst = blockWithVariableUsage;
             }
 
             // If there's no any variable usage, then distance = 0.


### PR DESCRIPTION
1 Issue https://github.com/checkstyle/checkstyle/issues/13095: kill mutation for VariableDeclarationUsageDistanceCheck 5

------------

# Check:-
https://checkstyle.org/config_coding.html#VariableDeclarationUsageDistance

-----------

# mutation covered
https://github.com/checkstyle/checkstyle/blob/6f451fbb49afc21b0e04b46c0576c7a984419a88/config/pitest-suppressions/pitest-coding-1-suppressions.xml#L111-L118

---------

# Explaination
ok so the whole loop will start if 
https://github.com/checkstyle/checkstyle/blob/c5566a6ea8c336ddedde446648b03ef56a73b7ba/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java#L613
currentScopeAst != null;

then 
https://github.com/checkstyle/checkstyle/blob/c5566a6ea8c336ddedde446648b03ef56a73b7ba/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java#L614-L619

here `searchResult` will find the first usage of variable
know lets take a example 
```
    public void testMethod9() {
        boolean result = false;
        boolean b1 = true;
        if (b1) {
            result = true;
        }
    }
```

ast for if block in method 
```
    |       |--LITERAL_IF -> if [19:8]
    |       |   |--LPAREN -> ( [19:11]
    |       |   |--EXPR -> EXPR [19:12]
    |       |   |   `--IDENT -> b1 [19:12]
    |       |   |--RPAREN -> ) [19:14]
    |       |   `--SLIST -> { [19:16]
    |       |       |--EXPR -> EXPR [20:19]
    |       |       |   `--ASSIGN -> = [20:19]
    |       |       |       |--IDENT -> result [20:12]
    |       |       |       `--LITERAL_TRUE -> true [20:21]
    |       |       |--SEMI -> ; [20:25]
    |       |       `--RCURLY -> } [21:8]
    |       `--RCURLY -> } [22:4]

```

lets suppose we have variable `result` know what does `searchResult` give the result as `LITERAL_IF -> if [19:8]` where it is used.

and variable usage expression will also get same values.

in this example size of list of variableUsageExpressions would be one. so if statment will execute. and over their `blockWithVariableUsage = variableUsageExpressions.get(o)` means in our example again it would be assigned as `LITERAL_IF -> if [19:8]`

in switch case 
https://github.com/checkstyle/checkstyle/blob/c5566a6ea8c336ddedde446648b03ef56a73b7ba/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java#L639-L641

`getFirstNodeInsideIfBlock` will execute this method basically provide 
https://github.com/checkstyle/checkstyle/blob/c5566a6ea8c336ddedde446648b03ef56a73b7ba/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java#L743-L745

`SLIST -> { [19:16]` in all the case if the variable is used in initalization then it will return `LITERAL_IF -> if [19:8]` this is same for all other case except default one.

and then here lets suppose if variable is used in 
initalization then 
https://github.com/checkstyle/checkstyle/blob/c5566a6ea8c336ddedde446648b03ef56a73b7ba/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/VariableDeclarationUsageDistanceCheck.java#L655-L657

currentScopeAst will become null and variable usage ast become blockWithVariableUsage hence in this case their is no issue.

but lets say if it is not null in the above example. then currentScope would become exprWithVariableUsage
and variableUsageAst become exprWithVariableUsage.

and the loop start again with the value of exprWithVariableUsage

and again `searchResult` will find the usage but know the scope will start from exprWithVariableUsage and again `blockWithVariableUsage` will get it value and here `variableUsageAst` is assgined as `blockWithVariableUsage`. 
know loop will run till currentScopeASt would not become null and if it is null then value of variableUsageAst will become `blockWithVariableUsage`
 so at the end the value will become only `blockWithVariableUsage` so istead of assigning it to
 `currentScopeAst` it will not make any issue if we assign it as blockWithVariableUsage 


-------------------

# Regression :- 
https://kevin222004.github.io/reports/M6/2023-06-01-T-14-00-21/test-report/index.html