### PR TITLE
Issue #13109: Kill mutation for EqualsAvoidNullCheck 3

### DIFF
--- a/config/pitest-suppressions/pitest-coding-1-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-1-suppressions.xml
@@ -30,15 +30,6 @@
   <mutation unstable="false">
     <sourceFile>EqualsAvoidNullCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheck$FieldFrame</mutatedClass>
-    <mutatedMethod>getChildren</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to java/util/Collections::unmodifiableSet with argument</description>
-    <lineContent>return Collections.unmodifiableSet(children);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>EqualsAvoidNullCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.EqualsAvoidNullCheck$FieldFrame</mutatedClass>
     <mutatedMethod>getMethodCalls</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
     <description>replaced call to java/util/Collections::unmodifiableSet with argument</description>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java
@@ -613,7 +613,7 @@ public class EqualsAvoidNullCheck extends AbstractCheck {
          * @return children of this frame.
          */
         public Set<FieldFrame> getChildren() {
-            return Collections.unmodifiableSet(children);
+            return new HashSet<>(children);
         }
 
         /**


### PR DESCRIPTION
Issue #13109: Kill mutation for EqualsAvoidNullCheck 3


**1 check** :- https://checkstyle.org/config_coding.html#EqualsAvoidNull

**2covering** :- 
https://github.com/checkstyle/checkstyle/blob/81448ea434cda883b748d3d2c77b2f58a8b22bbe/config/pitest-suppressions/pitest-coding-1-suppressions.xml#L30-L37

**3 Explaination**
getChildren method is used only at 
https://github.com/checkstyle/checkstyle/blob/81448ea434cda883b748d3d2c77b2f58a8b22bbe/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/EqualsAvoidNullCheck.java#L336

ok so as per https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Set.html#unmodifiable:~:text=They%20are%20unmodifiable.%20Elements%20cannot%20be%20added%20or%20removed. we cannot modify children

in above method we are not mdifiying the children in any way,
 so removal of it is not creating any issue.

|https://kevin222004.github.io/reports/Ev3/2023-06-01-T-23-12-41/test-report/index.html