### PR TITLE
Issue #13288: Remove redundant check name in anchor

### DIFF
--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -164,7 +164,7 @@ a[title="toTop"] {
     text-align: left;
   }
 
-  section[id$="Properties"] .wrapper .bodyTable tr td:first-child {
+  section[id="Properties"] .wrapper .bodyTable tr td:first-child {
     font-style: italic;
   }
 }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -358,24 +358,34 @@ public class XdocsPagesTest {
                     .isNotNull();
 
                 final String sectionName;
+                final String nameString = name.getNodeValue();
+                final String idString = id.getNodeValue();
+                final String expectedId;
 
                 if ("google_style.xml".equals(fileName)) {
                     sectionName = "Google";
+                    expectedId = (sectionName + " " + nameString).replace(' ', '_');
                 }
                 else if ("sun_style.xml".equals(fileName)) {
                     sectionName = "Sun";
+                    expectedId = (sectionName + " " + nameString).replace(' ', '_');
+                }
+                else if (path.toString().contains("filters")
+                        || path.toString().contains("checks")) {
+                    // Checks and filters have their own xdocs files, so the section name
+                    // is the same as the section id.
+                    sectionName = XmlUtil.getNameAttributeOfNode(subSection.getParentNode());
+                    expectedId = nameString.replace(' ', '_');
                 }
                 else {
                     sectionName = XmlUtil.getNameAttributeOfNode(subSection.getParentNode());
+                    expectedId = (sectionName + " " + nameString).replace(' ', '_');
                 }
-
-                final String nameString = name.getNodeValue();
-                final String idString = id.getNodeValue();
 
                 assertWithMessage(fileName + " sub-section " + nameString + " for section "
                         + sectionName + " must match")
                     .that(idString)
-                    .isEqualTo((sectionName + " " + nameString).replace(' ', '_'));
+                    .isEqualTo(expectedId);
             }
         }
     }

--- a/src/xdocs/checks/annotation/annotationlocation.xml
+++ b/src/xdocs/checks/annotation/annotationlocation.xml
@@ -9,7 +9,7 @@
     <section xmlns="http://maven.apache.org/XDOC/2.0"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="AnnotationLocation">
       <p>Since Checkstyle 6.0</p>
-      <subsection name="Description" id="AnnotationLocation_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks location of annotation on language elements.
           By default, Check enforce to locate annotations immediately after documentation block
@@ -41,7 +41,7 @@ public String getNameIfPresent() { ... }
         </source>
       </subsection>
 
-      <subsection name="Properties" id="AnnotationLocation_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -133,7 +133,7 @@ public String getNameIfPresent() { ... }
         </div>
       </subsection>
 
-      <subsection name="Examples" id="AnnotationLocation_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the default check to allow one single parameterless annotation on the same
             line:
@@ -239,7 +239,7 @@ public boolean equals(Object obj) { return true; }
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="AnnotationLocation_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AnnotationLocation">
@@ -252,7 +252,7 @@ public boolean equals(Object obj) { return true; }
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="AnnotationLocation_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fannotation%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22annotation.location%22">
@@ -270,11 +270,11 @@ public boolean equals(Object obj) { return true; }
         </p>
       </subsection>
 
-      <subsection name="Package" id="AnnotationLocation_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
       </subsection>
 
-      <subsection name="Parent Module" id="AnnotationLocation_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/annotation/annotationonsameline.xml
+++ b/src/xdocs/checks/annotation/annotationonsameline.xml
@@ -9,14 +9,14 @@
     <section xmlns="http://maven.apache.org/XDOC/2.0"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="AnnotationOnSameLine">
       <p>Since Checkstyle 8.2</p>
-      <subsection name="Description" id="AnnotationOnSameLine_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that annotations are located on the same line with their targets.
           Verifying with this check is not good practice, but it is using by some style guides.
         </p>
       </subsection>
 
