### PR TITLE
dependency: bump guava from 31.1-jre to 32.0.1-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>31.1-jre</version>
+      <version>32.0.1-jre</version>
       <exclusions>
         <exclusion>
           <groupId>org.checkerframework</groupId>


### PR DESCRIPTION
Addresses CVE-2020-8908 and CVE-2023-2976

Last update of version: https://github.com/checkstyle/checkstyle/commit/29bdef1e516b7cfe72f13d8a15553f59359df71b