### PR TITLE
minor: exclude mojohaus 301 link from linkcheck

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1985,6 +1985,7 @@
             <!-- temporal suppress till plugin update link in his source -->
             <excludedLink>http://www.mojohaus.org/exec-maven-plugin</excludedLink>
             <excludedLink>http://www.mojohaus.org/versions-maven-plugin</excludedLink>
+            <excludedLink>http://www.mojohaus.org/xml-maven-plugin</excludedLink>
             <!-- SSL -->
             <excludedLink>https://travis-ci.org/</excludedLink>
             <excludedLink>https://travis-ci.org/checkstyle/checkstyle</excludedLink>


### PR DESCRIPTION
Noticed at https://app.circleci.com/pipelines/github/checkstyle/checkstyle/19045/workflows/82da432e-cfa8-49ad-b077-b122122ba35d/jobs/313477?invite=true#step-103-2437
```
------------ grep of linkcheck.html--BEGIN
1a2
> <td><i><a class="externalLink" href="http://www.mojohaus.org/xml-maven-plugin/">http://www.mojohaus.org/xml-maven-plugin/</a>: 301 Moved Permanently</i></td></tr></table></td></tr>
------------ grep of linkcheck.html--END
Exit code:1

Exited with code exit status 1


```