### PR TITLE
Pull #13362: Restore xdoc-javadoc validation

### DIFF
--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/coding/IllegalTypeCheck.java
@@ -44,9 +44,10 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * </p>
  * <p>
  * For additional restriction of type usage see also:
- * <a href="https://checkstyle.org/checks/coding/illegalinstantiation.html">
+ * <a href="https://checkstyle.org/checks/coding/illegalinstantiation.html#IllegalInstantiation">
  * IllegalInstantiation</a>,
- * <a href="https://checkstyle.org/checks/imports/illegalimport.html">IllegalImport</a>
+ * <a href="https://checkstyle.org/checks/imports/illegalimport.html#IllegalImport">
+ * IllegalImport</a>
  * </p>
  * <p>
  * It is possible to set illegal class names via short or

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/header/RegexpHeaderCheck.java
@@ -38,7 +38,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * pattern</a> for each line of the source header.
  * </p>
  * <p>
- * Rationale: In some projects <a href="https://checkstyle.org/checks/header/header.html">
+ * Rationale: In some projects <a href="https://checkstyle.org/checks/header/header.html#Header">
  * checking against a fixed header</a> is not sufficient, e.g. the header might
  * require a copyright line where the year information is not static.
  * </p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/imports/ImportOrderCheck.java
@@ -282,7 +282,8 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </li>
  * </ul>
  * <p>
- * Note: a <a href="https://checkstyle.org/filters/suppressionxpathsinglefilter.html">
+ * Note: a
+ * <a href="https://checkstyle.org/filters/suppressionxpathsinglefilter.html#SuppressionXpathSingleFilter">
  * suppression xpath single filter</a> is needed because
  * IDEA has no blank line between "javax" and "java".
  * ImportOrder has a limitation by design to enforce an empty line between groups ("java", "javax").

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocContentLocationCheck.java
@@ -62,7 +62,7 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * This check does not validate the Javadoc summary itself nor its presence.
  * The check will not report any violations for missing or malformed javadoc summary.
  * To validate the Javadoc summary use
- * <a href="https://checkstyle.org/checks/javadoc/summaryjavadoc.html">
+ * <a href="https://checkstyle.org/checks/javadoc/summaryjavadoc.html#SummaryJavadoc">
  * SummaryJavadoc</a> check.
  * </p>
  * <p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/ClassMemberImpliedModifierCheck.java
@@ -32,7 +32,7 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * </p>
  * <p>
  * This check is effectively the opposite of
- * <a href="https://checkstyle.org/checks/modifier/redundantmodifier.html">
+ * <a href="https://checkstyle.org/checks/modifier/redundantmodifier.html#RedundantModifier">
  * RedundantModifier</a>.
  * It checks the modifiers on nested types in classes and records, ensuring that certain modifiers
  * are explicitly specified even though they are actually redundant.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/modifier/InterfaceMemberImpliedModifierCheck.java
@@ -31,7 +31,7 @@ import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
  * </p>
  * <p>
  * This check is effectively the opposite of
- * <a href="https://checkstyle.org/checks/modifier/redundantmodifier.html">
+ * <a href="https://checkstyle.org/checks/modifier/redundantmodifier.html#RedundantModifier">
  * RedundantModifier</a>.
  * It checks the modifiers on interface members, ensuring that certain modifiers are explicitly
  * specified even though they are actually redundant.

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/naming/ParameterNameCheck.java
@@ -34,12 +34,12 @@ import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
  * </p>
  * <p>
  * To validate {@code catch} parameters please use
- * <a href="https://checkstyle.org/checks/naming/catchparametername.html">
+ * <a href="https://checkstyle.org/checks/naming/catchparametername.html#CatchParameterName">
  * CatchParameterName</a>.
  * </p>
  * <p>
  * To validate lambda parameters please use
- * <a href="https://checkstyle.org/checks/naming/lambdaparametername.html">
+ * <a href="https://checkstyle.org/checks/naming/lambdaparametername.html#LambdaParameterName">
  * LambdaParameterName</a>.
  * </p>
  * <ul>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpCheck.java
@@ -37,7 +37,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </p>
  * <p>
  * This check combines all the functionality provided by
- * <a href="https://checkstyle.org/checks/header/regexpheader.html">RegexpHeader</a>
+ * <a href="https://checkstyle.org/checks/header/regexpheader.html#RegexpHeader">RegexpHeader</a>
  * except supplying the regular expression from a file.
  * </p>
  * <p>
@@ -248,7 +248,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * &lt;/module&gt;
  * </pre>
  * <p>
- * <b>To use like <a href="https://checkstyle.org/checks/header/regexpheader.html">
+ * <b>To use like <a href="https://checkstyle.org/checks/header/regexpheader.html#RegexpHeader">
  * RegexpHeader</a>:</b>
  * </p>
  * <p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/regexp/RegexpSinglelineJavaCheck.java
@@ -32,7 +32,8 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * </p>
  * <p>
  * This class is variation on
- * <a href="https://checkstyle.org/checks/regexp/regexpsingleline.html">RegexpSingleline</a>
+ * <a href="https://checkstyle.org/checks/regexp/regexpsingleline.html#RegexpSingleline">
+ * RegexpSingleline</a>
  * for detecting single-lines that match a supplied regular expression in Java files.
  * It supports suppressing matches in Java comments.
  * </p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/ParenPadCheck.java
@@ -35,12 +35,12 @@ import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
  * the right parenthesis of a try-with-resources resource specification where
  * the last resource variable has a trailing semicolon.
  * Use Check
- * <a href="https://checkstyle.org/checks/whitespace/emptyforiteratorpad.html">
+ * <a href="https://checkstyle.org/checks/whitespace/emptyforiteratorpad.html#EmptyForIteratorPad">
  * EmptyForIteratorPad</a> to validate empty for iterators and
- * <a href="https://checkstyle.org/checks/whitespace/emptyforinitializerpad.html">
+ * <a href="https://checkstyle.org/checks/whitespace/emptyforinitializerpad.html#EmptyForInitializerPad">
  * EmptyForInitializerPad</a> to validate empty for initializers.
  * Typecasts are also not checked, as there is
- * <a href="https://checkstyle.org/checks/whitespace/typecastparenpad.html">
+ * <a href="https://checkstyle.org/checks/whitespace/typecastparenpad.html#TypecastParenPad">
  * TypecastParenPad</a> to validate them.
  * </p>
  * <ul>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAfterCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/whitespace/WhitespaceAfterCheck.java