-      <subsection name="Properties" id="AnnotationOnSameLine_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -91,7 +91,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="AnnotationOnSameLine_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -168,7 +168,7 @@ class Bar implements Foo {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="AnnotationOnSameLine_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+AnnotationOnSameLine">
@@ -177,7 +177,7 @@ class Bar implements Foo {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="AnnotationOnSameLine_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fannotation%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22annotation.same.line%22">
@@ -191,11 +191,11 @@ class Bar implements Foo {
         </p>
       </subsection>
 
-      <subsection name="Package" id="AnnotationOnSameLine_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
       </subsection>
 
-      <subsection name="Parent Module" id="AnnotationOnSameLine_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/annotation/annotationusestyle.xml
+++ b/src/xdocs/checks/annotation/annotationusestyle.xml
@@ -9,7 +9,7 @@
     <section xmlns="http://maven.apache.org/XDOC/2.0"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="AnnotationUseStyle">
       <p>Since Checkstyle 5.0</p>
-      <subsection name="Description" id="AnnotationUseStyle_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks the style of elements in annotations.
         </p>
@@ -75,7 +75,7 @@
           Java Language specification, §9.7</a>.
         </p>
       </subsection>
-      <subsection name="Properties" id="AnnotationUseStyle_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -129,7 +129,7 @@
           </table>
         </div>
       </subsection>
-      <subsection name="Examples" id="AnnotationUseStyle_Examples">
+      <subsection name="Examples" id="Examples">
         <p> To configure the check:</p>
         <source>
 &lt;module name="AnnotationUseStyle"/&gt;
@@ -245,7 +245,7 @@ class TestTwo {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="AnnotationUseStyle_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+AnnotationUseStyle">
@@ -254,7 +254,7 @@ class TestTwo {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="AnnotationUseStyle_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fannotation%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22annotation.incorrect.style%22">
@@ -284,11 +284,11 @@ class TestTwo {
         </p>
       </subsection>
 
-      <subsection name="Package" id="AnnotationUseStyle_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
       </subsection>
 
-      <subsection name="Parent Module" id="AnnotationUseStyle_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/annotation/index.xml
+++ b/src/xdocs/checks/annotation/index.xml
@@ -50,6 +50,17 @@
           </tr>
           <tr>
             <td>
+              <a href="missingoverride.html#MissingOverride">
+                MissingOverride
+              </a>
+            </td>
+            <td>
+              Verifies that the <code>@Override</code> annotation is present
+              when the <code>@inheritDoc</code> javadoc tag is present.
+            </td>
+          </tr>
+          <tr>
+            <td>
               <a href="packageannotation.html#PackageAnnotation">
                 PackageAnnotation
               </a>

--- a/src/xdocs/checks/annotation/missingdeprecated.xml
+++ b/src/xdocs/checks/annotation/missingdeprecated.xml
@@ -9,7 +9,7 @@
     <section xmlns="http://maven.apache.org/XDOC/2.0"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="MissingDeprecated">
       <p>Since Checkstyle 5.0</p>
-      <subsection name="Description" id="MissingDeprecated_Description">
+      <subsection name="Description" id="Description">
         <p>
           Verifies that the annotation <code>@Deprecated</code> and the Javadoc tag
           <code>@deprecated</code> are both present when either of them is present.
@@ -46,7 +46,7 @@
 &lt;/module&gt;
         </source>
       </subsection>
-      <subsection name="Properties" id="MissingDeprecated_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -70,7 +70,7 @@
           </table>
         </div>
       </subsection>
-      <subsection name="Examples" id="MissingDeprecated_Examples">
+      <subsection name="Examples" id="Examples">
         <p> To configure the check:</p>
         <source>
 &lt;module name="MissingDeprecated"/&gt;
@@ -134,7 +134,7 @@ public static final int CONST = 12; // violation, tight HTML rules not obeyed
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="MissingDeprecated_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingDeprecated">
@@ -143,7 +143,7 @@ public static final int CONST = 12; // violation, tight HTML rules not obeyed
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="MissingDeprecated_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fannotation%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22annotation.missing.deprecated%22">
@@ -173,11 +173,11 @@ public static final int CONST = 12; // violation, tight HTML rules not obeyed
         </p>
       </subsection>
 
-      <subsection name="Package" id="MissingDeprecated_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
       </subsection>
 
-      <subsection name="Parent Module" id="MissingDeprecated_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/annotation/missingoverride.xml
+++ b/src/xdocs/checks/annotation/missingoverride.xml
@@ -9,7 +9,7 @@
     <section xmlns="http://maven.apache.org/XDOC/2.0"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="MissingOverride">
       <p>Since Checkstyle 5.0</p>
-      <subsection name="Description" id="MissingOverride_Description">
+      <subsection name="Description" id="Description">
         <p>
           Verifies that the <code>@Override</code> annotation is present
           when the <code>@inheritDoc</code> javadoc tag is present.
@@ -40,7 +40,7 @@
         </p>
 
       </subsection>
-      <subsection name="Properties" id="MissingOverride_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -66,7 +66,7 @@
           </table>
         </div>
       </subsection>
-      <subsection name="Examples" id="MissingOverride_Examples">
+      <subsection name="Examples" id="Examples">
         <p> To configure the check:</p>
         <source>
 &lt;module name="MissingOverride"/&gt;
@@ -151,7 +151,7 @@ class Test5 {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="MissingOverride_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingOverride">
@@ -160,7 +160,7 @@ class Test5 {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="MissingOverride_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fannotation%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22annotation.missing.override%22">
@@ -178,11 +178,11 @@ class Test5 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MissingOverride_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
       </subsection>
 
-      <subsection name="Parent Module" id="MissingOverride_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/annotation/packageannotation.xml
+++ b/src/xdocs/checks/annotation/packageannotation.xml
@@ -9,7 +9,7 @@
     <section xmlns="http://maven.apache.org/XDOC/2.0"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PackageAnnotation">
       <p>Since Checkstyle 5.0</p>
-      <subsection name="Description" id="PackageAnnotation_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that all package annotations are in the package-info.java file.
         </p>
@@ -28,7 +28,7 @@
         </p>
       </subsection>
 
-      <subsection name="Examples" id="PackageAnnotation_Examples">
+      <subsection name="Examples" id="Examples">
         <p> To configure the check:</p>
         <source> &lt;module name="PackageAnnotation"/&gt; </source>
         <p>Example of validating MyClass.java:</p>
@@ -47,7 +47,7 @@ package com.example.annotations.packageannotation; //ok
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="PackageAnnotation_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+PackageAnnotation">
@@ -56,7 +56,7 @@ package com.example.annotations.packageannotation; //ok
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="PackageAnnotation_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fannotation%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22annotation.package.location%22">
@@ -70,11 +70,11 @@ package com.example.annotations.packageannotation; //ok
         </p>
       </subsection>
 
-      <subsection name="Package" id="PackageAnnotation_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
       </subsection>
 
-      <subsection name="Parent Module" id="PackageAnnotation_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/annotation/suppresswarnings.xml
+++ b/src/xdocs/checks/annotation/suppresswarnings.xml
@@ -9,7 +9,7 @@
     <section xmlns="http://maven.apache.org/XDOC/2.0"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="SuppressWarnings">
       <p>Since Checkstyle 5.0</p>
-      <subsection name="Description" id="SuppressWarnings_Description">
+      <subsection name="Description" id="Description">
         <p>Allows to specify what warnings that <code>@SuppressWarnings</code>
           is not allowed to suppress.
         You can also specify a list of TokenTypes that
@@ -47,7 +47,7 @@
           See below of an example.
         </p>
       </subsection>
-      <subsection name="Properties" id="SuppressWarnings_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -138,7 +138,7 @@
           </table>
         </div>
       </subsection>
-      <subsection name="Examples" id="SuppressWarnings_Examples">
+      <subsection name="Examples" id="Examples">
         <p> To configure the check:</p>
         <source> &lt;module name="SuppressWarnings"/&gt;
         </source>
@@ -210,7 +210,7 @@ class TestB {}
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="SuppressWarnings_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressWarnings">
@@ -219,7 +219,7 @@ class TestB {}
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="SuppressWarnings_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fannotation%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22suppressed.warning.not.allowed%22">
@@ -233,11 +233,11 @@ class TestB {}
         </p>
       </subsection>
 
-      <subsection name="Package" id="SuppressWarnings_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.annotation </p>
       </subsection>
 
-      <subsection name="Parent Module" id="SuppressWarnings_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/annotation/suppresswarningsholder.xml
+++ b/src/xdocs/checks/annotation/suppresswarningsholder.xml
@@ -9,7 +9,7 @@
     <section xmlns="http://maven.apache.org/XDOC/2.0"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="SuppressWarningsHolder">
       <p>Since Checkstyle 5.7</p>
-      <subsection name="Description" id="SuppressWarningsHolder_Description">
+      <subsection name="Description" id="Description">
         <p>
           Maintains a set of check suppressions from
           <code>@SuppressWarnings</code> annotations. It allows to
@@ -24,7 +24,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="SuppressWarningsHolder_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -52,7 +52,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="SuppressWarningsHolder_Examples">
+      <subsection name="Examples" id="Examples">
         <p>To use default module configuration:</p>
         <source>
 &lt;module name="TreeWalker"&gt;
@@ -132,7 +132,7 @@ class Test {
 
       </subsection>
 
-      <subsection name="Example of Usage" id="SuppressWarningsHolder_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressWarningsHolder">
@@ -145,11 +145,11 @@ class Test {
         </ul>
       </subsection>
 
-      <subsection name="Package" id="SuppressWarningsHolder_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks </p>
       </subsection>
 
-      <subsection name="Parent Module" id="SuppressWarningsHolder_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
 

--- a/src/xdocs/checks/blocks/avoidnestedblocks.xml
+++ b/src/xdocs/checks/blocks/avoidnestedblocks.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="AvoidNestedBlocks">
       <p>Since Checkstyle 3.1</p>
-      <subsection name="Description" id="AvoidNestedBlocks_Description">
+      <subsection name="Description" id="Description">
         <p>
           Finds nested blocks (blocks that are used freely in the code).
         </p>
@@ -49,7 +49,7 @@ public void guessTheOutput()
         </p>
       </subsection>
 
-      <subsection name="Properties" id="AvoidNestedBlocks_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -70,7 +70,7 @@ public void guessTheOutput()
         </div>
       </subsection>
 
-      <subsection name="Examples" id="AvoidNestedBlocks_Examples">
+      <subsection name="Examples" id="Examples">
         <p>To configure the check:</p>
         <source>
 &lt;module name="AvoidNestedBlocks"/&gt;
@@ -126,7 +126,7 @@ public void foo() {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="AvoidNestedBlocks_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidNestedBlocks">
@@ -139,7 +139,7 @@ public void foo() {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="AvoidNestedBlocks_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fblocks%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22block.nested%22">
@@ -153,11 +153,11 @@ public void foo() {
         </p>
       </subsection>
 
-      <subsection name="Package" id="AvoidNestedBlocks_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.blocks </p>
       </subsection>
 
-      <subsection name="Parent Module" id="AvoidNestedBlocks_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/blocks/emptyblock.xml
+++ b/src/xdocs/checks/blocks/emptyblock.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="EmptyBlock">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="EmptyBlock_Description">
+      <subsection name="Description" id="Description">
         <p> Checks for empty blocks. This check does not validate sequential blocks. </p>
 
         <p> Sequential blocks won't be checked. Also, no violations for fallthrough: </p>
@@ -27,7 +27,7 @@ switch (a) {
         </p>
       </subsection>
 
-      <subsection name="Properties" id="EmptyBlock_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -112,7 +112,7 @@ switch (a) {
         </div>
       </subsection>
 
-      <subsection name="Examples" id="EmptyBlock_Examples">
+      <subsection name="Examples" id="Examples">
         <p> To configure the check: </p>
         <source>
 &lt;module name="EmptyBlock"/&gt;
@@ -186,7 +186,7 @@ public class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="EmptyBlock_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+EmptyBlock">
@@ -203,7 +203,7 @@ public class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="EmptyBlock_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fblocks%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22block.empty%22">
@@ -221,11 +221,11 @@ public class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="EmptyBlock_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.blocks </p>
       </subsection>
 
-      <subsection name="Parent Module" id="EmptyBlock_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/blocks/emptycatchblock.xml
+++ b/src/xdocs/checks/blocks/emptycatchblock.xml
@@ -8,14 +8,14 @@
   <body>
     <section name="EmptyCatchBlock">
       <p>Since Checkstyle 6.4</p>
-      <subsection name="Description" id="EmptyCatchBlock_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for empty catch blocks.
           By default, check allows empty catch block with any comment inside.
         </p>
       </subsection>
 
-      <subsection name="Notes" id="EmptyCatchBlock_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           There are two options to make validation more precise: <b>exceptionVariableName</b> and
           <b>commentFormat</b>.
@@ -23,7 +23,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="EmptyCatchBlock_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -58,7 +58,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="EmptyCatchBlock_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -219,7 +219,7 @@ try {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="EmptyCatchBlock_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+EmptyCatchBlock">
@@ -232,7 +232,7 @@ try {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="EmptyCatchBlock_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fblocks%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22catch.block.empty%22">
@@ -246,11 +246,11 @@ try {
         </p>
       </subsection>
 
-      <subsection name="Package" id="EmptyCatchBlock_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.blocks </p>
       </subsection>
 
-      <subsection name="Parent Module" id="EmptyCatchBlock_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/blocks/leftcurly.xml
+++ b/src/xdocs/checks/blocks/leftcurly.xml
@@ -8,14 +8,14 @@
   <body>
     <section name="LeftCurly">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="LeftCurly_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for the placement of left curly braces
           (<code>'{'</code>) for code blocks.
         </p>
       </subsection>
 
-      <subsection name="Properties" id="LeftCurly_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -151,7 +151,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="LeftCurly_Examples">
+      <subsection name="Examples" id="Examples">
         <p> To configure the check: </p>
         <source>
 &lt;module name="LeftCurly"/&gt;
@@ -257,7 +257,7 @@ class Test
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="LeftCurly_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LeftCurly">
@@ -274,7 +274,7 @@ class Test
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="LeftCurly_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fblocks%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22line.break.after%22">
@@ -296,11 +296,11 @@ class Test
         </p>
       </subsection>
 
-      <subsection name="Package" id="LeftCurly_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.blocks </p>
       </subsection>
 
-      <subsection name="Parent Module" id="LeftCurly_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/blocks/needbraces.xml
+++ b/src/xdocs/checks/blocks/needbraces.xml
@@ -8,11 +8,11 @@
   <body>
     <section name="NeedBraces">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="NeedBraces_Description">
+      <subsection name="Description" id="Description">
         <p> Checks for braces around code blocks. </p>
       </subsection>
 
-      <subsection name="Properties" id="NeedBraces_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -78,7 +78,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="NeedBraces_Examples">
+      <subsection name="Examples" id="Examples">
         <p> To configure the check: </p>
         <source>
 &lt;module name="NeedBraces"/&gt;
@@ -272,7 +272,7 @@ allowedFuture.addCallback(result -&gt; {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="NeedBraces_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NeedBraces">
@@ -289,7 +289,7 @@ allowedFuture.addCallback(result -&gt; {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="NeedBraces_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fblocks%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22needBraces%22">
@@ -303,11 +303,11 @@ allowedFuture.addCallback(result -&gt; {
         </p>
       </subsection>
 
-      <subsection name="Package" id="NeedBraces_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.blocks </p>
       </subsection>
 
-      <subsection name="Parent Module" id="NeedBraces_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/blocks/rightcurly.xml
+++ b/src/xdocs/checks/blocks/rightcurly.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="RightCurly">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="RightCurly_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks the placement of right curly braces (<code>'}'</code>) for code blocks.
           This check supports if-else, try-catch-finally blocks, switch statements,
@@ -22,7 +22,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="RightCurly_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -102,7 +102,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="RightCurly_Examples">
+      <subsection name="Examples" id="Examples">
         <p> To configure the check: </p>
         <source>
 &lt;module name="RightCurly"/&gt;
@@ -322,7 +322,7 @@ class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="RightCurly_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+RightCurly">
@@ -339,7 +339,7 @@ class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="RightCurly_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fblocks%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22line.alone%22">
@@ -361,11 +361,11 @@ class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="RightCurly_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.blocks </p>
       </subsection>
 
-      <subsection name="Parent Module" id="RightCurly_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/coding/arraytrailingcomma.xml
+++ b/src/xdocs/checks/coding/arraytrailingcomma.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="ArrayTrailingComma">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="ArrayTrailingComma_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that array initialization contains a trailing comma.
         </p>
@@ -77,7 +77,7 @@ return new int[] {
         </source>
       </subsection>
 
-      <subsection name="Properties" id="ArrayTrailingComma_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -101,7 +101,7 @@ return new int[] {
         </div>
       </subsection>
 
-      <subsection name="Examples" id="ArrayTrailingComma_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -187,7 +187,7 @@ int[] a2 = new int[]{
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="ArrayTrailingComma_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+ArrayTrailingComma">
@@ -196,7 +196,7 @@ int[] a2 = new int[]{
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="ArrayTrailingComma_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22array.trailing.comma%22">
@@ -210,13 +210,13 @@ int[] a2 = new int[]{
         </p>
       </subsection>
 
-      <subsection name="Package" id="ArrayTrailingComma_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="ArrayTrailingComma_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/avoiddoublebraceinitialization.xml
+++ b/src/xdocs/checks/coding/avoiddoublebraceinitialization.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="AvoidDoubleBraceInitialization">
       <p>Since Checkstyle 8.30</p>
-      <subsection name="Description" id="AvoidDoubleBraceInitialization_Description">
+      <subsection name="Description" id="Description">
         <p>
           Detects double brace initialization.
         </p>
@@ -30,7 +30,7 @@
         </p>
       </subsection>
 
-      <subsection name="Examples" id="AvoidDoubleBraceInitialization_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -74,7 +74,7 @@ class MyClass {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="AvoidDoubleBraceInitialization_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidDoubleBraceInitialization">
@@ -83,7 +83,7 @@ class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="AvoidDoubleBraceInitialization_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22avoid.double.brace.init%22">
@@ -97,13 +97,13 @@ class MyClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="AvoidDoubleBraceInitialization_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="AvoidDoubleBraceInitialization_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/avoidinlineconditionals.xml
+++ b/src/xdocs/checks/coding/avoidinlineconditionals.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="AvoidInlineConditionals">
       <p>Since Checkstyle 3.1</p>
-      <subsection name="Description" id="AvoidInlineConditionals_Description">
+      <subsection name="Description" id="Description">
         <p>
           Detects inline conditionals. Here is one example of an inline conditional:
         </p>
@@ -23,7 +23,7 @@ String b = (a==null || a.length()&lt;1) ? null : a.substring(1);
         </p>
       </subsection>
 
-      <subsection name="Examples" id="AvoidInlineConditionals_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -49,7 +49,7 @@ b = (a != null &amp;&amp; a.length() &gt;= 1) ? a.substring(1) : null; // violat
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="AvoidInlineConditionals_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidInlineConditionals">
@@ -58,7 +58,7 @@ b = (a != null &amp;&amp; a.length() &gt;= 1) ? a.substring(1) : null; // violat
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="AvoidInlineConditionals_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22inline.conditional.avoid%22">
@@ -72,13 +72,13 @@ b = (a != null &amp;&amp; a.length() &gt;= 1) ? a.substring(1) : null; // violat
         </p>
       </subsection>
 
-      <subsection name="Package" id="AvoidInlineConditionals_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="AvoidInlineConditionals_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/avoidnoargumentsuperconstructorcall.xml
+++ b/src/xdocs/checks/coding/avoidnoargumentsuperconstructorcall.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="AvoidNoArgumentSuperConstructorCall">
       <p>Since Checkstyle 8.29</p>
-      <subsection name="Description" id="AvoidNoArgumentSuperConstructorCall_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks if call to superclass constructor without arguments is present.
           Such invocation is redundant because constructor body implicitly
@@ -18,7 +18,7 @@
         </p>
       </subsection>
 
-      <subsection name="Examples" id="AvoidNoArgumentSuperConstructorCall_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -45,7 +45,7 @@ class MyClass extends SomeOtherClass {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="AvoidNoArgumentSuperConstructorCall_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidNoArgumentSuperConstructorCall">
@@ -55,7 +55,7 @@ class MyClass extends SomeOtherClass {
       </subsection>
 
       <subsection name="Violation Messages"
-        id="AvoidNoArgumentSuperConstructorCall_Violation_Messages">
+        id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22super.constructor.call%22">
@@ -69,13 +69,13 @@ class MyClass extends SomeOtherClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="AvoidNoArgumentSuperConstructorCall_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="AvoidNoArgumentSuperConstructorCall_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/covariantequals.xml
+++ b/src/xdocs/checks/coding/covariantequals.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="CovariantEquals">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="CovariantEquals_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that classes and records which define a covariant <code>equals()</code> method
           also override method <code>equals(Object)</code>.
@@ -61,7 +61,7 @@ public boolean equals(Foo obj) {...}
         </p>
       </subsection>
 
-      <subsection name="Examples" id="CovariantEquals_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -119,7 +119,7 @@ record Test(String str) {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="CovariantEquals_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+CovariantEquals">
@@ -128,7 +128,7 @@ record Test(String str) {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="CovariantEquals_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22covariant.equals%22">
@@ -142,13 +142,13 @@ record Test(String str) {
         </p>
       </subsection>
 
-      <subsection name="Package" id="CovariantEquals_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="CovariantEquals_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/declarationorder.xml
+++ b/src/xdocs/checks/coding/declarationorder.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="DeclarationOrder">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="DeclarationOrder_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that the parts of a class, record, or interface declaration appear in the order
           suggested by the
@@ -59,7 +59,7 @@ public class A {
         </source>
       </subsection>
 
-      <subsection name="Properties" id="DeclarationOrder_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -87,7 +87,7 @@ public class A {
         </div>
       </subsection>
 
-      <subsection name="Examples" id="DeclarationOrder_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -181,7 +181,7 @@ public class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="DeclarationOrder_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+DeclarationOrder">
@@ -190,7 +190,7 @@ public class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="DeclarationOrder_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22declaration.order.access%22">
@@ -216,13 +216,13 @@ public class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="DeclarationOrder_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="DeclarationOrder_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/defaultcomeslast.xml
+++ b/src/xdocs/checks/coding/defaultcomeslast.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="DefaultComesLast">
       <p>Since Checkstyle 3.4</p>
-      <subsection name="Description" id="DefaultComesLast_Description">
+      <subsection name="Description" id="Description">
         <p>
           Check that the <code>default</code> is after all the
           cases in a <code>switch</code> statement.
@@ -20,7 +20,7 @@
           more readable if it comes after the last <code>case</code>.
         </p>
       </subsection>
-      <subsection name="Properties" id="DefaultComesLast_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -43,7 +43,7 @@
           </table>
         </div>
       </subsection>
-      <subsection name="Examples" id="DefaultComesLast_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -126,7 +126,7 @@ case 2 -&gt; x = 32;
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="DefaultComesLast_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+DefaultComesLast">
@@ -135,7 +135,7 @@ case 2 -&gt; x = 32;
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="DefaultComesLast_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22default.comes.last%22">
@@ -153,13 +153,13 @@ case 2 -&gt; x = 32;
         </p>
       </subsection>
 
-      <subsection name="Package" id="DefaultComesLast_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="DefaultComesLast_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/emptystatement.xml
+++ b/src/xdocs/checks/coding/emptystatement.xml
@@ -8,14 +8,14 @@
   <body>
     <section name="EmptyStatement">
       <p>Since Checkstyle 3.1</p>
-      <subsection name="Description" id="EmptyStatement_Description">
+      <subsection name="Description" id="Description">
         <p>
           Detects empty statements (standalone <code>";"</code> semicolon).
           Empty statements often introduce bugs that are hard to spot
         </p>
       </subsection>
 
-      <subsection name="Examples" id="EmptyStatement_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -38,7 +38,7 @@ public void foo() {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="EmptyStatement_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+EmptyStatement">
@@ -51,7 +51,7 @@ public void foo() {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="EmptyStatement_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22empty.statement%22">
@@ -65,13 +65,13 @@ public void foo() {
         </p>
       </subsection>
 
-      <subsection name="Package" id="EmptyStatement_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="EmptyStatement_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/equalsavoidnull.xml
+++ b/src/xdocs/checks/coding/equalsavoidnull.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="EqualsAvoidNull">
       <p>Since Checkstyle 5.0</p>
-      <subsection name="Description" id="EqualsAvoidNull_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that any combination of String literals
           is on the left side of an <code>equals()</code> comparison.
@@ -26,7 +26,7 @@
 
       </subsection>
 
-      <subsection name="Properties" id="EqualsAvoidNull_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -49,7 +49,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="EqualsAvoidNull_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -87,7 +87,7 @@ nullString.equalsIgnoreCase("My_Sweet_String");  // OK
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="EqualsAvoidNull_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+EqualsAvoidNull">
@@ -96,7 +96,7 @@ nullString.equalsIgnoreCase("My_Sweet_String");  // OK
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="EqualsAvoidNull_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22equals.avoid.null%22">
@@ -114,13 +114,13 @@ nullString.equalsIgnoreCase("My_Sweet_String");  // OK
         </p>
       </subsection>
 
-      <subsection name="Package" id="EqualsAvoidNull_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="EqualsAvoidNull_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/equalshashcode.xml
+++ b/src/xdocs/checks/coding/equalshashcode.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="EqualsHashCode">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="EqualsHashCode_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that classes that either override <code>equals()</code>
           or <code>hashCode()</code> also overrides the other.
@@ -27,7 +27,7 @@
         </p>
       </subsection>
 
-      <subsection name="Examples" id="EqualsHashCode_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -90,7 +90,7 @@ public static class Example6 {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="EqualsHashCode_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+EqualsHashCode">
@@ -103,7 +103,7 @@ public static class Example6 {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="EqualsHashCode_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22equals.noEquals%22">
@@ -121,13 +121,13 @@ public static class Example6 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="EqualsHashCode_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="EqualsHashCode_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/explicitinitialization.xml
+++ b/src/xdocs/checks/coding/explicitinitialization.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="ExplicitInitialization">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="ExplicitInitialization_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks if any class or object member is explicitly initialized to
           default for its type value (<code>null</code> for
@@ -24,7 +24,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="ExplicitInitialization_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -46,7 +46,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="ExplicitInitialization_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -112,7 +112,7 @@ public class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="ExplicitInitialization_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+ExplicitInitialization">
@@ -121,7 +121,7 @@ public class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="ExplicitInitialization_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22explicit.init%22">
@@ -135,13 +135,13 @@ public class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ExplicitInitialization_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="ExplicitInitialization_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/fallthrough.xml
+++ b/src/xdocs/checks/coding/fallthrough.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="FallThrough">
       <p>Since Checkstyle 3.4</p>
-      <subsection name="Description" id="FallThrough_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for fall-through in <code>switch</code>
           statements. Finds locations where a <code>case</code>
@@ -34,7 +34,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="FallThrough_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -67,7 +67,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="FallThrough_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -192,7 +192,7 @@ switch (i) {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="FallThrough_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+FallThrough">
@@ -205,7 +205,7 @@ switch (i) {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="FallThrough_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22fall.through%22">
@@ -223,13 +223,13 @@ switch (i) {
         </p>
       </subsection>
 
-      <subsection name="Package" id="FallThrough_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="FallThrough_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/finallocalvariable.xml
+++ b/src/xdocs/checks/coding/finallocalvariable.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="FinalLocalVariable">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="FinalLocalVariable_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that local variables that never have their values changed are
           declared final. The check can be configured to also check that
@@ -16,14 +16,14 @@
         </p>
       </subsection>
 
-      <subsection name="Notes" id="FinalLocalVariable_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           When configured to check parameters, the check ignores parameters of
           interface methods and abstract methods.
         </p>
       </subsection>
 
-      <subsection name="Properties" id="FinalLocalVariable_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr class="header">
@@ -70,7 +70,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="FinalLocalVariable_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -138,7 +138,7 @@ public class MyClass {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="FinalLocalVariable_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+FinalLocalVariable">
@@ -147,7 +147,7 @@ public class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="FinalLocalVariable_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22final.variable%22">
@@ -161,13 +161,13 @@ public class MyClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="FinalLocalVariable_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="FinalLocalVariable_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/hiddenfield.xml
+++ b/src/xdocs/checks/coding/hiddenfield.xml
@@ -8,13 +8,13 @@
   <body>
     <section name="HiddenField">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="HiddenField_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that a local variable or a parameter does not shadow a field
           that is defined in the same class.
         </p>
       </subsection>
-      <subsection name="Notes" id="HiddenField_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           It is possible to configure the check to ignore all property setter methods.
         </p>
@@ -51,7 +51,7 @@ class PageBuilder {
         </p>
       </subsection>
 
-      <subsection name="Properties" id="HiddenField_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -143,7 +143,7 @@ class PageBuilder {
         </div>
       </subsection>
 
-      <subsection name="Examples" id="HiddenField_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -346,7 +346,7 @@ public class Demo extends SomeClass {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="HiddenField_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+HiddenField">
@@ -359,7 +359,7 @@ public class Demo extends SomeClass {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="HiddenField_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22hidden.field%22">
@@ -373,13 +373,13 @@ public class Demo extends SomeClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="HiddenField_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="HiddenField_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/illegalcatch.xml
+++ b/src/xdocs/checks/coding/illegalcatch.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="IllegalCatch">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="IllegalCatch_Description">
+      <subsection name="Description" id="Description">
         <p>
         Checks that certain exception types do not appear in a <code>catch</code> statement.
         </p>
@@ -24,7 +24,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="IllegalCatch_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -46,7 +46,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="IllegalCatch_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -131,7 +131,7 @@ try {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="IllegalCatch_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+IllegalCatch">
@@ -140,7 +140,7 @@ try {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="IllegalCatch_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22illegal.catch%22">
@@ -154,13 +154,13 @@ try {
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalCatch_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="IllegalCatch_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/illegalinstantiation.xml
+++ b/src/xdocs/checks/coding/illegalinstantiation.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="IllegalInstantiation">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="IllegalInstantiation_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for illegal instantiations where a factory method is
           preferred.
@@ -35,14 +35,14 @@
         </p>
       </subsection>
 
-      <subsection name="Notes" id="IllegalInstantiation_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           There is a limitation that it is currently not possible to specify
           array classes.
         </p>
       </subsection>
 
-      <subsection name="Properties" id="IllegalInstantiation_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -63,7 +63,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="IllegalInstantiation_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -138,7 +138,7 @@ public class MyTest {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="IllegalInstantiation_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+IllegalInstantiation">
@@ -151,7 +151,7 @@ public class MyTest {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="IllegalInstantiation_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22instantiation.avoid%22">
@@ -165,13 +165,13 @@ public class MyTest {
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalInstantiation_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="IllegalInstantiation_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/illegalthrows.xml
+++ b/src/xdocs/checks/coding/illegalthrows.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="IllegalThrows">
       <p>Since Checkstyle 4.0</p>
-      <subsection name="Description" id="IllegalThrows_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that specified types are not declared to be thrown.
           Declaring that a method throws <code>java.lang.Error</code> or
@@ -16,7 +16,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="IllegalThrows_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -56,7 +56,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="IllegalThrows_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -137,7 +137,7 @@ public class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="IllegalThrows_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+IllegalThrows">
@@ -146,7 +146,7 @@ public class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="IllegalThrows_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22illegal.throw%22">
@@ -160,13 +160,13 @@ public class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalThrows_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="IllegalThrows_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/illegaltoken.xml
+++ b/src/xdocs/checks/coding/illegaltoken.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="IllegalToken">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="IllegalToken_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for illegal tokens. By default, labels are prohibited.
         </p>
@@ -21,7 +21,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="IllegalToken_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -48,7 +48,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="IllegalToken_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -84,7 +84,7 @@ public native void myTest(); // violation
         </div>
       </subsection>
 
-      <subsection name="Example of Usage" id="IllegalToken_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+IllegalToken">
@@ -93,7 +93,7 @@ public native void myTest(); // violation
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="IllegalToken_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22illegal.token%22">
@@ -107,13 +107,13 @@ public native void myTest(); // violation
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalToken_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="IllegalToken_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/illegaltokentext.xml
+++ b/src/xdocs/checks/coding/illegaltokentext.xml
@@ -8,14 +8,14 @@
   <body>
     <section name="IllegalTokenText">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="IllegalTokenText_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks specified tokens text for matching an illegal pattern.
           By default, no tokens are specified.
         </p>
       </subsection>
 
-      <subsection name="Properties" id="IllegalTokenText_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -78,7 +78,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="IllegalTokenText_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check to forbid String literals containing
           <code>"a href"</code>:
@@ -155,7 +155,7 @@ public void myTest() {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="IllegalTokenText_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+IllegalTokenText">
@@ -168,7 +168,7 @@ public void myTest() {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="IllegalTokenText_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22illegal.token.text%22">
@@ -182,13 +182,13 @@ public void myTest() {
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalTokenText_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="IllegalTokenText_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/illegaltype.xml
+++ b/src/xdocs/checks/coding/illegaltype.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="IllegalType">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="IllegalType_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that particular classes or interfaces are never used.
         </p>
@@ -23,7 +23,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="IllegalType_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -145,7 +145,7 @@
         </div>
       </subsection>
 
-      <subsection name="Notes" id="IllegalType_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           It is possible to set illegal class names via short or
           <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-6.html#jls-6.7">
@@ -181,7 +181,7 @@ List list; //No violation here
         </p>
       </subsection>
 
-      <subsection name="Examples" id="IllegalType_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
             To configure the default check:
         </p>
@@ -361,7 +361,7 @@ public class Main {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="IllegalType_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+IllegalType">
@@ -370,7 +370,7 @@ public class Main {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="IllegalType_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22illegal.type%22">
@@ -384,13 +384,13 @@ public class Main {
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalType_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="IllegalType_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/innerassignment.xml
+++ b/src/xdocs/checks/coding/innerassignment.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="InnerAssignment">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="InnerAssignment_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for assignments in subexpressions, such as in
           <code>String s = Integer.toString(i = 2);</code>.
@@ -46,7 +46,7 @@ while ((line = bufferedReader.readLine()) != null); // OK
         </p>
       </subsection>
 
-      <subsection name="Examples" id="InnerAssignment_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -98,7 +98,7 @@ class MyClass {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="InnerAssignment_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+InnerAssignment">
@@ -111,7 +111,7 @@ class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="InnerAssignment_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22assignment.inner.avoid%22">
@@ -125,13 +125,13 @@ class MyClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="InnerAssignment_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="InnerAssignment_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/magicnumber.xml
+++ b/src/xdocs/checks/coding/magicnumber.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="MagicNumber">
       <p>Since Checkstyle 3.1</p>
-      <subsection name="Description" id="MagicNumber_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that there are no
           <a href="https://en.wikipedia.org/wiki/Magic_number_%28programming%29">
@@ -30,7 +30,7 @@ static final Integer ANSWER_TO_THE_ULTIMATE_QUESTION_OF_LIFE = new Integer(42);
         </source>
       </subsection>
 
-      <subsection name="Properties" id="MagicNumber_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -143,7 +143,7 @@ static final Integer ANSWER_TO_THE_ULTIMATE_QUESTION_OF_LIFE = new Integer(42);
         </div>
       </subsection>
 
-      <subsection name="Examples" id="MagicNumber_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check with default configuration:
         </p>
@@ -283,7 +283,7 @@ class TestHashCode {
 
       </subsection>
 
-      <subsection name="Example of Usage" id="MagicNumber_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MagicNumber">
@@ -296,7 +296,7 @@ class TestHashCode {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="MagicNumber_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22magic.number%22">
@@ -310,13 +310,13 @@ class TestHashCode {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MagicNumber_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="MagicNumber_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/matchxpath.xml
+++ b/src/xdocs/checks/coding/matchxpath.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="MatchXpath">
       <p>Since Checkstyle 8.39</p>
-      <subsection name="Description" id="MatchXpath_Description">
+      <subsection name="Description" id="Description">
         <p>
           Evaluates Xpath query and report violation on all matching AST nodes. This check allows
           user to implement custom checks using Xpath. If Xpath query is not specified explicitly,
@@ -33,7 +33,7 @@
 
       </subsection>
 
-      <subsection name="Properties" id="MatchXpath_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -54,7 +54,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="MatchXpath_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           Checkstyle provides <a href="https://checkstyle.org/cmdline.html">command line tool</a>
           and <a href="https://checkstyle.org/writingchecks.html#The_Checkstyle_SDK_Gui">GUI
@@ -180,7 +180,7 @@ public class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="MatchXpath_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MatchXpath">
@@ -189,7 +189,7 @@ public class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="MatchXpath_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22matchxpath.match%22">
@@ -203,13 +203,13 @@ public class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MatchXpath_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="MatchXpath_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/missingctor.xml
+++ b/src/xdocs/checks/coding/missingctor.xml
@@ -8,14 +8,14 @@
   <body>
     <section name="MissingCtor">
       <p>Since Checkstyle 3.4</p>
-      <subsection name="Description" id="MissingCtor_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that classes (except abstract ones) define a constructor and don't
           rely on the default one.
         </p>
       </subsection>
 
-      <subsection name="Examples" id="MissingCtor_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -45,7 +45,7 @@ abstract class AbstractExample { // OK
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="MissingCtor_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingCtor">
@@ -54,7 +54,7 @@ abstract class AbstractExample { // OK
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="MissingCtor_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22missing.ctor%22">
@@ -68,13 +68,13 @@ abstract class AbstractExample { // OK
         </p>
       </subsection>
 
-      <subsection name="Package" id="MissingCtor_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="MissingCtor_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/missingswitchdefault.xml
+++ b/src/xdocs/checks/coding/missingswitchdefault.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="MissingSwitchDefault">
       <p>Since Checkstyle 3.1</p>
-      <subsection name="Description" id="MissingSwitchDefault_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that switch statement has a <code>default</code> clause.
         </p>
@@ -40,7 +40,7 @@
         </p>
       </subsection>
 
-      <subsection name="Examples" id="MissingSwitchDefault_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -149,7 +149,7 @@ static int showSwitchExpressionExhaustiveness(Color color) {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="MissingSwitchDefault_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingSwitchDefault">
@@ -166,7 +166,7 @@ static int showSwitchExpressionExhaustiveness(Color color) {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="MissingSwitchDefault_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22missing.switch.default%22">
@@ -180,13 +180,13 @@ static int showSwitchExpressionExhaustiveness(Color color) {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MissingSwitchDefault_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="MissingSwitchDefault_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/modifiedcontrolvariable.xml
+++ b/src/xdocs/checks/coding/modifiedcontrolvariable.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="ModifiedControlVariable">
       <p>Since Checkstyle 3.5</p>
-      <subsection name="Description" id="ModifiedControlVariable_Description">
+      <subsection name="Description" id="Description">
         <p>
             Checks that for loop control variables are not modified inside
             the for block. An example is:
@@ -43,7 +43,7 @@ for (int a[]={0};a[0] &lt; 10;a[0]++) {
         </source>
       </subsection>
 
-      <subsection name="Properties" id="ModifiedControlVariable_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr class="header">
@@ -73,7 +73,7 @@ for (int a[]={0};a[0] &lt; 10;a[0]++) {
         </div>
       </subsection>
 
-      <subsection name="Examples" id="ModifiedControlVariable_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -121,7 +121,7 @@ for (String arg: args1) {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="ModifiedControlVariable_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+ModifiedControlVariable">
@@ -130,7 +130,7 @@ for (String arg: args1) {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="ModifiedControlVariable_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22modified.control.variable%22">
@@ -144,13 +144,13 @@ for (String arg: args1) {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ModifiedControlVariable_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="ModifiedControlVariable_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/multiplestringliterals.xml
+++ b/src/xdocs/checks/coding/multiplestringliterals.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="MultipleStringLiterals">
       <p>Since Checkstyle 3.5</p>
-      <subsection name="Description" id="MultipleStringLiterals_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for multiple occurrences of the same string literal within a
           single file.
@@ -20,7 +20,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="MultipleStringLiterals_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -69,7 +69,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="MultipleStringLiterals_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -162,7 +162,7 @@ public class MyClass {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="MultipleStringLiterals_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultipleStringLiterals">
@@ -171,7 +171,7 @@ public class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="MultipleStringLiterals_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22multiple.string.literal%22">
@@ -185,13 +185,13 @@ public class MyClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MultipleStringLiterals_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="MultipleStringLiterals_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/multiplevariabledeclarations.xml
+++ b/src/xdocs/checks/coding/multiplevariabledeclarations.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="MultipleVariableDeclarations">
       <p>Since Checkstyle 3.4</p>
-      <subsection name="Description" id="MultipleVariableDeclarations_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that each variable declaration is in its own statement and on
           its own line.
@@ -22,7 +22,7 @@
         </p>
       </subsection>
 
-      <subsection name="Examples" id="MultipleVariableDeclarations_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -52,7 +52,7 @@ public class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="MultipleVariableDeclarations_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MultipleVariableDeclarations">
@@ -69,7 +69,7 @@ public class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="MultipleVariableDeclarations_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22multiple.variable.declarations%22">
@@ -87,13 +87,13 @@ public class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MultipleVariableDeclarations_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="MultipleVariableDeclarations_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/nestedfordepth.xml
+++ b/src/xdocs/checks/coding/nestedfordepth.xml
@@ -8,11 +8,11 @@
   <body>
     <section name="NestedForDepth">
       <p>Since Checkstyle 5.3</p>
-      <subsection name="Description" id="NestedForDepth_Description">
+      <subsection name="Description" id="Description">
         <p>Restricts nested <code>for</code> blocks to a specified depth.</p>
       </subsection>
 
-      <subsection name="Properties" id="NestedForDepth_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -33,7 +33,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="NestedForDepth_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -82,7 +82,7 @@ for(int i=0; i&lt;10; i++) {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="NestedForDepth_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+NestedForDepth">
@@ -91,7 +91,7 @@ for(int i=0; i&lt;10; i++) {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="NestedForDepth_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22nested.for.depth%22">
@@ -105,13 +105,13 @@ for(int i=0; i&lt;10; i++) {
         </p>
       </subsection>
 
-      <subsection name="Package" id="NestedForDepth_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="NestedForDepth_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/nestedifdepth.xml
+++ b/src/xdocs/checks/coding/nestedifdepth.xml
@@ -8,11 +8,11 @@
   <body>
     <section name="NestedIfDepth">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="NestedIfDepth_Description">
+      <subsection name="Description" id="Description">
         <p>Restricts nested if-else blocks to a specified depth.</p>
       </subsection>
 
-      <subsection name="Properties" id="NestedIfDepth_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -33,7 +33,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="NestedIfDepth_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -92,7 +92,7 @@ if (true) {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="NestedIfDepth_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+NestedIfDepth">
@@ -101,7 +101,7 @@ if (true) {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="NestedIfDepth_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22nested.if.depth%22">
@@ -115,13 +115,13 @@ if (true) {
         </p>
       </subsection>
 
-      <subsection name="Package" id="NestedIfDepth_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="NestedIfDepth_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/nestedtrydepth.xml
+++ b/src/xdocs/checks/coding/nestedtrydepth.xml
@@ -8,11 +8,11 @@
   <body>
     <section name="NestedTryDepth">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="NestedTryDepth_Description">
+      <subsection name="Description" id="Description">
         <p>Restricts nested try-catch-finally blocks to a specified depth.</p>
       </subsection>
 
-      <subsection name="Properties" id="NestedTryDepth_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -33,7 +33,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="NestedTryDepth_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -130,7 +130,7 @@ try {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="NestedTryDepth_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+NestedTryDepth">
@@ -139,7 +139,7 @@ try {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="NestedTryDepth_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22nested.try.depth%22">
@@ -153,13 +153,13 @@ try {
         </p>
       </subsection>
 
-      <subsection name="Package" id="NestedTryDepth_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="NestedTryDepth_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/noarraytrailingcomma.xml
+++ b/src/xdocs/checks/coding/noarraytrailingcomma.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="NoArrayTrailingComma">
       <p>Since Checkstyle 8.28</p>
-      <subsection name="Description" id="NoArrayTrailingComma_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that array initialization do not contain a trailing comma.
           Rationale: JLS allows trailing commas in arrays and enumerations, but does not allow
@@ -31,7 +31,7 @@ String[] foo = new String[] {
 }
         </source>
       </subsection>
-      <subsection name="Examples" id="NoArrayTrailingComma_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -54,7 +54,7 @@ String[] foo3 = {
 String[] foo4 = { "FOO", "BAR" }; // OK
         </source>
       </subsection>
-      <subsection name="Example of Usage" id="NoArrayTrailingComma_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoArrayTrailingComma">
@@ -63,7 +63,7 @@ String[] foo4 = { "FOO", "BAR" }; // OK
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="NoArrayTrailingComma_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22no.array.trailing.comma%22">
@@ -77,13 +77,13 @@ String[] foo4 = { "FOO", "BAR" }; // OK
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoArrayTrailingComma_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="NoArrayTrailingComma_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/noclone.xml
+++ b/src/xdocs/checks/coding/noclone.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="NoClone">
       <p>Since Checkstyle 5.0</p>
-      <subsection name="Description" id="NoClone_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that the clone method is not overridden from the
           Object class.
@@ -111,7 +111,7 @@ System.out.println(s2 instanceof Square); //true
           Edition by Joshua Bloch pages 45-52.  Give Bloch credit for writing an excellent book.
         </p>
       </subsection>
-      <subsection name="Examples" id="NoClone_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -134,7 +134,7 @@ public class Foo {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="NoClone_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoClone">
@@ -143,7 +143,7 @@ public class Foo {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="NoClone_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22avoid.clone.method%22">
@@ -157,13 +157,13 @@ public class Foo {
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoClone_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="NoClone_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/noenumtrailingcomma.xml
+++ b/src/xdocs/checks/coding/noenumtrailingcomma.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="NoEnumTrailingComma">
       <p>Since Checkstyle 8.29</p>
-      <subsection name="Description" id="NoEnumTrailingComma_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that enum definition does not contain a trailing comma.
           Rationale: JLS allows trailing commas in arrays and enumerations, but does not allow
@@ -33,7 +33,7 @@ enum Foo1 {
         </source>
       </subsection>
 
-      <subsection name="Examples" id="NoEnumTrailingComma_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -77,7 +77,7 @@ enum Foo10 { FOO, BAR } // OK
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="NoEnumTrailingComma_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoEnumTrailingComma">
@@ -86,7 +86,7 @@ enum Foo10 { FOO, BAR } // OK
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="NoEnumTrailingComma_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22no.enum.trailing.comma%22">
@@ -100,13 +100,13 @@ enum Foo10 { FOO, BAR } // OK
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoEnumTrailingComma_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="NoEnumTrailingComma_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/nofinalizer.xml
+++ b/src/xdocs/checks/coding/nofinalizer.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="NoFinalizer">
       <p>Since Checkstyle 5.0</p>
-      <subsection name="Description" id="NoFinalizer_Description">
+      <subsection name="Description" id="Description">
         <p>Checks that there is no method <code>finalize</code> with zero parameters.</p>
         <p>
           See <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Object.html#finalize()">
@@ -22,7 +22,7 @@
         </p>
       </subsection>
 
-      <subsection name="Examples" id="NoFinalizer_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -46,7 +46,7 @@ public class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="NoFinalizer_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoFinalizer">
@@ -59,7 +59,7 @@ public class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="NoFinalizer_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22avoid.finalizer.method%22">
@@ -73,13 +73,13 @@ public class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoFinalizer_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="NoFinalizer_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/onestatementperline.xml
+++ b/src/xdocs/checks/coding/onestatementperline.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="OneStatementPerLine">
       <p>Since Checkstyle 5.3</p>
-      <subsection name="Description" id="OneStatementPerLine_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that there is only one statement per line.
         </p>
@@ -29,7 +29,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="OneStatementPerLine_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -50,7 +50,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="OneStatementPerLine_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -107,7 +107,7 @@ try (Reader r = new PipedReader(); s2; Reader s3 = new PipedReader() // violatio
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="OneStatementPerLine_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OneStatementPerLine">
@@ -120,7 +120,7 @@ try (Reader r = new PipedReader(); s2; Reader s3 = new PipedReader() // violatio
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="OneStatementPerLine_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22multiple.statements.line%22">
@@ -134,13 +134,13 @@ try (Reader r = new PipedReader(); s2; Reader s3 = new PipedReader() // violatio
         </p>
       </subsection>
 
-      <subsection name="Package" id="OneStatementPerLine_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="OneStatementPerLine_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/overloadmethodsdeclarationorder.xml
+++ b/src/xdocs/checks/coding/overloadmethodsdeclarationorder.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="OverloadMethodsDeclarationOrder">
       <p>Since Checkstyle 5.8</p>
-      <subsection name="Description" id="OverloadMethodsDeclarationOrder_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that overloaded methods are grouped together. Overloaded methods have the same
           name but different signatures where the signature can differ by the number of input
@@ -16,7 +16,7 @@
         </p>
       </subsection>
 
-      <subsection name="Examples" id="OverloadMethodsDeclarationOrder_Examples">
+      <subsection name="Examples" id="Examples">
         <p>To configure the check:</p>
         <source>
 &lt;module name="OverloadMethodsDeclarationOrder"/&gt;
@@ -39,7 +39,7 @@ public void foo(String s, int i) {}
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="OverloadMethodsDeclarationOrder_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OverloadMethodsDeclarationOrder">
@@ -52,7 +52,7 @@ public void foo(String s, int i) {}
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="OverloadMethodsDeclarationOrder_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22overload.methods.declaration%22">
@@ -66,13 +66,13 @@ public void foo(String s, int i) {}
         </p>
       </subsection>
 
-      <subsection name="Package" id="OverloadMethodsDeclarationOrder_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="OverloadMethodsDeclarationOrder_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/packagedeclaration.xml
+++ b/src/xdocs/checks/coding/packagedeclaration.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="PackageDeclaration">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="PackageDeclaration_Description">
+      <subsection name="Description" id="Description">
         <p>
           Ensures that a class has a package declaration, and (optionally) whether
           the package name matches the directory name for the source file.
@@ -25,7 +25,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="PackageDeclaration_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -46,7 +46,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="PackageDeclaration_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -82,7 +82,7 @@ public class AnnotationLocationCheck extends AbstractCheck {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="PackageDeclaration_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+PackageDeclaration">
@@ -91,7 +91,7 @@ public class AnnotationLocationCheck extends AbstractCheck {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="PackageDeclaration_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22mismatch.package.directory%22">
@@ -109,13 +109,13 @@ public class AnnotationLocationCheck extends AbstractCheck {
         </p>
       </subsection>
 
-      <subsection name="Package" id="PackageDeclaration_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="PackageDeclaration_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/parameterassignment.xml
+++ b/src/xdocs/checks/coding/parameterassignment.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="ParameterAssignment">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="ParameterAssignment_Description">
+      <subsection name="Description" id="Description">
         <p> Disallows assignment of parameters.</p>
         <p>
           Rationale: Parameter assignment is often considered poor programming
@@ -18,7 +18,7 @@
         </p>
       </subsection>
 
-      <subsection name="Examples" id="ParameterAssignment_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -61,7 +61,7 @@ class MyClass {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="ParameterAssignment_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+ParameterAssignment">
@@ -70,7 +70,7 @@ class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="ParameterAssignment_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22parameter.assignment%22">
@@ -84,13 +84,13 @@ class MyClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ParameterAssignment_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="ParameterAssignment_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/requirethis.xml
+++ b/src/xdocs/checks/coding/requirethis.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="RequireThis">
       <p>Since Checkstyle 3.4</p>
-      <subsection name="Description" id="RequireThis_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that references to instance variables and methods of the present
           object are explicitly of the form "this.varName" or
@@ -36,7 +36,7 @@
           </li>
         </ol>
       </subsection>
-      <subsection name="Notes" id="RequireThis_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           Limitations: Nothing is currently done about static variables
           or catch-blocks.  Static methods invoked on a class name seem to be OK;
@@ -46,7 +46,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="RequireThis_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -81,7 +81,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="RequireThis_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the default check:
         </p>
@@ -234,7 +234,7 @@ public class D {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="RequireThis_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+RequireThis">
@@ -243,7 +243,7 @@ public class D {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="RequireThis_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22require.this.method%22">
@@ -261,13 +261,13 @@ public class D {
         </p>
       </subsection>
 
-      <subsection name="Package" id="RequireThis_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="RequireThis_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/returncount.xml
+++ b/src/xdocs/checks/coding/returncount.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="ReturnCount">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="ReturnCount_Description">
+      <subsection name="Description" id="Description">
         <p>
           Restricts the number of return statements in methods, constructors and lambda expressions.
           Ignores specified methods (<code>equals</code> by default).
@@ -33,7 +33,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="ReturnCount_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -95,7 +95,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="ReturnCount_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check so that it doesn't allow more than three
           return statements per method (ignoring the <code>equals()</code>
@@ -295,7 +295,7 @@ public class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="ReturnCount_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+ReturnCount">
@@ -304,7 +304,7 @@ public class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="ReturnCount_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22return.count%22">
@@ -322,13 +322,13 @@ public class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ReturnCount_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="ReturnCount_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/simplifybooleanexpression.xml
+++ b/src/xdocs/checks/coding/simplifybooleanexpression.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="SimplifyBooleanExpression">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="SimplifyBooleanExpression_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for over-complicated boolean expressions. Currently, it finds
           code like <code> if (b == true)</code>, <code>b || true</code>, <code>!false</code>,
@@ -22,7 +22,7 @@
         </p>
       </subsection>
 
-      <subsection name="Examples" id="SimplifyBooleanExpression_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -58,7 +58,7 @@ public class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="SimplifyBooleanExpression_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SimplifyBooleanExpression">
@@ -71,7 +71,7 @@ public class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="SimplifyBooleanExpression_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22simplify.expression%22">
@@ -85,13 +85,13 @@ public class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="SimplifyBooleanExpression_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="SimplifyBooleanExpression_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/simplifybooleanreturn.xml
+++ b/src/xdocs/checks/coding/simplifybooleanreturn.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="SimplifyBooleanReturn">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="SimplifyBooleanReturn_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for over-complicated boolean return statements. For example
           the following code
@@ -33,7 +33,7 @@ return !valid();
         </p>
       </subsection>
 
-      <subsection name="Examples" id="SimplifyBooleanReturn_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -91,7 +91,7 @@ public class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="SimplifyBooleanReturn_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SimplifyBooleanReturn">
@@ -104,7 +104,7 @@ public class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="SimplifyBooleanReturn_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22simplify.boolReturn%22">
@@ -118,13 +118,13 @@ public class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="SimplifyBooleanReturn_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="SimplifyBooleanReturn_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/stringliteralequality.xml
+++ b/src/xdocs/checks/coding/stringliteralequality.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="StringLiteralEquality">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="StringLiteralEquality_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that string literals are not used with <code>==</code> or
           <code>!=</code>.
@@ -33,7 +33,7 @@ if ("something".equals(x))
         </source>
       </subsection>
 
-      <subsection name="Examples" id="StringLiteralEquality_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -61,7 +61,7 @@ if (name == getName()) {}
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="StringLiteralEquality_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+StringLiteralEquality">
@@ -70,7 +70,7 @@ if (name == getName()) {}
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="StringLiteralEquality_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22string.literal.equality%22">
@@ -84,13 +84,13 @@ if (name == getName()) {}
         </p>
       </subsection>
 
-      <subsection name="Package" id="StringLiteralEquality_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="StringLiteralEquality_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/superclone.xml
+++ b/src/xdocs/checks/coding/superclone.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="SuperClone">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="SuperClone_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that an overriding <code>clone()</code> method invokes
           <code>super.clone()</code>. Does not check native methods, as
@@ -21,7 +21,7 @@
         </p>
       </subsection>
 
-      <subsection name="Examples" id="SuperClone_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -56,7 +56,7 @@ class C {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="SuperClone_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuperClone">
@@ -65,7 +65,7 @@ class C {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="SuperClone_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22missing.super.call%22">
@@ -79,13 +79,13 @@ class C {
         </p>
       </subsection>
 
-      <subsection name="Package" id="SuperClone_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="SuperClone_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/superfinalize.xml
+++ b/src/xdocs/checks/coding/superfinalize.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="SuperFinalize">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="SuperFinalize_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that an overriding <code>finalize()</code> method invokes
           <code>super.finalize()</code>. Does not check native methods, as
@@ -24,7 +24,7 @@
         </p>
       </subsection>
 
-      <subsection name="Examples" id="SuperFinalize_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -48,7 +48,7 @@ public class B {
 
       </subsection>
 
-      <subsection name="Example of Usage" id="SuperFinalize_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuperFinalize">
@@ -57,7 +57,7 @@ public class B {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="SuperFinalize_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22missing.super.call%22">
@@ -71,13 +71,13 @@ public class B {
         </p>
       </subsection>
 
-      <subsection name="Package" id="SuperFinalize_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="SuperFinalize_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/unnecessaryparentheses.xml
+++ b/src/xdocs/checks/coding/unnecessaryparentheses.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="UnnecessaryParentheses">
       <p>Since Checkstyle 3.4</p>
-      <subsection name="Description" id="UnnecessaryParentheses_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks if unnecessary parentheses are used in a statement or expression.
           The check will flag the following with warnings:
@@ -26,7 +26,7 @@ boolean b = (~a) &gt; -27            // parens around ~a
         </source>
       </subsection>
 
-      <subsection name="Notes" id="UnnecessaryParentheses_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           The check is not "type aware", that is to say, it can't tell if parentheses
           are unnecessary based on the types in an expression. The check is partially aware about
@@ -75,7 +75,7 @@ if ((++f) &gt; g &amp;&amp; a) { // violation, unnecessary paren
         </source>
       </subsection>
 
-      <subsection name="Properties" id="UnnecessaryParentheses_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -271,7 +271,7 @@ if ((++f) &gt; g &amp;&amp; a) { // violation, unnecessary paren
         </div>
       </subsection>
 
-      <subsection name="Examples" id="UnnecessaryParentheses_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -352,7 +352,7 @@ class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="UnnecessaryParentheses_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+UnnecessaryParentheses">
@@ -361,7 +361,7 @@ class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="UnnecessaryParentheses_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22unnecessary.paren.assign%22">
@@ -399,13 +399,13 @@ class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnnecessaryParentheses_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="UnnecessaryParentheses_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/unnecessarysemicolonafteroutertypedeclaration.xml
+++ b/src/xdocs/checks/coding/unnecessarysemicolonafteroutertypedeclaration.xml
@@ -8,19 +8,19 @@
   <body>
     <section name="UnnecessarySemicolonAfterOuterTypeDeclaration">
       <p>Since Checkstyle 8.31</p>
-      <subsection name="Description" id="UnnecessarySemicolonAfterOuterTypeDeclaration_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks if unnecessary semicolon is used after type declaration.
         </p>
       </subsection>
-      <subsection name="Notes" id="UnnecessarySemicolonAfterOuterTypeDeclaration_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           This check is not applicable to nested type declarations,
           <a href="https://checkstyle.org/config_coding.html#UnnecessarySemicolonAfterTypeMemberDeclaration">
           UnnecessarySemicolonAfterTypeMemberDeclaration</a> is responsible for it.
         </p>
       </subsection>
-      <subsection name="Properties" id="UnnecessarySemicolonAfterOuterTypeDeclaration_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -66,7 +66,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="UnnecessarySemicolonAfterOuterTypeDeclaration_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -129,7 +129,7 @@ enum C {
       </subsection>
 
       <subsection name="Example of Usage"
-        id="UnnecessarySemicolonAfterOuterTypeDeclaration_Example_of_Usage">
+        id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+UnnecessarySemicolonAfterOuterTypeDeclaration">
@@ -139,7 +139,7 @@ enum C {
       </subsection>
 
       <subsection name="Violation Messages"
-        id="UnnecessarySemicolonAfterOuterTypeDeclaration_Violation_Messages">
+        id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22unnecessary.semicolon%22">
@@ -153,14 +153,14 @@ enum C {
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnnecessarySemicolonAfterOuterTypeDeclaration_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
       <subsection name="Parent Module"
-        id="UnnecessarySemicolonAfterOuterTypeDeclaration_Parent_Module">
+        id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/unnecessarysemicolonaftertypememberdeclaration.xml
+++ b/src/xdocs/checks/coding/unnecessarysemicolonaftertypememberdeclaration.xml
@@ -9,12 +9,12 @@
     <section name="UnnecessarySemicolonAfterTypeMemberDeclaration">
       <p>Since Checkstyle 8.24</p>
       <subsection name="Description"
-        id="UnnecessarySemicolonAfterTypeMemberDeclaration_Description">
+        id="Description">
         <p>
           Checks if unnecessary semicolon is used after type member declaration.
         </p>
       </subsection>
-      <subsection name="Notes" id="UnnecessarySemicolonAfterTypeMemberDeclaration_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           This check is not applicable to empty statements (unnecessary semicolons inside
           methods or init blocks),
@@ -22,7 +22,7 @@
           is responsible for it.
         </p>
       </subsection>
-      <subsection name="Properties" id="UnnecessarySemicolonAfterTypeMemberDeclaration_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -100,7 +100,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="UnnecessarySemicolonAfterTypeMemberDeclaration_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -136,7 +136,7 @@ class A {
       </subsection>
 
       <subsection name="Example of Usage"
-        id="UnnecessarySemicolonAfterTypeMemberDeclaration_Example_of_Usage">
+        id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+UnnecessarySemicolonAfterTypeMemberDeclaration">
@@ -146,7 +146,7 @@ class A {
       </subsection>
 
       <subsection name="Violation Messages"
-        id="UnnecessarySemicolonAfterTypeMemberDeclaration_Violation_Messages">
+        id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22unnecessary.semicolon%22">
@@ -160,14 +160,14 @@ class A {
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnnecessarySemicolonAfterTypeMemberDeclaration_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
       <subsection name="Parent Module"
-        id="UnnecessarySemicolonAfterTypeMemberDeclaration_Parent_Module">
+        id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/unnecessarysemicoloninenumeration.xml
+++ b/src/xdocs/checks/coding/unnecessarysemicoloninenumeration.xml
@@ -8,14 +8,14 @@
   <body>
     <section name="UnnecessarySemicolonInEnumeration">
       <p>Since Checkstyle 8.22</p>
-      <subsection name="Description" id="UnnecessarySemicolonInEnumeration_Description">
+      <subsection name="Description" id="Description">
         <p>
             Checks if unnecessary semicolon is in enum definitions.
             Semicolon is not needed if enum body contains only enum constants.
         </p>
       </subsection>
 
-      <subsection name="Examples" id="UnnecessarySemicolonInEnumeration_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -60,7 +60,7 @@ enum NoSemicolon {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="UnnecessarySemicolonInEnumeration_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+UnnecessarySemicolonInEnumeration">
@@ -70,7 +70,7 @@ enum NoSemicolon {
       </subsection>
 
       <subsection name="Violation Messages"
-        id="UnnecessarySemicolonInEnumeration_Violation_Messages">
+        id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22unnecessary.semicolon%22">
@@ -84,13 +84,13 @@ enum NoSemicolon {
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnnecessarySemicolonInEnumeration_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="UnnecessarySemicolonInEnumeration_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/unnecessarysemicolonintrywithresources.xml
+++ b/src/xdocs/checks/coding/unnecessarysemicolonintrywithresources.xml
@@ -8,13 +8,13 @@
   <body>
     <section name="UnnecessarySemicolonInTryWithResources">
       <p>Since Checkstyle 8.22</p>
-      <subsection name="Description" id="UnnecessarySemicolonInTryWithResources_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks if unnecessary semicolon is used in last resource declaration.
         </p>
       </subsection>
 
-      <subsection name="Properties" id="UnnecessarySemicolonInTryWithResources_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -36,7 +36,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="UnnecessarySemicolonInTryWithResources_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -84,7 +84,7 @@ class A {
       </subsection>
 
       <subsection name="Example of Usage"
-        id="UnnecessarySemicolonInTryWithResources_Example_of_Usage">
+        id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+UnnecessarySemicolonInTryWithResources">
@@ -94,7 +94,7 @@ class A {
       </subsection>
 
       <subsection name="Violation Messages"
-        id="UnnecessarySemicolonInTryWithResources_Violation_Messages">
+        id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22unnecessary.semicolon%22">
@@ -108,13 +108,13 @@ class A {
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnnecessarySemicolonInTryWithResources_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="UnnecessarySemicolonInTryWithResources_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/unusedlocalvariable.xml
+++ b/src/xdocs/checks/coding/unusedlocalvariable.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="UnusedLocalVariable">
       <p>Since Checkstyle 9.3</p>
-      <subsection name="Description" id="UnusedLocalVariable_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that a local variable is declared and/or assigned, but not used.
           Doesn't support <a href="https://docs.oracle.com/javase/specs/jls/se17/html/jls-14.html#jls-14.30">pattern variables yet</a>.
@@ -17,7 +17,7 @@
         </p>
       </subsection>
 
-      <subsection name="Examples" id="UnusedLocalVariable_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -85,7 +85,7 @@ class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="UnusedLocalVariable_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+UnusedLocalVariable">
@@ -94,7 +94,7 @@ class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="UnusedLocalVariable_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22unused.local.var%22">
@@ -109,13 +109,13 @@ class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnusedLocalVariable_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="UnusedLocalVariable_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/coding/variabledeclarationusagedistance.xml
+++ b/src/xdocs/checks/coding/variabledeclarationusagedistance.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="VariableDeclarationUsageDistance">
       <p>Since Checkstyle 5.8</p>
-      <subsection name="Description" id="VariableDeclarationUsageDistance_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks the distance between declaration of variable and its first usage.
           Note : Variable declaration/initialization statements are not counted
@@ -16,7 +16,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="VariableDeclarationUsageDistance_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -66,7 +66,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="VariableDeclarationUsageDistance_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
             To configure the check with default config:
         </p>
@@ -288,7 +288,7 @@ public class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="VariableDeclarationUsageDistance_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+VariableDeclarationUsageDistance">
@@ -302,7 +302,7 @@ public class Test {
       </subsection>
 
       <subsection name="Violation Messages"
-        id="VariableDeclarationUsageDistance_Violation_Messages">
+        id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fcoding%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22variable.declaration.usage.distance%22">
@@ -320,13 +320,13 @@ public class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="VariableDeclarationUsageDistance_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.coding
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="VariableDeclarationUsageDistance_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/design/designforextension.xml
+++ b/src/xdocs/checks/design/designforextension.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="DesignForExtension">
       <p>Since Checkstyle 3.1</p>
-      <subsection name="Description" id="DesignForExtension_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that classes are designed for extension (subclass creation).
         </p>
@@ -127,7 +127,7 @@ public abstract class Plant {
 }
         </source>
       </subsection>
-      <subsection name="Properties" id="DesignForExtension_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -159,7 +159,7 @@ public abstract class Plant {
           </table>
         </div>
       </subsection>
-      <subsection name="Examples" id="DesignForExtension_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -347,7 +347,7 @@ public abstract class Foo {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="DesignForExtension_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+DesignForExtension">
@@ -360,7 +360,7 @@ public abstract class Foo {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="DesignForExtension_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fdesign%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22design.forExtension%22">
@@ -374,13 +374,13 @@ public abstract class Foo {
         </p>
       </subsection>
 
-      <subsection name="Package" id="DesignForExtension_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.design
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="DesignForExtension_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/design/finalclass.xml
+++ b/src/xdocs/checks/design/finalclass.xml
@@ -8,14 +8,14 @@
   <body>
     <section name="FinalClass">
       <p>Since Checkstyle 3.1</p>
-      <subsection name="Description" id="FinalClass_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that a class that has only private constructors and
           has no descendant classes is declared as final.
         </p>
       </subsection>
 
-      <subsection name="Examples" id="FinalClass_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -58,7 +58,7 @@ class TestAnonymousInnerClasses { // OK, class has an anonymous inner class.
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="FinalClass_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+FinalClass">
@@ -71,7 +71,7 @@ class TestAnonymousInnerClasses { // OK, class has an anonymous inner class.
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="FinalClass_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fdesign%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22final.class%22">
@@ -85,13 +85,13 @@ class TestAnonymousInnerClasses { // OK, class has an anonymous inner class.
         </p>
       </subsection>
 
-      <subsection name="Package" id="FinalClass_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.design
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="FinalClass_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/design/hideutilityclassconstructor.xml
+++ b/src/xdocs/checks/design/hideutilityclassconstructor.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="HideUtilityClassConstructor">
       <p>Since Checkstyle 3.1</p>
-      <subsection name="Description" id="HideUtilityClassConstructor_Description">
+      <subsection name="Description" id="Description">
         <p>
           Makes sure that utility classes (classes that contain only static
           methods or fields in their API) do not have a public constructor.
@@ -42,7 +42,7 @@ public class StringUtils // not final to allow subclassing
         </source>
       </subsection>
 
-      <subsection name="Examples" id="HideUtilityClassConstructor_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -85,7 +85,7 @@ class UtilityClass { // violation, class only has a static field
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="HideUtilityClassConstructor_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+HideUtilityClassConstructor">
@@ -98,7 +98,7 @@ class UtilityClass { // violation, class only has a static field
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="HideUtilityClassConstructor_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fdesign%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22hide.utility.class%22">
@@ -112,13 +112,13 @@ class UtilityClass { // violation, class only has a static field
         </p>
       </subsection>
 
-      <subsection name="Package" id="HideUtilityClassConstructor_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.design
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="HideUtilityClassConstructor_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/design/innertypelast.xml
+++ b/src/xdocs/checks/design/innertypelast.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="InnerTypeLast">
       <p>Since Checkstyle 5.2</p>
-      <subsection name="Description" id="InnerTypeLast_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks nested (internal) classes/interfaces are declared at the bottom of the
           primary (top-level) class after all init and static init blocks,
@@ -16,7 +16,7 @@
         </p>
       </subsection>
 
-      <subsection name="Examples" id="InnerTypeLast_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -45,7 +45,7 @@ class Test3 {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="InnerTypeLast_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+InnerTypeLast">
@@ -54,7 +54,7 @@ class Test3 {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="InnerTypeLast_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fdesign%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22arrangement.members.before.inner%22">
@@ -68,13 +68,13 @@ class Test3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="InnerTypeLast_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.design
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="InnerTypeLast_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/design/interfaceistype.xml
+++ b/src/xdocs/checks/design/interfaceistype.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="InterfaceIsType">
       <p>Since Checkstyle 3.1</p>
-      <subsection name="Description" id="InterfaceIsType_Description">
+      <subsection name="Description" id="Description">
         <p>
           Implements Joshua Bloch, Effective Java, Item 17 - Use Interfaces only to
           define types.
@@ -29,7 +29,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="InterfaceIsType_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -53,7 +53,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="InterfaceIsType_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -95,7 +95,7 @@ public interface Test2 { // violation
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="InterfaceIsType_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+InterfaceIsType">
@@ -108,7 +108,7 @@ public interface Test2 { // violation
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="InterfaceIsType_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fdesign%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22interface.type%22">
@@ -122,13 +122,13 @@ public interface Test2 { // violation
         </p>
       </subsection>
 
-      <subsection name="Package" id="InterfaceIsType_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.design
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="InterfaceIsType_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/design/mutableexception.xml
+++ b/src/xdocs/checks/design/mutableexception.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="MutableException">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="MutableException_Description">
+      <subsection name="Description" id="Description">
         <p>
           Ensures that exception classes (classes with names conforming to some pattern
           and explicitly extending classes with names conforming to other
@@ -33,7 +33,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="MutableException_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -61,7 +61,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="MutableException_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -204,7 +204,7 @@ class BadException extends java.lang.Exception {
         </div>
       </subsection>
 
-      <subsection name="Example of Usage" id="MutableException_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MutableException">
@@ -213,7 +213,7 @@ class BadException extends java.lang.Exception {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="MutableException_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fdesign%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22mutable.exception%22">
@@ -227,13 +227,13 @@ class BadException extends java.lang.Exception {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MutableException_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.design
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="MutableException_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/design/onetoplevelclass.xml
+++ b/src/xdocs/checks/design/onetoplevelclass.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="OneTopLevelClass">
       <p>Since Checkstyle 5.8</p>
-      <subsection name="Description" id="OneTopLevelClass_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that each top-level class, interface, enum
           or annotation resides in a source file of its own.
@@ -19,7 +19,7 @@
         </p>
       </subsection>
 
-      <subsection name="Examples" id="OneTopLevelClass_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -74,7 +74,7 @@ public class Foo { // OK, only one top-level class
         </div>
       </subsection>
 
-      <subsection name="Example of Usage" id="OneTopLevelClass_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OneTopLevelClass">
@@ -87,7 +87,7 @@ public class Foo { // OK, only one top-level class
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="OneTopLevelClass_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fdesign%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22one.top.level.class%22">
@@ -101,13 +101,13 @@ public class Foo { // OK, only one top-level class
         </p>
       </subsection>
 
-      <subsection name="Package" id="OneTopLevelClass_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.design
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="OneTopLevelClass_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/design/throwscount.xml
+++ b/src/xdocs/checks/design/throwscount.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="ThrowsCount">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="ThrowsCount_Description">
+      <subsection name="Description" id="Description">
         <p>
           Restricts throws statements to a specified count.
           Methods with "Override" or "java.lang.Override" annotation are skipped
@@ -36,7 +36,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="ThrowsCount_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -64,7 +64,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="ThrowsCount_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure check:
         </p>
@@ -177,7 +177,7 @@ class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="ThrowsCount_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+ThrowsCount">
@@ -186,7 +186,7 @@ class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="ThrowsCount_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fdesign%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22throws.count%22">
@@ -200,13 +200,13 @@ class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ThrowsCount_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.design
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="ThrowsCount_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/design/visibilitymodifier.xml
+++ b/src/xdocs/checks/design/visibilitymodifier.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="VisibilityModifier">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="VisibilityModifier_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks visibility of class members. Only static final, immutable or annotated
           by specified annotation members may be public; other class members must be private
@@ -78,7 +78,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="VisibilityModifier_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -150,7 +150,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="VisibilityModifier_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -684,7 +684,7 @@ public class InputPublicImmutable {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="VisibilityModifier_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+VisibilityModifier">
@@ -697,7 +697,7 @@ public class InputPublicImmutable {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="VisibilityModifier_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fdesign%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22variable.notPrivate%22">
@@ -711,13 +711,13 @@ public class InputPublicImmutable {
         </p>
       </subsection>
 
-      <subsection name="Package" id="VisibilityModifier_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.design
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="VisibilityModifier_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/header/header.xml
+++ b/src/xdocs/checks/header/header.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="Header">
       <p>Since Checkstyle 6.9</p>
-      <subsection name="Description" id="Header_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that a source file begins with a specified header. Property
           <code>headerFile</code> specifies a file that contains
@@ -39,7 +39,7 @@ line 5: ////////////////////////////////////////////////////////////////////
         </p>
       </subsection>
 
-      <subsection name="Notes" id="Header_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           In default configuration, if header is not specified,
           the default value of header is set to <code>null</code>
@@ -47,7 +47,7 @@ line 5: ////////////////////////////////////////////////////////////////////
         </p>
       </subsection>
 
-      <subsection name="Properties" id="Header_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -105,7 +105,7 @@ line 5: ////////////////////////////////////////////////////////////////////
         </div>
       </subsection>
 
-      <subsection name="Examples" id="Header_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check such that no violations arise.
           Default values of properties are used.
@@ -149,7 +149,7 @@ line 5: ////////////////////////////////////////////////////////////////////
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="Header_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+Header">
@@ -158,7 +158,7 @@ line 5: ////////////////////////////////////////////////////////////////////
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="Header_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fheader%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22header.mismatch%22">
@@ -176,11 +176,11 @@ line 5: ////////////////////////////////////////////////////////////////////
         </p>
       </subsection>
 
-      <subsection name="Package" id="Header_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.header </p>
       </subsection>
 
-      <subsection name="Parent Module" id="Header_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#Checker">Checker</a>
         </p>

--- a/src/xdocs/checks/header/regexpheader.xml
+++ b/src/xdocs/checks/header/regexpheader.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="RegexpHeader">
       <p>Since Checkstyle 6.9</p>
-      <subsection name="Description" id="RegexpHeader_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks the header of a source file against a header that contains a
           <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Pattern.html">
@@ -86,7 +86,7 @@ line 6: ^\W*$
         </p>
       </subsection>
 
-      <subsection name="Properties" id="RegexpHeader_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -146,7 +146,7 @@ line 6: ^\W*$
         </div>
       </subsection>
 
-      <subsection name="Examples" id="RegexpHeader_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
             To configure the check such that no violations arise.
             Default values of properties are used.
@@ -221,7 +221,7 @@ public class ThisWillPass { }
         </p>
       </subsection>
 
-      <subsection name="Example of Usage" id="RegexpHeader_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+RegexpHeader">
@@ -230,7 +230,7 @@ public class ThisWillPass { }
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="RegexpHeader_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fheader%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22header.mismatch%22">
@@ -248,13 +248,13 @@ public class ThisWillPass { }
         </p>
       </subsection>
 
-      <subsection name="Package" id="RegexpHeader_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.header
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="RegexpHeader_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#Checker">Checker</a>
         </p>

--- a/src/xdocs/checks/imports/avoidstarimport.xml
+++ b/src/xdocs/checks/imports/avoidstarimport.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="AvoidStarImport">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="AvoidStarImport_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that there are no import statements that use the <code>*</code> notation.
         </p>
@@ -21,14 +21,14 @@
         </p>
       </subsection>
 
-      <subsection name="Notes" id="AvoidStarImport_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           Note that property <code>excludes</code> is not recursive,
           subpackages of excluded packages are not automatically excluded.
         </p>
       </subsection>
 
-      <subsection name="Properties" id="AvoidStarImport_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -73,7 +73,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="AvoidStarImport_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -191,7 +191,7 @@ import java.net.*;                // OK
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="AvoidStarImport_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidStarImport">
@@ -207,7 +207,7 @@ import java.net.*;                // OK
           </li>
         </ul>
       </subsection>
-      <subsection name="Violation Messages" id="AvoidStarImport_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fimports%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22import.avoidStar%22">
@@ -220,11 +220,11 @@ import java.net.*;                // OK
           to learn how to.
         </p>
       </subsection>
-      <subsection name="Package" id="AvoidStarImport_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.imports </p>
       </subsection>
 
-      <subsection name="Parent Module" id="AvoidStarImport_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/imports/avoidstaticimport.xml
+++ b/src/xdocs/checks/imports/avoidstaticimport.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="AvoidStaticImport">
       <p>Since Checkstyle 5.0</p>
-      <subsection name="Description" id="AvoidStaticImport_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that there are no static import statements.
         </p>
@@ -21,7 +21,7 @@
         </p>
       </subsection>
 
-      <subsection name="Notes" id="AvoidStaticImport_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           If you exclude a starred import on a class this automatically
           excludes each member individually.
@@ -33,7 +33,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="AvoidStaticImport_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -59,7 +59,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="AvoidStaticImport_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -96,7 +96,7 @@ import java.util.*;                        // OK
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="AvoidStaticImport_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidStaticImport">
@@ -105,7 +105,7 @@ import java.util.*;                        // OK
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="AvoidStaticImport_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fimports%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22import.avoidStatic%22">
@@ -119,11 +119,11 @@ import java.util.*;                        // OK
         </p>
       </subsection>
 
-      <subsection name="Package" id="AvoidStaticImport_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.imports </p>
       </subsection>
 
-      <subsection name="Parent Module" id="AvoidStaticImport_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/imports/customimportorder.xml
+++ b/src/xdocs/checks/imports/customimportorder.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="CustomImportOrder">
       <p>Since Checkstyle 5.8</p>
-      <subsection name="Description" id="CustomImportOrder_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that the groups of import declarations appear in the order specified
           by the user. If there is an import but its group is not specified in the
@@ -16,7 +16,7 @@
         </p>
       </subsection>
 
-      <subsection name="Rule Description" id="CustomImportOrder_Rule_Description">
+      <subsection name="Rule Description" id="Rule_Description">
         <p>
           The rule consists of:
         </p>
@@ -64,7 +64,7 @@ import java.util.regex.Matcher; //#8
         </ol>
       </subsection>
 
-      <subsection name="Notes" id="CustomImportOrder_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           Use the separator '###' between rules.
         </p>
@@ -112,7 +112,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
         </p>
       </subsection>
 
-      <subsection name="Properties" id="CustomImportOrder_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -171,7 +171,7 @@ import com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck;
         </div>
       </subsection>
 
-      <subsection name="Examples" id="CustomImportOrder_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check :
         </p>
@@ -597,7 +597,7 @@ import android.*;
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="CustomImportOrder_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+CustomImportOrder">
@@ -610,7 +610,7 @@ import android.*;
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="CustomImportOrder_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fimports%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22custom.import.order%22">
@@ -644,13 +644,13 @@ import android.*;
         </p>
       </subsection>
 
-      <subsection name="Package" id="CustomImportOrder_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.imports
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="CustomImportOrder_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/imports/illegalimport.xml
+++ b/src/xdocs/checks/imports/illegalimport.xml
@@ -8,13 +8,13 @@
   <body>
     <section name="IllegalImport">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="IllegalImport_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for imports from a set of illegal packages.
         </p>
       </subsection>
 
-      <subsection name="Notes" id="IllegalImport_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           Note: By default, the check rejects all <code>sun.*</code> packages since
           programs that contain direct calls to the <code>sun.*</code> packages are
@@ -25,7 +25,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="IllegalImport_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -70,7 +70,7 @@
 
       </subsection>
 
-      <subsection name="Examples" id="IllegalImport_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -253,7 +253,7 @@ public class InputIllegalImport { }
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="IllegalImport_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+IllegalImport">
@@ -266,7 +266,7 @@ public class InputIllegalImport { }
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="IllegalImport_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fimports%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22import.illegal%22">
@@ -280,13 +280,13 @@ public class InputIllegalImport { }
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalImport_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.imports
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="IllegalImport_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/imports/importcontrol.xml
+++ b/src/xdocs/checks/imports/importcontrol.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="ImportControl">
       <p>Since Checkstyle 4.0</p>
-      <subsection name="Description" id="ImportControl_Description">
+      <subsection name="Description" id="Description">
         <p>
           Controls what can be imported in each package and file. Useful for
           ensuring that application layering rules are not violated,
@@ -90,7 +90,7 @@
         </div>
       </subsection>
 
-      <subsection name="Properties" id="ImportControl_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -126,7 +126,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="ImportControl_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check using an import control file called
           "config/import-control.xml", then have the following:
@@ -453,7 +453,7 @@ import java.util.stream.IntStream;
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="ImportControl_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+ImportControl">
@@ -462,7 +462,7 @@ import java.util.stream.IntStream;
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="ImportControl_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fimports%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22import.control.disallowed%22">
@@ -484,13 +484,13 @@ import java.util.stream.IntStream;
         </p>
       </subsection>
 
-      <subsection name="Package" id="ImportControl_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.imports
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="ImportControl_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/imports/importorder.xml
+++ b/src/xdocs/checks/imports/importorder.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="ImportOrder">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="ImportOrder_Description">
+      <subsection name="Description" id="Description">
         <p>Checks the ordering/grouping of imports. Features are:</p>
         <ul>
           <li>groups type/static imports: ensures that groups of imports come in a
@@ -33,7 +33,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Properties" id="ImportOrder_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -146,7 +146,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="ImportOrder_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -530,7 +530,7 @@ public class SomeClass { }
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="ImportOrder_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+ImportOrder">
@@ -539,7 +539,7 @@ public class SomeClass { }
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="ImportOrder_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fimports%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22import.groups.separated.internally%22">
@@ -561,13 +561,13 @@ public class SomeClass { }
         </p>
       </subsection>
 
-      <subsection name="Package" id="ImportOrder_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.imports
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="ImportOrder_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/imports/redundantimport.xml
+++ b/src/xdocs/checks/imports/redundantimport.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="RedundantImport">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="RedundantImport_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for redundant import statements. An import statement is
           considered redundant if:
@@ -29,7 +29,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Examples" id="RedundantImport_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -52,7 +52,7 @@ public class MyClass{ };
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="RedundantImport_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+RedundantImport">
@@ -65,7 +65,7 @@ public class MyClass{ };
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="RedundantImport_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fimports%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22import.duplicate%22">
@@ -87,13 +87,13 @@ public class MyClass{ };
         </p>
       </subsection>
 
-      <subsection name="Package" id="RedundantImport_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.imports
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="RedundantImport_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/imports/unusedimports.xml
+++ b/src/xdocs/checks/imports/unusedimports.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="UnusedImports">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="UnusedImports_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for unused import statements. An
           import statement is considered unused if:
@@ -57,7 +57,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Properties" id="UnusedImports_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -78,7 +78,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="UnusedImports_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -147,7 +147,7 @@ class MyClass{
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="UnusedImports_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+UnusedImports">
@@ -160,7 +160,7 @@ class MyClass{
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="UnusedImports_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fimports%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22import.unused%22">
@@ -174,13 +174,13 @@ class MyClass{
         </p>
       </subsection>
 
-      <subsection name="Package" id="UnusedImports_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.imports
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="UnusedImports_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/javadoc/atclauseorder.xml
+++ b/src/xdocs/checks/javadoc/atclauseorder.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="AtclauseOrder">
       <p>Since Checkstyle 6.0</p>
-      <subsection name="Description" id="AtclauseOrder_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks the order of
           <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDBEFIF">
@@ -19,7 +19,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="AtclauseOrder_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -82,7 +82,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="AtclauseOrder_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
             To configure the default check:
         </p>
@@ -130,7 +130,7 @@ class Invalid implements Serializable
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="AtclauseOrder_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AtclauseOrder">
@@ -143,7 +143,7 @@ class Invalid implements Serializable
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="AtclauseOrder_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22at.clause.order%22">
@@ -169,13 +169,13 @@ class Invalid implements Serializable
         </p>
       </subsection>
 
-      <subsection name="Package" id="AtclauseOrder_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="AtclauseOrder_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/javadoc/invalidjavadocposition.xml
+++ b/src/xdocs/checks/javadoc/invalidjavadocposition.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="InvalidJavadocPosition">
       <p>Since Checkstyle 8.23</p>
-      <subsection name="Description" id="InvalidJavadocPosition_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that Javadocs are located at the correct position.
           As specified at
@@ -21,7 +21,7 @@
         </p>
       </subsection>
 
-      <subsection name="Examples" id="InvalidJavadocPosition_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -43,7 +43,7 @@ public class TestClass {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="InvalidJavadocPosition_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+InvalidJavadocPosition">
@@ -60,7 +60,7 @@ public class TestClass {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="InvalidJavadocPosition_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22invalid.position%22">
@@ -74,13 +74,13 @@ public class TestClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="InvalidJavadocPosition_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="InvalidJavadocPosition_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/javadoc/javadocblocktaglocation.xml
+++ b/src/xdocs/checks/javadoc/javadocblocktaglocation.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="JavadocBlockTagLocation">
       <p>Since Checkstyle 8.24</p>
-      <subsection name="Description" id="JavadocBlockTagLocation_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that a
           <a href="https://docs.oracle.com/en/java/javase/11/docs/specs/doc-comment-spec.html#block-tags">
@@ -29,7 +29,7 @@
           for details on how to escape.
         </p>
       </subsection>
-      <subsection name="Notes" id="JavadocBlockTagLocation_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           To place a tag explicitly as text, escape the <code>@</code> symbol
           with HTML entity &amp;#64; or place it inside <code>{@code }</code>,
@@ -41,7 +41,7 @@
  */
         </source>
       </subsection>
-      <subsection name="Properties" id="JavadocBlockTagLocation_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -74,7 +74,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="JavadocBlockTagLocation_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the default check:
         </p>
@@ -124,7 +124,7 @@ public int field;
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="JavadocBlockTagLocation_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocBlockTagLocation">
@@ -133,7 +133,7 @@ public int field;
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="JavadocBlockTagLocation_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.blockTagLocation%22">
@@ -159,13 +159,13 @@ public int field;
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocBlockTagLocation_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="JavadocBlockTagLocation_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/javadoc/javadoccontentlocation.xml
+++ b/src/xdocs/checks/javadoc/javadoccontentlocation.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="JavadocContentLocation">
       <p>Since Checkstyle 8.27</p>
-      <subsection name="Description" id="JavadocContentLocation_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that the Javadoc content begins from the same position
           for all Javadoc comments in the project. Any leading asterisks and spaces
@@ -40,7 +40,7 @@ public void method();
         </ul>
       </subsection>
 
-      <subsection name="Notes" id="JavadocContentLocation_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           This check does not validate the Javadoc summary itself nor its presence.
           The check will not report any violations for missing or malformed javadoc summary.
@@ -71,7 +71,7 @@ public void method();
         </p>
       </subsection>
 
-      <subsection name="Properties" id="JavadocContentLocation_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -95,7 +95,7 @@ public void method();
         </div>
       </subsection>
 
-      <subsection name="Examples" id="JavadocContentLocation_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the default check to validate that the Javadoc content starts from the
           second line:
@@ -139,7 +139,7 @@ public void method();
 /** This single-line comment also is OK. */
         </source>
       </subsection>
-      <subsection name="Example of Usage" id="JavadocContentLocation_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocContentLocation">
@@ -148,7 +148,7 @@ public void method();
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="JavadocContentLocation_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.content.first.line%22">
@@ -166,13 +166,13 @@ public void method();
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocContentLocation_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="JavadocContentLocation_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/javadoc/javadocmethod.xml
+++ b/src/xdocs/checks/javadoc/javadocmethod.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="JavadocMethod">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="JavadocMethod_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks the Javadoc of a method or constructor.
         </p>
@@ -83,7 +83,7 @@ public int checkReturnTag(final int aTagIndex,
 
       </subsection>
 
-      <subsection name="Properties" id="JavadocMethod_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -167,7 +167,7 @@ public int checkReturnTag(final int aTagIndex,
         </div>
       </subsection>
 
-      <subsection name="Examples" id="JavadocMethod_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the default check:
         </p>
@@ -505,7 +505,7 @@ public Runnable printLater(String s) {
 }
         </source>
       </subsection>
-      <subsection name="Example of Usage" id="JavadocMethod_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocMethod">
@@ -522,7 +522,7 @@ public Runnable printLater(String s) {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="JavadocMethod_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.classInfo%22">
@@ -560,13 +560,13 @@ public Runnable printLater(String s) {
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocMethod_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="JavadocMethod_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/javadoc/javadocmissingleadingasterisk.xml
+++ b/src/xdocs/checks/javadoc/javadocmissingleadingasterisk.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="JavadocMissingLeadingAsterisk">
       <p>Since Checkstyle 8.38</p>
-      <subsection name="Description" id="JavadocMissingLeadingAsterisk_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks if the javadoc has
           <a href="https://docs.oracle.com/en/java/javase/14/docs/specs/javadoc/doc-comment-spec.html#leading-asterisks">
@@ -23,7 +23,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="JavadocMissingLeadingAsterisk_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -48,7 +48,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="JavadocMissingLeadingAsterisk_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -97,7 +97,7 @@ class Code {}
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="JavadocMissingLeadingAsterisk_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocMissingLeadingAsterisk">
@@ -106,7 +106,7 @@ class Code {}
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="JavadocMissingLeadingAsterisk_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missed.html.close%22">
@@ -132,13 +132,13 @@ class Code {}
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocMissingLeadingAsterisk_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="JavadocMissingLeadingAsterisk_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/javadoc/javadocmissingwhitespaceafterasterisk.xml
+++ b/src/xdocs/checks/javadoc/javadocmissingwhitespaceafterasterisk.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="JavadocMissingWhitespaceAfterAsterisk">
       <p>Since Checkstyle 8.32</p>
-      <subsection name="Description" id="JavadocMissingWhitespaceAfterAsterisk_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that there is at least one whitespace after the leading asterisk.
           Although spaces after asterisks are optional in the Javadoc comments, their absence
@@ -17,7 +17,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="JavadocMissingWhitespaceAfterAsterisk_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -42,7 +42,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="JavadocMissingWhitespaceAfterAsterisk_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the default check:
         </p>
@@ -75,7 +75,7 @@ class TestClass {
       </subsection>
 
       <subsection name="Example of Usage"
-        id="JavadocMissingWhitespaceAfterAsterisk_Example_of_Usage">
+        id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocMissingWhitespaceAfterAsterisk">
@@ -85,7 +85,7 @@ class TestClass {
       </subsection>
 
       <subsection name="Violation Messages"
-        id="JavadocMissingWhitespaceAfterAsterisk_Violation_Messages">
+        id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missed.html.close%22">
@@ -111,13 +111,13 @@ class TestClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocMissingWhitespaceAfterAsterisk_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="JavadocMissingWhitespaceAfterAsterisk_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/javadoc/javadocpackage.xml
+++ b/src/xdocs/checks/javadoc/javadocpackage.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="JavadocPackage">
       <p>Since Checkstyle 5.0</p>
-      <subsection name="Description" id="JavadocPackage_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that each Java package has a Javadoc file used for
           commenting. By default, it only allows a <code>package-info.java</code> file, but can be
@@ -21,7 +21,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="JavadocPackage_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -51,7 +51,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="JavadocPackage_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -69,7 +69,7 @@
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="JavadocPackage_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocPackage">
@@ -82,7 +82,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="JavadocPackage_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.legacyPackageHtml%22">
@@ -100,13 +100,13 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocPackage_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="JavadocPackage_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#Checker">Checker</a>
         </p>

--- a/src/xdocs/checks/javadoc/javadocparagraph.xml
+++ b/src/xdocs/checks/javadoc/javadocparagraph.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="JavadocParagraph">
       <p>Since Checkstyle 6.0</p>
-      <subsection name="Description" id="JavadocParagraph_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks the Javadoc paragraph.
         </p>
@@ -26,7 +26,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Properties" id="JavadocParagraph_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -61,7 +61,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="JavadocParagraph_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the default check:
         </p>
@@ -116,7 +116,7 @@ public class TestClass {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="JavadocParagraph_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocParagraph">
@@ -129,7 +129,7 @@ public class TestClass {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="JavadocParagraph_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missed.html.close%22">
@@ -167,13 +167,13 @@ public class TestClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocParagraph_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="JavadocParagraph_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/javadoc/javadocstyle.xml
+++ b/src/xdocs/checks/javadoc/javadocstyle.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="JavadocStyle">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="JavadocStyle_Description">
+      <subsection name="Description" id="Description">
         <p>
           Validates Javadoc comments to help ensure they are well formed.
         </p>
@@ -62,7 +62,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="JavadocStyle_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -183,7 +183,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="JavadocStyle_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the default check:
         </p>
@@ -319,7 +319,7 @@ public class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="JavadocStyle_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocStyle">
@@ -332,7 +332,7 @@ public class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="JavadocStyle_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.empty%22">
@@ -362,13 +362,13 @@ public class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocStyle_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="JavadocStyle_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/javadoc/javadoctagcontinuationindentation.xml
+++ b/src/xdocs/checks/javadoc/javadoctagcontinuationindentation.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="JavadocTagContinuationIndentation">
       <p>Since Checkstyle 6.0</p>
-      <subsection name="Description" id="JavadocTagContinuationIndentation_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks the indentation of the continuation lines in block tags.
           That is whether the
@@ -19,7 +19,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="JavadocTagContinuationIndentation_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -52,7 +52,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="JavadocTagContinuationIndentation_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the default check:
         </p>
@@ -114,7 +114,7 @@ public class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="JavadocTagContinuationIndentation_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocTagContinuationIndentation">
@@ -128,7 +128,7 @@ public class Test {
       </subsection>
 
       <subsection name="Violation Messages"
-        id="JavadocTagContinuationIndentation_Violation_Messages">
+        id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missed.html.close%22">
@@ -154,13 +154,13 @@ public class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocTagContinuationIndentation_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="JavadocTagContinuationIndentation_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/javadoc/javadoctype.xml
+++ b/src/xdocs/checks/javadoc/javadoctype.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="JavadocType">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="JavadocType_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks the Javadoc comments for type definitions.
           By default, does not check for author or version tags. The
@@ -36,7 +36,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="JavadocType_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -135,7 +135,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="JavadocType_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the default check:
         </p>
@@ -418,7 +418,7 @@ class DatabaseConfiguration&lt;T&gt; {}
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="JavadocType_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocType">
@@ -431,7 +431,7 @@ class DatabaseConfiguration&lt;T&gt; {}
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="JavadocType_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.unknownTag%22">
@@ -461,13 +461,13 @@ class DatabaseConfiguration&lt;T&gt; {}
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocType_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="JavadocType_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/javadoc/javadocvariable.xml
+++ b/src/xdocs/checks/javadoc/javadocvariable.xml
@@ -8,14 +8,14 @@
   <body>
     <section name="JavadocVariable">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="JavadocVariable_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that a variable has a Javadoc comment. Ignores <code>serialVersionUID</code>
           fields.
         </p>
       </subsection>
 
-      <subsection name="Properties" id="JavadocVariable_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -67,7 +67,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="JavadocVariable_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the default check:
         </p>
@@ -181,7 +181,7 @@ private int logger; // OK
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="JavadocVariable_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavadocVariable">
@@ -194,7 +194,7 @@ private int logger; // OK
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="JavadocVariable_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missing%22">
@@ -208,13 +208,13 @@ private int logger; // OK
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavadocVariable_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="JavadocVariable_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/javadoc/missingjavadocmethod.xml
+++ b/src/xdocs/checks/javadoc/missingjavadocmethod.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="MissingJavadocMethod">
       <p>Since Checkstyle 8.21</p>
-      <subsection name="Description" id="MissingJavadocMethod_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for missing Javadoc comments for a method or constructor.
           The scope to verify is specified using the <code>Scope</code> class and
@@ -49,7 +49,7 @@ public boolean isSomething()
         </source>
       </subsection>
 
-      <subsection name="Properties" id="MissingJavadocMethod_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -137,7 +137,7 @@ public boolean isSomething()
         </div>
       </subsection>
 
-      <subsection name="Examples" id="MissingJavadocMethod_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the default check:
         </p>
@@ -268,7 +268,7 @@ public class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="MissingJavadocMethod_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingJavadocMethod">
@@ -285,7 +285,7 @@ public class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="MissingJavadocMethod_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missing%22">
@@ -299,13 +299,13 @@ public class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MissingJavadocMethod_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="MissingJavadocMethod_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/javadoc/missingjavadocpackage.xml
+++ b/src/xdocs/checks/javadoc/missingjavadocpackage.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="MissingJavadocPackage">
       <p>Since Checkstyle 8.22</p>
-      <subsection name="Description" id="MissingJavadocPackage_Description">
+      <subsection name="Description" id="Description">
         <p>
             Checks for missing package definition Javadoc comments in package-info.java files.
         </p>
@@ -26,7 +26,7 @@
         </p>
       </subsection>
 
-      <subsection name="Examples" id="MissingJavadocPackage_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
             To configure the check:
         </p>
@@ -46,7 +46,7 @@ package com.checkstyle.api; // violation
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="MissingJavadocPackage_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingJavadocPackage">
@@ -55,7 +55,7 @@ package com.checkstyle.api; // violation
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="MissingJavadocPackage_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22package.javadoc.missing%22">
@@ -69,13 +69,13 @@ package com.checkstyle.api; // violation
         </p>
       </subsection>
 
-      <subsection name="Package" id="MissingJavadocPackage_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="MissingJavadocPackage_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/javadoc/missingjavadoctype.xml
+++ b/src/xdocs/checks/javadoc/missingjavadoctype.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="MissingJavadocType">
       <p>Since Checkstyle 8.20</p>
-      <subsection name="Description" id="MissingJavadocType_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for missing Javadoc comments for class, enum, interface, and annotation
           interface definitions. The scope to verify is specified using the <code>Scope</code>
@@ -18,7 +18,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="MissingJavadocType_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -89,7 +89,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="MissingJavadocType_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the default check to make sure all public class, enum, interface, and
           annotation interface, definitions have javadocs:
@@ -181,7 +181,7 @@ class Class3 {}
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="MissingJavadocType_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MissingJavadocType">
@@ -194,7 +194,7 @@ class Class3 {}
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="MissingJavadocType_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missing%22">
@@ -208,13 +208,13 @@ class Class3 {}
         </p>
       </subsection>
 
-      <subsection name="Package" id="MissingJavadocType_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="MissingJavadocType_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/javadoc/nonemptyatclausedescription.xml
+++ b/src/xdocs/checks/javadoc/nonemptyatclausedescription.xml
@@ -8,13 +8,13 @@
   <body>
     <section name="NonEmptyAtclauseDescription">
       <p>Since Checkstyle 6.0</p>
-      <subsection name="Description" id="NonEmptyAtclauseDescription_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that the block tag is followed by description.
         </p>
       </subsection>
 
-      <subsection name="Properties" id="NonEmptyAtclauseDescription_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -70,7 +70,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="NonEmptyAtclauseDescription_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the default check that will check <code>@param</code>,
           <code>@deprecated</code>,<code>@throws</code>,<code>@return</code>:
@@ -129,7 +129,7 @@ class Test
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="NonEmptyAtclauseDescription_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NonEmptyAtclauseDescription">
@@ -142,7 +142,7 @@ class Test
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="NonEmptyAtclauseDescription_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missed.html.close%22">
@@ -168,13 +168,13 @@ class Test
         </p>
       </subsection>
 
-      <subsection name="Package" id="NonEmptyAtclauseDescription_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="NonEmptyAtclauseDescription_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/javadoc/requireemptylinebeforeblocktaggroup.xml
+++ b/src/xdocs/checks/javadoc/requireemptylinebeforeblocktaggroup.xml
@@ -8,12 +8,12 @@
   <body>
     <section name="RequireEmptyLineBeforeBlockTagGroup">
       <p>Since Checkstyle 8.36</p>
-      <subsection name="Description" id="RequireEmptyLineBeforeBlockTagGroup_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that one blank line before the block tag if it is present in Javadoc.
         </p>
       </subsection>
-      <subsection name="Properties" id="RequireEmptyLineBeforeBlockTagGroup_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -38,7 +38,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="RequireEmptyLineBeforeBlockTagGroup_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -75,7 +75,7 @@ public boolean testMethod(int firstParam) {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="RequireEmptyLineBeforeBlockTagGroup_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+RequireEmptyLineBeforeBlockTagGroup">
@@ -89,7 +89,7 @@ public boolean testMethod(int firstParam) {
       </subsection>
 
       <subsection name="Violation Messages"
-        id="RequireEmptyLineBeforeBlockTagGroup_Violation_Messages">
+        id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missed.html.close%22">
@@ -115,13 +115,13 @@ public boolean testMethod(int firstParam) {
         </p>
       </subsection>
 
-      <subsection name="Package" id="RequireEmptyLineBeforeBlockTagGroup_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="RequireEmptyLineBeforeBlockTagGroup_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/javadoc/singlelinejavadoc.xml
+++ b/src/xdocs/checks/javadoc/singlelinejavadoc.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="SingleLineJavadoc">
       <p>Since Checkstyle 6.0</p>
-      <subsection name="Description" id="SingleLineJavadoc_Description">
+      <subsection name="Description" id="Description">
         <p>
            Checks that a Javadoc block can fit in a single-line and doesn't
            contain block tags. Javadoc comment that contains at least one block tag
@@ -16,7 +16,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="SingleLineJavadoc_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -63,7 +63,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="SingleLineJavadoc_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -236,7 +236,7 @@ public int foobar() {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="SingleLineJavadoc_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SingleLineJavadoc">
@@ -249,7 +249,7 @@ public int foobar() {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="SingleLineJavadoc_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missed.html.close%22">
@@ -275,13 +275,13 @@ public int foobar() {
         </p>
       </subsection>
 
-      <subsection name="Package" id="SingleLineJavadoc_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="SingleLineJavadoc_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/javadoc/summaryjavadoc.xml
+++ b/src/xdocs/checks/javadoc/summaryjavadoc.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="SummaryJavadoc">
       <p>Since Checkstyle 6.0</p>
-      <subsection name="Description" id="SummaryJavadoc_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that
           <a href="https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html#firstsentence">
@@ -20,7 +20,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="SummaryJavadoc_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -59,7 +59,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="SummaryJavadoc_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the default check to validate that first sentence is not empty and first
           sentence is not missing:
@@ -184,7 +184,7 @@ public class Test {
 }
         </source>
       </subsection>
-      <subsection name="Example of Usage" id="SummaryJavadoc_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SummaryJavadoc">
@@ -197,7 +197,7 @@ public class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="SummaryJavadoc_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.missed.html.close%22">
@@ -235,13 +235,13 @@ public class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="SummaryJavadoc_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="SummaryJavadoc_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/javadoc/writetag.xml
+++ b/src/xdocs/checks/javadoc/writetag.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="WriteTag">
       <p>Since Checkstyle 4.2</p>
-      <subsection name="Description" id="WriteTag_Description">
+      <subsection name="Description" id="Description">
         <p>
          Requires user defined Javadoc tag to be present in Javadoc comment with
          defined format. To define the format for a tag, set property tagFormat to a regular
@@ -16,7 +16,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="WriteTag_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -92,7 +92,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="WriteTag_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           Example of default Check configuration that do nothing.
         </p>
@@ -187,7 +187,7 @@ public class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="WriteTag_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+WriteTag">
@@ -196,7 +196,7 @@ public class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="WriteTag_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fjavadoc%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22javadoc.writeTag%22">
@@ -218,13 +218,13 @@ public class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="WriteTag_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.javadoc
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="WriteTag_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/metrics/booleanexpressioncomplexity.xml
+++ b/src/xdocs/checks/metrics/booleanexpressioncomplexity.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="BooleanExpressionComplexity">
       <p>Since Checkstyle 3.4</p>
-      <subsection name="Description" id="BooleanExpressionComplexity_Description">
+      <subsection name="Description" id="Description">
         <p>
           Restricts the number of boolean operators (<code>&amp;&amp;</code>, <code>||</code>,
           <code>&amp;</code>, <code>|</code> and <code>^</code>) in an expression.
@@ -34,7 +34,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="BooleanExpressionComplexity_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -90,7 +90,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="BooleanExpressionComplexity_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -165,7 +165,7 @@ public class Test
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="BooleanExpressionComplexity_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+BooleanExpressionComplexity">
@@ -174,7 +174,7 @@ public class Test
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="BooleanExpressionComplexity_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fmetrics%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22booleanExpressionComplexity%22">
@@ -188,13 +188,13 @@ public class Test
         </p>
       </subsection>
 
-      <subsection name="Package" id="BooleanExpressionComplexity_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.metrics
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="BooleanExpressionComplexity_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/metrics/classdataabstractioncoupling.xml
+++ b/src/xdocs/checks/metrics/classdataabstractioncoupling.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="ClassDataAbstractionCoupling">
       <p>Since Checkstyle 3.4</p>
-      <subsection name="Description" id="ClassDataAbstractionCoupling_Description">
+      <subsection name="Description" id="Description">
         <p>
           Measures the number of instantiations of other
           classes within the given class or record. This type of coupling is not
@@ -69,7 +69,7 @@
         </ol>
       </subsection>
 
-      <subsection name="Properties" id="ClassDataAbstractionCoupling_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -122,7 +122,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="ClassDataAbstractionCoupling_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -389,7 +389,7 @@ class Foo {
         </p>
       </subsection>
 
-      <subsection name="Example of Usage" id="ClassDataAbstractionCoupling_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+ClassDataAbstractionCoupling">
@@ -398,7 +398,7 @@ class Foo {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="ClassDataAbstractionCoupling_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fmetrics%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22classDataAbstractionCoupling%22">
@@ -412,13 +412,13 @@ class Foo {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ClassDataAbstractionCoupling_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.metrics
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="ClassDataAbstractionCoupling_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/metrics/classfanoutcomplexity.xml
+++ b/src/xdocs/checks/metrics/classfanoutcomplexity.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="ClassFanOutComplexity">
       <p>Since Checkstyle 3.4</p>
-      <subsection name="Description" id="ClassFanOutComplexity_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks the number of other types a given class/record/interface/enum/annotation
           relies on. Also, the square of this has been shown to indicate the amount of
@@ -35,7 +35,7 @@
         </ol>
       </subsection>
 
-      <subsection name="Properties" id="ClassFanOutComplexity_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -91,7 +91,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="ClassFanOutComplexity_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -362,7 +362,7 @@ class Foo {
         </p>
       </subsection>
 
-      <subsection name="Example of Usage" id="ClassFanOutComplexity_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+ClassFanOutComplexity">
@@ -371,7 +371,7 @@ class Foo {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="ClassFanOutComplexity_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fmetrics%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22classFanOutComplexity%22">
@@ -385,13 +385,13 @@ class Foo {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ClassFanOutComplexity_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.metrics
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="ClassFanOutComplexity_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/metrics/cyclomaticcomplexity.xml
+++ b/src/xdocs/checks/metrics/cyclomaticcomplexity.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="CyclomaticComplexity">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="CyclomaticComplexity_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks cyclomatic complexity against a specified limit.
           It is a measure of the minimum number of
@@ -42,7 +42,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="CyclomaticComplexity_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -125,7 +125,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="CyclomaticComplexity_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -256,7 +256,7 @@ class CyclomaticComplexity {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="CyclomaticComplexity_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+CyclomaticComplexity">
@@ -265,7 +265,7 @@ class CyclomaticComplexity {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="CyclomaticComplexity_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fmetrics%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22cyclomaticComplexity%22">
@@ -279,13 +279,13 @@ class CyclomaticComplexity {
         </p>
       </subsection>
 
-      <subsection name="Package" id="CyclomaticComplexity_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.metrics
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="CyclomaticComplexity_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/metrics/javancss.xml
+++ b/src/xdocs/checks/metrics/javancss.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="JavaNCSS">
       <p>Since Checkstyle 3.5</p>
-      <subsection name="Description" id="JavaNCSS_Description">
+      <subsection name="Description" id="Description">
         <p>
           Determines complexity of methods, classes and files by
           counting the Non Commenting Source Statements (NCSS). This
@@ -40,7 +40,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="JavaNCSS_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -94,7 +94,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="JavaNCSS_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -191,7 +191,7 @@ class Test2 {
         </source>
 
       </subsection>
-      <subsection name="Example of Usage" id="JavaNCSS_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+JavaNCSS">
@@ -200,7 +200,7 @@ class Test2 {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="JavaNCSS_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fmetrics%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22ncss.class%22">
@@ -226,13 +226,13 @@ class Test2 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="JavaNCSS_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.metrics
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="JavaNCSS_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/metrics/npathcomplexity.xml
+++ b/src/xdocs/checks/metrics/npathcomplexity.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="NPathComplexity">
       <p>Since Checkstyle 3.4</p>
-      <subsection name="Description" id="NPathComplexity_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks the NPATH complexity against a specified limit.
         </p>
@@ -103,7 +103,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="NPathComplexity_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -124,7 +124,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="NPathComplexity_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -230,7 +230,7 @@ public abstract void print(String str);
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="NPathComplexity_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+NPathComplexity">
@@ -239,7 +239,7 @@ public abstract void print(String str);
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="NPathComplexity_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fmetrics%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22npathComplexity%22">
@@ -253,13 +253,13 @@ public abstract void print(String str);
         </p>
       </subsection>
 
-      <subsection name="Package" id="NPathComplexity_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.metrics
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="NPathComplexity_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/misc/arraytypestyle.xml
+++ b/src/xdocs/checks/misc/arraytypestyle.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="ArrayTypeStyle">
       <p>Since Checkstyle 3.1</p>
-      <subsection name="Description" id="ArrayTypeStyle_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks the style of array type definitions. Some like Java style:
           <code>public static void main(String[] args)</code> and some like
@@ -24,7 +24,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="ArrayTypeStyle_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -47,7 +47,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="ArrayTypeStyle_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check to enforce Java style:
         </p>
@@ -98,7 +98,7 @@ public class MyClass {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="ArrayTypeStyle_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ArrayTypeStyle">
@@ -115,7 +115,7 @@ public class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="ArrayTypeStyle_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22array.type.style%22">
@@ -129,13 +129,13 @@ public class MyClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ArrayTypeStyle_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="ArrayTypeStyle_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/misc/avoidescapedunicodecharacters.xml
+++ b/src/xdocs/checks/misc/avoidescapedunicodecharacters.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="AvoidEscapedUnicodeCharacters">
       <p>Since Checkstyle 5.8</p>
-      <subsection name="Description" id="AvoidEscapedUnicodeCharacters_Description">
+      <subsection name="Description" id="Description">
         <p>
           Restricts using
           <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-3.html#jls-3.3">
@@ -22,7 +22,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="AvoidEscapedUnicodeCharacters_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -64,7 +64,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="AvoidEscapedUnicodeCharacters_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
             To configure the check:
         </p>
@@ -151,7 +151,7 @@ return '\ufeff' + content;           // OK, non-printable escape character.
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="AvoidEscapedUnicodeCharacters_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AvoidEscapedUnicodeCharacters">
@@ -164,7 +164,7 @@ return '\ufeff' + content;           // OK, non-printable escape character.
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="AvoidEscapedUnicodeCharacters_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22forbid.escaped.unicode.char%22">
@@ -178,13 +178,13 @@ return '\ufeff' + content;           // OK, non-printable escape character.
         </p>
       </subsection>
 
-      <subsection name="Package" id="AvoidEscapedUnicodeCharacters_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="AvoidEscapedUnicodeCharacters_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/misc/commentsindentation.xml
+++ b/src/xdocs/checks/misc/commentsindentation.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="CommentsIndentation">
       <p>Since Checkstyle 6.10</p>
-      <subsection name="Description" id="CommentsIndentation_Description">
+      <subsection name="Description" id="Description">
         <p>
           Controls the indentation between comments and surrounding code.
           Comments are indented at the same level as the surrounding code.
@@ -17,7 +17,7 @@
           here</a>
         </p>
       </subsection>
-      <subsection name="Properties" id="CommentsIndentation_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -51,7 +51,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="CommentsIndentation_Examples">
+      <subsection name="Examples" id="Examples">
         <p>Please take a look at the following examples to understand how the check works:</p>
 
         <p>Example #1: Block comments.</p>
@@ -220,7 +220,7 @@
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="CommentsIndentation_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+CommentsIndentation">
@@ -233,7 +233,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="CommentsIndentation_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Findentation%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22comments.indentation.block%22">
@@ -251,13 +251,13 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="CommentsIndentation_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.indentation
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="CommentsIndentation_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/misc/descendanttoken.xml
+++ b/src/xdocs/checks/misc/descendanttoken.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="DescendantToken">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="DescendantToken_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for restricted tokens beneath other tokens.
         </p>
@@ -23,7 +23,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="DescendantToken_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -109,7 +109,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="DescendantToken_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check to produce a violation on a switch statement
           with no default case:
@@ -637,7 +637,7 @@ class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="DescendantToken_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+DescendantToken">
@@ -646,7 +646,7 @@ class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="DescendantToken_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22descendant.token.max%22">
@@ -672,13 +672,13 @@ class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="DescendantToken_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="DescendantToken_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/misc/finalparameters.xml
+++ b/src/xdocs/checks/misc/finalparameters.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="FinalParameters">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="FinalParameters_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that parameters for methods, constructors, catch and for-each blocks are
           final. Interface, abstract, and native methods are not checked: the final
@@ -24,7 +24,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="FinalParameters_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -69,7 +69,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="FinalParameters_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check to enforce final parameters for methods and
           constructors:
@@ -137,7 +137,7 @@ public class Point {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="FinalParameters_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+FinalParameters">
@@ -150,7 +150,7 @@ public class Point {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="FinalParameters_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22final.parameter%22">
@@ -164,13 +164,13 @@ public class Point {
         </p>
       </subsection>
 
-      <subsection name="Package" id="FinalParameters_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="FinalParameters_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/misc/indentation.xml
+++ b/src/xdocs/checks/misc/indentation.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="Indentation">
       <p>Since Checkstyle 3.1</p>
-      <subsection name="Description" id="Indentation_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks correct indentation of Java code.
         </p>
@@ -47,7 +47,7 @@ if ((condition1 &amp;&amp; condition2)
         </source>
       </subsection>
 
-      <subsection name="Properties" id="Indentation_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -116,7 +116,7 @@ if ((condition1 &amp;&amp; condition2)
         </div>
       </subsection>
 
-      <subsection name="Examples" id="Indentation_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the default check:
         </p>
@@ -232,7 +232,7 @@ void foo(String aFooString,
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="Indentation_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+Indentation">
@@ -245,7 +245,7 @@ void foo(String aFooString,
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="Indentation_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Findentation%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22indentation.child.error%22">
@@ -271,13 +271,13 @@ void foo(String aFooString,
         </p>
       </subsection>
 
-      <subsection name="Package" id="Indentation_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.indentation
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="Indentation_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/misc/newlineatendoffile.xml
+++ b/src/xdocs/checks/misc/newlineatendoffile.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="NewlineAtEndOfFile">
       <p>Since Checkstyle 3.1</p>
-      <subsection name="Description" id="NewlineAtEndOfFile_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks whether files end with a line separator.
         </p>
@@ -50,7 +50,7 @@ StaticMethodCandidateCheck.name = Static Method Candidate
         </p>
       </subsection>
 
-      <subsection name="Notes" id="NewlineAtEndOfFile_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           This will check against the platform-specific default line separator.
         </p>
@@ -60,7 +60,7 @@ StaticMethodCandidateCheck.name = Static Method Candidate
         </p>
       </subsection>
 
-      <subsection name="Properties" id="NewlineAtEndOfFile_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -93,7 +93,7 @@ StaticMethodCandidateCheck.name = Static Method Candidate
         </div>
       </subsection>
 
-      <subsection name="Examples" id="NewlineAtEndOfFile_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -158,7 +158,7 @@ This is a sample text file. // ok, this file is not specified in the config.
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="NewlineAtEndOfFile_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NewlineAtEndOfFile">
@@ -171,7 +171,7 @@ This is a sample text file. // ok, this file is not specified in the config.
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="NewlineAtEndOfFile_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22noNewlineAtEOF%22">
@@ -193,13 +193,13 @@ This is a sample text file. // ok, this file is not specified in the config.
         </p>
       </subsection>
 
-      <subsection name="Package" id="NewlineAtEndOfFile_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="NewlineAtEndOfFile_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#Checker">Checker</a>
         </p>

--- a/src/xdocs/checks/misc/nocodeinfile.xml
+++ b/src/xdocs/checks/misc/nocodeinfile.xml
@@ -9,7 +9,7 @@
     <section name="NoCodeInFile">
       <p>Since Checkstyle 8.33</p>
 
-      <subsection name="Description" id="NoCodeInFile_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks whether file contains code.
           Files which are considered to have no code:
@@ -27,7 +27,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Examples" id="NoCodeInFile_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -50,7 +50,7 @@
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="NoCodeInFile_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoCodeInFile">
@@ -59,7 +59,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="NoCodeInFile_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22nocode.in.file%22">
@@ -73,13 +73,13 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoCodeInFile_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="NoCodeInFile_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/misc/orderedproperties.xml
+++ b/src/xdocs/checks/misc/orderedproperties.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="OrderedProperties">
       <p>Since Checkstyle 8.22</p>
-      <subsection name="Description" id="OrderedProperties_Description">
+      <subsection name="Description" id="Description">
         <p>
           Detects if keys in properties files are in correct order.
         </p>
@@ -31,7 +31,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="OrderedProperties_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -52,7 +52,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="OrderedProperties_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -87,7 +87,7 @@ key.png =value - violation
 
       </subsection>
 
-      <subsection name="Example of Usage" id="OrderedProperties_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+OrderedProperties">
@@ -96,7 +96,7 @@ key.png =value - violation
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="OrderedProperties_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22properties.notSorted.property%22">
@@ -114,13 +114,13 @@ key.png =value - violation
         </p>
       </subsection>
 
-      <subsection name="Package" id="OrderedProperties_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="OrderedProperties_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#Checker">Checker</a>
         </p>

--- a/src/xdocs/checks/misc/outertypefilename.xml
+++ b/src/xdocs/checks/misc/outertypefilename.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="OuterTypeFilename">
       <p>Since Checkstyle 5.3</p>
-      <subsection name="Description" id="OuterTypeFilename_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that the outer type name and the file name match. For example,
           the class <code>Foo</code> must be in a file named
@@ -16,7 +16,7 @@
         </p>
       </subsection>
 
-      <subsection name="Examples" id="OuterTypeFilename_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -55,7 +55,7 @@ record Foo { // violation
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="OuterTypeFilename_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OuterTypeFilename">
@@ -68,7 +68,7 @@ record Foo { // violation
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="OuterTypeFilename_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22type.file.mismatch%22">
@@ -82,13 +82,13 @@ record Foo { // violation
         </p>
       </subsection>
 
-      <subsection name="Package" id="OuterTypeFilename_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="OuterTypeFilename_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/misc/todocomment.xml
+++ b/src/xdocs/checks/misc/todocomment.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="TodoComment">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="TodoComment_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for <code>TODO:</code> comments. Actually
           it is a generic
@@ -18,7 +18,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="TodoComment_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -39,7 +39,7 @@
         </div>
       </subsection>
 
-      <subsection name="Notes" id="TodoComment_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           Using <code>TODO:</code> comments is a great way
           to keep track of tasks that need to be done. Having them
@@ -48,7 +48,7 @@
         </p>
       </subsection>
 
-      <subsection name="Examples" id="TodoComment_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -81,7 +81,7 @@ i=i/x; // FIX :  handle x = 0 case         // OK
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="TodoComment_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+TodoComment">
@@ -94,7 +94,7 @@ i=i/x; // FIX :  handle x = 0 case         // OK
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="TodoComment_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22todo.match%22">
@@ -108,13 +108,13 @@ i=i/x; // FIX :  handle x = 0 case         // OK
         </p>
       </subsection>
 
-      <subsection name="Package" id="TodoComment_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="TodoComment_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/misc/trailingcomment.xml
+++ b/src/xdocs/checks/misc/trailingcomment.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="TrailingComment">
       <p>Since Checkstyle 3.4</p>
-      <subsection name="Description" id="TrailingComment_Description">
+      <subsection name="Description" id="Description">
         <p>
           The check to ensure that lines with code do not end with comment.
           For the case of <code>//</code> comments that means that the only thing
@@ -71,7 +71,7 @@ d = e / f;        // Another comment for this line
         </p>
       </subsection>
 
-      <subsection name="Properties" id="TrailingComment_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -100,7 +100,7 @@ d = e / f;        // Another comment for this line
         </div>
       </subsection>
 
-      <subsection name="Examples" id="TrailingComment_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -199,7 +199,7 @@ public class Test {
 
       </subsection>
 
-      <subsection name="Example of Usage" id="TrailingComment_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+TrailingComment">
@@ -208,7 +208,7 @@ public class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="TrailingComment_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22trailing.comments%22">
@@ -222,13 +222,13 @@ public class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="TrailingComment_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="TrailingComment_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/misc/translation.xml
+++ b/src/xdocs/checks/misc/translation.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="Translation">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="Translation_Description">
+      <subsection name="Description" id="Description">
         <p>
           Ensures the correct translation of code by checking property files for
           consistency regarding their keys. Two property files
@@ -44,7 +44,7 @@ messages.properties: Key 'ok' missing.
         </source>
       </subsection>
 
-      <subsection name="Notes" id="Translation_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           Language code for the property <code>requiredTranslations</code> is composed of
           the lowercase, two-letter codes as defined by
@@ -67,7 +67,7 @@ messages.properties: Key 'ok' missing.
         </p>
       </subsection>
 
-      <subsection name="Properties" id="Translation_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -113,7 +113,7 @@ messages.properties: Key 'ok' missing.
         </div>
       </subsection>
 
-      <subsection name="Examples" id="Translation_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           Note, that files with the same path and base name but which have different
           extensions will be considered as files that belong to different resource bundles.
@@ -204,7 +204,7 @@ messages_ja.properties: Key 'name' missing.
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="Translation_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+Translation">
@@ -217,7 +217,7 @@ messages_ja.properties: Key 'name' missing.
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="Translation_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22translation.missingKey%22">
@@ -235,13 +235,13 @@ messages_ja.properties: Key 'name' missing.
         </p>
       </subsection>
 
-      <subsection name="Package" id="Translation_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="Translation_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#Checker">Checker</a>
         </p>

--- a/src/xdocs/checks/misc/uncommentedmain.xml
+++ b/src/xdocs/checks/misc/uncommentedmain.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="UncommentedMain">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="UncommentedMain_Description">
+      <subsection name="Description" id="Description">
         <p>
           Detects uncommented <code>main</code> methods.
         </p>
@@ -23,7 +23,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="UncommentedMain_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -45,7 +45,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="UncommentedMain_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -112,7 +112,7 @@ public record MyRecord1 {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="UncommentedMain_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+UncommentedMain">
@@ -121,7 +121,7 @@ public record MyRecord1 {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="UncommentedMain_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22uncommented.main%22">
@@ -135,13 +135,13 @@ public record MyRecord1 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="UncommentedMain_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="UncommentedMain_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/misc/uniqueproperties.xml
+++ b/src/xdocs/checks/misc/uniqueproperties.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="UniqueProperties">
       <p>Since Checkstyle 5.7</p>
-      <subsection name="Description" id="UniqueProperties_Description">
+      <subsection name="Description" id="Description">
         <p>
           Detects duplicated keys in properties files.
         </p>
@@ -21,7 +21,7 @@
 
       </subsection>
 
-      <subsection name="Properties" id="UniqueProperties_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -42,7 +42,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="UniqueProperties_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -83,7 +83,7 @@ key.one=54 // OK, file is not checked
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="UniqueProperties_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+UniqueProperties">
@@ -92,7 +92,7 @@ key.one=54 // OK, file is not checked
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="UniqueProperties_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22properties.duplicate.property%22">
@@ -110,13 +110,13 @@ key.one=54 // OK, file is not checked
         </p>
       </subsection>
 
-      <subsection name="Package" id="UniqueProperties_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="UniqueProperties_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#Checker">Checker</a>
         </p>

--- a/src/xdocs/checks/misc/upperell.xml
+++ b/src/xdocs/checks/misc/upperell.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="UpperEll">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="UpperEll_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that long constants are defined with an upper ell. That
           is <code>'L'</code> and not <code>'l'</code>. This is in accordance with the Java
@@ -22,7 +22,7 @@
         </p>
       </subsection>
 
-      <subsection name="Examples" id="UpperEll_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -38,7 +38,7 @@ class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="UpperEll_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+UpperEll">
@@ -55,7 +55,7 @@ class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="UpperEll_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22upperEll%22">
@@ -69,13 +69,13 @@ class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="UpperEll_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="UpperEll_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/modifier/classmemberimpliedmodifier.xml
+++ b/src/xdocs/checks/modifier/classmemberimpliedmodifier.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="ClassMemberImpliedModifier">
       <p>Since Checkstyle 8.16</p>
-      <subsection name="Description" id="ClassMemberImpliedModifier_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for implicit modifiers on nested types in classes and records.
         </p>
@@ -39,7 +39,7 @@ public final class Person {
         </p>
       </subsection>
 
-      <subsection name="Properties" id="ClassMemberImpliedModifier_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -80,7 +80,7 @@ public final class Person {
         </div>
       </subsection>
 
-      <subsection name="Examples" id="ClassMemberImpliedModifier_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check so that it checks that all implicit modifiers on nested interfaces,
           enums, and records are explicitly specified in classes and records.
@@ -121,7 +121,7 @@ public final class Person {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="ClassMemberImpliedModifier_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+ClassMemberImpliedModifier">
@@ -130,7 +130,7 @@ public final class Person {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="ClassMemberImpliedModifier_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fmodifier%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22class.implied.modifier%22">
@@ -144,11 +144,11 @@ public final class Person {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ClassMemberImpliedModifier_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.modifier </p>
       </subsection>
 
-      <subsection name="Parent Module" id="ClassMemberImpliedModifier_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/modifier/interfacememberimpliedmodifier.xml
+++ b/src/xdocs/checks/modifier/interfacememberimpliedmodifier.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="InterfaceMemberImpliedModifier">
       <p>Since Checkstyle 8.12</p>
-      <subsection name="Description" id="InterfaceMemberImpliedModifier_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for implicit modifiers on interface members and nested types.
         </p>
@@ -81,7 +81,7 @@ public interface AddressFactory {
         </p>
       </subsection>
 
-      <subsection name="Properties" id="InterfaceMemberImpliedModifier_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -158,7 +158,7 @@ public interface AddressFactory {
         </div>
       </subsection>
 
-      <subsection name="Examples" id="InterfaceMemberImpliedModifier_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check so that it checks that all implicit modifiers on methods,
           fields and nested types are explicitly specified in interfaces.
@@ -220,7 +220,7 @@ public interface RoadFeature {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="InterfaceMemberImpliedModifier_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+InterfaceMemberImpliedModifier">
@@ -229,7 +229,7 @@ public interface RoadFeature {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="InterfaceMemberImpliedModifier_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fmodifier%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22interface.implied.modifier%22">
@@ -243,11 +243,11 @@ public interface RoadFeature {
         </p>
       </subsection>
 
-      <subsection name="Package" id="InterfaceMemberImpliedModifier_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.modifier </p>
       </subsection>
 
-      <subsection name="Parent Module" id="InterfaceMemberImpliedModifier_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/modifier/modifierorder.xml
+++ b/src/xdocs/checks/modifier/modifierorder.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="ModifierOrder">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="ModifierOrder_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that the order of modifiers conforms to the suggestions in
           the <a href="https://docs.oracle.com/javase/specs/jls/se16/preview/specs/sealed-classes-jls.html">Java
@@ -75,14 +75,14 @@
         </p>
       </subsection>
 
-      <subsection name="Examples" id="ModifierOrder_Examples">
+      <subsection name="Examples" id="Examples">
         <p> To configure the check: </p>
         <source>
 &lt;module name="ModifierOrder"/&gt;
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="ModifierOrder_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ModifierOrder">
@@ -99,7 +99,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="ModifierOrder_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fmodifier%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22annotation.order%22">
@@ -117,11 +117,11 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="ModifierOrder_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.modifier </p>
       </subsection>
 
-      <subsection name="Parent Module" id="ModifierOrder_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/modifier/redundantmodifier.xml
+++ b/src/xdocs/checks/modifier/redundantmodifier.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="RedundantModifier">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="RedundantModifier_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for redundant modifiers.
         </p>
@@ -143,7 +143,7 @@ public class ClassExtending extends ClassExample {
         </source>
       </subsection>
 
-      <subsection name="Properties" id="RedundantModifier_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -209,7 +209,7 @@ public class ClassExtending extends ClassExample {
         </div>
       </subsection>
 
-      <subsection name="Examples" id="RedundantModifier_Examples">
+      <subsection name="Examples" id="Examples">
         <p> To configure the check: </p>
         <source>
 &lt;module name="RedundantModifier"/&gt;
@@ -225,7 +225,7 @@ public class ClassExtending extends ClassExample {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="RedundantModifier_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+RedundantModifier">
@@ -238,7 +238,7 @@ public class ClassExtending extends ClassExample {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="RedundantModifier_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fmodifier%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22redundantModifier%22">
@@ -252,11 +252,11 @@ public class ClassExtending extends ClassExample {
         </p>
       </subsection>
 
-      <subsection name="Package" id="RedundantModifier_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.modifier </p>
       </subsection>
 
-      <subsection name="Parent Module" id="RedundantModifier_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/naming/abbreviationaswordinname.xml
+++ b/src/xdocs/checks/naming/abbreviationaswordinname.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="AbbreviationAsWordInName">
       <p>Since Checkstyle 5.8</p>
-      <subsection name="Description" id="AbbreviationAsWordInName_Description">
+      <subsection name="Description" id="Description">
         <p>
           Validates abbreviations (consecutive capital letters) length in identifier name,
           it also allows to enforce camel case naming. Please read more at
@@ -40,7 +40,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="AbbreviationAsWordInName_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -158,7 +158,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="AbbreviationAsWordInName_Examples">
+      <subsection name="Examples" id="Examples">
         <p>To configure the check:</p>
         <source>
 &lt;module name="AbbreviationAsWordInName"/&gt;
@@ -351,7 +351,7 @@ public class MyClass {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="AbbreviationAsWordInName_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+AbbreviationAsWordInName">
@@ -364,7 +364,7 @@ public class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="AbbreviationAsWordInName_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22abbreviation.as.word%22">
@@ -378,11 +378,11 @@ public class MyClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="AbbreviationAsWordInName_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
-      <subsection name="Parent Module" id="AbbreviationAsWordInName_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/naming/abstractclassname.xml
+++ b/src/xdocs/checks/naming/abstractclassname.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="AbstractClassName">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="AbstractClassName_Description">
+      <subsection name="Description" id="Description">
         <p>
           Ensures that the names of abstract classes conforming to some pattern and
           check that <code>abstract</code> modifier exists.
@@ -20,7 +20,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="AbstractClassName_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -63,7 +63,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="AbstractClassName_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -143,7 +143,7 @@ class Example4 {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="AbstractClassName_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+AbstractClassName">
@@ -152,7 +152,7 @@ class Example4 {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="AbstractClassName_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22illegal.abstract.class.name%22">
@@ -170,11 +170,11 @@ class Example4 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="AbstractClassName_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
-      <subsection name="Parent Module" id="AbstractClassName_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/naming/catchparametername.xml
+++ b/src/xdocs/checks/naming/catchparametername.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="CatchParameterName">
       <p>Since Checkstyle 6.14</p>
-      <subsection name="Description" id="CatchParameterName_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that <code>catch</code> parameter names conform to a specified pattern.
         </p>
@@ -28,7 +28,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Properties" id="CatchParameterName_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -51,7 +51,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="CatchParameterName_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -121,7 +121,7 @@ public class MyTest {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="CatchParameterName_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+CatchParameterName">
@@ -136,7 +136,7 @@ public class MyTest {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="CatchParameterName_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -150,11 +150,11 @@ public class MyTest {
         </p>
       </subsection>
 
-      <subsection name="Package" id="CatchParameterName_Package">
+      <subsection name="Package" id="Package">
         <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
       </subsection>
 
-      <subsection name="Parent Module" id="CatchParameterName_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/naming/classtypeparametername.xml
+++ b/src/xdocs/checks/naming/classtypeparametername.xml
@@ -8,11 +8,11 @@
   <body>
     <section name="ClassTypeParameterName">
       <p>Since Checkstyle 5.0</p>
-      <subsection name="Description" id="ClassTypeParameterName_Description">
+      <subsection name="Description" id="Description">
         <p>Checks that class type parameter names conform to a specified pattern.</p>
       </subsection>
 
-      <subsection name="Properties" id="ClassTypeParameterName_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -33,7 +33,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="ClassTypeParameterName_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -83,7 +83,7 @@ class MyClass5&lt;RequestT&gt; {} // OK
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="ClassTypeParameterName_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ClassTypeParameterName">
@@ -96,7 +96,7 @@ class MyClass5&lt;RequestT&gt; {} // OK
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="ClassTypeParameterName_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -110,11 +110,11 @@ class MyClass5&lt;RequestT&gt; {} // OK
         </p>
       </subsection>
 
-      <subsection name="Package" id="ClassTypeParameterName_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
-      <subsection name="Parent Module" id="ClassTypeParameterName_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/naming/constantname.xml
+++ b/src/xdocs/checks/naming/constantname.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="ConstantName">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="ConstantName_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that constant names conform to a specified pattern.
           A <em>constant</em> is a <strong>static</strong> and <strong>final</strong> field or an
@@ -17,7 +17,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="ConstantName_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -68,7 +68,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="ConstantName_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -140,7 +140,7 @@ class Example3 {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="ConstantName_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ConstantName">
@@ -153,7 +153,7 @@ class Example3 {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="ConstantName_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -167,11 +167,11 @@ class Example3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ConstantName_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
-      <subsection name="Parent Module" id="ConstantName_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/naming/illegalidentifiername.xml
+++ b/src/xdocs/checks/naming/illegalidentifiername.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="IllegalIdentifierName">
       <p>Since Checkstyle 8.36</p>
-      <subsection name="Description" id="IllegalIdentifierName_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks identifiers with a pattern for a set of illegal names, such as those
           that are restricted or contextual keywords. Examples include "yield", "record",
@@ -21,7 +21,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="IllegalIdentifierName_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -160,7 +160,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="IllegalIdentifierName_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -214,7 +214,7 @@ public class TestClass {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="IllegalIdentifierName_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+IllegalIdentifierName">
@@ -224,7 +224,7 @@ public class TestClass {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="IllegalIdentifierName_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -239,11 +239,11 @@ public class TestClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="IllegalIdentifierName_Package">
+      <subsection name="Package" id="Package">
         <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
       </subsection>
 
-      <subsection name="Parent Module" id="IllegalIdentifierName_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/naming/index.xml
+++ b/src/xdocs/checks/naming/index.xml
@@ -7,7 +7,7 @@
   </head>
   <body>
     <section name="Naming Conventions Checks">
-      <subsection name="Overview" id="Naming_Conventions_Checks_Overview">
+      <subsection name="Overview" id="Overview">
         <p>
           Each of these naming modules validates identifiers for particular code
           elements. Valid identifiers for a naming module are specified by its

--- a/src/xdocs/checks/naming/interfacetypeparametername.xml
+++ b/src/xdocs/checks/naming/interfacetypeparametername.xml
@@ -8,13 +8,13 @@
   <body>
     <section name="InterfaceTypeParameterName">
       <p>Since Checkstyle 5.8</p>
-      <subsection name="Description" id="InterfaceTypeParameterName_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that interface type parameter names conform to a specified pattern.
         </p>
       </subsection>
 
-      <subsection name="Properties" id="InterfaceTypeParameterName_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -35,7 +35,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="InterfaceTypeParameterName_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -65,7 +65,7 @@ interface ThirdInterface&lt;type&gt; {} // violation, name 'type' must
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="InterfaceTypeParameterName_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+InterfaceTypeParameterName">
@@ -78,7 +78,7 @@ interface ThirdInterface&lt;type&gt; {} // violation, name 'type' must
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="InterfaceTypeParameterName_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -92,11 +92,11 @@ interface ThirdInterface&lt;type&gt; {} // violation, name 'type' must
         </p>
       </subsection>
 
-      <subsection name="Package" id="InterfaceTypeParameterName_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
-      <subsection name="Parent Module" id="InterfaceTypeParameterName_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/naming/lambdaparametername.xml
+++ b/src/xdocs/checks/naming/lambdaparametername.xml
@@ -8,13 +8,13 @@
   <body>
     <section name="LambdaParameterName">
       <p>Since Checkstyle 8.11</p>
-      <subsection name="Description" id="LambdaParameterName_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks lambda parameter names.
         </p>
       </subsection>
 
-      <subsection name="Properties" id="LambdaParameterName_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -35,7 +35,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="LambdaParameterName_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -74,7 +74,7 @@ class MyClass {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="LambdaParameterName_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LambdaParameterName">
@@ -87,7 +87,7 @@ class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="LambdaParameterName_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -101,11 +101,11 @@ class MyClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="LambdaParameterName_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
-      <subsection name="Parent Module" id="LambdaParameterName_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/naming/localfinalvariablename.xml
+++ b/src/xdocs/checks/naming/localfinalvariablename.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="LocalFinalVariableName">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="LocalFinalVariableName_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that local final variable names conform to a specified pattern.
           A catch parameter and resources in try statements
@@ -16,7 +16,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="LocalFinalVariableName_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -61,7 +61,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="LocalFinalVariableName_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -119,7 +119,7 @@ class MyClass {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="LocalFinalVariableName_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LocalFinalVariableName">
@@ -132,7 +132,7 @@ class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="LocalFinalVariableName_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -146,11 +146,11 @@ class MyClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="LocalFinalVariableName_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
-      <subsection name="Parent Module" id="LocalFinalVariableName_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/naming/localvariablename.xml
+++ b/src/xdocs/checks/naming/localvariablename.xml
@@ -8,14 +8,14 @@
   <body>
     <section name="LocalVariableName">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="LocalVariableName_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that local, non-<code>final</code> variable names conform to a specified pattern.
           A catch parameter is considered to be a local variable.
         </p>
       </subsection>
 
-      <subsection name="Properties" id="LocalVariableName_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -48,7 +48,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="LocalVariableName_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -157,7 +157,7 @@ class MyClass {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="LocalVariableName_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LocalVariableName">
@@ -174,7 +174,7 @@ class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="LocalVariableName_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -188,11 +188,11 @@ class MyClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="LocalVariableName_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
-      <subsection name="Parent Module" id="LocalVariableName_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/naming/membername.xml
+++ b/src/xdocs/checks/naming/membername.xml
@@ -8,13 +8,13 @@
   <body>
     <section name="MemberName">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="MemberName_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that instance variable names conform to a specified pattern.
         </p>
       </subsection>
 
-      <subsection name="Properties" id="MemberName_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -65,7 +65,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="MemberName_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
          To configure the check:
         </p>
@@ -141,7 +141,7 @@ class MyClass {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="MemberName_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MemberName">
@@ -158,7 +158,7 @@ class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="MemberName_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -172,11 +172,11 @@ class MyClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MemberName_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
-      <subsection name="Parent Module" id="MemberName_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/naming/methodname.xml
+++ b/src/xdocs/checks/naming/methodname.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="MethodName">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="MethodName_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that method names conform to a specified pattern.
         </p>
@@ -22,7 +22,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="MethodName_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -94,7 +94,7 @@ class MyClass {
         </div>
       </subsection>
 
-      <subsection name="Examples" id="MethodName_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -188,7 +188,7 @@ class MyClass {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="MethodName_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodName">
@@ -205,7 +205,7 @@ class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="MethodName_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22method.name.equals.class.name%22">
@@ -223,11 +223,11 @@ class MyClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MethodName_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
-      <subsection name="Parent Module" id="MethodName_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/naming/methodtypeparametername.xml
+++ b/src/xdocs/checks/naming/methodtypeparametername.xml
@@ -8,13 +8,13 @@
   <body>
     <section name="MethodTypeParameterName">
       <p>Since Checkstyle 5.0</p>
-      <subsection name="Description" id="MethodTypeParameterName_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that method type parameter names conform to a specified pattern.
         </p>
       </subsection>
 
-      <subsection name="Properties" id="MethodTypeParameterName_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -35,7 +35,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="MethodTypeParameterName_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -70,7 +70,7 @@ class MyClass {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="MethodTypeParameterName_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodTypeParameterName">
@@ -83,7 +83,7 @@ class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="MethodTypeParameterName_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -97,11 +97,11 @@ class MyClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MethodTypeParameterName_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
-      <subsection name="Parent Module" id="MethodTypeParameterName_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/naming/packagename.xml
+++ b/src/xdocs/checks/naming/packagename.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="PackageName">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="PackageName_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that package names conform to a specified pattern.
         </p>
@@ -24,7 +24,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="PackageName_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -45,7 +45,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="PackageName_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -87,7 +87,7 @@ package com._checkstyle.checks_; // violation, name 'com._checkstyle.checks_' mu
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="PackageName_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+PackageName">
@@ -104,7 +104,7 @@ package com._checkstyle.checks_; // violation, name 'com._checkstyle.checks_' mu
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="PackageName_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -118,11 +118,11 @@ package com._checkstyle.checks_; // violation, name 'com._checkstyle.checks_' mu
         </p>
       </subsection>
 
-      <subsection name="Package" id="PackageName_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
-      <subsection name="Parent Module" id="PackageName_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/naming/parametername.xml
+++ b/src/xdocs/checks/naming/parametername.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="ParameterName">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="ParameterName_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that method parameter names conform to a specified pattern.
           By using <code>accessModifiers</code> property it is possible
@@ -28,7 +28,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="ParameterName_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -69,7 +69,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="ParameterName_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -170,7 +170,7 @@ class MyClass {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="ParameterName_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ParameterName">
@@ -187,7 +187,7 @@ class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="ParameterName_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -201,11 +201,11 @@ class MyClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="ParameterName_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
-      <subsection name="Parent Module" id="ParameterName_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/naming/patternvariablename.xml
+++ b/src/xdocs/checks/naming/patternvariablename.xml
@@ -8,13 +8,13 @@
   <body>
     <section name="PatternVariableName">
       <p>Since Checkstyle 8.36</p>
-      <subsection name="Description" id="PatternVariableName_Description">
+      <subsection name="Description" id="Description">
         <p>
             Checks that pattern variable names conform to a specified pattern.
         </p>
       </subsection>
 
-      <subsection name="Properties" id="PatternVariableName_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -35,7 +35,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="PatternVariableName_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -101,7 +101,7 @@ class MyClass {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="PatternVariableName_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+PatternVariableName">
@@ -116,7 +116,7 @@ class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="PatternVariableName_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -131,11 +131,11 @@ class MyClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="PatternVariableName_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
-      <subsection name="Parent Module" id="PatternVariableName_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/naming/recordcomponentname.xml
+++ b/src/xdocs/checks/naming/recordcomponentname.xml
@@ -8,11 +8,11 @@
   <body>
     <section name="RecordComponentName">
       <p>Since Checkstyle 8.40</p>
-      <subsection name="Description" id="RecordComponentName_Description">
+      <subsection name="Description" id="Description">
         <p>Checks that record component names conform to a specified pattern.</p>
       </subsection>
 
-      <subsection name="Properties" id="RecordComponentName_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -37,7 +37,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="RecordComponentName_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -70,7 +70,7 @@ record MyRecord3(double myNumber) {} // violation, the record component name
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="RecordComponentName_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+RecordComponentName">
@@ -85,7 +85,7 @@ record MyRecord3(double myNumber) {} // violation, the record component name
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="RecordComponentName_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -100,11 +100,11 @@ record MyRecord3(double myNumber) {} // violation, the record component name
         </p>
       </subsection>
 
-      <subsection name="Package" id="RecordComponentName_Package">
+      <subsection name="Package" id="Package">
         <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
       </subsection>
 
-      <subsection name="Parent Module" id="RecordComponentName_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/naming/recordtypeparametername.xml
+++ b/src/xdocs/checks/naming/recordtypeparametername.xml
@@ -8,11 +8,11 @@
   <body>
     <section name="RecordTypeParameterName">
       <p>Since Checkstyle 8.36</p>
-      <subsection name="Description" id="RecordTypeParameterName_Description">
+      <subsection name="Description" id="Description">
         <p>Checks that record type parameter names conform to a specified pattern.</p>
       </subsection>
 
-      <subsection name="Properties" id="RecordTypeParameterName_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -37,7 +37,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="RecordTypeParameterName_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -62,7 +62,7 @@ record MyRecord3&lt;abc&gt; {} // violation, the record type parameter
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="RecordTypeParameterName_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+RecordTypeParameterName">
@@ -77,7 +77,7 @@ record MyRecord3&lt;abc&gt; {} // violation, the record type parameter
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="RecordTypeParameterName_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -92,11 +92,11 @@ record MyRecord3&lt;abc&gt; {} // violation, the record type parameter
         </p>
       </subsection>
 
-      <subsection name="Package" id="RecordTypeParameterName_Package">
+      <subsection name="Package" id="Package">
         <p>com.puppycrawl.tools.checkstyle.checks.naming</p>
       </subsection>
 
-      <subsection name="Parent Module" id="RecordTypeParameterName_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/naming/staticvariablename.xml
+++ b/src/xdocs/checks/naming/staticvariablename.xml
@@ -8,14 +8,14 @@
   <body>
     <section name="StaticVariableName">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="StaticVariableName_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that <code>static</code>, non-<code>final</code> variable names
           conform to a specified pattern.
         </p>
       </subsection>
 
-      <subsection name="Properties" id="StaticVariableName_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -66,7 +66,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="StaticVariableName_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -124,7 +124,7 @@ class MyClass {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="StaticVariableName_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+StaticVariableName">
@@ -137,7 +137,7 @@ class MyClass {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="StaticVariableName_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -151,11 +151,11 @@ class MyClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="StaticVariableName_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
-      <subsection name="Parent Module" id="StaticVariableName_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/naming/typename.xml
+++ b/src/xdocs/checks/naming/typename.xml
@@ -8,13 +8,13 @@
   <body>
     <section name="TypeName">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="TypeName_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that type names conform to a specified pattern.
         </p>
       </subsection>
 
-      <subsection name="Properties" id="TypeName_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -97,7 +97,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="TypeName_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -155,7 +155,7 @@ interface SecondName {} // violation, name 'SecondName'
 
       </subsection>
 
-      <subsection name="Example of Usage" id="TypeName_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+TypeName">
@@ -172,7 +172,7 @@ interface SecondName {} // violation, name 'SecondName'
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="TypeName_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fnaming%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22name.invalidPattern%22">
@@ -186,11 +186,11 @@ interface SecondName {} // violation, name 'SecondName'
         </p>
       </subsection>
 
-      <subsection name="Package" id="TypeName_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.checks.naming </p>
       </subsection>
 
-      <subsection name="Parent Module" id="TypeName_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/checks/regexp/regexp.xml
+++ b/src/xdocs/checks/regexp/regexp.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="Regexp">
       <p>Since Checkstyle 4.0</p>
-      <subsection name="Description" id="Regexp_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that a specified pattern exists, exists less
           than a set number of times, or does not exist in the file.
@@ -56,7 +56,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="Regexp_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -116,7 +116,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="Regexp_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
             To configure the check:
         </p>
@@ -436,7 +436,7 @@ public static final int A_SETPOINT = 1;
         </p>
       </subsection>
 
-      <subsection name="Example of Usage" id="Regexp_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+Regexp">
@@ -445,7 +445,7 @@ public static final int A_SETPOINT = 1;
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="Regexp_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fregexp%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22duplicate.regexp%22">
@@ -467,13 +467,13 @@ public static final int A_SETPOINT = 1;
         </p>
       </subsection>
 
-      <subsection name="Package" id="Regexp_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.regexp
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="Regexp_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/regexp/regexpmultiline.xml
+++ b/src/xdocs/checks/regexp/regexpmultiline.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="RegexpMultiline">
       <p>Since Checkstyle 5.0</p>
-      <subsection name="Description" id="RegexpMultiline_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that a specified pattern matches across multiple lines in
           any file type.
@@ -20,7 +20,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="RegexpMultiline_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -84,7 +84,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="RegexpMultiline_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
         To run the check with its default configuration (no matches will be):
         </p>
@@ -241,7 +241,7 @@ void method() {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="RegexpMultiline_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+RegexpMultiline">
@@ -250,7 +250,7 @@ void method() {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="RegexpMultiline_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fregexp%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22regexp.StackOverflowError%22">
@@ -276,13 +276,13 @@ void method() {
         </p>
       </subsection>
 
-      <subsection name="Package" id="RegexpMultiline_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.regexp
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="RegexpMultiline_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#Checker">Checker</a>
         </p>

--- a/src/xdocs/checks/regexp/regexponfilename.xml
+++ b/src/xdocs/checks/regexp/regexponfilename.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="RegexpOnFilename">
       <p>Since Checkstyle 6.15</p>
-      <subsection name="Description" id="RegexpOnFilename_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that a specified pattern matches based on file and/or folder path.
           It can also be used to verify files match specific naming
@@ -49,7 +49,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="RegexpOnFilename_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -100,7 +100,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="RegexpOnFilename_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check to report file names that contain a space:
         </p>
@@ -236,7 +236,7 @@ src/main/main_class.java  //violation, file names should be in Camel Case
         </div>
       </subsection>
 
-      <subsection name="Example of Usage" id="RegexpOnFilename_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+RegexpOnFilename">
@@ -245,7 +245,7 @@ src/main/main_class.java  //violation, file names should be in Camel Case
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="RegexpOnFilename_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fregexp%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22regexp.filename.match%22">
@@ -263,13 +263,13 @@ src/main/main_class.java  //violation, file names should be in Camel Case
         </p>
       </subsection>
 
-      <subsection name="Package" id="RegexpOnFilename_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.regexp
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="RegexpOnFilename_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#Checker">Checker</a>
         </p>

--- a/src/xdocs/checks/regexp/regexpsingleline.xml
+++ b/src/xdocs/checks/regexp/regexpsingleline.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="RegexpSingleline">
       <p>Since Checkstyle 5.0</p>
-      <subsection name="Description" id="RegexpSingleline_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that a specified pattern matches a single-line in any file type.
         </p>
@@ -20,7 +20,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="RegexpSingleline_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -77,7 +77,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="RegexpSingleline_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
         To configure the default check:
         </p>
@@ -188,7 +188,7 @@ CREATE DATABASE MyDB;
 CREATE DATABASE MyDB;
         </source>
       </subsection>
-      <subsection name="Example of Usage" id="RegexpSingleline_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+RegexpSingleline">
@@ -201,7 +201,7 @@ CREATE DATABASE MyDB;
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="RegexpSingleline_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fregexp%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22regexp.exceeded%22">
@@ -219,13 +219,13 @@ CREATE DATABASE MyDB;
         </p>
       </subsection>
 
-      <subsection name="Package" id="RegexpSingleline_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.regexp
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="RegexpSingleline_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#Checker">Checker</a>
         </p>

--- a/src/xdocs/checks/regexp/regexpsinglelinejava.xml
+++ b/src/xdocs/checks/regexp/regexpsinglelinejava.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="RegexpSinglelineJava">
       <p>Since Checkstyle 6.0</p>
-      <subsection name="Description" id="RegexpSinglelineJava_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that a specified pattern matches a single-line in Java files.
         </p>
@@ -20,7 +20,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="RegexpSinglelineJava_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -77,7 +77,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="RegexpSinglelineJava_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the default check:
         </p>
@@ -203,7 +203,7 @@ class Foo{
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="RegexpSinglelineJava_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+RegexpSinglelineJava">
@@ -212,7 +212,7 @@ class Foo{
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="RegexpSinglelineJava_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fregexp%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22regexp.exceeded%22">
@@ -230,13 +230,13 @@ class Foo{
         </p>
       </subsection>
 
-      <subsection name="Package" id="RegexpSinglelineJava_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.regexp
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="RegexpSinglelineJava_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/sizes/anoninnerlength.xml
+++ b/src/xdocs/checks/sizes/anoninnerlength.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="AnonInnerLength">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="AnonInnerLength_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for long anonymous inner classes.
         </p>
@@ -22,7 +22,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="AnonInnerLength_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -43,7 +43,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="AnonInnerLength_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check to accept anonymous classes with up to 20 lines:
         </p>
@@ -60,7 +60,7 @@
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="AnonInnerLength_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+AnonInnerLength">
@@ -69,7 +69,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="AnonInnerLength_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fsizes%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22maxLen.anonInner%22">
@@ -83,13 +83,13 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="AnonInnerLength_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.sizes
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="AnonInnerLength_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/sizes/executablestatementcount.xml
+++ b/src/xdocs/checks/sizes/executablestatementcount.xml
@@ -8,11 +8,11 @@
   <body>
     <section name="ExecutableStatementCount">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="ExecutableStatementCount_Description">
+      <subsection name="Description" id="Description">
         <p>Restricts the number of executable statements to a specified limit.</p>
       </subsection>
 
-      <subsection name="Properties" id="ExecutableStatementCount_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -69,7 +69,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="ExecutableStatementCount_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -89,7 +89,7 @@
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="ExecutableStatementCount_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+ExecutableStatementCount">
@@ -98,7 +98,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="ExecutableStatementCount_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fsizes%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22executableStatementCount%22">
@@ -112,13 +112,13 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="ExecutableStatementCount_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.sizes
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="ExecutableStatementCount_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/sizes/filelength.xml
+++ b/src/xdocs/checks/sizes/filelength.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="FileLength">
       <p>Since Checkstyle 5.0</p>
-      <subsection name="Description" id="FileLength_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for long source files.
         </p>
@@ -20,7 +20,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="FileLength_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -48,7 +48,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="FileLength_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -65,7 +65,7 @@
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="FileLength_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+FileLength">
@@ -78,7 +78,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="FileLength_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fsizes%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22maxLen.file%22">
@@ -92,13 +92,13 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="FileLength_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.sizes
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="FileLength_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#Checker">Checker</a>
         </p>

--- a/src/xdocs/checks/sizes/lambdabodylength.xml
+++ b/src/xdocs/checks/sizes/lambdabodylength.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="LambdaBodyLength">
       <p>Since Checkstyle 8.37</p>
-      <subsection name="Description" id="LambdaBodyLength_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks lambda body length.
         </p>
@@ -21,7 +21,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="LambdaBodyLength_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -42,7 +42,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="LambdaBodyLength_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check to accept lambda bodies with up to 10 lines:
         </p>
@@ -128,7 +128,7 @@ class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="LambdaBodyLength_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+LambdaBodyLength">
@@ -137,7 +137,7 @@ class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="LambdaBodyLength_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fsizes%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22maxLen.lambdaBody%22">
@@ -151,13 +151,13 @@ class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="LambdaBodyLength_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.sizes
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="LambdaBodyLength_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/sizes/linelength.xml
+++ b/src/xdocs/checks/sizes/linelength.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="LineLength">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="LineLength_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for long lines.
         </p>
@@ -21,7 +21,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="LineLength_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -56,7 +56,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="LineLength_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check to accept lines up to 80 characters long:
         </p>
@@ -125,7 +125,7 @@ import java.util.Arrays; // ok
         </source>
       </subsection>
 
-      <subsection name="Notes" id="LineLength_Notes">
+      <subsection name="Notes" id="Notes">
         <ul>
           <li>
             The calculation of the length of a line takes into account the
@@ -152,7 +152,7 @@ import java.util.regex.Pattern; // The length of this comment will be taken into
         </ul>
       </subsection>
 
-      <subsection name="Example of Usage" id="LineLength_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+LineLength">
@@ -169,7 +169,7 @@ import java.util.regex.Pattern; // The length of this comment will be taken into
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="LineLength_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fsizes%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22maxLineLen%22">
@@ -183,13 +183,13 @@ import java.util.regex.Pattern; // The length of this comment will be taken into
         </p>
       </subsection>
 
-      <subsection name="Package" id="LineLength_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.sizes
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="LineLength_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#Checker">Checker</a>
         </p>

--- a/src/xdocs/checks/sizes/methodcount.xml
+++ b/src/xdocs/checks/sizes/methodcount.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="MethodCount">
       <p>Since Checkstyle 5.3</p>
-      <subsection name="Description" id="MethodCount_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks the number of methods declared in each type declaration by access modifier or
           total count.
@@ -53,7 +53,7 @@ public class ExampleClass {
         </source>
       </subsection>
 
-      <subsection name="Properties" id="MethodCount_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -141,7 +141,7 @@ public class ExampleClass {
         </div>
       </subsection>
 
-      <subsection name="Examples" id="MethodCount_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the default check:
         </p>
@@ -171,7 +171,7 @@ public class ExampleClass {
 
       </subsection>
 
-      <subsection name="Example of Usage" id="MethodCount_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodCount">
@@ -180,7 +180,7 @@ public class ExampleClass {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="MethodCount_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fsizes%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22too.many.methods%22">
@@ -210,13 +210,13 @@ public class ExampleClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MethodCount_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.sizes
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="MethodCount_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/sizes/methodlength.xml
+++ b/src/xdocs/checks/sizes/methodlength.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="MethodLength">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="MethodLength_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for long methods and constructors.
         </p>
@@ -20,7 +20,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="MethodLength_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -76,7 +76,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="MethodLength_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -189,7 +189,7 @@ public class MyTest {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="MethodLength_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodLength">
@@ -202,7 +202,7 @@ public class MyTest {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="MethodLength_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fsizes%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22maxLen.method%22">
@@ -216,13 +216,13 @@ public class MyTest {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MethodLength_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.sizes
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="MethodLength_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/sizes/outertypenumber.xml
+++ b/src/xdocs/checks/sizes/outertypenumber.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="OuterTypeNumber">
       <p>Since Checkstyle 5.0</p>
-      <subsection name="Description" id="OuterTypeNumber_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for the number of types declared at the <i>outer</i>
           (or <i>root</i>) level in a file.
@@ -20,7 +20,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="OuterTypeNumber_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -41,7 +41,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="OuterTypeNumber_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check to accept 1 outer type per file:
         </p>
@@ -60,7 +60,7 @@
 
       </subsection>
 
-      <subsection name="Example of Usage" id="OuterTypeNumber_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+OuterTypeNumber">
@@ -69,7 +69,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="OuterTypeNumber_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fsizes%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22maxOuterTypes%22">
@@ -83,13 +83,13 @@
         </p>
       </subsection>
 
-      <subsection name="Package" id="OuterTypeNumber_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.sizes
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="OuterTypeNumber_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/sizes/parameternumber.xml
+++ b/src/xdocs/checks/sizes/parameternumber.xml
@@ -8,13 +8,13 @@
   <body>
     <section name="ParameterNumber">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="ParameterNumber_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks the number of parameters of a method or constructor.
         </p>
       </subsection>
 
-      <subsection name="Properties" id="ParameterNumber_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -66,7 +66,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="ParameterNumber_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -109,7 +109,7 @@ public void needsLotsOfParameters(int a,
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="ParameterNumber_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ParameterNumber">
@@ -122,7 +122,7 @@ public void needsLotsOfParameters(int a,
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="ParameterNumber_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fsizes%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22maxParam%22">
@@ -136,13 +136,13 @@ public void needsLotsOfParameters(int a,
         </p>
       </subsection>
 
-      <subsection name="Package" id="ParameterNumber_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.sizes
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="ParameterNumber_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/sizes/recordcomponentnumber.xml
+++ b/src/xdocs/checks/sizes/recordcomponentnumber.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="RecordComponentNumber">
       <p>Since Checkstyle 8.36</p>
-      <subsection name="Description" id="RecordComponentNumber_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks the number of record components in the
           <a href="https://docs.oracle.com/javase/specs/jls/se14/preview/specs/records-jls.html#jls-8.10.1">
@@ -18,7 +18,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="RecordComponentNumber_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -56,7 +56,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="RecordComponentNumber_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -130,7 +130,7 @@ private record MyRecord2(int x, int y, String str, Node node) { // violation
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="RecordComponentNumber_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+RecordComponentNumber">
@@ -139,7 +139,7 @@ private record MyRecord2(int x, int y, String str, Node node) { // violation
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="RecordComponentNumber_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fsizes%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22too.many.components%22">
@@ -153,13 +153,13 @@ private record MyRecord2(int x, int y, String str, Node node) { // violation
         </p>
       </subsection>
 
-      <subsection name="Package" id="RecordComponentNumber_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.sizes
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="RecordComponentNumber_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/whitespace/emptyforinitializerpad.xml
+++ b/src/xdocs/checks/whitespace/emptyforinitializerpad.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="EmptyForInitializerPad">
       <p>Since Checkstyle 3.4</p>
-      <subsection name="Description" id="EmptyForInitializerPad_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks the padding of an empty for initializer; that is whether
           a white space is required at an empty for initializer, or such white
@@ -22,7 +22,7 @@ for (
         </source>
       </subsection>
 
-      <subsection name="Properties" id="EmptyForInitializerPad_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -43,7 +43,7 @@ for (
         </div>
       </subsection>
 
-      <subsection name="Examples" id="EmptyForInitializerPad_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -84,7 +84,7 @@ for (
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="EmptyForInitializerPad_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+EmptyForInitializerPad">
@@ -93,7 +93,7 @@ for (
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="EmptyForInitializerPad_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22ws.notPreceded%22">
@@ -111,13 +111,13 @@ for (
         </p>
       </subsection>
 
-      <subsection name="Package" id="EmptyForInitializerPad_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.whitespace
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="EmptyForInitializerPad_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/whitespace/emptyforiteratorpad.xml
+++ b/src/xdocs/checks/whitespace/emptyforiteratorpad.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="EmptyForIteratorPad">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="EmptyForIteratorPad_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks the padding of an empty for iterator; that is whether a white
           space is required at an empty for iterator, or such white space is
@@ -22,7 +22,7 @@ for (Iterator foo = very.long.line.iterator();
         </source>
       </subsection>
 
-      <subsection name="Properties" id="EmptyForIteratorPad_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -43,7 +43,7 @@ for (Iterator foo = very.long.line.iterator();
         </div>
       </subsection>
 
-      <subsection name="Examples" id="EmptyForIteratorPad_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -86,7 +86,7 @@ for (Iterator foo = very.long.line.iterator();
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="EmptyForIteratorPad_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+EmptyForIteratorPad">
@@ -99,7 +99,7 @@ for (Iterator foo = very.long.line.iterator();
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="EmptyForIteratorPad_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22ws.followed%22">
@@ -117,13 +117,13 @@ for (Iterator foo = very.long.line.iterator();
         </p>
       </subsection>
 
-      <subsection name="Package" id="EmptyForIteratorPad_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.whitespace
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="EmptyForIteratorPad_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/whitespace/emptylineseparator.xml
+++ b/src/xdocs/checks/whitespace/emptylineseparator.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="EmptyLineSeparator">
       <p>Since Checkstyle 5.8</p>
-      <subsection name="Description" id="EmptyLineSeparator_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks for empty line separators before package, all import declarations,
           fields, constructors, methods, nested classes,
@@ -31,7 +31,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="EmptyLineSeparator_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -129,7 +129,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="EmptyLineSeparator_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
             To configure the default check:
         </p>
@@ -329,7 +329,7 @@ class FirstClass {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="EmptyLineSeparator_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+EmptyLineSeparator">
@@ -342,7 +342,7 @@ class FirstClass {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="EmptyLineSeparator_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22empty.line.separator%22">
@@ -368,13 +368,13 @@ class FirstClass {
         </p>
       </subsection>
 
-      <subsection name="Package" id="EmptyLineSeparator_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.whitespace
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="EmptyLineSeparator_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/whitespace/filetabcharacter.xml
+++ b/src/xdocs/checks/whitespace/filetabcharacter.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="FileTabCharacter">
       <p>Since Checkstyle 5.0</p>
-      <subsection name="Description" id="FileTabCharacter_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that there are no tab characters (<code>'\t'</code>) in the source code.
         </p>
@@ -31,7 +31,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Properties" id="FileTabCharacter_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -61,7 +61,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="FileTabCharacter_Examples">
+      <subsection name="Examples" id="Examples">
         <p>To configure the check to report only the first instance in each file:</p>
         <source>
 &lt;module name="FileTabCharacter"/&gt;
@@ -127,7 +127,7 @@ public class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="FileTabCharacter_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+FileTabCharacter">
@@ -144,7 +144,7 @@ public class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="FileTabCharacter_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22containsTab%22">
@@ -162,13 +162,13 @@ public class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="FileTabCharacter_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.whitespace
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="FileTabCharacter_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#Checker">Checker</a>
         </p>

--- a/src/xdocs/checks/whitespace/genericwhitespace.xml
+++ b/src/xdocs/checks/whitespace/genericwhitespace.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="GenericWhitespace">
       <p>Since Checkstyle 5.0</p>
-      <subsection name="Description" id="GenericWhitespace_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that the whitespace around the Generic tokens (angle brackets)
           "&lt;" and "&gt;" are correct to the <i>typical</i> convention.
@@ -34,7 +34,7 @@
         </ul>
       </subsection>
 
-      <subsection name="Examples" id="GenericWhitespace_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -80,7 +80,7 @@ Pair&lt;Integer, Integer &gt; p; // violation, "&gt;" preceded with whitespace
         </div>
       </subsection>
 
-      <subsection name="Example of Usage" id="GenericWhitespace_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+GenericWhitespace">
@@ -97,7 +97,7 @@ Pair&lt;Integer, Integer &gt; p; // violation, "&gt;" preceded with whitespace
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="GenericWhitespace_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22ws.followed%22">
@@ -123,13 +123,13 @@ Pair&lt;Integer, Integer &gt; p; // violation, "&gt;" preceded with whitespace
         </p>
       </subsection>
 
-      <subsection name="Package" id="GenericWhitespace_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.whitespace
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="GenericWhitespace_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/whitespace/methodparampad.xml
+++ b/src/xdocs/checks/whitespace/methodparampad.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="MethodParamPad">
       <p>Since Checkstyle 3.4</p>
-      <subsection name="Description" id="MethodParamPad_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks the padding between the identifier of a method definition,
           constructor definition, method call, or constructor invocation; and
@@ -22,7 +22,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="MethodParamPad_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -96,7 +96,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="MethodParamPad_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -152,7 +152,7 @@ public class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="MethodParamPad_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+MethodParamPad">
@@ -169,7 +169,7 @@ public class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="MethodParamPad_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22line.previous%22">
@@ -191,13 +191,13 @@ public class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="MethodParamPad_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.whitespace
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="MethodParamPad_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/whitespace/nolinewrap.xml
+++ b/src/xdocs/checks/whitespace/nolinewrap.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="NoLineWrap">
       <p>Since Checkstyle 5.8</p>
-      <subsection name="Description" id="NoLineWrap_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that chosen statements are not line-wrapped. By default, this
           Check restricts wrapping import and package statements, but it's possible to check
@@ -16,7 +16,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="NoLineWrap_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -67,7 +67,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="NoLineWrap_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check to force no line-wrapping
           in package and import statements (default values):
@@ -176,7 +176,7 @@ import static java.math.BigInteger.ZERO;
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="NoLineWrap_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoLineWrap">
@@ -189,7 +189,7 @@ import static java.math.BigInteger.ZERO;
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="NoLineWrap_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22no.line.wrap%22">
@@ -203,13 +203,13 @@ import static java.math.BigInteger.ZERO;
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoLineWrap_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.whitespace
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="NoLineWrap_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/whitespace/nowhitespaceafter.xml
+++ b/src/xdocs/checks/whitespace/nowhitespaceafter.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="NoWhitespaceAfter">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="NoWhitespaceAfter_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that there is no whitespace after a token. More specifically,
           it checks that it is not followed by whitespace, or (if linebreaks
@@ -48,7 +48,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="NoWhitespaceAfter_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -135,7 +135,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="NoWhitespaceAfter_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -205,7 +205,7 @@ class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="NoWhitespaceAfter_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoWhitespaceAfter">
@@ -218,7 +218,7 @@ class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="NoWhitespaceAfter_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22ws.followed%22">
@@ -232,13 +232,13 @@ class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoWhitespaceAfter_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.whitespace
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="NoWhitespaceAfter_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/whitespace/nowhitespacebefore.xml
+++ b/src/xdocs/checks/whitespace/nowhitespacebefore.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="NoWhitespaceBefore">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="NoWhitespaceBefore_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that there is no whitespace before a token. More
           specifically, it checks that it is not preceded with whitespace, or
@@ -19,7 +19,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="NoWhitespaceBefore_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -86,7 +86,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="NoWhitespaceBefore_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -178,7 +178,7 @@ Lists.charactersOf("foo")
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="NoWhitespaceBefore_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoWhitespaceBefore">
@@ -195,7 +195,7 @@ Lists.charactersOf("foo")
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="NoWhitespaceBefore_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22ws.preceded%22">
@@ -209,13 +209,13 @@ Lists.charactersOf("foo")
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoWhitespaceBefore_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.whitespace
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="NoWhitespaceBefore_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/whitespace/nowhitespacebeforecasedefaultcolon.xml
+++ b/src/xdocs/checks/whitespace/nowhitespacebeforecasedefaultcolon.xml
@@ -8,13 +8,13 @@
   <body>
     <section name="NoWhitespaceBeforeCaseDefaultColon">
       <p>Since Checkstyle 8.45</p>
-      <subsection name="Description" id="NoWhitespaceBeforeCaseDefaultColon_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that there is no whitespace before the colon in a switch block.
         </p>
       </subsection>
 
-      <subsection name="Examples" id="NoWhitespaceBeforeCaseDefaultColon_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -54,7 +54,7 @@ class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="NoWhitespaceBeforeCaseDefaultColon_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+NoWhitespaceBeforeCaseDefaultColon">
@@ -68,7 +68,7 @@ class Test {
       </subsection>
 
       <subsection name="Violation Messages"
-        id="NoWhitespaceBeforeCaseDefaultColon_Violation_Messages">
+        id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22ws.preceded%22">
@@ -82,13 +82,13 @@ class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="NoWhitespaceBeforeCaseDefaultColon_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.whitespace
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="NoWhitespaceBeforeCaseDefaultColon_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/whitespace/operatorwrap.xml
+++ b/src/xdocs/checks/whitespace/operatorwrap.xml
@@ -8,13 +8,13 @@
   <body>
     <section name="OperatorWrap">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="OperatorWrap_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks the policy on how to wrap lines on operators.
         </p>
       </subsection>
 
-      <subsection name="Properties" id="OperatorWrap_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -169,7 +169,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="OperatorWrap_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -260,7 +260,7 @@ class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="OperatorWrap_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+OperatorWrap">
@@ -277,7 +277,7 @@ class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="OperatorWrap_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22line.new%22">
@@ -295,13 +295,13 @@ class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="OperatorWrap_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.whitespace
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="OperatorWrap_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/whitespace/parenpad.xml
+++ b/src/xdocs/checks/whitespace/parenpad.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="ParenPad">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="ParenPad_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks the policy on the padding of parentheses; that is whether a
           space is required after a left parenthesis and before a right
@@ -27,7 +27,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="ParenPad_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -150,7 +150,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="ParenPad_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -248,7 +248,7 @@ try (Closeable resource = acquire(); ) // no check before right parenthesis
 
       </subsection>
 
-      <subsection name="Example of Usage" id="ParenPad_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+ParenPad">
@@ -265,7 +265,7 @@ try (Closeable resource = acquire(); ) // no check before right parenthesis
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="ParenPad_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22ws.followed%22">
@@ -291,13 +291,13 @@ try (Closeable resource = acquire(); ) // no check before right parenthesis
         </p>
       </subsection>
 
-      <subsection name="Package" id="ParenPad_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.whitespace
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="ParenPad_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/whitespace/separatorwrap.xml
+++ b/src/xdocs/checks/whitespace/separatorwrap.xml
@@ -8,13 +8,13 @@
   <body>
     <section name="SeparatorWrap">
       <p>Since Checkstyle 5.8</p>
-      <subsection name="Description" id="SeparatorWrap_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks line wrapping with separators.
         </p>
       </subsection>
 
-      <subsection name="Properties" id="SeparatorWrap_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -75,7 +75,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="SeparatorWrap_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -170,7 +170,7 @@ class Test3 {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="SeparatorWrap_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SeparatorWrap">
@@ -183,7 +183,7 @@ class Test3 {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="SeparatorWrap_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22line.new%22">
@@ -201,13 +201,13 @@ class Test3 {
         </p>
       </subsection>
 
-      <subsection name="Package" id="SeparatorWrap_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.whitespace
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="SeparatorWrap_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/whitespace/singlespaceseparator.xml
+++ b/src/xdocs/checks/whitespace/singlespaceseparator.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="SingleSpaceSeparator">
       <p>Since Checkstyle 6.19</p>
-      <subsection name="Description" id="SingleSpaceSeparator_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that non-whitespace characters are separated by no more than one
           whitespace. Separating characters by tabs or multiple spaces will be
@@ -39,7 +39,7 @@ public long toMicros(long d) { return d / (C1 / C0); }
         </source>
       </subsection>
 
-      <subsection name="Properties" id="SingleSpaceSeparator_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -60,7 +60,7 @@ public long toMicros(long d) { return d / (C1 / C0); }
         </div>
       </subsection>
 
-      <subsection name="Examples" id="SingleSpaceSeparator_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -108,7 +108,7 @@ float f1; // OK, 1 whitespace
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="SingleSpaceSeparator_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SingleSpaceSeparator">
@@ -117,7 +117,7 @@ float f1; // OK, 1 whitespace
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="SingleSpaceSeparator_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22single.space.separator%22">
@@ -131,13 +131,13 @@ float f1; // OK, 1 whitespace
         </p>
       </subsection>
 
-      <subsection name="Package" id="SingleSpaceSeparator_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.whitespace
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="SingleSpaceSeparator_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/whitespace/typecastparenpad.xml
+++ b/src/xdocs/checks/whitespace/typecastparenpad.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="TypecastParenPad">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="TypecastParenPad_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks the policy on the padding of parentheses for typecasts. That
           is, whether a space is required after a left parenthesis and before
@@ -16,7 +16,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="TypecastParenPad_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -37,7 +37,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="TypecastParenPad_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -95,7 +95,7 @@ class Bar {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="TypecastParenPad_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fsun_checks.xml+repo%3Acheckstyle%2Fcheckstyle+TypecastParenPad">
@@ -108,7 +108,7 @@ class Bar {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="TypecastParenPad_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22ws.followed%22">
@@ -134,13 +134,13 @@ class Bar {
         </p>
       </subsection>
 
-      <subsection name="Package" id="TypecastParenPad_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.whitespace
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="TypecastParenPad_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/whitespace/whitespaceafter.xml
+++ b/src/xdocs/checks/whitespace/whitespaceafter.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="WhitespaceAfter">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="WhitespaceAfter_Description">
+      <subsection name="Description" id="Description">
         <p>
           Checks that a token is followed by whitespace, with the exception that it
           does not check for whitespace after the semicolon of an empty for iterator. Use Check
@@ -17,7 +17,7 @@
         </p>
       </subsection>
 
-      <subsection name="Properties" id="WhitespaceAfter_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -121,7 +121,7 @@
         </div>
       </subsection>
 
-      <subsection name="Examples" id="WhitespaceAfter_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -206,7 +206,7 @@ public void myTest() {
         </div>
       </subsection>
 
-      <subsection name="Example of Usage" id="WhitespaceAfter_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+WhitespaceAfter">
@@ -223,7 +223,7 @@ public void myTest() {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="WhitespaceAfter_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22ws.notFollowed%22">
@@ -241,13 +241,13 @@ public void myTest() {
         </p>
       </subsection>
 
-      <subsection name="Package" id="WhitespaceAfter_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.whitespace
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="WhitespaceAfter_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/checks/whitespace/whitespacearound.xml
+++ b/src/xdocs/checks/whitespace/whitespacearound.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="WhitespaceAround">
       <p>Since Checkstyle 3.0</p>
-      <subsection name="Description" id="WhitespaceAround_Description">
+      <subsection name="Description" id="Description">
         <p>
         Checks that a token is surrounded by whitespace. Empty constructor,
         method, class, enum, interface, loop bodies (blocks), lambdas of the form
@@ -59,7 +59,7 @@ try {
         </p>
       </subsection>
 
-      <subsection name="Properties" id="WhitespaceAround_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -352,7 +352,7 @@ try {
         </div>
       </subsection>
 
-      <subsection name="Examples" id="WhitespaceAround_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check:
         </p>
@@ -572,7 +572,7 @@ class Test {
         </source>
       </subsection>
 
-      <subsection name="Example of Usage" id="WhitespaceAround_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+WhitespaceAround">
@@ -589,7 +589,7 @@ class Test {
         </ul>
       </subsection>
 
-      <subsection name="Violation Messages" id="WhitespaceAround_Violation_Messages">
+      <subsection name="Violation Messages" id="Violation_Messages">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%2Fcom%2Fpuppycrawl%2Ftools%2Fcheckstyle%2Fchecks%2Fwhitespace%20path%3A**%2Fmessages*.properties+repo%3Acheckstyle%2Fcheckstyle+%22ws.notFollowed%22">
@@ -607,13 +607,13 @@ class Test {
         </p>
       </subsection>
 
-      <subsection name="Package" id="WhitespaceAround_Package">
+      <subsection name="Package" id="Package">
         <p>
           com.puppycrawl.tools.checkstyle.checks.whitespace
         </p>
       </subsection>
 
-      <subsection name="Parent Module" id="WhitespaceAround_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p>
           <a href="../../config.html#TreeWalker">TreeWalker</a>
         </p>

--- a/src/xdocs/filefilters/beforeexecutionexclusionfilefilter.xml
+++ b/src/xdocs/filefilters/beforeexecutionexclusionfilefilter.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="BeforeExecutionExclusionFileFilter">
       <p>Since Checkstyle 7.2</p>
-      <subsection name="Description" id="BeforeExecutionExclusionFileFilter_Description">
+      <subsection name="Description" id="Description">
         <p>
           File filter <code>BeforeExecutionExclusionFileFilter</code> decides which files should be
           excluded from being processed by the utility.
@@ -29,7 +29,7 @@
           no testing for violations will be performed on them.
         </p>
       </subsection>
-      <subsection name="Properties" id="BeforeExecutionExclusionFileFilter_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -49,7 +49,7 @@
           </table>
         </div>
       </subsection>
-      <subsection name="Examples" id="BeforeExecutionExclusionFileFilter_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the filter to exclude all 'module-info.java' files:
         </p>
@@ -79,7 +79,7 @@
 &lt;/module&gt;
         </source>
       </subsection>
-      <subsection name="Example of Usage" id="BeforeExecutionExclusionFileFilter_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+BeforeExecutionExclusionFileFilter">
@@ -95,11 +95,11 @@
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="BeforeExecutionExclusionFileFilter_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.filefilters </p>
       </subsection>
 
-      <subsection name="Parent Module" id="BeforeExecutionExclusionFileFilter_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../config.html#Checker">Checker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/filters/severitymatchfilter.xml
+++ b/src/xdocs/filters/severitymatchfilter.xml
@@ -8,19 +8,19 @@
   <body>
     <section name="SeverityMatchFilter">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="SeverityMatchFilter_Description">
+      <subsection name="Description" id="Description">
         <p>
           Filter <code>SeverityMatchFilter</code> decides
           audit events according to the <a href="../config.html#Severity">severity
           level</a> of the event.
         </p>
       </subsection>
-      <subsection name="Notes" id="SeverityMatchFilter_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           SeverityMatchFilter can suppress Checks that have Treewalker or Checker as parent module.
         </p>
       </subsection>
-      <subsection name="Properties" id="SeverityMatchFilter_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -54,7 +54,7 @@
           </table>
         </div>
       </subsection>
-      <subsection name="Examples" id="SeverityMatchFilter_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           For example, the following configuration fragment directs the
           Checker to not report audit events with severity
@@ -67,7 +67,7 @@
 &lt;/module&gt;
         </source>
       </subsection>
-      <subsection name="Example of Usage" id="SeverityMatchFilter_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SeverityMatchFilter">
@@ -75,11 +75,11 @@
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SeverityMatchFilter_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.filters </p>
       </subsection>
 
-      <subsection name="Parent Module" id="SeverityMatchFilter_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../config.html#Checker">Checker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/filters/suppressioncommentfilter.xml
+++ b/src/xdocs/filters/suppressioncommentfilter.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="SuppressionCommentFilter">
       <p>Since Checkstyle 3.5</p>
-      <subsection name="Description" id="SuppressionCommentFilter_Description">
+      <subsection name="Description" id="Description">
         <p>
           Filter <code>SuppressionCommentFilter</code> uses
           pairs of comments to suppress audit events.
@@ -35,7 +35,7 @@
           SuppressWithPlainTextCommentFilter</a> or similar filter must be used.
         </p>
       </subsection>
-      <subsection name="Notes" id="SuppressionCommentFilter_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           <code>offCommentFormat</code> and <code>onCommentFormat</code> must have equal
           <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/regex/Matcher.html#groupCount()">
@@ -45,7 +45,7 @@
           SuppressionCommentFilter can suppress Checks that have Treewalker as parent module.
         </p>
       </subsection>
-      <subsection name="Properties" id="SuppressionCommentFilter_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -107,7 +107,7 @@
           </table>
         </div>
       </subsection>
-      <subsection name="Examples" id="SuppressionCommentFilter_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure a filter to suppress audit events (MemberNameCheck,
           ConstantNameCheck and IllegalCatchCheck have been taken here for reference)
@@ -484,7 +484,7 @@ class InputSuppressionCommentFilter
 }
         </source>
       </subsection>
-      <subsection name="Example of Usage" id="SuppressionCommentFilter_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionCommentFilter">
@@ -496,11 +496,11 @@ class InputSuppressionCommentFilter
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressionCommentFilter_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.filters </p>
       </subsection>
 
-      <subsection name="Parent Module" id="SuppressionCommentFilter_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/filters/suppressionfilter.xml
+++ b/src/xdocs/filters/suppressionfilter.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="SuppressionFilter">
       <p>Since Checkstyle 3.2</p>
-      <subsection name="Description" id="SuppressionFilter_Description">
+      <subsection name="Description" id="Description">
         <p>
           Filter <code>SuppressionFilter</code> rejects
           audit events for Check violations according to
@@ -18,7 +18,7 @@
           suppressions file was not found the Filter accepts all audit events.
         </p>
       </subsection>
-      <subsection name="Properties" id="SuppressionFilter_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -53,7 +53,7 @@
           </table>
         </div>
       </subsection>
-      <subsection name="Notes" id="SuppressionFilter_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           A <a href="/dtds/suppressions_1_2.dtd">suppressions XML
           document</a> contains a set of <code>suppress</code> elements, where
@@ -130,7 +130,7 @@
           SuppressionFilter can suppress Checks that have Treewalker or Checker as parent module.
         </p>
       </subsection>
-      <subsection name="Examples" id="SuppressionFilter_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
             For example, the following configuration fragment directs the
             Checker to use a <code>SuppressionFilter</code>
@@ -229,7 +229,7 @@ files="com[\\/]mycompany[\\/]app[\\/].*IT.java"/&gt;
 &lt;suppress message="Name 'log' must match pattern"/&gt;
         </source>
       </subsection>
-      <subsection name="Example of Usage" id="SuppressionFilter_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionFilter">
@@ -245,11 +245,11 @@ files="com[\\/]mycompany[\\/]app[\\/].*IT.java"/&gt;
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressionFilter_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.filters </p>
       </subsection>
 
-      <subsection name="Parent Module" id="SuppressionFilter_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../config.html#Checker">Checker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/filters/suppressionsinglefilter.xml
+++ b/src/xdocs/filters/suppressionsinglefilter.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="SuppressionSingleFilter">
       <p>Since Checkstyle 8.23</p>
-      <subsection name="Description" id="SuppressionSingleFilter_Description">
+      <subsection name="Description" id="Description">
         <p>
           Filter <code>SuppressionSingleFilter</code> suppresses audit events for
           Checks violations in the specified file, class, checks, message, module id,
@@ -30,13 +30,13 @@
           multiple instances if users wants to suppress multiple violations.
         </p>
       </subsection>
-      <subsection name="Notes" id="SuppressionSingleFilter_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           SuppressionSingleFilter can suppress Checks that have Treewalker or
           Checker as parent module.
         </p>
       </subsection>
-      <subsection name="Properties" id="SuppressionSingleFilter_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -97,7 +97,7 @@
           </table>
         </div>
       </subsection>
-      <subsection name="Examples" id="SuppressionSingleFilter_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           The following suppressions directs
           a <code>SuppressionSingleFilter</code> to
@@ -207,7 +207,7 @@
 &lt;/module&gt;
         </source>
       </subsection>
-      <subsection name="Example of Usage" id="SuppressionSingleFilter_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionSingleFilter">
@@ -215,10 +215,10 @@
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressionSingleFilter_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.filters </p>
       </subsection>
-      <subsection name="Parent Module" id="SuppressionSingleFilter_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../config.html#Checker">Checker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/filters/suppressionxpathfilter.xml
+++ b/src/xdocs/filters/suppressionxpathfilter.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="SuppressionXpathFilter">
       <p>Since Checkstyle 8.6</p>
-      <subsection name="Description" id="SuppressionXpathFilter_Description">
+      <subsection name="Description" id="Description">
         <p>
           Filter <code>SuppressionXpathFilter</code> works as
           <a href="suppressionfilter.html#SuppressionFilter">
@@ -20,7 +20,7 @@
         <p>
           Currently, filter does not support the following checks:
         </p>
-        <ul id="SuppressionXpathFilter_IncompatibleChecks">
+        <ul id="IncompatibleChecks">
           <li>NoCodeInFile (reason is that AST is not generated for a file not containing code)</li>
           <li>Regexp (reason is at <a href="https://github.com/checkstyle/checkstyle/issues/7759#issuecomment-605525287"> #7759</a>)</li>
           <li>RegexpSinglelineJava (reason is at <a href="https://github.com/checkstyle/checkstyle/issues/7759#issuecomment-605525287"> #7759</a>)</li>
@@ -28,7 +28,7 @@
         <p>
           Also, the filter does not support suppressions inside javadoc reported by Javadoc checks:
         </p>
-        <ul id="SuppressionXpathFilter_JavadocChecks">
+        <ul id="JavadocChecks">
           <li>AtclauseOrder</li>
           <li>JavadocBlockTagLocation</li>
           <li>JavadocMethod</li>
@@ -75,7 +75,7 @@
           for more details.
         </p>
       </subsection>
-      <subsection name="Notes" id="SuppressionXpathFilter_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           The suppression file location is checked in following order:
         </p>
@@ -95,7 +95,7 @@
           SuppressionXpathFilter can suppress Checks that have Treewalker as parent module.
         </p>
       </subsection>
-      <subsection name="Properties" id="SuppressionXpathFilter_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -130,7 +130,7 @@
           </table>
         </div>
       </subsection>
-      <subsection name="Examples" id="SuppressionXpathFilter_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           For example, the following configuration fragment directs the
           Checker to use a <code>SuppressionXpathFilter</code>
@@ -451,7 +451,7 @@ CLASS_DEF -&gt; CLASS_DEF [1:0]
             ./IDENT[@text='Generated'] and ./EXPR/STRING_LITERAL[@text='second']]]"/&gt;
         </source>
       </subsection>
-      <subsection name="Example of Usage" id="SuppressionXpathFilter_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Asrc%2Fmain%2Fresources%20path%3A**%2Fgoogle_checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionXpathFilter">
@@ -467,11 +467,11 @@ CLASS_DEF -&gt; CLASS_DEF [1:0]
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressionXpathFilter_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.filters </p>
       </subsection>
 
-      <subsection name="Parent Module" id="SuppressionXpathFilter_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/filters/suppressionxpathsinglefilter.xml
+++ b/src/xdocs/filters/suppressionxpathsinglefilter.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="SuppressionXpathSingleFilter">
       <p>Since Checkstyle 8.18</p>
-      <subsection name="Description" id="SuppressionXpathSingleFilter_Description">
+      <subsection name="Description" id="Description">
         <p>
           Filter <code>SuppressionXpathSingleFilter</code> suppresses audit events for
           Checks violations in the specified file, class, checks, message, module id,
@@ -30,12 +30,12 @@
           multiple instances if users wants to suppress multiple violations.
         </p>
       </subsection>
-      <subsection name="Notes" id="SuppressionXpathSingleFilter_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           SuppressionXpathSingleFilter can suppress Checks that have Treewalker as parent module.
         </p>
       </subsection>
-      <subsection name="Properties" id="SuppressionXpathSingleFilter_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -87,7 +87,7 @@
           </table>
         </div>
       </subsection>
-      <subsection name="Examples" id="SuppressionXpathSingleFilter_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure to suppress the MethodName check
           for all methods with name MyMethod
@@ -446,7 +446,7 @@ public class TestClass {
           </pre>
         </div>
       </subsection>
-      <subsection name="Example of Usage" id="SuppressionXpathSingleFilter_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressionXpathSingleFilter">
@@ -460,10 +460,10 @@ public class TestClass {
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressionXpathSingleFilter_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.filters </p>
       </subsection>
-      <subsection name="Parent Module" id="SuppressionXpathSingleFilter_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/filters/suppresswarningsfilter.xml
+++ b/src/xdocs/filters/suppresswarningsfilter.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="SuppressWarningsFilter">
       <p>Since Checkstyle 5.7</p>
-      <subsection name="Description" id="SuppressWarningsFilter_Description">
+      <subsection name="Description" id="Description">
         <p>
           Filter <code>SuppressWarningsFilter</code> uses annotation
           <code>@SuppressWarnings</code> to suppress audit events.
@@ -34,13 +34,13 @@
           and should be written with any dotted prefix or "Check" suffix removed.
         </p>
       </subsection>
-      <subsection name="Notes" id="SuppressWarningsFilter_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           SuppressWarningsFilter can suppress Checks that have Treewalker or
           Checker as parent module.
         </p>
       </subsection>
-      <subsection name="Examples" id="SuppressWarningsFilter_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the check that makes tha annotations available to
           the filter.
@@ -105,7 +105,7 @@ public static void foo() {
 }
         </source>
       </subsection>
-      <subsection name="Example of Usage" id="SuppressWarningsFilter_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressWarningsFilter">
@@ -117,11 +117,11 @@ public static void foo() {
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressWarningsFilter_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.filters </p>
       </subsection>
 
-      <subsection name="Parent Module" id="SuppressWarningsFilter_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../config.html#Checker">Checker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/filters/suppresswithnearbycommentfilter.xml
+++ b/src/xdocs/filters/suppresswithnearbycommentfilter.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="SuppressWithNearbyCommentFilter">
       <p>Since Checkstyle 5.0</p>
-      <subsection name="Description" id="SuppressWithNearbyCommentFilter_Description">
+      <subsection name="Description" id="Description">
         <p>
           Filter <code>SuppressWithNearbyCommentFilter</code> uses
           nearby comments to suppress audit events.
@@ -30,13 +30,13 @@
           SuppressWithPlainTextCommentFilter</a> or similar filter must be used.
         </p>
       </subsection>
-      <subsection name="Notes" id="SuppressWithNearbyCommentFilter_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           SuppressWithNearbyCommentFilter can suppress Checks that have
           Treewalker as parent module.
         </p>
       </subsection>
-      <subsection name="Properties" id="SuppressWithNearbyCommentFilter_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -99,7 +99,7 @@
           </table>
         </div>
       </subsection>
-      <subsection name="Examples" id="SuppressWithNearbyCommentFilter_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure a filter to suppress audit events for <i>check</i>
           on any line with a comment <code>SUPPRESS CHECKSTYLE <i>check</i></code>:
@@ -264,7 +264,7 @@ public class UserService {
 }
         </source>
       </subsection>
-      <subsection name="Example of Usage" id="SuppressWithNearbyCommentFilter_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressWithNearbyCommentFilter">
@@ -276,11 +276,11 @@ public class UserService {
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressWithNearbyCommentFilter_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.filters </p>
       </subsection>
 
-      <subsection name="Parent Module" id="SuppressWithNearbyCommentFilter_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../config.html#TreeWalker">TreeWalker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/filters/suppresswithnearbytextfilter.xml
+++ b/src/xdocs/filters/suppresswithnearbytextfilter.xml
@@ -8,14 +8,14 @@
   <body>
     <section name="SuppressWithNearbyTextFilter">
       <p>Since Checkstyle 10.10.0</p>
-      <subsection name="Description" id="SuppressWithNearbyTextFilter_Description">
+      <subsection name="Description" id="Description">
         <p>
           Filter <code>SuppressWithNearbyTextFilter</code> uses plain text to suppress
           nearby audit events. The filter can suppress all checks which have Checker
           as a parent module.
         </p>
       </subsection>
-      <subsection name="Notes" id="SuppressWithNearbyTextFilter_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           Setting <code>.*</code> value to <code>nearbyTextPattern</code> property will see
           <b>any</b> text as a suppression and will likely suppress all audit events in the file.
@@ -23,7 +23,7 @@
           it out of the rest of the file as a suppression. See the default value as an example.
         </p>
       </subsection>
-      <subsection name="Properties" id="SuppressWithNearbyTextFilter_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -78,7 +78,7 @@
           </table>
         </div>
       </subsection>
-      <subsection name="Examples" id="SuppressWithNearbyTextFilter_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure the filter to suppress audit events on the same line:
         </p>
@@ -284,7 +284,7 @@ int e = 46; // violation
 public static final boolean SOME_FLAG = false;
         </source>
       </subsection>
-      <subsection name="Example of Usage" id="SuppressWithNearbyTextFilter_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressWithNearbyTextFilter">
@@ -292,11 +292,11 @@ public static final boolean SOME_FLAG = false;
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressWithNearbyTextFilter_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.filters </p>
       </subsection>
 
-      <subsection name="Parent Module" id="SuppressWithNearbyTextFilter_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../config.html#Checker">Checker</a> </p>
       </subsection>
     </section>

--- a/src/xdocs/filters/suppresswithplaintextcommentfilter.xml
+++ b/src/xdocs/filters/suppresswithplaintextcommentfilter.xml
@@ -8,7 +8,7 @@
   <body>
     <section name="SuppressWithPlainTextCommentFilter">
       <p>Since Checkstyle 8.6</p>
-      <subsection name="Description" id="SuppressWithPlainTextCommentFilter_Description">
+      <subsection name="Description" id="Description">
         <p>
           Filter <code>SuppressWithPlainTextCommentFilter</code> uses plain text to suppress
           audit events. The filter can be used only to suppress audit events received from
@@ -37,7 +37,7 @@
           You can use more than one suppression comment each on separate line.
         </p>
       </subsection>
-      <subsection name="Properties" id="SuppressWithPlainTextCommentFilter_Properties">
+      <subsection name="Properties" id="Properties">
         <div class="wrapper">
           <table>
             <tr>
@@ -85,7 +85,7 @@
           </table>
         </div>
       </subsection>
-      <subsection name="Notes" id="SuppressWithPlainTextCommentFilter_Notes">
+      <subsection name="Notes" id="Notes">
         <p>
           Properties <code>offCommentFormat</code> and <code>onCommentFormat</code>
           must have equal
@@ -97,7 +97,7 @@
           Checker as parent module.
         </p>
       </subsection>
-      <subsection name="Examples" id="SuppressWithPlainTextCommentFilter_Examples">
+      <subsection name="Examples" id="Examples">
         <p>
           To configure a filter to suppress audit events between a comment
           containing <code>CHECKSTYLE:OFF</code> and a comment containing
@@ -311,7 +311,7 @@ CREATE TABLE STATION (
   LONG_W REAL);
         </source>
       </subsection>
-      <subsection name="Example of Usage" id="SuppressWithPlainTextCommentFilter_Example_of_Usage">
+      <subsection name="Example of Usage" id="Example_of_Usage">
         <ul>
           <li>
             <a href="https://github.com/search?q=path%3Aconfig%20path%3A**%2Fcheckstyle-checks.xml+repo%3Acheckstyle%2Fcheckstyle+SuppressWithPlainTextCommentFilter">
@@ -319,11 +319,11 @@ CREATE TABLE STATION (
           </li>
         </ul>
       </subsection>
-      <subsection name="Package" id="SuppressWithPlainTextCommentFilter_Package">
+      <subsection name="Package" id="Package">
         <p> com.puppycrawl.tools.checkstyle.filters </p>
       </subsection>
 
-      <subsection name="Parent Module" id="SuppressWithPlainTextCommentFilter_Parent_Module">
+      <subsection name="Parent Module" id="Parent_Module">
         <p> <a href="../config.html#Checker">Checker</a> </p>
       </subsection>
     </section>


### PR DESCRIPTION
Resolves #13288

- Removed all leading `<check name>_` from subsection id's. For example `AbstractClassName_Examples` turns into `Examples`.
- Make CSS exactly match `Properties` id as described in https://github.com/checkstyle/checkstyle/issues/13288#issuecomment-1601601325
- Extend test to ensure subsection name and id match in `checks`, `filters` and `filefilters` folder.

Script used: https://gist.github.com/stoyanK7/9519c7c1358ffdc8ab3998cecc3b774d