### PR TITLE
Issue #13109: Kill mutation for EqualsAvoidNullCheck

### DIFF
--- a/config/pitest-suppressions/pitest-coding-1-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-1-suppressions.xml
@@ -15,15 +15,6 @@
     <mutatedMethod>isStringFieldOrVariableFromClass</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
     <description>replaced call to com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck::getObjectFrame with argument</description>
-    <lineContent>FieldFrame frame = getObjectFrame(currentFrame);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>EqualsAvoidNullCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheck</mutatedClass>
-    <mutatedMethod>isStringFieldOrVariableFromClass</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck::getObjectFrame with argument</description>
     <lineContent>frame = getObjectFrame(frame.getParent());</lineContent>
   </mutation>
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -494,7 +494,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
             final String className) {
         boolean result = false;
         final String name = objCalledOn.getText();
-        FieldFrame frame = getObjectFrame(currentFrame);
+        FieldFrame frame = currentFrame;
         while (frame != null) {
             if (className.equals(frame.getFrameName())) {
                 final DetailAST field = frame.findField(name);


### PR DESCRIPTION
Issue #13109: Kill mutation for EqualsAvoidNullCheck

**1 check** :- https://checkstyle.org/config_coding.html#EqualsAvoidNull

**2covering** :- 
https://github.com/checkstyle/checkstyle/blob/81448ea434cda883b748d3d2c77b2f58a8b22bbe/config/pitest-suppressions/pitest-coding-1-suppressions.xml#L12-L19

**3 Explaination**
`getObjectFrame()` method will provide the nearest parent frame of class, enum.

if we remove getObjectFramefrom the `FieldFrame frame = getObjectFrame(currentFrame);` and `frame = getObjectFrame(frame.getParent());` they will go through all the frame instead of directly going to frame which are class or enum.

and as per the condition in loop `className.equals(frame.getFrameName())` 
frameName would always be of class enum as per
 https://github.com/checkstyle/checkstyle/blob/81448ea434cda883b748d3d2c77b2f58a8b22bbe/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java#L568-L569

so removal of that not make any issue 
https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/b863d4b_2023095222/reports/diff/index.html