### PR TITLE
Issue #13109: Kill mutation for FileText

### DIFF
--- a/config/pitest-suppressions/pitest-api-suppressions.xml
+++ b/config/pitest-suppressions/pitest-api-suppressions.xml
@@ -4,15 +4,6 @@
     <sourceFile>FileText.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.api.FileText</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable charset</description>
-    <lineContent>charset = null;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>FileText.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.api.FileText</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
     <description>removed call to java/nio/charset/CharsetDecoder::onMalformedInput</description>
     <lineContent>decoder.onMalformedInput(CodingErrorAction.REPLACE);</lineContent>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java
@@ -75,7 +75,7 @@ public final class FileText {
      * The charset used to read the file.
      * {@code null} if the file was reconstructed from a list of lines.
      */
-    private final Charset charset;
+    private Charset charset;
 
     /**
      * The lines of the file, without terminators.
@@ -128,7 +128,6 @@ public final class FileText {
         }
 
         this.file = file;
-        charset = null;
         fullText = buf.toString();
         this.lines = lines.toArray(CommonUtil.EMPTY_STRING_ARRAY);
     }


### PR DESCRIPTION
Issue #13109: Kill mutation for FileText

---------

# mutation covered 
https://github.com/checkstyle/checkstyle/blob/e2d41a956becef80a6ba59ed1cb11a76906ffe59/config/pitest-suppressions/pitest-api-suppressions.xml#L2-L10

-----

# Explaination
One more bad side effect of pitest.

https://github.com/checkstyle/checkstyle/blob/63cd22df005ed5113247de84d3920d0893533dc1/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java#L131
this line is mutated and it is declared in the constructor. and  https://github.com/checkstyle/checkstyle/blob/63cd22df005ed5113247de84d3920d0893533dc1/src/main/java/com/puppycrawl/tools/checkstyle/api/FileText.java#L78 it is a final we cannot remove it from the constructor. 

How to resolve this mutation?