### PR TITLE
Issue #13109: Kill mutation for NestedIfDepthCheck

### DIFF
--- a/config/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -82,15 +82,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>NestedIfDepthCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.NestedIfDepthCheck</mutatedClass>
-    <mutatedMethod>beginTree</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable depth</description>
-    <lineContent>depth = 0;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>OneStatementPerLineCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedIfDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedIfDepthCheck.java
@@ -145,11 +145,6 @@ public final class NestedIfDepthCheck extends AbstractCheck {
     }
 
     @Override
-    public void beginTree(DetailAST rootAST) {
-        depth = 0;
-    }
-
-    @Override
     public void visitToken(DetailAST literalIf) {
         if (!CheckUtil.isElseIf(literalIf)) {
             if (depth > max) {


### PR DESCRIPTION
Issue #13109: Kill mutation for NestedIfDepthCheck

--------

# Check :- 
https://checkstyle.org/config_coding.html#NestedIfDepth 

----------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/3f25c37d731544f47d13020b47bfbec2a1bf57b6/config/pitest-suppressions/pitest-coding-2-suppressions.xml#L102-L109

----------

# Explaination 
All the values will increase by visit token and decrement by leave Token so I don't see we should require to reset the value using beginTree because at the end it will be reset by leaveToken 
but lets see Regression

---------

# Regression

Report-1 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/033e5f2_2023175528/reports/diff/index.html

Report-2 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/033e5f2_2023190546/reports/diff/index.html

----------
 
Diff Regression config: https://gist.githubusercontent.com/Kevin222004/b79c1d6f36c0d6db4516ff0aa57b8aee/raw/6e708ea645d0a75bfde0bd2baaff2adbf01730e0/NestedIf.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: R1