@@ -30,7 +30,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * Checks that a token is followed by whitespace, with the exception that it
  * does not check for whitespace after the semicolon of an empty for iterator.
  * Use Check
- * <a href="https://checkstyle.org/checks/whitespace/emptyforiteratorpad.html">
+ * <a href="https://checkstyle.org/checks/whitespace/emptyforiteratorpad.html#EmptyForIteratorPad">
  * EmptyForIteratorPad</a> to validate empty for iterators.
  * </p>
  * <ul>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWarningsFilter.java
@@ -37,7 +37,7 @@ import com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder;
  * </p>
  * <p>
  * Usage: This filter only works in conjunction with a
- * <a href="https://checkstyle.org/checks/annotation/suppresswarningsholder.html">
+ * <a href="https://checkstyle.org/checks/annotation/suppresswarningsholder.html#SuppressWarningsHolder">
  * SuppressWarningsHolder</a>,
  * since that check finds the annotations in the Java files and makes them available for the filter.
  * Because of that, a configuration that includes this filter must also include

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressWithNearbyCommentFilter.java
@@ -51,7 +51,8 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * Attention: This filter may only be specified within the TreeWalker module
  * ({@code &lt;module name="TreeWalker"/&gt;}) and only applies to checks which are also
  * defined within this module. To filter non-TreeWalker checks like {@code RegexpSingleline},
- * a <a href="https://checkstyle.org/filters/suppresswithplaintextcommentfilter.html">
+ * a
+ * <a href="https://checkstyle.org/filters/suppresswithplaintextcommentfilter.html#SuppressWithPlainTextCommentFilter">
  * SuppressWithPlainTextCommentFilter</a> or similar filter must be used.
  * </p>
  * <p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionCommentFilter.java
@@ -59,7 +59,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  * Attention: This filter may only be specified within the TreeWalker module
  * ({@code &lt;module name="TreeWalker"/&gt;}) and only applies to checks which are also
  * defined within this module. To filter non-TreeWalker checks like {@code RegexpSingleline}, a
- * <a href="https://checkstyle.org/filters/suppresswithplaintextcommentfilter.html">
+ * <a href="https://checkstyle.org/filters/suppresswithplaintextcommentfilter.html#SuppressWithPlainTextCommentFilter">
  * SuppressWithPlainTextCommentFilter</a> or similar filter must be used.
  * </p>
  * <p>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/filters/SuppressionXpathFilter.java
