### PR TITLE
Issue #13321: Kill mutation for SummaryJavaDocCheck-9

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -940,23 +940,23 @@
     <lineContent>final String summarySentence = sentence.trim();</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>SummaryJavadocCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck</mutatedClass>
-    <mutatedMethod>isTextPresentInsideHtmlTag</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/String::isBlank</description>
-    <lineContent>isTextPresentInsideHtmlTag = !nestedChild.getText().isBlank();</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>SummaryJavadocCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck</mutatedClass>
-    <mutatedMethod>isTextPresentInsideHtmlTag</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>isTextPresentInsideHtmlTag = !nestedChild.getText().isBlank();</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>SummaryJavadocCheck.java</sourceFile>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
@@ -160,6 +160,7 @@ public class SummaryJavadocCheckTest extends AbstractModuleTestSupport {
             "74: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
             // Until https://github.com/checkstyle/checkstyle/issues/11425
             "82: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+            "93: " + getCheckMessage(MSG_SUMMARY_MISSING_PERIOD),
         };
 
         verifyWithInlineConfigParser(

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocIncorrect3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocIncorrect3.java
@@ -87,4 +87,12 @@ public class InputSummaryJavadocIncorrect3 {
      */
     public void testMultipleElements() {
     }
+
+    /**
+     * <p> </p>
+     * {@summary This is not the summary}
+     */
+    // violation 2 lines above 'Summary of Javadoc is missing an ending period'
+    public void testHtmlTags3() {
+    }
 }


### PR DESCRIPTION
Issue #13321: Kill mutation for SummaryJavaDocCheck-9

-----

# Check :- 
https://checkstyle.org/checks/javadoc/summaryjavadoc.html#SummaryJavadoc

-----

# Mutation 
https://github.com/checkstyle/checkstyle/blob/c3c7ab8f444509ccbd9e85add37f875bc8951b46/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L943-L959

-----

# Explaination
Test added

-----

