### PR TITLE
Issue #13109: Kill mutation for FullIdent.java

### DIFF
--- a/config/pitest-suppressions/pitest-api-suppressions.xml
+++ b/config/pitest-suppressions/pitest-api-suppressions.xml
@@ -55,24 +55,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>FullIdent.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.FullIdent</mutatedClass>
-    <mutatedMethod>isArrayTypeDeclaration</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getFirstChild with receiver</description>
-    <lineContent>DetailAST expression = arrayDeclarator.getFirstChild();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>FullIdent.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.FullIdent</mutatedClass>
-    <mutatedMethod>isArrayTypeDeclaration</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getFirstChild</description>
-    <lineContent>expression = expression.getFirstChild();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>Violation.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.api.Violation</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java
@@ -117,7 +117,7 @@ public final class FullIdent {
      * @return true if ast is an array type declaration
      */
     private static boolean isArrayTypeDeclaration(DetailAST arrayDeclarator) {
-        DetailAST expression = arrayDeclarator.getFirstChild();
+        DetailAST expression = arrayDeclarator;
         while (expression != null) {
             if (expression.getType() == TokenTypes.EXPR) {
                 break;


### PR DESCRIPTION
Issue #13109: Kill mutation for FullIdent.java

--------------

# Mutation Covered 
https://github.com/checkstyle/checkstyle/blob/b8753a7a025f706d41e6e7b1de302d94da3b8c0f/config/pitest-suppressions/pitest-api-suppressions.xml#L57-L73

---------------

# Explaination
So we have code :- 
https://github.com/checkstyle/checkstyle/blob/b8753a7a025f706d41e6e7b1de302d94da3b8c0f/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java#L119-L128
in which 
https://github.com/checkstyle/checkstyle/blob/b8753a7a025f706d41e6e7b1de302d94da3b8c0f/src/main/java/com/puppycrawl/tools/checkstyle/api/FullIdent.java#L120
is mutated as 
`DetailAST expression = arrayDeclarator`

Here expression is assigned as `arrayDeclarator.getFirstChild` 
when the loop is going to start it will check whether the expression is null or not know if we remove `.getFirstChild` then `expression=arrayDeclarator` know arrayDeclarator is never going to be null so the loop will always execute, in the loop we have if a condition like `expression.getType() == TokenTypes.EXPR` which always becomes false because ast is an arrayDeclarator token.
and then at last `expression = expression.getFirstChild()` hence here is the case why the removal will not affect.
the expression here is again assigned as `expression.getFirstChild`. so it is not possible a test case in which we can create a test where `.getFirstChild()` will fail if we assigned it or not it will always execute.

by removal of this effect would the loop run one time more than it was running before.

------------

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/1f89420b96e95d45a945d0f8846d0d0f/raw/ed5ab114bdbdd1359c85db6edf11c4126a0e5965/fullident.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Regression-2