### PR TITLE
infra: update jdk for eclipse static analysis

### DIFF
--- a/.ci/eclipse-compiler-javac.sh
+++ b/.ci/eclipse-compiler-javac.sh
@@ -12,8 +12,14 @@ fi
 JAVA_RELEASE=${2:-11}
 
 ECLIPSE_URL="http://ftp-stud.fht-esslingen.de/pub/Mirrors/eclipse/eclipse/downloads/drops4"
-ECJ_MAVEN_VERSION=$(wget --quiet -O- "$ECLIPSE_URL/?C=M;O=D" | grep -o "R-[^/]*" | head -n1)
-echo "Latest eclipse release is $ECJ_MAVEN_VERSION"
+
+# ECJ is not available in maven central, so we have to download it from eclipse.org.
+# Since ECJ has migrated to Java 17, we need to pin version until checkstyle does the same.
+# Until https://github.com/checkstyle/checkstyle/issues/13209
+# ECJ_MAVEN_VERSION=$(wget --quiet -O- "$ECLIPSE_URL/?C=M;O=D" | grep -o "R-[^/]*" | head -n1)
+# echo "Latest eclipse release is $ECJ_MAVEN_VERSION"
+
+ECJ_MAVEN_VERSION="R-4.27-202303020300"
 ECJ_JAR=$(wget --quiet -O- "$ECLIPSE_URL/$ECJ_MAVEN_VERSION/" | grep -o "ecj-[^\"]*" | head -n1)
 ECJ_PATH=~/.m2/repository/$ECJ_MAVEN_VERSION/$ECJ_JAR
 


### PR DESCRIPTION
Noticed at https://checkstyle.semaphoreci.com/jobs/a2f1d5ba-6547-45a8-a9b1-fc00c7f7c49c, we need to update jdk for this job to 17 (major ver. 61)