### PR TITLE
Issue #13321: Kill mutation for JavadocMethod-1

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheck.java
@@ -690,11 +690,6 @@ public class JavadocMethodCheck extends AbstractCheck {
     }
 
     @Override
-    public void beginTree(DetailAST rootAST) {
-        currentClassName = "";
-    }
-
-    @Override
     public final void visitToken(DetailAST ast) {
         if (ast.getType() == TokenTypes.CLASS_DEF
                  || ast.getType() == TokenTypes.INTERFACE_DEF


### PR DESCRIPTION
Issue #13321: Kill mutation for JavadocMethod-1

-----

# Check :- 
https://checkstyle.org/checks/javadoc/javadocmethod.html#JavadocMethod

-----

# Mutation 
https://github.com/checkstyle/checkstyle/blob/fa39b3e147fd32c6b6e96f7a2c04443ad7199857/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L93-L100

-----

# Explaination
Reset by leaveToken

-----

# Regression :- 

https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/be97aac_2023225354/reports/diff/index.html

https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/be97aac_2023060414/reports/diff/index.html

-----

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/df2ff7a8f9969bb2c68d7251a97ffa8b/raw/6a4e81a624fa36483f23b0adcf1fc513ca6df350/JavadocMethod.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Regression-2

