### PR TITLE
Issue #13109: Kill mutation for UnusedLocalVariableCheck 2

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -2412,6 +2412,28 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter scope of VariableDesc.</message>
+    <lineContent>this(name, null, null);</lineContent>
+    <details>
+      found   : null (NullType)
+      required: @Initialized @NonNull DetailAST
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java</fileName>
+    <specifier>argument</specifier>
+    <message>incompatible argument for parameter typeAst of VariableDesc.</message>
+    <lineContent>this(name, null, null);</lineContent>
+    <details>
+      found   : null (NullType)
+      required: @Initialized @NonNull DetailAST
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java</fileName>
     <specifier>assignment</specifier>
     <message>incompatible types in assignment.</message>
     <lineContent>packageName = null;</lineContent>

--- a/config/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -228,42 +228,6 @@
   <mutation unstable="false">
     <sourceFile>UnusedLocalVariableCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck</mutatedClass>
-    <mutatedMethod>addInstanceOrClassVar</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::findFirstToken</description>
-    <lineContent>varDefAst.findFirstToken(TokenTypes.TYPE), findScopeOfVariable(varDefAst));</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>UnusedLocalVariableCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck</mutatedClass>
-    <mutatedMethod>addInstanceOrClassVar</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck::findScopeOfVariable</description>
-    <lineContent>varDefAst.findFirstToken(TokenTypes.TYPE), findScopeOfVariable(varDefAst));</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>UnusedLocalVariableCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck</mutatedClass>
-    <mutatedMethod>addInstanceOrClassVar</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck::findScopeOfVariable with argument</description>
-    <lineContent>varDefAst.findFirstToken(TokenTypes.TYPE), findScopeOfVariable(varDefAst));</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>UnusedLocalVariableCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck</mutatedClass>
-    <mutatedMethod>addInstanceOrClassVar</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::findFirstToken with receiver</description>
-    <lineContent>varDefAst.findFirstToken(TokenTypes.TYPE), findScopeOfVariable(varDefAst));</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>UnusedLocalVariableCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck</mutatedClass>
     <mutatedMethod>isInsideLocalAnonInnerClass</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
     <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getParent with receiver</description>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
@@ -511,8 +511,7 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
         if (isNonLocalTypeDeclaration(parentAst.getParent())
                 && !isPrivateInstanceVariable(varDefAst)) {
             final DetailAST ident = varDefAst.findFirstToken(TokenTypes.IDENT);
-            final VariableDesc desc = new VariableDesc(ident.getText(),
-                    varDefAst.findFirstToken(TokenTypes.TYPE), findScopeOfVariable(varDefAst));
+            final VariableDesc desc = new VariableDesc(ident.getText());
             typeDeclAstToTypeDeclDesc.get(parentAst.getParent()).addInstOrClassVar(desc);
         }
     }
@@ -865,6 +864,15 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
             this.name = name;
             this.typeAst = typeAst;
             this.scope = scope;
+        }
+
+        /**
+         * Create a new VariableDesc instance.
+         *
+         * @param name name of the variable
+         */
+        private VariableDesc(String name) {
+            this(name, null, null);
         }
 
         /**


### PR DESCRIPTION
Issue #13109: Kill mutation for UnusedLocalVariableCheck 2

------------

# check:-  
https://checkstyle.org/config_coding.html#UnusedLocalVariable

-------------

# Mutation Covered :-  
https://github.com/checkstyle/checkstyle/blob/958051594a64ea5a228359919ed7426e69a242d7/config/pitest-suppressions/pitest-coding-2-suppressions.xml#L273-L308

-------------

# Explaination :- 
This might not be a good changes but still,

Here in the method 
https://github.com/checkstyle/checkstyle/blob/958051594a64ea5a228359919ed7426e69a242d7/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java#L509-L518

the code 
```
final VariableDesc desc = new VariableDesc(ident.getTe(),
                    varDefAst.findFirstToken(TokenTypes.TYPE), findScopeOfVariable(varDefAst));

```
is mutated as 
```
            final VariableDesc desc = new VariableDesc(ident.getText(),
                    null, null);
```

Know if we look at class VariableDec constructor 
https://github.com/checkstyle/checkstyle/blob/958051594a64ea5a228359919ed7426e69a242d7/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java#L864-L867

2nd and 3rd parameter is being registered as typeAst and scope.

know if we see in the whole check the usage of typeAst and scope of variableDesc class is only to log the violation at 
https://github.com/checkstyle/checkstyle/blob/958051594a64ea5a228359919ed7426e69a242d7/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java#L423-L432

hence their is no other usage of this.

know the method will only register instance variables and class variables on which we are throwing violation
https://github.com/checkstyle/checkstyle/blob/958051594a64ea5a228359919ed7426e69a242d7/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java#L503-L509

As per my analysis using input it is not possible to cover this.

------------
Diff Regression config: https://gist.githubusercontent.com/Kevin222004/0dbdfb487f8e9a050ed0e6356f1a35b4/raw/31f7927f400e11e4285e86fd086b373095227848/unusedLocal.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/21e3934e85f802e2fbd48af06d122364/raw/604256badd733d8568064f371d55657c04b00dfd/test-projects-2.properties
Report label: Latest-Report-2