### PR TITLE
Issue #13109: Kill mutation for NestedTryDepthCheck

### DIFF
--- a/config/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -100,15 +100,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>NestedTryDepthCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.NestedTryDepthCheck</mutatedClass>
-    <mutatedMethod>beginTree</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable depth</description>
-    <lineContent>depth = 0;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>OneStatementPerLineCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck</mutatedClass>
     <mutatedMethod>&lt;init&gt;</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedTryDepthCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/NestedTryDepthCheck.java
@@ -182,11 +182,6 @@ public final class NestedTryDepthCheck extends AbstractCheck {
     }
 
     @Override
-    public void beginTree(DetailAST rootAST) {
-        depth = 0;
-    }
-
-    @Override
     public void visitToken(DetailAST literalTry) {
         if (depth > max) {
             log(literalTry, MSG_KEY, depth, max);


### PR DESCRIPTION
Issue #13109: Kill mutation for NestedTryDepthCheck
--------

# Check :- 
https://checkstyle.org/config_coding.html#NestedTryDepth

----------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/3f25c37d731544f47d13020b47bfbec2a1bf57b6/config/pitest-suppressions/pitest-coding-2-suppressions.xml#L111-L118

----------

# Explaination 
All the values will increase by visit token and decrement by leave Token so I don't see we should require to reset the value using beginTree because at the end it will be reset by leaveToken 
but lets see Regression

---------

# Regression
 
 Report-1 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/dac5a8c_2023201111/reports/diff/index.html

Report-2 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/dac5a8c_2023225538/reports/diff/index.html

--------
 
 
Diff Regression config: https://gist.githubusercontent.com/Kevin222004/1a5e00ff61776c73c881b8752b0495a0/raw/77a12ab981e96fabfcd4b674d3f8d825df3ea946/NestedTry.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/21e3934e85f802e2fbd48af06d122364/raw/604256badd733d8568064f371d55657c04b00dfd/test-projects-2.properties
Report label: R2