### PR TITLE
Issue #13109: Kill mutation for FileText 2

### DIFF
--- a/config/archunit-store/slices-should-be-free-of-cycles-suppressions
+++ b/config/archunit-store/slices-should-be-free-of-cycles-suppressions
@@ -3,9 +3,9 @@ Cycle detected: Slice api -> \
                 Slice api\
   1. Dependencies of Slice api\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.process(java.io.File, com.puppycrawl.tools.checkstyle.api.FileText)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.matchesFileExtension(java.io.File, [Ljava.lang.String;)> in (AbstractFileSetCheck.java:97)\
-    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.util.List)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:136)\
+    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.util.List)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:133)\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.setFileExtensions([Ljava.lang.String;)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.startsWithChar(java.lang.String, char)> in (AbstractFileSetCheck.java:177)\
-    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.lang.String)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:183)\
+    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.lang.String)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:180)\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.log(int, int, java.lang.String, [Ljava.lang.Object;)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.lengthExpandedTabs(java.lang.String, int, int)> in (AbstractFileSetCheck.java:230)\
     - Method <com.puppycrawl.tools.checkstyle.api.FileContents.lineIsBlank(int)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.isBlank(java.lang.String)> in (FileContents.java:234)\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractCheck.log(int, int, java.lang.String, [Ljava.lang.Object;)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.lengthExpandedTabs(java.lang.String, int, int)> in (AbstractCheck.java:245)\
@@ -362,9 +362,9 @@ Cycle detected: Slice api -> \
                 Slice api\
   1. Dependencies of Slice api\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.process(java.io.File, com.puppycrawl.tools.checkstyle.api.FileText)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.matchesFileExtension(java.io.File, [Ljava.lang.String;)> in (AbstractFileSetCheck.java:97)\
-    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.util.List)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:136)\
+    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.util.List)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:133)\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.setFileExtensions([Ljava.lang.String;)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.startsWithChar(java.lang.String, char)> in (AbstractFileSetCheck.java:177)\
-    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.lang.String)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:183)\
+    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.lang.String)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:180)\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.log(int, int, java.lang.String, [Ljava.lang.Object;)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.lengthExpandedTabs(java.lang.String, int, int)> in (AbstractFileSetCheck.java:230)\
     - Method <com.puppycrawl.tools.checkstyle.api.FileContents.lineIsBlank(int)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.isBlank(java.lang.String)> in (FileContents.java:234)\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractCheck.log(int, int, java.lang.String, [Ljava.lang.Object;)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.lengthExpandedTabs(java.lang.String, int, int)> in (AbstractCheck.java:245)\
@@ -888,9 +888,9 @@ Cycle detected: Slice api -> \
                 Slice api\
   1. Dependencies of Slice api\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.process(java.io.File, com.puppycrawl.tools.checkstyle.api.FileText)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.matchesFileExtension(java.io.File, [Ljava.lang.String;)> in (AbstractFileSetCheck.java:97)\
-    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.util.List)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:136)\
+    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.util.List)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:133)\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.setFileExtensions([Ljava.lang.String;)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.startsWithChar(java.lang.String, char)> in (AbstractFileSetCheck.java:177)\
-    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.lang.String)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:183)\
+    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.lang.String)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:180)\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.log(int, int, java.lang.String, [Ljava.lang.Object;)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.lengthExpandedTabs(java.lang.String, int, int)> in (AbstractFileSetCheck.java:230)\
     - Method <com.puppycrawl.tools.checkstyle.api.FileContents.lineIsBlank(int)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.isBlank(java.lang.String)> in (FileContents.java:234)\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractCheck.log(int, int, java.lang.String, [Ljava.lang.Object;)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.lengthExpandedTabs(java.lang.String, int, int)> in (AbstractCheck.java:245)\
@@ -1040,9 +1040,9 @@ Cycle detected: Slice api -> \
                 Slice api\
   1. Dependencies of Slice api\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.process(java.io.File, com.puppycrawl.tools.checkstyle.api.FileText)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.matchesFileExtension(java.io.File, [Ljava.lang.String;)> in (AbstractFileSetCheck.java:97)\
-    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.util.List)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:136)\
+    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.util.List)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:133)\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.setFileExtensions([Ljava.lang.String;)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.startsWithChar(java.lang.String, char)> in (AbstractFileSetCheck.java:177)\
-    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.lang.String)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:183)\
+    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.lang.String)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:180)\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.log(int, int, java.lang.String, [Ljava.lang.Object;)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.lengthExpandedTabs(java.lang.String, int, int)> in (AbstractFileSetCheck.java:230)\
     - Method <com.puppycrawl.tools.checkstyle.api.FileContents.lineIsBlank(int)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.isBlank(java.lang.String)> in (FileContents.java:234)\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractCheck.log(int, int, java.lang.String, [Ljava.lang.Object;)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.lengthExpandedTabs(java.lang.String, int, int)> in (AbstractCheck.java:245)\
@@ -1069,9 +1069,9 @@ Cycle detected: Slice api -> \
                 Slice api\
   1. Dependencies of Slice api\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.process(java.io.File, com.puppycrawl.tools.checkstyle.api.FileText)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.matchesFileExtension(java.io.File, [Ljava.lang.String;)> in (AbstractFileSetCheck.java:97)\
-    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.util.List)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:136)\
+    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.util.List)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:133)\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.setFileExtensions([Ljava.lang.String;)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.startsWithChar(java.lang.String, char)> in (AbstractFileSetCheck.java:177)\
-    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.lang.String)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:183)\
+    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.lang.String)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:180)\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.log(int, int, java.lang.String, [Ljava.lang.Object;)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.lengthExpandedTabs(java.lang.String, int, int)> in (AbstractFileSetCheck.java:230)\
     - Method <com.puppycrawl.tools.checkstyle.api.FileContents.lineIsBlank(int)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.isBlank(java.lang.String)> in (FileContents.java:234)\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractCheck.log(int, int, java.lang.String, [Ljava.lang.Object;)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.lengthExpandedTabs(java.lang.String, int, int)> in (AbstractCheck.java:245)\
@@ -1219,9 +1219,9 @@ Cycle detected: Slice api -> \
                 Slice api\
   1. Dependencies of Slice api\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.process(java.io.File, com.puppycrawl.tools.checkstyle.api.FileText)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.matchesFileExtension(java.io.File, [Ljava.lang.String;)> in (AbstractFileSetCheck.java:97)\
-    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.util.List)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:136)\
+    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.util.List)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:133)\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.setFileExtensions([Ljava.lang.String;)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.startsWithChar(java.lang.String, char)> in (AbstractFileSetCheck.java:177)\
-    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.lang.String)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:183)\
+    - Constructor <com.puppycrawl.tools.checkstyle.api.FileText.<init>(java.io.File, java.lang.String)> gets field <com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRAY> in (FileText.java:180)\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck.log(int, int, java.lang.String, [Ljava.lang.Object;)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.lengthExpandedTabs(java.lang.String, int, int)> in (AbstractFileSetCheck.java:230)\
     - Method <com.puppycrawl.tools.checkstyle.api.FileContents.lineIsBlank(int)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.isBlank(java.lang.String)> in (FileContents.java:234)\
     - Method <com.puppycrawl.tools.checkstyle.api.AbstractCheck.log(int, int, java.lang.String, [Ljava.lang.Object;)> calls method <com.puppycrawl.tools.checkstyle.utils.CommonUtil.lengthExpandedTabs(java.lang.String, int, int)> in (AbstractCheck.java:245)\

--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -1262,17 +1262,6 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>lineBreaks = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull int @Initialized @NonNull []
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java</fileName>
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: lineBreaks</message>
     <lineContent>public FileText(File file, List&lt;String&gt; lines) {</lineContent>
@@ -1283,6 +1272,13 @@
     <specifier>initialization.fields.uninitialized</specifier>
     <message>the constructor does not initialize fields: lineBreaks</message>
     <lineContent>public FileText(File file, String charsetName) throws IOException {</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java</fileName>
+    <specifier>initialization.fields.uninitialized</specifier>
+    <message>the constructor does not initialize fields: lineBreaks</message>
+    <lineContent>public FileText(FileText fileText) {</lineContent>
   </checkerFrameworkError>
 
   <checkerFrameworkError unstable="false">

--- a/config/pitest-suppressions/pitest-api-suppressions.xml
+++ b/config/pitest-suppressions/pitest-api-suppressions.xml
@@ -73,15 +73,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>FileText.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.FileText</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable lineBreaks</description>
-    <lineContent>lineBreaks = null;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>FullIdent.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.api.FullIdent</mutatedClass>
     <mutatedMethod>createFullIdentBelow</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
@@ -105,10 +105,7 @@ public final class FileText {
         charset = fileText.charset;
         fullText = fileText.fullText;
         lines = fileText.lines.clone();
-        if (fileText.lineBreaks == null) {
-            lineBreaks = null;
-        }
-        else {
+        if (fileText.lineBreaks != null) {
             lineBreaks = fileText.lineBreaks.clone();
         }
     }


### PR DESCRIPTION
Issue #13109: Kill mutation for FileText 2

--------------

# Mutation covered 
https://github.com/checkstyle/checkstyle/blob/82b6ac46193fafdfbcfc5dacbb848004c36a82e4/config/pitest-suppressions/pitest-api-suppressions.xml#L75-L82

--------------

# Explaination
Our code is
```
    public FileText(FileText fileText) {
        file = fileText.file;
        charset = fileText.charset;
        fullText = fileText.fullText;
        lines = fileText.lines.clone();
        if (fileText.lineBreaks == null) {
            lineBreaks = null;
        }
        else {
            lineBreaks = fileText.lineBreaks.clone();
        }
    }

```

Here the part of code  
```
        if (fileText.lineBreaks == null) {
            lineBreaks = null;
        }
```

is mutated as 
```
        if (fileText.lineBreaks == null) {
        }
```

Here the condition in if statment is 
something like 
```
fileText.lineBreaks == null
```

know if we see logically their is 2 possiblity 
either `fileText.lineBreaks` is `null` or it is
`not null`  if it is null then the if block will
execute and in the case of `not null` else will execute.

know instead of doing this `fileText.lineBreaks == null` in if block and set the lineBreaks to null 
 we can change the if condition to 
```
        if (fileText.lineBreaks != null) {
            lineBreaks = fileText.lineBreaks.clone();
        }
```
so the new code look like 
```
    public FileText(FileText fileText) {
        file = fileText.file;
        charset = fileText.charset;
        fullText = fileText.fullText;
        lines = fileText.lines.clone();
        if (fileText.lineBreaks != null) {
            lineBreaks = fileText.lineBreaks.clone();
        }
        else {
            lineBreaks = null;
        }
    }
```

Here `lineBreaks` set to null which is its default value and this is constructor. so if we remove the default value it won't effect anything.
in this case when `fileText.lineBreaks == null` by default it will asign  `lineBreaks = null;`
it will not make any effect to code

so finall code we write as 
```
    public FileText(FileText fileText) {
        file = fileText.file;
        charset = fileText.charset;
        fullText = fileText.fullText;
        lines = fileText.lines.clone();
        if (fileText.lineBreaks != null) {
            lineBreaks = fileText.lineBreaks.clone();
        }
    }
```