### PR TITLE
Issue #13109: Kill mutation for UnnecessaryParenthesesCheck

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -2369,17 +2369,6 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>parentToSkip = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull DetailAST
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field parentToSkip</message>
     <lineContent>private DetailAST parentToSkip;</lineContent>

--- a/config/pitest-suppressions/pitest-coding-1-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-1-suppressions.xml
@@ -28,15 +28,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>UnnecessaryParenthesesCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessaryParenthesesCheck</mutatedClass>
-    <mutatedMethod>checkExpression</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable parentToSkip</description>
-    <lineContent>parentToSkip = null;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
     <mutatedMethod>isInitializationSequence</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
@@ -642,8 +642,6 @@ public class UnnecessaryParenthesesCheck extends AbstractCheck {
                 log(ast, MSG_EXPR);
             }
         }
-
-        parentToSkip = null;
     }
 
     /**


### PR DESCRIPTION
Issue #13109: Kill mutation for UnnecessaryParenthesesCheck

-------------

# Check :- 
https://checkstyle.org/config_coding.html#UnnecessaryParentheses

---------

# mutation 
https://github.com/checkstyle/checkstyle/blob/c5566a6ea8c336ddedde446648b03ef56a73b7ba/config/pitest-suppressions/pitest-coding-1-suppressions.xml#L48-L55

---------

# Explaination 
The only reason i can see to removal of this will not make issue is the checkExpression method is used only in leaveToken 
```
            if (type == TokenTypes.EXPR) {
                checkExpression(ast);
            }
```
so the changes of ParentToSkip will not really make any effect in code because token will be leaved if the is statment is been executed, it will never be used after it.

------
Regression :- 
https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/13cdd33_2023060542/reports/diff/index.html

https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/13cdd33_2023085740/reports/diff/index.html