### PR TITLE
Issue #13321: Kill mutation for OrderedPropertiesCheck-2

### DIFF
--- a/config/pitest-suppressions/pitest-misc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-misc-suppressions.xml
@@ -36,23 +36,22 @@
 
 
 
-  <mutation unstable="false">
-    <sourceFile>OrderedPropertiesCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck</mutatedClass>
-    <mutatedMethod>getKeyPattern</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to java/util/regex/Matcher::quoteReplacement</description>
-    <lineContent>.replaceAll(Matcher.quoteReplacement(&quot;\\\\ &quot;)) + &quot;[\\s:=].*&quot;;</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>OrderedPropertiesCheck.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.OrderedPropertiesCheck</mutatedClass>
-    <mutatedMethod>getKeyPattern</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to java/util/regex/Matcher::quoteReplacement with argument</description>
-    <lineContent>.replaceAll(Matcher.quoteReplacement(&quot;\\\\ &quot;)) + &quot;[\\s:=].*&quot;;</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheckTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/OrderedPropertiesCheckTest.java
@@ -180,6 +180,15 @@ public class OrderedPropertiesCheckTest extends AbstractModuleTestSupport {
                 .isEqualTo(check.getFileExtensions()[0]);
     }
 
+    @Test
+    public void test() throws Exception {
+        final DefaultConfiguration checkConfig = createModuleConfig(OrderedPropertiesCheck.class);
+        final String[] expected = {
+            "3: " + getCheckMessage(MSG_KEY, " A ", " B"),
+        };
+        verify(checkConfig, getPath("InputOrderedProperties2.properties"), expected);
+    }
+
     /**
      * Method generates NoSuchFileException details. It tries to open a file that does not exist.
      *

--- a/src/test/resources/com/puppycrawl/tools/checkstyle/checks/orderedproperties/InputOrderedProperties2.properties
+++ b/src/test/resources/com/puppycrawl/tools/checkstyle/checks/orderedproperties/InputOrderedProperties2.properties
@@ -1,0 +1,5 @@
+\ a\  =97
+\ B =66
+\ A\ =65
+key =107 than nothing
+key.sub =k is 107 and dot is 46


### PR DESCRIPTION
Issue #13321: Kill mutation for OrderedPropertiesCheck-2

---------

# Check :- 
https://checkstyle.org/checks/misc/orderedproperties.html#OrderedProperties

-----------

# Mutation :- 
https://github.com/checkstyle/checkstyle/blob/20a52f70548476a4ca3bb0f56e4d8fcd9cd775b7/config/pitest-suppressions/pitest-misc-suppressions.xml#L39-L55

----------

# Explaination 
Test added

---------

Diff Regression config: https://gist.githubusercontent.com/Kevin222004/c3213434af8523d918594b88ce5554f7/raw/3565cfcd975e228af515bb34ce22c83afce0a7c7/opc.xml
Diff Regression projects: https://gist.githubusercontent.com/Kevin222004/9600f179b602d4c971bdb0a050099005/raw/360a95ed7bb60d7a0956e531199d484c4d6f6617/test-projects.properties
Report label: Regression-2
