### PR TITLE
Issue #12671: Kill mutation for finalLocalVariable-2

### DIFF
--- a/config/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -20,15 +20,6 @@
 
   <mutation unstable="false">
     <sourceFile>FinalLocalVariableCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck</mutatedClass>
-    <mutatedMethod>updateUninitializedVariables</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>&amp;&amp; isSameVariables(storedVariable, variable)</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>FinalLocalVariableCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.FinalLocalVariableCheck$ScopeData</mutatedClass>
     <mutatedMethod>findFinalVariableCandidateForAst</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/FinalLocalVariableCheck.java
@@ -488,7 +488,6 @@ public class FinalLocalVariableCheck extends AbstractCheck {
                         storedVariable = candidate.variableIdent;
                     }
                     if (storedVariable != null
-                            && isSameVariables(storedVariable, variable)
                             && isSameVariables(assignedVariable, variable)) {
                         scopeData.uninitializedVariables.push(variable);
                         shouldRemove = true;


### PR DESCRIPTION
Issue #12671: Kill mutation for finalLocalVariable-2

----------

# Check 
 https://checkstyle.org/config_coding.html#FinalLocalVariable
 
 --------
 
 # mutation covered 
 https://github.com/checkstyle/checkstyle/blob/c5566a6ea8c336ddedde446648b03ef56a73b7ba/config/pitest-suppressions/pitest-coding-2-suppressions.xml#L21-L28
 
 --------
 
 # Explanination 
 ok so the `&& isSameVariables(storedVariable, variable)` condition in if will check wether the StoredVariable and variable is same or not.

Know if Storedvariable is null then the condition will not execute and if it is not then `storedVariable = candidate.variableIdent;` and `final FinalVariableCandidate candidate = scopeData.scope.get(variable.getText());` 
know as per the initalization of candidate it will always get data scope which is variable 

and stored variable is also assigned as ` storedVariable = candidate.variableIdent;` hence to compare storedVariable, variable will always become ture.

-----------

# Regreesion
1) https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/767ef0a_2023201302/reports/diff/index.html
2) https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/767ef0a_2023162013/reports/diff/index.html