### PR TITLE
Issue #13109: Kill mutation for IllegalTokenTextCheck

### DIFF
--- a/config/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -55,24 +55,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>IllegalTokenTextCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/regex/Pattern::compile</description>
-    <lineContent>private Pattern format = Pattern.compile(formatString);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>IllegalTokenTextCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.IllegalTokenTextCheck</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable format</description>
-    <lineContent>private Pattern format = Pattern.compile(formatString);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>IllegalTypeCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.IllegalTypeCheck</mutatedClass>
     <mutatedMethod>setIllegalAbstractClassNameFormat</mutatedMethod>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTokenTextCheckTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
 
 public class IllegalTokenTextCheckTest
@@ -189,4 +190,11 @@ public class IllegalTokenTextCheckTest
         }
     }
 
+    @Test
+    public void testDefaultFormat() throws Exception {
+
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputIllegalTokenTextDefaultFormat.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextDefaultFormat.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/illegaltokentext/InputIllegalTokenTextDefaultFormat.java
@@ -1,0 +1,19 @@
+/*
+IllegalTokenText
+format = (default)^$
+ignoreCase = (default)false
+message = (default)
+tokens = STRING_LITERAL
+
+
+*/
+
+
+package com.puppycrawl.tools.checkstyle.checks.coding.illegaltokentext;
+
+public class InputIllegalTokenTextDefaultFormat { // ok
+    public void myTest() {
+        String test = "a href";
+        String test2 = "A href";
+    }
+}


### PR DESCRIPTION
Issue #13109: Kill mutation for IllegalTokenTextCheck

-------

# Check
https://checkstyle.org/config_coding.html#IllegalTokenText

----------

# Mutation covered 
https://github.com/checkstyle/checkstyle/blob/eaed451ba71f543d7a98675d521ca8bb428f79d5/config/pitest-suppressions/pitest-coding-2-suppressions.xml#L57-L73

-----------

# Explaintaion 
Test cases added

----

# Regression 

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/13ca2532a9d40774066ac08c558f4111/raw/e41a49826864eac40ca16a3d2865cfb993255e98/IllegalTokenText.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/21e3934e85f802e2fbd48af06d122364/raw/604256badd733d8568064f371d55657c04b00dfd/test-projects-2.properties
Report label: Report-2