### PR TITLE
Issue #13109: Kill mutation for FileContents

### DIFF
--- a/config/pitest-suppressions/pitest-api-suppressions.xml
+++ b/config/pitest-suppressions/pitest-api-suppressions.xml
@@ -1,24 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
-    <sourceFile>FileContents.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.FileContents</mutatedClass>
-    <mutatedMethod>getBlockComments</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to java/util/Collections::unmodifiableMap with argument</description>
-    <lineContent>return Collections.unmodifiableMap(clangComments);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>FileContents.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.FileContents</mutatedClass>
-    <mutatedMethod>getSingleLineComments</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to java/util/Collections::unmodifiableMap with argument</description>
-    <lineContent>return Collections.unmodifiableMap(cppComments);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>FileText.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.api.FileText</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileContentsTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.api;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.util.Arrays;
@@ -332,4 +333,21 @@ public class FileContentsTest {
                 .isTrue();
     }
 
+    @Test
+    public void testUnmodifiableGetSingleLineComment() {
+        final FileContents cppComments = new FileContents(new FileText(new File("filename"),
+                Arrays.asList("// comment ", " A + B ", " ")));
+        cppComments.reportSingleLineComment(1, 0);
+        final Map<Integer, TextBlock> comments = cppComments.getSingleLineComments();
+        assertThrows(UnsupportedOperationException.class, () -> comments.remove(0));
+    }
+
+    @Test
+    public void testUnmodifiableGetBlockComments() {
+        final FileContents clangComments = new FileContents(new FileText(new File("filename"),
+                Arrays.asList("/* comment ", " ", " comment */")));
+        clangComments.reportBlockComment(1, 0, 3, 9);
+        final Map<Integer, List<TextBlock>> comments = clangComments.getBlockComments();
+        assertThrows(UnsupportedOperationException.class, () -> comments.remove(0));
+    }
 }


### PR DESCRIPTION
Issue #13109: Kill mutation for FileContents

---------------------

# Mutation covered 

https://github.com/checkstyle/checkstyle/blob/82b6ac46193fafdfbcfc5dacbb848004c36a82e4/config/pitest-suppressions/pitest-api-suppressions.xml#L3-L19

--------------------

# Explaination 
Test cases expanded.
If we see `return Collections.unmodifiableMap(cppComments);` is mutated to `return cppComments;`. basically  Collections. unmodifiable will not allow us to make any updates to the map. if we try to update it it will throw `UnsupportedOperationException`. so in this test case if we try to remove data from the comment so it will throw the exception