### PR TITLE
Issue #13109: Kill mutation for CustomImportOrderCheck

### DIFF
--- a/config/pitest-suppressions/pitest-imports-suppressions.xml
+++ b/config/pitest-suppressions/pitest-imports-suppressions.xml
@@ -4,24 +4,6 @@
     <sourceFile>CustomImportOrderCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/regex/Pattern::compile</description>
-    <lineContent>private Pattern specialImportsRegExp = Pattern.compile(&quot;^$&quot;);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CustomImportOrderCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable specialImportsRegExp</description>
-    <lineContent>private Pattern specialImportsRegExp = Pattern.compile(&quot;^$&quot;);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CustomImportOrderCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
     <description>Removed assignment to member variable samePackageMatchingDepth</description>
     <lineContent>private int samePackageMatchingDepth = 2;</lineContent>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheckTest.java
@@ -748,4 +748,12 @@ public class CustomImportOrderCheckTest extends AbstractModuleTestSupport {
                 getNonCompilablePath("InputCustomImportOrderEclipseDefaultPositive.java"),
                 expected);
     }
+
+    @Test
+    public void testInputCustomImportOrderSpecialImportsRegExp() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputCustomImportOrderSpecialImportsRegExp.java"),
+                expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderSpecialImportsRegExp.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/customimportorder/InputCustomImportOrderSpecialImportsRegExp.java
@@ -1,0 +1,18 @@
+/*
+CustomImportOrder
+customImportOrderRules = SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE
+standardPackageRegExp = junit
+thirdPartyPackageRegExp = (default).*
+specialImportsRegExp = (default)^$
+separateLineBetweenGroups = (default)true
+sortImportsInGroupAlphabetically = (default)false
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.imports.customimportorder;
+
+import org.junit.Test;
+
+public class InputCustomImportOrderSpecialImportsRegExp { // ok
+}


### PR DESCRIPTION
Issue #13109: Kill mutation for CustomImportOrderCheck

--------

Check :- 
https://checkstyle.org/config_imports.html#CustomImportOrder

-----

# Mutation Covered
https://github.com/checkstyle/checkstyle/blob/3f77dd11d7e7ac8e23ecc817a1caeeea7d1a489d/config/pitest-suppressions/pitest-imports-suppressions.xml#L2-L19

-----------

# Explaination
Test cases added