### PR TITLE
Issue #13328: Kill mutation for OneStatementPerLineCheck

### DIFF
--- a/config/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -54,14 +54,11 @@
     <lineContent>this.query = query;</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>OneStatementPerLineCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck</mutatedClass>
-    <mutatedMethod>beginTree</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable lastStatementEnd</description>
-    <lineContent>lastStatementEnd = 0;</lineContent>
-  </mutation>
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>OneStatementPerLineCheck.java</sourceFile>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheckTest.java
@@ -22,8 +22,12 @@ package com.puppycrawl.tools.checkstyle.checks.coding;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck.MSG_KEY;
 
+import java.io.File;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableMap;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
@@ -138,5 +142,21 @@ public class OneStatementPerLineCheckTest extends AbstractModuleTestSupport {
 
         verify(checkConfig, getPath("InputOneStatementPerLine.java"),
                 expected);
+    }
+
+    @Test
+    public void testStateIsClearedOnBeginTreeForLastStatementEnd() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(OneStatementPerLineCheck.class);
+        final String inputWithWarnings = getPath("InputOneStatementPerLineBeginTree1.java");
+        final String inputWithoutWarnings = getPath("InputOneStatementPerLineBeginTree2.java");
+        final List<String> expectedFirstInput = List.of(
+                "1:96: " + getCheckMessage(MSG_KEY)
+        );
+        final List<String> expectedSecondInput = List.of(CommonUtil.EMPTY_STRING_ARRAY);
+        final File[] inputs = {new File(inputWithWarnings), new File(inputWithoutWarnings)};
+
+        verify(createChecker(checkConfig), inputs, ImmutableMap.of(
+            inputWithWarnings, expectedFirstInput,
+            inputWithoutWarnings, expectedSecondInput));
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineBeginTree1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineBeginTree1.java
@@ -1,0 +1,5 @@
+package com.puppycrawl.tools.checkstyle.checks.coding.onestatementperline; import java.util.Set;
+// violation above 'Only one statement per line allowed'
+
+public class InputOneStatementPerLineBeginTree1 {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineBeginTree2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineBeginTree2.java
@@ -1,0 +1,6 @@
+package com.puppycrawl.tools.checkstyle.checks.coding.onestatementperline;
+
+// ok
+public class InputOneStatementPerLineBeginTree2 {
+    int a;
+}


### PR DESCRIPTION
Issue #13328: Kill mutation for OneStatementPerLineCheck

-------------

# Check :-
 https://checkstyle.org/config_coding.html#OneStatementPerLine

-----------

# Mutation covered 
https://github.com/checkstyle/checkstyle/blob/6324a9d693324eb755c2cdfdbd90c2300d3c7f02/config/pitest-suppressions/pitest-coding-2-suppressions.xml#L174-L181