### PR TITLE
Issue #13109: Kill mutation for UnusedImportCheck-2

### DIFF
--- a/config/pitest-suppressions/pitest-imports-suppressions.xml
+++ b/config/pitest-suppressions/pitest-imports-suppressions.xml
@@ -165,15 +165,6 @@
   <mutation unstable="false">
     <sourceFile>UnusedImportsCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck</mutatedClass>
-    <mutatedMethod>collectReferencesFromJavadoc</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/util/stream/Stream::filter with receiver</description>
-    <lineContent>.filter(JavadocTag::canReferenceImports)</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>UnusedImportsCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck</mutatedClass>
     <mutatedMethod>processJavadocTag</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
     <description>replaced call to java/lang/String::trim with receiver</description>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/UnusedImportsCheckTest.java
@@ -302,4 +302,13 @@ public class UnusedImportsCheckTest extends AbstractModuleTestSupport {
                 getPath("InputUnusedImportsShadowed.java"), expected);
     }
 
+    @Test
+    public void testUnusedImports3() throws Exception {
+        final String[] expected = {
+            "11:8: " + getCheckMessage(MSG_KEY, "java.awt.Rectangle"),
+            "13:8: " + getCheckMessage(MSG_KEY, "java.awt.event.KeyEvent"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputUnusedImports3.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImports3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/unusedimports/InputUnusedImports3.java
@@ -1,0 +1,45 @@
+/*
+UnusedImports
+processJavadoc = (default)true
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.imports.unusedimports;
+
+import java.awt.AWTException;
+import java.awt.Rectangle; // violation 'Unused import - java.awt.Rectangle'
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent; // violation 'Unused import - java.awt.event.KeyEvent'
+
+public class InputUnusedImports3 extends java.awt.Robot {
+    private int delay;
+
+    protected InputUnusedImports3() throws AWTException {
+        super();
+    }
+
+    /**
+     * Attention: usage of class by short name KeyEvent is not qualified as usage of type
+     * Qualified usage is by javadoc tag 'link'.
+     *
+     * @param keycode which key to press. For example, KeyEvent
+     */
+    public void hitKey(int keycode) {
+        keyPress(keycode);
+        delay();
+    }
+
+    public void clickMouse(int buttons) {
+        mousePress(buttons);
+        delay();
+    }
+
+    public void clickMouse() {
+        clickMouse(InputEvent.BUTTON1_MASK);
+    }
+
+    public void delay() {
+        delay(delay);
+    }
+}


### PR DESCRIPTION
Issue #13109: Kill mutation for UnusedImportCheck-2

---------

Check : 
https://checkstyle.org/config_imports.html#UnusedImports

----------

# Mutation covered 
https://github.com/checkstyle/checkstyle/blob/c7f3688f4380144bb712bee7ad6808cd075b327c/config/pitest-suppressions/pitest-imports-suppressions.xml#L174-L181

--------

# Explaination
Test added

---------

# Regression 

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/27bfdb307fbeb7459ca132bcc5104c5b/raw/0d6a50d1d09d825a0947355e7ba1af3f80d94d74/UnusedImport.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: R2