### PR TITLE
Issue #13109: Kill mutation for MagicNumber

### DIFF
--- a/config/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -64,15 +64,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>MagicNumberCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.MagicNumberCheck</mutatedClass>
-    <mutatedMethod>isInHashCodeMethod</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getParent with receiver</description>
-    <lineContent>DetailAST methodDefAST = ast.getParent();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>MatchXpathCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.MatchXpathCheck</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MagicNumberCheck.java
@@ -477,12 +477,12 @@ public class MagicNumberCheck extends AbstractCheck {
      */
     private static boolean isInHashCodeMethod(DetailAST ast) {
         // find the method definition AST
-        DetailAST methodDefAST = ast.getParent();
-        while (methodDefAST != null
-                && methodDefAST.getType() != TokenTypes.METHOD_DEF) {
-            methodDefAST = methodDefAST.getParent();
+        DetailAST currentAST = ast;
+        while (currentAST != null
+                && currentAST.getType() != TokenTypes.METHOD_DEF) {
+            currentAST = currentAST.getParent();
         }
-
+        final DetailAST methodDefAST = currentAST;
         boolean inHashCodeMethod = false;
 
         if (methodDefAST != null) {


### PR DESCRIPTION
Issue #13109: Kill mutation for MagicNumber

--------

# Check :- 
https://checkstyle.org/config_coding.html#MagicNumber

---------

# Mutation Covered 
https://github.com/checkstyle/checkstyle/blob/eaed451ba71f543d7a98675d521ca8bb428f79d5/config/pitest-suppressions/pitest-coding-2-suppressions.xml#L93-L100

------------

# Explaination :-  
if we remove .getParent no issue will their because in loop it will be update by `currentAST = currentAST.getParent();` so the loops run one timr more.

---------
# Regression 

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/6c454ec1c672a21710fc0cda01ceaf5b/raw/3fc36498aa1511c61c41cefb46ff02cdf8a1d2bb/magic.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/21e3934e85f802e2fbd48af06d122364/raw/604256badd733d8568064f371d55657c04b00dfd/test-projects-2.properties
Report label: Report-2