### PR TITLE
Issue #13672: Kill mutation for SummaryJavaDocCheck-11

### DIFF
--- a/config/checker-framework-suppressions/checker-index-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-index-suppressions.xml
@@ -1679,17 +1679,6 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java</fileName>
-    <specifier>array.access.unsafe.high</specifier>
-    <message>Potentially unsafe array access: the index could be larger than the array&apos;s bound</message>
-    <lineContent>final DetailNode child = children[i];</lineContent>
-    <details>
-      found   : int
-      required: @IndexFor(&quot;children&quot;) or @LTLengthOf(&quot;children&quot;) -- an integer less than children&apos;s length
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java</fileName>
     <specifier>array.access.unsafe.high.constant</specifier>
     <message>Potentially unsafe array access: the constant index 0 could be larger than the array&apos;s bound</message>
     <lineContent>&amp;&amp; node.getChildren()[0].getChildren().length &gt; 1) {</lineContent>

--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -816,14 +816,14 @@
 
 
 
-  <mutation unstable="false">
-    <sourceFile>SummaryJavadocCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck</mutatedClass>
-    <mutatedMethod>startsWithInheritDoc</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>for (int i = 0; !found; i++) {</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
 
 

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck.java
@@ -512,15 +512,14 @@ public class SummaryJavadocCheck extends AbstractJavadocCheck {
      */
     private static boolean startsWithInheritDoc(DetailNode root) {
         boolean found = false;
-        final DetailNode[] children = root.getChildren();
 
-        for (int i = 0; !found; i++) {
-            final DetailNode child = children[i];
+        for (DetailNode child : root.getChildren()) {
             if (child.getType() == JavadocTokenTypes.JAVADOC_INLINE_TAG
                     && child.getChildren()[1].getType() == JavadocTokenTypes.INHERIT_DOC_LITERAL) {
                 found = true;
             }
-            else if (child.getType() != JavadocTokenTypes.LEADING_ASTERISK
+            if ((child.getType() == JavadocTokenTypes.TEXT
+                    || child.getType() == JavadocTokenTypes.HTML_ELEMENT)
                     && !CommonUtil.isBlank(child.getText())) {
                 break;
             }

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
@@ -313,4 +313,14 @@ public class SummaryJavadocCheckTest extends AbstractModuleTestSupport {
         verifyWithInlineConfigParser(
                 getPath("InputSummaryJavadoc1.java"), expected);
     }
+
+    @Test
+    public void testInheritDoc() throws Exception {
+        final String[] expected = {
+            "14: " + getCheckMessage(MSG_SUMMARY_FIRST_SENTENCE),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputSummaryJavadocInheritDoc.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInheritDoc.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInheritDoc.java
@@ -1,0 +1,16 @@
+/*
+SummaryJavadoc
+violateExecutionOnNonTightHtml = (default)false
+forbiddenSummaryFragments = (default)^$
+period = (default).
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
+
+public class InputSummaryJavadocInheritDoc {
+
+    /** <h1> Some header </h1> {@inheritDoc} {@code bar1} text*/
+    void bar2() {} // violation above 'First sentence of Javadoc is missing an ending period'
+}


### PR DESCRIPTION
Issue #13672: Kill mutation for SummaryJavaDocCheck-11

-----

# Check :- 
https://checkstyle.org/checks/javadoc/summaryjavadoc.html#SummaryJavadoc

-----

# Mutation 
https://github.com/checkstyle/checkstyle/blob/3d8ed42ab60c0399550b3e7d54ca9dd767583101/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L912-L919

-----

# Explaination

The mutation is `for (int i = 0; !found; i++) {` to change !found == true which has been into for each loop and after making this changes The coverage of code will be missing as https://github.com/checkstyle/checkstyle/pull/13329#issuecomment-1616684730 looks like https://github.com/checkstyle/checkstyle/pull/13329#discussion_r1288190352. 

basically the extra code that has been changed is for the pattern like 
```
    /** <h1> Some header </h1> {@inheritDoc} {@code bar1} text*/
    void bar2() {}
```
and 
```
         /**
          * mm{@inheritDoc}
          */
         void foo7() {}
```

where their is some text before `{@inheritDoc}` so 
instead of checking every node as per old code.
```
else if (child.getType() != JavadocTokenTypes.LEADING_ASTERISK
                    && !CommonUtil.isBlank(child.getText())) {
```
we can only check for 
```
if ((child.getType() == JavadocTokenTypes.TEXT
                    || child.getType() == JavadocTokenTypes.HTML_ELEMENT)
```
as per AST they are the only two possible token in which their may be a extra text before `{@inheritDoc}`
using this we can get the code coverage as well mutation coverage 
   
-----

# Regression :- 


-----

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/61eaa69fe98585b6ee1882ca082362bc/raw/316ca02ce9fd290119d9bfc560f2b11e84a1b685/Summary.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/21e3934e85f802e2fbd48af06d122364/raw/604256badd733d8568064f371d55657c04b00dfd/test-projects-2.properties
Report label: Report-2