### PR TITLE
Issue #13328: Kill mutation for StringLiteralEqualityCheck

### DIFF
--- a/config/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -54,14 +54,14 @@
     <lineContent>this.query = query;</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>StringLiteralEqualityCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.StringLiteralEqualityCheck</mutatedClass>
-    <mutatedMethod>areStringsConcatenated</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::findFirstToken with receiver</description>
-    <lineContent>DetailAST plusAst = ast.findFirstToken(TokenTypes.PLUS);</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>UnusedLocalVariableCheck.java</sourceFile>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java
@@ -113,10 +113,7 @@ public class StringLiteralEqualityCheck extends AbstractCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
-        final boolean hasStringLiteralChild =
-                ast.findFirstToken(TokenTypes.STRING_LITERAL) != null
-                    || ast.findFirstToken(TokenTypes.TEXT_BLOCK_LITERAL_BEGIN) != null
-                    || areStringsConcatenated(ast);
+        final boolean hasStringLiteralChild = hasStringLiteralChild(ast);
 
         if (hasStringLiteralChild) {
             log(ast, MSG_KEY, ast.getText());
@@ -129,13 +126,13 @@ public class StringLiteralEqualityCheck extends AbstractCheck {
      * @param ast ast
      * @return {@code true} if string literal or text block literals are concatenated
      */
-    private static boolean areStringsConcatenated(DetailAST ast) {
-        DetailAST plusAst = ast.findFirstToken(TokenTypes.PLUS);
+    private static boolean hasStringLiteralChild(DetailAST ast) {
+        DetailAST currentAst = ast;
         boolean result = false;
-        while (plusAst != null) {
-            if (plusAst.findFirstToken(TokenTypes.STRING_LITERAL) == null
-                    && plusAst.findFirstToken(TokenTypes.TEXT_BLOCK_LITERAL_BEGIN) == null) {
-                plusAst = plusAst.findFirstToken(TokenTypes.PLUS);
+        while (currentAst != null) {
+            if (currentAst.findFirstToken(TokenTypes.STRING_LITERAL) == null
+                    && currentAst.findFirstToken(TokenTypes.TEXT_BLOCK_LITERAL_BEGIN) == null) {
+                currentAst = currentAst.findFirstToken(TokenTypes.PLUS);
             }
             else {
                 result = true;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheckTest.java
@@ -96,6 +96,16 @@ public class StringLiteralEqualityCheckTest
     }
 
     @Test
+    public void test() throws Exception {
+        final String[] expected = {
+            "32:24: " + getCheckMessage(MSG_KEY, "=="),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputStringLiteralEqualityCheck.java"),
+                expected);
+    }
+
+    @Test
     public void testTokensNotNull() {
         final StringLiteralEqualityCheck check = new StringLiteralEqualityCheck();
         assertWithMessage("Acceptable tokens should not be null")

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/stringliteralequality/InputStringLiteralEqualityCheck.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/stringliteralequality/InputStringLiteralEqualityCheck.java
@@ -1,0 +1,38 @@
+/*
+StringLiteralEquality
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.coding.stringliteralequality;
+
+public class InputStringLiteralEqualityCheck {
+
+    int method(int a) {
+        if (a == 2 + 3
+                + 5 + 2) {
+            return 0;
+        }
+        else {
+            return 1;
+        }
+    }
+
+    boolean method() {
+        boolean result = false;
+        if (result == false && 3 - 0 == 9) {
+        }
+        return result;
+    }
+
+    boolean method2() {
+        boolean result = false;
+        String str = "check";
+        if (result == false && 3 - 0 == 9
+                && str == "check" + "Style"
+                // violation above 'Literal Strings should be compared using equals(), not '==''
+                + "code" + "convention") {
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
Issue #13328: Kill mutation for StringLiteralEqualityCheck

-------

Check :- 
https://checkstyle.org/config_coding.html#StringLiteralEquality

--------

# Mutation :- 
https://github.com/checkstyle/checkstyle/blob/ca00dfad4c00df56eacc6174e379cdd8a2b38784/config/pitest-suppressions/pitest-coding-2-suppressions.xml#L192-L199

------

# Explaination

Reomval of this will not make any issue

the ast https://github.com/checkstyle/checkstyle/blob/ca00dfad4c00df56eacc6174e379cdd8a2b38784/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java#L132
is always either `==` or `!=` 

so while entering in the while loop ast is never going to be null so it will alwyas execute.
know lets suppose we have code like 
```
if (s == "a") {}
```

so the ast look like 
```
    |       |--LITERAL_IF -> if [14:8]
    |       |   |--LPAREN -> ( [14:11]
    |       |   |--EXPR -> EXPR [14:14]
    |       |   |   `--EQUAL -> == [14:14]
    |       |   |       |--IDENT -> s [14:12]
    |       |   |       `--STRING_LITERAL -> "a" [14:17]
    |       |   |--RPAREN -> ) [14:20]
    |       |   `--SLIST -> { [14:22]
    |       |       `--RCURLY -> } [15:8]

```

our ast would be `EQUAL -> == [14:14]` and when it enetr the while loop the if will not execute https://github.com/checkstyle/checkstyle/blob/ca00dfad4c00df56eacc6174e379cdd8a2b38784/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java#L136

and result become true which is already set true by https://github.com/checkstyle/checkstyle/blob/ca00dfad4c00df56eacc6174e379cdd8a2b38784/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java#L117 

so output will not effect and in the case if 

`if (s == "a" + "bc") {}`
the ast 
```
    |       |   |--EXPR -> EXPR [14:14]
    |       |   |   `--EQUAL -> == [14:14]
    |       |   |       |--IDENT -> s [14:12]
    |       |   |       `--PLUS -> + [14:21]
    |       |   |           |--STRING_LITERAL -> "a" [14:17]
    |       |   |           `--STRING_LITERAL -> "bc" [14:23]
    |       |   |--RPAREN -> ) [14:27]

```

here plus always become parent if it is used between string literal so if will execute 
https://github.com/checkstyle/checkstyle/blob/ca00dfad4c00df56eacc6174e379cdd8a2b38784/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java#L136-L139

and it will change ast to TokenTypes.Plus

Know as above explaintaion 
```
if (s == "a") {}
```
this is also going to be the same as 
https://github.com/checkstyle/checkstyle/blob/3d8ed42ab60c0399550b3e7d54ca9dd767583101/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/StringLiteralEqualityCheck.java#L117-L118
so removal of this both make not issue.

------

# Regression :- 

Report 1 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/04dd886_2023175346/reports/diff/index.html

Report 2:- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/04dd886_2023063730/reports/diff/index.html

------------------

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/694cadb00ab976e27fd978d7bc8841a1/raw/8f4e4d48b33f7ccefab4cca495181c0236846380/StringLiteralEquality.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: R2