### PR TITLE
Pull #13287: Automatically scroll to first h2 in mobile views

### DIFF
--- a/src/site/resources/js/scroll-to-h2.js
+++ b/src/site/resources/js/scroll-to-h2.js
@@ -1,0 +1,16 @@
+window.addEventListener("load", function () {
+    if (window.innerWidth > 823) {
+        return;
+    }
+
+    const anchorIsAlreadySelected = document.URL.includes("#");
+    if (anchorIsAlreadySelected) {
+        return;
+    }
+
+    const elements = document.querySelectorAll("h2 > a[name]");
+    if (elements.length > 0) {
+        const element = elements[0];
+        element.scrollIntoView({ behavior: 'smooth' });
+    }
+});

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -50,6 +50,7 @@
               src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
         <script type="text/javascript" src="$relativePath/js/anchors.js"></script>
         <script type="text/javascript" src="$relativePath/js/google-analytics.js"></script>
+        <script type="text/javascript" src="$relativePath/js/scroll-to-h2.js"></script>
         <link rel="icon" href="$relativePath/images/favicon.png" type="image/x-icon" />
         <link rel="shortcut icon" href="$relativePath/images/favicon.ico" type="image/ico" />
       ]]>


### PR DESCRIPTION
Resolves problem where anchors cannot be added to menu items in `site.xml`
https://github.com/checkstyle/checkstyle/blob/fbbf38a0d9e3517cbea6e41ab95293d6ae20bbb6/src/site/site.xml#L83
doing `checks/annotation/annotationlocation.html#AnnotationLocation` doesn't work since when one clicks on the link, the menu collapses. Look at https://stoyank7.github.io/checks/annotation/index.html. Try to click any annotation check in menu and see how the menu collapses once the page is opened. 

PR changes work only in mobile view (screens below `823px`) and applies to all pages.