### PR TITLE
Issue #13321: Kill mutation for DetailAstImpl

### DIFF
--- a/config/pitest-suppressions/pitest-common-2-suppressions.xml
+++ b/config/pitest-suppressions/pitest-common-2-suppressions.xml
@@ -66,46 +66,10 @@
   <mutation unstable="false">
     <sourceFile>DetailAstImpl.java</sourceFile>
     <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
-    <mutatedMethod>getHiddenAfter</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to java/util/Collections::unmodifiableList with argument</description>
-    <lineContent>returnList = Collections.unmodifiableList(hiddenAfter);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>DetailAstImpl.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
-    <mutatedMethod>getHiddenBefore</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to java/util/Collections::unmodifiableList with argument</description>
-    <lineContent>returnList = Collections.unmodifiableList(hiddenBefore);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>DetailAstImpl.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
     <mutatedMethod>removeChildren</mutatedMethod>
     <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
     <description>Removed assignment to member variable firstChild</description>
     <lineContent>firstChild = null;</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>DetailAstImpl.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
-    <mutatedMethod>setHiddenAfter</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to java/util/Collections::unmodifiableList with argument</description>
-    <lineContent>this.hiddenAfter = Collections.unmodifiableList(hiddenAfter);</lineContent>
-  </mutation>
-
-  <mutation unstable="false">
-    <sourceFile>DetailAstImpl.java</sourceFile>
-    <mutatedClass>com.puppycrawl.tools.checkstyle.DetailAstImpl</mutatedClass>
-    <mutatedMethod>setHiddenBefore</mutatedMethod>
-    <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.ArgumentPropagationMutator</mutator>
-    <description>replaced call to java/util/Collections::unmodifiableList with argument</description>
-    <lineContent>this.hiddenBefore = Collections.unmodifiableList(hiddenBefore);</lineContent>
   </mutation>
 
   <mutation unstable="false">

--- a/pom.xml
+++ b/pom.xml
@@ -4397,6 +4397,9 @@
                 <avoidCallsTo>
                   com.puppycrawl.tools.checkstyle.XmlLoader$LoadExternalDtdFeatureProvider
                 </avoidCallsTo>
+                <avoidCallsTo>
+                  com.puppycrawl.tools.checkstyle.utils.UnmodifiableCollectionUtil
+                </avoidCallsTo>
               </avoidCallsTo>
               <coverageThreshold>100</coverageThreshold>
               <mutationThreshold>96</mutationThreshold>

--- a/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java
@@ -20,13 +20,13 @@
 package com.puppycrawl.tools.checkstyle;
 
 import java.util.BitSet;
-import java.util.Collections;
 import java.util.List;
 
 import org.antlr.v4.runtime.Token;
 
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.utils.TokenUtil;
+import com.puppycrawl.tools.checkstyle.utils.UnmodifiableCollectionUtil;
 
 /**
  * The implementation of {@link DetailAST}. This should only be directly used to
@@ -507,7 +507,7 @@ public final class DetailAstImpl implements DetailAST {
     public List<Token> getHiddenBefore() {
         List<Token> returnList = null;
         if (hiddenBefore != null) {
-            returnList = Collections.unmodifiableList(hiddenBefore);
+            returnList = UnmodifiableCollectionUtil.unmodifiableList(hiddenBefore);
         }
         return returnList;
     }
@@ -521,7 +521,7 @@ public final class DetailAstImpl implements DetailAST {
     public List<Token> getHiddenAfter() {
         List<Token> returnList = null;
         if (hiddenAfter != null) {
-            returnList = Collections.unmodifiableList(hiddenAfter);
+            returnList = UnmodifiableCollectionUtil.unmodifiableList(hiddenAfter);
         }
         return returnList;
     }
@@ -532,7 +532,7 @@ public final class DetailAstImpl implements DetailAST {
      * @param hiddenBefore comment token preceding this DetailAstImpl
      */
     public void setHiddenBefore(List<Token> hiddenBefore) {
-        this.hiddenBefore = Collections.unmodifiableList(hiddenBefore);
+        this.hiddenBefore = UnmodifiableCollectionUtil.unmodifiableList(hiddenBefore);
     }
 
     /**
@@ -541,6 +541,6 @@ public final class DetailAstImpl implements DetailAST {
      * @param hiddenAfter comment token following this DetailAstImpl
      */
     public void setHiddenAfter(List<Token> hiddenAfter) {
-        this.hiddenAfter = Collections.unmodifiableList(hiddenAfter);
+        this.hiddenAfter = UnmodifiableCollectionUtil.unmodifiableList(hiddenAfter);
     }
 }

--- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java
+++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/UnmodifiableCollectionUtil.java
@@ -20,6 +20,7 @@
 package com.puppycrawl.tools.checkstyle.utils;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -47,5 +48,16 @@ public final class UnmodifiableCollectionUtil {
      */
     public static <T> Set<T> unmodifiableSet(Set<T> collection) {
         return Collections.unmodifiableSet(collection);
+    }
+
+    /**
+     * Creates an unmodifiable list based on the provided collection.
+     *
+     * @param collection the collection to create an unmodifiable list from
+     * @param <T> the type of elements in the set
+     * @return an unmodifiable list containing the elements from the provided collection
+     */
+    public static <T> List<T> unmodifiableList(List<T> collection) {
+        return Collections.unmodifiableList(collection);
     }
 }


### PR DESCRIPTION
Issue #13321: Kill mutation for DetailAstImpl


https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/DetailAstImpl.java

--------

# Mutation 
https://github.com/checkstyle/checkstyle/blob/88486f7ca9795f613d28fa6c2a53beccef521dfc/config/pitest-suppressions/pitest-common-2-suppressions.xml#L66-L82
and 
https://github.com/checkstyle/checkstyle/blob/88486f7ca9795f613d28fa6c2a53beccef521dfc/config/pitest-suppressions/pitest-common-2-suppressions.xml#L93-L109

# Explaintaion 
Expanded unmodifiableCollectionUtil class