### PR TITLE
Issue #13109: Kill mutation for ImportOrderCheck

### DIFF
--- a/config/pitest-suppressions/pitest-imports-suppressions.xml
+++ b/config/pitest-suppressions/pitest-imports-suppressions.xml
@@ -118,15 +118,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>ImportOrderCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck</mutatedClass>
-    <mutatedMethod>setOption</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/lang/String::trim with receiver</description>
-    <lineContent>option = ImportOrderOption.valueOf(optionStr.trim().toUpperCase(Locale.ENGLISH));</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>PkgImportControl.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.PkgImportControl</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -772,4 +772,14 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
                 expected);
     }
 
+    @Test
+    public void testTrimOption() throws Exception {
+        final String[] expected = {
+            "25:1: " + getCheckMessage(MSG_ORDERING, "java.util.Set"),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputImportOrderTestTrimInOption.java"),
+                expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderTestTrimInOption.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderTestTrimInOption.java
@@ -1,0 +1,30 @@
+/*
+ImportOrder
+option = above\t
+groups = java, org
+ordered = (default)true
+separated = true
+separatedStaticGroups = (default)false
+caseSensitive = (default)true
+staticGroups = (default)
+sortStaticImportsAlphabetically = (default)false
+useContainerOrderingForStatic = (default)false
+tokens = (default)STATIC_IMPORT
+
+
+*/
+
+
+package com.puppycrawl.tools.checkstyle.checks.imports.importorder;
+
+import static java.lang.Math.*; // ok
+
+import static org.antlr.v4.runtime.CommonToken.*; // ok
+import static org.antlr.v4.runtime.CommonToken.*;  // ok
+
+import java.util.Set; // violation 'Wrong order for 'java.util.Set' import.'
+
+import org.junit.Test; // ok
+
+public class InputImportOrderTestTrimInOption {
+}


### PR DESCRIPTION
Issue #13109: Kill mutation for ImportOrderCheck

--------

# check 
https://checkstyle.org/config_imports.html#ImportOrder

---------

# mutation 
https://github.com/checkstyle/checkstyle/blob/c7f3688f4380144bb712bee7ad6808cd075b327c/config/pitest-suppressions/pitest-imports-suppressions.xml#L120-L127

------------

# Explaintaion
Test added