### PR TITLE
infra: fix for validaton.sh pgjdbc failure

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -638,7 +638,7 @@ no-error-pgjdbc)
   checkout_from https://github.com/pgjdbc/pgjdbc.git
   cd .ci-temp/pgjdbc
   # pgjdbc easily damage build, we should use stable versions
-  git checkout "135be5a4395033a4ba23a1dd70ad76e0bd443a8d"
+  git checkout "4911ed072681e209423fb608b4bf2da""ad01bb94d"
   ./gradlew --no-parallel --no-daemon checkstyleAll \
             -PenableMavenLocal -Pcheckstyle.version="${CS_POM_VERSION}"
   cd ../


### PR DESCRIPTION
just tried to use latest commit from this repo.

https://github.com/pgjdbc/pgjdbc/commits/master

https://checkstyle.semaphoreci.com/jobs/c5552a3b-390a-4773-96d6-ea140a06ce78

```
> Task :buildSrc:jar 02:46
:jar: No valid plugin descriptors were found in META-INF/gradle-plugins 02:46
> Task :buildSrc:assemble 02:46
> Task :buildSrc:compileTestKotlin NO-SOURCE 02:46
> Task :buildSrc:pluginUnderTestMetadata 02:46
> Task :buildSrc:compileTestJava NO-SOURCE 02:46
> Task :buildSrc:compileTestGroovy NO-SOURCE 02:46
> Task :buildSrc:testClasses UP-TO-DATE 02:46
> Task :buildSrc:test NO-SOURCE 02:46
> Task :buildSrc:validatePlugins 02:46
> Task :buildSrc:check 02:46
> Task :buildSrc:build 02:46
  03:18
FAILURE: Build failed with an exception. 03:18
* What went wrong: 03:18
A problem occurred configuring root project 'pgjdbc'. 03:18
> Could not resolve all files for configuration ':classpath'. 03:18
   > Could not find org.ajoberstar.grgit:grgit-core:4.0.1. 03:18
     Searched in the following locations: 03:18
       - https://plugins.gradle.org/m2/org/ajoberstar/grgit/grgit-core/4.0.1/grgit-core-4.0.1.pom 03:18
     If the artifact you are trying to retrieve can be found in the repository but without metadata in 'Maven POM' format, you need to adjust the 'metadataSources { ... }' of the repository declaration. 03:18
     Required by: 03:18
         project : > com.github.vlsi.stage-vote-release:com.github.vlsi.stage-vote-release.gradle.plugin:1.82 > com.github.vlsi.gradle:stage-vote-release-plugin:1.82 03:18
         project : > com.github.vlsi.stage-vote-release:com.github.vlsi.stage-vote-release.gradle.plugin:1.82 > com.github.vlsi.gradle:stage-vote-release-plugin:1.82 > 
```