### PR TITLE
Issue #13321: Kill mutation for SummaryJavaDocCheck-1

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -855,14 +855,14 @@
     <lineContent>while (count &lt;= 1</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>SummaryJavadocCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck</mutatedClass>
-    <mutatedMethod>containsForbiddenFragment</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to java/lang/String::trim with receiver</description>
-    <lineContent>.matcher(firstSentence).replaceAll(&quot; &quot;).trim();</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
 
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
@@ -304,4 +304,13 @@ public class SummaryJavadocCheckTest extends AbstractModuleTestSupport {
                 getPath("InputSummaryJavadocTestForbiddenFragments2.java"), expected);
     }
 
+    @Test
+    public void testSummaryJavaDoc() throws Exception {
+        final String[] expected = {
+            "15: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputSummaryJavadoc1.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadoc1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadoc1.java
@@ -1,0 +1,20 @@
+/*
+SummaryJavadoc
+violateExecutionOnNonTightHtml = true
+forbiddenSummaryFragments = ^Returns the customer ID. This method returns.$
+period = .
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
+
+public class InputSummaryJavadoc1 {
+
+    // violation 2 lines below 'Forbidden summary fragment'
+    /**
+     * {@summary Returns the customer ID.
+     *  This method returns. }
+     */
+    public void foo() {
+    }
+}


### PR DESCRIPTION
Issue #13321: Kill mutation for SummaryJavaDocCheck-1

-----

# Check :- 
https://checkstyle.org/checks/javadoc/summaryjavadoc.html#SummaryJavadoc

-----

# Mutation 
https://github.com/checkstyle/checkstyle/blob/3d8ed42ab60c0399550b3e7d54ca9dd767583101/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L858-L865

-----

# Explaination

The removal of trim will effect the programme it will increase the number of times in loop.

There are total 3 usage of the `containsForbiddenFragment`

1) In `validateUntaggedSummary` method at 
https://github.com/checkstyle/checkstyle/blob/6073cd4194af4e673a5805fcfc6a2cddb0e4547d/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java#L343-L345
Note:-  If this `condition` execute then violation thrown and violation message doesn't contains any relation with the text.

Know when `containsForbiddenFragment` will be execute then https://github.com/checkstyle/checkstyle/blob/6073cd4194af4e673a5805fcfc6a2cddb0e4547d/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java#L603-L606 
javadocText will not be trimmed lets suppose if we have sentence `This is summary javadoc                .` 
then javaDoctext would become `This is summary javadoc                ` 

and as a return statment we call `trimExcessWhitespaces` to match `forbiddenSummaryFragment` and in trimExcessWhitespaces for loop will run as more time as we have extra spaces which is not been removed as we remove trim.
and the string will return with the extra space but it will not affect the output. 


And for the second and third usage the explaintaion is same as above 
https://github.com/checkstyle/checkstyle/blob/6073cd4194af4e673a5805fcfc6a2cddb0e4547d/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java#L528-L530
and 
https://github.com/checkstyle/checkstyle/blob/6073cd4194af4e673a5805fcfc6a2cddb0e4547d/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java#L511-L513

-----

# Regression :- 

Report-1 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/5d08f12_2023202818/reports/diff/index.html

Report-2:- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/5d08f12_2023084141/reports/diff/index.html

-----

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/61eaa69fe98585b6ee1882ca082362bc/raw/c74195e574d09886a3406be17a9d46787da9545e/Summary.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Regression-2