### PR TITLE
minor: exclude xdocs-examples resources from sevntu checks

### DIFF
--- a/config/ant-phase-verify-sevntu.xml
+++ b/config/ant-phase-verify-sevntu.xml
@@ -29,6 +29,7 @@
                includes="**/*"
                excludes="**/it/resources/**/*,**/it/resources-noncompilable/**/*,
                ,**/test/resources/**/*,**/test/resources-noncompilable/**/*,
+               ,**/xdocs-examples/resources/**/*,**/xdocs-examples/resources-noncompilable/**/*,
                ,**/gen/**"/>
       <formatter type="plain"/>
       <formatter type="xml" toFile="${mvn.project.build.directory}/cs_sevntu_errors.xml"/>


### PR DESCRIPTION
https://github.com/checkstyle/checkstyle/pull/13135 and https://github.com/checkstyle/checkstyle/pull/13143 fail on sevntu check. We have to exclude resources from this