### PR TITLE
Issue #13321: Kill mutation for SummaryJavaDocCheck-12

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -967,14 +967,14 @@
     <lineContent>for (int i = 0; !found; i++) {</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>SummaryJavadocCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.SummaryJavadocCheck</mutatedClass>
-    <mutatedMethod>validateInlineReturnTag</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheck::getVisibleContent with argument</description>
-    <lineContent>final String returnVisible = getVisibleContent(inlineReturn);</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
 
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/SummaryJavadocCheckTest.java
@@ -201,6 +201,16 @@ public class SummaryJavadocCheckTest extends AbstractModuleTestSupport {
     }
 
     @Test
+    public void testInlineReturn2() throws Exception {
+        final String[] expected = {
+            "15: " + getCheckMessage(MSG_SUMMARY_JAVADOC_MISSING),
+        };
+
+        verifyWithInlineConfigParser(
+                getPath("InputSummaryJavadocInlineReturn2.java"), expected);
+    }
+
+    @Test
     public void testInlineReturnForbidden() throws Exception {
         final String[] expected = {
             "14: " + getCheckMessage(MSG_SUMMARY_JAVADOC),

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturn2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/summaryjavadoc/InputSummaryJavadocInlineReturn2.java
@@ -1,0 +1,20 @@
+/*
+SummaryJavadoc
+violateExecutionOnNonTightHtml = (default)false
+forbiddenSummaryFragments = (default)^$
+period = (default).
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.summaryjavadoc;
+
+class InputSummaryJavadocInlineReturn2 {
+
+    /**
+     * // violation below 'Summary javadoc is missing.'
+     * {@return <p></p>}
+     */
+    int returnNothing() {
+        return 0;
+    }
+}


### PR DESCRIPTION
Issue #13321: Kill mutation for SummaryJavaDocCheck-12

-----

# Check :- 
https://checkstyle.org/checks/javadoc/summaryjavadoc.html#SummaryJavadoc

-----

# Mutation 
https://github.com/checkstyle/checkstyle/blob/82589c1736430393bb3a04ebb575839952445c04/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L970-L977

-----

# Explaination
Test added
