### PR TITLE
minor: remove gitkeeps that are no longer needed

### DIFF
--- a/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/.gitkeep
+++ b/src/xdocs-examples/java/com/puppycrawl/tools/checkstyle/checks/.gitkeep
@@ -1,1 +1,0 @@
-# This comment is here to avoid violations

--- a/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/.gitkeep
+++ b/src/xdocs-examples/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/.gitkeep
@@ -1,1 +1,0 @@
-# This comment is here to avoid violations

--- a/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/.gitkeep
+++ b/src/xdocs-examples/resources/com/puppycrawl/tools/checkstyle/checks/.gitkeep
@@ -1,1 +1,0 @@
-# This comment is here to avoid violations


### PR DESCRIPTION
We no longer need those `gitkeep`s since the directories have other files in them.
