### PR TITLE
Issue #13321: Kill mutation for NewLineAtEnd

### DIFF
--- a/config/pitest-suppressions/pitest-misc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-misc-suppressions.xml
@@ -18,23 +18,23 @@
     <lineContent>private int[] counts = CommonUtil.EMPTY_INT_ARRAY;</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>NewlineAtEndOfFileCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck</mutatedClass>
-    <mutatedMethod>readAndCheckFile</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/io/File::getPath</description>
-    <lineContent>log(1, MSG_KEY_NO_NEWLINE_EOF, file.getPath());</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>NewlineAtEndOfFileCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck</mutatedClass>
-    <mutatedMethod>readAndCheckFile</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/io/File::getPath</description>
-    <lineContent>log(1, MSG_KEY_WRONG_ENDING, file.getPath());</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>OrderedPropertiesCheck.java</sourceFile>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/NewlineAtEndOfFileCheck.java
@@ -224,10 +224,10 @@ public class NewlineAtEndOfFileCheck
         try (RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r")) {
             if (lineSeparator == LineSeparatorOption.LF
                     && endsWithNewline(randomAccessFile, LineSeparatorOption.CRLF)) {
-                log(1, MSG_KEY_WRONG_ENDING, file.getPath());
+                log(1, MSG_KEY_WRONG_ENDING);
             }
             else if (!endsWithNewline(randomAccessFile, lineSeparator)) {
-                log(1, MSG_KEY_NO_NEWLINE_EOF, file.getPath());
+                log(1, MSG_KEY_NO_NEWLINE_EOF);
             }
         }
     }


### PR DESCRIPTION
Issue #13321: Kill mutation for NewLineAtEnd

-------

# check
https://checkstyle.org/checks/misc/newlineatendoffile.html#NewlineAtEndOfFile

-------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/2be5780673b9ba5397526aadab981be68f874172/config/pitest-suppressions/pitest-misc-suppressions.xml#L21-L37

--------

# Explaination
https://github.com/checkstyle/checkstyle/blob/2be5780673b9ba5397526aadab981be68f874172/src/main/resources/com/puppycrawl/tools/checkstyle/checks/messages.properties#L9
https://github.com/checkstyle/checkstyle/blob/2be5780673b9ba5397526aadab981be68f874172/src/main/resources/com/puppycrawl/tools/checkstyle/checks/messages.properties#L22 

we are not showing any filepath