### PR TITLE
Issue #13109: Kill mutation for OneStatementPerLineCheck-2

### DIFF
--- a/config/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -93,46 +93,10 @@
   <mutation unstable="false">
     <sourceFile>OneStatementPerLineCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable forStatementEnd</description>
-    <lineContent>private int forStatementEnd = -1;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>OneStatementPerLineCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable lambdaStatementEnd</description>
-    <lineContent>private int lambdaStatementEnd = -1;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>OneStatementPerLineCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable lastStatementEnd</description>
-    <lineContent>private int lastStatementEnd = -1;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>OneStatementPerLineCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable lastVariableResourceStatementEnd</description>
-    <lineContent>private int lastVariableResourceStatementEnd = -1;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>OneStatementPerLineCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck</mutatedClass>
     <mutatedMethod>beginTree</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
     <description>Removed assignment to member variable lastStatementEnd</description>
-    <lineContent>lastStatementEnd = -1;</lineContent>
+    <lineContent>lastStatementEnd = 0;</lineContent>
   </mutation>
 
   <mutation unstable="false">
@@ -141,7 +105,7 @@
     <mutatedMethod>beginTree</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
     <description>Removed assignment to member variable lastVariableResourceStatementEnd</description>
-    <lineContent>lastVariableResourceStatementEnd = -1;</lineContent>
+    <lineContent>lastVariableResourceStatementEnd = 0;</lineContent>
   </mutation>
 
   <mutation unstable="false">

--- a/pom.xml
+++ b/pom.xml
@@ -1761,6 +1761,9 @@
                 <!-- content of file does not matter at all -->
                 <exclude>**/RegexpOnFilenameCheckTest.class</exclude>
 
+                <!-- due to https://github.com/checkstyle/checkstyle/pull/13193 All the code needs to be in single line -->
+                <exclude>**/OneStatementPerLineCheckTest.class</exclude>
+
                 <!-- all bellow until https://github.com/checkstyle/checkstyle/issues/11446 -->
 
                 <!-- usage of custom internal module, 'execute' method should be used -->

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
@@ -138,12 +138,12 @@ public final class OneStatementPerLineCheck extends AbstractCheck {
     /**
      * Hold the line-number where the last statement ended.
      */
-    private int lastStatementEnd = -1;
+    private int lastStatementEnd;
 
     /**
      * Hold the line-number where the last 'for-loop' statement ended.
      */
-    private int forStatementEnd = -1;
+    private int forStatementEnd;
 
     /**
      * The for-header usually has 3 statements on one line, but THIS IS OK.
@@ -158,12 +158,12 @@ public final class OneStatementPerLineCheck extends AbstractCheck {
     /**
      * Hold the line-number where the last lambda statement ended.
      */
-    private int lambdaStatementEnd = -1;
+    private int lambdaStatementEnd;
 
     /**
      * Hold the line-number where the last resource variable statement ended.
      */
-    private int lastVariableResourceStatementEnd = -1;
+    private int lastVariableResourceStatementEnd;
 
     /**
      * Enable resources processing.
@@ -201,8 +201,8 @@ public final class OneStatementPerLineCheck extends AbstractCheck {
 
     @Override
     public void beginTree(DetailAST rootAST) {
-        lastStatementEnd = -1;
-        lastVariableResourceStatementEnd = -1;
+        lastStatementEnd = 0;
+        lastVariableResourceStatementEnd = 0;
     }
 
     @Override
@@ -229,8 +229,8 @@ public final class OneStatementPerLineCheck extends AbstractCheck {
         switch (ast.getType()) {
             case TokenTypes.SEMI:
                 lastStatementEnd = ast.getLineNo();
-                forStatementEnd = -1;
-                lambdaStatementEnd = -1;
+                forStatementEnd = 0;
+                lambdaStatementEnd = 0;
                 break;
             case TokenTypes.FOR_ITERATOR:
                 inForHeader = false;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheckTest.java
@@ -25,6 +25,7 @@ import static com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineC
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 public class OneStatementPerLineCheckTest extends AbstractModuleTestSupport {
@@ -120,4 +121,22 @@ public class OneStatementPerLineCheckTest extends AbstractModuleTestSupport {
                 expected);
     }
 
+    @Test
+    public void testAllTheCodeInSingleLine() throws Exception {
+        final DefaultConfiguration checkConfig =
+                createModuleConfig(OneStatementPerLineCheck.class);
+
+        final String[] expected = {
+            "1:102: " + getCheckMessage(MSG_KEY),
+            "1:131: " + getCheckMessage(MSG_KEY),
+            "1:165: " + getCheckMessage(MSG_KEY),
+            "1:231: " + getCheckMessage(MSG_KEY),
+            "1:406: " + getCheckMessage(MSG_KEY),
+            "1:443: " + getCheckMessage(MSG_KEY),
+            "1:455: " + getCheckMessage(MSG_KEY),
+        };
+
+        verify(checkConfig, getPath("InputOneStatementPerLine.java"),
+                expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLine.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLine.java
@@ -1,0 +1,2 @@
+package com.puppycrawl.tools.checkstyle.checks.coding.onestatementperline; import java.io.IOException; import java.io.OutputStream; import java.io.PipedOutputStream; public class InputOneStatementPerLine {  int e = 1, f = 2, g = 5; private void foo2() { try (OutputStream s12 = new PipedOutputStream(); OutputStream s3 = new PipedOutputStream()) { } catch (IOException ex) { throw new RuntimeException(ex); } } private void foo() { toString(); toString(); } }
+// 7 violations above


### PR DESCRIPTION
Issue #13109: Kill mutation for OneStatementPerLineCheck-2

-----------

# check 
https://checkstyle.org/config_coding.html#OneStatementPerLine

----------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/c5566a6ea8c336ddedde446648b03ef56a73b7ba/config/pitest-suppressions/pitest-coding-2-suppressions.xml#L183-L217

---------

# Regression

Report-1 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/88d109b_2023082948/reports/diff/index.html

Report-2 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/2907cd7_2023142213/reports/diff/index.html

---------

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/3bd236a24ed8eacd760e6b12b47f7455/raw/97d7a64aa97fc35488a6db5d7345ee23ae9b9507/olc.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Regression-2