### PR TITLE
Issue #13109: Kill mutation for ReturnCountCheck

### DIFF
--- a/config/pitest-suppressions/pitest-coding-1-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-1-suppressions.xml
@@ -28,24 +28,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>ReturnCountCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.ReturnCountCheck</mutatedClass>
-    <mutatedMethod>leaveToken</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/Object::toString</description>
-    <lineContent>throw new IllegalStateException(ast.toString());</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>ReturnCountCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.ReturnCountCheck</mutatedClass>
-    <mutatedMethod>visitToken</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/Object::toString</description>
-    <lineContent>throw new IllegalStateException(ast.toString());</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>UnnecessaryParenthesesCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnnecessaryParenthesesCheck</mutatedClass>
     <mutatedMethod>checkExpression</mutatedMethod>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheckTest.java
@@ -22,6 +22,7 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.coding.ReturnCountCheck.MSG_KEY;
 import static com.puppycrawl.tools.checkstyle.checks.coding.ReturnCountCheck.MSG_KEY_VOID;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.util.Collection;
@@ -172,6 +173,44 @@ public class ReturnCountCheckTest extends AbstractModuleTestSupport {
                         "contextStack",
                         contextStack -> ((Collection<Set<String>>) contextStack).isEmpty()))
                 .isTrue();
+    }
+
+    /**
+     * Tries to reproduce system failure to call Check on not acceptable token.
+     * It can not be reproduced by Input files. Maintainers thinks that keeping
+     * exception on unknown token is beneficial.
+     *
+     */
+    @Test
+    public void testImproperVisitToken() {
+        final ReturnCountCheck check = new ReturnCountCheck();
+        final DetailAstImpl classDefAst = new DetailAstImpl();
+        classDefAst.setType(TokenTypes.CLASS_DEF);
+        final IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> check.visitToken(classDefAst), "IllegalStateException was expected");
+
+        assertWithMessage("Message doesn't contain ast")
+                .that(exception.getMessage())
+                .isEqualTo(classDefAst.toString());
+    }
+
+    /**
+     * Tries to reproduce system failure to call Check on not acceptable token.
+     * It can not be reproduced by Input files. Maintainers thinks that keeping
+     * exception on unknown token is beneficial.
+     *
+     */
+    @Test
+    public void testImproperLeaveToken() {
+        final ReturnCountCheck check = new ReturnCountCheck();
+        final DetailAstImpl classDefAst = new DetailAstImpl();
+        classDefAst.setType(TokenTypes.CLASS_DEF);
+        final IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> check.leaveToken(classDefAst), "IllegalStateException was expected");
+
+        assertWithMessage("Message doesn't contain ast")
+                .that(exception.getMessage())
+                .isEqualTo(classDefAst.toString());
     }
 
 }


### PR DESCRIPTION
Issue #13109: Kill mutation for ReturnCountCheck

-------------------

# Check :-

 https://checkstyle.org/config_coding.html#ReturnCount

----------------------

# Mutation Covered 
https://github.com/checkstyle/checkstyle/blob/655196ed840b1cb443607a9e6f330a562bfcb2c4/config/pitest-suppressions/pitest-coding-1-suppressions.xml#L39-L55

-----------------------

# Explaination 

**1) Test cases**
Here in this check, we have an acceptable token
https://github.com/checkstyle/checkstyle/blob/655196ed840b1cb443607a9e6f330a562bfcb2c4/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java#L332-L338
and in visitToken and Leave Token all the acceptable tokens have their own case.
so without pure unit testing not possible to create such kind of scenario to cover default.

**2) Removal of code**
Here in this check, we have an acceptable token
https://github.com/checkstyle/checkstyle/blob/655196ed840b1cb443607a9e6f330a562bfcb2c4/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/ReturnCountCheck.java#L332-L338
and in visitToken and Leave Token all the acceptable tokens have their own case so Removal of default won't make any issue.
Regression are also clean 

Currently applied **1) Test cases**
