### PR TITLE
Issue #13321: Kill mutation for TODOCommentCheck-1

### DIFF
--- a/config/pitest-suppressions/pitest-misc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-misc-suppressions.xml
@@ -126,23 +126,23 @@
     <lineContent>switch (firstChild.getType()) {</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>TodoCommentCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/regex/Pattern::compile</description>
-    <lineContent>private Pattern format = Pattern.compile(&quot;TODO:&quot;);</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>TodoCommentCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.TodoCommentCheck</mutatedClass>
-    <mutatedMethod>&lt;init&gt;</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable format</description>
-    <lineContent>private Pattern format = Pattern.compile(&quot;TODO:&quot;);</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>TranslationCheck.java</sourceFile>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/TodoCommentCheckTest.java
@@ -69,4 +69,12 @@ public class TodoCommentCheckTest
             .isEqualTo(expected);
     }
 
+    @Test
+    public void test() throws Exception {
+        final String[] expected = {
+            "11:16: " + getCheckMessage(MSG_KEY, "TODO:"),
+        };
+        verifyWithInlineConfigParser(
+                getPath("InputTodoCommentDefault.java"), expected);
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/todocomment/InputTodoCommentDefault.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/todocomment/InputTodoCommentDefault.java
@@ -1,0 +1,15 @@
+/*
+TodoComment
+
+*/
+
+package com.puppycrawl.tools.checkstyle.checks.todocomment;
+
+public class InputTodoCommentDefault {
+    int i;
+    public void method() { // violation below 'Comment matches .*'
+        i++; // TODO: do differently in future
+        i++;
+    }
+
+}


### PR DESCRIPTION
Issue #13321: Kill mutation for TODOCommentCheck-1

---------

# Check
https://checkstyle.org/checks/misc/todocomment.html#TodoComment

---------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/2be5780673b9ba5397526aadab981be68f874172/config/pitest-suppressions/pitest-misc-suppressions.xml#L156-L172

---------

# Explaination 
Test added