### PR TITLE
Issue #13501: Kill mutation for UnusedLocalVariableCheck 9  

### DIFF
--- a/config/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -57,15 +57,6 @@
 
   <mutation unstable="false">
     <sourceFile>UnusedLocalVariableCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck</mutatedClass>
-    <mutatedMethod>isInsideLocalAnonInnerClass</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getParent with receiver</description>
-    <lineContent>if (TokenUtil.isTypeDeclaration(currentAst.getParent().getType())) {</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>UnusedLocalVariableCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck$TypeDeclDesc</mutatedClass>
     <mutatedMethod>getUpdatedCopyOfVarStack</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/UnusedLocalVariableCheck.java
@@ -294,8 +294,7 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
         else if (type == TokenTypes.IDENT) {
             visitIdentToken(ast, variables);
         }
-        else if (type == TokenTypes.LITERAL_NEW
-                && isInsideLocalAnonInnerClass(ast)) {
+        else if (isInsideLocalAnonInnerClass(ast)) {
             visitLocalAnonInnerClass(ast);
         }
         else if (TokenUtil.isTypeDeclaration(type)) {
@@ -403,13 +402,13 @@ public class UnusedLocalVariableCheck extends AbstractCheck {
         final DetailAST lastChild = literalNewAst.getLastChild();
         if (lastChild != null && lastChild.getType() == TokenTypes.OBJBLOCK) {
             DetailAST currentAst = literalNewAst;
-            while (currentAst.getType() != TokenTypes.SLIST) {
-                if (TokenUtil.isTypeDeclaration(currentAst.getParent().getType())) {
+            while (!TokenUtil.isTypeDeclaration(currentAst.getType())) {
+                if (currentAst.getType() == TokenTypes.SLIST) {
+                    result = true;
                     break;
                 }
                 currentAst = currentAst.getParent();
             }
-            result = currentAst.getType() == TokenTypes.SLIST;
         }
         return result;
     }


### PR DESCRIPTION
Issue #13501: Kill mutation for UnusedLocalVariableCheck 9  

------

# Check :- 
https://checkstyle.org/checks/coding/unusedlocalvariable.html#UnusedLocalVariable

--------

# Mutation
https://github.com/checkstyle/checkstyle/blob/554a87ea9b5ae27f9519e8dbca15a116bcc108a4/config/pitest-suppressions/pitest-coding-2-suppressions.xml#L66-L73

-----------

# Explaination

TokenUtil.isTypeDeclaration check if the ast is of type 
class, enum, record or interface.

know in this all type of the last child is alwyas objBlock token. so the parent of SList never going to be 
from isTypeDeclaration so either of checking currentASt Parent if the loops run 1 time more and currentast would be change then ultimately in 
`result = currentAst.getType() == TokenTypes.SLIST;` it will make affect but result will not change.

----------

# Regression :- 

Report-1 ; https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/5346d57_2023074741/reports/diff/index.html

Report-2 : https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/5346d57_2023125641/reports/diff/index.html

--------

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/0dbdfb487f8e9a050ed0e6356f1a35b4/raw/31f7927f400e11e4285e86fd086b373095227848/unusedLocal.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Regression-Aug-5-2