### PR TITLE
Issue #13321: Kill mutation for SuppressWarningHolderCheck-1

### DIFF
--- a/config/pitest-suppressions/pitest-misc-suppressions.xml
+++ b/config/pitest-suppressions/pitest-misc-suppressions.xml
@@ -90,41 +90,34 @@
     <lineContent>final int firstColumn = targetAST.getColumnNo();</lineContent>
   </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>SuppressWarningsHolder.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder</mutatedClass>
-    <mutatedMethod>findAllExpressionsInChildren</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-    <description>removed call to com/puppycrawl/tools/checkstyle/api/DetailAST::getNextSibling</description>
-    <lineContent>childAST = childAST.getNextSibling();</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>SuppressWarningsHolder.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder</mutatedClass>
-    <mutatedMethod>getStringExpr</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.NakedReceiverMutator</mutator>
-    <description>replaced call to com/puppycrawl/tools/checkstyle/api/DetailAST::getLastChild with receiver</description>
-    <lineContent>expr = firstChild.getLastChild().getText();</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>SuppressWarningsHolder.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder</mutatedClass>
-    <mutatedMethod>getStringExpr</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_0</mutator>
-    <description>RemoveSwitch 0 (case value 58)</description>
-    <lineContent>switch (firstChild.getType()) {</lineContent>
-  </mutation>
 
-  <mutation unstable="false">
-    <sourceFile>SuppressWarningsHolder.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder</mutatedClass>
-    <mutatedMethod>getStringExpr</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.RemoveSwitchMutator_1</mutator>
-    <description>RemoveSwitch 1 (case value 59)</description>
-    <lineContent>switch (firstChild.getType()) {</lineContent>
-  </mutation>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 

--- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
+++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/SuppressWarningsHolderTest.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.checks;
 
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck.MSG_UNUSED_LOCAL_VARIABLE;
 
 import java.io.File;
 import java.lang.reflect.Constructor;
@@ -39,6 +40,7 @@ import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.api.Violation;
+import com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.AbstractNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.ConstantNameCheck;
 import com.puppycrawl.tools.checkstyle.checks.naming.MemberNameCheck;
@@ -505,6 +507,27 @@ public class SuppressWarningsHolderTest extends AbstractModuleTestSupport {
 
         verifyWithInlineConfigParser(
                 getPath("InputSuppressWarningsHolderAlias2.java"),
+                expected);
+    }
+
+    @Test
+    public void testIdent() throws Exception {
+        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputSuppressWarningsHolder1.java"),
+                expected);
+    }
+
+    @Test
+    public void testIdent2() throws Exception {
+        final String[] expected = {
+            "37:9: " + getCheckMessage(UnusedLocalVariableCheck.class,
+                    MSG_UNUSED_LOCAL_VARIABLE, "a"),
+            "42:9: " + getCheckMessage(UnusedLocalVariableCheck.class,
+                    MSG_UNUSED_LOCAL_VARIABLE, "a"),
+        };
+        verifyWithInlineConfigParser(
+                getNonCompilablePath("InputSuppressWarningsHolder2.java"),
                 expected);
     }
 }

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder1.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder1.java
@@ -1,0 +1,27 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder
+aliasList = (default)
+
+com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter
+
+com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck
+
+*/
+
+//non-compiled with eclipse: The value for annotation attribute must be a constant expression
+package com.puppycrawl.tools.checkstyle.checks.suppresswarningsholder;
+
+public class InputSuppressWarningsHolder1 {
+    static final String unusedLocalVariableCheck
+            = "UnusedLocalVariableCheck";
+
+    void test() {
+        @SuppressWarnings(unusedLocalVariableCheck)
+        int a;
+    }
+
+    void test2() {
+        @SuppressWarnings(InputSuppressWarningsHolder1.unusedLocalVariableCheck)
+        int a;
+    }
+}

--- a/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder2.java
+++ b/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/suppresswarningsholder/InputSuppressWarningsHolder2.java
@@ -1,0 +1,44 @@
+/*
+com.puppycrawl.tools.checkstyle.checks.SuppressWarningsHolder
+aliasList = (default)
+
+com.puppycrawl.tools.checkstyle.filters.SuppressWarningsFilter
+
+com.puppycrawl.tools.checkstyle.checks.coding.UnusedLocalVariableCheck
+
+com.puppycrawl.tools.checkstyle.checks.naming.LocalVariableNameCheck
+format = ^[a-z][_a-zA-Z0-9]{2,}$
+
+
+*/
+
+//non-compiled with eclipse: The value for annotation attribute must be a constant expression
+package com.puppycrawl.tools.checkstyle.checks.suppresswarningsholder;
+
+public class InputSuppressWarningsHolder2 {
+    static final String unusedLocalVariableCheck
+            = "UnusedLocalVariableCheck";
+    static final String localVariableNameCheck
+            = "LocalVariableNameCheck";
+
+    void test2() {
+        @SuppressWarnings({InputSuppressWarningsHolder2.unusedLocalVariableCheck,
+                InputSuppressWarningsHolder2.localVariableNameCheck})
+        int a;
+    }
+
+    void test3() {
+        @SuppressWarnings({unusedLocalVariableCheck, localVariableNameCheck})
+        int a;
+    }
+
+    void test1() {
+        @SuppressWarnings(InputSuppressWarningsHolder2.localVariableNameCheck)
+        int a; // violation 'Unused local variable 'a''
+    }
+
+    void test4() {
+        @SuppressWarnings(localVariableNameCheck)
+        int a; // violation 'Unused local variable 'a''
+    }
+}


### PR DESCRIPTION
Issue #13321: Kill mutation for SuppressWarningHolderCheck-1

----------

# Check :- 
https://checkstyle.org/checks/annotation/suppresswarningsholder.html#SuppressWarningsHolder

----------

# Mutation
https://github.com/checkstyle/checkstyle/blob/0169b0891563cd7e12d39aa42acc6e6b2cb0ee38/config/pitest-suppressions/pitest-misc-suppressions.xml#L93-L127

---------

# Explaination
Test added 