### PR TITLE
Issue #13109: Kill mutation for UnusedImportCheck

### DIFF
--- a/config/pitest-suppressions/pitest-imports-suppressions.xml
+++ b/config/pitest-suppressions/pitest-imports-suppressions.xml
@@ -162,12 +162,4 @@
     <lineContent>collect = false;</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>UnusedImportsCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck</mutatedClass>
-    <mutatedMethod>processJavadocTag</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/lang/String::trim with receiver</description>
-    <lineContent>final String identifier = tag.getFirstArg().trim();</lineContent>
-  </mutation>
 </suppressedMutations>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheck.java
@@ -421,7 +421,7 @@ public class UnusedImportsCheck extends AbstractCheck {
      */
     private static Set<String> processJavadocTag(JavadocTag tag) {
         final Set<String> references = new HashSet<>();
-        final String identifier = tag.getFirstArg().trim();
+        final String identifier = tag.getFirstArg();
         for (Pattern pattern : new Pattern[]
         {FIRST_CLASS_NAME, ARGUMENT_NAME}) {
             references.addAll(matchPattern(identifier, pattern));


### PR DESCRIPTION
Issue #13109: Kill mutation for UnusedImportCheck

---------

Check : 
https://checkstyle.org/config_imports.html#UnusedImports

----------

# Mutation covered 
https://github.com/checkstyle/checkstyle/blob/c7f3688f4380144bb712bee7ad6808cd075b327c/config/pitest-suppressions/pitest-imports-suppressions.xml#L183-L190

--------

# Explaination
The trim function is basically used to remove the space from the starting and end of the string.
over here  `{@link JavadocTag}` space needs to be removed before and after arg JavadocTag.
I have tried many ways to put space before and after but there I no case available where this function usage is coming it is already trimmed.
Regression also finds nothing

---------

# Regression 

Report-1 :-  https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/895e49c_2023101010/reports/diff/index.html

Report-2 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/895e49c_2023124458/reports/diff/index.html

------

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/27bfdb307fbeb7459ca132bcc5104c5b/raw/0d6a50d1d09d825a0947355e7ba1af3f80d94d74/UnusedImport.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: R2