### PR TITLE
Issue #13109: Kill mutation for OneStatmentPerLineCheck-3

### DIFF
--- a/config/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -149,33 +149,6 @@
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck</mutatedClass>
     <mutatedMethod>beginTree</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable forStatementEnd</description>
-    <lineContent>forStatementEnd = -1;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>OneStatementPerLineCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck</mutatedClass>
-    <mutatedMethod>beginTree</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable inForHeader</description>
-    <lineContent>inForHeader = false;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>OneStatementPerLineCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck</mutatedClass>
-    <mutatedMethod>beginTree</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable isInLambda</description>
-    <lineContent>isInLambda = false;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>OneStatementPerLineCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck</mutatedClass>
-    <mutatedMethod>beginTree</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
     <description>Removed assignment to member variable lastStatementEnd</description>
     <lineContent>lastStatementEnd = -1;</lineContent>
   </mutation>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheck.java
@@ -201,10 +201,7 @@ public final class OneStatementPerLineCheck extends AbstractCheck {
 
     @Override
     public void beginTree(DetailAST rootAST) {
-        inForHeader = false;
         lastStatementEnd = -1;
-        forStatementEnd = -1;
-        isInLambda = false;
         lastVariableResourceStatementEnd = -1;
     }
 


### PR DESCRIPTION
Issue #13109: Kill mutation for OneStatmentPerLineCheck-3

-----

# Check 
https://checkstyle.org/config_coding.html#OneStatementPerLine

------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/e0d3066777834ba62c489d86bd3edc9727aa79e3/config/pitest-suppressions/pitest-coding-2-suppressions.xml#L147-L172

-----

# Explaination 
This all are getting their origin value at the time of init while leaving token. so no need to reset 

-----

# Regression 

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/3bd236a24ed8eacd760e6b12b47f7455/raw/97d7a64aa97fc35488a6db5d7345ee23ae9b9507/olc.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Regression-2