### PR TITLE
Issue #13328: Kill mutation for OneStatmentPerLineCheck-4

### DIFF
--- a/config/pitest-suppressions/pitest-coding-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-coding-2-suppressions.xml
@@ -54,21 +54,6 @@
     <lineContent>this.query = query;</lineContent>
   </mutation>
 
-
-
-
-
-
-
-  <mutation unstable="false">
-    <sourceFile>OneStatementPerLineCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck</mutatedClass>
-    <mutatedMethod>beginTree</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable lastVariableResourceStatementEnd</description>
-    <lineContent>lastVariableResourceStatementEnd = 0;</lineContent>
-  </mutation>
-
   <mutation unstable="false">
     <sourceFile>StringLiteralEqualityCheck.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.coding.StringLiteralEqualityCheck</mutatedClass>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/coding/OneStatementPerLineCheckTest.java
@@ -159,4 +159,23 @@ public class OneStatementPerLineCheckTest extends AbstractModuleTestSupport {
             inputWithWarnings, expectedFirstInput,
             inputWithoutWarnings, expectedSecondInput));
     }
+
+    @Test
+    public void testStateIsClearedOnBeginTreeForLastVariableStatement() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(OneStatementPerLineCheck.class);
+        checkConfig.addProperty("treatTryResourcesAsStatement", "true");
+        final String file1 = getPath(
+                "InputOneStatementPerLineBeginTreeLastVariableResourcesStatementEnd1.java");
+        final String file2 = getPath(
+                "InputOneStatementPerLineBeginTreeLastVariableResourcesStatementEnd2.java");
+        final List<String> expectedFirstInput = List.of(
+                "8:59: " + getCheckMessage(MSG_KEY)
+        );
+        final List<String> expectedSecondInput = List.of(CommonUtil.EMPTY_STRING_ARRAY);
+        final File[] inputs = {new File(file1), new File(file2)};
+
+        verify(createChecker(checkConfig), inputs, ImmutableMap.of(
+            file1, expectedFirstInput,
+            file2, expectedSecondInput));
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineBeginTreeLastVariableResourcesStatementEnd1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineBeginTreeLastVariableResourcesStatementEnd1.java
@@ -1,0 +1,12 @@
+package com.puppycrawl.tools.checkstyle.checks.coding.onestatementperline;
+
+import java.io.*;
+
+// ok
+public class InputOneStatementPerLineBeginTreeLastVariableResourcesStatementEnd1 {
+    public void resourceListExists() throws IOException {
+        try (FileInputStream f1 = new FileInputStream("1"); FileInputStream f2 =
+                new FileInputStream("2")) {
+        }
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineBeginTreeLastVariableResourcesStatementEnd2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/onestatementperline/InputOneStatementPerLineBeginTreeLastVariableResourcesStatementEnd2.java
@@ -1,0 +1,12 @@
+package com.puppycrawl.tools.checkstyle.checks.coding.onestatementperline;
+
+import java.io.*;
+
+// ok
+public class InputOneStatementPerLineBeginTreeLastVariableResourcesStatementEnd2 {
+    void m(OutputStream out) throws IOException {
+        try (out; InputStream in = new FileInputStream("filename")) {
+
+        }
+  }
+}


### PR DESCRIPTION
Issue #13328: Kill mutation for OneStatmentPerLineCheck-4

-----

# Check 
https://checkstyle.org/config_coding.html#OneStatementPerLine

------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/6324a9d693324eb755c2cdfdbd90c2300d3c7f02/config/pitest-suppressions/pitest-coding-2-suppressions.xml#L183-L190

-----

# Explaination 
Test added

-----

# Regression 

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/3bd236a24ed8eacd760e6b12b47f7455/raw/97d7a64aa97fc35488a6db5d7345ee23ae9b9507/olc.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/21e3934e85f802e2fbd48af06d122364/raw/604256badd733d8568064f371d55657c04b00dfd/test-projects-2.properties
Report label: Regression-2
