### PR TITLE
Issue #13321: Kill mutation for JavadocMethod-2

### DIFF
--- a/config/pitest-suppressions/pitest-javadoc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-javadoc-suppressions.xml
@@ -99,14 +99,14 @@
     <lineContent>currentClassName = &quot;&quot;;</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>JavadocMethodCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck</mutatedClass>
-    <mutatedMethod>checkComment</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getLineNo</description>
-    <lineContent>checkReturnTag(tags, ast.getLineNo(), true);</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>JavadocMethodCheck.java</sourceFile>
@@ -135,14 +135,14 @@
     <lineContent>final Token token = new Token(tag.getFirstArg(), tag.getLineNo(), tag</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>JavadocMethodCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck</mutatedClass>
-    <mutatedMethod>checkThrowsTags</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.RemoveConditionalMutator_EQUAL_IF</mutator>
-    <description>removed conditional - replaced equality check with true</description>
-    <lineContent>if (validateThrows &amp;&amp; reportExpectedTags) {</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>JavadocMethodCheck.java</sourceFile>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocMethodCheckTest.java
@@ -496,4 +496,30 @@ public class JavadocMethodCheckTest extends AbstractModuleTestSupport {
         verifyWithInlineConfigParser(
             getPath("InputJavadocMethodCustomMessage.java"), expected);
     }
+
+    @Test
+    public void test1() throws Exception {
+        final String[] expected = {
+            "23: " + getCheckMessage(MSG_RETURN_EXPECTED),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocMethod1.java"), expected);
+    }
+
+    @Test
+    public void test2() throws Exception {
+        final String[] expected = {
+            "15:8: " + getCheckMessage(MSG_UNUSED_TAG, "@param", "<"),
+            "19:13: " + getCheckMessage(MSG_EXPECTED_TAG, "@param", "<X>"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocMethod2.java"), expected);
+    }
+
+    @Test
+    public void test3() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getPath("InputJavadocMethod3.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod1.java
@@ -1,0 +1,24 @@
+/*
+JavadocMethod
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
+
+/**
+ * @deprecated stuff
+ */
+public class InputJavadocMethod1 {
+}
+
+/**
+ * @deprecated stuff
+ */
+@interface Bleh {
+
+    /**
+     * @deprecated stuff
+     */
+    int method(); // violation '@return tag should be present and have description'
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod2.java
@@ -1,0 +1,22 @@
+/*
+JavadocMethod
+
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
+
+public class InputJavadocMethod2 {
+
+    // violation 4 lines below 'Unused @param tag for '<''
+    /**
+     * Some explanation.
+     *
+     * @param < X >  A type param
+     * @param <Y1> Another type param
+     * @return a string
+     */
+    public <X, Y1> String doSomething() { // violation 'Expected @param tag for '<X>''
+        return null;
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod3.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/javadoc/javadocmethod/InputJavadocMethod3.java
@@ -1,0 +1,46 @@
+/*
+JavadocMethod
+validateThrows = true
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.javadoc.javadocmethod;
+
+// ok
+interface Input {
+
+    void setHeader(String header);
+}
+
+public class InputJavadocMethod3 implements Input {
+
+    /**
+     * Setter to define the required header specified inline.
+     * Individual header lines must be separated by the string {@code "\n"}
+     * (even on platforms with a different line separator).
+     * For header lines containing {@code "\n\n"} checkstyle will forcefully
+     * expect an empty line to exist. See examples below.
+     * Regular expressions must not span multiple lines.
+     *
+     * @param header the header value to validate and set (in that order)
+     */
+    @Override
+    public void setHeader(String header) {
+        if (!CommonUtil.isBlank(header)) {
+            if (!CommonUtil.isPatternValid(header)) {
+                throw new IllegalArgumentException("Unable to parse format: " + header);
+            }
+        }
+    }
+}
+
+class CommonUtil {
+
+    public static boolean isBlank(String header) {
+        return false;
+    }
+
+    public static boolean isPatternValid(String header) {
+        return false;
+    }
+}


### PR DESCRIPTION
Issue #13321: Kill mutation for JavadocMethod-2

-----

# Check :- 
https://checkstyle.org/checks/javadoc/javadocmethod.html#JavadocMethod

-----

# Mutation 
https://github.com/checkstyle/checkstyle/blob/73ec12d6960f417c5f84c079773702724af7430a/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L102-L109
and 
https://github.com/checkstyle/checkstyle/blob/73ec12d6960f417c5f84c079773702724af7430a/config/pitest-suppressions/pitest-javadoc-suppressions.xml#L138-L145

-----

# Explaination
Test added

-----

# Regression :- 


-----

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/df2ff7a8f9969bb2c68d7251a97ffa8b/raw/6a4e81a624fa36483f23b0adcf1fc513ca6df350/JavadocMethod.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/21e3934e85f802e2fbd48af06d122364/raw/604256badd733d8568064f371d55657c04b00dfd/test-projects-2.properties
Report label: Regression-1

