### PR TITLE
Issue #13109: Kill mutation for FileText

### DIFF
--- a/config/pitest-suppressions/pitest-api-suppressions.xml
+++ b/config/pitest-suppressions/pitest-api-suppressions.xml
@@ -24,15 +24,6 @@
     <mutatedMethod>&lt;init&gt;</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
     <description>Removed assignment to member variable charset</description>
-    <lineContent>charset = fileText.charset;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>FileText.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.FileText</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable charset</description>
     <lineContent>charset = null;</lineContent>
   </mutation>
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
@@ -190,4 +190,13 @@ public class FileTextTest extends AbstractPathTestSupport {
                 .isEqualTo(lineBreaks);
     }
 
+    @Test
+    public void testCharsetAfterCopyConstructor() throws IOException {
+        final Charset charset = StandardCharsets.ISO_8859_1;
+        final String filepath = getPath("InputFileTextImportControl.xml");
+        final FileText fileText = new FileText(new File(filepath), charset.name());
+        final FileText copy = new FileText(fileText);
+        assertWithMessage("Should not be null")
+                .that(copy.getCharset()).isNotNull();
+    }
 }


### PR DESCRIPTION
Issue #13109: Kill mutation for FileText

--------------------

# Mutation Covered 
https://github.com/checkstyle/checkstyle/blob/82b6ac46193fafdfbcfc5dacbb848004c36a82e4/config/pitest-suppressions/pitest-api-suppressions.xml#L21-L28

-----------------------

# Explaination
Test cases added