### PR TITLE
Issue #13328: Kill mutation ImportOrderCheck  

### DIFF
--- a/config/pitest-suppressions/pitest-imports-suppressions.xml
+++ b/config/pitest-suppressions/pitest-imports-suppressions.xml
@@ -54,14 +54,14 @@
 
 
 
-  <mutation unstable="false">
-    <sourceFile>ImportOrderCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck</mutatedClass>
-    <mutatedMethod>beginTree</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable lastImportStatic</description>
-    <lineContent>lastImportStatic = false;</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>ImportOrderCheck.java</sourceFile>

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderBeginTree.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/imports/importorder/InputImportOrderBeginTree.java
@@ -1,0 +1,6 @@
+package com.puppycrawl.tools.checkstyle.checks.imports.importorder;
+
+import static java.io.IOException.*; // ok
+
+public class InputImportOrderBeginTree {
+}


### PR DESCRIPTION
Issue #13328: Kill mutation ImportOrderCheck  

--------------

# Check 
https://checkstyle.org/checks/imports/importorder.html#ImportOrder

------------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/b8915dab95432f57df7218f4f16ef7306e049e54/config/pitest-suppressions/pitest-imports-suppressions.xml#L57-L64

--------------

# Explaination 
begin tree always reset data. for `lastImportStatic = false` so we need to create two input somehow lastImportStatic become true while the sequentially second file will be come in process and that is easy we only have to set last import of first file as true.

lets start from visitToken
In visit token the parameter `isStatic` will check wether the current import is static or not.
https://github.com/checkstyle/checkstyle/blob/b8915dab95432f57df7218f4f16ef7306e049e54/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java#L800-L810

To move further 
all the condition 
https://github.com/checkstyle/checkstyle/blob/b8915dab95432f57df7218f4f16ef7306e049e54/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java#L814-L825

call `doVisitToken` know our target is to check that output get affected if remove `lastimportStatic` from beginTree 
https://github.com/checkstyle/checkstyle/blob/b8915dab95432f57df7218f4f16ef7306e049e54/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java#L845

know in `doVisitToken` only 2 parameter is iportant for us `isStatic` and `previous` 
https://github.com/checkstyle/checkstyle/blob/b8915dab95432f57df7218f4f16ef7306e049e54/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java#L815-L816
https://github.com/checkstyle/checkstyle/blob/b8915dab95432f57df7218f4f16ef7306e049e54/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java#L818-L820

because they and the reason is they are only one right know which related with `lastimportstatic` and violation throwing 
and in the whole method previous is used only at 
https://github.com/checkstyle/checkstyle/blob/b8915dab95432f57df7218f4f16ef7306e049e54/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java#L856-L858

know this condition is not big deal we can execute that and if we look closure on https://github.com/checkstyle/checkstyle/blob/b8915dab95432f57df7218f4f16ef7306e049e54/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java#L923 this will execute when https://github.com/checkstyle/checkstyle/blob/b8915dab95432f57df7218f4f16ef7306e049e54/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java#L925 which is by default true so that is not issue in that if never execute because in from visittoken condition.

know in else either https://github.com/checkstyle/checkstyle/blob/b8915dab95432f57df7218f4f16ef7306e049e54/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java#L936 
needs to be true or in that either https://github.com/checkstyle/checkstyle/blob/b8915dab95432f57df7218f4f16ef7306e049e54/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java#L940-L942 
this is need to be true


**case 1**
lets see the previous first we know that we need previos true and 
https://github.com/checkstyle/checkstyle/blob/b8915dab95432f57df7218f4f16ef7306e049e54/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java#L814-L817

lets suppose we set option as above so previous import needs to be nonStatic and current ast need to be static so from here it is for sure that
we want previous as true `previous = true` know suppose option is set to be true so previous value is comming from visitToken so we need top set `isStatic = false` and `lastimportStatic = true` so in previous file lastimportstatic needs to be non static it means false then if it already same then no need to be reset so begin tree is redundant.

know lets suppose option is set to Bottom or under
https://github.com/checkstyle/checkstyle/blob/b8915dab95432f57df7218f4f16ef7306e049e54/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java#L818-L821

in this case to set previous true we need to set `lastimportstatic = true` mean previous file import needs to be static and in current file ast needs to be non static it means `isStatic=fasle` and `isLastImport=true` in this case https://github.com/checkstyle/checkstyle/blob/b8915dab95432f57df7218f4f16ef7306e049e54/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java#L856-L858 this never will be equal so conditon will never execute

this is alsosimilar if both are static 

so no test cases looks possible to clear the state using input 

--------------------------------------

# Regression 

Report-1 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/920122e_2023074505/reports/diff/index.html

Report-2 :- https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/920122e_2023090228/reports/diff/index.html

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/e3a00111b4bb7b8c054483466b88606d/raw/4895c88b1daf686479058c972bad0c27cd0818ef/IOC.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: new-Regression-1