### PR TITLE
Issue #12042: Add implementation for check empty line before return

### DIFF
--- a/config/checkstyle-checks.xml
+++ b/config/checkstyle-checks.xml
@@ -835,6 +835,7 @@
     <module name="EmptyLineSeparator">
       <property name="allowNoEmptyLineBetweenFields" value="true"/>
       <property name="allowMultipleEmptyLinesInsideClassMembers" value="false"/>
+      <property name="allowEmptyLineBeforeReturn" value="false"/>
     </module>
     <module name="GenericWhitespace"/>
     <module name="MethodParamPad"/>

--- a/config/suppressions.xml
+++ b/config/suppressions.xml
@@ -60,6 +60,8 @@
   <suppress checks="MethodCount" files="[\\/]RequireThisCheck.java$"/>
   <!-- Apart from complex logic, there is a nested class which contains many methods.  -->
   <suppress checks="MethodCount" files="[\\/]UnusedLocalVariableCheck.java"/>
+  <!-- EmptyLineSeparatorCheck has 3 options which require 3 additional methods (setters)  -->
+  <suppress checks="MethodCount" files="[\\/]EmptyLineSeparatorCheck.java"/>
   <!-- parse method needs catching Exceptions to print context of execution -->
   <suppress checks="IllegalCatch" files="[\\/]src[\\/]test[\\/].*[\\/]InlineConfigParser\.java"/>
   <!-- exception maybe thrown while executing the static block -->

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheck.java
@@ -367,6 +367,9 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
     /** Allow no empty line between fields. */
     private boolean allowNoEmptyLineBetweenFields;
 
+    /** Allow empty line before return. */
+    private boolean allowEmptyLineBeforeReturn;
+
     /** Allow multiple empty lines between class members. */
     private boolean allowMultipleEmptyLines = true;
 
@@ -381,6 +384,15 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
      */
     public final void setAllowNoEmptyLineBetweenFields(boolean allow) {
         allowNoEmptyLineBetweenFields = allow;
+    }
+
+    /**
+     * Setter to allow empty lines before return.
+     *
+     * @param allow User's value.
+     */
+    public final void setAllowEmptyLineBeforeReturn(boolean allow) {
+        allowEmptyLineBeforeReturn = allow;
     }
 
     /**
@@ -427,6 +439,7 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
             TokenTypes.VARIABLE_DEF,
             TokenTypes.RECORD_DEF,
             TokenTypes.COMPACT_CTOR_DEF,
+            TokenTypes.LITERAL_RETURN,
         };
     }
 
@@ -446,6 +459,9 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
         }
         if (ast.getType() == TokenTypes.PACKAGE_DEF) {
             checkCommentInModifiers(ast);
+        }
+        if (allowEmptyLineBeforeReturn && ast.getType() == TokenTypes.LITERAL_RETURN) {
+            processReturn(ast);
         }
         DetailAST nextToken = ast.getNextSibling();
         while (nextToken != null && TokenUtil.isCommentType(nextToken.getType())) {
@@ -485,7 +501,7 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
                 }
                 else if (!hasEmptyLineAfter(ast)) {
                     log(nextToken, MSG_SHOULD_BE_SEPARATED,
-                        nextToken.getText());
+                            nextToken.getText());
                 }
         }
     }
@@ -643,6 +659,16 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
     }
 
     /**
+     * Checks if a token has an empty line before return is allowed.
+     *
+     * @param token DetailAST token
+     * @return true, if token allows empty line before return, and false if it does not
+     */
+    private boolean hasEmptyLineBeforeReturn(DetailAST token) {
+        return hasEmptyLineBefore(token);
+    }
+
+    /**
      * Process Package.
      *
      * @param ast token
@@ -709,6 +735,17 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
         if (!TokenUtil.isOfType(nextToken, TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT)
             && !hasEmptyLineAfter(ast)) {
             log(nextToken, MSG_SHOULD_BE_SEPARATED, nextToken.getText());
+        }
+    }
+
+    /**
+     * Process Return Token.
+     *
+     * @param ast token
+     */
+    private void processReturn(DetailAST ast) {
+        if (!hasEmptyLineBeforeReturn(ast)) {
+            log(ast, MSG_SHOULD_BE_SEPARATED, ast.getText());
         }
     }
 
@@ -942,5 +979,4 @@ public class EmptyLineSeparatorCheck extends AbstractCheck {
     private static boolean isTypeField(DetailAST variableDef) {
         return TokenUtil.isTypeDeclaration(variableDef.getParent().getParent().getType());
     }
-
 }

--- a/src/main/resources/google_checks.xml
+++ b/src/main/resources/google_checks.xml
@@ -143,7 +143,7 @@
       <property name="tokens"
                value="PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
                     STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, RECORD_DEF,
-                    COMPACT_CTOR_DEF"/>
+                    COMPACT_CTOR_DEF, LITERAL_RETURN"/>
       <property name="allowNoEmptyLineBetweenFields" value="true"/>
     </module>
     <module name="SeparatorWrap">

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/whitespace/EmptyLineSeparatorCheckTest.java
@@ -305,6 +305,7 @@ public class EmptyLineSeparatorCheckTest
             TokenTypes.VARIABLE_DEF,
             TokenTypes.RECORD_DEF,
             TokenTypes.COMPACT_CTOR_DEF,
+            TokenTypes.LITERAL_RETURN,
         };
         assertWithMessage("Default acceptable tokens are invalid")
             .that(actual)
@@ -631,4 +632,13 @@ public class EmptyLineSeparatorCheckTest
                 expected);
     }
 
+    @Test
+    public void shouldBeEmptyLineBeforeReturn() throws Exception {
+        final String[] expected = {
+            "24:9: " + getCheckMessage(MSG_SHOULD_BE_SEPARATED, "return"),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputEmptyLineSeparatorBeforeReturn.java"),
+                expected);
+    }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/ImmutabilityTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/ImmutabilityTest.java
@@ -152,7 +152,9 @@ public class ImmutabilityTest {
         "com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck.formatString",
         "com.puppycrawl.tools.checkstyle.checks.javadoc.WriteTagCheck.tagRegExp",
         "com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck.format",
-        "com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck.option"
+        "com.puppycrawl.tools.checkstyle.checks.whitespace.AbstractParenPadCheck.option",
+        "com.puppycrawl.tools.checkstyle.checks.whitespace.EmptyLineSeparatorCheck"
+            + ".allowEmptyLineBeforeReturn"
     );
 
     /**

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorBeforeReturn.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/whitespace/emptylineseparator/InputEmptyLineSeparatorBeforeReturn.java
@@ -1,0 +1,34 @@
+/*
+EmptyLineSeparator
+allowEmptyLineBeforeReturn = true
+
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.whitespace.emptylineseparator;
+
+public class InputEmptyLineSeparatorBeforeReturn {
+    boolean test(){
+        int a = 6;
+        int b = 6;
+
+
+
+
+        return a == b; // ok
+    }
+
+    boolean isEquals4() {
+        int result = calculate();
+        return result == 4; // violation ''return' should be separated from previous line.'
+    }
+
+    int calculate() {
+
+        return 2 + 2; // ok
+    }
+}
+
+
+


### PR DESCRIPTION
Potential implementation for Issue #12042.

    - Built successful with mvn clean verify
    - Embedded feature into EmptyLineSeparatorCheck.java
    - Added new test case
    - For the allowEmptyLineBeforeReturn variable
	- a value of false turns feature off 
	- a value of true causes a violation if there is no empty line between return and previous line
    - If allowMultipleEmptyLinesInsideClassMembers is set to true this also disables our feature to prevent conflict
