### PR TITLE
 Issue #13102: kill mutation for DeclarationOrderCheck 2

### DIFF
--- a/config/pitest-suppressions/pitest-coding-1-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-1-suppressions.xml
@@ -1,15 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
-    <sourceFile>DeclarationOrderCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.DeclarationOrderCheck</mutatedClass>
-    <mutatedMethod>processModifiersState</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable currentScopeState</description>
-    <lineContent>state.currentScopeState = STATE_STATIC_VARIABLE_DEF;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>EqualsAvoidNullCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheck$FieldFrame</mutatedClass>
     <mutatedMethod>getChildren</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java
@@ -366,17 +366,10 @@ public class DeclarationOrderCheck extends AbstractCheck {
                 state.currentScopeState = STATE_INSTANCE_VARIABLE_DEF;
             }
         }
-        else {
-            if (state.currentScopeState > STATE_STATIC_VARIABLE_DEF) {
-                if (!ignoreModifiers
-                        || state.currentScopeState > STATE_INSTANCE_VARIABLE_DEF) {
-                    isStateValid = false;
-                    log(modifierAst, MSG_STATIC);
-                }
-            }
-            else {
-                state.currentScopeState = STATE_STATIC_VARIABLE_DEF;
-            }
+        else if (state.currentScopeState > STATE_INSTANCE_VARIABLE_DEF
+                || state.currentScopeState > STATE_STATIC_VARIABLE_DEF && !ignoreModifiers) {
+            isStateValid = false;
+            log(modifierAst, MSG_STATIC);
         }
         return isStateValid;
     }


### PR DESCRIPTION
 Issue #13102: kill mutation for DeclarationOrderCheck 2

check :- https://checkstyle.org/config_coding.html#DeclarationOrder

covering :- 
  https://github.com/checkstyle/checkstyle/blob/81448ea434cda883b748d3d2c77b2f58a8b22bbe/config/pitest-suppressions/pitest-coding-1-suppressions.xml#L3-L10

Explanation:- 
  if we look at else part the if condition will execute when state.`currentScopeState` is greater than `STATE_STATIC_VARIABLE_DEF`
 As per https://github.com/checkstyle/checkstyle/blob/81448ea434cda883b748d3d2c77b2f58a8b22bbe/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/DeclarationOrderCheck.java#L228

 the value of `STATE_STATIC_VARIABLE_DEF` is 1 
 know if will only execute when state.current scope if either 2, 3, 4 means greater than 1 not even 1.

 so if their the value of state.currentScopeState is 1 then only else part will exectue and in else part we are assigning state.curcurrentScopeState to `STATE_STATIC_VARIABLE_DEF` which value is 1. so we are assigning the same value to  `state.currentScopeState` so removal of else part wont make any effect.

Regression 
https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/f5bfcc9_2023093628/reports/diff/index.html
