### PR TITLE
Issue #13109: Kill mutation for UnusedLocalVariableCheck 6

### DIFF
--- a/config/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -309,15 +309,6 @@
   <mutation unstable="false">
     <sourceFile>UnusedLocalVariableCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck</mutatedClass>
-    <mutatedMethod>getBlockContainingLocalAnonInnerClass</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getParent with receiver</description>
-    <lineContent>DetailAST parentAst = literalNewAst.getParent();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>UnusedLocalVariableCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck</mutatedClass>
     <mutatedMethod>isInsideLocalAnonInnerClass</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
     <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getParent with receiver</description>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
@@ -461,17 +461,17 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
      * @return the block containing local anon inner class
      */
     private static DetailAST getBlockContainingLocalAnonInnerClass(DetailAST literalNewAst) {
-        DetailAST parentAst = literalNewAst.getParent();
+        DetailAST currentAst = literalNewAst;
         DetailAST result = null;
-        while (!TokenUtil.isOfType(parentAst, CONTAINERS_FOR_ANON_INNERS)) {
-            if (parentAst.getType() == TokenTypes.LAMBDA
-                    && parentAst.getParent()
+        while (!TokenUtil.isOfType(currentAst, CONTAINERS_FOR_ANON_INNERS)) {
+            if (currentAst.getType() == TokenTypes.LAMBDA
+                    && currentAst.getParent()
                     .getParent().getParent().getType() == TokenTypes.OBJBLOCK) {
-                result = parentAst;
+                result = currentAst;
                 break;
             }
-            parentAst = parentAst.getParent();
-            result = parentAst;
+            currentAst = currentAst.getParent();
+            result = currentAst;
         }
         return result;
     }


### PR DESCRIPTION
Issue #13109: Kill mutation for UnusedLocalVariableCheck 6

---------

# Checks 
https://checkstyle.org/config_coding.html#UnusedLocalVariable

--------

# Mutation covered 
https://github.com/checkstyle/checkstyle/blob/958051594a64ea5a228359919ed7426e69a242d7/config/pitest-suppressions/pitest-coding-2-suppressions.xml#L309-L316

--------

# Explaination 
hence it is not possible to create a such test that kills mutation. instead of starting the loop with `literalNewAst.getParent()` if we start from `literalnewAst` at the end of the first iteration in the loop it will become literalNewAst.getParent. loops run one time more then it was running previously.
hence while as per my changes currentAST go in loop it never be in array of CONTAINERS_FOR_ANON_INNERS https://github.com/checkstyle/checkstyle/blob/958051594a64ea5a228359919ed7426e69a242d7/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java#L188-L194
because it always be TokenTypes.Literal_NEW. same for if statment in it 
currentAST never be TokenTypes.lambda so it will not execute 
so removal will not make any effect 

--------

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/0dbdfb487f8e9a050ed0e6356f1a35b4/raw/31f7927f400e11e4285e86fd086b373095227848/unusedLocal.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Regression-2