### PR TITLE
Pull #13285: Ensure category index page tables are in sync with checks.xml page table

### DIFF
--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -285,6 +285,36 @@ public class XdocsPagesTest {
         }
     }
 
+    @Test
+    public void testCategoryIndexPageTableInSyncWithAllChecksPageTable() throws Exception {
+        final Map<String, String> summaries = readSummaries();
+        for (Path path : XdocUtil.getXdocsConfigFilePaths(XdocUtil.getXdocsFilePaths())) {
+            final String fileName = path.getFileName().toString();
+            if (!"index.xml".equals(fileName)
+                    && !path.getParent().toString().contains("filters")) {
+                continue;
+            }
+
+            final String input = Files.readString(path);
+            final Document document = XmlUtil.getRawXml(fileName, input, input);
+            final NodeList sources = document.getElementsByTagName("tr");
+
+            for (int position = 0; position < sources.getLength(); position++) {
+                final Node tableRow = sources.item(position);
+                final Iterator<Node> cells = XmlUtil
+                        .findChildElementsByTag(tableRow, "td").iterator();
+                final String checkName = XmlUtil.sanitizeXml(cells.next().getTextContent());
+                final String description = XmlUtil.sanitizeXml(cells.next().getTextContent());
+                assertWithMessage("The summary for check " + checkName
+                        + " in the file \"" + path + "\""
+                        + " should match the summary"
+                        + " for this check in the file \"" + AVAILABLE_CHECKS_PATH + "\"")
+                    .that(description)
+                    .isEqualTo(summaries.get(checkName));
+            }
+        }
+    }
+
     private static Map<String, String> readSummaries() throws Exception {
         final String fileName = AVAILABLE_CHECKS_PATH.getFileName().toString();
         final String input = Files.readString(AVAILABLE_CHECKS_PATH);

--- a/src/xdocs/checks/blocks/index.xml
+++ b/src/xdocs/checks/blocks/index.xml
@@ -46,7 +46,7 @@
               </a>
             </td>
             <td>
-              Checks for the placement of left curly braces (
+              Checks for the placement of left curly braces (<code>'{'</code>) for code blocks.
             </td>
           </tr>
           <tr>
@@ -66,7 +66,7 @@
               </a>
             </td>
             <td>
-              Checks the placement of right curly braces (
+              Checks the placement of right curly braces (<code>'}'</code>) for code blocks.
             </td>
           </tr>
         </table>

--- a/src/xdocs/checks/whitespace/index.xml
+++ b/src/xdocs/checks/whitespace/index.xml
@@ -178,7 +178,8 @@
               </a>
             </td>
             <td>
-              Checks that there is at least one whitespace after the leading asterisk.
+              Checks that a token is followed by whitespace, with the exception that it does not
+              check for whitespace after the semicolon of an empty for iterator.
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
Identified at https://github.com/checkstyle/checkstyle/pull/13258#discussion_r1236976318

The tables in `index.xml` in each category(`blocks`, `naming`,etc..) are an exact copy of `checks.xml`. It turned out that the script doesn't extract them correctly, hence we need this check.

Test run found 3 issues merged. Here is one
```
The summary for check WhitespaceAfter in the file "src/xdocs/checks/whitespace/index.xml" should match the summary for this check in the file "src/xdocs/checks.xml"
expected: Checks that a token is followed by whitespace, with the exception that it does not check for whitespace after the semicolon of an empty for iterator.
but was : Checks that there is at least one whitespace after the leading asterisk.
```