@@ -34,7 +34,8 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
 /**
  * <p>
  * Filter {@code SuppressionXpathFilter} works as
- * <a href="https://checkstyle.org/filters/suppressionfilter.html">SuppressionFilter</a>.
+ * <a href="https://checkstyle.org/filters/suppressionfilter.html#SuppressionFilter">
+ * SuppressionFilter</a>.
  * Additionally, filter processes {@code suppress-xpath} elements,
  * which contains xpath-expressions. Xpath-expressions are queries for
  * suppressed nodes inside the AST tree.
@@ -42,7 +43,7 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * <p>
  * Currently, filter does not support the following checks:
  * </p>
- * <ul id="SuppressionXpathFilter_IncompatibleChecks">
+ * <ul id="IncompatibleChecks">
  * <li>
  * NoCodeInFile (reason is that AST is not generated for a file not containing code)
  * </li>
@@ -58,7 +59,7 @@ import com.puppycrawl.tools.checkstyle.utils.FilterUtil;
  * <p>
  * Also, the filter does not support suppressions inside javadoc reported by Javadoc checks:
  * </p>
- * <ul id="SuppressionXpathFilter_JavadocChecks">
+ * <ul id="JavadocChecks">
  * <li>
  * AtclauseOrder
  * </li>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/IllegalTypeCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/coding/IllegalTypeCheck.xml
@@ -12,9 +12,10 @@
  &lt;/p&gt;
  &lt;p&gt;
  For additional restriction of type usage see also:
- &lt;a href="https://checkstyle.org/checks/coding/illegalinstantiation.html"&gt;
+ &lt;a href="https://checkstyle.org/checks/coding/illegalinstantiation.html#IllegalInstantiation"&gt;
  IllegalInstantiation&lt;/a&gt;,
- &lt;a href="https://checkstyle.org/checks/imports/illegalimport.html"&gt;IllegalImport&lt;/a&gt;
+ &lt;a href="https://checkstyle.org/checks/imports/illegalimport.html#IllegalImport"&gt;
+ IllegalImport&lt;/a&gt;
  &lt;/p&gt;
  &lt;p&gt;
  It is possible to set illegal class names via short or

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/header/RegexpHeaderCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/header/RegexpHeaderCheck.xml
@@ -10,7 +10,7 @@
  pattern&lt;/a&gt; for each line of the source header.
  &lt;/p&gt;
  &lt;p&gt;
- Rationale: In some projects &lt;a href="https://checkstyle.org/checks/header/header.html"&gt;
+ Rationale: In some projects &lt;a href="https://checkstyle.org/checks/header/header.html#Header"&gt;
  checking against a fixed header&lt;/a&gt; is not sufficient, e.g. the header might
  require a copyright line where the year information is not static.
  &lt;/p&gt;

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocContentLocationCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/javadoc/JavadocContentLocationCheck.xml
@@ -37,7 +37,7 @@
  This check does not validate the Javadoc summary itself nor its presence.
  The check will not report any violations for missing or malformed javadoc summary.
  To validate the Javadoc summary use
- &lt;a href="https://checkstyle.org/checks/javadoc/summaryjavadoc.html"&gt;
+ &lt;a href="https://checkstyle.org/checks/javadoc/summaryjavadoc.html#SummaryJavadoc"&gt;
  SummaryJavadoc&lt;/a&gt; check.
  &lt;/p&gt;
  &lt;p&gt;

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/modifier/ClassMemberImpliedModifierCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/modifier/ClassMemberImpliedModifierCheck.xml
@@ -9,7 +9,7 @@
  &lt;/p&gt;
  &lt;p&gt;
  This check is effectively the opposite of
- &lt;a href="https://checkstyle.org/checks/modifier/redundantmodifier.html"&gt;
+ &lt;a href="https://checkstyle.org/checks/modifier/redundantmodifier.html#RedundantModifier"&gt;
  RedundantModifier&lt;/a&gt;.
  It checks the modifiers on nested types in classes and records, ensuring that certain modifiers
  are explicitly specified even though they are actually redundant.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/modifier/InterfaceMemberImpliedModifierCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/modifier/InterfaceMemberImpliedModifierCheck.xml
@@ -9,7 +9,7 @@
  &lt;/p&gt;
  &lt;p&gt;
  This check is effectively the opposite of
- &lt;a href="https://checkstyle.org/checks/modifier/redundantmodifier.html"&gt;
+ &lt;a href="https://checkstyle.org/checks/modifier/redundantmodifier.html#RedundantModifier"&gt;
  RedundantModifier&lt;/a&gt;.
  It checks the modifiers on interface members, ensuring that certain modifiers are explicitly
  specified even though they are actually redundant.

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/naming/ParameterNameCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/naming/ParameterNameCheck.xml
@@ -11,12 +11,12 @@
  &lt;/p&gt;
  &lt;p&gt;
  To validate {@code catch} parameters please use
- &lt;a href="https://checkstyle.org/checks/naming/catchparametername.html"&gt;
+ &lt;a href="https://checkstyle.org/checks/naming/catchparametername.html#CatchParameterName"&gt;
  CatchParameterName&lt;/a&gt;.
  &lt;/p&gt;
  &lt;p&gt;
  To validate lambda parameters please use
- &lt;a href="https://checkstyle.org/checks/naming/lambdaparametername.html"&gt;
+ &lt;a href="https://checkstyle.org/checks/naming/lambdaparametername.html#LambdaParameterName"&gt;
  LambdaParameterName&lt;/a&gt;.
  &lt;/p&gt;</description>
          <properties>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/regexp/RegexpCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/regexp/RegexpCheck.xml
@@ -10,7 +10,7 @@
  &lt;/p&gt;
  &lt;p&gt;
  This check combines all the functionality provided by
- &lt;a href="https://checkstyle.org/checks/header/regexpheader.html"&gt;RegexpHeader&lt;/a&gt;
+ &lt;a href="https://checkstyle.org/checks/header/regexpheader.html#RegexpHeader"&gt;RegexpHeader&lt;/a&gt;
  except supplying the regular expression from a file.
  &lt;/p&gt;
  &lt;p&gt;

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/regexp/RegexpSinglelineJavaCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/regexp/RegexpSinglelineJavaCheck.xml
@@ -9,7 +9,8 @@
  &lt;/p&gt;
  &lt;p&gt;
  This class is variation on
- &lt;a href="https://checkstyle.org/checks/regexp/regexpsingleline.html"&gt;RegexpSingleline&lt;/a&gt;
+ &lt;a href="https://checkstyle.org/checks/regexp/regexpsingleline.html#RegexpSingleline"&gt;
+ RegexpSingleline&lt;/a&gt;
  for detecting single-lines that match a supplied regular expression in Java files.
  It supports suppressing matches in Java comments.
  &lt;/p&gt;</description>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/whitespace/ParenPadCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/whitespace/ParenPadCheck.xml
@@ -12,12 +12,12 @@
  the right parenthesis of a try-with-resources resource specification where
  the last resource variable has a trailing semicolon.
  Use Check
- &lt;a href="https://checkstyle.org/checks/whitespace/emptyforiteratorpad.html"&gt;
+ &lt;a href="https://checkstyle.org/checks/whitespace/emptyforiteratorpad.html#EmptyForIteratorPad"&gt;
  EmptyForIteratorPad&lt;/a&gt; to validate empty for iterators and
- &lt;a href="https://checkstyle.org/checks/whitespace/emptyforinitializerpad.html"&gt;
+ &lt;a href="https://checkstyle.org/checks/whitespace/emptyforinitializerpad.html#EmptyForInitializerPad"&gt;
  EmptyForInitializerPad&lt;/a&gt; to validate empty for initializers.
  Typecasts are also not checked, as there is
- &lt;a href="https://checkstyle.org/checks/whitespace/typecastparenpad.html"&gt;
+ &lt;a href="https://checkstyle.org/checks/whitespace/typecastparenpad.html#TypecastParenPad"&gt;
  TypecastParenPad&lt;/a&gt; to validate them.
  &lt;/p&gt;</description>
          <properties>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/whitespace/WhitespaceAfterCheck.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/checks/whitespace/WhitespaceAfterCheck.xml
@@ -8,7 +8,7 @@
  Checks that a token is followed by whitespace, with the exception that it
  does not check for whitespace after the semicolon of an empty for iterator.
  Use Check
- &lt;a href="https://checkstyle.org/checks/whitespace/emptyforiteratorpad.html"&gt;
+ &lt;a href="https://checkstyle.org/checks/whitespace/emptyforiteratorpad.html#EmptyForIteratorPad"&gt;
  EmptyForIteratorPad&lt;/a&gt; to validate empty for iterators.
  &lt;/p&gt;</description>
          <properties>

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressWarningsFilter.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressWarningsFilter.xml
@@ -16,7 +16,7 @@
  &lt;/p&gt;
  &lt;p&gt;
  Usage: This filter only works in conjunction with a
- &lt;a href="https://checkstyle.org/checks/annotation/suppresswarningsholder.html"&gt;
+ &lt;a href="https://checkstyle.org/checks/annotation/suppresswarningsholder.html#SuppressWarningsHolder"&gt;
  SuppressWarningsHolder&lt;/a&gt;,
  since that check finds the annotations in the Java files and makes them available for the filter.
  Because of that, a configuration that includes this filter must also include

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressWithNearbyCommentFilter.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressWithNearbyCommentFilter.xml
@@ -17,7 +17,8 @@
  Attention: This filter may only be specified within the TreeWalker module
  ({@code &amp;lt;module name="TreeWalker"/&amp;gt;}) and only applies to checks which are also
  defined within this module. To filter non-TreeWalker checks like {@code RegexpSingleline},
- a &lt;a href="https://checkstyle.org/filters/suppresswithplaintextcommentfilter.html"&gt;
+ a
+ &lt;a href="https://checkstyle.org/filters/suppresswithplaintextcommentfilter.html#SuppressWithPlainTextCommentFilter"&gt;
  SuppressWithPlainTextCommentFilter&lt;/a&gt; or similar filter must be used.
  &lt;/p&gt;
  &lt;p&gt;

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressionCommentFilter.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressionCommentFilter.xml
@@ -24,7 +24,7 @@
  Attention: This filter may only be specified within the TreeWalker module
  ({@code &amp;lt;module name="TreeWalker"/&amp;gt;}) and only applies to checks which are also
  defined within this module. To filter non-TreeWalker checks like {@code RegexpSingleline}, a
- &lt;a href="https://checkstyle.org/filters/suppresswithplaintextcommentfilter.html"&gt;
+ &lt;a href="https://checkstyle.org/filters/suppresswithplaintextcommentfilter.html#SuppressWithPlainTextCommentFilter"&gt;
  SuppressWithPlainTextCommentFilter&lt;/a&gt; or similar filter must be used.
  &lt;/p&gt;
  &lt;p&gt;

--- a/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressionXpathFilter.xml
+++ b/src/main/resources/com/puppycrawl/tools/checkstyle/meta/filters/SuppressionXpathFilter.xml
@@ -6,7 +6,8 @@
               parent="com.puppycrawl.tools.checkstyle.TreeWalker">
          <description>&lt;p&gt;
  Filter {@code SuppressionXpathFilter} works as
- &lt;a href="https://checkstyle.org/filters/suppressionfilter.html"&gt;SuppressionFilter&lt;/a&gt;.
+ &lt;a href="https://checkstyle.org/filters/suppressionfilter.html#SuppressionFilter"&gt;
+ SuppressionFilter&lt;/a&gt;.
  Additionally, filter processes {@code suppress-xpath} elements,
  which contains xpath-expressions. Xpath-expressions are queries for
  suppressed nodes inside the AST tree.
@@ -14,7 +15,7 @@
  &lt;p&gt;
  Currently, filter does not support the following checks:
  &lt;/p&gt;
- &lt;ul id="SuppressionXpathFilter_IncompatibleChecks"&gt;
+ &lt;ul id="IncompatibleChecks"&gt;
  &lt;li&gt;
  NoCodeInFile (reason is that AST is not generated for a file not containing code)
  &lt;/li&gt;
@@ -30,7 +31,7 @@
  &lt;p&gt;
  Also, the filter does not support suppressions inside javadoc reported by Javadoc checks:
  &lt;/p&gt;
- &lt;ul id="SuppressionXpathFilter_JavadocChecks"&gt;
+ &lt;ul id="JavadocChecks"&gt;
  &lt;li&gt;
  AtclauseOrder
  &lt;/li&gt;

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
@@ -1,0 +1,758 @@
+///////////////////////////////////////////////////////////////////////////////////////////////
+// checkstyle: Checks Java source code and other text files for adherence to a set of rules.
+// Copyright (C) 2001-2023 the original author or authors.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+///////////////////////////////////////////////////////////////////////////////////////////////
+
+package com.puppycrawl.tools.checkstyle.internal;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import com.google.common.collect.ImmutableMap;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.Checker;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.ModuleFactory;
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.Scope;
+import com.puppycrawl.tools.checkstyle.api.SeverityLevel;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.checks.LineSeparatorOption;
+import com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck;
+import com.puppycrawl.tools.checkstyle.checks.blocks.BlockOption;
+import com.puppycrawl.tools.checkstyle.checks.blocks.LeftCurlyOption;
+import com.puppycrawl.tools.checkstyle.checks.blocks.RightCurlyOption;
+import com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderOption;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocContentLocationOption;
+import com.puppycrawl.tools.checkstyle.checks.naming.AccessModifierOption;
+import com.puppycrawl.tools.checkstyle.checks.whitespace.PadOption;
+import com.puppycrawl.tools.checkstyle.checks.whitespace.WrapOption;
+import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
+import com.puppycrawl.tools.checkstyle.internal.utils.XdocUtil;
+import com.puppycrawl.tools.checkstyle.internal.utils.XmlUtil;
+import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
+import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
+import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
+import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
+
+public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
+    private static final Map<String, Class<?>> FULLY_QUALIFIED_CLASS_NAMES =
+            ImmutableMap.<String, Class<?>>builder()
+            .put("int", int.class)
+            .put("int[]", int[].class)
+            .put("boolean", boolean.class)
+            .put("double", double.class)
+            .put("double[]", double[].class)
+            .put("String", String.class)
+            .put("String[]", String[].class)
+            .put("Pattern", Pattern.class)
+            .put("Pattern[]", Pattern[].class)
+            .put("AccessModifierOption[]", AccessModifierOption[].class)
+            .put("BlockOption", BlockOption.class)
+            .put("ClosingParensOption", AnnotationUseStyleCheck.ClosingParensOption.class)
+            .put("ElementStyleOption", AnnotationUseStyleCheck.ElementStyleOption.class)
+            .put("File", File.class)
+            .put("ImportOrderOption", ImportOrderOption.class)
+            .put("JavadocContentLocationOption", JavadocContentLocationOption.class)
+            .put("LeftCurlyOption", LeftCurlyOption.class)
+            .put("LineSeparatorOption", LineSeparatorOption.class)
+            .put("PadOption", PadOption.class)
+            .put("RightCurlyOption", RightCurlyOption.class)
+            .put("Scope", Scope.class)
+            .put("SeverityLevel", SeverityLevel.class)
+            .put("TrailingArrayCommaOption", AnnotationUseStyleCheck.TrailingArrayCommaOption.class)
+            .put("URI", URI.class)
+            .put("WrapOption", WrapOption.class)
+            .put("PARAM_LITERAL", int[].class).build();
+
+    private static final Set<String> NON_BASE_TOKEN_PROPERTIES = Collections.unmodifiableSet(
+        Arrays.stream(new String[] {
+            "AtclauseOrder - target",
+            "DescendantToken - limitedTokens",
+            "IllegalType - memberModifiers",
+            "MagicNumber - constantWaiverParentToken",
+            "MultipleStringLiterals - ignoreOccurrenceContext",
+        }).collect(Collectors.toSet()));
+
+    private static final List<List<Node>> CHECK_PROPERTIES = new ArrayList<>();
+    private static final Map<String, String> CHECK_PROPERTY_DOC = new HashMap<>();
+    private static final Map<String, String> CHECK_TEXT = new HashMap<>();
+
+    private static Checker checker;
+
+    private static String checkName;
+
+    private static Path currentXdocPath;
+
+    @Override
+    protected String getPackageLocation() {
+        return "com.puppycrawl.tools.checkstyle.internal";
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        final DefaultConfiguration checkConfig = new DefaultConfiguration(
+                JavaDocCapture.class.getName());
+        checker = createChecker(checkConfig);
+    }
+
+    /**
+     * Validates check javadocs and xdocs for consistency.
+     *
+     * @noinspection JUnitTestMethodWithNoAssertions
+     * @noinspectionreason JUnitTestMethodWithNoAssertions - asserts in callstack,
+     *      but not in this method
+     */
+    @Test
+    public void testAllCheckSectionJavaDocs() throws Exception {
+        final ModuleFactory moduleFactory = TestUtil.getPackageObjectFactory();
+
+        for (Path path : XdocUtil.getXdocsConfigFilePaths(XdocUtil.getXdocsFilePaths())) {
+            currentXdocPath = path;
+            final File file = path.toFile();
+            final String fileName = file.getName();
+
+            if ("config_system_properties.xml".equals(fileName)
+                    || "index.xml".equals(fileName)) {
+                continue;
+            }
+
+            final String input = Files.readString(path);
+            final Document document = XmlUtil.getRawXml(fileName, input, input);
+            final NodeList sources = document.getElementsByTagName("section");
+
+            for (int position = 0; position < sources.getLength(); position++) {
+                final Node section = sources.item(position);
+                final String sectionName = XmlUtil.getNameAttributeOfNode(section);
+
+                if ("Content".equals(sectionName) || "Overview".equals(sectionName)) {
+                    continue;
+                }
+
+                examineCheckSection(moduleFactory, fileName, sectionName, section);
+            }
+        }
+    }
+
+    private static void examineCheckSection(ModuleFactory moduleFactory, String fileName,
+            String sectionName, Node section) throws Exception {
+        final Object instance;
+
+        try {
+            instance = moduleFactory.createModule(sectionName);
+        }
+        catch (CheckstyleException ex) {
+            throw new CheckstyleException(fileName + " couldn't find class: " + sectionName, ex);
+        }
+
+        CHECK_TEXT.clear();
+        CHECK_PROPERTIES.clear();
+        CHECK_PROPERTY_DOC.clear();
+        checkName = sectionName;
+
+        examineCheckSectionChildren(section);
+
+        final List<File> files = new ArrayList<>();
+        files.add(new File("src/main/java/" + instance.getClass().getName().replace(".", "/")
+                + ".java"));
+
+        checker.process(files);
+    }
+
+    private static void examineCheckSectionChildren(Node section) {
+        for (Node subSection : XmlUtil.getChildrenElements(section)) {
+            if (!"subsection".equals(subSection.getNodeName())) {
+                final String text = getNodeText(subSection);
+                if (text.startsWith("Since Checkstyle")) {
+                    CHECK_TEXT.put("since", text.substring(17));
+                }
+                continue;
+            }
+
+            final String subSectionName = XmlUtil.getNameAttributeOfNode(subSection);
+
+            examineCheckSubSection(subSection, subSectionName);
+        }
+    }
+
+    private static void examineCheckSubSection(Node subSection, String subSectionName) {
+        switch (subSectionName) {
+            case "Description":
+            case "Examples":
+            case "Notes":
+            case "Rule Description":
+                CHECK_TEXT.put(subSectionName, getNodeText(subSection).replace("\r", ""));
+                break;
+            case "Properties":
+                populateProperties(subSection);
+                CHECK_TEXT.put(subSectionName, createPropertiesText());
+                break;
+            case "Example of Usage":
+            case "Violation Messages":
+                CHECK_TEXT.put(subSectionName,
+                        createViolationMessagesText(getViolationMessages(subSection)));
+                break;
+            case "Package":
+            case "Parent Module":
+                CHECK_TEXT.put(subSectionName, createParentText(subSection));
+                break;
+            default:
+                break;
+        }
+    }
+
+    private static List<String> getViolationMessages(Node subsection) {
+        final Node child = XmlUtil.getFirstChildElement(subsection);
+        final List<String> violationMessages = new ArrayList<>();
+        for (Node row : XmlUtil.getChildrenElements(child)) {
+            violationMessages.add(row.getTextContent().trim());
+        }
+        return violationMessages;
+    }
+
+    private static String createViolationMessagesText(List<String> violationMessages) {
+        final StringBuilder result = new StringBuilder(100);
+        result.append("\n<p>\nViolation Message Keys:\n</p>\n<ul>");
+
+        for (String msg : violationMessages) {
+            result.append("\n<li>\n{@code ").append(msg).append("}\n</li>");
+        }
+
+        result.append("\n</ul>");
+        return result.toString();
+    }
+
+    private static String createParentText(Node subsection) {
+        return "\n<p>\nParent is {@code com.puppycrawl.tools.checkstyle."
+                + XmlUtil.getFirstChildElement(subsection).getTextContent().trim() + "}\n</p>";
+    }
+
+    private static void populateProperties(Node subSection) {
+        boolean skip = true;
+
+        // if the first child is a wrapper element instead of the first table row containing
+        // the table headset
+        //   element to populate properties for to the current elements first child
+        Node child = XmlUtil.getFirstChildElement(subSection);
+        if (child.hasAttributes() && child.getAttributes().getNamedItem("class") != null
+                && "wrapper".equals(child.getAttributes().getNamedItem("class")
+                .getTextContent())) {
+            child = XmlUtil.getFirstChildElement(child);
+        }
+        for (Node row : XmlUtil.getChildrenElements(child)) {
+            if (skip) {
+                skip = false;
+                continue;
+            }
+            CHECK_PROPERTIES.add(new ArrayList<>(XmlUtil.getChildrenElements(row)));
+        }
+    }
+
+    private static String createPropertiesText() {
+        final StringBuilder result = new StringBuilder(100);
+
+        result.append("\n<ul>");
+
+        for (List<Node> property : CHECK_PROPERTIES) {
+            final String propertyName = getNodeText(property.get(0));
+
+            result.append("\n<li>\nProperty {@code ");
+            result.append(propertyName);
+            result.append("} - ");
+
+            final String temp = getNodeText(property.get(1));
+
+            result.append(temp);
+            CHECK_PROPERTY_DOC.put(propertyName, temp);
+
+            String typeText = "java.lang.String[]";
+            final String propertyType = property.get(2).getTextContent();
+            final boolean isSpecialAllTokensType = propertyType.contains("set of any supported");
+            final boolean isPropertyTokenType = isSpecialAllTokensType
+                    || propertyType.contains("subset of tokens")
+                    || propertyType.contains("subset of javadoc tokens");
+            if (!isPropertyTokenType) {
+                final String typeName =
+                        getCorrectNodeBasedOnPropertyType(property).getTextContent().trim();
+                typeText = FULLY_QUALIFIED_CLASS_NAMES.get(typeName).getTypeName();
+            }
+            if (isSpecialAllTokensType) {
+                typeText = "anyTokenTypesSet";
+            }
+            result.append(" Type is {@code ").append(typeText).append("}.");
+
+            if (!isSpecialAllTokensType) {
+                final String validationType = getValidationType(isPropertyTokenType, propertyName);
+                if (validationType != null) {
+                    result.append(validationType);
+                }
+            }
+
+            result.append(getDefaultValueOfType(propertyName, isSpecialAllTokensType));
+
+            result.append(emptyStringArrayDefaultValue(property.get(3), isPropertyTokenType));
+
+            if (result.charAt(result.length() - 1) != '.') {
+                result.append('.');
+            }
+
+            result.append("\n</li>");
+        }
+
+        result.append("\n</ul>");
+
+        return result.toString();
+    }
+
+    private static Node getCorrectNodeBasedOnPropertyType(List<Node> property) {
+        final Node result;
+        if (property.get(2).getFirstChild().getFirstChild() == null) {
+            result = property.get(2).getFirstChild().getNextSibling();
+        }
+        else {
+            result = property.get(2).getFirstChild().getFirstChild();
+        }
+        return result;
+    }
+
+    private static String getDefaultValueOfType(String propertyName,
+                                                boolean isSpecialAllTokensType) {
+        final String result;
+        if (!isSpecialAllTokensType
+                && (propertyName.endsWith("token") || propertyName.endsWith(
+                "tokens"))) {
+            result = " Default value is: ";
+        }
+        else {
+            result = " Default value is ";
+        }
+        return result;
+    }
+
+    private static String getValidationType(boolean isPropertyTokenType, String propertyName) {
+        String result = null;
+        if (NON_BASE_TOKEN_PROPERTIES.contains(checkName + " - " + propertyName)) {
+            result = " Validation type is {@code tokenTypesSet}.";
+        }
+        else if (isPropertyTokenType) {
+            result = " Validation type is {@code tokenSet}.";
+        }
+        return result;
+    }
+
+    private static String emptyStringArrayDefaultValue(Node defaultValueNode,
+                                                boolean isPropertyTokenType) {
+        String defaultValueText = getNodeText(defaultValueNode);
+        if ("{@code {}}".equals(defaultValueText)
+            || "{@code all files}".equals(defaultValueText)
+            || isPropertyTokenType && "{@code empty}".equals(defaultValueText)) {
+            defaultValueText = "{@code \"\"}";
+        }
+        return defaultValueText;
+    }
+
+    private static String getNodeText(Node node) {
+        final StringBuilder result = new StringBuilder(20);
+
+        for (Node child = node.getFirstChild(); child != null; child = child.getNextSibling()) {
+            if (child.getNodeType() == Node.TEXT_NODE) {
+                for (String temp : child.getTextContent().split("\n")) {
+                    final String text = temp.trim();
+
+                    if (!text.isEmpty()) {
+                        if (shouldAppendSpace(result, text.charAt(0))) {
+                            result.append(' ');
+                        }
+
+                        result.append(text);
+                    }
+                }
+            }
+            else {
+                if (child.hasAttributes() && child.getAttributes().getNamedItem("class") != null
+                        && "wrapper".equals(child.getAttributes().getNamedItem("class")
+                        .getNodeValue())) {
+                    appendNodeText(result, XmlUtil.getFirstChildElement(child));
+                }
+                else {
+                    appendNodeText(result, child);
+                }
+            }
+        }
+
+        return result.toString();
+    }
+
+    // -@cs[CyclomaticComplexity] No simple way to split this apart.
+    private static void appendNodeText(StringBuilder result, Node node) {
+        final String name = transformXmlToJavaDocName(node.getNodeName());
+        final boolean list = "ol".equals(name) || "ul".equals(name);
+        final boolean newLineOpenBefore = list || "p".equals(name) || "pre".equals(name)
+                || "li".equals(name);
+        final boolean newLineOpenAfter = newLineOpenBefore && !list;
+        final boolean newLineClose = newLineOpenAfter || list;
+        final boolean sanitize = "pre".equals(name);
+        final boolean changeToTag = "code".equals(name);
+
+        if (newLineOpenBefore) {
+            result.append('\n');
+        }
+        else if (shouldAppendSpace(result, '<')) {
+            result.append(' ');
+        }
+
+        if (changeToTag) {
+            result.append("{@");
+            result.append(name);
+            result.append(' ');
+        }
+        else {
+            result.append('<');
+            result.append(name);
+            result.append(getAttributeText(name, node.getAttributes()));
+            result.append('>');
+        }
+
+        if (newLineOpenAfter) {
+            result.append('\n');
+        }
+
+        if (sanitize) {
+            result.append(XmlUtil.sanitizeXml(node.getTextContent()));
+        }
+        else {
+            result.append(getNodeText(node));
+        }
+
+        if (newLineClose) {
+            result.append('\n');
+        }
+
+        if (changeToTag) {
+            result.append('}');
+        }
+        else {
+            result.append("</");
+            result.append(name);
+            result.append('>');
+        }
+    }
+
+    private static boolean shouldAppendSpace(StringBuilder text, char firstCharToAppend) {
+        final boolean result;
+
+        if (text.length() == 0) {
+            result = false;
+        }
+        else {
+            final char last = text.charAt(text.length() - 1);
+
+            result = (firstCharToAppend == '@'
+                    || Character.getType(firstCharToAppend) == Character.DASH_PUNCTUATION
+                    || Character.getType(last) == Character.OTHER_PUNCTUATION
+                    || Character.isAlphabetic(last)
+                    || Character.isAlphabetic(firstCharToAppend)) && !Character.isWhitespace(last);
+        }
+
+        return result;
+    }
+
+    private static String transformXmlToJavaDocName(String name) {
+        final String result;
+
+        if ("source".equals(name)) {
+            result = "pre";
+        }
+        else if ("h4".equals(name)) {
+            result = "p";
+        }
+        else {
+            result = name;
+        }
+
+        return result;
+    }
+
+    private static String getAttributeText(String nodeName, NamedNodeMap attributes) {
+        final StringBuilder result = new StringBuilder(20);
+
+        for (int i = 0; i < attributes.getLength(); i++) {
+            result.append(' ');
+
+            final Node attribute = attributes.item(i);
+            final String attrName = attribute.getNodeName();
+            final String attrValue;
+
+            if ("a".equals(nodeName) && "href".equals(attrName)) {
+                final String value = attribute.getNodeValue();
+
+                assertWithMessage("links starting with '#' aren't supported: " + value)
+                    .that(value.charAt(0))
+                    .isNotEqualTo('#');
+
+                attrValue = getLinkValue(value);
+            }
+            else {
+                attrValue = attribute.getNodeValue();
+            }
+
+            result.append(attrName);
+            result.append("=\"");
+            result.append(attrValue);
+            result.append('"');
+        }
+
+        return result.toString();
+    }
+
+    private static String getLinkValue(String initialValue) {
+        String value = initialValue;
+        final String attrValue;
+        if (value.contains("://")) {
+            attrValue = value;
+        }
+        else {
+            if (value.charAt(0) == '/') {
+                value = value.substring(1);
+            }
+
+            // Relative links to DTDs are prohibited, so we don't try to resolve them
+            if (!initialValue.startsWith("/dtds")) {
+                value = currentXdocPath
+                        .getParent()
+                        .resolve(Paths.get(value))
+                        .normalize()
+                        .toString()
+                        .replaceAll("src[\\\\/]xdocs[\\\\/]", "")
+                        .replaceAll("\\\\", "/");
+            }
+
+            attrValue = "https://checkstyle.org/" + value;
+        }
+        return attrValue;
+    }
+
+    public static class JavaDocCapture extends AbstractCheck {
+        private static final Pattern SETTER_PATTERN = Pattern.compile("^set[A-Z].*");
+
+        @Override
+        public boolean isCommentNodesRequired() {
+            return true;
+        }
+
+        @Override
+        public int[] getRequiredTokens() {
+            return new int[] {
+                TokenTypes.BLOCK_COMMENT_BEGIN,
+            };
+        }
+
+        @Override
+        public int[] getDefaultTokens() {
+            return getRequiredTokens();
+        }
+
+        @Override
+        public int[] getAcceptableTokens() {
+            return getRequiredTokens();
+        }
+
+        @Override
+        public void visitToken(DetailAST ast) {
+            if (JavadocUtil.isJavadocComment(ast)) {
+                final DetailAST parentNode = getParent(ast);
+
+                switch (parentNode.getType()) {
+                    case TokenTypes.CLASS_DEF:
+                        visitClass(ast);
+                        break;
+                    case TokenTypes.METHOD_DEF:
+                        visitMethod(ast, parentNode);
+                        break;
+                    case TokenTypes.VARIABLE_DEF:
+                        visitField(ast, parentNode);
+                        break;
+                    case TokenTypes.CTOR_DEF:
+                    case TokenTypes.ENUM_DEF:
+                    case TokenTypes.ENUM_CONSTANT_DEF:
+                        // ignore
+                        break;
+                    default:
+                        assertWithMessage(
+                                "Unknown token '" + TokenUtil.getTokenName(parentNode.getType())
+                                        + "': " + ast.getLineNo()).fail();
+                        break;
+                }
+            }
+        }
+
+        private static DetailAST getParent(DetailAST node) {
+            DetailAST result = node.getParent();
+            int type = result.getType();
+
+            while (type == TokenTypes.MODIFIERS || type == TokenTypes.ANNOTATION) {
+                result = result.getParent();
+                type = result.getType();
+            }
+
+            return result;
+        }
+
+        private static void visitClass(DetailAST node) {
+            String violationMessagesText = CHECK_TEXT.get("Violation Messages");
+
+            if (checkName.endsWith("Filter") || "SuppressWarningsHolder".equals(checkName)) {
+                violationMessagesText = "";
+            }
+
+            if (ScopeUtil.isInScope(node, Scope.PUBLIC)) {
+                assertWithMessage(checkName + "'s class-level JavaDoc")
+                    .that(getJavaDocText(node))
+                    .isEqualTo(CHECK_TEXT.get("Description")
+                        + CHECK_TEXT.computeIfAbsent("Rule Description", unused -> "")
+                        + CHECK_TEXT.computeIfAbsent("Notes", unused -> "")
+                        + CHECK_TEXT.computeIfAbsent("Properties", unused -> "")
+                        + CHECK_TEXT.get("Examples")
+                        + CHECK_TEXT.get("Parent Module")
+                        + violationMessagesText + " @since "
+                        + CHECK_TEXT.get("since"));
+            }
+        }
+
+        private static void visitField(DetailAST node, DetailAST parentNode) {
+            if (ScopeUtil.isInScope(parentNode, Scope.PUBLIC)) {
+                final String propertyName = parentNode.findFirstToken(TokenTypes.IDENT).getText();
+                final String propertyDoc = CHECK_PROPERTY_DOC.get(propertyName);
+
+                if (propertyDoc != null) {
+                    assertWithMessage(checkName + "'s class field-level JavaDoc for "
+                            + propertyName)
+                        .that(getJavaDocText(node))
+                        .isEqualTo(makeFirstUpper(propertyDoc));
+                }
+            }
+        }
+
+        private static void visitMethod(DetailAST node, DetailAST parentNode) {
+            if (ScopeUtil.isInScope(node, Scope.PUBLIC) && isSetterMethod(parentNode)) {
+                final String propertyUpper = parentNode.findFirstToken(TokenTypes.IDENT)
+                        .getText().substring(3);
+                final String propertyName = makeFirstLower(propertyUpper);
+                final String propertyDoc = CHECK_PROPERTY_DOC.get(propertyName);
+
+                if (propertyDoc != null) {
+                    final String javaDoc = getJavaDocText(node);
+
+                    assertWithMessage(checkName + "'s class method-level JavaDoc for "
+                            + propertyName)
+                        .that(javaDoc.substring(0, javaDoc.indexOf(" @param")))
+                        .isEqualTo("Setter to " + makeFirstLower(propertyDoc));
+                }
+            }
+        }
+
+        /**
+         * Returns whether an AST represents a setter method. This is similar to
+         * {@link CheckUtil#isSetterMethod(DetailAST)} except this doesn't care
+         * about the number of children in the method.
+         *
+         * @param ast the AST to check with.
+         * @return whether the AST represents a setter method.
+         */
+        private static boolean isSetterMethod(DetailAST ast) {
+            boolean setterMethod = false;
+
+            if (ast.getType() == TokenTypes.METHOD_DEF) {
+                final DetailAST type = ast.findFirstToken(TokenTypes.TYPE);
+                final String name = type.getNextSibling().getText();
+                final boolean matchesSetterFormat = SETTER_PATTERN.matcher(name).matches();
+                final boolean voidReturnType = type.findFirstToken(TokenTypes.LITERAL_VOID) != null;
+
+                final DetailAST params = ast.findFirstToken(TokenTypes.PARAMETERS);
+                final boolean singleParam = params.getChildCount(TokenTypes.PARAMETER_DEF) == 1;
+
+                if (matchesSetterFormat && voidReturnType && singleParam) {
+                    final DetailAST slist = ast.findFirstToken(TokenTypes.SLIST);
+
+                    setterMethod = slist != null;
+                }
+            }
+            return setterMethod;
+        }
+
+        private static String getJavaDocText(DetailAST node) {
+            final String text = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<document>\n"
+                    + node.getFirstChild().getText().replaceAll("(^|\\r?\\n)\\s*\\* ?", "\n")
+                            .replaceAll("\\n?@noinspection.*\\r?\\n[^@]*", "\n")
+                            .trim() + "\n</document>";
+            String result = null;
+
+            try {
+                result = getNodeText(XmlUtil.getRawXml(checkName, text, text).getFirstChild())
+                        .replace("\r", "");
+            }
+            catch (ParserConfigurationException ex) {
+                assertWithMessage("Exception: " + ex.getClass() + " - " + ex.getMessage()).fail();
+            }
+
+            return result;
+        }
+
+        private static String makeFirstUpper(String str) {
+            final char ch = str.charAt(0);
+            final String result;
+
+            if (Character.isLowerCase(ch)) {
+                result = Character.toUpperCase(ch) + str.substring(1);
+            }
+            else {
+                result = str;
+            }
+
+            return result;
+        }
+
+        private static String makeFirstLower(String str) {
+            return Character.toLowerCase(str.charAt(0)) + str.substring(1);
+        }
+    }
+}

