### PR TITLE
minor: fix broken link in releasenotes

### DIFF
--- a/src/xdocs/releasenotes.xml
+++ b/src/xdocs/releasenotes.xml
@@ -3320,7 +3320,7 @@ Azure.
           <li>
             Refactor input files in check tests. 102 Check tests were updated.
             Author: Shashwat Jaiswal
-            <a href="Refactor input files in check tests">#10080</a>
+            <a href="https://github.com/checkstyle/checkstyle/issues/10080">#10080</a>
           </li>
           <li>
             Add Configuration.getPropertyNames and Configuration.getProperty and


### PR DESCRIPTION
Detected while doing local runs with linkcheck
![Screenshot from 2023-06-06 21-34-01](https://github.com/checkstyle/checkstyle/assets/23459549/1be3ff8f-a6e4-4144-af00-85934f6e9920)
