### PR TITLE
Issue #13140: Fix NullPointerException

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanExpressionCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/SimplifyBooleanExpressionCheck.java
@@ -121,7 +121,7 @@ public class SimplifyBooleanExpressionCheck
             case TokenTypes.QUESTION:
                 final DetailAST nextSibling = ast.getNextSibling();
                 if (TokenUtil.isBooleanLiteralType(parent.getFirstChild().getType())
-                        || nextSibling != null
+                        || nextSibling != null && nextSibling.getNextSibling() != null
                         && TokenUtil.isBooleanLiteralType(
                         nextSibling.getNextSibling().getType())) {
                     log(parent, MSG_KEY);

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/simplifybooleanexpression/InputSimplifyBooleanExpression.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/simplifybooleanexpression/InputSimplifyBooleanExpression.java
@@ -109,5 +109,6 @@ public class InputSimplifyBooleanExpression
         temp = true ? a() : b(); // violation
         int d = false ? 1 : 2; // violation
         temp = a() ? true : true; // violation
+        temp = value != null ? value : (false); // ok
     }
 }


### PR DESCRIPTION
# Fix Issue #13140 

NullChecking is missing to avoid an error when reading a ternary operator that contain unnecessary parenthesis, these can of course be removed but this is another checkstyle rule and should not throw any exception while reading this line

Diff Regression config: https://gist.githubusercontent.com/SebHeuze/2925a42bb90d851892522cb4c2d1c9dc/raw/23982ee5bf8813df8776f14854aac4064649310c/my_check.xml