### PR TITLE
Issue #13321: Kill mutation for TranslationCheck-1

### DIFF
--- a/config/pitest-suppressions/pitest-misc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-misc-suppressions.xml
@@ -144,23 +144,22 @@
     <lineContent>private Pattern format = Pattern.compile(&quot;TODO:&quot;);</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>TranslationCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.TranslationCheck</mutatedClass>
-    <mutatedMethod>logException</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/checks/TranslationCheck::getId</description>
-    <lineContent>getId(),</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>TranslationCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.TranslationCheck$ResourceBundle</mutatedClass>
-    <mutatedMethod>getFiles</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to java/util/Collections::unmodifiableSet with argument</description>
-    <lineContent>return Collections.unmodifiableSet(files);</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -2999,6 +2999,10 @@
                 <!-- needed for SuppressWarningsFilter -->
                 <param>com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilterTest</param>
               </targetTests>
+              <avoidCallsTo>
+                <avoidCallsTo>com.puppycrawl.tools.checkstyle.utils.UnmodifiableCollectionUtil</avoidCallsTo>
+                <avoidCallsTo>org.apache.commons.logging</avoidCallsTo>
+              </avoidCallsTo>
               <excludedMethods>
                 <!-- destroy method was added in case module had to free up resources
                 before ending, but currently it does ThreadLocal cleanup,

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java
@@ -24,7 +24,6 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
@@ -51,6 +50,7 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.MessageDispatcher;
 import com.puppycrawl.tools.checkstyle.api.Violation;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+import com.puppycrawl.tools.checkstyle.utils.UnmodifiableCollectionUtil;
 
 /**
  * <p>
@@ -731,7 +731,7 @@ public class TranslationCheck extends AbstractFileSetCheck {
          * @return the set of files
          */
         public Set<File> getFiles() {
-            return Collections.unmodifiableSet(files);
+            return UnmodifiableCollectionUtil.unmodifiableSet(files);
         }
 
         /**

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheckTest.java
@@ -249,6 +249,7 @@ public class TranslationCheckTest extends AbstractXmlTestSupport {
         final TestMessageDispatcher dispatcher = new TestMessageDispatcher();
         check.configure(checkConfig);
         check.setMessageDispatcher(dispatcher);
+        check.setId("ID1");
 
         final Exception exception = new IOException("test exception");
         TestUtil.invokeMethod(check, "logException", exception, new File(""));
@@ -258,7 +259,7 @@ public class TranslationCheckTest extends AbstractXmlTestSupport {
             .isEqualTo(1);
         final Violation violation = new Violation(0,
                 Definitions.CHECKSTYLE_BUNDLE, "general.exception",
-                new String[] {exception.getMessage()}, null, TranslationCheck.class, null);
+                new String[] {exception.getMessage()}, "ID1", TranslationCheck.class, null);
         assertWithMessage("Invalid violation")
             .that(dispatcher.savedErrors.iterator().next())
             .isEqualTo(violation);


### PR DESCRIPTION
Issue #13321: Kill mutation for TranslationCheck-1

---------

# Check
https://checkstyle.org/checks/misc/translation.html#Translation

---------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/2be5780673b9ba5397526aadab981be68f874172/config/pitest-suppressions/pitest-misc-suppressions.xml#L174-L190

---------

# Explaination 
To Kill the mutation unmodifiableCollectionUtil I have used avoid call to for out class created to wrap that method in util by default avoidcall to is applied to https://pitest.org/quickstart/maven/#:~:text=If%20a%20list%20is%20not%20explicitly%20supplied%20then%20PIT%20will%20default%20to%20a%20list%20of%20common%20logging%20packages%20as%20follows 
so add log method to avoid the error at https://github.com/checkstyle/checkstyle/blob/2be5780673b9ba5397526aadab981be68f874172/src/main/java/com/puppycrawl/tools/checkstyle/checks/TranslationCheck.java#L672

https://github.com/checkstyle/checkstyle/blob/0831953d82df93e5ebe7f178c2f2b904af8b8f3b/src/main/java/com/puppycrawl/tools/checkstyle/api/Violation.java#L327

-------
