### PR TITLE
minor: fix trailing whitespace violations

### DIFF
--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/singlespaceseparator/Example1.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/singlespaceseparator/Example1.java
@@ -11,8 +11,8 @@ class Example1 {
   int foo()   { // violation 'Use a single space'
     return  1; // violation 'Use a single space'
   }
-  int fun1() { 
-    return 3; 
+  int fun1() {
+    return 3;
   }
   void  fun2() {} // violation 'Use a single space'
   // xdoc section -- end

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/singlespaceseparator/Example2.java
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/singlespaceseparator/Example2.java
@@ -22,7 +22,7 @@ class Example2 {
    * This is a Javadoc comment
    */  int b; // 2 whitespaces after the javadoc comment ends
   // violation above 'Use a single space'
-  float f1; 
+  float f1;
 
   /**
    * OK, 1 white space after the doc comment ends


### PR DESCRIPTION
Noticed in https://github.com/checkstyle/checkstyle/pull/13286#issuecomment-1603676583

The checks for examples got merged yesterday and 3 trailing whitespace slipped into master.

```
[INFO] [checkstyle] Running Checkstyle  on 54 files
[ERROR] [checkstyle] [ERROR] /home/kevin/Desktop/check_style/checkstyle/checkstyle/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/singlespaceseparator/Example1.java:14: Trailing whitespace is not allowed [noTrailingWhitespace]
[ERROR] [checkstyle] [ERROR] /home/kevin/Desktop/check_style/checkstyle/checkstyle/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/singlespaceseparator/Example1.java:15: Trailing whitespace is not allowed [noTrailingWhitespace]
[ERROR] [checkstyle] [ERROR] /home/kevin/Desktop/check_style/checkstyle/checkstyle/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/whitespace/singlespaceseparator/Example2.java:25: Trailing whitespace is not allowed [noTrailingWhitespace]
[INFO] ------------------------------------------------------------------------
```