### PR TITLE
Issue #13109: Kill mutation for FileText3

### DIFF
--- a/config/checkstyle-checks.xml
+++ b/config/checkstyle-checks.xml
@@ -46,6 +46,13 @@
     <property name="files"
               value=".*[\\/]src[\\/](test|it|xdocs-examples)[\\/].*(?&lt;!Support)\.java"/>
   </module>
+  <!-- require for charset testing -->
+  <module name="SuppressionSingleFilter">
+    <property name="checks" value="RegexpSinglelineJava"/>
+    <property name="files"
+              value=".*[\\/]src[\\/]test[\\/]java[\\/].*[\\/]api[\\/]FileTextTest.java"/>
+    <property name="lines" value="225"/>
+  </module>
   <module name="SuppressWarningsFilter"/>
   <module name="SuppressWithPlainTextCommentFilter">
     <!--

--- a/config/pitest-suppressions/pitest-api-suppressions.xml
+++ b/config/pitest-suppressions/pitest-api-suppressions.xml
@@ -10,42 +10,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>FileText.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.FileText</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/nio/charset/CharsetDecoder::onMalformedInput</description>
-    <lineContent>decoder.onMalformedInput(CodingErrorAction.REPLACE);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>FileText.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.FileText</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/nio/charset/CharsetDecoder::onMalformedInput with receiver</description>
-    <lineContent>decoder.onMalformedInput(CodingErrorAction.REPLACE);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>FileText.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.FileText</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/nio/charset/CharsetDecoder::onUnmappableCharacter</description>
-    <lineContent>decoder.onUnmappableCharacter(CodingErrorAction.REPLACE);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>FileText.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.FileText</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/nio/charset/CharsetDecoder::onUnmappableCharacter with receiver</description>
-    <lineContent>decoder.onUnmappableCharacter(CodingErrorAction.REPLACE);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>Violation.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.api.Violation</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/api/FileTextTest.java
@@ -26,6 +26,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -198,5 +200,30 @@ public class FileTextTest extends AbstractPathTestSupport {
         final FileText copy = new FileText(fileText);
         assertWithMessage("Should not be null")
                 .that(copy.getCharset()).isNotNull();
+    }
+
+    @Test
+    public void testDecoderOnMalformedInput1() throws IOException {
+        final Charset charset = StandardCharsets.US_ASCII;
+        final String filepath = getPath("InputFileText.java");
+        final FileText fileText = new FileText(new File(filepath), charset.name());
+        assertWithMessage("")
+                .that(fileText)
+                .isNotNull();
+    }
+
+    @Test
+    public void testDecoderOnMalformedInput2() throws IOException {
+        final Charset charset = Charset.forName("IBM1098");
+        final Path tempFile = Files.createTempFile("InputFileText", null);
+
+        Files.newOutputStream(tempFile).write(0x80);
+
+        final FileText fileText = new FileText(tempFile.toFile(), charset.name());
+        assertWithMessage("Expected and actual text differ")
+                .that(fileText.get(0))
+                .isEqualTo("�");
+
+        Files.delete(tempFile);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/api/filetext/InputFileText.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/api/filetext/InputFileText.java
@@ -1,0 +1,11 @@
+package com.puppycrawl.tools.checkstyle.api.filetext;
+
+public class InputFileText {
+}
+
+/**
+ * Test case for the "design for inheritance" check.
+ * @author Lars Kühne
+ **/
+class Extra {
+}


### PR DESCRIPTION
Issue #13109: Kill mutation for FileText3

---------

# Mutation Covered
https://github.com/checkstyle/checkstyle/blob/958051594a64ea5a228359919ed7426e69a242d7/config/pitest-suppressions/pitest-api-suppressions.xml#L12-L28