### PR TITLE
infra: migrate jdk14 package-site to jdk17

### DIFF
--- a/.ci/validation.sh
+++ b/.ci/validation.sh
@@ -594,7 +594,7 @@ javac19)
   fi
   ;;
 
-jdk14-assembly-site)
+package-site)
   mvn -e --no-transfer-progress package -Passembly,no-validations
   mvn -e --no-transfer-progress site -Pno-validations
   ;;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,9 +282,9 @@ workflows:
   site-validation:
     jobs:
       - validate-with-maven-script:
-          name: "jdk14-assembly-site"
-          image-name: "cimg/openjdk:14.0.2"
-          command: "./.ci/validation.sh jdk14-assembly-site"
+          name: "jdk17-assembly-site"
+          image-name: "cimg/openjdk:17.0"
+          command: "./.ci/validation.sh package-site"
       - validate-with-maven-script:
           name: "assembly-site"
           image-name: *custom_img


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/checkstyle/checkstyle/19401/workflows/9a79a9f1-33ed-49cb-9df2-bfc1912c54e7/jobs/327834?invite=true#step-103-82

`[ERROR] Failed to execute goal org.jacoco:jacoco-maven-plugin:0.8.8:instrument (default-instrument) on project checkstyle: Execution default-instrument of goal org.jacoco:jacoco-maven-plugin:0.8.8:instrument failed: Plugin org.jacoco:jacoco-maven-plugin:0.8.8 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.shared:maven-shared-io:jar:1.1 from/to central (https://repo.maven.apache.org/maven2): transfer failed for https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-io/1.1/maven-shared-io-1.1.jar: Connection reset -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.jacoco:jacoco-maven-plugin:0.8.8:instrument (default-instrument) on project checkstyle: Execution default-instrument of goal org.jacoco:jacoco-maven-plugin:0.8.8:instrument failed: Plugin org.jacoco:jacoco-maven-plugin:0.8.8 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.shared:maven-shared-io:jar:1.1 from/to central (https://repo.maven.apache.org/maven2): transfer failed for https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-io/1.1/maven-shared-io-1.1.jar`

https://circleci.com/developer/images/image/cimg/openjdk?psafe_param=1&utm_source=google&utm_medium=sem&utm_campaign=sem-google-dg--uscan-en-dsa-tROAS-auth-brand&utm_term=g_-_c__dsa_&utm_content=&gclid=EAIaIQobChMI3JHy243z_wIVDh6tBh1oBw9dEAAYASAAEgLWUPD_BwE

