### PR TITLE
Issue #13109: Kill mutation for EqualsAvoidNullCheck 2

### DIFF
--- a/config/pitest-suppressions/pitest-coding-1-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-1-suppressions.xml
@@ -11,15 +11,6 @@
 
   <mutation unstable="false">
     <sourceFile>EqualsAvoidNullCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheck</mutatedClass>
-    <mutatedMethod>isStringFieldOrVariableFromClass</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck::getObjectFrame with argument</description>
-    <lineContent>frame = getObjectFrame(frame.getParent());</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>EqualsAvoidNullCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheck$FieldFrame</mutatedClass>
     <mutatedMethod>getChildren</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -501,7 +501,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
                 result = STRING.equals(getFieldType(field));
                 break;
             }
-            frame = getObjectFrame(frame.getParent());
+            frame = frame.getParent();
         }
         return result;
     }
@@ -514,7 +514,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
      */
     private static FieldFrame getObjectFrame(FieldFrame frame) {
         FieldFrame objectFrame = frame;
-        while (objectFrame != null && !objectFrame.isClassOrEnumOrRecordDef()) {
+        while (!objectFrame.isClassOrEnumOrRecordDef()) {
             objectFrame = objectFrame.getParent();
         }
         return objectFrame;


### PR DESCRIPTION
Issue #13109: Kill mutation for EqualsAvoidNullCheck 2

**1 check** :- https://checkstyle.org/config_coding.html#EqualsAvoidNull

**2covering** :- 
https://github.com/checkstyle/checkstyle/blob/81448ea434cda883b748d3d2c77b2f58a8b22bbe/config/pitest-suppressions/pitest-coding-1-suppressions.xml#L21-L28

**3 Explaination**
`getObjectFrame()` method will provide the nearest parent frame of class, enum.

if we remove getObjectFramefrom the `FieldFrame frame = getObjectFrame(currentFrame);` and `frame = getObjectFrame(frame.getParent());` they will go through all the frame instead of directly going to frame which are class or enum.

and as per the condition in loop `className.equals(frame.getFrameName())` 
frameName would always be of class enum as per
 https://github.com/checkstyle/checkstyle/blob/81448ea434cda883b748d3d2c77b2f58a8b22bbe/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java#L568-L569

so removal of that not make any issue 

https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/c201250_2023104332/reports/diff/index.html

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/c515fe44cd311783e6cbdf0f5788b4d3/raw/15647eeebde66f0c3a366f655442b02b4d55efef/equal.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/21e3934e85f802e2fbd48af06d122364/raw/604256badd733d8568064f371d55657c04b00dfd/test-projects-2.properties
Report label: Project-list-2
