### PR TITLE
Issue #13328: Kill mutation for MatchXpathCheck

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -2026,6 +2026,13 @@
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
+    <message>the default constructor does not initialize field query</message>
+    <lineContent>private String query;</lineContent>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java</fileName>
+    <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field xpathExpression</message>
     <lineContent>private XPathExpression xpathExpression;</lineContent>
   </checkerFrameworkError>

--- a/config/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -18,42 +18,14 @@
     <lineContent>prevScopeUninitializedVariables.pop();</lineContent>
   </mutation>
 
-
-
-
-
-
-
-
-
-
-
-  <mutation unstable="false">
-    <sourceFile>MatchXpathCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.MatchXpathCheck</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable query</description>
-    <lineContent>private String query = &quot;&quot;;</lineContent>
-  </mutation>
-
   <mutation unstable="false">
     <sourceFile>MatchXpathCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.MatchXpathCheck</mutatedClass>
     <mutatedMethod>setQuery</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable query</description>
-    <lineContent>this.query = query;</lineContent>
+    <description>Removed assignment to member variable xpathExpression</description>
+    <lineContent>this.xpathExpression = null;</lineContent>
   </mutation>
-
-
-
-
-
-
-
-
-
 
   <mutation unstable="false">
     <sourceFile>UnusedLocalVariableCheck.java</sourceFile>
@@ -63,5 +35,4 @@
     <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getLastChild with receiver</description>
     <lineContent>final DetailAST updatedScope = literalNewAst.getLastChild();</lineContent>
   </mutation>
-
 </suppressedMutations>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java
@@ -60,7 +60,7 @@ import net.sf.saxon.trans.XPathException;
  * <li>
  * Property {@code query} - Specify Xpath query.
  * Type is {@code java.lang.String}.
- * Default value is {@code ""}.
+ * Default value is {@code null}.
  * </li>
  * </ul>
  * <p>
@@ -223,7 +223,7 @@ public class MatchXpathCheck extends AbstractCheck {
     public static final String MSG_KEY = "matchxpath.match";
 
     /** Specify Xpath query. */
-    private String query = "";
+    private String query;
 
     /** Xpath expression. */
     private XPathExpression xpathExpression;
@@ -236,8 +236,8 @@ public class MatchXpathCheck extends AbstractCheck {
      * @since 8.39
      */
     public void setQuery(String query) {
-        this.query = query;
         if (!query.isEmpty()) {
+            this.query = query;
             try {
                 final XPathEvaluator xpathEvaluator =
                         new XPathEvaluator(Configuration.newConfiguration());
@@ -246,6 +246,9 @@ public class MatchXpathCheck extends AbstractCheck {
             catch (XPathException ex) {
                 throw new IllegalStateException("Creating Xpath expression failed: " + query, ex);
             }
+        }
+        else {
+            this.xpathExpression = null;
         }
     }
 

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/MatchXpathCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/MatchXpathCheck.xml
@@ -25,7 +25,7 @@
      XpathUtil&lt;/a&gt;.
  &lt;/p&gt;</description>
          <properties>
-            <property default-value="" name="query" type="java.lang.String">
+            <property name="query" type="java.lang.String">
                <description>Specify Xpath query.</description>
             </property>
          </properties>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheckTest.java
@@ -19,12 +19,15 @@
 
 package com.puppycrawl.tools.checkstyle.checks.coding;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 import com.puppycrawl.tools.checkstyle.DetailAstImpl;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
@@ -229,5 +232,37 @@ public class MatchXpathCheckTest
         assertWithMessage("Expected empty array")
                 .that(matchXpathCheck.getRequiredTokens())
                 .isEmpty();
+    }
+
+    @Test
+    public void testMatchXpathExceptionTest() {
+        final CheckstyleException ex = assertThrows(CheckstyleException.class,
+                () -> verifyWithInlineConfigParser(getPath("InputMatchXpath5.java")));
+        assertThat(ex.getCause().getMessage())
+                .isEqualTo("Evaluation of Xpath query failed: count(*) div 0");
+    }
+
+    @Test
+    public void testMatchXpathDefaultQuery() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputMatchXpath6.java"),
+                expected);
+    }
+
+    @Test
+    public void testMatchXpathSetNullQueryTest() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputMatchXpath7.java"),
+                expected);
+    }
+
+    @Test
+    public void testSetEmptyQuery() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputMatchXpath8.java"),
+                expected);
     }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/InputMatchXpath5.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/InputMatchXpath5.java
@@ -1,0 +1,11 @@
+/*
+MatchXpath
+query = count(*) div 0
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.matchxpath;
+
+public class InputMatchXpath5 {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/InputMatchXpath6.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/InputMatchXpath6.java
@@ -1,0 +1,10 @@
+/*
+MatchXpath
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.matchxpath;
+
+public class InputMatchXpath6 {
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/InputMatchXpath7.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/InputMatchXpath7.java
@@ -1,0 +1,11 @@
+/*
+MatchXpath
+query = null
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.matchxpath;
+
+public class InputMatchXpath7 {
+    String str = null;
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/InputMatchXpath8.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/matchxpath/InputMatchXpath8.java
@@ -1,0 +1,10 @@
+/*
+MatchXpath
+query =
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.matchxpath;
+
+public class InputMatchXpath8 {
+}


### PR DESCRIPTION
Issue #13328: Kill mutation for MatchXpathCheck

------

# Check 
https://checkstyle.org/config_coding.html#MatchXpath

-------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/3f25c37d731544f47d13020b47bfbec2a1bf57b6/config/pitest-suppressions/pitest-coding-2-suppressions.xml#L39-L55

------

# Explaination 
The reason to create a pure unit testing for mutation https://github.com/checkstyle/checkstyle/blob/3f25c37d731544f47d13020b47bfbec2a1bf57b6/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java#L238  https://github.com/checkstyle/checkstyle/blob/3f25c37d731544f47d13020b47bfbec2a1bf57b6/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java#L297 hence to get the exact message I have to create a pure Ut. else test case is not possible removal of that statement is also not going to create issue because in all the set method if query is required it will be used from parameter the only usage after the setter is to throw exception message so user can see what is wrong 

https://github.com/checkstyle/checkstyle/blob/3f25c37d731544f47d13020b47bfbec2a1bf57b6/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/MatchXpathCheck.java#L226
Removal of " " will not create an issue as it is going to change to null. This check always require to set property.

 
