### PR TITLE
minor: construct non-compilable path based on resource location

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/AbstractModuleTestSupport.java
@@ -172,7 +172,8 @@ public abstract class AbstractModuleTestSupport extends AbstractPathTestSupport 
      * @throws IOException if I/O exception occurs while forming the path.
      */
     protected final String getNonCompilablePath(String filename) throws IOException {
-        return new File("src/test/resources-noncompilable/" + getPackageLocation() + "/"
+        return new File("src/" + getResourceLocation()
+                + "/resources-noncompilable/" + getPackageLocation() + "/"
                 + filename).getCanonicalPath();
     }
 


### PR DESCRIPTION
This is needed for examples that will go in `resources-noncompilable` folder.

`getResourceLocation` is specified in each examples test:
https://github.com/checkstyle/checkstyle/blob/81cb6f1ee7d6fb729df255681c4c7cd7340ebb67/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/naming/AbstractClassNameCheckExamplesTest.java#L33-L35