### PR TITLE
Issue #13321: Kill mutation for UncommentedMainCheck-3

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -1519,17 +1519,6 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java</fileName>
-    <specifier>assignment</specifier>
-    <message>incompatible types in assignment.</message>
-    <lineContent>currentClass = null;</lineContent>
-    <details>
-      found   : null (NullType)
-      required: @Initialized @NonNull String
-    </details>
-  </checkerFrameworkError>
-
-  <checkerFrameworkError unstable="false">
-    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java</fileName>
     <specifier>initialization.field.uninitialized</specifier>
     <message>the default constructor does not initialize field currentClass</message>
     <lineContent>private String currentClass;</lineContent>

--- a/config/pitest-suppressions/pitest-misc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-misc-suppressions.xml
@@ -198,14 +198,14 @@
     <lineContent>classDepth = 0;</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>UncommentedMainCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.UncommentedMainCheck</mutatedClass>
-    <mutatedMethod>beginTree</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable currentClass</description>
-    <lineContent>currentClass = null;</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>UncommentedMainCheck.java</sourceFile>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/UncommentedMainCheck.java
@@ -189,7 +189,6 @@ public class UncommentedMainCheck
     @Override
     public void beginTree(DetailAST rootAST) {
         packageName = FullIdent.createFullIdent(null);
-        currentClass = null;
         classDepth = 0;
     }
 


### PR DESCRIPTION
Issue #13321: Kill mutation for UncommentedMainCheck-3

---------

# Check
https://checkstyle.org/checks/misc/uncommentedmain.html

---------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/2be5780673b9ba5397526aadab981be68f874172/config/pitest-suppressions/pitest-misc-suppressions.xml#L201-L208

---------

# Explaination 
In visitToken when Token is classDEF or RecordDef it call visitClassOrRecordDef where if classDepth == 0 then only currentClass will update know every time when new file come sequentially they alwyas have a class and that time the classDepth is always 0. and classdepth is reset to 0 in begintree. 

-------

# Regression 


------

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/92e6545d9dda7c3febcd4ad8f8a91443/raw/5b88dc50b3b7828cca1bce0d4d6aa47209d25647/UMC.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Regression-2
