### PR TITLE
Issue #13109: Kill mutation for MultipleStringLiteralCheck

### DIFF
--- a/config/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -55,15 +55,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>MultipleStringLiteralsCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.MultipleStringLiteralsCheck</mutatedClass>
-    <mutatedMethod>isInIgnoreOccurrenceContext</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getParent with receiver</description>
-    <lineContent>token.getParent() != null;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>MultipleVariableDeclarationsCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.MultipleVariableDeclarationsCheck</mutatedClass>
     <mutatedMethod>getLastNode</mutatedMethod>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MultipleStringLiteralsCheck.java
@@ -313,9 +313,7 @@ public class MultipleStringLiteralsCheck extends AbstractCheck {
      */
     private boolean isInIgnoreOccurrenceContext(DetailAST ast) {
         boolean isInIgnoreOccurrenceContext = false;
-        for (DetailAST token = ast;
-             token.getParent() != null;
-             token = token.getParent()) {
+        for (DetailAST token = ast; token != null; token = token.getParent()) {
             final int type = token.getType();
             if (ignoreOccurrenceContext.get(type)) {
                 isInIgnoreOccurrenceContext = true;


### PR DESCRIPTION
Issue #13109: Kill mutation for MultipleStringLiteralCheck

----------

# Check :- 
https://checkstyle.org/config_coding.html#MultipleStringLiterals

----------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/3f25c37d731544f47d13020b47bfbec2a1bf57b6/config/pitest-suppressions/pitest-coding-2-suppressions.xml#L57-L64

---------

# Explaination 
The loops run one time more.

---------

# Regression 

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/7d3bd1d1b0d117d9b3d1a23fb9a7ae26/raw/d1f8aec7b4247bda070e645445515de2b8421c7a/MultipleStringLiterals.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/21e3934e85f802e2fbd48af06d122364/raw/604256badd733d8568064f371d55657c04b00dfd/test-projects-2.properties
Report label: R1 
