### PR TITLE
Issue #13501: Kill mutation for ImportOrderCheck-2

### DIFF
--- a/config/pitest-suppressions/pitest-imports-suppressions.xml
+++ b/config/pitest-suppressions/pitest-imports-suppressions.xml
@@ -36,42 +36,6 @@
     <lineContent>final boolean regex = containsRegexAttribute(attributes);</lineContent>
   </mutation>
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-  <mutation unstable="false">
-    <sourceFile>ImportOrderCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck</mutatedClass>
-    <mutatedMethod>getGroupNumber</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/regex/Matcher::end</description>
-    <lineContent>bestEnd = matcher.end();</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>ImportOrderCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck</mutatedClass>
-    <mutatedMethod>getGroupNumber</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/regex/Matcher::start</description>
-    <lineContent>if (matcher.start() &lt; bestPos) {</lineContent>
-  </mutation>
-
   <mutation unstable="false">
     <sourceFile>PkgImportControl.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.PkgImportControl</mutatedClass>
@@ -98,5 +62,4 @@
     <description>Removed assignment to member variable regex</description>
     <lineContent>this.regex = false;</lineContent>
   </mutation>
-
 </suppressedMutations>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheckTest.java
@@ -48,6 +48,14 @@ public class ImportOrderCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testVeryPreciseGrouping() throws Exception {
+        final String[] expected = {};
+
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputImportOrder6.java"), expected);
+    }
+
+    @Test
     public void testGetTokens() {
         final ImportOrderCheck checkObj = new ImportOrderCheck();
         final int[] expected = {TokenTypes.IMPORT, TokenTypes.STATIC_IMPORT};

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrder6.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrder6.java
@@ -1,0 +1,28 @@
+/*
+ImportOrder
+option = (default)under
+groups = /awt/, /jar/, /jar.*.JarInputStream/, /jar.*.JarInput/
+ordered = (default)true
+separated = true
+separatedStaticGroups = (default)false
+caseSensitive = (default)true
+staticGroups = (default)
+sortStaticImportsAlphabetically = (default)false
+useContainerOrderingForStatic = (default)false
+
+
+*/
+
+//non-compiled with javac: contains specially crafted set of imports for testing
+package com.puppycrawl.tools.checkstyle.checks.imports.importorder;
+
+import java.awt.Button;
+
+import java.util.jar.Some;
+
+import java.util.jar.JarInputStream;
+
+import java.util.jar.JarInputMy;
+
+public class InputImportOrder6 {
+}


### PR DESCRIPTION
Issue #13501: Kill mutation for ImportOrderCheck-2

---------

Check : 
https://checkstyle.org/config_imports.html#ImportOrder
https://checkstyle.org/checks/imports/importorder.html#ImportOrder

----------

# Mutation covered 
https://github.com/checkstyle/checkstyle/blob/58fdccf566a46b2ad4eea3987be3157d323bb3a8/config/pitest-suppressions/pitest-imports-suppressions.xml#L57-L73


--------

# Explaination

https://pitest.org/quickstart/mutators/#non-void-method-call-mutator-non_void_method_calls

test was added.

---------

# Regression 

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/64068f25e12fc53287e29c691b44b0cd/raw/3f08e73e3946ef9ef59bd119028bb67eff99b15b/ImportOrder.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/21e3934e85f802e2fbd48af06d122364/raw/604256badd733d8568064f371d55657c04b00dfd/test-projects-2.properties
Report label: R2