### PR TITLE
Issue #13321: Kill mutation for OuterTypeFile-2

### DIFF
--- a/config/pitest-suppressions/pitest-misc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-misc-suppressions.xml
@@ -82,33 +82,6 @@
   </mutation>
 
   <mutation unstable="false">
-    <sourceFile>OuterTypeFilenameCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck</mutatedClass>
-    <mutatedMethod>beginTree</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable hasPublic</description>
-    <lineContent>hasPublic = false;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>OuterTypeFilenameCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck</mutatedClass>
-    <mutatedMethod>beginTree</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable seenFirstToken</description>
-    <lineContent>seenFirstToken = false;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>OuterTypeFilenameCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck</mutatedClass>
-    <mutatedMethod>beginTree</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-    <description>Removed assignment to member variable wrongType</description>
-    <lineContent>wrongType = null;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
     <sourceFile>SuppressWarningsHolder.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder</mutatedClass>
     <mutatedMethod>addSuppressions</mutatedMethod>

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/OuterTypeFilenameCheckTest.java
@@ -22,9 +22,14 @@ package com.puppycrawl.tools.checkstyle.checks;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck.MSG_KEY;
 
+import java.io.File;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
+import com.google.common.collect.ImmutableMap;
 import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
@@ -165,4 +170,37 @@ public class OuterTypeFilenameCheckTest extends AbstractModuleTestSupport {
                 getNonCompilablePath("InputOuterTypeFilenameRecord.java"), expected);
     }
 
+    @Test
+    public void testStateIsClearedOnBeginTree2() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(OuterTypeFilenameCheck.class);
+        final String file1 = getPath(
+                "InputOuterTypeFilenameBeginTree1.java");
+        final String file2 = getPath(
+                "InputOuterTypeFilenameBeginTree2.java");
+        final List<String> expectedFirstInput = List.of(CommonUtil.EMPTY_STRING_ARRAY);
+        final List<String> expectedSecondInput = List.of(CommonUtil.EMPTY_STRING_ARRAY);
+        final File[] inputs = {new File(file1), new File(file2)};
+
+        verify(createChecker(checkConfig), inputs, ImmutableMap.of(
+            file1, expectedFirstInput,
+            file2, expectedSecondInput));
+    }
+
+    @Test
+    public void testStateIsClearedOnBeginTree3() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(OuterTypeFilenameCheck.class);
+        final String file1 = getPath(
+                "InputOuterTypeFilenameBeginTree1.java");
+        final String file2 = getPath(
+                "InputOuterTypeFilename1a.java");
+        final List<String> expectedFirstInput = List.of(CommonUtil.EMPTY_STRING_ARRAY);
+        final List<String> expectedSecondInput = List.of(
+                "9:1: " + getCheckMessage(MSG_KEY)
+        );
+        final File[] inputs = {new File(file1), new File(file2)};
+
+        verify(createChecker(checkConfig), inputs, ImmutableMap.of(
+            file1, expectedFirstInput,
+            file2, expectedSecondInput));
+    }
 }

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/outertypefilename/InputOuterTypeFilenameBeginTree1.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/outertypefilename/InputOuterTypeFilenameBeginTree1.java
@@ -1,0 +1,35 @@
+package com.puppycrawl.tools.checkstyle.checks.outertypefilename;
+
+@interface MyAnnotation2 {
+    String name();
+    int version();
+}
+
+@MyAnnotation2(name = "ABC", version = 1)
+public class InputOuterTypeFilenameBeginTree1
+{
+
+}
+
+enum Enum2 //ok
+{
+    A, B, C;
+    Enum2() {}
+    public String toString() {
+        return ""; //some custom implementation
+    }
+}
+// ok
+interface TestRequireThisEnum2
+{
+    enum DAY_OF_WEEK
+    {
+        SUNDAY,
+        MONDAY,
+        TUESDAY,
+        WEDNESDAY,
+        THURSDAY,
+        FRIDAY,
+        SATURDAY
+    }
+}

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/outertypefilename/InputOuterTypeFilenameBeginTree2.java
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/outertypefilename/InputOuterTypeFilenameBeginTree2.java
@@ -1,0 +1,8 @@
+package com.puppycrawl.tools.checkstyle.checks.outertypefilename;
+
+/**
+ * Test for Begin Tree
+ */
+public class InputOuterTypeFilenameBeginTree2 {
+// ok
+}


### PR DESCRIPTION
Issue #13321: Kill mutation for OuterTypeFile-2

-----

# Check :- 
https://checkstyle.org/checks/misc/outertypefilename.html#OuterTypeFilename

-----

# Mutation 
https://github.com/checkstyle/checkstyle/blob/20a52f70548476a4ca3bb0f56e4d8fcd9cd775b7/config/pitest-suppressions/pitest-misc-suppressions.xml#L84-L109

-----

# Explaination
Test added

-----

# Regression :- 


-----

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/19becb64b46958e038d7cc25e7ee2653/raw/8a01e220b6dda4d1bca26cb1916437d230ab8fa4/out.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/21e3934e85f802e2fbd48af06d122364/raw/604256badd733d8568064f371d55657c04b00dfd/test-projects-2.properties
Report label: Regression-1
