### PR TITLE
Issue #13109: Kill mutation for CustomImportOrderCheck 4

### DIFF
--- a/config/pitest-suppressions/pitest-imports-suppressions.xml
+++ b/config/pitest-suppressions/pitest-imports-suppressions.xml
@@ -28,15 +28,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>CustomImportOrderCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.CustomImportOrderCheck</mutatedClass>
-    <mutatedMethod>setCustomImportOrderRules</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable customImportOrderRules</description>
-    <lineContent>customImportOrderRules = inputCustomImportOrder;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>FileImportControl.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.FileImportControl</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java
@@ -716,14 +716,14 @@ public class CustomImportOrderCheck extends AbstractCheck {
     /** Pattern used to separate groups of imports. */
     private static final Pattern GROUP_SEPARATOR_PATTERN = Pattern.compile("\\s*###\\s*");
 
+    /** Specify format of order declaration customizing by user. */
+    private static final String DEFAULT_CUSTOM_IMPORT_ORDER_RULES = "";
+
     /** Processed list of import order rules. */
     private final List<String> customOrderRules = new ArrayList<>();
 
     /** Contains objects with import attributes. */
     private final List<ImportDetails> importToGroupList = new ArrayList<>();
-
-    /** Specify format of order declaration customizing by user. */
-    private String customImportOrderRules = "";
 
     /** Specify RegExp for SAME_PACKAGE group imports. */
     private String samePackageDomainsRegExp = "";
@@ -807,13 +807,12 @@ public class CustomImportOrderCheck extends AbstractCheck {
      *        user value.
      */
     public final void setCustomImportOrderRules(final String inputCustomImportOrder) {
-        if (!customImportOrderRules.equals(inputCustomImportOrder)) {
+        if (!DEFAULT_CUSTOM_IMPORT_ORDER_RULES.equals(inputCustomImportOrder)) {
             for (String currentState : GROUP_SEPARATOR_PATTERN.split(inputCustomImportOrder)) {
                 addRulesToList(currentState);
             }
             customOrderRules.add(NON_GROUP_RULE_GROUP);
         }
-        customImportOrderRules = inputCustomImportOrder;
     }
 
     @Override


### PR DESCRIPTION
Issue #13109: Kill mutation for CustomImportOrderCheck 4

----

# check 
https://checkstyle.org/config_imports.html#CustomImportOrder

------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/79d3c5536760d2645b0676c5a7f31da3bb0eed72/config/pitest-suppressions/pitest-imports-suppressions.xml#L30-L37


----------

# Explaination

This is setter for  https://github.com/checkstyle/checkstyle/blob/79d3c5536760d2645b0676c5a7f31da3bb0eed72/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java#L726
 which is https://github.com/checkstyle/checkstyle/blob/79d3c5536760d2645b0676c5a7f31da3bb0eed72/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java#L809-L817 
we are not directly using this property hence all the rule will be first stored in https://github.com/checkstyle/checkstyle/blob/79d3c5536760d2645b0676c5a7f31da3bb0eed72/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java#L720

hence in all the code wherever we define the property all the logic has been written using  
https://github.com/checkstyle/checkstyle/blob/79d3c5536760d2645b0676c5a7f31da3bb0eed72/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/CustomImportOrderCheck.java#L720
so no test case is possible


--------

# Regression

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/2463f07cae06e0317712d3aae38b3d0b/raw/42a3cd2e7a12eb3b02ccac0906aace21ddaa02ce/custom.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Report 1