--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java
@@ -141,14 +141,8 @@ public class XdocsPagesTest {
             // loads string into memory similar to file
             "Header.header",
             "RegexpHeader.header",
-            // deprecated fields
-            "JavadocMethod.minLineCount",
-            "JavadocMethod.allowMissingJavadoc",
-            "JavadocMethod.allowMissingPropertyJavadoc",
-            "JavadocMethod.ignoreMethodNamesRegex",
-            "JavadocMethod.logLoadErrors",
-            "JavadocMethod.suppressLoadErrors",
-            "MissingDeprecated.skipNoJavadoc"
+            // until https://github.com/checkstyle/checkstyle/issues/13376
+            "CustomImportOrder.customImportOrderRules"
     );
 
     private static final Set<String> SUN_MODULES = Collections.unmodifiableSet(
@@ -520,10 +514,13 @@ public class XdocsPagesTest {
 
     @Test
     public void testAllCheckSections() throws Exception {
+        final ModuleFactory moduleFactory = TestUtil.getPackageObjectFactory();
+
         for (Path path : XdocUtil.getXdocsConfigFilePaths(XdocUtil.getXdocsFilePaths())) {
             final String fileName = path.getFileName().toString();
 
-            if ("config_system_properties.xml".equals(fileName)) {
+            if ("config_system_properties.xml".equals(fileName)
+                    || "index.xml".equals(fileName)) {
                 continue;
             }
 
@@ -554,6 +551,8 @@ public class XdocsPagesTest {
                                             lastSectionName.toLowerCase(Locale.ENGLISH)) >= 0)
                                     .isTrue();
                 }
+
+                validateCheckSection(moduleFactory, fileName, sectionName, section);
 
                 lastSectionName = sectionName;
             }
@@ -1387,10 +1386,14 @@ public class XdocsPagesTest {
                 .isEqualTo("");
         }
         else {
+            final String subsectionTextContent = subSection.getTextContent()
+                    .replaceAll("\n\\s+", "\n")
+                    .replaceAll("\\s+", " ")
+                    .trim();
             assertWithMessage(fileName + " section '" + sectionName
                             + "' should have the expected error keys")
-                .that(subSection.getTextContent().replaceAll("\n\\s+", "\n").trim())
-                .isEqualTo(expectedText.toString().trim());
+                .that(subsectionTextContent)
+                .isEqualTo(expectedText.toString().replaceAll("\n", " ").trim());
 
             for (Node node : XmlUtil.findChildElementsByTag(subSection, "a")) {
                 final String url = node.getAttributes().getNamedItem("href").getTextContent();
@@ -1398,7 +1401,7 @@ public class XdocsPagesTest {
                 final String expectedUrl;
 
                 if ("see the documentation".equals(linkText)) {
-                    expectedUrl = "config.html#Custom_messages";
+                    expectedUrl = "../../config.html#Custom_messages";
                 }
                 else {
                     expectedUrl = "https://github.com/search?q="

--- a/src/xdocs/checks/design/finalclass.xml
+++ b/src/xdocs/checks/design/finalclass.xml
@@ -15,7 +15,7 @@
         </p>
         <ol>
           <li>
-              Private classes with implicit constructor.
+              Private classes with no declared constructors.
           </li>
           <li>
               Classes with any modifier, and contains only private constructors.

--- a/src/xdocs/checks/design/visibilitymodifier.xml
+++ b/src/xdocs/checks/design/visibilitymodifier.xml
@@ -508,12 +508,12 @@ class Example7 {
 }
         </source>
         <p>
-          To configure the Check passing fields annotated with @com.annotation.CustomAnnotation:
+          To configure the Check passing fields annotated with @java.lang.Deprecated:
         </p>
         <source>
 &lt;module name="VisibilityModifier"&gt;
   &lt;property name="ignoreAnnotationCanonicalNames"
-    value="com.annotation.CustomAnnotation"/&gt;
+    value="java.lang.Deprecated"/&gt;
 &lt;/module&gt;
         </source>
         <p>
@@ -614,7 +614,7 @@ class Example9 {
         <source>
 &lt;module name="VisibilityModifier"&gt;
   &lt;property name="ignoreAnnotationCanonicalNames"
-    value="CustomAnnotation"/&gt;
+    value="Deprecated"/&gt;
 &lt;/module&gt;
         </source>
         <p>

--- a/src/xdocs/checks/header/header.xml
+++ b/src/xdocs/checks/header/header.xml
@@ -71,7 +71,7 @@ line 5: ////////////////////////////////////////////////////////////////////
               <td>
                 <code>
                   the charset property of the parent<a href="../../config.html#Checker">
-                  Checker</a>module
+                  Checker</a> module
                 </code>
               </td>
               <td>5.0</td>

--- a/src/xdocs/checks/header/regexpheader.xml
+++ b/src/xdocs/checks/header/regexpheader.xml
@@ -110,7 +110,7 @@ line 6: ^\W*$
               <td>
                 <code>
                   the charset property of the parent<a href="../../config.html#Checker">
-                  Checker</a>module
+                  Checker</a> module
                 </code>
               </td>
               <td>5.0</td>


### PR DESCRIPTION
Restores xdoc-javadoc validation that was removed in https://github.com/checkstyle/checkstyle/pull/13117/files#diff-350da613cecad468adf5dcb54826f8aa2cca63e699aee79a7d8bad4f8257f48d prior to splitting xdocs.