### PR TITLE
Issue #13109: Kill mutation for CustomImport

### DIFF
--- a/config/pitest-suppressions/pitest-imports-suppressions.xml
+++ b/config/pitest-suppressions/pitest-imports-suppressions.xml
@@ -1,33 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressedMutations>
   <mutation unstable="false">
-    <sourceFile>CustomImportOrderCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable samePackageMatchingDepth</description>
-    <lineContent>private int samePackageMatchingDepth = 2;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CustomImportOrderCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck</mutatedClass>
-    <mutatedMethod>getFirstDomainsFromIdent</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/StringBuilder::append</description>
-    <lineContent>builder.append(tokens.nextToken()).append(&apos;.&apos;);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>CustomImportOrderCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck</mutatedClass>
-    <mutatedMethod>getFirstDomainsFromIdent</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/lang/StringBuilder::append with receiver</description>
-    <lineContent>builder.append(tokens.nextToken()).append(&apos;.&apos;);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>FileImportControl.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.FileImportControl</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -747,7 +747,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
     private boolean sortImportsInGroupAlphabetically;
 
     /** Number of first domains for SAME_PACKAGE group. */
-    private int samePackageMatchingDepth = 2;
+    private int samePackageMatchingDepth;
 
     /**
      * Setter to specify RegExp for STANDARD_JAVA_PACKAGE group imports.
@@ -1268,7 +1268,7 @@ public class CustomImportOrderCheck extends AbstractCheck {
         int count = firstPackageDomainsCount;
 
         while (count > 0 && tokens.hasMoreTokens()) {
-            builder.append(tokens.nextToken()).append('.');
+            builder.append(tokens.nextToken());
             count--;
         }
         return builder.toString();


### PR DESCRIPTION
Issue #13109: Kill mutation for CustomImport

---------

# Check:-
https://checkstyle.org/config_imports.html#CustomImportOrder

--------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/c7f3688f4380144bb712bee7ad6808cd075b327c/config/pitest-suppressions/pitest-imports-suppressions.xml#L3-L19

---------

# Explaination 
ok so there are 4 places where `samePackageMatchingDepth` is used let's talk about first in method `addRulesToList`
https://github.com/checkstyle/checkstyle/blob/c7f3688f4380144bb712bee7ad6808cd075b327c/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java#L1225-L1234
know it will actually call by only a setter method which is `setCustomImportOrderRules` 
https://github.com/checkstyle/checkstyle/blob/c7f3688f4380144bb712bee7ad6808cd075b327c/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java#L809-L817

know else if part only executes when condition  `ruleStr.startsWith(SAME_PACKAGE_RULE_GROUP)` meet hence in this method user always defined such like `SAME_PACKAGE(3)` 
know here we are reassigning `samePackageMatchingDepth` 
with the value inside the bracket in `SAME_PACKAGE` hence whatever value of `samePackageMatchingDepth` doesn't matter because the further operation will be performed based on the new value. 

 **append('.')**

ok so basically the removal of append('.') is not creating an issue the reason is this method basically used in 2 methods 1) `createSamePackageRegexp`
https://github.com/checkstyle/checkstyle/blob/c7f3688f4380144bb712bee7ad6808cd075b327c/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java#L1249C1-L1252
which is actually called `visitToken` when 
https://github.com/checkstyle/checkstyle/blob/c7f3688f4380144bb712bee7ad6808cd075b327c/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java#L844-L849
`ast` is equal to `PACKAGE_DEF`. 
so logically here `samePackageDomainsRegExp` will assign to the String which will be return by 
our method `getFirstDomainsFromIdent` here if we remove 
`append('.')` so let's suppose if 
String with `append('.')` look like 'java.awt.button.'
look like `javaawtbutton`. 

know the `samePackageDomainsRegExp` has a use case only in 
`getImportGroup` 
https://github.com/checkstyle/checkstyle/blob/c7f3688f4380144bb712bee7ad6808cd075b327c/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java#L1084-L1090

at https://github.com/checkstyle/checkstyle/blob/c7f3688f4380144bb712bee7ad6808cd075b327c/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java#L1085-L1087
in if statement know we are equaling `samePackageDomainsRegExp` with `importPathTrimmedToSamePackageDepth` and  `importPathTrimmedToSamePackageDepth` will also call
`getFirstDomainsFromIdent` to get string so here if we remove append it will affect both 
`samePackageDomainsRegExp` and `importPathTrimmedToSamePackageDepth` and remove doty from both so their will no issue appear here while comparing. apart from this, there is no usage of `samePackageDomainsRegExp`  which will cause output/logging violation hence the test for `append('.')` is not possible.

and know rest two usage of `samePackageMatchingDepth` are here. while calling `getFirstDomainsFromIdent`
they always pass samePackageMatchingDepth with it. and that value of samePackageMatchingDepth will be updated 
`addRulesToList` so it never be  `zero` and update by the value provided by user in `SAME_PACKAGE_RULE_GROUP` 
so no issue is their 

--------

# Regression

Report-1:  https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/1d4f30f_2023083444/reports/diff/index.html

Report-2: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/1d4f30f_2023105216/reports/diff/index.html

Report-3: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/1d4f30f_2023223348/reports/diff/index.html

Report-4: https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/1d4f30f_2023055327/reports/diff/index.html

-------

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/c77cb85c86c9676985cf8fb916591a94/raw/713375f8427445ec0297b481413a185f4afbe8dc/cic.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: New Report-2(2)