### PR TITLE
Issue #13109: Kill mutation for NestedForDepthCheck

### DIFF
--- a/config/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -82,15 +82,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>NestedForDepthCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.NestedForDepthCheck</mutatedClass>
-    <mutatedMethod>beginTree</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable depth</description>
-    <lineContent>depth = 0;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>NestedIfDepthCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.NestedIfDepthCheck</mutatedClass>
     <mutatedMethod>beginTree</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedForDepthCheck.java
@@ -134,11 +134,6 @@ public final class NestedForDepthCheck extends AbstractCheck {
     }
 
     @Override
-    public void beginTree(DetailAST rootAST) {
-        depth = 0;
-    }
-
-    @Override
     public void visitToken(DetailAST ast) {
         if (depth > max) {
             log(ast, MSG_KEY, depth, max);


### PR DESCRIPTION
Issue #13109: Kill mutation for NestedForDepthCheck

--------

# Check :- 
https://checkstyle.org/config_coding.html#NestedForDepth

----------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/3f25c37d731544f47d13020b47bfbec2a1bf57b6/config/pitest-suppressions/pitest-coding-2-suppressions.xml#L93-L100

----------

# Explaination 
All the values will increase by visit token and decrement by leave Token so I don't see we should require to reset the value using beginTree because at the end it will be reset by leaveToken 
but lets see Regression

---------

# Regression

Report 1:- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/1f65036_2023200854/reports/diff/index.html

Report-2:- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/1f65036_2023230138/reports/diff/index.html

---------
 
Diff Regression config: https://gist.githubusercontent.com/Kevin222004/d0dc40653198aa6eca1700004f0ca8c7/raw/93cb657f3fc7ee3fdfa84024513435ddacb6547c/NestedForDepthCheck.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/21e3934e85f802e2fbd48af06d122364/raw/604256badd733d8568064f371d55657c04b00dfd/test-projects-2.properties
Report label: R2
