### PR TITLE
minor: trim table,tr and td tags in linkcheck

### DIFF
--- a/.ci/run-link-check-plugin.sh
+++ b/.ci/run-link-check-plugin.sh
@@ -13,9 +13,10 @@ mkdir -p .ci-temp
 
 echo "------------ grep of linkcheck.html--BEGIN"
 grep -E "doesn't exist|externalLink" target/site/linkcheck.html | grep -v 'Read timed out' \
-  | sort > .ci-temp/linkcheck-errors-sorted.txt
+  | sed 's/<\/table><\/td><\/tr>//g' | sort > .ci-temp/linkcheck-errors-sorted.txt
 
-sort config/linkcheck-suppressions.txt > .ci-temp/linkcheck-suppressions-sorted.txt
+sort config/linkcheck-suppressions.txt | sed 's/<\/table><\/td><\/tr>//g' \
+  > .ci-temp/linkcheck-suppressions-sorted.txt
 
 # Suppressions exist until https://github.com/checkstyle/checkstyle/issues/11572
 diff .ci-temp/linkcheck-suppressions-sorted.txt .ci-temp/linkcheck-errors-sorted.txt || true


### PR DESCRIPTION
Noticed at https://github.com/checkstyle/checkstyle/pull/13255#issuecomment-1596653952 (and other PRs)
Linkcheck script constantly has problems with items that are at the end of a table
```
------------ grep of linkcheck.html--BEGIN
501c501
< <td><i><a href="apidocs/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.html#%3Cinit%3E()">#%3Cinit%3E()</a>: doesn't exist.</i></td></tr>
---
> <td><i><a href="apidocs/com/puppycrawl/tools/checkstyle/checks/modifier/ModifierOrderCheck.html#%3Cinit%3E()">#%3Cinit%3E()</a>: doesn't exist.</i></td></tr></table></td></tr>
------------ grep of linkcheck.html--END
```
The difference here is just `</table></td></tr>` - the link is still the same
The link gets moved around and happens to be at the end of the table. Therefore, we get a diff error. 

Proof of commit working is at https://github.com/checkstyle/checkstyle/pull/13255