### PR TITLE
Issue #13109: Kill mutation for UnnecessaryParenthesesCheck 2

### DIFF
--- a/config/pitest-suppressions/pitest-coding-1-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-1-suppressions.xml
@@ -64,15 +64,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>UnnecessaryParenthesesCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessaryParenthesesCheck</mutatedClass>
-    <mutatedMethod>visitToken</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getText</description>
-    <lineContent>log(ast, MSG_LAMBDA, ast.getText());</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>VariableDeclarationUsageDistanceCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.VariableDeclarationUsageDistanceCheck</mutatedClass>
     <mutatedMethod>calculateDistanceBetweenScopes</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnnecessaryParenthesesCheck.java
@@ -528,7 +528,7 @@ public class UnnecessaryParenthesesCheck extends AbstractCheck {
         final DetailAST parent = ast.getParent();
 
         if (isLambdaSingleParameterSurrounded(ast)) {
-            log(ast, MSG_LAMBDA, ast.getText());
+            log(ast, MSG_LAMBDA);
         }
         else if (parent.getType() != TokenTypes.ANNOTATION_MEMBER_VALUE_PAIR) {
             final int type = ast.getType();


### PR DESCRIPTION
Issue #13109: Kill mutation for UnnecessaryParenthesesCheck 2

# check :- https://checkstyle.org/config_coding.html#UnnecessaryParentheses

----------------

# Mutation covered
https://github.com/checkstyle/checkstyle/blob/655196ed840b1cb443607a9e6f330a562bfcb2c4/config/pitest-suppressions/pitest-coding-1-suppressions.xml#L66-L73

------------

# Explaination 
ast.gettext() is not require because we are not showing it.
https://github.com/checkstyle/checkstyle/blob/655196ed840b1cb443607a9e6f330a562bfcb2c4/src/main/resources/com/puppycrawl/tools/checkstyle/checks/coding/messages.properties#L60