### PR TITLE
Issue #13321: Kill mutation for SummaryJavaDocCheck-10

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -976,23 +976,14 @@
     <lineContent>final String returnVisible = getVisibleContent(inlineReturn);</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>SummaryJavadocCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck</mutatedClass>
-    <mutatedMethod>validateUntaggedSummary</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/lang/String::isEmpty</description>
-    <lineContent>else if (!period.isEmpty()) {</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>SummaryJavadocCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck</mutatedClass>
-    <mutatedMethod>validateUntaggedSummary</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>else if (!period.isEmpty()) {</lineContent>
-  </mutation>
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>TagParser.java</sourceFile>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
@@ -266,4 +266,31 @@ public class SummaryJavadocCheckTest extends AbstractModuleTestSupport {
         verifyWithInlineConfigParser(
                 getPath("InputSummaryJavadocTestForbiddenFragments.java"), expected);
     }
+
+    @Test
+    public void testEmptyPeriod() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWithInlineConfigParser(
+                getPath("InputSummaryJavadocEmptyPeriod.java"), expected);
+    }
+
+    @Test
+    public void testForbidden3() throws Exception {
+        final String[] expected = {
+            "14: " + getCheckMessage(MSG_SUMMARY_JAVADOC),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputSummaryJavadocTestForbiddenFragments3.java"), expected);
+    }
+
+    @Test
+    public void testForbidden2() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+
+        verifyWithInlineConfigParser(
+                getPath("InputSummaryJavadocTestForbiddenFragments2.java"), expected);
+    }
+
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocEmptyPeriod.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocEmptyPeriod.java
@@ -1,0 +1,39 @@
+/*
+SummaryJavadoc
+violateExecutionOnNonTightHtml = (default)false
+forbiddenSummaryFragments = .*CheckStyle$
+period =
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
+
+// ok
+public class InputSummaryJavadocEmptyPeriod {
+
+    /**
+     * checkStyle. check rule of CheckStyle.
+     */
+    public int count = 0;
+
+    /**
+     * checkStyle check rule of CheckStyle.
+     */
+    public int count1 = 0;
+
+    /**
+     * check rule of CheckStyle. checkstyle.
+     */
+    public int count2 = 0;
+
+    /**
+     * Maintains point for structure
+     */
+    public int pointer = -1;
+
+    /**
+     * size of CheckStyle.
+     */
+    public int size;
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocTestForbiddenFragments2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocTestForbiddenFragments2.java
@@ -1,0 +1,24 @@
+/*
+SummaryJavadoc
+violateExecutionOnNonTightHtml = true
+forbiddenSummaryFragments = .*
+period =
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
+
+// ok
+public class InputSummaryJavadocTestForbiddenFragments2 {
+
+    /**
+     * Returns {@link String} instance for the given module name.
+     * This implementation uses {@link #getModuleConfig(String)} method inside.
+     *
+     * @param moduleName module name.
+     * @return {@link String} instance for the given module name.
+     */
+    protected static String getModuleConfig(String moduleName) {
+        return getModuleConfig(moduleName);
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocTestForbiddenFragments3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocTestForbiddenFragments3.java
@@ -1,0 +1,19 @@
+/*
+SummaryJavadoc
+violateExecutionOnNonTightHtml = (default)false
+forbiddenSummaryFragments = .*CheckStyle$
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
+
+public class InputSummaryJavadocTestForbiddenFragments3 {
+
+    // violation below 'Forbidden summary fragment'
+    /**
+     * A simple correct Javadoc for CheckStyle.
+     */
+    void foo1() {
+    }
+}


### PR DESCRIPTION
Issue #13321: Kill mutation for SummaryJavaDocCheck-10

-----

# Check :- 
https://checkstyle.org/checks/javadoc/summaryjavadoc.html#SummaryJavadoc

-----

# Mutation 
https://github.com/checkstyle/checkstyle/blob/aed4d3835de0da5e12c41e677e9a10be77b8a372/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L975-L1000

-----

# Explaination
Test added

-----

# Regression :- 


-----

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/61eaa69fe98585b6ee1882ca082362bc/raw/316ca02ce9fd290119d9bfc560f2b11e84a1b685/Summary.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/21e3934e85f802e2fbd48af06d122364/raw/604256badd733d8568064f371d55657c04b00dfd/test-projects-2.properties
Report label: Regression-1
