### PR TITLE
Issue #13321: Kill mutation for OrderedPropertiesCheck-1

### DIFF
--- a/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
+++ b/config/checker-framework-suppressions/checker-nullness-optional-interning-suppressions.xml
@@ -1384,6 +1384,17 @@
 
   <checkerFrameworkError unstable="false">
     <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java</fileName>
+    <specifier>contracts.postcondition</specifier>
+    <message>postcondition of put is not satisfied.</message>
+    <lineContent>public synchronized Object put(Object key, Object value) {</lineContent>
+    <details>
+      found   : key is @UnknownKeyFor
+      required: key is @KeyFor(&quot;this&quot;)
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java</fileName>
     <specifier>method.invocation</specifier>
     <message>call to setFileExtensions(java.lang.String...) not allowed on the given receiver.</message>
     <lineContent>setFileExtensions(&quot;properties&quot;);</lineContent>
@@ -1405,6 +1416,17 @@
       Enumeration&lt;Object&gt; keys(SequencedProperties this)
       cannot override method in Hashtable&lt;Object, Object&gt;
       Enumeration&lt;@KeyFor(&quot;this&quot;) Object&gt; keys(Hashtable&lt;Object, Object&gt; this)
+    </details>
+  </checkerFrameworkError>
+
+  <checkerFrameworkError unstable="false">
+    <fileName>src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java</fileName>
+    <specifier>return</specifier>
+    <message>incompatible types in return.</message>
+    <lineContent>return null;</lineContent>
+    <details>
+      type of expression: null (NullType)
+      method return type: @Initialized @NonNull Object
     </details>
   </checkerFrameworkError>
 

--- a/config/pitest-suppressions/pitest-misc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-misc-suppressions.xml
@@ -54,32 +54,32 @@
     <lineContent>.replaceAll(Matcher.quoteReplacement(&quot;\\\\ &quot;)) + &quot;[\\s:=].*&quot;;</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>OrderedPropertiesCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck$SequencedProperties</mutatedClass>
-    <mutatedMethod>put</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/Properties::put</description>
-    <lineContent>return super.put(key, value);</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>OrderedPropertiesCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck$SequencedProperties</mutatedClass>
-    <mutatedMethod>put</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to java/util/Properties::put with argument</description>
-    <lineContent>return super.put(key, value);</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>OrderedPropertiesCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck$SequencedProperties</mutatedClass>
-    <mutatedMethod>put</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.NullReturnValsMutator</mutator>
-    <description>replaced return value with null for com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck$SequencedProperties::put</description>
-    <lineContent>return super.put(key, value);</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
   <mutation unstable="false">
     <sourceFile>SuppressWarningsHolder.java</sourceFile>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheck.java
@@ -248,7 +248,7 @@ public class OrderedPropertiesCheck extends AbstractFileSetCheck {
         public synchronized Object put(Object key, Object value) {
             keyList.add(key);
 
-            return super.put(key, value);
+            return null;
         }
     }
 }


### PR DESCRIPTION
Issue #13321: Kill mutation for OrderedPropertiesCheck-1

---------

# Check :- 
https://checkstyle.org/checks/misc/orderedproperties.html#OrderedProperties

-----------

# Mutation :- 
https://github.com/checkstyle/checkstyle/blob/20a52f70548476a4ca3bb0f56e4d8fcd9cd775b7/config/pitest-suppressions/pitest-misc-suppressions.xml#L57-L82

----------

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/c3213434af8523d918594b88ce5554f7/raw/3565cfcd975e228af515bb34ce22c83afce0a7c7/opc.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Regression-2
